### PR TITLE
Add C++ syntax highlighting for !lambda values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "esphome-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@home-assistant/webawesome": "3.2.1-ha.3",
@@ -52,6 +53,16 @@
         "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-yaml": {
@@ -668,6 +679,17 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
       "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.5.tgz",
+      "integrity": "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\""
   },
   "dependencies": {
+    "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@home-assistant/webawesome": "3.2.1-ha.3",

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,5 +1,4 @@
 import { consume } from "@lit/context";
-import { yaml } from "@codemirror/lang-yaml";
 import { StateEffect, StateField } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { Decoration, type DecorationSet } from "@codemirror/view";
@@ -8,6 +7,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { basicSetup, EditorView } from "codemirror";
 import { EditorState } from "@codemirror/state";
 import { darkModeContext } from "../context/index.js";
+import { esphomeYaml } from "../util/esphome-yaml-lang.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 
 export type HighlightRange = Pick<YamlSection, "fromLine" | "toLine">;
@@ -79,7 +79,7 @@ export class ESPHomeYamlEditor extends LitElement {
         doc: this.value,
         extensions: [
           basicSetup,
-          yaml(),
+          esphomeYaml(),
           highlightField,
           EditorView.theme({
             "&": { height: "100%" },

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -1,0 +1,87 @@
+/**
+ * ESPHome YAML language support with embedded C++ highlighting for lambdas.
+ *
+ * Wraps the standard YAML parser with parseMixed to detect `!lambda` tagged
+ * values and parse them as C++ using an overlay. Handles:
+ *
+ * - Inline:  `value: !lambda return x;`
+ * - Quoted:  `value: !lambda 'return x;'`
+ * - Block:   `value: !lambda |-\n  return x;`
+ */
+import { parser as yamlParser } from "@lezer/yaml";
+import { cppLanguage } from "@codemirror/lang-cpp";
+import { LRLanguage, LanguageSupport } from "@codemirror/language";
+import { parseMixed } from "@lezer/common";
+import type { SyntaxNodeRef, Input } from "@lezer/common";
+
+const LAMBDA_TAG = "!lambda";
+
+/**
+ * Mixed parser wrapper: when we encounter a Tagged node whose Tag is
+ * `!lambda`, overlay the C++ parser on the value content.
+ */
+function nestLambdas(node: SyntaxNodeRef, input: Input) {
+  // Only interested in Tagged nodes (e.g. `!lambda <value>`)
+  if (node.name !== "Tagged") return null;
+
+  // Verify the Tag child is `!lambda`
+  const tagNode = node.node.getChild("Tag");
+  if (!tagNode) return null;
+  const tagText = input.read(tagNode.from, tagNode.to);
+  if (tagText !== LAMBDA_TAG) return null;
+
+  // Find the value node — could be Literal, QuotedLiteral, or BlockLiteral
+  const literal = node.node.getChild("Literal");
+  const quoted = node.node.getChild("QuotedLiteral");
+  const block = node.node.getChild("BlockLiteral");
+
+  if (literal) {
+    // Inline: `!lambda return x;` → overlay the Literal
+    return {
+      parser: cppLanguage.parser,
+      overlay: [{ from: literal.from, to: literal.to }],
+    };
+  }
+
+  if (quoted) {
+    // Quoted: `!lambda 'return x;'` → overlay content inside quotes
+    return {
+      parser: cppLanguage.parser,
+      overlay: [{ from: quoted.from + 1, to: quoted.to - 1 }],
+    };
+  }
+
+  if (block) {
+    // Block: `!lambda |-\n  code` → overlay the BlockLiteralContent
+    const content = block.getChild("BlockLiteralContent");
+    if (content) {
+      return {
+        parser: cppLanguage.parser,
+        overlay: [{ from: content.from, to: content.to }],
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * ESPHome YAML language with embedded C++ lambda support.
+ */
+export const esphomeYamlLanguage = LRLanguage.define({
+  name: "esphome-yaml",
+  parser: yamlParser.configure({
+    wrap: parseMixed(nestLambdas),
+  }),
+  languageData: {
+    commentTokens: { line: "#" },
+    indentOnInput: /^\s*[\]}]$/,
+  },
+});
+
+/**
+ * Language support bundle for ESPHome YAML.
+ */
+export function esphomeYaml(): LanguageSupport {
+  return new LanguageSupport(esphomeYamlLanguage);
+}


### PR DESCRIPTION
## Summary
- Adds `@codemirror/lang-cpp` dependency
- Creates `esphome-yaml-lang.ts` that wraps the YAML Lezer parser with `parseMixed` to detect `!lambda` tagged nodes and overlay the C++ parser
- Handles all three lambda forms: inline (`!lambda return x;`), quoted (`!lambda 'return x;'`), and block (`!lambda |-`)
- Ports the lambda detection logic from the `esphome/dashboard` Monaco Monarch tokenizer to CodeMirror 6's Lezer-based mixed-language system

## Test plan
- [ ] Open a device config containing `!lambda` inline values and verify C++ highlighting
- [ ] Test block-style lambdas (`!lambda |-`) with multi-line C++ code
- [ ] Test quoted lambdas (`!lambda 'return x;'`)
- [ ] Verify regular YAML highlighting is unaffected for non-lambda values
- [ ] Verify dark mode highlighting works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)