### PR TITLE
Add keyboard navigation to dashboard device cards

### DIFF
--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -20,6 +20,7 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { commandPaletteStyles } from "./command-palette.styles.js";
@@ -93,13 +94,17 @@ export class ESPHomeCommandPalette extends LitElement {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
       e.preventDefault();
       this._toggle();
-      return;
-    }
-    if (this._open && e.key === "Escape") {
-      e.preventDefault();
-      this.close();
     }
   };
+
+  /* Cmd+K is always-on (it opens the palette), so it stays on a
+     dedicated keydown listener. Esc only matters while the palette is
+     open and is handled by EscapeController, which attaches/detaches
+     in lockstep with ``_open``. */
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this.close();
+  });
 
   connectedCallback() {
     super.connectedCallback();
@@ -228,6 +233,10 @@ export class ESPHomeCommandPalette extends LitElement {
         .toLowerCase();
       return haystack.includes(q);
     });
+  }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("_open")) this._escape.set(this._open);
   }
 
   protected updated(changed: Map<string, unknown>) {

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -15,6 +15,7 @@ import { DeviceState } from "../../api/types.js";
 import type { ConfiguredDevice } from "../../api/types.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -390,31 +391,10 @@ export class ESPHomeDeviceDrawer extends LitElement {
     );
   }
 
-  disconnectedCallback() {
-    this._setEscListener(false);
-    super.disconnectedCallback();
-  }
+  private _escape = new EscapeController(this, () => this._close());
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("open")) this._setEscListener(this.open);
-  }
-
-  private _onWindowKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this._close();
-    }
-  };
-
-  private _escBound = false;
-  private _setEscListener(active: boolean) {
-    if (active && !this._escBound) {
-      window.addEventListener("keydown", this._onWindowKeydown);
-      this._escBound = true;
-    } else if (!active && this._escBound) {
-      window.removeEventListener("keydown", this._onWindowKeydown);
-      this._escBound = false;
-    }
+    if (changed.has("open")) this._escape.set(this.open);
   }
 
   private _emitAction(name: string) {

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -391,7 +391,10 @@ export class ESPHomeDeviceDrawer extends LitElement {
     );
   }
 
-  private _escape = new EscapeController(this, () => this._close());
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this._close();
+  });
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("open")) this._escape.set(this.open);

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -390,6 +390,33 @@ export class ESPHomeDeviceDrawer extends LitElement {
     );
   }
 
+  disconnectedCallback() {
+    this._setEscListener(false);
+    super.disconnectedCallback();
+  }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("open")) this._setEscListener(this.open);
+  }
+
+  private _onWindowKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this._close();
+    }
+  };
+
+  private _escBound = false;
+  private _setEscListener(active: boolean) {
+    if (active && !this._escBound) {
+      window.addEventListener("keydown", this._onWindowKeydown);
+      this._escBound = true;
+    } else if (!active && this._escBound) {
+      window.removeEventListener("keydown", this._onWindowKeydown);
+      this._escBound = false;
+    }
+  }
+
   private _emitAction(name: string) {
     this.dispatchEvent(
       new CustomEvent(name, {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -268,6 +268,39 @@ export class ESPHomeTableRowMenu extends LitElement {
     `;
   }
 
+  disconnectedCallback() {
+    /* Belt-and-braces: if the host is removed while the menu is open
+       (e.g. dashboard view swap), drop the window listener so we don't
+       leak it. _setEscListener with false is a no-op when nothing is
+       currently bound. */
+    this._setEscListener(false);
+    super.disconnectedCallback();
+  }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("device") || changed.has("position")) {
+      this._setEscListener(this.device != null && this.position != null);
+    }
+  }
+
+  private _onWindowKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this._close();
+    }
+  };
+
+  private _escBound = false;
+  private _setEscListener(active: boolean) {
+    if (active && !this._escBound) {
+      window.addEventListener("keydown", this._onWindowKeydown);
+      this._escBound = true;
+    } else if (!active && this._escBound) {
+      window.removeEventListener("keydown", this._onWindowKeydown);
+      this._escBound = false;
+    }
+  }
+
   protected updated() {
     if (!this._menuEl || !this.position) return;
 

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -269,7 +269,10 @@ export class ESPHomeTableRowMenu extends LitElement {
     `;
   }
 
-  private _escape = new EscapeController(this, () => this._close());
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this._close();
+  });
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("device") || changed.has("position")) {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -20,6 +20,7 @@ import type { ConfiguredDevice } from "../../api/types.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { EscapeController } from "../../util/escape-controller.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -268,36 +269,11 @@ export class ESPHomeTableRowMenu extends LitElement {
     `;
   }
 
-  disconnectedCallback() {
-    /* Belt-and-braces: if the host is removed while the menu is open
-       (e.g. dashboard view swap), drop the window listener so we don't
-       leak it. _setEscListener with false is a no-op when nothing is
-       currently bound. */
-    this._setEscListener(false);
-    super.disconnectedCallback();
-  }
+  private _escape = new EscapeController(this, () => this._close());
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("device") || changed.has("position")) {
-      this._setEscListener(this.device != null && this.position != null);
-    }
-  }
-
-  private _onWindowKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this._close();
-    }
-  };
-
-  private _escBound = false;
-  private _setEscListener(active: boolean) {
-    if (active && !this._escBound) {
-      window.addEventListener("keydown", this._onWindowKeydown);
-      this._escBound = true;
-    } else if (!active && this._escBound) {
-      window.removeEventListener("keydown", this._onWindowKeydown);
-      this._escBound = false;
+      this._escape.set(this.device != null && this.position != null);
     }
   }
 

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -128,6 +128,7 @@ export class ESPHomeDeviceCard extends LitElement {
     css`
       :host {
         display: block;
+        outline: none;
       }
 
       .device-card {
@@ -142,6 +143,14 @@ export class ESPHomeDeviceCard extends LitElement {
 
       .device-card:hover {
         box-shadow: var(--wa-shadow-m);
+      }
+
+      /* Keyboard focus ring on the card itself. The host carries
+         tabindex/role so screen readers and Tab land here; we draw the
+         outline on the inner card so it follows the rounded corners. */
+      :host(:focus-visible) .device-card {
+        outline: 2px solid var(--esphome-primary);
+        outline-offset: 2px;
       }
 
       .device-card--clickable {
@@ -446,6 +455,43 @@ export class ESPHomeDeviceCard extends LitElement {
     `,
   ];
 
+  connectedCallback() {
+    super.connectedCallback();
+    /* The host is the focusable target for keyboard nav: Tab lands on
+       the card, Enter/Space activates it, arrow keys move to a sibling
+       card in the grid. Inner action buttons remain in the tab order
+       after the card so keyboard users can reach Edit / Install / Logs
+       without leaving the keyboard. */
+    if (!this.hasAttribute("tabindex")) this.tabIndex = 0;
+    if (!this.hasAttribute("role")) this.setAttribute("role", "button");
+    this.addEventListener("keydown", this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener("keydown", this._onKeydown);
+    super.disconnectedCallback();
+  }
+
+  protected willUpdate(changedProperties: Map<string, unknown>) {
+    if (
+      changedProperties.has("name") ||
+      changedProperties.has("selectMode") ||
+      changedProperties.has("selected")
+    ) {
+      this.setAttribute(
+        "aria-label",
+        this.selectMode
+          ? `${this.name} (${this.selected ? "selected" : "not selected"})`
+          : this.name,
+      );
+      if (this.selectMode) {
+        this.setAttribute("aria-pressed", String(this.selected));
+      } else {
+        this.removeAttribute("aria-pressed");
+      }
+    }
+  }
+
   protected render() {
     return html`
       <div
@@ -602,6 +648,72 @@ export class ESPHomeDeviceCard extends LitElement {
           ? this._localize("dashboard.offline")
           : this._localize("dashboard.unknown")}
     </div>`;
+  }
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    /* Only handle keys that actually originate on the host. Inner
+       buttons (Edit, Install, kebab, etc.) get their own keyboard
+       behaviour from the browser; if the user is focused on Edit and
+       presses Enter, the button click handler fires — we shouldn't
+       also navigate the card. composedPath()[0] is the real target
+       inside the shadow tree; e.target is retargeted to the host
+       from outside, so it can't be used to distinguish these. */
+    if (e.composedPath()[0] !== this) return;
+
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this._emit(this.selectMode ? "toggle-select" : "card-click");
+      return;
+    }
+
+    if (
+      e.key === "ArrowRight" ||
+      e.key === "ArrowLeft" ||
+      e.key === "ArrowUp" ||
+      e.key === "ArrowDown" ||
+      e.key === "Home" ||
+      e.key === "End"
+    ) {
+      e.preventDefault();
+      this._navigateCards(e.key);
+    }
+  };
+
+  private _navigateCards(key: string) {
+    const grid = this.parentElement;
+    if (!grid) return;
+    const cards = Array.from(
+      grid.querySelectorAll<ESPHomeDeviceCard>("esphome-device-card"),
+    );
+    const idx = cards.indexOf(this);
+    if (idx < 0) return;
+
+    if (key === "Home") return cards[0]?.focus();
+    if (key === "End") return cards[cards.length - 1]?.focus();
+    if (key === "ArrowRight") return cards[idx + 1]?.focus();
+    if (key === "ArrowLeft") return cards[idx - 1]?.focus();
+
+    /* Up / Down: pick the card on the next row whose horizontal centre
+       is closest to ours. The grid uses auto-fill columns so the column
+       count varies by viewport — using the rendered rects keeps the nav
+       working at any width without re-deriving the column count. */
+    const rect = this.getBoundingClientRect();
+    const myCenter = rect.left + rect.width / 2;
+    const direction = key === "ArrowDown" ? 1 : -1;
+    const withRects = cards
+      .filter((c) => c !== this)
+      .map((c) => ({ c, r: c.getBoundingClientRect() }))
+      .filter(({ r }) => direction * (r.top - rect.top) > 1);
+    if (!withRects.length) return;
+    withRects.sort((a, b) => direction * (a.r.top - b.r.top));
+    const targetTop = withRects[0].r.top;
+    const sameRow = withRects.filter(({ r }) => Math.abs(r.top - targetTop) < 1);
+    sameRow.sort(
+      (a, b) =>
+        Math.abs(a.r.left + a.r.width / 2 - myCenter) -
+        Math.abs(b.r.left + b.r.width / 2 - myCenter),
+    );
+    sameRow[0]?.c.focus();
   }
 
   private _onContextMenu(e: MouseEvent) {

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -465,25 +465,31 @@ export class ESPHomeDeviceCard extends LitElement {
     if (!this.hasAttribute("tabindex")) this.tabIndex = 0;
     if (!this.hasAttribute("role")) this.setAttribute("role", "button");
     this.addEventListener("keydown", this._onKeydown);
+    /* Activation has to live on the host. Some assistive tech
+       activates a focused role="button" by dispatching `click` on the
+       focused element itself; if the handler were on the inner
+       .device-card div, that synthesised click wouldn't reach it.
+       Inner buttons + the actions row already stopPropagation, so a
+       host-level click only fires for clicks on the card body. */
+    this.addEventListener("click", this._onClick);
+    this.addEventListener("contextmenu", this._onHostContextMenu);
   }
 
   disconnectedCallback() {
     this.removeEventListener("keydown", this._onKeydown);
+    this.removeEventListener("click", this._onClick);
+    this.removeEventListener("contextmenu", this._onHostContextMenu);
     super.disconnectedCallback();
   }
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
-    if (
-      changedProperties.has("name") ||
-      changedProperties.has("selectMode") ||
-      changedProperties.has("selected")
-    ) {
-      this.setAttribute(
-        "aria-label",
-        this.selectMode
-          ? `${this.name} (${this.selected ? "selected" : "not selected"})`
-          : this.name,
-      );
+    if (changedProperties.has("name")) {
+      /* Label is just the device name; selected state is conveyed via
+         aria-pressed below so screen readers announce it in the user's
+         locale instead of a hard-coded English string. */
+      this.setAttribute("aria-label", this.name);
+    }
+    if (changedProperties.has("selectMode") || changedProperties.has("selected")) {
       if (this.selectMode) {
         this.setAttribute("aria-pressed", String(this.selected));
       } else {
@@ -496,8 +502,6 @@ export class ESPHomeDeviceCard extends LitElement {
     return html`
       <div
         class="device-card ${this.selectMode ? "device-card--selectable" : "device-card--clickable"} ${this.selectMode && this.selected ? "device-card--selected" : ""}"
-        @click=${this.selectMode ? () => this._emit("toggle-select") : () => this._emit("card-click")}
-        @contextmenu=${this.selectMode ? nothing : this._onContextMenu}
       >
         <div class="device-card-header">
           ${this.selectMode
@@ -716,7 +720,15 @@ export class ESPHomeDeviceCard extends LitElement {
     sameRow[0]?.c.focus();
   }
 
-  private _onContextMenu(e: MouseEvent) {
+  private _onClick = () => {
+    this._emit(this.selectMode ? "toggle-select" : "card-click");
+  };
+
+  private _onHostContextMenu = (e: MouseEvent) => {
+    /* Suppressed in select mode — the dashboard hides per-row actions
+       there and a right-click menu would just be misleading. Otherwise
+       open the same overflow menu the kebab dispatches. */
+    if (this.selectMode) return;
     e.preventDefault();
     e.stopPropagation();
     this.dispatchEvent(
@@ -726,7 +738,7 @@ export class ESPHomeDeviceCard extends LitElement {
         composed: true,
       }),
     );
-  }
+  };
 
   private _onDotsClick(e: MouseEvent) {
     e.stopPropagation();

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -465,6 +465,7 @@ export class ESPHomeDeviceCard extends LitElement {
     if (!this.hasAttribute("tabindex")) this.tabIndex = 0;
     if (!this.hasAttribute("role")) this.setAttribute("role", "button");
     this.addEventListener("keydown", this._onKeydown);
+    this.addEventListener("keyup", this._onKeyup);
     /* Activation has to live on the host. Some assistive tech
        activates a focused role="button" by dispatching `click` on the
        focused element itself; if the handler were on the inner
@@ -477,6 +478,7 @@ export class ESPHomeDeviceCard extends LitElement {
 
   disconnectedCallback() {
     this.removeEventListener("keydown", this._onKeydown);
+    this.removeEventListener("keyup", this._onKeyup);
     this.removeEventListener("click", this._onClick);
     this.removeEventListener("contextmenu", this._onHostContextMenu);
     super.disconnectedCallback();
@@ -664,9 +666,22 @@ export class ESPHomeDeviceCard extends LitElement {
        from outside, so it can't be used to distinguish these. */
     if (e.composedPath()[0] !== this) return;
 
-    if (e.key === "Enter" || e.key === " ") {
+    if (e.key === "Enter") {
+      /* Native buttons activate Enter on keydown — match that so users
+         get the same instant feedback they'd see on a <button>. */
+      if (e.repeat) return;
       e.preventDefault();
       this._emit(this.selectMode ? "toggle-select" : "card-click");
+      return;
+    }
+
+    if (e.key === " ") {
+      /* Space activation is deferred to keyup (the native <button>
+         contract). preventDefault on keydown stops the page-scroll
+         that Space would otherwise trigger; the actual emit happens
+         in _onKeyup so a held-down Space doesn't fire repeatedly. */
+      e.preventDefault();
+      this._spaceArmed = true;
       return;
     }
 
@@ -681,6 +696,16 @@ export class ESPHomeDeviceCard extends LitElement {
       e.preventDefault();
       this._navigateCards(e.key);
     }
+  };
+
+  private _spaceArmed = false;
+  private _onKeyup = (e: KeyboardEvent) => {
+    if (e.key !== " ") return;
+    if (e.composedPath()[0] !== this) return;
+    if (!this._spaceArmed) return;
+    this._spaceArmed = false;
+    e.preventDefault();
+    this._emit(this.selectMode ? "toggle-select" : "card-click");
   };
 
   private _navigateCards(key: string) {
@@ -729,6 +754,19 @@ export class ESPHomeDeviceCard extends LitElement {
        there and a right-click menu would just be misleading. Otherwise
        open the same overflow menu the kebab dispatches. */
     if (this.selectMode) return;
+    /* Don't hijack right-clicks that originate on inner interactive
+       controls. The Visit Web UI link in particular needs the
+       browser's native context menu so users can "Open in new tab" /
+       "Copy link"; same goes for any inner button. composedPath()
+       crosses the shadow boundary so we see the real target. */
+    for (const el of e.composedPath()) {
+      if (!(el instanceof HTMLElement)) continue;
+      if (el === this) break;
+      const tag = el.tagName;
+      if (tag === "A" || tag === "BUTTON" || tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+        return;
+      }
+    }
     e.preventDefault();
     e.stopPropagation();
     this.dispatchEvent(

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -15,6 +15,7 @@ import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, yamlDiffButtonContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { deviceEditorStyles } from "./device-editor.styles.js";
 import type { HighlightRange } from "../yaml-editor.js";
@@ -80,24 +81,24 @@ export class ESPHomeDeviceEditor extends LitElement {
     this._isMobile = e.matches;
   };
 
-  /** Cmd/Ctrl+S → save the YAML if there are unsaved changes. Also
-   *  ESC to exit fullscreen so the editor matches the logs dialog
-   *  pattern. Listens at the document level so the shortcut works
-   *  regardless of which child (CodeMirror, navigator, etc.) currently
-   *  has focus. */
+  /** Cmd/Ctrl+S → save the YAML if there are unsaved changes.
+   *  Listens at the window level so the shortcut works regardless of
+   *  which child (CodeMirror, navigator, etc.) currently has focus.
+   *  Esc-to-exit-fullscreen is wired through EscapeController below
+   *  so the listener is only attached while fullscreen is active. */
   private _onGlobalKeyDown = (e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "s") {
       e.preventDefault();
       if (this.yaml !== this.savedYaml) {
         this._onSave();
       }
-      return;
-    }
-    if (e.key === "Escape" && this._fullscreen) {
-      e.preventDefault();
-      this._fullscreen = false;
     }
   };
+
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this._fullscreen = false;
+  });
 
   connectedCallback() {
     super.connectedCallback();
@@ -387,6 +388,7 @@ export class ESPHomeDeviceEditor extends LitElement {
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_fullscreen")) {
       this.toggleAttribute("fullscreen", this._fullscreen);
+      this._escape.set(this._fullscreen);
     }
   }
 

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -14,6 +14,7 @@ import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { firmwareJobsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -253,31 +254,10 @@ export class ESPHomeHeaderActions extends LitElement {
     this._open = false;
   }
 
-  disconnectedCallback() {
-    this._setEscListener(false);
-    super.disconnectedCallback();
-  }
+  private _escape = new EscapeController(this, () => this._close());
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("_open")) this._setEscListener(this._open);
-  }
-
-  private _onWindowKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this._close();
-    }
-  };
-
-  private _escBound = false;
-  private _setEscListener(active: boolean) {
-    if (active && !this._escBound) {
-      window.addEventListener("keydown", this._onWindowKeydown);
-      this._escBound = true;
-    } else if (!active && this._escBound) {
-      window.removeEventListener("keydown", this._onWindowKeydown);
-      this._escBound = false;
-    }
+    if (changed.has("_open")) this._escape.set(this._open);
   }
 
   private _onCheckboxKeydown = (e: KeyboardEvent) => {

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -254,7 +254,10 @@ export class ESPHomeHeaderActions extends LitElement {
     this._open = false;
   }
 
-  private _escape = new EscapeController(this, () => this._close());
+  private _escape = new EscapeController(this, (e) => {
+    e.preventDefault();
+    this._close();
+  });
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._escape.set(this._open);

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -253,6 +253,33 @@ export class ESPHomeHeaderActions extends LitElement {
     this._open = false;
   }
 
+  disconnectedCallback() {
+    this._setEscListener(false);
+    super.disconnectedCallback();
+  }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("_open")) this._setEscListener(this._open);
+  }
+
+  private _onWindowKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this._close();
+    }
+  };
+
+  private _escBound = false;
+  private _setEscListener(active: boolean) {
+    if (active && !this._escBound) {
+      window.addEventListener("keydown", this._onWindowKeydown);
+      this._escBound = true;
+    } else if (!active && this._escBound) {
+      window.removeEventListener("keydown", this._onWindowKeydown);
+      this._escBound = false;
+    }
+  }
+
   private _onCheckboxKeydown = (e: KeyboardEvent) => {
     /* The toggle is a ``<div role="menuitemcheckbox">`` rather than
        a ``<button>`` so it sits visually flush with the surrounding

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -13,6 +13,7 @@ import { mdiClose, mdiMagnify, mdiPalette } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
+import { EscapeController } from "../util/escape-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -377,27 +378,33 @@ export class ESPHomeMdiIconPicker extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener("click", this._onDocumentClick, true);
-    document.addEventListener("keydown", this._onDocumentKeydown);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener("click", this._onDocumentClick, true);
-    document.removeEventListener("keydown", this._onDocumentKeydown);
   }
+
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("_open")) this._escape.set(this._open);
+  }
+
+  /* Esc binds to ``document`` (not ``window``) and the callback uses
+     ``stopPropagation`` so a parent dialog wrapping the picker doesn't
+     also close on the same keypress. */
+  private _escape = new EscapeController(
+    this,
+    (e) => {
+      e.stopPropagation();
+      this._close();
+    },
+    { target: document },
+  );
 
   private _onDocumentClick = (e: Event) => {
     if (!this._open) return;
     const path = e.composedPath();
     if (!path.includes(this)) {
-      this._close();
-    }
-  };
-
-  private _onDocumentKeydown = (e: KeyboardEvent) => {
-    if (!this._open) return;
-    if (e.key === "Escape") {
-      e.stopPropagation();
       this._close();
     }
   };

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -471,7 +471,7 @@ export class ESPHomePageDashboard extends LitElement {
               @update-device=${() => this._openCommand(device, "install")}
               @open-logs=${() => this._openLogs(device)}
               @show-progress=${() => this._showJobProgress(device)}
-              @card-click=${() => { this._drawerDevice = device; this._drawerOpen = true; }}
+              @card-click=${() => this._toggleDrawerForDevice(device)}
               @card-context-menu=${(e: CustomEvent) => { this._cardContextDevice = device; this._cardContextPosition = e.detail; }}
               @toggle-select=${() => this._toggleDevice(device.configuration)}
             ></esphome-device-card>
@@ -498,7 +498,7 @@ export class ESPHomePageDashboard extends LitElement {
         @table-sort-change=${this._saveTablePreference}
         @table-visibility-change=${this._saveTablePreference}
         @table-page-size-change=${this._saveTablePreference}
-        @row-click=${(e: CustomEvent<ConfiguredDevice>) => { this._drawerDevice = e.detail; this._drawerOpen = true; }}
+        @row-click=${(e: CustomEvent<ConfiguredDevice>) => this._toggleDrawerForDevice(e.detail)}
         @show-progress=${(e: CustomEvent<ConfiguredDevice>) => this._showJobProgress(e.detail)}
         @toggle-select=${(e: CustomEvent<string>) => this._toggleDevice(e.detail)}
         @select-all=${() => { this._selectedDevices = new Set(this._devices.map((d) => d.configuration)); }}
@@ -822,6 +822,19 @@ export class ESPHomePageDashboard extends LitElement {
       // Detection failed or user cancelled — open wizard at board step as fallback
       this._createDialog.open("board");
     }
+  }
+
+  private _toggleDrawerForDevice(device: ConfiguredDevice) {
+    /* Card / row activation toggles the drawer rather than always
+       opening it, so a keyboard user can hit Enter or Space twice on
+       the same card to dismiss it without reaching for Escape. Tapping
+       a different card while one is open swaps to the new device. */
+    if (this._drawerOpen && this._drawerDevice?.configuration === device.configuration) {
+      this._drawerOpen = false;
+      return;
+    }
+    this._drawerDevice = device;
+    this._drawerOpen = true;
   }
 
   private _openCommand(device: ConfiguredDevice, type: CommandType, port?: string) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -210,6 +210,7 @@ export class ESPHomePageDevice extends LitElement {
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
+    window.addEventListener("keydown", this._onKeydown);
   }
 
   disconnectedCallback() {
@@ -217,7 +218,44 @@ export class ESPHomePageDevice extends LitElement {
     setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
+    window.removeEventListener("keydown", this._onKeydown);
     this._resolvePendingLeave(false);
+  }
+
+  private _onKeydown = (e: KeyboardEvent) => {
+    if (e.key !== "Escape") return;
+    /* Don't intercept Esc while the user is typing — the YAML editor,
+       text inputs, and contentEditable surfaces all use Esc for their
+       own behaviour (closing autocomplete, dropping focus, etc.).
+       composedPath()[0] is the actual focused element across shadow
+       boundaries; e.target gets retargeted to the host. */
+    const target = e.composedPath()[0] as HTMLElement | undefined;
+    if (this._isTextEntry(target)) return;
+    if (this._drawerOpen) {
+      e.preventDefault();
+      this._drawerOpen = false;
+      return;
+    }
+    /* Otherwise leave the editor — same path as the back button, so
+       the unsaved-changes guard runs via popstate. */
+    e.preventDefault();
+    window.history.back();
+  };
+
+  private _isTextEntry(el: HTMLElement | undefined): boolean {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+    if (el.isContentEditable) return true;
+    /* The Monaco-style YAML editor renders its caret inside a
+       textarea-like child but the focused element can vary by version.
+       Walk up looking for a recognisable editor host. */
+    let cur: HTMLElement | null = el;
+    while (cur) {
+      if (cur.tagName === "ESPHOME-YAML-EDITOR") return true;
+      cur = cur.parentElement;
+    }
+    return false;
   }
 
   updated(changedProperties: Map<string, unknown>) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -224,6 +224,11 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onKeydown = (e: KeyboardEvent) => {
     if (e.key !== "Escape") return;
+    /* If a deeper component (the fullscreen YAML editor, an open
+       dialog, etc.) already handled this Esc, don't also navigate
+       back. Mirrors the EscapeController guard so the leave-page
+       behaviour only fires when nothing else has claimed the key. */
+    if (e.defaultPrevented) return;
     /* Don't intercept Esc while the user is typing — the YAML editor,
        text inputs, and contentEditable surfaces all use Esc for their
        own behaviour (closing autocomplete, dropping focus, etc.).

--- a/src/util/escape-controller.ts
+++ b/src/util/escape-controller.ts
@@ -1,11 +1,25 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
+export interface EscapeControllerOptions {
+  /** Where to bind the keydown listener. Defaults to ``window``. Use
+   *  ``document`` when the host needs to ``stopPropagation`` so an
+   *  ancestor (a dialog wrapping a popup, for example) doesn't also
+   *  swallow the same Escape. */
+  target?: Window | Document;
+}
+
 /**
  * Reactive controller that runs ``onEscape`` whenever the user presses
  * Escape, but only while the controller is "active". Components that
  * own a popup or drawer call ``set(open)`` from ``willUpdate`` so the
- * window listener attaches when the surface opens and detaches when it
+ * listener attaches when the surface opens and detaches when it
  * closes — no leaks, no extra bookkeeping in each component.
+ *
+ * The callback receives the raw event so the caller decides whether to
+ * ``preventDefault`` / ``stopPropagation`` (semantics differ across
+ * use sites: a dropdown nested in a dialog wants to stop propagation
+ * so the dialog doesn't also close, while a top-level drawer just
+ * wants to swallow the default).
  *
  * Hooking up via Lit's ``addController`` means the listener is also
  * dropped automatically when the host disconnects, even if the host
@@ -13,11 +27,14 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
  */
 export class EscapeController implements ReactiveController {
   private _bound = false;
+  private readonly _target: Window | Document;
 
   constructor(
     host: ReactiveControllerHost,
-    private readonly onEscape: () => void,
+    private readonly onEscape: (e: KeyboardEvent) => void,
+    options: EscapeControllerOptions = {},
   ) {
+    this._target = options.target ?? window;
     host.addController(this);
   }
 
@@ -28,17 +45,19 @@ export class EscapeController implements ReactiveController {
   set(active: boolean) {
     if (active === this._bound) return;
     if (active) {
-      window.addEventListener("keydown", this._handler);
+      this._target.addEventListener("keydown", this._handler);
     } else {
-      window.removeEventListener("keydown", this._handler);
+      this._target.removeEventListener("keydown", this._handler);
     }
     this._bound = active;
   }
 
-  private _handler = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this.onEscape();
-    }
+  /* Typed as EventListener so the union of Window | Document accepts
+     the registration (each addEventListener overload narrows on the
+     event-name argument; the union loses that narrowing). The cast is
+     local — callers receive a properly typed KeyboardEvent. */
+  private _handler: EventListener = (e) => {
+    const ke = e as KeyboardEvent;
+    if (ke.key === "Escape") this.onEscape(ke);
   };
 }

--- a/src/util/escape-controller.ts
+++ b/src/util/escape-controller.ts
@@ -4,8 +4,9 @@ export interface EscapeControllerOptions {
   /** Where to bind the keydown listener. Defaults to ``window``. Use
    *  ``document`` when the host needs to ``stopPropagation`` so an
    *  ancestor (a dialog wrapping a popup, for example) doesn't also
-   *  swallow the same Escape. */
-  target?: Window | Document;
+   *  swallow the same Escape. Accepts any ``EventTarget`` so tests can
+   *  inject a stub. */
+  target?: EventTarget;
 }
 
 /**
@@ -27,7 +28,7 @@ export interface EscapeControllerOptions {
  */
 export class EscapeController implements ReactiveController {
   private _bound = false;
-  private readonly _target: Window | Document;
+  private readonly _target: EventTarget;
 
   constructor(
     host: ReactiveControllerHost,
@@ -58,6 +59,14 @@ export class EscapeController implements ReactiveController {
      local — callers receive a properly typed KeyboardEvent. */
   private _handler: EventListener = (e) => {
     const ke = e as KeyboardEvent;
-    if (ke.key === "Escape") this.onEscape(ke);
+    if (ke.key !== "Escape") return;
+    /* Bail if a deeper handler already claimed this Escape (typically
+       by calling preventDefault). Each callback in this codebase
+       preventDefaults, so when multiple surfaces happen to be open at
+       once only the first listener to fire actually closes. Without
+       this guard a single Esc press would close every overlay
+       unintentionally. */
+    if (ke.defaultPrevented) return;
+    this.onEscape(ke);
   };
 }

--- a/src/util/escape-controller.ts
+++ b/src/util/escape-controller.ts
@@ -1,0 +1,44 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/**
+ * Reactive controller that runs ``onEscape`` whenever the user presses
+ * Escape, but only while the controller is "active". Components that
+ * own a popup or drawer call ``set(open)`` from ``willUpdate`` so the
+ * window listener attaches when the surface opens and detaches when it
+ * closes — no leaks, no extra bookkeeping in each component.
+ *
+ * Hooking up via Lit's ``addController`` means the listener is also
+ * dropped automatically when the host disconnects, even if the host
+ * never explicitly calls ``set(false)``.
+ */
+export class EscapeController implements ReactiveController {
+  private _bound = false;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly onEscape: () => void,
+  ) {
+    host.addController(this);
+  }
+
+  hostDisconnected() {
+    this.set(false);
+  }
+
+  set(active: boolean) {
+    if (active === this._bound) return;
+    if (active) {
+      window.addEventListener("keydown", this._handler);
+    } else {
+      window.removeEventListener("keydown", this._handler);
+    }
+    this._bound = active;
+  }
+
+  private _handler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this.onEscape();
+    }
+  };
+}

--- a/test/util/escape-controller.test.ts
+++ b/test/util/escape-controller.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { EscapeController } from "../../src/util/escape-controller.js";
+
+class FakeHost implements ReactiveControllerHost {
+  controllers: ReactiveController[] = [];
+  addController(c: ReactiveController) {
+    this.controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {}
+  updateComplete = Promise.resolve(true);
+}
+
+/* The runtime test environment is plain Node (no jsdom), so we feed
+   the controller our own EventTarget and dispatch raw ``Event``s with
+   a ``key`` property tacked on — KeyboardEvent isn't available
+   without a DOM polyfill, but the controller only reads ``key`` and
+   ``defaultPrevented``. */
+function makeEsc(): Event {
+  const e = new Event("keydown", { cancelable: true });
+  Object.defineProperty(e, "key", { value: "Escape" });
+  return e;
+}
+
+function makeKey(key: string): Event {
+  const e = new Event("keydown", { cancelable: true });
+  Object.defineProperty(e, "key", { value: key });
+  return e;
+}
+
+describe("EscapeController", () => {
+  it("invokes the callback when active and ignores it when not", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new EscapeController(host, cb, { target });
+
+    target.dispatchEvent(makeEsc());
+    expect(cb).not.toHaveBeenCalled();
+
+    ctrl.set(true);
+    target.dispatchEvent(makeEsc());
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    ctrl.set(false);
+    target.dispatchEvent(makeEsc());
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("only attaches one listener for repeated set(true) calls", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new EscapeController(host, cb, { target });
+
+    ctrl.set(true);
+    ctrl.set(true);
+    ctrl.set(true);
+    target.dispatchEvent(makeEsc());
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keys other than Escape", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new EscapeController(host, cb, { target });
+    ctrl.set(true);
+
+    target.dispatchEvent(makeKey("Enter"));
+    target.dispatchEvent(makeKey("a"));
+    expect(cb).not.toHaveBeenCalled();
+
+    target.dispatchEvent(makeEsc());
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips when the event was already defaultPrevented", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new EscapeController(host, cb, { target });
+    ctrl.set(true);
+
+    const e = makeEsc();
+    e.preventDefault();
+    target.dispatchEvent(e);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("hostDisconnected detaches even if still active", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new EscapeController(host, cb, { target });
+    ctrl.set(true);
+
+    ctrl.hostDisconnected();
+    target.dispatchEvent(makeEsc());
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("passes the event to the callback", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    let received: Event | null = null;
+    const ctrl = new EscapeController(
+      host,
+      (e) => {
+        received = e;
+        e.preventDefault();
+      },
+      { target },
+    );
+    ctrl.set(true);
+
+    const e = makeEsc();
+    target.dispatchEvent(e);
+    expect(received).toBe(e);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("auto-registers as a controller on the host", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const ctrl = new EscapeController(host, () => {}, { target });
+    expect(host.controllers).toContain(ctrl);
+  });
+});


### PR DESCRIPTION
## Summary

First pass on keyboard-only navigation for the dashboard. Targets the configured-device card grid:

- Tab lands on each card (host gets `tabindex="0"` and `role="button"`)
- Enter / Space activates the card — opens the device drawer, or toggles selection in select mode
- Arrow keys move between cards in the grid; Up/Down find the card directly above or below using rendered rect centres so it works at any column count
- Home / End jump to the first/last card
- `aria-label` and (in select mode) `aria-pressed` describe the card to assistive tech
- `:focus-visible` outline on the card so the focused element is unambiguous

Inner action buttons (Edit, Install, Logs, Visit Web UI, kebab) remain in the tab order after the card so keyboard users still reach the per-card actions. Arrow keys are filtered to the host (via `composedPath()[0] === this`) so they don't fire when focus is on those inner buttons.

This is intentionally scoped to the card view. Follow-up passes:
- Dialog focus traps + consistent Esc-to-close
- Global shortcuts (Cmd/Ctrl+K for command palette, `/` to focus search)
- Table-view row keyboard nav
- Wizard step navigation

## Test plan

- [ ] Tab from the toolbar lands on the first card; visible focus ring appears
- [ ] Enter on a focused card opens the drawer
- [ ] Space on a focused card in select mode toggles selection without scrolling the page
- [ ] ArrowRight / ArrowLeft step through cards in DOM order
- [ ] ArrowDown / ArrowUp jump to the card directly below / above (verify at narrow + wide viewports — column count differs)
- [ ] Home / End jump to first / last card
- [ ] Tab from a focused card moves into Edit / Install / Logs / Web UI / kebab in order, then to the next card
- [ ] When focused on Edit, ArrowRight does NOT jump to the next card
- [ ] Screen reader announces the device name + button role