### PR TITLE
Compact editor header + expand toggle for full-viewport editing

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -24,6 +24,23 @@ export const deviceEditorStyles = css`
     color: var(--esphome-on-primary);
   }
 
+  /* Navigator hidden + YAML-only layout = the title bar is the only
+     non-editor chrome left on screen. Squeeze it so it gives the
+     YAML editor back the vertical space the user already implicitly
+     asked for by collapsing both panels. */
+  .card-header--compact {
+    padding: var(--wa-space-2xs) var(--wa-space-m);
+  }
+
+  .card-header--compact .editor-header-title {
+    font-size: var(--wa-font-size-2xs);
+  }
+
+  .card-header--compact .layout-toggle wa-icon,
+  .card-header--compact .diff-toggle wa-icon {
+    font-size: 16px;
+  }
+
   .editor-header-main {
     display: flex;
     flex-direction: column;

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -5,6 +5,20 @@ export const deviceEditorStyles = css`
     display: contents;
   }
 
+  /* Fullscreen mode covers the surrounding app shell (top bar,
+     navigator, page padding). The card-header stays visible so the
+     user keeps Save / layout / Collapse within reach — same shape as
+     the logs dialog's expand mode. z-index sits above app chrome
+     (which uses values up to ~50) but below modal dialogs (>=1000). */
+  :host([fullscreen]) .card {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
   .card {
     background: var(--wa-color-surface-default);
     border-radius: var(--wa-border-radius-l);
@@ -162,6 +176,30 @@ export const deviceEditorStyles = css`
 
   .diff-toggle wa-icon {
     font-size: 18px;
+  }
+
+  .fullscreen-toggle {
+    border: none;
+    background: transparent;
+    color: var(--esphome-on-primary);
+    padding: 2px 4px;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .fullscreen-toggle wa-icon {
+    font-size: 18px;
+  }
+
+  .fullscreen-toggle:hover {
+    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+  }
+
+  .card-header--compact .fullscreen-toggle wa-icon {
+    font-size: 16px;
   }
 
   .layout-toggle {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -1,5 +1,7 @@
 import { consume } from "@lit/context";
 import {
+  mdiArrowCollapse,
+  mdiArrowExpand,
   mdiContentSave,
   mdiDockLeft,
   mdiDockRight,
@@ -24,6 +26,8 @@ import "../yaml-diff.js";
 import "./device-board-info.js";
 
 registerMdiIcons({
+  "arrow-collapse": mdiArrowCollapse,
+  "arrow-expand": mdiArrowExpand,
   "content-save": mdiContentSave,
   "layout-left": mdiDockLeft,
   "layout-right": mdiDockRight,
@@ -67,21 +71,31 @@ export class ESPHomeDeviceEditor extends LitElement {
   @state()
   private _isMobile = false;
 
+  @state()
+  private _fullscreen = false;
+
   private _mql = window.matchMedia("(max-width: 900px)");
 
   private _onMqlChange = (e: MediaQueryListEvent) => {
     this._isMobile = e.matches;
   };
 
-  /** Cmd/Ctrl+S → save the YAML if there are unsaved changes. Listens at
-   *  the document level so the shortcut works regardless of which child
-   *  (CodeMirror, navigator, etc.) currently has focus. */
+  /** Cmd/Ctrl+S → save the YAML if there are unsaved changes. Also
+   *  ESC to exit fullscreen so the editor matches the logs dialog
+   *  pattern. Listens at the document level so the shortcut works
+   *  regardless of which child (CodeMirror, navigator, etc.) currently
+   *  has focus. */
   private _onGlobalKeyDown = (e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "s") {
       e.preventDefault();
       if (this.yaml !== this.savedYaml) {
         this._onSave();
       }
+      return;
+    }
+    if (e.key === "Escape" && this._fullscreen) {
+      e.preventDefault();
+      this._fullscreen = false;
     }
   };
 
@@ -217,6 +231,24 @@ export class ESPHomeDeviceEditor extends LitElement {
                 <wa-icon library="mdi" name="layout-right"></wa-icon>
               </button>
             </div>
+            ${this._isMobile
+              ? nothing
+              : html`<button
+                  type="button"
+                  class="fullscreen-toggle"
+                  aria-pressed=${this._fullscreen}
+                  @click=${this._toggleFullscreen}
+                  title=${this._localize(
+                    this._fullscreen
+                      ? "device.editor_collapse"
+                      : "device.editor_expand",
+                  )}
+                >
+                  <wa-icon
+                    library="mdi"
+                    name=${this._fullscreen ? "arrow-collapse" : "arrow-expand"}
+                  ></wa-icon>
+                </button>`}
           </div>
         </header>
         <div class="card-body">
@@ -346,6 +378,16 @@ export class ESPHomeDeviceEditor extends LitElement {
         composed: true,
       })
     );
+  }
+
+  private _toggleFullscreen() {
+    this._fullscreen = !this._fullscreen;
+  }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("_fullscreen")) {
+      this.toggleAttribute("fullscreen", this._fullscreen);
+    }
   }
 
   /**

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -46,6 +46,13 @@ export class ESPHomeDeviceEditor extends LitElement {
   @property()
   layout: DeviceLayoutMode = "both";
 
+  /** Forwarded from the page so the editor can shrink its own header
+   *  chrome when both side panels are out of view (navigator hidden +
+   *  YAML-only layout). With nothing else on screen the title bar
+   *  ate vertical space the user couldn't reclaim. */
+  @property({ type: Boolean })
+  navCollapsed = false;
+
   @property()
   deviceTitle = "";
 
@@ -142,6 +149,14 @@ export class ESPHomeDeviceEditor extends LitElement {
         : effectiveLayout === "left"
           ? "editor-layout--left"
           : "editor-layout--right";
+    /* When the user has hidden the navigator AND chosen YAML-only,
+       the only thing on screen is the YAML editor — the bulky title
+       bar is just chrome at that point. Compact it (less padding,
+       smaller title) so the editor reclaims the vertical space.
+       Mobile already has its own header treatment so we leave that
+       alone. */
+    const compactHeader =
+      !this._isMobile && this.navCollapsed && effectiveLayout === "right";
 
     // Single, calm title — guidance for empty / partially-filled
     // devices belongs in the content pane (the cards / step prompts),
@@ -152,7 +167,7 @@ export class ESPHomeDeviceEditor extends LitElement {
 
     return html`
       <section class="card">
-        <header class="card-header">
+        <header class="card-header ${compactHeader ? "card-header--compact" : ""}">
           <slot name="mobile-menu"></slot>
           <div class="editor-header-main">
             <h2 class="editor-header-title">${title}</h2>

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -374,6 +374,7 @@ export class ESPHomePageDevice extends LitElement {
             .yaml=${this._yaml}
             .savedYaml=${this._savedYaml}
             .layout=${this._layout}
+            ?navCollapsed=${this._navCollapsed}
             .deviceTitle=${deviceTitle}
             .board=${this._board}
             .highlightRange=${this._highlightRange}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -416,6 +416,8 @@
     "add_automation_unavailable": "Automation support is not yet available",
     "add_config_error": "Failed to add config section",
     "editor_layout_label": "Editor layout",
+    "editor_expand": "Expand editor",
+    "editor_collapse": "Collapse editor",
     "yaml_preview": "YAML preview",
     "yaml_preview_toggle": "Show YAML",
     "diff_view_diff": "Show diff against saved",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -348,6 +348,8 @@
     "add_automation_unavailable": "Le support des automatisations n'est pas encore disponible",
     "add_config_error": "Échec de l'ajout de la section de configuration",
     "editor_layout_label": "Disposition de l'éditeur",
+    "editor_expand": "Agrandir l'éditeur",
+    "editor_collapse": "Réduire l'éditeur",
     "editor_title_ready": "Édition de {name}",
     "delete_section": "Supprimer la section",
     "confirm_delete_section": "Êtes-vous sûr de vouloir supprimer la section « {name} » ?",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -348,6 +348,8 @@
     "add_automation_unavailable": "Ondersteuning voor automatiseringen is nog niet beschikbaar",
     "add_config_error": "Toevoegen van configuratiesectie mislukt",
     "editor_layout_label": "Editor-indeling",
+    "editor_expand": "Editor uitvouwen",
+    "editor_collapse": "Editor inklappen",
     "editor_title_ready": "{name} bewerken",
     "delete_section": "Sectie verwijderen",
     "confirm_delete_section": "Weet u zeker dat u de sectie '{name}' wilt verwijderen?",


### PR DESCRIPTION
## Summary

Two related ergonomics fixes for the device editor:

- **Compact header** — when the user has hidden the navigator AND chosen YAML-only layout, the card-header (title + diff + layout toggles) shrinks: tighter vertical padding, smaller title and toggle icons. With both side panels gone the only thing on screen is the YAML editor, so the bulky title bar was eating space the user implicitly asked to reclaim.
- **Expand / collapse toggle** — a new arrow-expand button (mirrors the logs dialog's pattern) flips the editor card to `position: fixed; inset: 0` so it covers the surrounding app shell (top bar, navigator, page padding) while keeping its own header (Save / Diff / Layout / Collapse) accessible. ESC exits fullscreen. Hidden on mobile (which already goes edge-to-edge via the existing `@media (max-width: 900px)` rules).

## Test plan

- [x] Desktop, navigator visible, layout=both: header normal size, no expand button regression.
- [x] Desktop, navigator hidden, layout=right: header noticeably shrinks (less padding, smaller title).
- [x] Desktop, click expand: editor covers full viewport, app top bar / navigator / page padding all gone, editor card-header still visible.
- [x] Click collapse (or press ESC): editor returns to its in-page slot.
- [x] Switch layouts while expanded: layout buttons still work, fullscreen state preserved.
- [x] Mobile: expand button is hidden (the existing mobile full-bleed rules already cover that case).
- [x] localizations (en/nl/fr) carry `editor_expand` / `editor_collapse`.