### PR TITLE
Link loaded-integration tags in the device drawer to esphome.io docs

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -674,6 +674,19 @@ export class ESPHomeAPI {
     return this.sendCommand<PagedComponentsResponse>("components/get_components", args);
   }
 
+  /**
+   * Map of integration name → esphome.io docs URL for every
+   * loaded-integration name we can resolve. Names with no docs page
+   * are simply absent from the map; the dashboard renders those as
+   * plain text. Fetched once at app load — the dataset only refreshes
+   * with a backend release.
+   */
+  async getIntegrationDocs(): Promise<Record<string, string>> {
+    return this.sendCommand<Record<string, string>>(
+      "components/get_integration_docs",
+    );
+  }
+
   // ─── Config Commands ──────────────────────────────────────
 
   /** Get ESPHome and server version. */

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -680,11 +680,31 @@ export class ESPHomeAPI {
    * are simply absent from the map; the dashboard renders those as
    * plain text. Fetched once at app load — the dataset only refreshes
    * with a backend release.
+   *
+   * The WS layer doesn't enforce a shape, so we filter the payload to
+   * the ``{string: string}`` contract here: anything that isn't a
+   * plain object is replaced with ``{}``, and entries with non-string
+   * keys/values are dropped. Consumers can rely on the result being
+   * safe to spread into a context without further validation.
    */
   async getIntegrationDocs(): Promise<Record<string, string>> {
-    return this.sendCommand<Record<string, string>>(
+    const raw = await this.sendCommand<unknown>(
       "components/get_integration_docs",
     );
+    if (
+      raw === null ||
+      typeof raw !== "object" ||
+      Array.isArray(raw)
+    ) {
+      return {};
+    }
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof key === "string" && typeof value === "string" && value) {
+        result[key] = value;
+      }
+    }
+    return result;
   }
 
   // ─── Config Commands ──────────────────────────────────────

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -48,6 +48,7 @@ import {
   recentJobsContext,
   firmwareJobsContext,
   importableDevicesContext,
+  integrationDocsContext,
   isHaIngressContext,
   localizeContext,
   versionContext,
@@ -142,6 +143,13 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: yamlDiffButtonContext })
   @state()
   private _yamlDiffButton = false;
+
+  // Frozen catalog-derived map; refreshed only with a backend release.
+  // Cheap to leave at {} until the fetch lands — the device drawer
+  // falls back to plain-text tags whenever a name isn't in the map.
+  @provide({ context: integrationDocsContext })
+  @state()
+  private _integrationDocs: Record<string, string> = {};
 
   // ─── Router ──────────────────────────────────────────────
 
@@ -262,6 +270,7 @@ export class ESPHomeApp extends LitElement {
       this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
       this._subscribeToEvents();
       this._subscribeToFollowJobs();
+      this._loadIntegrationDocs();
     };
 
     this._api.onDisconnected = () => {
@@ -277,6 +286,21 @@ export class ESPHomeApp extends LitElement {
       this._loadThemePreference();
     } catch (err) {
       console.error("Failed to connect to WebSocket:", err);
+    }
+  }
+
+  /**
+   * Fetch the integration → docs URL map once per connection and stash
+   * it in context. The map is catalog-derived and only changes with a
+   * backend release, so no need to re-fetch on event flow. A failure
+   * here is non-fatal: we leave ``_integrationDocs`` empty and the
+   * drawer falls back to plain-text tags.
+   */
+  private async _loadIntegrationDocs() {
+    try {
+      this._integrationDocs = await this._api.getIntegrationDocs();
+    } catch (err) {
+      console.warn("Failed to load integration docs URLs:", err);
     }
   }
 

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -39,6 +39,25 @@ registerMdiIcons({
   upload: mdiUpload,
 });
 
+/**
+ * Whitelist docs URLs to the canonical esphome.io site over HTTPS.
+ *
+ * The map is populated by the backend from the in-house catalog, so a
+ * compromised payload is the practical concern here — interpolating an
+ * untrusted ``href`` directly would let a ``javascript:`` or
+ * ``data:`` scheme run code on click. Bound the rendered anchors to
+ * exactly the host the catalog targets and fall back to plain text
+ * otherwise.
+ */
+function _isSafeDocsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "esphome.io";
+  } catch {
+    return false;
+  }
+}
+
 @customElement("esphome-device-drawer-content")
 export class ESPHomeDeviceDrawerContent extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -168,9 +187,18 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           border-color 0.12s;
       }
 
-      .tag--link:hover {
+      .tag--link:hover,
+      .tag--link:focus-visible {
         background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
         border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+      }
+
+      /* Keyboard users tabbing onto the tag need the same affordance
+         mouse users get on hover, plus a visible focus ring so the
+         active tag stands out from its peers in the row. */
+      .tag--link:focus-visible {
+        outline: 2px solid var(--esphome-primary);
+        outline-offset: 2px;
       }
 
       .status-badges {
@@ -296,7 +324,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
               <div class="tags-wrap">
                 ${d.loaded_integrations.map((i) => {
                   const url = this._integrationDocs[i];
-                  return url
+                  return url && _isSafeDocsUrl(url)
                     ? html`<a
                         class="tag tag--link"
                         href=${url}

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -16,7 +16,10 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { ConfiguredDevice } from "../../api/types.js";
-import { localizeContext } from "../../context/index.js";
+import {
+  integrationDocsContext,
+  localizeContext,
+} from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
@@ -41,6 +44,10 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: integrationDocsContext, subscribe: true })
+  @state()
+  private _integrationDocs: Record<string, string> = {};
 
   @property({ attribute: false })
   device!: ConfiguredDevice;
@@ -145,6 +152,25 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         background: var(--wa-color-surface-lowered);
         color: var(--wa-color-text-quiet);
         border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+      }
+
+      /* Linked tags get the dashboard's primary colour to read as
+         "this opens something" without pulling so far from the plain
+         tag styling that the row looks visually noisy. text-decoration
+         is reset because the anchor variant inherits the .tag chrome
+         and the underline would clash with the rounded pill shape. */
+      .tag--link {
+        color: var(--esphome-primary);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background 0.12s,
+          border-color 0.12s;
+      }
+
+      .tag--link:hover {
+        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+        border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
       }
 
       .status-badges {
@@ -268,9 +294,18 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
             <div class="section">
               <h4 class="section-title">${this._localize("dashboard.drawer_loaded_integrations")}</h4>
               <div class="tags-wrap">
-                ${d.loaded_integrations.map(
-                  (i) => html`<span class="tag">${i}</span>`,
-                )}
+                ${d.loaded_integrations.map((i) => {
+                  const url = this._integrationDocs[i];
+                  return url
+                    ? html`<a
+                        class="tag tag--link"
+                        href=${url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >${i}</a
+                      >`
+                    : html`<span class="tag">${i}</span>`;
+                })}
               </div>
             </div>
           `

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -72,3 +72,11 @@ export const firmwareJobsContext = createContext<Map<string, FirmwareJob>>(
 export const yamlDiffButtonContext = createContext<boolean>(
   Symbol("esphome-yaml-diff-button")
 );
+
+/** Context for the integration → esphome.io docs URL map. Populated
+ *  once on app load via ``components/get_integration_docs``; the
+ *  drawer's loaded-integration tags consult it to decide whether to
+ *  render each name as a link or plain text. */
+export const integrationDocsContext = createContext<Record<string, string>>(
+  Symbol("esphome-integration-docs")
+);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -11,4 +11,5 @@ export {
   recentJobsContext,
   firmwareJobsContext,
   yamlDiffButtonContext,
+  integrationDocsContext,
 } from "./contexts.js";


### PR DESCRIPTION
## Summary

Each tag in the device drawer's **Loaded Integrations** section is now a clickable link when the integration name resolves to an esphome.io page; tags without a docs hit fall back to the plain `<span>`.

Linked tags get the dashboard's primary colour with a subtle hover so "this opens something" reads at a glance, but the rounded-pill shape is unchanged so the row stays visually consistent.

### Where the data comes from

The mapping is fetched once per WebSocket connection from the backend's `components/get_integration_docs` WS command (added in **esphome/device-builder#57**), stored on `app-shell.ts`, and provided down the tree via the new `integrationDocsContext`. A failed fetch is non-fatal — `_integrationDocs` stays `{}` and every tag renders as plain text, same behaviour as today.

The backend's lookup is catalog-derived (top-level component → category landing → stem alias, in priority order), so a present URL is also a guarantee that the docs page exists.

### Files

- `src/api/esphome-api.ts` — new `getIntegrationDocs()` client method.
- `src/context/{contexts,index}.ts` — new `integrationDocsContext`.
- `src/components/app-shell.ts` — provides the context, fetches once on `onConnected`.
- `src/components/dashboard/device-drawer-content.ts` — consumes the context, swaps `<span class="tag">` for `<a class="tag tag--link">` when a URL is present, plus a `.tag--link` style block.

## Test plan

- [x] Lint clean.
- [x] All 108 existing tests pass.
- [ ] Pairs with backend PR #57 — once that lands, open the device drawer; integrations like `api`, `wifi`, `mdns`, `sensor`, `ltr390` show as links and open the matching esphome.io page in a new tab.
- [ ] Integrations the catalog doesn't know (`runtime_stats`, `web_server_id`, etc.) stay rendered as plain tags.
- [ ] Without the backend deployed, the drawer still renders — every tag falls back to plain text.