### PR TITLE
Make firmware-tasks panel a real task viewer

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -496,6 +496,11 @@ export class ESPHomeAPI {
     return this.sendCommand<FirmwareJob>("firmware/clean", { configuration });
   }
 
+  /** Queue a reset-build-environment job (wipes the toolchain cache). */
+  async firmwareResetBuildEnv(): Promise<FirmwareJob> {
+    return this.sendCommand<FirmwareJob>("firmware/reset_build_env");
+  }
+
   /** Queue compile for multiple devices. */
   async firmwareCompileBulk(configurations: string[]): Promise<FirmwareJob[]> {
     return this.sendCommand<FirmwareJob[]>("firmware/compile_bulk", { configurations });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -516,6 +516,7 @@ export enum JobType {
   UPLOAD = "upload",
   INSTALL = "install",
   CLEAN = "clean",
+  RESET_BUILD_ENV = "reset_build_env",
 }
 
 export interface FirmwareJob {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -13,7 +13,13 @@ import { css, html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { ESPHomeAPI } from "../api/index.js";
-import { DeviceEventType, DeviceState, Theme } from "../api/types.js";
+import {
+  DeviceEventType,
+  DeviceState,
+  JobStatus,
+  JobType,
+  Theme,
+} from "../api/types.js";
 import type {
   AdoptableDevice,
   ConfiguredDevice,
@@ -46,6 +52,20 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+
+// Mirrors the backend's `_PRIMARY_JOB_TYPES` retention pool — these
+// are the job types deduplicated to one terminal entry per device.
+const PRIMARY_JOB_TYPES: ReadonlySet<JobType> = new Set([
+  JobType.COMPILE,
+  JobType.UPLOAD,
+  JobType.INSTALL,
+]);
+
+const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
+  JobStatus.COMPLETED,
+  JobStatus.FAILED,
+  JobStatus.CANCELLED,
+]);
 
 // Import child components
 import "../pages/dashboard.js";
@@ -281,7 +301,7 @@ export class ESPHomeApp extends LitElement {
       case "job_completed":
       case "job_failed":
       case "job_cancelled": {
-        this._removeJob(data as FirmwareJob);
+        this._terminateJob(data as FirmwareJob);
         break;
       }
       case "job_progress": {
@@ -313,9 +333,44 @@ export class ESPHomeApp extends LitElement {
     this._activeJobs = active;
   }
 
-  private _removeJob(job: FirmwareJob): void {
+  /** Job reached a terminal state — keep it in `_firmwareJobs` for
+   *  the manage-tasks panel's retained history, drop any older
+   *  terminal entry for the same device so a re-compile replaces
+   *  rather than stacks, then clear the per-device "active" slot.
+   *  Cancellations that already have a live successor for the same
+   *  device are treated as a backend supersede and dropped silently
+   *  (no "Recent" entry) — the backend fires JOB_QUEUED for the new
+   *  job before cancelling the old one specifically so we can spot
+   *  this case here. */
+  private _terminateJob(job: FirmwareJob): void {
+    if (job.status === JobStatus.CANCELLED && job.configuration) {
+      const supersededByActive = [...this._firmwareJobs.values()].some(
+        (j) =>
+          j.job_id !== job.job_id &&
+          j.configuration === job.configuration &&
+          !TERMINAL_STATUSES.has(j.status),
+      );
+      if (supersededByActive) {
+        const next = new Map(this._firmwareJobs);
+        next.delete(job.job_id);
+        this._firmwareJobs = next;
+        return;
+      }
+    }
     const next = new Map(this._firmwareJobs);
-    next.delete(job.job_id);
+    next.set(job.job_id, job);
+    if (PRIMARY_JOB_TYPES.has(job.job_type) && job.configuration) {
+      for (const [id, existing] of next) {
+        if (id === job.job_id) continue;
+        if (
+          PRIMARY_JOB_TYPES.has(existing.job_type) &&
+          existing.configuration === job.configuration &&
+          TERMINAL_STATUSES.has(existing.status)
+        ) {
+          next.delete(id);
+        }
+      }
+    }
     this._firmwareJobs = next;
     // Only clear the per-device active slot if it points at *this* job —
     // a freshly-queued follow-up for the same device must stay visible.
@@ -412,7 +467,9 @@ export class ESPHomeApp extends LitElement {
         @set-yaml-diff-button=${this._onSetYamlDiffButton}
         @set-language=${this._onSetLanguage}
       ></esphome-settings-dialog>
-      <esphome-firmware-jobs-dialog></esphome-firmware-jobs-dialog>
+      <esphome-firmware-jobs-dialog
+        @firmware-history-cleared=${this._onFirmwareHistoryCleared}
+      ></esphome-firmware-jobs-dialog>
     `;
   }
 
@@ -453,6 +510,18 @@ export class ESPHomeApp extends LitElement {
 
   private _onOpenFirmwareJobs() {
     this._firmwareJobsDialog?.open();
+  }
+
+  /** Prune retained terminal jobs locally after the user clears
+   *  history — `firmware/clear` doesn't broadcast an event. */
+  private _onFirmwareHistoryCleared() {
+    const next = new Map<string, FirmwareJob>();
+    for (const [id, job] of this._firmwareJobs) {
+      if (!TERMINAL_STATUSES.has(job.status)) {
+        next.set(id, job);
+      }
+    }
+    this._firmwareJobs = next;
   }
 }
 

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -9,8 +9,8 @@ import {
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { JobStatus } from "../api/types.js";
-import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
+import { JobStatus, JobType } from "../api/types.js";
+import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -28,8 +28,16 @@ registerMdiIcons({
   "alert-circle": mdiAlertCircle,
 });
 
-export type CommandType = "install" | "compile" | "validate" | "clean";
+export type CommandType = "install" | "compile" | "validate" | "clean" | "reset";
 type CommandState = "running" | "success" | "error";
+
+const JOB_TYPE_TO_COMMAND: Record<string, CommandType> = {
+  [JobType.COMPILE]: "compile",
+  [JobType.INSTALL]: "install",
+  [JobType.UPLOAD]: "install",
+  [JobType.CLEAN]: "clean",
+  [JobType.RESET_BUILD_ENV]: "reset",
+};
 
 @customElement("esphome-command-dialog")
 export class ESPHomeCommandDialog extends LitElement {
@@ -218,17 +226,17 @@ export class ESPHomeCommandDialog extends LitElement {
     this._start();
   }
 
-  /** Attach to an already-running job (from the device card "in progress" state). */
-  public followJob(device: ConfiguredDevice, job: FirmwareJob) {
-    this.configuration = device.configuration;
-    this.name = device.friendly_name || device.name;
-    const typeMap: Record<string, CommandType> = {
-      compile: "compile",
-      install: "install",
-      clean: "clean",
-      upload: "install",
-    };
-    this._commandType = typeMap[job.job_type] ?? "install";
+  /**
+   * Attach to a firmware job's output stream. Handles any state —
+   * terminal jobs replay buffered output and resolve to the final
+   * success/error banner. `displayName` shows in the title; pass the
+   * device's friendly name, or a synthetic label for jobs with an
+   * empty `configuration` (e.g. `reset_build_env`).
+   */
+  public followJob(job: FirmwareJob, displayName: string) {
+    this.configuration = job.configuration;
+    this.name = displayName;
+    this._commandType = JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
     this._port = job.port || "OTA";
     this._state = "running";
     this._lines = [];

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -8,6 +8,7 @@ import {
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { JobStatus } from "../api/types.js";
 import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { firmwareJobsContext, localizeContext } from "../context/index.js";
@@ -187,12 +188,17 @@ export class ESPHomeHeaderActions extends LitElement {
   ];
 
   protected render() {
-    const jobCount = this._jobs.size;
+    let activeCount = 0;
+    for (const job of this._jobs.values()) {
+      if (job.status === JobStatus.QUEUED || job.status === JobStatus.RUNNING) {
+        activeCount++;
+      }
+    }
     return html`
       <button class="menu-btn" @click=${this._toggle}>
         <wa-icon library="mdi" name="dots-vertical"></wa-icon>
-        ${jobCount > 0
-          ? html`<span class="menu-btn-badge" aria-label=${this._localize("firmware_jobs.badge_label", { count: jobCount })}></span>`
+        ${activeCount > 0
+          ? html`<span class="menu-btn-badge" aria-label=${this._localize("firmware_jobs.badge_label", { count: activeCount })}></span>`
           : nothing}
       </button>
       ${this._open
@@ -210,8 +216,8 @@ export class ESPHomeHeaderActions extends LitElement {
               <div class="menu-item" @click=${this._openFirmwareJobs}>
                 <wa-icon library="mdi" name="playlist-check"></wa-icon>
                 <span class="menu-item-label">${this._localize("firmware_jobs.menu_item")}</span>
-                ${jobCount > 0
-                  ? html`<span class="menu-item-count">${jobCount}</span>`
+                ${activeCount > 0
+                  ? html`<span class="menu-item-count">${activeCount}</span>`
                   : nothing}
               </div>
               <div class="menu-item" @click=${this._openSecrets}>

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -1,8 +1,13 @@
 import { consume } from "@lit/context";
 import {
   mdiBroom,
+  mdiCancel,
+  mdiCheckCircle,
   mdiClockOutline,
   mdiClose,
+  mdiCloseCircle,
+  mdiCogRefresh,
+  mdiDeleteSweep,
   mdiHammerWrench,
   mdiPlaylistRemove,
   mdiUpload,
@@ -12,6 +17,7 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { JobStatus, JobType } from "../api/types.js";
 import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
+import { activeLocale } from "../common/localize.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
@@ -20,16 +26,28 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+} from "../util/format-job-time.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import "./command-dialog.js";
+import type { ESPHomeCommandDialog } from "./command-dialog.js";
+import "./confirm-dialog.js";
+import type { ESPHomeConfirmDialog } from "./confirm-dialog.js";
 
 registerMdiIcons({
   broom: mdiBroom,
+  cancel: mdiCancel,
+  "check-circle": mdiCheckCircle,
   "clock-outline": mdiClockOutline,
   close: mdiClose,
+  "close-circle": mdiCloseCircle,
+  "cog-refresh": mdiCogRefresh,
+  "delete-sweep": mdiDeleteSweep,
   "hammer-wrench": mdiHammerWrench,
   "playlist-remove": mdiPlaylistRemove,
   upload: mdiUpload,
@@ -40,7 +58,18 @@ const TYPE_ICONS: Record<JobType, string> = {
   [JobType.UPLOAD]: "upload",
   [JobType.INSTALL]: "upload",
   [JobType.CLEAN]: "broom",
+  [JobType.RESET_BUILD_ENV]: "cog-refresh",
 };
+
+const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
+  JobStatus.COMPLETED,
+  JobStatus.FAILED,
+  JobStatus.CANCELLED,
+]);
+
+function isTerminal(job: FirmwareJob): boolean {
+  return TERMINAL_STATUSES.has(job.status);
+}
 
 @customElement("esphome-firmware-jobs-dialog")
 export class ESPHomeFirmwareJobsDialog extends LitElement {
@@ -62,19 +91,40 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
+  @query("esphome-command-dialog")
+  private _commandDialog!: ESPHomeCommandDialog;
+
+  @query("esphome-confirm-dialog")
+  private _confirmDialog!: ESPHomeConfirmDialog;
+
+  // Ticker for live relative-time strings ("started 2m ago"). Only
+  // runs while the dialog is open.
+  @state()
+  private _now: number = Date.now();
+
+  private _tickHandle: ReturnType<typeof setInterval> | null = null;
+
   open() {
+    this._now = Date.now();
     this._dialog.open = true;
+    this._startTicker();
   }
 
   close() {
     this._dialog.open = false;
+    this._stopTicker();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._stopTicker();
   }
 
   static styles = [
     espHomeStyles,
     css`
       wa-dialog {
-        --width: min(560px, 95vw);
+        --width: min(620px, 95vw);
       }
 
       wa-dialog::part(header) {
@@ -106,7 +156,56 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       }
 
       wa-dialog::part(body) {
-        padding: var(--wa-space-s);
+        padding: 0;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+        padding: var(--wa-space-s) var(--wa-space-m);
+        border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-default);
+      }
+
+      .toolbar .spacer {
+        flex: 1;
+      }
+
+      .tool-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: var(--wa-border-radius-m);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-default);
+        font-family: inherit;
+        font-size: var(--wa-font-size-xs);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+        cursor: pointer;
+        transition: background 0.1s, border-color 0.1s, color 0.1s;
+      }
+
+      .tool-btn:hover {
+        background: var(--wa-color-surface-lowered);
+        border-color: var(--wa-color-text-quiet);
+      }
+
+      .tool-btn wa-icon {
+        font-size: 16px;
+      }
+
+      .tool-btn--ghost {
+        background: transparent;
+        border-color: transparent;
+        color: var(--wa-color-text-quiet);
+      }
+
+      .tool-btn--ghost:hover {
+        background: var(--wa-color-surface-lowered);
+        color: var(--wa-color-text-normal);
       }
 
       .empty {
@@ -135,7 +234,19 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       .jobs {
         display: flex;
         flex-direction: column;
-        gap: var(--wa-space-2xs);
+        gap: 0;
+        padding: var(--wa-space-2xs);
+        max-height: 60vh;
+        overflow-y: auto;
+      }
+
+      .group-label {
+        padding: var(--wa-space-s) var(--wa-space-m) var(--wa-space-2xs);
+        font-size: var(--wa-font-size-2xs);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-quiet);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
       }
 
       .job {
@@ -145,11 +256,20 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         gap: var(--wa-space-s);
         padding: var(--wa-space-s) var(--wa-space-m);
         border-radius: var(--wa-border-radius-m);
+        cursor: pointer;
         transition: background 0.1s;
+        text-align: left;
+        background: transparent;
+        border: none;
+        font-family: inherit;
+        color: inherit;
+        width: 100%;
       }
 
-      .job:hover {
+      .job:hover,
+      .job:focus-visible {
         background: var(--wa-color-surface-lowered);
+        outline: none;
       }
 
       .job-icon {
@@ -162,6 +282,11 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         flex-shrink: 0;
         background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
         color: var(--esphome-primary);
+      }
+
+      .job-icon--terminal {
+        background: var(--wa-color-surface-lowered);
+        color: var(--wa-color-text-quiet);
       }
 
       .job-icon wa-icon {
@@ -208,6 +333,18 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         font-size: 13px;
       }
 
+      .job-time {
+        white-space: nowrap;
+      }
+
+      .job-status--success {
+        color: var(--esphome-success);
+      }
+
+      .job-status--error {
+        color: var(--esphome-error);
+      }
+
       .progress {
         margin-top: 4px;
         width: 100%;
@@ -223,7 +360,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         transition: width 0.2s;
       }
 
-      .cancel-btn {
+      .row-action {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -234,30 +371,87 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         background: transparent;
         color: var(--wa-color-text-quiet);
         cursor: pointer;
-        transition:
-          background 0.1s,
-          color 0.1s;
+        transition: background 0.1s, color 0.1s;
       }
 
-      .cancel-btn:hover {
+      .row-action:hover {
         background: color-mix(in srgb, var(--esphome-error), transparent 90%);
         color: var(--esphome-error);
       }
 
-      .cancel-btn wa-icon {
+      .row-action wa-icon {
         font-size: 18px;
+      }
+
+      .row-status-icon {
+        width: 30px;
+        height: 30px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+      }
+
+      .row-status-icon--success {
+        color: var(--esphome-success);
+      }
+
+      .row-status-icon--error {
+        color: var(--esphome-error);
+      }
+
+      .row-status-icon--cancelled {
+        color: var(--wa-color-text-quiet);
       }
     `,
   ];
 
   protected render() {
-    const jobs = [...this._jobs.values()].sort((a, b) =>
-      a.created_at.localeCompare(b.created_at),
-    );
+    const sorted = [...this._jobs.values()].sort(this._compareJobs);
+    const active = sorted.filter((j) => !isTerminal(j));
+    const terminal = sorted.filter((j) => isTerminal(j));
+    const hasJobs = sorted.length > 0;
+
     return html`
-      <wa-dialog light-dismiss label=${this._localize("firmware_jobs.title")}>
-        ${jobs.length === 0 ? this._renderEmpty() : this._renderJobs(jobs)}
+      <wa-dialog
+        light-dismiss
+        label=${this._localize("firmware_jobs.title")}
+        @wa-after-hide=${this._stopTicker}
+      >
+        <div class="toolbar">
+          <button
+            class="tool-btn"
+            title=${this._localize("firmware_jobs.reset_build_env")}
+            @click=${this._onResetClick}
+          >
+            <wa-icon library="mdi" name="cog-refresh"></wa-icon>
+            ${this._localize("firmware_jobs.reset_build_env")}
+          </button>
+          <span class="spacer"></span>
+          ${terminal.length > 0
+            ? html`
+                <button
+                  class="tool-btn tool-btn--ghost"
+                  title=${this._localize("firmware_jobs.clear_history")}
+                  @click=${this._onClearHistory}
+                >
+                  <wa-icon library="mdi" name="delete-sweep"></wa-icon>
+                  ${this._localize("firmware_jobs.clear_history")}
+                </button>
+              `
+            : nothing}
+        </div>
+        ${hasJobs
+          ? this._renderGroups(active, terminal)
+          : this._renderEmpty()}
       </wa-dialog>
+      <esphome-command-dialog></esphome-command-dialog>
+      <esphome-confirm-dialog
+        heading=${this._localize("firmware_jobs.reset_confirm_title")}
+        confirm-label=${this._localize("firmware_jobs.reset_confirm_button")}
+        message=${this._localize("firmware_jobs.reset_confirm_message")}
+        @confirm=${this._onResetConfirmed}
+      ></esphome-confirm-dialog>
     `;
   }
 
@@ -271,21 +465,43 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     `;
   }
 
-  private _renderJobs(jobs: FirmwareJob[]) {
-    return html`<div class="jobs">${jobs.map((j) => this._renderJob(j))}</div>`;
+  private _renderGroups(active: FirmwareJob[], terminal: FirmwareJob[]) {
+    return html`
+      <div class="jobs">
+        ${active.length > 0
+          ? html`
+              <div class="group-label">
+                ${this._localize("firmware_jobs.group_active")}
+              </div>
+              ${active.map((j) => this._renderJob(j))}
+            `
+          : nothing}
+        ${terminal.length > 0
+          ? html`
+              <div class="group-label">
+                ${this._localize("firmware_jobs.group_history")}
+              </div>
+              ${terminal.map((j) => this._renderJob(j))}
+            `
+          : nothing}
+      </div>
+    `;
   }
 
   private _renderJob(job: FirmwareJob) {
-    const device = this._devices.find((d) => d.configuration === job.configuration);
-    const name = device?.friendly_name || device?.name || job.configuration;
+    const name = this._jobDisplayName(job);
     const typeIcon = TYPE_ICONS[job.job_type] ?? "hammer-wrench";
     const typeLabel = this._localize(`firmware_jobs.type_${job.job_type}`);
     const showProgress =
       job.status === JobStatus.RUNNING && typeof job.progress === "number";
+    const terminal = isTerminal(job);
 
     return html`
-      <div class="job">
-        <div class="job-icon">
+      <button
+        class="job"
+        @click=${() => this._openJob(job)}
+      >
+        <div class="job-icon ${terminal ? "job-icon--terminal" : ""}">
           <wa-icon library="mdi" name=${typeIcon}></wa-icon>
         </div>
         <div class="job-content">
@@ -294,6 +510,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
             <span>${typeLabel}</span>
             <span>•</span>
             ${this._renderStatus(job)}
+            ${this._renderTimestamp(job)}
           </div>
           ${showProgress
             ? html`
@@ -303,15 +520,42 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
               `
             : nothing}
         </div>
-        <button
-          class="cancel-btn"
-          title=${this._localize("firmware_jobs.cancel")}
-          aria-label=${this._localize("firmware_jobs.cancel")}
-          @click=${() => this._cancel(job)}
-        >
-          <wa-icon library="mdi" name="close"></wa-icon>
-        </button>
-      </div>
+        ${this._renderRowAction(job)}
+      </button>
+    `;
+  }
+
+  private _renderRowAction(job: FirmwareJob) {
+    if (job.status === JobStatus.COMPLETED) {
+      return html`
+        <span class="row-status-icon row-status-icon--success" aria-label=${this._localize("firmware_jobs.status_completed")}>
+          <wa-icon library="mdi" name="check-circle"></wa-icon>
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.FAILED) {
+      return html`
+        <span class="row-status-icon row-status-icon--error" aria-label=${this._localize("firmware_jobs.status_failed")}>
+          <wa-icon library="mdi" name="close-circle"></wa-icon>
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.CANCELLED) {
+      return html`
+        <span class="row-status-icon row-status-icon--cancelled" aria-label=${this._localize("firmware_jobs.status_cancelled")}>
+          <wa-icon library="mdi" name="cancel"></wa-icon>
+        </span>
+      `;
+    }
+    return html`
+      <button
+        class="row-action"
+        title=${this._localize("firmware_jobs.cancel")}
+        aria-label=${this._localize("firmware_jobs.cancel")}
+        @click=${(e: Event) => this._onCancelClick(e, job)}
+      >
+        <wa-icon library="mdi" name="close"></wa-icon>
+      </button>
     `;
   }
 
@@ -334,7 +578,119 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         </span>
       `;
     }
+    if (job.status === JobStatus.COMPLETED) {
+      return html`
+        <span class="job-status job-status--success">
+          ${this._localize("firmware_jobs.status_completed")}
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.FAILED) {
+      return html`
+        <span class="job-status job-status--error">
+          ${this._localize("firmware_jobs.status_failed")}
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.CANCELLED) {
+      return html`
+        <span class="job-status">
+          ${this._localize("firmware_jobs.status_cancelled")}
+        </span>
+      `;
+    }
     return nothing;
+  }
+
+  /** Active rows show a relative time ("started 2m ago") that ticks
+   *  alongside the dialog's `_now` ticker; terminal rows show an
+   *  absolute "finished HH:MM" since the moment doesn't change once
+   *  it lands. */
+  private _renderTimestamp(job: FirmwareJob) {
+    const locale = activeLocale();
+    if (job.status === JobStatus.RUNNING && job.started_at) {
+      return html`
+        <span>•</span>
+        <span class="job-time">
+          ${this._localize("firmware_jobs.time_started", {
+            time: formatRelativeTime(job.started_at, this._now, locale),
+          })}
+        </span>
+      `;
+    }
+    if (job.status === JobStatus.QUEUED) {
+      return html`
+        <span>•</span>
+        <span class="job-time">
+          ${this._localize("firmware_jobs.time_queued", {
+            time: formatRelativeTime(job.created_at, this._now, locale),
+          })}
+        </span>
+      `;
+    }
+    if (isTerminal(job) && job.completed_at) {
+      return html`
+        <span>•</span>
+        <span class="job-time">
+          ${this._localize("firmware_jobs.time_finished", {
+            time: formatAbsoluteTime(job.completed_at, this._now, locale),
+          })}
+        </span>
+      `;
+    }
+    return nothing;
+  }
+
+  private _startTicker() {
+    if (this._tickHandle !== null) return;
+    this._tickHandle = setInterval(() => {
+      this._now = Date.now();
+    }, 30_000);
+  }
+
+  private _stopTicker = () => {
+    if (this._tickHandle !== null) {
+      clearInterval(this._tickHandle);
+      this._tickHandle = null;
+    }
+  };
+
+  /** Sort: running → queued → terminal. Active queued/running by oldest
+   *  first (FIFO order); terminal by most-recent first so the latest
+   *  finished job is at the top of the history. */
+  private _compareJobs = (a: FirmwareJob, b: FirmwareJob) => {
+    const rank = (j: FirmwareJob) =>
+      j.status === JobStatus.RUNNING
+        ? 0
+        : j.status === JobStatus.QUEUED
+          ? 1
+          : 2;
+    const ra = rank(a);
+    const rb = rank(b);
+    if (ra !== rb) return ra - rb;
+    if (ra === 2) {
+      const ta = a.completed_at ?? a.created_at;
+      const tb = b.completed_at ?? b.created_at;
+      return tb.localeCompare(ta);
+    }
+    return a.created_at.localeCompare(b.created_at);
+  };
+
+  private _jobDisplayName(job: FirmwareJob): string {
+    if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
+      return this._localize("firmware_jobs.build_env_label");
+    }
+    const device = this._devices.find((d) => d.configuration === job.configuration);
+    return device?.friendly_name || device?.name || job.configuration;
+  }
+
+  private _openJob(job: FirmwareJob) {
+    this._commandDialog.followJob(job, this._jobDisplayName(job));
+  }
+
+  private _onCancelClick(e: Event, job: FirmwareJob) {
+    e.stopPropagation();
+    this._cancel(job);
   }
 
   private async _cancel(job: FirmwareJob) {
@@ -343,6 +699,39 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     } catch {
       /* The job may have already finished — follow_jobs will reconcile. */
     }
+  }
+
+  private _onResetClick() {
+    this._confirmDialog.open();
+  }
+
+  private async _onResetConfirmed() {
+    let job: FirmwareJob;
+    try {
+      job = await this._api.firmwareResetBuildEnv();
+    } catch (err) {
+      console.error("Failed to queue reset_build_env job:", err);
+      return;
+    }
+    // Drop the user into the log viewer so they can watch the wipe.
+    this._commandDialog.followJob(job, this._jobDisplayName(job));
+  }
+
+  private async _onClearHistory() {
+    try {
+      await this._api.firmwareClear();
+    } catch (err) {
+      console.error("Failed to clear firmware history:", err);
+      return;
+    }
+    // firmware/clear has no broadcast event — let app-shell prune
+    // the local context so the "Recent" group updates immediately.
+    this.dispatchEvent(
+      new CustomEvent("firmware-history-cleared", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }
 

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -51,10 +51,11 @@ export const activeJobsContext = createContext<Map<string, FirmwareJob>>(
   Symbol("esphome-active-jobs")
 );
 
-/** Context for every non-terminal firmware job, keyed by `job_id`.
+/** Context for every firmware job the backend currently exposes
+ *  (active and the trimmed terminal history), keyed by `job_id`.
  *  Powers the firmware-tasks dialog — a device can have several jobs
- *  in flight (e.g. compile + clean queued back-to-back), so we key by
- *  job_id to keep them all distinct. */
+ *  in flight (e.g. compile + clean queued back-to-back), so we key
+ *  by job_id to keep them all distinct. */
 export const firmwareJobsContext = createContext<Map<string, FirmwareJob>>(
   Symbol("esphome-firmware-jobs")
 );

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -554,7 +554,7 @@ export class ESPHomePageDashboard extends LitElement {
   private _showJobProgress(device: ConfiguredDevice) {
     const job = this._activeJobs.get(device.configuration);
     if (job) {
-      this._commandDialog.followJob(device, job);
+      this._commandDialog.followJob(job, device.friendly_name || device.name);
     }
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -159,6 +159,7 @@
     "compile_title": "Compile — {name}",
     "validate_title": "Validate — {name}",
     "clean_title": "Clean — {name}",
+    "reset_title": "Reset build environment",
     "stop": "Stop",
     "retry": "Retry",
     "close": "Close",
@@ -172,7 +173,9 @@
     "validate_success": "Configuration is valid!",
     "validate_failed": "Validation failed.",
     "clean_success": "Build files cleaned.",
-    "clean_failed": "Clean failed."
+    "clean_failed": "Clean failed.",
+    "reset_success": "Build environment reset. The next compile will redownload the toolchain.",
+    "reset_failed": "Failed to reset the build environment."
   },
   "firmware": {
     "install_title": "Install — {name}",
@@ -496,14 +499,29 @@
     "menu_item": "Firmware tasks",
     "title": "Firmware tasks",
     "badge_label": "{count} active firmware task(s)",
-    "empty_title": "No firmware tasks running",
+    "empty_title": "No firmware tasks yet",
     "empty_desc": "Compile, install, or clean jobs you start will show up here.",
+    "group_active": "Active",
+    "group_history": "Recent",
     "status_queued": "Queued",
     "status_running": "Running…",
+    "status_completed": "Completed",
+    "status_failed": "Failed",
+    "status_cancelled": "Cancelled",
     "cancel": "Cancel",
+    "clear_history": "Clear history",
+    "build_env_label": "(build environment)",
+    "reset_build_env": "Reset build environment",
+    "reset_confirm_title": "Reset build environment?",
+    "reset_confirm_message": "This wipes the toolchain cache and platform/library installs. The next compile will be slow because everything has to re-download. Continue?",
+    "reset_confirm_button": "Reset",
     "type_compile": "Compile",
     "type_upload": "Upload",
     "type_install": "Install",
-    "type_clean": "Clean"
+    "type_clean": "Clean",
+    "type_reset_build_env": "Reset",
+    "time_queued": "queued {time}",
+    "time_started": "started {time}",
+    "time_finished": "finished {time}"
   }
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -155,6 +155,7 @@
     "compile_title": "Compilation — {name}",
     "validate_title": "Validation — {name}",
     "clean_title": "Nettoyage — {name}",
+    "reset_title": "Réinitialiser l'environnement de compilation",
     "stop": "Arrêter",
     "retry": "Réessayer",
     "close": "Fermer",
@@ -168,7 +169,9 @@
     "validate_success": "La configuration est valide !",
     "validate_failed": "Échec de la validation.",
     "clean_success": "Fichiers de compilation nettoyés.",
-    "clean_failed": "Échec du nettoyage."
+    "clean_failed": "Échec du nettoyage.",
+    "reset_success": "Environnement de compilation réinitialisé. La prochaine compilation retéléchargera la chaîne d'outils.",
+    "reset_failed": "Échec de la réinitialisation de l'environnement de compilation."
   },
   "serial": {
     "title": "Appareil USB",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -155,6 +155,7 @@
     "compile_title": "Compileren — {name}",
     "validate_title": "Valideren — {name}",
     "clean_title": "Opschonen — {name}",
+    "reset_title": "Bouw-omgeving resetten",
     "stop": "Stoppen",
     "retry": "Opnieuw",
     "close": "Sluiten",
@@ -168,7 +169,9 @@
     "validate_success": "Configuratie is geldig!",
     "validate_failed": "Validatie mislukt.",
     "clean_success": "Bouwbestanden opgeschoond.",
-    "clean_failed": "Opschonen mislukt."
+    "clean_failed": "Opschonen mislukt.",
+    "reset_success": "Bouw-omgeving gereset. De volgende compilatie downloadt de toolchain opnieuw.",
+    "reset_failed": "Resetten van de bouw-omgeving mislukt."
   },
   "serial": {
     "title": "USB-apparaat",

--- a/src/util/format-job-time.ts
+++ b/src/util/format-job-time.ts
@@ -1,0 +1,52 @@
+/**
+ * Render an ISO timestamp as a short relative phrase ("2m ago",
+ * "in 30s") via Intl.RelativeTimeFormat. Picks the coarsest unit that
+ * keeps the magnitude readable — seconds → minutes → hours → days.
+ * `now` is passed in so callers can drive re-renders from a ticker
+ * and tests are deterministic.
+ */
+export function formatRelativeTime(
+  iso: string,
+  now: number,
+  locale?: string,
+): string {
+  const past = new Date(iso).getTime();
+  const diffSec = Math.round((past - now) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  const absSec = Math.abs(diffSec);
+  if (absSec < 60) return rtf.format(diffSec, "second");
+  const diffMin = Math.round(diffSec / 60);
+  if (Math.abs(diffMin) < 60) return rtf.format(diffMin, "minute");
+  const diffHour = Math.round(diffMin / 60);
+  if (Math.abs(diffHour) < 24) return rtf.format(diffHour, "hour");
+  const diffDay = Math.round(diffHour / 24);
+  return rtf.format(diffDay, "day");
+}
+
+/**
+ * Render an ISO timestamp as a compact absolute time. Same-day stamps
+ * drop the date so they stay short; older stamps prefix a short
+ * month/day.
+ */
+export function formatAbsoluteTime(
+  iso: string,
+  now: number,
+  locale?: string,
+): string {
+  const date = new Date(iso);
+  const today = new Date(now);
+  const isSameDay =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  const time = date.toLocaleTimeString(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  if (isSameDay) return time;
+  const dateStr = date.toLocaleDateString(locale, {
+    month: "short",
+    day: "numeric",
+  });
+  return `${dateStr} ${time}`;
+}

--- a/test/util/format-job-time.test.ts
+++ b/test/util/format-job-time.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+} from "../../src/util/format-job-time.js";
+
+const NOW = new Date("2026-05-01T14:00:00Z").getTime();
+
+describe("formatRelativeTime", () => {
+  it("renders seconds in the past", () => {
+    const iso = new Date(NOW - 30 * 1000).toISOString();
+    expect(formatRelativeTime(iso, NOW, "en")).toBe("30 seconds ago");
+  });
+
+  it("renders minutes in the past", () => {
+    const iso = new Date(NOW - 5 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(iso, NOW, "en")).toBe("5 minutes ago");
+  });
+
+  it("renders hours in the past", () => {
+    const iso = new Date(NOW - 3 * 60 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(iso, NOW, "en")).toBe("3 hours ago");
+  });
+
+  it("renders days in the past", () => {
+    const iso = new Date(NOW - 4 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(iso, NOW, "en")).toBe("4 days ago");
+  });
+
+  it("uses 'now' phrasing for sub-second deltas", () => {
+    expect(formatRelativeTime(new Date(NOW).toISOString(), NOW, "en")).toBe("now");
+  });
+});
+
+describe("formatAbsoluteTime", () => {
+  it("drops the date for same-day timestamps", () => {
+    const iso = new Date("2026-05-01T13:32:00Z").toISOString();
+    // Hour/minute output depends on the test runner's tz; just assert
+    // it has the HH:MM shape and no month abbreviation.
+    const out = formatAbsoluteTime(iso, NOW, "en-US");
+    expect(out).toMatch(/^\d{1,2}:\d{2}(\s?(AM|PM))?$/);
+  });
+
+  it("includes month/day for older timestamps", () => {
+    const iso = new Date("2026-04-28T13:32:00Z").toISOString();
+    const out = formatAbsoluteTime(iso, NOW, "en-US");
+    expect(out).toMatch(/^[A-Z][a-z]{2}\s\d{1,2}\s\d{1,2}:\d{2}(\s?(AM|PM))?$/);
+  });
+});


### PR DESCRIPTION
## Problem

The firmware-tasks dialog disappeared active jobs as soon as they finished and didn't let you click into a row to see what happened. There was also no way to recover from a poisoned PlatformIO toolchain cache from the UI, and queuing a fresh job on a device that already had one running just stacked another row in the panel.

## Changes

- Show retained terminal history (one entry per device for compile/upload/install, last 5 clean/reset) in a **Recent** group alongside the live **Active** group
- Click any row to open the existing log viewer — works for active and finished jobs (backend replays buffered output)
- Show queued/running/completed/failed/cancelled status per row plus a timestamp: relative for active rows ("started 2m ago"), absolute for finished rows ("finished 14:32"); ticks live while the dialog is open
- Add `JobType.RESET_BUILD_ENV` and a **Reset build environment** toolbar button that confirms, queues `firmware/reset_build_env`, and drops the user into the log viewer
- Treat backend supersede cancellations as silent: when a fresh active job for the same device is already present, drop the cancelled predecessor instead of parking it in Recent
- Header badge / count now reflects only non-terminal jobs so retained history doesn't inflate the indicator
- **Clear history** toolbar button (`firmware/clear`) with optimistic local prune since the backend doesn't broadcast clear
- New `format-job-time` util with vitest coverage