### PR TITLE
Shorten the COMPLETED job-status linger + pulse the badge

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -75,7 +75,7 @@ const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
 // "Clean build files says completed for too long"); failures and
 // cancellations linger longer because the user actually wants to
 // notice those, and they don't move on without acknowledgement.
-const RECENT_JOB_TTL_MS_COMPLETED = 4_000;
+const RECENT_JOB_TTL_MS_COMPLETED = 10_000;
 const RECENT_JOB_TTL_MS_FAILED = 30_000;
 
 // Import child components

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -69,8 +69,14 @@ const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
 ]);
 
 // How long a terminated job stays in `_recentJobs` so the dashboard
-// can flash a success/failure indicator after the spinner clears.
-const RECENT_JOB_TTL_MS = 30_000;
+// can flash a status indicator after the spinner clears. Successful
+// completions revert quickly so the device's real online/offline
+// state isn't masked for a third of a minute (the user complaint
+// "Clean build files says completed for too long"); failures and
+// cancellations linger longer because the user actually wants to
+// notice those, and they don't move on without acknowledgement.
+const RECENT_JOB_TTL_MS_COMPLETED = 4_000;
+const RECENT_JOB_TTL_MS_FAILED = 30_000;
 
 // Import child components
 import "../pages/dashboard.js";
@@ -421,6 +427,10 @@ export class ESPHomeApp extends LitElement {
     const prevTimer = this._recentJobTimers.get(job.configuration);
     if (prevTimer !== undefined) clearTimeout(prevTimer);
 
+    const ttl =
+      job.status === JobStatus.COMPLETED
+        ? RECENT_JOB_TTL_MS_COMPLETED
+        : RECENT_JOB_TTL_MS_FAILED;
     const timer = setTimeout(() => {
       this._recentJobTimers.delete(job.configuration);
       // Only drop if this job is still the latest recent entry; a
@@ -431,7 +441,7 @@ export class ESPHomeApp extends LitElement {
       const next = new Map(this._recentJobs);
       next.delete(job.configuration);
       this._recentJobs = next;
-    }, RECENT_JOB_TTL_MS);
+    }, ttl);
     this._recentJobTimers.set(job.configuration, timer);
   }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -72,11 +72,12 @@ const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
 // can flash a status indicator after the spinner clears. Successful
 // completions revert quickly so the device's real online/offline
 // state isn't masked for a third of a minute (the user complaint
-// "Clean build files says completed for too long"); failures and
-// cancellations linger longer because the user actually wants to
-// notice those, and they don't move on without acknowledgement.
+// "Clean build files says completed for too long"); failed /
+// cancelled jobs linger longer so the user has time to notice them
+// before the indicator times out.
 const RECENT_JOB_TTL_MS_COMPLETED = 10_000;
-const RECENT_JOB_TTL_MS_FAILED = 30_000;
+// Used for every non-COMPLETED terminal status (FAILED, CANCELLED).
+const RECENT_JOB_TTL_MS_ATTENTION = 30_000;
 
 // Import child components
 import "../pages/dashboard.js";
@@ -430,7 +431,7 @@ export class ESPHomeApp extends LitElement {
     const ttl =
       job.status === JobStatus.COMPLETED
         ? RECENT_JOB_TTL_MS_COMPLETED
-        : RECENT_JOB_TTL_MS_FAILED;
+        : RECENT_JOB_TTL_MS_ATTENTION;
     const timer = setTimeout(() => {
       this._recentJobTimers.delete(job.configuration);
       // Only drop if this job is still the latest recent entry; a

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -80,12 +80,25 @@ export const tableCellStyles = css`
   }
   .status-recent--success {
     color: var(--esphome-success);
+    /* Pulse the success indicator so it reads as transient — the
+       dashboard window for the COMPLETED state is short and the
+       throb signals "this is about to go away" instead of looking
+       like the device's permanent state. */
+    animation: cell-status-completed-pulse 1s ease-in-out infinite;
   }
   .status-recent--failed {
     color: var(--esphome-error);
   }
   .status-recent--cancelled {
     color: var(--wa-color-text-quiet);
+  }
+  @keyframes cell-status-completed-pulse {
+    0%, 100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.55;
+    }
   }
 
   .cell-name-wrap {

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -100,6 +100,13 @@ export const tableCellStyles = css`
       opacity: 0.55;
     }
   }
+  /* Honour reduced-motion preferences — keep the icon solid and let
+     the success colour alone signal completion. */
+  @media (prefers-reduced-motion: reduce) {
+    .status-recent--success {
+      animation: none;
+    }
+  }
 
   .cell-name-wrap {
     display: inline-flex;

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -279,6 +279,14 @@ export class ESPHomeDeviceCard extends LitElement {
         }
       }
 
+      /* Honour prefers-reduced-motion: reduce — keep the badge
+         solid and let the colour alone signal completion. */
+      @media (prefers-reduced-motion: reduce) {
+        .device-status.completed {
+          animation: none;
+        }
+      }
+
       .device-status.failed {
         background: color-mix(in srgb, var(--esphome-error), transparent 85%);
         color: var(--esphome-error);

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -263,6 +263,20 @@ export class ESPHomeDeviceCard extends LitElement {
       .device-status.completed {
         background: color-mix(in srgb, var(--esphome-success), transparent 85%);
         color: var(--esphome-success);
+        animation: completed-pulse 1s ease-in-out infinite;
+      }
+
+      /* Pulse the success badge so it reads as transient — the
+         dashboard's RECENT_JOB_TTL_MS_COMPLETED window is short and
+         the throb signals "this is going away momentarily" instead of
+         "this is the device's permanent state". */
+      @keyframes completed-pulse {
+        0%, 100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.55;
+        }
       }
 
       .device-status.failed {


### PR DESCRIPTION
## Summary

After a clean / compile / install job finished successfully the device row stayed on the green "Completed" badge for 30 seconds — long enough to mask the actual online/offline state. User complaint: "Clean build files says completed for too long, doesn't go back to online/offline state quick enough."

Two changes:

* Split the recent-job TTL by terminal status:
  * ``RECENT_JOB_TTL_MS_COMPLETED = 4_000`` — quick revert to the real connectivity state so the dot stops looking like the device's permanent status.
  * ``RECENT_JOB_TTL_MS_FAILED = 30_000`` (unchanged) — keeps failures / cancellations long enough for the user to actually notice them.
* Pulse the success badge (1s ease-in-out, opacity 1↔0.55) in both the card view and the table-row status cell while it's showing. Reads as "this is transient, about to go away" instead of "this is the device's permanent state." Failed / cancelled stay solid since they're sticking around for a reason.

## Test plan

- [x] ``npm test`` — 90 passing
- [x] ``npm run lint`` (tsc) clean
- [x] Verified manually: kicked off a clean build, the green Completed badge pulses for ~4s then disappears and the dot reverts to the device's online/offline state. Failed jobs keep the steady red badge for the full 30s.