### PR TITLE
Add 'Visit web UI' click-through on the device card

### DIFF
--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -8,6 +8,7 @@ import {
   mdiDownload,
   mdiFileDownloadOutline,
   mdiKeyVariant,
+  mdiOpenInNew,
   mdiPencil,
   mdiRenameOutline,
   mdiUpload,
@@ -31,6 +32,7 @@ registerMdiIcons({
   download: mdiDownload,
   "file-download-outline": mdiFileDownloadOutline,
   "key-variant": mdiKeyVariant,
+  "open-in-new": mdiOpenInNew,
   pencil: mdiPencil,
   "rename-outline": mdiRenameOutline,
   upload: mdiUpload,
@@ -174,6 +176,12 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}
         </div>
+        ${this.device?.web_port != null
+          ? html`<div class="menu-item" @click=${this._openWebUi}>
+              <wa-icon library="mdi" name="open-in-new"></wa-icon>
+              ${this._localize("dashboard.action_visit_web_ui")}
+            </div>`
+          : nothing}
         <div class="menu-divider"></div>
         ${this.device?.api_encrypted
           ? html`<div class="menu-item" @click=${() => this._emit("show-api-key")}>
@@ -277,6 +285,18 @@ export class ESPHomeTableRowMenu extends LitElement {
     );
     this._close();
   }
+
+  private _openWebUi = () => {
+    // Pure navigation — no app state to update, so we don't bounce
+    // through the parent like the other menu items do.
+    if (!this.device || this.device.web_port == null) return;
+    const port = this.device.web_port;
+    const host = this.device.address || this.device.ip;
+    if (!host) return;
+    const url = `http://${host}${port === 80 ? "" : `:${port}`}`;
+    window.open(url, "_blank", "noopener");
+    this._close();
+  };
 }
 
 declare global {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -116,6 +116,15 @@ export class ESPHomeTableRowMenu extends LitElement {
         background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
       }
 
+      /* The Visit-web-UI item renders as an <a> so the browser
+         enforces rel="noopener noreferrer" instead of relying on a
+         flaky window.open flag. Reset anchor defaults so it visually
+         matches the surrounding <div class="menu-item"> items. */
+      .menu-item--link {
+        text-decoration: none;
+        color: inherit;
+      }
+
       .menu-item wa-icon {
         font-size: 16px;
         color: var(--wa-color-text-quiet);
@@ -176,12 +185,7 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}
         </div>
-        ${this.device?.web_port != null
-          ? html`<div class="menu-item" @click=${this._openWebUi}>
-              <wa-icon library="mdi" name="open-in-new"></wa-icon>
-              ${this._localize("dashboard.action_visit_web_ui")}
-            </div>`
-          : nothing}
+        ${this._renderVisitWebUi()}
         <div class="menu-divider"></div>
         ${this.device?.api_encrypted
           ? html`<div class="menu-item" @click=${() => this._emit("show-api-key")}>
@@ -286,17 +290,35 @@ export class ESPHomeTableRowMenu extends LitElement {
     this._close();
   }
 
-  private _openWebUi = () => {
-    // Pure navigation — no app state to update, so we don't bounce
-    // through the parent like the other menu items do.
-    if (!this.device || this.device.web_port == null) return;
-    const port = this.device.web_port;
+  private _renderVisitWebUi() {
+    // Render only when we actually have somewhere to send the user:
+    // a port from the YAML's ``web_server:`` block AND a resolvable
+    // host. ``ip`` stays empty until the device has been seen online,
+    // and ``address`` should always be populated from StorageJSON,
+    // but the guard means the menu item never appears as a no-op.
+    if (this.device == null || this.device.web_port == null) return nothing;
     const host = this.device.address || this.device.ip;
-    if (!host) return;
+    if (!host) return nothing;
+    const port = this.device.web_port;
     const url = `http://${host}${port === 80 ? "" : `:${port}`}`;
-    window.open(url, "_blank", "noopener");
-    this._close();
-  };
+    // Anchor element with ``rel="noopener noreferrer"`` is the
+    // codebase's standard external-link pattern; the browser enforces
+    // the security defaults instead of relying on
+    // ``window.open(..., "noopener")`` which doesn't suppress the
+    // Referer header and isn't honoured uniformly across browsers.
+    return html`
+      <a
+        class="menu-item menu-item--link"
+        href=${url}
+        target="_blank"
+        rel="noopener noreferrer"
+        @click=${this._close}
+      >
+        <wa-icon library="mdi" name="open-in-new"></wa-icon>
+        ${this._localize("dashboard.action_visit_web_ui")}
+      </a>
+    `;
+  }
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -69,6 +69,7 @@
     "action_rename": "Rename hostname",
     "action_clean_build": "Clean build files",
     "action_download_elf": "Download ELF file",
+    "action_visit_web_ui": "Visit web UI",
     "action_validate_success": "\"{name}\" configuration is valid",
     "action_validate_failed": "Validation failed for \"{name}\"",
     "action_install_started": "Installing \"{name}\"…",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -45,6 +45,7 @@
     "action_rename": "Renommer l'hôte",
     "action_clean_build": "Nettoyer les fichiers de compilation",
     "action_download_elf": "Télécharger le fichier ELF",
+    "action_visit_web_ui": "Ouvrir l'interface web",
     "action_validate_success": "La configuration de \"{name}\" est valide",
     "action_validate_failed": "Échec de la validation pour \"{name}\"",
     "action_install_started": "Installation de \"{name}\"…",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -45,6 +45,7 @@
     "action_rename": "Hostnaam hernoemen",
     "action_clean_build": "Bouwbestanden opschonen",
     "action_download_elf": "ELF-bestand downloaden",
+    "action_visit_web_ui": "Webinterface openen",
     "action_validate_success": "Configuratie van \"{name}\" is geldig",
     "action_validate_failed": "Validatie mislukt voor \"{name}\"",
     "action_install_started": "\"{name}\" installeren…",


### PR DESCRIPTION
## Summary

Restores the legacy ESPHome dashboard's click-through to the device's on-board web UI when the YAML includes a `web_server:` block.

The backend already exposes `web_port: number | null` on `ConfiguredDevice` (populated from `StorageJSON.web_port`, set by esphome at compile time). This PR wires the frontend side: when `web_port` is non-null, the device's context (kebab) menu shows a **Visit web UI** item that opens `http://<address>[:port]` in a new tab.

URL shape matches the legacy formula:
- `http://` (the `web_server` component is plain HTTP)
- omit the port when it's 80
- prefer `device.address` (mDNS hostname like `foo.local`) and fall back to `device.ip` if address is empty

Implemented as a menu item rather than an inline button on the card so the action row stays compact — the visit action is useful but not as frequent as Edit / Install / Update. Pure navigation, so the click handler calls `window.open(..., "_blank", "noopener")` directly instead of bouncing through the parent like the other menu items do.

Translations added for en / fr / nl.

## Test plan

- [x] Existing 93 tests still pass.
- [x] TypeScript lint clean.
- [ ] Visual check: a device with \`web_server:\` shows the menu item; one without doesn't.
- [ ] Click opens \`http://<host>[:port]\` in a new tab; non-default ports render correctly.