### PR TITLE
Move white-space: pre from log-container to log-line

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -221,17 +221,21 @@ export class ESPHomeAnsiLog extends LitElement {
       height: 100%;
       overflow-y: auto;
       overflow-x: auto;
-      white-space: pre;
       line-height: 18px;
       box-sizing: border-box;
       tab-size: 4;
     }
 
+    /* white-space: pre lives on the line, not the container. On the
+       container Lit's html-template inter-element text nodes
+       (whitespace between <div> and the interpolated children) render
+       as visible blank lines above the first real log line. */
     .log-line {
       margin: 0;
       padding: 0;
       border-radius: 2px;
       line-height: 18px;
+      white-space: pre;
     }
 
     .log-line:hover {


### PR DESCRIPTION
## Summary
Fresh `esphome logs` sessions rendered a couple of blank "garbage" lines above the first INFO line. Cause is purely CSS: Lit's html template renders inter-element text nodes (the whitespace between the opening `<div class=\"log-container\">` and the interpolated child elements) as live text nodes. With `white-space: pre` on the container that whitespace was preserved verbatim — newline + indentation = a couple of visible blank lines at the top.

Move `white-space: pre` from `.log-container` to `.log-line` where it's actually doing useful work (preserving intra-line spacing for log content alignment). The container can now collapse the inter-element whitespace it doesn't own.

## Test plan
- [x] `npm test` (90 passed)
- [x] `npm run lint` clean
- [x] Manual: open a logs dialog on a fresh device — first visible line is the INFO line, no blank rectangle above it.