### PR TITLE
Inline row actions on table + card; dedupe with kebab

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -7,11 +7,14 @@ import {
   mdiChevronDown,
   mdiChevronUp,
   mdiCloseCircle,
+  mdiConsole,
   mdiDotsVertical,
   mdiLock,
   mdiLockOpenVariant,
+  mdiOpenInNew,
   mdiPencil,
   mdiUnfoldMoreHorizontal,
+  mdiUpload,
 } from "@mdi/js";
 import {
   TableController,
@@ -52,11 +55,14 @@ registerMdiIcons({
   "chevron-up": mdiChevronUp,
   "chevron-down": mdiChevronDown,
   "close-circle": mdiCloseCircle,
+  console: mdiConsole,
   "dots-vertical": mdiDotsVertical,
   lock: mdiLock,
   "lock-open-variant": mdiLockOpenVariant,
+  "open-in-new": mdiOpenInNew,
   pencil: mdiPencil,
   "unfold-more-horizontal": mdiUnfoldMoreHorizontal,
+  upload: mdiUpload,
 });
 
 // ─── Cached row-model factories (created once, reused forever) ───

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -412,7 +412,7 @@ export class ESPHomeDeviceTable extends LitElement {
                       : sorted === "desc"
                         ? "descending"
                         : "none"}
-                    class="${canSort ? "sortable" : ""} ${sorted ? "sorted" : ""}"
+                    class="${canSort ? "sortable" : ""} ${sorted ? "sorted" : ""} col-${header.column.id}"
                     style="width:${header.getSize()}px"
                     @click=${canSort ? () => header.column.toggleSorting() : nothing}
                   >
@@ -481,7 +481,7 @@ export class ESPHomeDeviceTable extends LitElement {
                     .getVisibleCells()
                     .map(
                       (cell: any) =>
-                        html`<td role="gridcell">
+                        html`<td role="gridcell" class="col-${cell.column.id}">
                           ${flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </td>`
                     )}

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -316,6 +316,7 @@ export class ESPHomeDeviceTable extends LitElement {
         .device=${this._contextMenuDevice}
         .position=${this._contextMenuPos}
         ?anchor-right=${this._contextMenuAnchorRight}
+        ?has-pending=${this._contextMenuDevice?.has_pending_changes === true}
         ?busy=${this._contextMenuDevice ? this.activeJobs.has(this._contextMenuDevice.configuration) : false}
         @menu-close=${this._closeContextMenu}
         @edit-device=${(e: CustomEvent) => {

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -546,12 +546,18 @@ export class ESPHomeDeviceTable extends LitElement {
   }
 
   private _onRowKeydown(e: KeyboardEvent, device: ConfiguredDevice) {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      this.selectMode
-        ? this._onToggleSelect(device.configuration)
-        : this._onRowClick(device);
-    }
+    if (e.key !== "Enter" && e.key !== " ") return;
+    /* Don't double-fire when the user is keyboard-activating an
+       inline action control (Edit / Logs / Install / Update / Visit
+       Web / kebab). The native button/anchor handles its own activation
+       and the event bubbles up to the row — without this guard,
+       pressing Enter on a focused action also opens the row drawer
+       behind it. */
+    if ((e.target as Element)?.closest("button, a")) return;
+    e.preventDefault();
+    this.selectMode
+      ? this._onToggleSelect(device.configuration)
+      : this._onRowClick(device);
   }
 
   private _openActionsMenu(e: MouseEvent, device: ConfiguredDevice) {

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -192,6 +192,10 @@ export const tableCellStyles = css`
     color: var(--wa-color-text-quiet);
     cursor: pointer;
     padding: 0;
+    /* Reset anchor presentation so the Visit Web UI link (rendered
+       as <a> for rel=noopener security) matches the surrounding
+       <button> action controls — no underline, no visited tint. */
+    text-decoration: none;
     transition:
       background 0.12s,
       color 0.12s,

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -222,4 +222,17 @@ export const tableCellStyles = css`
     color: var(--esphome-primary);
     border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
   }
+
+  /* Below the mobile breakpoint the table is cramped — every visible
+     column is competing for horizontal space and the row-end kebab
+     already exposes every action. Drop the entire actions column
+     (header + body cells) so the row stops fighting for width; the
+     row-end actions-col kebab stays visible and opens the row menu
+     with the same Edit / Logs / Install / Update entries plus
+     everything else. */
+  @media (max-width: 768px) {
+    .col-actions {
+      display: none;
+    }
+  }
 `;

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -225,34 +225,30 @@ export const tableCellStyles = css`
 
   /* Progressive overflow into the row-end kebab: as the viewport
      narrows we drop inline action buttons in priority order so the
-     table keeps as many one-click actions visible as it can. The
-     priority order matches the user model:
-       prio-1 Edit            (kept until the column itself drops)
+     table keeps as many one-click actions visible as it can.
+     Priority order matches the user model:
+       prio-1 Edit            (always visible)
        prio-2 Install/Update  (only one of these is rendered at a time)
        prio-3 Logs
        prio-4 Visit Web UI
-     The kebab in actions-col remains visible at every width and
+     The kebab in actions-col stays visible at every width and
      mirrors every action the buttons expose, so nothing becomes
-     unreachable. Below the mobile breakpoint the entire actions
-     column drops out — phone-width tables have no room for inline
-     icons at all and the kebab is right there. */
-  @media (max-width: 1100px) {
+     unreachable. Mobile users get the card view by default, so we
+     deliberately don't tear the actions column off entirely at any
+     viewport — Edit + kebab is a fine fallback if someone forces
+     table view on a phone. */
+  @media (max-width: 1024px) {
     .cell-action-btn--prio-4 {
       display: none;
     }
   }
-  @media (max-width: 980px) {
+  @media (max-width: 920px) {
     .cell-action-btn--prio-3 {
       display: none;
     }
   }
-  @media (max-width: 860px) {
+  @media (max-width: 820px) {
     .cell-action-btn--prio-2 {
-      display: none;
-    }
-  }
-  @media (max-width: 768px) {
-    .col-actions {
       display: none;
     }
   }

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -230,11 +230,12 @@ export const tableCellStyles = css`
   /* Progressive overflow into the row-end kebab: as the viewport
      narrows we drop inline action buttons in priority order so the
      table keeps as many one-click actions visible as it can.
-     Priority order matches the user model:
-       prio-1 Edit            (always visible)
-       prio-2 Install/Update  (only one of these is rendered at a time)
-       prio-3 Logs
-       prio-4 Visit Web UI
+     Priority order (highest → lowest, last to drop):
+       Edit          (always visible)
+       Install /
+       Update        (mutually exclusive — only one renders)
+       Logs
+       Visit Web UI
      The kebab in actions-col stays visible at every width and
      mirrors every action the buttons expose, so nothing becomes
      unreachable. Mobile users get the card view by default, so we
@@ -242,17 +243,17 @@ export const tableCellStyles = css`
      viewport — Edit + kebab is a fine fallback if someone forces
      table view on a phone. */
   @media (max-width: 1024px) {
-    .cell-action-btn--prio-4 {
+    .cell-action-btn--visit-web {
       display: none;
     }
   }
   @media (max-width: 920px) {
-    .cell-action-btn--prio-3 {
+    .cell-action-btn--logs {
       display: none;
     }
   }
   @media (max-width: 820px) {
-    .cell-action-btn--prio-2 {
+    .cell-action-btn--install {
       display: none;
     }
   }

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -223,13 +223,34 @@ export const tableCellStyles = css`
     border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
   }
 
-  /* Below the mobile breakpoint the table is cramped — every visible
-     column is competing for horizontal space and the row-end kebab
-     already exposes every action. Drop the entire actions column
-     (header + body cells) so the row stops fighting for width; the
-     row-end actions-col kebab stays visible and opens the row menu
-     with the same Edit / Logs / Install / Update entries plus
-     everything else. */
+  /* Progressive overflow into the row-end kebab: as the viewport
+     narrows we drop inline action buttons in priority order so the
+     table keeps as many one-click actions visible as it can. The
+     priority order matches the user model:
+       prio-1 Edit            (kept until the column itself drops)
+       prio-2 Install/Update  (only one of these is rendered at a time)
+       prio-3 Logs
+       prio-4 Visit Web UI
+     The kebab in actions-col remains visible at every width and
+     mirrors every action the buttons expose, so nothing becomes
+     unreachable. Below the mobile breakpoint the entire actions
+     column drops out — phone-width tables have no room for inline
+     icons at all and the kebab is right there. */
+  @media (max-width: 1100px) {
+    .cell-action-btn--prio-4 {
+      display: none;
+    }
+  }
+  @media (max-width: 980px) {
+    .cell-action-btn--prio-3 {
+      display: none;
+    }
+  }
+  @media (max-width: 860px) {
+    .cell-action-btn--prio-2 {
+      display: none;
+    }
+  }
   @media (max-width: 768px) {
     .col-actions {
       display: none;

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -187,26 +187,30 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         const device = row._device;
         const showInstall = row.hasPendingChanges;
         const showUpdate = !row.hasPendingChanges && row.hasUpdateAvailable;
+        // Visit Web UI only when the YAML exposes a web_server port AND
+        // we have a host to point at. Mirrors the kebab menu's guard.
+        const webHost = device.address || device.ip;
+        const showVisit = device.web_port != null && !!webHost;
+        const visitUrl = showVisit
+          ? `http://${webHost}${device.web_port === 80 ? "" : `:${device.web_port}`}`
+          : "";
+        // Priority order (highest → lowest, last to drop on narrow
+        // viewports): edit > install/update > logs > visit web. Each
+        // button carries a ``--prio-N`` class so the CSS in
+        // ``table-cell-styles`` can hide them progressively as room
+        // runs out; the row-end kebab keeps every action reachable.
         return html`<span class="cell-actions">
           <button
-            class="cell-action-btn"
+            class="cell-action-btn cell-action-btn--prio-1"
             aria-label=${localize("dashboard.table_action_edit")}
             title=${localize("dashboard.table_action_edit")}
             @click=${(e: Event) => dispatchRowEvent(e, "edit-device", device)}
           >
             <wa-icon library="mdi" name="pencil"></wa-icon>
           </button>
-          <button
-            class="cell-action-btn"
-            aria-label=${localize("dashboard.table_action_logs")}
-            title=${localize("dashboard.table_action_logs")}
-            @click=${(e: Event) => dispatchRowEvent(e, "open-logs", device)}
-          >
-            <wa-icon library="mdi" name="console"></wa-icon>
-          </button>
           ${showInstall
             ? html`<button
-                class="cell-action-btn cell-action-btn--accent"
+                class="cell-action-btn cell-action-btn--accent cell-action-btn--prio-2"
                 aria-label=${localize("dashboard.table_action_install")}
                 title=${localize("dashboard.table_action_install")}
                 ?disabled=${row.busy}
@@ -217,7 +221,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             : nothing}
           ${showUpdate
             ? html`<button
-                class="cell-action-btn cell-action-btn--accent"
+                class="cell-action-btn cell-action-btn--accent cell-action-btn--prio-2"
                 aria-label=${localize("dashboard.table_action_update")}
                 title=${localize("dashboard.table_action_update")}
                 ?disabled=${row.busy}
@@ -226,9 +230,30 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                 <wa-icon library="mdi" name="upload"></wa-icon>
               </button>`
             : nothing}
+          <button
+            class="cell-action-btn cell-action-btn--prio-3"
+            aria-label=${localize("dashboard.table_action_logs")}
+            title=${localize("dashboard.table_action_logs")}
+            @click=${(e: Event) => dispatchRowEvent(e, "open-logs", device)}
+          >
+            <wa-icon library="mdi" name="console"></wa-icon>
+          </button>
+          ${showVisit
+            ? html`<a
+                class="cell-action-btn cell-action-btn--prio-4"
+                href=${visitUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label=${localize("dashboard.action_visit_web_ui")}
+                title=${localize("dashboard.action_visit_web_ui")}
+                @click=${(e: Event) => e.stopPropagation()}
+              >
+                <wa-icon library="mdi" name="open-in-new"></wa-icon>
+              </a>`
+            : nothing}
         </span>`;
       },
-      size: 120,
+      size: 160,
       enableSorting: false,
       enableHiding: false,
     },

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -3,6 +3,7 @@ import type { ColumnDef } from "@tanstack/lit-table";
 import { DeviceState, JobStatus } from "../../api/types.js";
 import type { ConfiguredDevice, FirmwareJob } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
 export interface DeviceRow {
   status: DeviceState;
@@ -187,21 +188,17 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         const device = row._device;
         const showInstall = row.hasPendingChanges;
         const showUpdate = !row.hasPendingChanges && row.hasUpdateAvailable;
-        // Visit Web UI only when the YAML exposes a web_server port AND
-        // we have a host to point at. Mirrors the kebab menu's guard.
-        const webHost = device.address || device.ip;
-        const showVisit = device.web_port != null && !!webHost;
-        const visitUrl = showVisit
-          ? `http://${webHost}${device.web_port === 80 ? "" : `:${device.web_port}`}`
-          : "";
+        const visitUrl = buildWebUiUrl(device);
+        const showVisit = visitUrl !== "";
         // Priority order (highest → lowest, last to drop on narrow
         // viewports): edit > install/update > logs > visit web. Each
-        // button carries a ``--prio-N`` class so the CSS in
-        // ``table-cell-styles`` can hide them progressively as room
-        // runs out; the row-end kebab keeps every action reachable.
+        // button carries a per-action class (cell-action-btn--edit,
+        // --install, --logs, --visit-web) so the media queries in
+        // table-cell-styles can hide them progressively as room runs
+        // out; the row-end kebab keeps every action reachable.
         return html`<span class="cell-actions">
           <button
-            class="cell-action-btn cell-action-btn--prio-1"
+            class="cell-action-btn cell-action-btn--edit"
             aria-label=${localize("dashboard.table_action_edit")}
             title=${localize("dashboard.table_action_edit")}
             @click=${(e: Event) => dispatchRowEvent(e, "edit-device", device)}
@@ -210,7 +207,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           </button>
           ${showInstall
             ? html`<button
-                class="cell-action-btn cell-action-btn--accent cell-action-btn--prio-2"
+                class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
                 aria-label=${localize("dashboard.table_action_install")}
                 title=${localize("dashboard.table_action_install")}
                 ?disabled=${row.busy}
@@ -221,7 +218,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             : nothing}
           ${showUpdate
             ? html`<button
-                class="cell-action-btn cell-action-btn--accent cell-action-btn--prio-2"
+                class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
                 aria-label=${localize("dashboard.table_action_update")}
                 title=${localize("dashboard.table_action_update")}
                 ?disabled=${row.busy}
@@ -231,7 +228,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
               </button>`
             : nothing}
           <button
-            class="cell-action-btn cell-action-btn--prio-3"
+            class="cell-action-btn cell-action-btn--logs"
             aria-label=${localize("dashboard.table_action_logs")}
             title=${localize("dashboard.table_action_logs")}
             @click=${(e: Event) => dispatchRowEvent(e, "open-logs", device)}
@@ -240,7 +237,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           </button>
           ${showVisit
             ? html`<a
-                class="cell-action-btn cell-action-btn--prio-4"
+                class="cell-action-btn cell-action-btn--visit-web"
                 href=${visitUrl}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -61,6 +61,14 @@ export class ESPHomeTableRowMenu extends LitElement {
   @property({ type: Boolean, attribute: "anchor-right" })
   anchorRight = false;
 
+  /** When true, the menu is being shown for a card view where every
+   *  inline action button is always rendered. The duplicate menu items
+   *  (Logs, Visit Web UI) are hidden via CSS so the kebab only carries
+   *  what isn't already on the card. The host attribute drives the
+   *  CSS selector — keep it in sync with the property. */
+  @property({ type: Boolean, attribute: "card-mode", reflect: true })
+  cardMode = false;
+
   @query(".menu")
   private _menuEl!: HTMLDivElement;
 
@@ -157,6 +165,30 @@ export class ESPHomeTableRowMenu extends LitElement {
       .menu-item--danger:hover wa-icon {
         color: var(--esphome-error);
       }
+
+      /* Dedupe with the inline action buttons. The card always shows
+         every inline action when applicable, so card-mode hides the
+         duplicate kebab entries unconditionally. The table only shows
+         the inline buttons above each priority breakpoint, so for the
+         table the kebab entries hide only above those same widths.
+         Breakpoints are off-by-one from the inline rules so the
+         transition pixel never has both copies hidden:
+           prio-3 logs    inline shown when width > 920px
+           prio-4 visit   inline shown when width > 1024px */
+      :host([card-mode]) .menu-item--prio-3,
+      :host([card-mode]) .menu-item--prio-4 {
+        display: none;
+      }
+      @media (min-width: 921px) {
+        :host(:not([card-mode])) .menu-item--prio-3 {
+          display: none;
+        }
+      }
+      @media (min-width: 1025px) {
+        :host(:not([card-mode])) .menu-item--prio-4 {
+          display: none;
+        }
+      }
     `,
   ];
 
@@ -169,10 +201,6 @@ export class ESPHomeTableRowMenu extends LitElement {
         class="menu"
         style=${this._initialStyle()}
       >
-        <div class="menu-item" @click=${() => this._emit("edit-device")}>
-          <wa-icon library="mdi" name="pencil"></wa-icon>
-          ${this._localize("dashboard.drawer_edit")}
-        </div>
         <div class="menu-item" @click=${() => this._emit("validate-device")}>
           <wa-icon library="mdi" name="check-decagram"></wa-icon>
           ${this._localize("dashboard.action_validate")}
@@ -181,7 +209,7 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="upload"></wa-icon>
           ${this._localize("dashboard.action_install")}
         </div>
-        <div class="menu-item ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("open-logs")}>
+        <div class="menu-item menu-item--prio-3 ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("open-logs")}>
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}
         </div>
@@ -308,7 +336,7 @@ export class ESPHomeTableRowMenu extends LitElement {
     // Referer header and isn't honoured uniformly across browsers.
     return html`
       <a
-        class="menu-item menu-item--link"
+        class="menu-item menu-item--link menu-item--prio-4"
         href=${url}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -20,6 +20,7 @@ import type { ConfiguredDevice } from "../../api/types.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
@@ -63,11 +64,18 @@ export class ESPHomeTableRowMenu extends LitElement {
 
   /** When true, the menu is being shown for a card view where every
    *  inline action button is always rendered. The duplicate menu items
-   *  (Logs, Visit Web UI) are hidden via CSS so the kebab only carries
-   *  what isn't already on the card. The host attribute drives the
-   *  CSS selector — keep it in sync with the property. */
+   *  (Logs, Visit Web UI, Install when pending) are hidden via CSS
+   *  so the kebab only carries what isn't already on the card. The
+   *  host attribute drives the CSS selector — keep it in sync. */
   @property({ type: Boolean, attribute: "card-mode", reflect: true })
   cardMode = false;
+
+  /** Mirrors ``ConfiguredDevice.has_pending_changes`` for the open
+   *  device. The inline Install button only renders when this is true,
+   *  so the kebab Install entry hides at the same widths to avoid the
+   *  duplicate. Reflected so CSS can target it via host attribute. */
+  @property({ type: Boolean, attribute: "has-pending", reflect: true })
+  hasPending = false;
 
   @query(".menu")
   private _menuEl!: HTMLDivElement;
@@ -171,21 +179,30 @@ export class ESPHomeTableRowMenu extends LitElement {
          duplicate kebab entries unconditionally. The table only shows
          the inline buttons above each priority breakpoint, so for the
          table the kebab entries hide only above those same widths.
-         Breakpoints are off-by-one from the inline rules so the
-         transition pixel never has both copies hidden:
-           prio-3 logs    inline shown when width > 920px
-           prio-4 visit   inline shown when width > 1024px */
-      :host([card-mode]) .menu-item--prio-3,
-      :host([card-mode]) .menu-item--prio-4 {
+         Class names match the inline cell-action-btn modifiers so the
+         pairing is obvious at a glance; breakpoints are off-by-one
+         from the inline rules so the transition pixel never has both
+         copies hidden:
+           menu-item--install  (only when has-pending)  inline > 820px
+           menu-item--logs                              inline > 920px
+           menu-item--visit-web                         inline > 1024px */
+      :host([card-mode]) .menu-item--logs,
+      :host([card-mode]) .menu-item--visit-web,
+      :host([card-mode][has-pending]) .menu-item--install {
         display: none;
       }
+      @media (min-width: 821px) {
+        :host(:not([card-mode])[has-pending]) .menu-item--install {
+          display: none;
+        }
+      }
       @media (min-width: 921px) {
-        :host(:not([card-mode])) .menu-item--prio-3 {
+        :host(:not([card-mode])) .menu-item--logs {
           display: none;
         }
       }
       @media (min-width: 1025px) {
-        :host(:not([card-mode])) .menu-item--prio-4 {
+        :host(:not([card-mode])) .menu-item--visit-web {
           display: none;
         }
       }
@@ -205,11 +222,11 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="check-decagram"></wa-icon>
           ${this._localize("dashboard.action_validate")}
         </div>
-        <div class="menu-item ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("install-device")}>
+        <div class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("install-device")}>
           <wa-icon library="mdi" name="upload"></wa-icon>
           ${this._localize("dashboard.action_install")}
         </div>
-        <div class="menu-item menu-item--prio-3 ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("open-logs")}>
+        <div class="menu-item menu-item--logs ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("open-logs")}>
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}
         </div>
@@ -319,16 +336,13 @@ export class ESPHomeTableRowMenu extends LitElement {
   }
 
   private _renderVisitWebUi() {
-    // Render only when we actually have somewhere to send the user:
-    // a port from the YAML's ``web_server:`` block AND a resolvable
-    // host. ``ip`` stays empty until the device has been seen online,
-    // and ``address`` should always be populated from StorageJSON,
-    // but the guard means the menu item never appears as a no-op.
-    if (this.device == null || this.device.web_port == null) return nothing;
-    const host = this.device.address || this.device.ip;
-    if (!host) return nothing;
-    const port = this.device.web_port;
-    const url = `http://${host}${port === 80 ? "" : `:${port}`}`;
+    // Render only when we actually have somewhere to send the user.
+    // ``buildWebUiUrl`` is the single source of truth for the
+    // host/port/protocol logic; it returns "" when the YAML didn't
+    // expose web_server or we don't have a host yet.
+    if (this.device == null) return nothing;
+    const url = buildWebUiUrl(this.device);
+    if (!url) return nothing;
     // Anchor element with ``rel="noopener noreferrer"`` is the
     // codebase's standard external-link pattern; the browser enforces
     // the security defaults instead of relying on
@@ -336,7 +350,7 @@ export class ESPHomeTableRowMenu extends LitElement {
     // Referer header and isn't honoured uniformly across browsers.
     return html`
       <a
-        class="menu-item menu-item--link menu-item--prio-4"
+        class="menu-item menu-item--link menu-item--visit-web"
         href=${url}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -109,10 +109,11 @@ export class ESPHomeDeviceCard extends LitElement {
   @property({ type: Boolean })
   selected = false;
 
-  /** Pre-built http(s) URL to the device's web UI when its YAML
-   *  exposes ``web_server`` and we have a host. Empty string hides
-   *  the inline Visit Web button. Pre-built so the card doesn't have
-   *  to know about ``ConfiguredDevice`` shape. */
+  /** Pre-built http URL to the device's web UI when its YAML exposes
+   *  ``web_server`` and we have a host. Empty string hides the inline
+   *  Visit Web button. Pre-built so the card doesn't have to know
+   *  about ``ConfiguredDevice`` shape; ``buildWebUiUrl`` is the
+   *  shared source of truth for protocol/port logic. */
   @property()
   webUrl = "";
 
@@ -399,9 +400,10 @@ export class ESPHomeDeviceCard extends LitElement {
       }
 
       /* Compact icon-only button that sits inline with the labelled
-         buttons (Edit / Install) — same visual size as the kebab but
-         without the auto left-margin that pushes the kebab to the
-         right edge. Used for Logs and Visit Web UI. */
+         buttons — same visual size as the kebab but without the auto
+         left-margin that pushes the kebab to the right edge. Used by
+         the Visit Web UI control (icon-only since the open-in-new
+         icon is self-explanatory). */
       .action-btn--tile {
         padding: 5px;
         flex-shrink: 0;

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -6,11 +6,13 @@ import {
   mdiCheckboxBlankOutline,
   mdiCheckboxMarked,
   mdiCloseCircle,
+  mdiConsole,
   mdiDotsVertical,
   mdiHelpNetworkOutline,
   mdiLock,
   mdiLockOpenVariant,
   mdiNetworkOffOutline,
+  mdiOpenInNew,
   mdiPencil,
   mdiUpload,
 } from "@mdi/js";
@@ -32,12 +34,14 @@ registerMdiIcons({
   "checkbox-blank-outline": mdiCheckboxBlankOutline,
   "checkbox-marked": mdiCheckboxMarked,
   "close-circle": mdiCloseCircle,
+  console: mdiConsole,
   "dots-vertical": mdiDotsVertical,
   "check-network-outline": mdiCheckNetworkOutline,
   "help-network-outline": mdiHelpNetworkOutline,
   lock: mdiLock,
   "lock-open-variant": mdiLockOpenVariant,
   "network-off-outline": mdiNetworkOffOutline,
+  "open-in-new": mdiOpenInNew,
   pencil: mdiPencil,
   upload: mdiUpload,
 });
@@ -104,6 +108,13 @@ export class ESPHomeDeviceCard extends LitElement {
 
   @property({ type: Boolean })
   selected = false;
+
+  /** Pre-built http(s) URL to the device's web UI when its YAML
+   *  exposes ``web_server`` and we have a host. Empty string hides
+   *  the inline Visit Web button. Pre-built so the card doesn't have
+   *  to know about ``ConfiguredDevice`` shape. */
+  @property()
+  webUrl = "";
 
   static styles = [
     espHomeStyles,
@@ -381,6 +392,15 @@ export class ESPHomeDeviceCard extends LitElement {
         flex-shrink: 0;
         margin-left: auto;
       }
+
+      /* Compact icon-only button that sits inline with the labelled
+         buttons (Edit / Install) — same visual size as the kebab but
+         without the auto left-margin that pushes the kebab to the
+         right edge. Used for Logs and Visit Web UI. */
+      .action-btn--tile {
+        padding: 5px;
+        flex-shrink: 0;
+      }
     `,
   ];
 
@@ -460,6 +480,27 @@ export class ESPHomeDeviceCard extends LitElement {
                         </button>
                       `
                     : nothing}
+                <button
+                  class="action-btn action-btn--ghost action-btn--tile"
+                  aria-label=${this._localize("dashboard.drawer_logs")}
+                  title=${this._localize("dashboard.drawer_logs")}
+                  @click=${() => this._emit("open-logs")}
+                >
+                  <wa-icon library="mdi" name="console"></wa-icon>
+                </button>
+                ${this.webUrl
+                  ? html`<a
+                      class="action-btn action-btn--ghost action-btn--tile"
+                      href=${this.webUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label=${this._localize("dashboard.action_visit_web_ui")}
+                      title=${this._localize("dashboard.action_visit_web_ui")}
+                      @click=${(e: Event) => e.stopPropagation()}
+                    >
+                      <wa-icon library="mdi" name="open-in-new"></wa-icon>
+                    </a>`
+                  : nothing}
                 <button
                   class="action-btn action-btn--ghost action-btn--icon-only"
                   aria-label=${this._localize("dashboard.more_options")}

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -486,12 +486,11 @@ export class ESPHomeDeviceCard extends LitElement {
                       `
                     : nothing}
                 <button
-                  class="action-btn action-btn--ghost action-btn--tile"
-                  aria-label=${this._localize("dashboard.drawer_logs")}
-                  title=${this._localize("dashboard.drawer_logs")}
+                  class="action-btn action-btn--ghost"
                   @click=${() => this._emit("open-logs")}
                 >
                   <wa-icon library="mdi" name="console"></wa-icon>
+                  ${this._localize("dashboard.drawer_logs")}
                 </button>
                 ${this.webUrl
                   ? html`<a

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -345,6 +345,11 @@ export class ESPHomeDeviceCard extends LitElement {
         font-family: inherit;
         cursor: pointer;
         border: var(--wa-border-width-s) solid transparent;
+        /* Reset anchor presentation so the Visit Web UI link
+           (rendered as <a> for rel=noopener security) matches the
+           surrounding <button> action controls — no underline, no
+           visited tint. */
+        text-decoration: none;
         transition:
           background 0.12s,
           border-color 0.12s;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -322,6 +322,15 @@ export class ESPHomePageDashboard extends LitElement {
       <div class="devices-grid">
         ${this._devices.length === 0 ? this._renderAddDeviceCard() : ""}
         ${filtered.map((device) => {
+          // Pre-build the Visit Web UI URL when the YAML exposes a
+          // web_server port AND we have a host. Mirrors the kebab menu
+          // / table guard so the inline icon only appears when the
+          // link would actually go somewhere.
+          const webHost = device.address || device.ip;
+          const webUrl =
+            device.web_port != null && webHost
+              ? `http://${webHost}${device.web_port === 80 ? "" : `:${device.web_port}`}`
+              : "";
           return html`
             <esphome-device-card
               .name=${device.friendly_name || device.name}
@@ -333,11 +342,13 @@ export class ESPHomePageDashboard extends LitElement {
               ?api-encrypted=${device.api_encrypted === true}
               ?busy=${this._activeJobs.has(device.configuration)}
               .recentJob=${this._recentJobs.get(device.configuration) ?? null}
+              .webUrl=${webUrl}
               ?select-mode=${this._selectMode}
               ?selected=${this._selectedDevices.has(device.configuration)}
               @edit-device=${() => editDevice(device)}
               @install-device=${() => this._openInstallMethod(device)}
               @update-device=${() => this._openCommand(device, "install")}
+              @open-logs=${() => this._openLogs(device)}
               @show-progress=${() => this._showJobProgress(device)}
               @card-click=${() => { this._drawerDevice = device; this._drawerOpen = true; }}
               @card-context-menu=${(e: CustomEvent) => { this._cardContextDevice = device; this._cardContextPosition = e.detail; }}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -426,6 +426,7 @@ export class ESPHomePageDashboard extends LitElement {
       <esphome-table-row-menu
         .device=${this._cardContextDevice}
         .position=${this._cardContextPosition}
+        card-mode
         ?busy=${this._cardContextDevice ? this._activeJobs.has(this._cardContextDevice.configuration) : false}
         @menu-close=${() => { this._cardContextDevice = null; this._cardContextPosition = null; }}
         @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -35,6 +35,7 @@ import {
   fetchApiKey,
   streamSerialToDialog,
 } from "./dashboard-actions.js";
+import { buildWebUiUrl } from "../util/web-ui-url.js";
 import { detectChip, disconnect } from "../util/web-serial.js";
 import { cardSkeletonTemplate, tableSkeletonTemplate } from "./dashboard-skeletons.js";
 import { dashboardStyles } from "./dashboard-styles.js";
@@ -322,15 +323,7 @@ export class ESPHomePageDashboard extends LitElement {
       <div class="devices-grid">
         ${this._devices.length === 0 ? this._renderAddDeviceCard() : ""}
         ${filtered.map((device) => {
-          // Pre-build the Visit Web UI URL when the YAML exposes a
-          // web_server port AND we have a host. Mirrors the kebab menu
-          // / table guard so the inline icon only appears when the
-          // link would actually go somewhere.
-          const webHost = device.address || device.ip;
-          const webUrl =
-            device.web_port != null && webHost
-              ? `http://${webHost}${device.web_port === 80 ? "" : `:${device.web_port}`}`
-              : "";
+          const webUrl = buildWebUiUrl(device);
           return html`
             <esphome-device-card
               .name=${device.friendly_name || device.name}
@@ -427,6 +420,7 @@ export class ESPHomePageDashboard extends LitElement {
         .device=${this._cardContextDevice}
         .position=${this._cardContextPosition}
         card-mode
+        ?has-pending=${this._cardContextDevice?.has_pending_changes === true}
         ?busy=${this._cardContextDevice ? this._activeJobs.has(this._cardContextDevice.configuration) : false}
         @menu-close=${() => { this._cardContextDevice = null; this._cardContextPosition = null; }}
         @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}

--- a/src/util/web-ui-url.ts
+++ b/src/util/web-ui-url.ts
@@ -1,0 +1,18 @@
+import type { ConfiguredDevice } from "../api/types.js";
+
+/**
+ * Build the device's web-UI URL, or return ``""`` when the YAML didn't
+ * expose a ``web_server`` port or we don't have a host to point at.
+ *
+ * Single source of truth for the dashboard's "Visit Web UI" affordance —
+ * the table column, the device card, and the row-menu fallback all
+ * share this so the host/port/protocol logic can't drift between
+ * call sites. Returns empty string (not ``null``) so callers can
+ * skip-render with a truthy check.
+ */
+export function buildWebUiUrl(device: ConfiguredDevice): string {
+  if (device.web_port == null) return "";
+  const host = device.address || device.ip;
+  if (!host) return "";
+  return `http://${host}${device.web_port === 80 ? "" : `:${device.web_port}`}`;
+}


### PR DESCRIPTION
## Summary

Promote the most-used per-device actions out of the kebab into the row / card and dedupe so each action shows up exactly once.

### Inline action priority

In priority order (highest → lowest, last to drop): **Edit → Install/Update → Logs → Visit Web UI**. Install and Update are mutually exclusive (only one renders at a time), so up to 4 buttons are visible simultaneously.

### Table view

- Each inline button carries a per-action class (`cell-action-btn--edit`, `--install`, `--logs`, `--visit-web`). Progressive `max-width` media queries hide them in reverse priority order so the row keeps as many one-click actions visible as the window allows:
  | viewport | --visit-web | --logs | --install/update | --edit |
  |---|---|---|---|---|
  | ≥1025px | ✓ | ✓ | ✓ | ✓ |
  | 921-1024px | — | ✓ | ✓ | ✓ |
  | 821-920px | — | — | ✓ | ✓ |
  | <821px | — | — | — | ✓ |
- Edit stays visible at every width — the row-end kebab is right next to it for everything else. Mobile users default to the card view, so the actions column is never torn off entirely; Edit + kebab is a fine fallback if someone forces table view on a phone.
- Generic `col-${id}` class on every `<th>` / `<td>` so future columns can opt into the same hide-on-narrow pattern.
- Bumped the actions column size from 120 to 160px for breathing room when all four buttons are visible.

### Card view

- Cards now render Edit (text+icon, primary), Install/Update (text+icon, accent, conditional), Logs (text+icon, ghost), Visit Web UI (icon-only, ghost, when `web_port` set), then the kebab.
- Cards always show every applicable inline action — the grid keeps each card ≥300px wide so there's room.

### Kebab dedup

The kebab shares the `esphome-table-row-menu` component; new `card-mode` and `has-pending` reflected attributes let it know its context. Each duplicated entry uses the same semantic class as its inline counterpart so the pairing is obvious:

| menu item | hides when |
|---|---|
| `menu-item--edit` | always (Edit is always inline at every width) → removed entirely |
| `menu-item--install` | `card-mode + has-pending`, or table at ≥821px when `has-pending` |
| `menu-item--logs` | `card-mode`, or table at ≥921px |
| `menu-item--visit-web` | `card-mode`, or table at ≥1025px |

The kebab `min-width` boundaries are off-by-one from the inline `max-width` boundaries (e.g. inline `max-width: 920` ↔ kebab `min-width: 921`) so the transition pixel never has both copies hidden — exactly one copy of each action is reachable at every viewport width.

Validate / Show API key / Download YAML / Rename / Clean build / Download ELF / Select / Delete remain in the kebab — none of them are inline.

### DRY-up

- New `src/util/web-ui-url.ts:buildWebUiUrl(device)` — single source of truth for protocol/host/port logic. Used by `pages/dashboard.ts` (card), `dashboard/table-columns.ts` (table cell), and `dashboard/table-row-menu.ts` (kebab fallback).

### Accessibility / polish

- `_onRowKeydown` ignores Enter/Space when the event originated inside a button or anchor descendant, so keyboard-activating an inline action doesn't also trigger the row drawer behind it.
- `text-decoration: none` reset on `.cell-action-btn` and `.action-btn` so the Visit Web `<a>` matches the surrounding `<button>` controls.

## Test plan

- [x] Wide window (≥1025px), table view: Edit, Install/Update, Logs, Visit Web all inline; kebab shows Validate / Install (only when not pending) / API key / Download YAML / Rename / Clean / Download ELF / Select / Delete.
- [x] Narrowing past each breakpoint drops one inline button at a time; the kebab regains the corresponding entry at the same pixel.
- [x] Phone-width table view: Edit + kebab; kebab includes Logs + Visit Web entries (Install too if not pending).
- [x] Card view at any width: all four inline actions always shown when applicable; kebab never shows Edit / Logs / Visit Web duplicates; Install duplicate hides only when device has pending changes.
- [x] Visit Web button (card and table): opens device's web UI in a new tab; doesn't fire row-click; keyboard-activating doesn't trigger row drawer.
- [x] No console / lint errors.