### PR TITLE
Logs dialog: full viewport on mobile, toolbar always visible

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -103,22 +103,16 @@ export class ESPHomeLogsDialog extends LitElement {
           --width: 100vw;
         }
 
-        wa-dialog::part(dialog) {
-          position: fixed !important;
+        /* :host bumps specificity above dialog:modal (0,1,1) — the
+           user-agent rule that sets position/inset/max-* on a modal
+           <dialog>. Drop wa-dialog's max-* constraints and let the
+           positioning fill the viewport. */
+        :host wa-dialog::part(dialog) {
           inset: 0 !important;
-          width: 100vw !important;
-          max-width: 100vw !important;
-          height: 100vh !important;
-          height: 100dvh !important;
-          max-height: 100vh !important;
-          max-height: 100dvh !important;
+          max-width: none !important;
+          max-height: none !important;
           margin: 0 !important;
           border-radius: 0 !important;
-        }
-
-        wa-dialog::part(body) {
-          flex: 1 1 auto !important;
-          min-height: 0 !important;
         }
 
         .logs-content {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -93,46 +93,6 @@ export class ESPHomeLogsDialog extends LitElement {
         max-height: 85vh;
       }
 
-      /* Mobile: dialog takes the whole viewport. dvh accounts for
-         mobile browser chrome (URL bar) so the toolbar cannot scroll
-         out from under the user. The selector uses [open] so the
-         specificity beats wa-dialog's internal .dialog rule (single
-         class, otherwise wins against a bare ::part(dialog)). */
-      @media (max-width: 700px) {
-        wa-dialog {
-          --width: 100vw;
-        }
-
-        /* :host bumps specificity above dialog:modal (0,1,1).
-           Force position + inset so the dialog fills the viewport
-           whether wa-dialog is using modal or non-modal show(). */
-        :host wa-dialog::part(dialog) {
-          position: fixed !important;
-          inset: 0 !important;
-          width: 100vw !important;
-          height: 100dvh !important;
-          max-width: none !important;
-          max-height: none !important;
-          margin: 0 !important;
-          border-radius: 0 !important;
-        }
-
-        .logs-content {
-          height: 100%;
-          max-height: none;
-          min-height: 0;
-        }
-
-        /* Expand is desktop-only — the dialog is already full-screen
-           on mobile so there's nothing to expand. .term-btn declares
-           display: inline-flex later in the stylesheet with the same
-           single-class specificity, so we double-up the selector to
-           win on specificity. */
-        .term-btn.expand-btn {
-          display: none;
-        }
-      }
-
       wa-dialog::part(header) {
         background: var(--term-bg);
         padding: 0 var(--wa-space-m);
@@ -263,6 +223,42 @@ export class ESPHomeLogsDialog extends LitElement {
       @keyframes pulse {
         0%, 100% { opacity: 1; }
         50% { opacity: 0.3; }
+      }
+
+      /* Mobile overrides — placed last so source-order wins against
+         desktop sizing for same-specificity selectors. dvh accounts
+         for iOS Safari's collapsing URL bar so the toolbar can't be
+         pushed off-screen. */
+      @media (max-width: 700px) {
+        wa-dialog {
+          --width: 100vw;
+        }
+
+        /* :host bumps specificity above dialog:modal (0,1,1). Force
+           position + inset so the dialog fills the viewport whether
+           wa-dialog opens modal or non-modal. */
+        :host wa-dialog::part(dialog) {
+          position: fixed !important;
+          inset: 0 !important;
+          width: 100vw !important;
+          height: 100dvh !important;
+          max-width: none !important;
+          max-height: none !important;
+          margin: 0 !important;
+          border-radius: 0 !important;
+        }
+
+        .logs-content {
+          height: 100%;
+          max-height: none;
+          min-height: 0;
+        }
+
+        /* Expand is desktop-only — dialog is already full-screen on
+           mobile. Doubled selector beats .term-btn's display: inline-flex. */
+        .term-btn.expand-btn {
+          display: none;
+        }
       }
     `,
   ];

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -240,6 +240,7 @@ export class ESPHomeLogsDialog extends LitElement {
              dialog at its desktop size. dvh handles iOS Safari's
              collapsing URL bar. */
           width: 100vw;
+          height: 100vh;
           height: 100dvh;
           max-width: none;
           max-height: none;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -104,11 +104,13 @@ export class ESPHomeLogsDialog extends LitElement {
         }
 
         wa-dialog[open]::part(dialog) {
-          max-width: 100vw;
-          max-height: 100dvh;
-          height: 100dvh;
-          margin: 0;
-          border-radius: 0;
+          max-width: 100vw !important;
+          max-height: 100vh !important;
+          max-height: 100dvh !important;
+          height: 100vh !important;
+          height: 100dvh !important;
+          margin: 0 !important;
+          border-radius: 0 !important;
         }
 
         .logs-content {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -234,6 +234,13 @@ export class ESPHomeLogsDialog extends LitElement {
         :host wa-dialog::part(dialog) {
           position: fixed;
           inset: 0;
+          /* width/height are explicit because wa-dialog's
+             width: var(--width) and the UA's
+             max-height: calc(100% - ...) would otherwise keep the
+             dialog at its desktop size. dvh handles iOS Safari's
+             collapsing URL bar. */
+          width: 100vw;
+          height: 100dvh;
           max-width: none;
           max-height: none;
           margin: 0;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -237,8 +237,10 @@ export class ESPHomeLogsDialog extends LitElement {
           /* width/height are explicit because wa-dialog's
              width: var(--width) and the UA's
              max-height: calc(100% - ...) would otherwise keep the
-             dialog at its desktop size. dvh handles iOS Safari's
-             collapsing URL bar. */
+             dialog at its desktop size. The vh declaration is the
+             fallback for pre-2022 Safari / Chrome / Firefox that
+             don't recognise dvh; modern browsers pick the dvh line
+             which adjusts as iOS Safari's URL bar collapses. */
           width: 100vw;
           height: 100vh;
           height: 100dvh;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -225,27 +225,19 @@ export class ESPHomeLogsDialog extends LitElement {
         50% { opacity: 0.3; }
       }
 
-      /* Mobile overrides — placed last so source-order wins against
-         desktop sizing for same-specificity selectors. dvh accounts
-         for iOS Safari's collapsing URL bar so the toolbar can't be
-         pushed off-screen. */
+      /* Mobile overrides — placed last so same-specificity rules
+         in this file win source-order against the desktop defaults.
+         :host wa-dialog::part(dialog) lands at (0,1,2), beating both
+         wa-dialog's internal .dialog (0,1,0) and the user-agent's
+         dialog:modal (0,1,1) without needing !important. */
       @media (max-width: 700px) {
-        wa-dialog {
-          --width: 100vw;
-        }
-
-        /* :host bumps specificity above dialog:modal (0,1,1). Force
-           position + inset so the dialog fills the viewport whether
-           wa-dialog opens modal or non-modal. */
         :host wa-dialog::part(dialog) {
-          position: fixed !important;
-          inset: 0 !important;
-          width: 100vw !important;
-          height: 100dvh !important;
-          max-width: none !important;
-          max-height: none !important;
-          margin: 0 !important;
-          border-radius: 0 !important;
+          position: fixed;
+          inset: 0;
+          max-width: none;
+          max-height: none;
+          margin: 0;
+          border-radius: 0;
         }
 
         .logs-content {
@@ -254,8 +246,6 @@ export class ESPHomeLogsDialog extends LitElement {
           min-height: 0;
         }
 
-        /* Expand is desktop-only — dialog is already full-screen on
-           mobile. Doubled selector beats .term-btn's display: inline-flex. */
         .term-btn.expand-btn {
           display: none;
         }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -93,6 +93,37 @@ export class ESPHomeLogsDialog extends LitElement {
         max-height: 85vh;
       }
 
+      /* Mobile: dialog takes the whole viewport. dvh accounts for
+         mobile browser chrome (URL bar) so the toolbar cannot scroll
+         out from under the user. The selector uses [open] so the
+         specificity beats wa-dialog's internal .dialog rule (single
+         class, otherwise wins against a bare ::part(dialog)). */
+      @media (max-width: 700px) {
+        wa-dialog {
+          --width: 100vw;
+        }
+
+        wa-dialog[open]::part(dialog) {
+          max-width: 100vw;
+          max-height: 100dvh;
+          height: 100dvh;
+          margin: 0;
+          border-radius: 0;
+        }
+
+        .logs-content {
+          height: 100%;
+          max-height: none;
+          min-height: 0;
+        }
+
+        /* Expand is desktop-only — the dialog is already full-screen
+           on mobile so there's nothing to expand. */
+        .expand-btn {
+          display: none;
+        }
+      }
+
       wa-dialog::part(header) {
         background: var(--term-bg);
         padding: 0 var(--wa-space-m);
@@ -284,7 +315,7 @@ export class ESPHomeLogsDialog extends LitElement {
               : ""}
             <span class="spacer"></span>
             <button
-              class="term-btn term-btn--ghost"
+              class="term-btn term-btn--ghost expand-btn"
               @click=${this._toggleExpanded}
             >
               <wa-icon library="mdi" name=${this._expanded ? "arrow-collapse" : "arrow-expand"}></wa-icon>

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -103,14 +103,22 @@ export class ESPHomeLogsDialog extends LitElement {
           --width: 100vw;
         }
 
-        wa-dialog[open]::part(dialog) {
+        wa-dialog::part(dialog) {
+          position: fixed !important;
+          inset: 0 !important;
+          width: 100vw !important;
           max-width: 100vw !important;
-          max-height: 100vh !important;
-          max-height: 100dvh !important;
           height: 100vh !important;
           height: 100dvh !important;
+          max-height: 100vh !important;
+          max-height: 100dvh !important;
           margin: 0 !important;
           border-radius: 0 !important;
+        }
+
+        wa-dialog::part(body) {
+          flex: 1 1 auto !important;
+          min-height: 0 !important;
         }
 
         .logs-content {
@@ -120,8 +128,11 @@ export class ESPHomeLogsDialog extends LitElement {
         }
 
         /* Expand is desktop-only — the dialog is already full-screen
-           on mobile so there's nothing to expand. */
-        .expand-btn {
+           on mobile so there's nothing to expand. .term-btn declares
+           display: inline-flex later in the stylesheet with the same
+           single-class specificity, so we double-up the selector to
+           win on specificity. */
+        .term-btn.expand-btn {
           display: none;
         }
       }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -103,12 +103,14 @@ export class ESPHomeLogsDialog extends LitElement {
           --width: 100vw;
         }
 
-        /* :host bumps specificity above dialog:modal (0,1,1) — the
-           user-agent rule that sets position/inset/max-* on a modal
-           <dialog>. Drop wa-dialog's max-* constraints and let the
-           positioning fill the viewport. */
+        /* :host bumps specificity above dialog:modal (0,1,1).
+           Force position + inset so the dialog fills the viewport
+           whether wa-dialog is using modal or non-modal show(). */
         :host wa-dialog::part(dialog) {
+          position: fixed !important;
           inset: 0 !important;
+          width: 100vw !important;
+          height: 100dvh !important;
           max-width: none !important;
           max-height: none !important;
           margin: 0 !important;


### PR DESCRIPTION
## Summary
Three issues with the logs dialog on phone-width viewports:

1. **Expand didn't go full-screen** — tapping the expand button left wasted space around the dialog instead of taking the whole screen.
2. **Toolbar fell below the fold after expand** — the dialog grew taller than the viewport so the stop / clear / download / collapse buttons disappeared with no scroll handle to bring them back. No way to stop streaming once expanded.
3. **Wasted bottom gap pre-expand** — the fixed `60vh` log area left a useless strip below the dialog on tall phone viewports.

Fix with a `@media (max-width: 700px)` block (same breakpoint used elsewhere in the app):

* Dialog is `100vw` × `100dvh` with no margin or border-radius — true full-screen, regardless of expanded state.
* `.logs-content` fills the dialog body so the log area takes every pixel above the toolbar.
* `dvh` (dynamic viewport height) ensures iOS Safari's collapsing URL bar doesn't push the toolbar out from under the user.

Desktop behaviour (`min(900px, 90vw)`, `60vh` / `80vh` for normal / expanded) is unchanged.

## Test plan
- [x] `npm test` (90 passed)
- [x] `npm run lint` clean
- [ ] Manual: phone-width viewport — dialog opens full-screen, toolbar always visible (with and without expand pressed); desktop layout unchanged.