### PR TITLE
Copy public/assets/ into the wheel build output

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -93,6 +93,11 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
     new rspack.CopyRspackPlugin({
       patterns: [
         {
+          from: path.resolve(PUBLIC_DIR, "assets"),
+          to: path.resolve(OUTPUT_DIR, "assets"),
+          noErrorOnMissing: true,
+        },
+        {
           from: path.resolve(PUBLIC_DIR, "static"),
           to: path.resolve(OUTPUT_DIR, "static"),
           noErrorOnMissing: true,

--- a/test/build-scripts/rspack-config.test.ts
+++ b/test/build-scripts/rspack-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+interface CopyPattern {
+  from: string;
+  to: string;
+}
+
+const loadPatterns = async (): Promise<CopyPattern[]> => {
+  const mod = (await import("../../build-scripts/rspack.cjs")) as {
+    createRspackConfig: () => {
+      plugins: Array<{ constructor?: { name?: string }; _args?: unknown[] }>;
+    };
+  };
+  const cfg = mod.createRspackConfig();
+  const copyPlugin = cfg.plugins.find(
+    (p) => p?.constructor?.name === "CopyRspackPlugin",
+  );
+  if (!copyPlugin) {
+    throw new Error("CopyRspackPlugin not found in rspack plugins");
+  }
+  // CopyRspackPlugin stores its constructor args at `_args`.
+  const firstArg = (copyPlugin._args ?? [])[0] as { patterns: CopyPattern[] };
+  return firstArg.patterns;
+};
+
+describe("rspack config", () => {
+  it("copies public/assets/ into the wheel output dir", async () => {
+    // Regression: without this pattern, the published wheel ships
+    // index.html and the JS bundles but no logos/board images, so
+    // the running dashboard 404s every static asset request.
+    const patterns = await loadPatterns();
+    const assetsPattern = patterns.find((p) =>
+      p.from.endsWith("/public/assets"),
+    );
+    expect(assetsPattern, "expected a copy pattern for public/assets").toBeDefined();
+    expect(assetsPattern!.to).toMatch(
+      /\/esphome_device_builder_frontend\/assets$/,
+    );
+  });
+
+  it("copies the package __init__.py so pip install ships where()", async () => {
+    const patterns = await loadPatterns();
+    const initPattern = patterns.find((p) =>
+      p.from.endsWith("/public/__init__.py"),
+    );
+    expect(initPattern, "expected a copy pattern for __init__.py").toBeDefined();
+    expect(initPattern!.to).toMatch(
+      /\/esphome_device_builder_frontend\/__init__\.py$/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
The rspack `CopyRspackPlugin` config copies `public/static/` (which doesn't exist) and `public/__init__.py` but not `public/assets/`, so wheels built from this tree ship `index.html` and the JS bundles with **no logo or board images**. A running dashboard then 404s every `/assets/logo/...` and `/assets/board/...` request.

Add a copy pattern for `public/assets/` so the build output mirrors what the SPA expects, plus a small vitest test that asserts the rspack config still includes both the `assets` copy and the `__init__.py` copy — so the next time someone reorganises the build pipeline, this regression is caught before another wheel ships.

Pairs with a backend hardening PR ([device-builder#30](https://github.com/esphome/device-builder/pull/30)) that refuses to start when the installed frontend wheel is missing `assets/`.

## Test plan
- [x] `npm test` (89 passed)
- [x] `npm run lint` (clean)
- [x] `npm run build` populates `esphome_device_builder_frontend/assets/{board,logo}/...`
- [x] Manually verified `pip install`'d wheel ships the asset tree and the dashboard's `/assets/logo/esphome.svg` resolves