### PR TITLE
Make dialog close button a comfortable hit target

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -108,8 +108,9 @@ export class ESPHomeCommandDialog extends LitElement {
       wa-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the close button sits flush with the
-           dialog's corner — the button's own padding gives it a square
-           hit target right where the user reaches for it. */
+           dialog's corner — the button is explicitly sized to a 40x40
+           square below to give the X a comfortable hit target right
+           where the user reaches for it. */
         padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -107,7 +107,10 @@ export class ESPHomeCommandDialog extends LitElement {
          of the dashboard chrome. Body keeps the terminal palette. */
       wa-dialog::part(header) {
         background: var(--esphome-primary);
-        padding: 0 var(--wa-space-m);
+        /* Right padding is 0 so the close button sits flush with the
+           dialog's corner — the button's own padding gives it a square
+           hit target right where the user reaches for it. */
+        padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
@@ -119,7 +122,11 @@ export class ESPHomeCommandDialog extends LitElement {
       }
       wa-dialog::part(close-button__base) {
         background: transparent; border: none; box-shadow: none;
-        padding: 0; min-width: unset; min-height: unset;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. */
+        padding: 0; width: 40px; height: 40px;
+        min-width: unset; min-height: unset;
         color: var(--esphome-on-primary); cursor: pointer;
       }
       /* Same affordance for hover and keyboard focus so the close

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -119,8 +119,9 @@ export class ESPHomeLogsDialog extends LitElement {
       wa-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the close button sits flush with the
-           dialog's corner — the button's own padding gives it a square
-           hit target right where the user reaches for it. */
+           dialog's corner — the button is explicitly sized to a 40x40
+           square below to give the X a comfortable hit target right
+           where the user reaches for it. */
         padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -118,7 +118,10 @@ export class ESPHomeLogsDialog extends LitElement {
          bar. */
       wa-dialog::part(header) {
         background: var(--esphome-primary);
-        padding: 0 var(--wa-space-m);
+        /* Right padding is 0 so the close button sits flush with the
+           dialog's corner — the button's own padding gives it a square
+           hit target right where the user reaches for it. */
+        padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
@@ -134,7 +137,12 @@ export class ESPHomeLogsDialog extends LitElement {
         background: transparent;
         border: none;
         box-shadow: none;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. */
         padding: 0;
+        width: 40px;
+        height: 40px;
         min-width: unset;
         min-height: unset;
         color: var(--esphome-on-primary);


### PR DESCRIPTION
## Summary

The close X on the logs and command dialogs sat in a ~14px footprint, inset from the right edge by `--wa-space-m` of header padding. Reaching for the corner missed it.

- Drop the header's right padding so the close button sits flush with the dialog's corner
- Size the button to a 40x40 square (matching the header height) so the entire upper-right region of the dialog is clickable

## Test plan

- [x] Open Logs dialog, click the X near the top-right corner — registers
- [x] Open Install/Compile dialog, same
- [x] On mobile, the corner is comfortably tappable