### PR TITLE
Add firmware tasks panel for pending/running jobs

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -444,6 +444,36 @@ export class ESPHomeAPI {
     return this.sendStreamCommand("firmware/follow_job", { job_id: jobId }, callbacks);
   }
 
+  /**
+   * Subscribe to lifecycle, output, and progress events for every job.
+   *
+   * Stays open for the connection's lifetime — there's no per-subscription
+   * cancel on the backend. Events delivered to `callback`:
+   *  - `snapshot` (FirmwareJob) — replayed on subscribe for each
+   *    non-terminal job, when `snapshot` arg is `true` (default).
+   *  - `job_queued` / `job_started` / `job_completed` / `job_failed`
+   *    / `job_cancelled` — payload is the full FirmwareJob.
+   *  - `job_output` — `{ job_id, line }`.
+   *  - `job_progress` — `{ job_id, progress }`.
+   */
+  firmwareFollowJobs(
+    callback: EventSubscriptionCallback,
+    snapshot = true
+  ): string {
+    if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket not connected");
+    }
+    const messageId = this._nextMessageId();
+    this._eventSubscriptions.set(messageId, callback);
+    const msg: CommandMessage = {
+      command: "firmware/follow_jobs",
+      message_id: messageId,
+      args: { snapshot },
+    };
+    this._ws.send(JSON.stringify(msg));
+    return messageId;
+  }
+
   // ─── Firmware Commands (job queue) ────────────────────────
 
   /** Queue a compile job. */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -527,6 +527,10 @@ export interface FirmwareJob {
   output: string[];
   error: string | null;
   port: string;
+  /** 0–100 progress, monotonically non-decreasing while the job runs.
+   *  `null` until the underlying tooling (PlatformIO/esptool) emits a
+   *  percentage we can latch onto. */
+  progress: number | null;
 }
 
 export interface FirmwareBinary {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -13,7 +13,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { ESPHomeAPI } from "../api/index.js";
-import { DeviceEventType, DeviceState, JobStatus, Theme } from "../api/types.js";
+import { DeviceEventType, DeviceState, Theme } from "../api/types.js";
 import type {
   AdoptableDevice,
   ConfiguredDevice,
@@ -22,7 +22,6 @@ import type {
   FirmwareJob,
   ImportableDeviceEventData,
   InitialStateEventData,
-  JobEventData,
   ServerInfoMessage,
 } from "../api/types.js";
 import {
@@ -39,6 +38,7 @@ import {
   devicesContext,
   devicesLoadedContext,
   activeJobsContext,
+  firmwareJobsContext,
   importableDevicesContext,
   isHaIngressContext,
   localizeContext,
@@ -51,6 +51,8 @@ import { espHomeStyles } from "../styles/shared.js";
 import "../pages/dashboard.js";
 import "./command-palette.js";
 import "./esphome-layout.js";
+import "./firmware-jobs-dialog.js";
+import type { ESPHomeFirmwareJobsDialog } from "./firmware-jobs-dialog.js";
 import "./settings-dialog.js";
 import type { ESPHomeSettingsDialog } from "./settings-dialog.js";
 
@@ -88,6 +90,10 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: activeJobsContext })
   @state()
   private _activeJobs: Map<string, FirmwareJob> = new Map();
+
+  @provide({ context: firmwareJobsContext })
+  @state()
+  private _firmwareJobs: Map<string, FirmwareJob> = new Map();
 
   @provide({ context: localizeContext })
   @state()
@@ -214,6 +220,7 @@ export class ESPHomeApp extends LitElement {
       this._version = info.esphome_version;
       this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
       this._subscribeToEvents();
+      this._subscribeToFollowJobs();
     };
 
     this._api.onDisconnected = () => {
@@ -234,22 +241,6 @@ export class ESPHomeApp extends LitElement {
 
   // ─── Event Subscription ──────────────────────────────────
 
-  private async _loadActiveJobs() {
-    try {
-      const [queued, running] = await Promise.all([
-        this._api.firmwareGetJobs({ status: JobStatus.QUEUED }),
-        this._api.firmwareGetJobs({ status: JobStatus.RUNNING }),
-      ]);
-      const map = new Map<string, FirmwareJob>();
-      for (const job of [...queued, ...running]) {
-        map.set(job.configuration, job);
-      }
-      this._activeJobs = map;
-    } catch {
-      // Not critical
-    }
-  }
-
   private async _subscribeToEvents() {
     try {
       await this._api.subscribeEvents((event, data) =>
@@ -260,13 +251,87 @@ export class ESPHomeApp extends LitElement {
     }
   }
 
+  /**
+   * Subscribe to `firmware/follow_jobs` for the canonical view of every
+   * job. Replaces an earlier flow that combined `firmware/get_jobs` with
+   * partial events from `subscribe_events` — that path missed
+   * `job_progress` and `job_cancelled`. We reset both job maps on
+   * (re)connect so the snapshot is the source of truth.
+   */
+  private _subscribeToFollowJobs() {
+    this._activeJobs = new Map();
+    this._firmwareJobs = new Map();
+    try {
+      this._api.firmwareFollowJobs((event, data) =>
+        this._handleJobEvent(event, data)
+      );
+    } catch (err) {
+      console.error("Failed to follow firmware jobs:", err);
+    }
+  }
+
+  private _handleJobEvent(event: string, data: unknown): void {
+    switch (event) {
+      case "snapshot":
+      case "job_queued":
+      case "job_started": {
+        this._upsertJob(data as FirmwareJob);
+        break;
+      }
+      case "job_completed":
+      case "job_failed":
+      case "job_cancelled": {
+        this._removeJob(data as FirmwareJob);
+        break;
+      }
+      case "job_progress": {
+        const { job_id, progress } = data as { job_id: string; progress: number };
+        const existing = this._firmwareJobs.get(job_id);
+        if (!existing) return;
+        const updated = { ...existing, progress };
+        const next = new Map(this._firmwareJobs);
+        next.set(job_id, updated);
+        this._firmwareJobs = next;
+        if (this._activeJobs.get(updated.configuration)?.job_id === job_id) {
+          const active = new Map(this._activeJobs);
+          active.set(updated.configuration, updated);
+          this._activeJobs = active;
+        }
+        break;
+      }
+      // job_output is handled per-job via firmware/follow_job in the
+      // command-dialog — no app-level use for the line stream.
+    }
+  }
+
+  private _upsertJob(job: FirmwareJob): void {
+    const next = new Map(this._firmwareJobs);
+    next.set(job.job_id, job);
+    this._firmwareJobs = next;
+    const active = new Map(this._activeJobs);
+    active.set(job.configuration, job);
+    this._activeJobs = active;
+  }
+
+  private _removeJob(job: FirmwareJob): void {
+    const next = new Map(this._firmwareJobs);
+    next.delete(job.job_id);
+    this._firmwareJobs = next;
+    // Only clear the per-device active slot if it points at *this* job —
+    // a freshly-queued follow-up for the same device must stay visible.
+    if (this._activeJobs.get(job.configuration)?.job_id === job.job_id) {
+      const active = new Map(this._activeJobs);
+      active.delete(job.configuration);
+      this._activeJobs = active;
+    }
+  }
+
   private _handleEvent(event: string, data: unknown): void {
     switch (event) {
       case DeviceEventType.INITIAL_STATE: {
         const { devices } = data as InitialStateEventData;
         this._devices = devices;
         this._devicesLoaded = true;
-        this._loadActiveJobs();
         break;
       }
       case DeviceEventType.DEVICE_ADDED: {
@@ -315,22 +380,6 @@ export class ESPHomeApp extends LitElement {
         );
         break;
       }
-      case DeviceEventType.JOB_QUEUED:
-      case DeviceEventType.JOB_STARTED: {
-        const { job } = data as JobEventData;
-        const next = new Map(this._activeJobs);
-        next.set(job.configuration, job);
-        this._activeJobs = next;
-        break;
-      }
-      case DeviceEventType.JOB_COMPLETED:
-      case DeviceEventType.JOB_FAILED: {
-        const { job } = data as JobEventData;
-        const next = new Map(this._activeJobs);
-        next.delete(job.configuration);
-        this._activeJobs = next;
-        break;
-      }
     }
   }
 
@@ -339,6 +388,9 @@ export class ESPHomeApp extends LitElement {
   @query("esphome-settings-dialog")
   private _settingsDialog!: ESPHomeSettingsDialog;
 
+  @query("esphome-firmware-jobs-dialog")
+  private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
+
   protected render() {
     return html`
       <esphome-layout
@@ -346,6 +398,7 @@ export class ESPHomeApp extends LitElement {
         @set-yaml-diff-button=${this._onSetYamlDiffButton}
         @set-language=${this._onSetLanguage}
         @open-settings=${this._onOpenSettings}
+        @open-firmware-jobs=${this._onOpenFirmwareJobs}
       >
         ${this._router.outlet()}
       </esphome-layout>
@@ -359,6 +412,7 @@ export class ESPHomeApp extends LitElement {
         @set-yaml-diff-button=${this._onSetYamlDiffButton}
         @set-language=${this._onSetLanguage}
       ></esphome-settings-dialog>
+      <esphome-firmware-jobs-dialog></esphome-firmware-jobs-dialog>
     `;
   }
 
@@ -395,6 +449,10 @@ export class ESPHomeApp extends LitElement {
 
   private _onOpenSettings() {
     this._settingsDialog?.open();
+  }
+
+  private _onOpenFirmwareJobs() {
+    this._firmwareJobsDialog?.open();
   }
 }
 

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -3,12 +3,14 @@ import {
   mdiCog,
   mdiDotsVertical,
   mdiKeyVariant,
+  mdiPlaylistCheck,
   mdiUpdate,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { localizeContext } from "../context/index.js";
+import { firmwareJobsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -19,6 +21,7 @@ registerMdiIcons({
   cog: mdiCog,
   "dots-vertical": mdiDotsVertical,
   "key-variant": mdiKeyVariant,
+  "playlist-check": mdiPlaylistCheck,
   update: mdiUpdate,
 });
 
@@ -27,6 +30,10 @@ export class ESPHomeHeaderActions extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: firmwareJobsContext, subscribe: true })
+  @state()
+  private _jobs: Map<string, FirmwareJob> = new Map();
 
   @state()
   private _path = window.location.pathname;
@@ -56,6 +63,7 @@ export class ESPHomeHeaderActions extends LitElement {
       }
 
       .menu-btn {
+        position: relative;
         display: inline-flex;
         align-items: center;
         border: none;
@@ -77,6 +85,17 @@ export class ESPHomeHeaderActions extends LitElement {
         font-size: 20px;
       }
 
+      .menu-btn-badge {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--esphome-warning, #f59e0b);
+        box-shadow: 0 0 0 2px var(--esphome-primary);
+      }
+
       .backdrop {
         position: fixed;
         inset: 0;
@@ -86,7 +105,7 @@ export class ESPHomeHeaderActions extends LitElement {
       .menu {
         position: fixed;
         z-index: 101;
-        min-width: 190px;
+        min-width: 220px;
         background: var(--wa-color-surface-raised);
         border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         border-radius: var(--wa-border-radius-l);
@@ -138,6 +157,18 @@ export class ESPHomeHeaderActions extends LitElement {
         color: var(--esphome-primary);
       }
 
+      .menu-item-count {
+        margin-left: auto;
+        font-size: var(--wa-font-size-2xs);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--esphome-on-primary);
+        background: var(--esphome-primary);
+        border-radius: 999px;
+        padding: 1px 8px;
+        min-width: 18px;
+        text-align: center;
+      }
+
       .menu-divider {
         height: 1px;
         background: var(--wa-color-surface-border);
@@ -156,9 +187,13 @@ export class ESPHomeHeaderActions extends LitElement {
   ];
 
   protected render() {
+    const jobCount = this._jobs.size;
     return html`
       <button class="menu-btn" @click=${this._toggle}>
         <wa-icon library="mdi" name="dots-vertical"></wa-icon>
+        ${jobCount > 0
+          ? html`<span class="menu-btn-badge" aria-label=${this._localize("firmware_jobs.badge_label", { count: jobCount })}></span>`
+          : nothing}
       </button>
       ${this._open
         ? html`
@@ -172,6 +207,13 @@ export class ESPHomeHeaderActions extends LitElement {
                     </div>
                   `
                 : nothing}
+              <div class="menu-item" @click=${this._openFirmwareJobs}>
+                <wa-icon library="mdi" name="playlist-check"></wa-icon>
+                <span class="menu-item-label">${this._localize("firmware_jobs.menu_item")}</span>
+                ${jobCount > 0
+                  ? html`<span class="menu-item-count">${jobCount}</span>`
+                  : nothing}
+              </div>
               <div class="menu-item" @click=${this._openSecrets}>
                 <wa-icon library="mdi" name="key-variant"></wa-icon>
                 ${this._localize("layout.secrets")}
@@ -203,6 +245,16 @@ export class ESPHomeHeaderActions extends LitElement {
   private _openUpdateAll() {
     this._close();
     window.dispatchEvent(new CustomEvent("esphome-enter-select-mode"));
+  }
+
+  private _openFirmwareJobs() {
+    this._close();
+    this.dispatchEvent(
+      new CustomEvent("open-firmware-jobs", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private _openSettings() {

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -1,0 +1,353 @@
+import { consume } from "@lit/context";
+import {
+  mdiBroom,
+  mdiClockOutline,
+  mdiClose,
+  mdiHammerWrench,
+  mdiPlaylistRemove,
+  mdiUpload,
+} from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, query, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../api/index.js";
+import { JobStatus, JobType } from "../api/types.js";
+import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import {
+  apiContext,
+  devicesContext,
+  firmwareJobsContext,
+  localizeContext,
+} from "../context/index.js";
+import { espHomeStyles } from "../styles/shared.js";
+import { registerMdiIcons } from "../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+
+registerMdiIcons({
+  broom: mdiBroom,
+  "clock-outline": mdiClockOutline,
+  close: mdiClose,
+  "hammer-wrench": mdiHammerWrench,
+  "playlist-remove": mdiPlaylistRemove,
+  upload: mdiUpload,
+});
+
+const TYPE_ICONS: Record<JobType, string> = {
+  [JobType.COMPILE]: "hammer-wrench",
+  [JobType.UPLOAD]: "upload",
+  [JobType.INSTALL]: "upload",
+  [JobType.CLEAN]: "broom",
+};
+
+@customElement("esphome-firmware-jobs-dialog")
+export class ESPHomeFirmwareJobsDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  private _api!: ESPHomeAPI;
+
+  @consume({ context: firmwareJobsContext, subscribe: true })
+  @state()
+  private _jobs: Map<string, FirmwareJob> = new Map();
+
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  private _devices: ConfiguredDevice[] = [];
+
+  @query("wa-dialog")
+  private _dialog!: HTMLElement & { open: boolean };
+
+  open() {
+    this._dialog.open = true;
+  }
+
+  close() {
+    this._dialog.open = false;
+  }
+
+  static styles = [
+    espHomeStyles,
+    css`
+      wa-dialog {
+        --width: min(560px, 95vw);
+      }
+
+      wa-dialog::part(header) {
+        background: var(--esphome-primary);
+        padding: 0 var(--wa-space-m);
+        height: 40px;
+        box-sizing: border-box;
+      }
+
+      wa-dialog::part(title) {
+        color: var(--esphome-on-primary);
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-bold);
+      }
+
+      wa-dialog::part(close-button__base) {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        min-width: unset;
+        min-height: unset;
+        color: var(--esphome-on-primary);
+        cursor: pointer;
+      }
+
+      wa-dialog::part(footer) {
+        display: none;
+      }
+
+      wa-dialog::part(body) {
+        padding: var(--wa-space-s);
+      }
+
+      .empty {
+        padding: var(--wa-space-2xl) var(--wa-space-m);
+        text-align: center;
+        color: var(--wa-color-text-quiet);
+      }
+
+      .empty wa-icon {
+        display: block;
+        margin: 0 auto var(--wa-space-s);
+        font-size: 48px;
+        opacity: 0.4;
+      }
+
+      .empty-title {
+        font-size: var(--wa-font-size-m);
+        color: var(--wa-color-text-normal);
+        margin-bottom: var(--wa-space-2xs);
+      }
+
+      .empty-desc {
+        font-size: var(--wa-font-size-s);
+      }
+
+      .jobs {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+      }
+
+      .job {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: var(--wa-space-s);
+        padding: var(--wa-space-s) var(--wa-space-m);
+        border-radius: var(--wa-border-radius-m);
+        transition: background 0.1s;
+      }
+
+      .job:hover {
+        background: var(--wa-color-surface-lowered);
+      }
+
+      .job-icon {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+        color: var(--esphome-primary);
+      }
+
+      .job-icon wa-icon {
+        font-size: 18px;
+      }
+
+      .job-content {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .job-name {
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .job-meta {
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-quiet);
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+      }
+
+      .job-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .job-status wa-spinner {
+        font-size: 12px;
+        --indicator-color: var(--esphome-primary);
+        --track-color: transparent;
+      }
+
+      .job-status wa-icon {
+        font-size: 13px;
+      }
+
+      .progress {
+        margin-top: 4px;
+        width: 100%;
+        height: 4px;
+        border-radius: 2px;
+        background: var(--wa-color-surface-lowered);
+        overflow: hidden;
+      }
+
+      .progress-fill {
+        height: 100%;
+        background: var(--esphome-primary);
+        transition: width 0.2s;
+      }
+
+      .cancel-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 30px;
+        height: 30px;
+        border-radius: var(--wa-border-radius-m);
+        border: none;
+        background: transparent;
+        color: var(--wa-color-text-quiet);
+        cursor: pointer;
+        transition:
+          background 0.1s,
+          color 0.1s;
+      }
+
+      .cancel-btn:hover {
+        background: color-mix(in srgb, var(--esphome-error), transparent 90%);
+        color: var(--esphome-error);
+      }
+
+      .cancel-btn wa-icon {
+        font-size: 18px;
+      }
+    `,
+  ];
+
+  protected render() {
+    const jobs = [...this._jobs.values()].sort((a, b) =>
+      a.created_at.localeCompare(b.created_at),
+    );
+    return html`
+      <wa-dialog light-dismiss label=${this._localize("firmware_jobs.title")}>
+        ${jobs.length === 0 ? this._renderEmpty() : this._renderJobs(jobs)}
+      </wa-dialog>
+    `;
+  }
+
+  private _renderEmpty() {
+    return html`
+      <div class="empty">
+        <wa-icon library="mdi" name="playlist-remove"></wa-icon>
+        <div class="empty-title">${this._localize("firmware_jobs.empty_title")}</div>
+        <div class="empty-desc">${this._localize("firmware_jobs.empty_desc")}</div>
+      </div>
+    `;
+  }
+
+  private _renderJobs(jobs: FirmwareJob[]) {
+    return html`<div class="jobs">${jobs.map((j) => this._renderJob(j))}</div>`;
+  }
+
+  private _renderJob(job: FirmwareJob) {
+    const device = this._devices.find((d) => d.configuration === job.configuration);
+    const name = device?.friendly_name || device?.name || job.configuration;
+    const typeIcon = TYPE_ICONS[job.job_type] ?? "hammer-wrench";
+    const typeLabel = this._localize(`firmware_jobs.type_${job.job_type}`);
+    const showProgress =
+      job.status === JobStatus.RUNNING && typeof job.progress === "number";
+
+    return html`
+      <div class="job">
+        <div class="job-icon">
+          <wa-icon library="mdi" name=${typeIcon}></wa-icon>
+        </div>
+        <div class="job-content">
+          <div class="job-name">${name}</div>
+          <div class="job-meta">
+            <span>${typeLabel}</span>
+            <span>•</span>
+            ${this._renderStatus(job)}
+          </div>
+          ${showProgress
+            ? html`
+                <div class="progress">
+                  <div class="progress-fill" style="width:${job.progress}%"></div>
+                </div>
+              `
+            : nothing}
+        </div>
+        <button
+          class="cancel-btn"
+          title=${this._localize("firmware_jobs.cancel")}
+          aria-label=${this._localize("firmware_jobs.cancel")}
+          @click=${() => this._cancel(job)}
+        >
+          <wa-icon library="mdi" name="close"></wa-icon>
+        </button>
+      </div>
+    `;
+  }
+
+  private _renderStatus(job: FirmwareJob) {
+    if (job.status === JobStatus.RUNNING) {
+      return html`
+        <span class="job-status">
+          <wa-spinner></wa-spinner>
+          ${typeof job.progress === "number"
+            ? `${job.progress}%`
+            : this._localize("firmware_jobs.status_running")}
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.QUEUED) {
+      return html`
+        <span class="job-status">
+          <wa-icon library="mdi" name="clock-outline"></wa-icon>
+          ${this._localize("firmware_jobs.status_queued")}
+        </span>
+      `;
+    }
+    return nothing;
+  }
+
+  private async _cancel(job: FirmwareJob) {
+    try {
+      await this._api.firmwareCancel(job.job_id);
+    } catch {
+      /* The job may have already finished — follow_jobs will reconcile. */
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-firmware-jobs-dialog": ESPHomeFirmwareJobsDialog;
+  }
+}

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -43,9 +43,20 @@ export const isHaIngressContext = createContext<boolean>(
   Symbol("esphome-is-ha-ingress")
 );
 
-/** Context for active firmware jobs, keyed by device configuration. */
+/** Context for active firmware jobs, keyed by device configuration.
+ *  Tracks the latest non-terminal job per device (used for the busy
+ *  spinner on cards/tables). For the full multi-job view, see
+ *  `firmwareJobsContext`. */
 export const activeJobsContext = createContext<Map<string, FirmwareJob>>(
   Symbol("esphome-active-jobs")
+);
+
+/** Context for every non-terminal firmware job, keyed by `job_id`.
+ *  Powers the firmware-tasks dialog — a device can have several jobs
+ *  in flight (e.g. compile + clean queued back-to-back), so we key by
+ *  job_id to keep them all distinct. */
+export const firmwareJobsContext = createContext<Map<string, FirmwareJob>>(
+  Symbol("esphome-firmware-jobs")
 );
 
 /** Context for whether the YAML diff button is enabled in the editor. */

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -8,5 +8,6 @@ export {
   devicesLoadedContext,
   isHaIngressContext,
   activeJobsContext,
+  firmwareJobsContext,
   yamlDiffButtonContext,
 } from "./contexts.js";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -487,5 +487,19 @@
     "saved": "Secrets saved",
     "save_error": "Failed to save secrets",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n"
+  },
+  "firmware_jobs": {
+    "menu_item": "Firmware tasks",
+    "title": "Firmware tasks",
+    "badge_label": "{count} active firmware task(s)",
+    "empty_title": "No firmware tasks running",
+    "empty_desc": "Compile, install, or clean jobs you start will show up here.",
+    "status_queued": "Queued",
+    "status_running": "Running…",
+    "cancel": "Cancel",
+    "type_compile": "Compile",
+    "type_upload": "Upload",
+    "type_install": "Install",
+    "type_clean": "Clean"
   }
 }


### PR DESCRIPTION
## Problem

There's no way to see what compile/install/clean jobs are queued or running across the dashboard. Once you start a job and close the command dialog, the only signal is a per-card spinner — no progress, no list, no way to cancel without opening that one device.

## Changes

- New **Firmware tasks** entry in the top-right `…` menu, with a dot badge on the menu button and a count chip on the menu item when jobs are active.
- New `firmware-jobs-dialog` that lists every queued/running job with its type, live progress bar, status, and a one-click cancel.
- Switched the active-jobs state from the partial `subscribe_events` flow to `firmware/follow_jobs`, so we now also receive `job_progress` and `job_cancelled` events. As a side effect, the per-card busy spinner now also clears correctly after a cancel.
- Added the `progress` field (already emitted by the backend) to the `FirmwareJob` type and a `firmwareFollowJobs` API helper.