### PR TITLE
Use transport-agnostic icons for device online/offline/unknown

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -1,5 +1,13 @@
 import { consume } from "@lit/context";
-import { mdiClose, mdiConsole, mdiPencil, mdiUpload, mdiWifi, mdiWifiOff } from "@mdi/js";
+import {
+  mdiCheckNetworkOutline,
+  mdiClose,
+  mdiConsole,
+  mdiHelpNetworkOutline,
+  mdiNetworkOffOutline,
+  mdiPencil,
+  mdiUpload,
+} from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -13,12 +21,13 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./device-drawer-content.js";
 
 registerMdiIcons({
+  "check-network-outline": mdiCheckNetworkOutline,
   close: mdiClose,
   console: mdiConsole,
+  "help-network-outline": mdiHelpNetworkOutline,
+  "network-off-outline": mdiNetworkOffOutline,
   pencil: mdiPencil,
   upload: mdiUpload,
-  wifi: mdiWifi,
-  "wifi-off": mdiWifiOff,
 });
 
 @customElement("esphome-device-drawer")
@@ -177,6 +186,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
           color-mix(in srgb, var(--esphome-error), transparent 70%);
       }
 
+      .status-banner.unknown {
+        background: var(--wa-color-surface-lowered);
+        color: var(--wa-color-text-quiet);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+      }
+
       .status-banner wa-icon {
         font-size: 20px;
       }
@@ -198,6 +213,11 @@ export class ESPHomeDeviceDrawer extends LitElement {
         background: var(--esphome-error);
         box-shadow: 0 0 8px
           color-mix(in srgb, var(--esphome-error), transparent 50%);
+      }
+
+      .status-dot.unknown {
+        background: var(--wa-color-text-quiet);
+        opacity: 0.5;
       }
 
       /* ─── Body ─── */
@@ -293,7 +313,21 @@ export class ESPHomeDeviceDrawer extends LitElement {
     if (!device) return nothing;
 
     const online = device.state === DeviceState.ONLINE;
-    const stateClass = device.state === DeviceState.ONLINE ? "online" : "offline";
+    const offline = device.state === DeviceState.OFFLINE;
+    const stateClass = online ? "online" : offline ? "offline" : "unknown";
+    // Transport-agnostic network icons — wifi/wifi-off implied a
+    // wireless link, but plenty of devices on the network are on
+    // ethernet, so the icon was misleading at best on those.
+    const stateIcon = online
+      ? "check-network-outline"
+      : offline
+        ? "network-off-outline"
+        : "help-network-outline";
+    const stateLabel = online
+      ? this._localize("dashboard.drawer_device_online")
+      : offline
+        ? this._localize("dashboard.drawer_device_offline")
+        : this._localize("dashboard.drawer_device_unknown");
 
     return html`
       <div class="backdrop" @click=${this._close}></div>
@@ -310,11 +344,8 @@ export class ESPHomeDeviceDrawer extends LitElement {
 
         <div class="status-banner ${stateClass}">
           <span class="status-dot ${stateClass}"></span>
-          <wa-icon
-            library="mdi"
-            name=${online ? "wifi" : "wifi-off"}
-          ></wa-icon>
-          ${online ? this._localize("dashboard.drawer_device_online") : this._localize("dashboard.drawer_device_offline")}
+          <wa-icon library="mdi" name=${stateIcon}></wa-icon>
+          ${stateLabel}
         </div>
 
         <div class="body">

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -480,9 +480,10 @@ export class ESPHomeDeviceCard extends LitElement {
     }
     // Transport-agnostic network icons — wifi/wifi-off implied a
     // wireless link, but plenty of devices on the network are on
-    // ethernet. The ``check-network`` / ``network-off`` /
-    // ``help-network`` trio reads as "online", "offline", and
-    // "unknown" without baking in a guess about the link type.
+    // ethernet. The ``check-network-outline`` /
+    // ``network-off-outline`` / ``help-network-outline`` trio reads
+    // as "online", "offline", and "unknown" without baking in a
+    // guess about the link type.
     const stateIcon =
       this.state === DeviceState.ONLINE
         ? "check-network-outline"

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -2,16 +2,17 @@ import { consume } from "@lit/context";
 import {
   mdiCancel,
   mdiCheckCircle,
+  mdiCheckNetworkOutline,
   mdiCheckboxBlankOutline,
   mdiCheckboxMarked,
   mdiCloseCircle,
   mdiDotsVertical,
+  mdiHelpNetworkOutline,
   mdiLock,
   mdiLockOpenVariant,
+  mdiNetworkOffOutline,
   mdiPencil,
   mdiUpload,
-  mdiWifi,
-  mdiWifiOff,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -32,12 +33,13 @@ registerMdiIcons({
   "checkbox-marked": mdiCheckboxMarked,
   "close-circle": mdiCloseCircle,
   "dots-vertical": mdiDotsVertical,
+  "check-network-outline": mdiCheckNetworkOutline,
+  "help-network-outline": mdiHelpNetworkOutline,
   lock: mdiLock,
   "lock-open-variant": mdiLockOpenVariant,
+  "network-off-outline": mdiNetworkOffOutline,
   pencil: mdiPencil,
   upload: mdiUpload,
-  wifi: mdiWifi,
-  "wifi-off": mdiWifiOff,
 });
 
 const RECENT_JOB_ICON: Record<JobStatus, string | null> = {
@@ -476,11 +478,19 @@ export class ESPHomeDeviceCard extends LitElement {
         </div>`;
       }
     }
+    // Transport-agnostic network icons — wifi/wifi-off implied a
+    // wireless link, but plenty of devices on the network are on
+    // ethernet. The ``check-network`` / ``network-off`` /
+    // ``help-network`` trio reads as "online", "offline", and
+    // "unknown" without baking in a guess about the link type.
+    const stateIcon =
+      this.state === DeviceState.ONLINE
+        ? "check-network-outline"
+        : this.state === DeviceState.OFFLINE
+          ? "network-off-outline"
+          : "help-network-outline";
     return html`<div class="device-status ${this.state}">
-      <wa-icon
-        library="mdi"
-        name=${this.state === DeviceState.ONLINE ? "wifi" : "wifi-off"}
-      ></wa-icon>
+      <wa-icon library="mdi" name=${stateIcon}></wa-icon>
       ${this.state === DeviceState.ONLINE
         ? this._localize("dashboard.online")
         : this.state === DeviceState.OFFLINE

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -141,6 +141,7 @@
     "drawer_close": "Close",
     "drawer_device_online": "Device Online",
     "drawer_device_offline": "Device Offline",
+    "drawer_device_unknown": "Status Unknown",
     "drawer_edit": "Edit",
     "drawer_update": "Update",
     "drawer_logs": "Logs",


### PR DESCRIPTION
## Summary

The card and drawer used ``mdi:wifi`` / ``mdi:wifi-off`` for device state — implying every device is on a wireless link. Plenty of devices in a typical fleet run over ethernet, so "Device Online" rendered next to a wifi icon for a hard-wired sensor reads oddly. Switch to MDI's network family which doesn't bake in a guess about the transport:

* online → ``check-network-outline``
* offline → ``network-off-outline``
* unknown → ``help-network-outline``

The drawer's banner previously only handled ONLINE / OFFLINE — UNKNOWN got lumped with offline. Add a third ``unknown`` variant (banner + status-dot styles, plus a new ``drawer_device_unknown`` localised string "Status Unknown") so devices the dashboard hasn't observed yet stop being labelled "Offline".

## Test plan

- [x] ``npm test`` — 90 passing
- [x] ``npm run lint`` (tsc) clean
- [x] Verified manually: card + drawer render the new icons for all three states; ethernet-only devices no longer show a wifi glyph; unknown state now reads "Status Unknown" instead of being mislabelled offline