### PR TITLE
Use wa-input with-clear for the dashboard search box

### DIFF
--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -94,42 +94,14 @@ export const dashboardStyles = css`
   }
 
   .search-wrap {
-    position: relative;
     max-width: 380px;
     flex: 1;
   }
-  .search-icon {
-    position: absolute;
-    left: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 18px;
-    color: var(--wa-color-text-quiet);
-    pointer-events: none;
-    display: flex;
-    align-items: center;
-  }
   .search-input {
     width: 100%;
-    box-sizing: border-box;
-    padding: 9px 14px 9px 38px;
-    font-size: var(--wa-font-size-s);
-    font-family: inherit;
-    color: var(--wa-color-text-normal);
-    background: var(--wa-color-surface-raised);
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-m);
-    outline: none;
-    transition:
-      border-color 0.15s,
-      box-shadow 0.15s;
-  }
-  .search-input::placeholder {
-    color: var(--wa-color-text-quiet);
-  }
-  .search-input:focus {
-    border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    /* wa-input owns its own border / radius / focus ring; we only
+       set the font size so it tracks the rest of the toolbar. */
+    --font-size-medium: var(--wa-font-size-s);
   }
   .device-count {
     font-size: var(--wa-font-size-xs);

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -277,7 +277,13 @@ export class ESPHomePageDashboard extends LitElement {
         with-clear
         placeholder=${this._localize("dashboard.search_placeholder")}
         .value=${this._search}
-        @input=${(e: Event) => { this._search = (e.target as HTMLInputElement).value; }}
+        @input=${(e: Event) => {
+          // ``e.target`` is the ``<wa-input>`` custom-element host,
+          // not the inner native input — read from ``currentTarget``
+          // typed as the ``{ value }`` shape we actually rely on
+          // rather than casting to HTMLInputElement (which it isn't).
+          this._search = (e.currentTarget as unknown as { value: string }).value;
+        }}
       >
         <wa-icon slot="start" library="mdi" name="magnify"></wa-icon>
       </wa-input>

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -40,6 +40,7 @@ import { cardSkeletonTemplate, tableSkeletonTemplate } from "./dashboard-skeleto
 import { dashboardStyles } from "./dashboard-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/input/input.js";
 import "../components/api-key-dialog.js";
 import type { ESPHomeApiKeyDialog } from "../components/api-key-dialog.js";
 import "../components/confirm-dialog.js";
@@ -265,6 +266,24 @@ export class ESPHomePageDashboard extends LitElement {
     }
   };
 
+  private _renderSearchInput() {
+    // ``wa-input`` carries a built-in cross-browser clear button via
+    // ``with-clear`` — no need to hand-roll one or work around
+    // Firefox not rendering ``::-webkit-search-cancel-button``.
+    return html`<div class="search-wrap">
+      <wa-input
+        class="search-input"
+        type="search"
+        with-clear
+        placeholder=${this._localize("dashboard.search_placeholder")}
+        .value=${this._search}
+        @input=${(e: Event) => { this._search = (e.target as HTMLInputElement).value; }}
+      >
+        <wa-icon slot="start" library="mdi" name="magnify"></wa-icon>
+      </wa-input>
+    </div>`;
+  }
+
   private _renderToolbar(matchCount: number, total: number) {
     const q = this._search.trim();
     const unit = matchCount === 1 ? this._localize("dashboard.device_singular") : this._localize("dashboard.device_plural");
@@ -272,14 +291,7 @@ export class ESPHomePageDashboard extends LitElement {
     return html`
       <div class="toolbar">
         <div class="toolbar-row">
-          <div class="search-wrap">
-            <span class="search-icon"><wa-icon library="mdi" name="magnify"></wa-icon></span>
-            <input class="search-input" type="search"
-              placeholder=${this._localize("dashboard.search_placeholder")}
-              .value=${this._search}
-              @input=${(e: Event) => { this._search = (e.target as HTMLInputElement).value; }}
-            />
-          </div>
+          ${this._renderSearchInput()}
           ${this._renderSelectToggle()}
           ${this._renderViewToggle()}
         </div>
@@ -366,14 +378,7 @@ export class ESPHomePageDashboard extends LitElement {
         @enter-select-mode=${(e: CustomEvent<string>) => this._onEnterSelectMode(e.detail)}
       >
         <div slot="toolbar" class="toolbar-row">
-          <div class="search-wrap">
-            <span class="search-icon"><wa-icon library="mdi" name="magnify"></wa-icon></span>
-            <input class="search-input" type="search"
-              placeholder=${this._localize("dashboard.search_placeholder")}
-              .value=${this._search}
-              @input=${(e: Event) => { this._search = (e.target as HTMLInputElement).value; }}
-            />
-          </div>
+          ${this._renderSearchInput()}
           ${this._renderSelectToggle()}
           ${this._renderViewToggle()}
         </div>


### PR DESCRIPTION
## Summary

Firefox doesn't render ``::-webkit-search-cancel-button`` for ``<input type="search">``, so the X-to-clear in the dashboard search box was Chrome/Safari-only — Firefox users had to backspace to clear the filter.

We were using a raw ``<input>`` and would have had to hand-roll the missing affordance, but the project already pulls in ``@home-assistant/webawesome``'s ``wa-input``, which has a built-in cross-browser clear button via the ``with-clear`` attribute plus a ``start`` slot for a leading icon. Drop the bespoke input + custom focus-ring CSS + webkit-pseudo override and use the existing component:

```html
<wa-input type="search" with-clear ...>
  <wa-icon slot="start" library="mdi" name="magnify"></wa-icon>
</wa-input>
```

Pulled the input render into a single ``_renderSearchInput`` helper so the table and card views share one call site. ``wa-input`` owns its own border / radius / focus ring; the dashboard CSS shrinks to one ``--font-size-medium`` override.

## Test plan

- [x] ``npm test`` — 90 passing
- [x] ``npm run lint`` (tsc) clean
- [x] Verified manually in Chrome **and** Firefox: typing in the search box shows the X, clicking it clears the filter and restores the full device list. Magnify icon still renders on the left.