### PR TITLE
Add hide-states toggle to log viewer toolbar

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -457,8 +457,17 @@ export class ESPHomeAPI {
   }
 
   /** Stream logs from a device (streaming, not queued). */
-  logs(configuration: string, port: string, callbacks: StreamCallbacks): string {
-    return this.sendStreamCommand("devices/logs", { configuration, port }, callbacks);
+  logs(
+    configuration: string,
+    port: string,
+    callbacks: StreamCallbacks,
+    options: { noStates?: boolean } = {},
+  ): string {
+    const payload: Record<string, unknown> = { configuration, port };
+    if (options.noStates) {
+      payload.no_states = true;
+    }
+    return this.sendStreamCommand("devices/logs", payload, callbacks);
   }
 
   /**

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -410,7 +410,6 @@ export class ESPHomeLogsDialog extends LitElement {
   private _startStreaming() {
     if (this._streaming) return;
     this._streaming = true;
-    this._lines = [];
 
     this._streamId = this._api.logs(
       this.configuration,

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -23,15 +23,6 @@ registerMdiIcons({
   pulse: mdiPulse,
 });
 
-/* Match component state-publish lines so the user can mute the
-   high-volume sensor / binary_sensor / switch / cover / climate
-   noise and still see the lower-frequency lifecycle messages. The
-   anchors (`: ` or ` - `) keep the test from triggering on
-   incidental occurrences of the phrase inside a free-form log
-   message. */
-const STATE_LINE_RE =
-  /(?:: |\s-\s)(?:Sending state|Publishing:|Got state|Received state)\b/i;
-
 @customElement("esphome-logs-dialog")
 export class ESPHomeLogsDialog extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -347,9 +338,6 @@ export class ESPHomeLogsDialog extends LitElement {
 
   protected render() {
     const title = this._localize("dashboard.logs_title", { name: this.name });
-    const visibleLines = this._hideStates
-      ? this._lines.filter((line) => !STATE_LINE_RE.test(line))
-      : this._lines;
     const toggleLabel = this._localize(
       this._hideStates ? "dashboard.logs_show_states" : "dashboard.logs_hide_states",
     );
@@ -362,7 +350,7 @@ export class ESPHomeLogsDialog extends LitElement {
       >
         <div class="logs-content">
           <esphome-ansi-log
-            .lines=${visibleLines}
+            .lines=${this._lines}
             placeholder=${this._localize("dashboard.logs_placeholder")}
             ?light=${!this._darkMode}
           ></esphome-ansi-log>
@@ -378,7 +366,6 @@ export class ESPHomeLogsDialog extends LitElement {
               aria-pressed=${this._hideStates ? "true" : "false"}
             >
               <wa-icon library="mdi" name="pulse"></wa-icon>
-              ${toggleLabel}
             </button>
             <button
               class="term-btn term-btn--ghost expand-btn"
@@ -424,19 +411,24 @@ export class ESPHomeLogsDialog extends LitElement {
     this._streaming = true;
     this._lines = [];
 
-    this._streamId = this._api.logs(this.configuration, this._port, {
-      onOutput: (line: string) => {
-        this._lines = [...this._lines, line];
+    this._streamId = this._api.logs(
+      this.configuration,
+      this._port,
+      {
+        onOutput: (line: string) => {
+          this._lines = [...this._lines, line];
+        },
+        onResult: () => {
+          this._streaming = false;
+          this._streamId = "";
+        },
+        onError: () => {
+          this._streaming = false;
+          this._streamId = "";
+        },
       },
-      onResult: () => {
-        this._streaming = false;
-        this._streamId = "";
-      },
-      onError: () => {
-        this._streaming = false;
-        this._streamId = "";
-      },
-    });
+      { noStates: this._hideStates },
+    );
   }
 
   private _stopStreaming() {
@@ -470,6 +462,15 @@ export class ESPHomeLogsDialog extends LitElement {
 
   private _toggleHideStates() {
     this._hideStates = !this._hideStates;
+    /* The --no-states flag is set on the esphome subprocess at spawn
+       time, so flipping the toggle has to tear down the current
+       stream and start a fresh one. Only restart if we were actively
+       streaming — if the user already hit Stop, leave the buffer
+       alone and let them hit Start themselves. */
+    if (this._streamId) {
+      this._stopStreaming();
+      this._startStreaming();
+    }
   }
 
   private _clearLogs() {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -366,6 +366,7 @@ export class ESPHomeLogsDialog extends LitElement {
               aria-pressed=${this._hideStates ? "true" : "false"}
             >
               <wa-icon library="mdi" name="pulse"></wa-icon>
+              ${this._localize("dashboard.logs_states")}
             </button>
             <button
               class="term-btn term-btn--ghost expand-btn"

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -49,7 +49,7 @@ export class ESPHomeLogsDialog extends LitElement {
   private _expanded = false;
 
   @state()
-  private _hideStates = true;
+  private _showStates = true;
 
   @state()
   _lines: string[] = [];
@@ -339,7 +339,7 @@ export class ESPHomeLogsDialog extends LitElement {
   protected render() {
     const title = this._localize("dashboard.logs_title", { name: this.name });
     const toggleLabel = this._localize(
-      this._hideStates ? "dashboard.logs_show_states" : "dashboard.logs_hide_states",
+      this._showStates ? "dashboard.logs_hide_states" : "dashboard.logs_show_states",
     );
 
     return html`
@@ -360,10 +360,10 @@ export class ESPHomeLogsDialog extends LitElement {
               : ""}
             <span class="spacer"></span>
             <button
-              class="term-btn term-btn--ghost ${this._hideStates ? "is-active" : ""}"
-              @click=${this._toggleHideStates}
+              class="term-btn term-btn--ghost ${this._showStates ? "is-active" : ""}"
+              @click=${this._toggleShowStates}
               title=${toggleLabel}
-              aria-pressed=${this._hideStates ? "true" : "false"}
+              aria-pressed=${this._showStates ? "true" : "false"}
             >
               <wa-icon library="mdi" name="pulse"></wa-icon>
               ${this._localize("dashboard.logs_states")}
@@ -428,7 +428,7 @@ export class ESPHomeLogsDialog extends LitElement {
           this._streamId = "";
         },
       },
-      { noStates: this._hideStates },
+      { noStates: !this._showStates },
     );
   }
 
@@ -461,8 +461,8 @@ export class ESPHomeLogsDialog extends LitElement {
     this._expanded = !this._expanded;
   }
 
-  private _toggleHideStates() {
-    this._hideStates = !this._hideStates;
+  private _toggleShowStates() {
+    this._showStates = !this._showStates;
     /* The --no-states flag is set on the esphome subprocess at spawn
        time, so flipping the toggle has to tear down the current
        stream and start a fresh one. Only restart if we were actively

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -206,9 +206,10 @@ export class ESPHomeLogsDialog extends LitElement {
         border-color: var(--term-fg-muted);
       }
 
-      /* Highlight the states toggle when filtering is on so the user
-         sees at a glance that some lines are being suppressed. Same
-         palette as --start; the icon flip alone is too subtle. */
+      /* Tint the states toggle with the accent palette while the
+         "show states" mode is on so the user can tell at a glance
+         whether component state lines are flowing. Same palette as
+         --start so it visually reads as "this is active". */
       .term-btn--ghost.is-active {
         background: color-mix(in srgb, var(--term-accent), transparent 85%);
         color: var(--term-accent);
@@ -431,16 +432,17 @@ export class ESPHomeLogsDialog extends LitElement {
     );
   }
 
-  private _stopStreaming() {
+  private _stopStreaming(): Promise<void> {
     const streamId = this._streamId;
     this._streaming = false;
     this._streamId = "";
-    if (streamId) {
-      // Tell the backend to kill the subprocess. If the WS isn't open
-      // anymore there's nothing to cancel server-side anyway, so swallow
-      // any error from the call.
-      this._api.stopStream(streamId).catch(() => {});
-    }
+    if (!streamId) return Promise.resolve();
+    // Tell the backend to kill the subprocess. If the WS isn't open
+    // anymore there's nothing to cancel server-side anyway, so swallow
+    // any error from the call. Returns a promise so callers that need
+    // to wait for the cancel to land (e.g. the states toggle, which
+    // immediately spawns a fresh stream) can await it.
+    return this._api.stopStream(streamId).catch(() => undefined).then(() => undefined);
   }
 
   private _downloadLogs() {
@@ -460,17 +462,19 @@ export class ESPHomeLogsDialog extends LitElement {
     this._expanded = !this._expanded;
   }
 
-  private _toggleShowStates() {
+  private async _toggleShowStates() {
     this._showStates = !this._showStates;
     /* The --no-states flag is set on the esphome subprocess at spawn
        time, so flipping the toggle has to tear down the current
-       stream and start a fresh one. Only restart if we were actively
-       streaming — if the user already hit Stop, leave the buffer
-       alone and let them hit Start themselves. */
-    if (this._streamId) {
-      this._stopStreaming();
-      this._startStreaming();
-    }
+       stream and start a fresh one. Await the cancel so the backend
+       has actually killed the old subprocess before we spawn the new
+       one — otherwise a fast double-toggle could leave two log
+       readers attached to the device API at once. Only restart if we
+       were actively streaming — if the user already hit Stop, leave
+       the buffer alone and let them hit Start themselves. */
+    if (!this._streamId) return;
+    await this._stopStreaming();
+    this._startStreaming();
   }
 
   private _clearLogs() {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowCollapse, mdiArrowExpand, mdiClose, mdiDeleteSweep, mdiDownload, mdiPlay, mdiStop } from "@mdi/js";
+import { mdiArrowCollapse, mdiArrowExpand, mdiClose, mdiDeleteSweep, mdiDownload, mdiPlay, mdiPulse, mdiStop } from "@mdi/js";
 import { LitElement, css, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
@@ -20,7 +20,17 @@ registerMdiIcons({
   play: mdiPlay,
   stop: mdiStop,
   "delete-sweep": mdiDeleteSweep,
+  pulse: mdiPulse,
 });
+
+/* Match component state-publish lines so the user can mute the
+   high-volume sensor / binary_sensor / switch / cover / climate
+   noise and still see the lower-frequency lifecycle messages. The
+   anchors (`: ` or ` - `) keep the test from triggering on
+   incidental occurrences of the phrase inside a free-form log
+   message. */
+const STATE_LINE_RE =
+  /(?:: |\s-\s)(?:Sending state|Publishing:|Got state|Received state)\b/i;
 
 @customElement("esphome-logs-dialog")
 export class ESPHomeLogsDialog extends LitElement {
@@ -46,6 +56,9 @@ export class ESPHomeLogsDialog extends LitElement {
 
   @state()
   private _expanded = false;
+
+  @state()
+  private _hideStates = false;
 
   @state()
   _lines: string[] = [];
@@ -202,6 +215,15 @@ export class ESPHomeLogsDialog extends LitElement {
         border-color: var(--term-fg-muted);
       }
 
+      /* Highlight the states toggle when filtering is on so the user
+         sees at a glance that some lines are being suppressed. Same
+         palette as --start; the icon flip alone is too subtle. */
+      .term-btn--ghost.is-active {
+        background: color-mix(in srgb, var(--term-accent), transparent 85%);
+        color: var(--term-accent);
+        border-color: color-mix(in srgb, var(--term-accent), transparent 60%);
+      }
+
       .term-btn--start {
         background: color-mix(in srgb, var(--term-accent), transparent 85%);
         color: var(--term-accent);
@@ -325,6 +347,12 @@ export class ESPHomeLogsDialog extends LitElement {
 
   protected render() {
     const title = this._localize("dashboard.logs_title", { name: this.name });
+    const visibleLines = this._hideStates
+      ? this._lines.filter((line) => !STATE_LINE_RE.test(line))
+      : this._lines;
+    const toggleLabel = this._localize(
+      this._hideStates ? "dashboard.logs_show_states" : "dashboard.logs_hide_states",
+    );
 
     return html`
       <wa-dialog
@@ -334,7 +362,7 @@ export class ESPHomeLogsDialog extends LitElement {
       >
         <div class="logs-content">
           <esphome-ansi-log
-            .lines=${this._lines}
+            .lines=${visibleLines}
             placeholder=${this._localize("dashboard.logs_placeholder")}
             ?light=${!this._darkMode}
           ></esphome-ansi-log>
@@ -343,6 +371,15 @@ export class ESPHomeLogsDialog extends LitElement {
               ? html`<span class="streaming-dot"></span>`
               : ""}
             <span class="spacer"></span>
+            <button
+              class="term-btn term-btn--ghost ${this._hideStates ? "is-active" : ""}"
+              @click=${this._toggleHideStates}
+              title=${toggleLabel}
+              aria-pressed=${this._hideStates ? "true" : "false"}
+            >
+              <wa-icon library="mdi" name="pulse"></wa-icon>
+              ${toggleLabel}
+            </button>
             <button
               class="term-btn term-btn--ghost expand-btn"
               @click=${this._toggleExpanded}
@@ -429,6 +466,10 @@ export class ESPHomeLogsDialog extends LitElement {
 
   private _toggleExpanded() {
     this._expanded = !this._expanded;
+  }
+
+  private _toggleHideStates() {
+    this._hideStates = !this._hideStates;
   }
 
   private _clearLogs() {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -49,7 +49,7 @@ export class ESPHomeLogsDialog extends LitElement {
   private _expanded = false;
 
   @state()
-  private _hideStates = false;
+  private _hideStates = true;
 
   @state()
   _lines: string[] = [];

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -52,6 +52,9 @@ export class ESPHomeLogsDialog extends LitElement {
   private _showStates = true;
 
   @state()
+  private _passive = false;
+
+  @state()
   _lines: string[] = [];
 
   private _streamId = "";
@@ -317,6 +320,12 @@ export class ESPHomeLogsDialog extends LitElement {
     this._lines = [];
     this._streaming = false;
     this._expanded = false;
+    /* Reset to the default each open. Persisting "hide states" across
+       a close/reopen would surprise the user — the dialog is supposed
+       to behave the same way every time it pops up unless the user
+       explicitly flips the toggle this session. */
+    this._showStates = true;
+    this._passive = false;
     this._streamId = "";
     this._dialog.open = true;
     this._startStreaming();
@@ -328,6 +337,12 @@ export class ESPHomeLogsDialog extends LitElement {
     this._lines = [];
     this._streaming = true;
     this._expanded = false;
+    this._showStates = true;
+    /* Web Serial drives output directly into ``_lines`` via
+       ``streamSerialToDialog`` — there's no backend ``esphome logs``
+       subprocess to pass ``--no-states`` to, so the toggle is hidden
+       in passive mode to avoid implying state filtering is available. */
+    this._passive = true;
     this._streamId = "";
     this._dialog.open = true;
   }
@@ -360,15 +375,19 @@ export class ESPHomeLogsDialog extends LitElement {
               ? html`<span class="streaming-dot"></span>`
               : ""}
             <span class="spacer"></span>
-            <button
-              class="term-btn term-btn--ghost ${this._showStates ? "is-active" : ""}"
-              @click=${this._toggleShowStates}
-              title=${toggleLabel}
-              aria-pressed=${this._showStates ? "true" : "false"}
-            >
-              <wa-icon library="mdi" name="pulse"></wa-icon>
-              ${this._localize("dashboard.logs_states")}
-            </button>
+            ${this._passive
+              ? ""
+              : html`
+                  <button
+                    class="term-btn term-btn--ghost ${this._showStates ? "is-active" : ""}"
+                    @click=${this._toggleShowStates}
+                    title=${toggleLabel}
+                    aria-pressed=${this._showStates ? "true" : "false"}
+                  >
+                    <wa-icon library="mdi" name="pulse"></wa-icon>
+                    ${this._localize("dashboard.logs_states")}
+                  </button>
+                `}
             <button
               class="term-btn term-btn--ghost expand-btn"
               @click=${this._toggleExpanded}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,6 +43,7 @@
     "logs_start": "Start",
     "logs_close": "Close",
     "logs_clear": "Clear",
+    "logs_states": "States",
     "logs_hide_states": "Hide states",
     "logs_show_states": "Show states",
     "select_all": "Select all",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,6 +43,8 @@
     "logs_start": "Start",
     "logs_close": "Close",
     "logs_clear": "Clear",
+    "logs_hide_states": "Hide states",
+    "logs_show_states": "Show states",
     "select_all": "Select all",
     "deselect_all": "Deselect all",
     "selected_count": "{count} selected",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -133,6 +133,8 @@
     "logs_start": "Démarrer",
     "logs_close": "Fermer",
     "logs_clear": "Effacer",
+    "logs_hide_states": "Masquer les états",
+    "logs_show_states": "Afficher les états",
     "install_method_title": "Comment voulez-vous installer le firmware ?",
     "install_method_network": "Sur le réseau",
     "install_method_network_desc": "Nécessite que l'appareil soit en ligne",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -133,6 +133,7 @@
     "logs_start": "Démarrer",
     "logs_close": "Fermer",
     "logs_clear": "Effacer",
+    "logs_states": "États",
     "logs_hide_states": "Masquer les états",
     "logs_show_states": "Afficher les états",
     "install_method_title": "Comment voulez-vous installer le firmware ?",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -133,6 +133,8 @@
     "logs_start": "Starten",
     "logs_close": "Sluiten",
     "logs_clear": "Wissen",
+    "logs_hide_states": "Statussen verbergen",
+    "logs_show_states": "Statussen tonen",
     "install_method_title": "Hoe wilt u de firmware installeren?",
     "install_method_network": "Via het netwerk",
     "install_method_network_desc": "Vereist dat het apparaat online is",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -133,6 +133,7 @@
     "logs_start": "Starten",
     "logs_close": "Sluiten",
     "logs_clear": "Wissen",
+    "logs_states": "Statussen",
     "logs_hide_states": "Statussen verbergen",
     "logs_show_states": "Statussen tonen",
     "install_method_title": "Hoe wilt u de firmware installeren?",

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -410,6 +410,36 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     expect(sent.args).toEqual({ configuration: "foo.yaml" });
   });
 
+  it("logs sends devices/logs without no_states by default", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const id = api.logs("foo.yaml", "OTA", { onOutput: () => {} });
+    expect(id).toBeTruthy();
+    const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
+    expect(sent.command).toBe("devices/logs");
+    expect(sent.args).toEqual({ configuration: "foo.yaml", port: "OTA" });
+  });
+
+  it("logs forwards no_states=true when noStates is set", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    api.logs("foo.yaml", "OTA", { onOutput: () => {} }, { noStates: true });
+    const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
+    expect(sent.args).toEqual({
+      configuration: "foo.yaml",
+      port: "OTA",
+      no_states: true,
+    });
+  });
+
+  it("logs omits no_states when noStates is false", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    api.logs("foo.yaml", "OTA", { onOutput: () => {} }, { noStates: false });
+    const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
+    expect(sent.args).toEqual({ configuration: "foo.yaml", port: "OTA" });
+  });
+
   it("updatePreferences passes the partial prefs as args", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);


### PR DESCRIPTION
## Summary

- Adds a "States" toggle to the logs dialog toolbar that mirrors the legacy ESPHome dashboard's "Show entity state changes" option.
- Toggle is **on by default** so the dialog opens with the full stream visible. Unchecking it tears down and restarts the log subprocess with `--no-states` (paired with backend [device-builder#53](https://github.com/esphome/device-builder/pull/53)) — filtering happens at the source, no client-side regex.
- Toggle is highlighted with the accent palette while active so the muted state is visible at a glance; `aria-pressed` is set for screen readers.
- The log buffer is preserved across the toggle, Stop, and Start. Only the Clear button (and switching devices) wipes it.

## Test plan

- [x] Open a device's logs — toggle is checked, full stream flows including sensor state lines.
- [x] Click the toggle — stream restarts with `--no-states`, state lines stop arriving, prior buffer is preserved.
- [x] Click again — full stream resumes.
- [x] Stop, Start — buffer preserved.
- [x] Clear — buffer wiped.
- [x] Switch to a different device's logs — buffer wiped (new context).