### PR TITLE
Hide header subtitle on mobile, clip title to one line

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -132,11 +132,19 @@ export class ESPHomeLayout extends LitElement {
         font-size: 20px;
       }
 
+      .header-text {
+        min-width: 0;
+        overflow: hidden;
+      }
+
       .header-text h1 {
         margin: 0;
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--esphome-on-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .header-text p {
@@ -144,10 +152,21 @@ export class ESPHomeLayout extends LitElement {
         font-size: var(--wa-font-size-xs);
         color: var(--esphome-on-primary);
         opacity: 0.75;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .header-spacer {
         flex: 1;
+      }
+
+      /* Mobile: drop the subtitle so the title isn't squashed against
+         the top of the viewport, and keep header height compact. */
+      @media (max-width: 700px) {
+        .header-text p {
+          display: none;
+        }
       }
     `,
   ];


### PR DESCRIPTION
## Summary
On phone-width viewports the dashboard header was bunched up: the title wrapped to two lines, the "Create and make your smart devices and automations" subtitle stacked under it, and the actual content got pushed off-screen.

Drop the subtitle below 700px (the project's standard mobile breakpoint, already used in `settings-dialog` and `dashboard/table-styles`). Also constrain both the title and subtitle to a single ellipsised line so an unusually long localisation can't reintroduce the wrap on desktop.

## Test plan
- [x] `npm test` (90 passed)
- [x] `npm run lint` clean
- [x] Manual: dashboard at <700px shows just the title (single line, no wrap), >=700px shows title + subtitle as before.