### PR TITLE
Make the device editor full-bleed on mobile

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -247,5 +247,15 @@ export const deviceEditorStyles = css`
     .layout-toggle .split-btn {
       display: none;
     }
+
+    /* Drop the card frame on mobile — the page wrapper already
+       removes its padding so the editor occupies the full viewport.
+       Border / border-radius / shadow at small widths just shave
+       pixels off the editing area without adding any meaning. */
+    .card {
+      border: none;
+      border-radius: 0;
+      box-shadow: none;
+    }
   }
 `;

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -54,9 +54,19 @@ export const devicePageStyles = css`
   }
 
   @media (max-width: 900px) {
+    /* Drop the page padding on mobile so the editor goes edge-to-edge.
+       The card itself is already small at this width — wasting ~16px
+       on each side to a frame just makes it harder to read; logs go
+       full-screen the same way for the same reason. */
+    .page {
+      padding: 0;
+      min-height: calc(100dvh - var(--esphome-header-height));
+    }
+
     .layout-grid {
       grid-template-columns: 1fr;
-      height: calc(100vh - var(--esphome-header-height) - 2 * var(--wa-space-l));
+      gap: 0;
+      height: calc(100dvh - var(--esphome-header-height));
     }
 
     .desktop-nav {

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -57,15 +57,22 @@ export const devicePageStyles = css`
     /* Drop the page padding on mobile so the editor goes edge-to-edge.
        The card itself is already small at this width — wasting ~16px
        on each side to a frame just makes it harder to read; logs go
-       full-screen the same way for the same reason. */
+       full-screen the same way for the same reason.
+       Each dvh line is paired with a vh fallback above it so
+       pre-2022 browsers that don't recognise dvh still pick up the
+       mobile sizing instead of dropping the declaration and falling
+       through to the desktop rule (which had an extra
+       2 * var(--wa-space-l) subtracted and would leave a gap). */
     .page {
       padding: 0;
+      min-height: calc(100vh - var(--esphome-header-height));
       min-height: calc(100dvh - var(--esphome-header-height));
     }
 
     .layout-grid {
       grid-template-columns: 1fr;
       gap: 0;
+      height: calc(100vh - var(--esphome-header-height));
       height: calc(100dvh - var(--esphome-header-height));
     }
 


### PR DESCRIPTION
## Summary

The editor card was sitting inside a ``var(--wa-space-l)`` (~16-24px) page padding on mobile and rendered with its desktop border / radius / shadow on top. On a ~360-400px wide screen that's already too small to comfortably read YAML, that's another ~32-48px lost to chrome that adds no meaning at this size. The logs dialog already goes full-screen on the same breakpoint for the same reason.

Changes (both gated on ``max-width: 900px``):
* ``device-styles``: drop the ``.page`` padding and ``.layout-grid`` gap; switch ``height``/``min-height`` from ``vh`` to ``dvh`` so iOS Safari URL-bar collapse doesn't leave a gap below the editor.
* ``device-editor.styles``: strip the card's ``border``, ``border-radius``, and ``box-shadow`` so the edge-to-edge editor reads as a full-bleed surface instead of a rounded frame floating against the page background.

Desktop is unchanged.

## Test plan

- [x] ``npm test`` — 90 passing
- [x] ``npm run lint`` (tsc) clean
- [x] Verified manually on a narrow viewport: editor occupies the full mobile viewport (no surrounding padding, no rounded corners), header / nav-toggle / install/save buttons all still reachable, desktop layout unchanged