### PR TITLE
Wire stop button to devices/stop_stream

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -445,8 +445,15 @@ export class ESPHomeAPI {
    * The backend kills the underlying subprocess and the streaming task
    * ends in CANCELLED state — no further `output`/`result` events are
    * sent for that stream. Returns once the backend confirms.
+   *
+   * The local handler for `streamId` is dropped synchronously so any
+   * already-in-flight `output` events (or a misbehaving backend that
+   * keeps sending) won't reach the caller after the stop, and the
+   * `_streamHandlers` entry doesn't leak when the cancelled task
+   * never emits a terminal `result` event.
    */
   async stopStream(streamId: string): Promise<{ cancelled: boolean }> {
+    this._streamHandlers.delete(streamId);
     return this.sendCommand<{ cancelled: boolean }>("devices/stop_stream", {
       stream_id: streamId,
     });

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -439,6 +439,19 @@ export class ESPHomeAPI {
     return this.sendStreamCommand("devices/logs", { configuration, port }, callbacks);
   }
 
+  /**
+   * Cancel a previously-issued streaming command (validate or logs).
+   *
+   * The backend kills the underlying subprocess and the streaming task
+   * ends in CANCELLED state — no further `output`/`result` events are
+   * sent for that stream. Returns once the backend confirms.
+   */
+  async stopStream(streamId: string): Promise<{ cancelled: boolean }> {
+    return this.sendCommand<{ cancelled: boolean }>("devices/stop_stream", {
+      stream_id: streamId,
+    });
+  }
+
   /** Follow a job's output: historical lines + live stream until completion. */
   firmwareFollowJob(jobId: string, callbacks: StreamCallbacks): string {
     return this.sendStreamCommand("firmware/follow_job", { job_id: jobId }, callbacks);

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -343,8 +343,15 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _stopStreaming() {
+    const streamId = this._streamId;
     this._streaming = false;
     this._streamId = "";
+    if (streamId) {
+      // Tell the backend to kill the subprocess. If the WS isn't open
+      // anymore there's nothing to cancel server-side anyway, so swallow
+      // any error from the call.
+      this._api.stopStream(streamId).catch(() => {});
+    }
   }
 
   private _downloadLogs() {

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -260,6 +260,30 @@ describe("ESPHomeAPI — streaming commands", () => {
     expect(onError).toHaveBeenCalledWith("WebSocket connection closed");
   });
 
+  it("stopStream sends devices/stop_stream with the stream id", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    // Start a streaming command so we have a message_id worth cancelling.
+    const streamId = api.sendStreamCommand(
+      "devices/logs",
+      { configuration: "foo.yaml", port: "" },
+      { onOutput: vi.fn(), onResult: vi.fn() },
+    );
+
+    const pending = api.stopStream(streamId);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: { stream_id: string };
+    }>(1);
+    expect(sent.command).toBe("devices/stop_stream");
+    expect(sent.args).toEqual({ stream_id: streamId });
+
+    ws.receive({ message_id: sent.message_id, result: { cancelled: true } });
+    await expect(pending).resolves.toEqual({ cancelled: true });
+  });
+
   it("signals an error via onError if send is attempted while disconnected", () => {
     const api = new ESPHomeAPI();
     const onError = vi.fn();

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -284,6 +284,37 @@ describe("ESPHomeAPI — streaming commands", () => {
     await expect(pending).resolves.toEqual({ cancelled: true });
   });
 
+  it("stopStream drops the local handler so further output events are ignored", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const onOutput = vi.fn();
+    const onResult = vi.fn();
+
+    const streamId = api.sendStreamCommand(
+      "devices/logs",
+      { configuration: "foo.yaml", port: "" },
+      { onOutput, onResult },
+    );
+
+    // Pre-stop: events flow normally.
+    ws.receive({ message_id: streamId, event: "output", data: "before-stop" });
+    expect(onOutput).toHaveBeenCalledWith("before-stop");
+
+    api.stopStream(streamId);
+
+    // Anything that arrives after stop — whether genuinely racing or a
+    // misbehaving backend that keeps sending — must not reach the caller.
+    ws.receive({ message_id: streamId, event: "output", data: "after-stop" });
+    ws.receive({
+      message_id: streamId,
+      event: "result",
+      data: { success: false, code: -1 },
+    });
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
   it("signals an error via onError if send is attempted while disconnected", () => {
     const api = new ESPHomeAPI();
     const onError = vi.fn();


### PR DESCRIPTION
## Summary
The logs dialog's stop button only cleared client state — the backend's `esphome logs` subprocess kept running and re-emitting output, which is especially obvious when the device is in a crash-trace loop and the upstream API connection keeps reconnecting. The dashboard kept flooding output until the dialog was closed.

Pairs with [device-builder#34](https://github.com/esphome/device-builder/pull/34) which adds the backend `devices/stop_stream` WS command (kills the subprocess on the server side).

* New `stopStream(streamId)` helper on `ESPHomeAPI` — sends `devices/stop_stream` and resolves with `{ cancelled: boolean }`.
* `logs-dialog._stopStreaming` fires the WS call (best-effort — `.catch(() => {})` so a closed/stale WS doesn't surface as an error to the user).

## Test plan
- [x] `npm test` (89 passed, including a new case asserting `stopStream` sends `devices/stop_stream` with the original stream id)
- [x] `npm run lint` clean
- [x] Manual: with the matching backend PR, clicking stop on a crash-looping device terminates the subprocess immediately and the output stream halts