### PR TITLE
Reset ansi-log scroll state when reopening logs / command dialog

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -12,6 +12,7 @@ import type { ESPHomeAPI } from "../api/index.js";
 import { JobStatus, JobType } from "../api/types.js";
 import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import type { ESPHomeAnsiLog } from "./ansi-log.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -72,6 +73,9 @@ export class ESPHomeCommandDialog extends LitElement {
 
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
+
+  @query("esphome-ansi-log")
+  private _ansiLog?: ESPHomeAnsiLog;
 
   static styles = [
     espHomeStyles,
@@ -243,7 +247,17 @@ export class ESPHomeCommandDialog extends LitElement {
     this._jobId = "";
     this._streamId = "";
     this._dialog.open = true;
+    this._resetAnsiLogScroll();
     this._start();
+  }
+
+  private _resetAnsiLogScroll() {
+    /* The ansi-log instance is reused across opens; if the user
+       scrolled up in a previous session its ``_isUserScrolled`` flag
+       is still set and would suppress auto-scroll for the new
+       session. ``scrollToBottom()`` clears the flag and re-engages
+       streaming-to-bottom for the next batch of lines. */
+    this.updateComplete.then(() => this._ansiLog?.scrollToBottom());
   }
 
   /**
@@ -264,6 +278,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._jobId = job.job_id;
     this._streamId = "";
     this._dialog.open = true;
+    this._resetAnsiLogScroll();
     this._followJob(job.job_id);
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import type { ESPHomeAnsiLog } from "./ansi-log.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -61,6 +62,9 @@ export class ESPHomeLogsDialog extends LitElement {
 
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
+
+  @query("esphome-ansi-log")
+  private _ansiLog?: ESPHomeAnsiLog;
 
   static styles = [
     espHomeStyles,
@@ -356,7 +360,19 @@ export class ESPHomeLogsDialog extends LitElement {
     this._passive = false;
     this._streamId = "";
     this._dialog.open = true;
+    this._resetAnsiLogScroll();
     this._startStreaming();
+  }
+
+  private _resetAnsiLogScroll() {
+    /* The ansi-log instance is reused across opens. If the user
+       scrolled up in a previous session its ``_isUserScrolled`` flag
+       is still true, which suppresses auto-scroll for the new
+       session — incoming lines pile up unseen until the user scrolls
+       back to the bottom themselves. ``scrollToBottom()`` clears the
+       flag and forces a scroll. updateComplete makes sure the @query
+       has resolved on first open. */
+    this.updateComplete.then(() => this._ansiLog?.scrollToBottom());
   }
 
   /** Open dialog without auto-starting streaming (for Web Serial feed). */
@@ -373,6 +389,7 @@ export class ESPHomeLogsDialog extends LitElement {
     this._passive = true;
     this._streamId = "";
     this._dialog.open = true;
+    this._resetAnsiLogScroll();
   }
 
   public close() {


### PR DESCRIPTION
## Summary

Repro:
1. Open Logs for device A, scroll up
2. Close the dialog
3. Open Logs for device B

Expected: B's logs stream live to the bottom.
Actual: dialog stays scrolled wherever A was, and incoming lines pile up offscreen until you scroll back to the bottom yourself.

`esphome-ansi-log` tracks `_isUserScrolled` so it can pause auto-scroll while you read older lines. That flag is correctly sticky within a session, but the dialog reuses the same `<esphome-ansi-log>` instance across opens, so the flag persisted across close/reopen.

Fix: both `logs-dialog` and `command-dialog` call `scrollToBottom()` on the ansi-log inside their public open paths. That method already clears `_isUserScrolled` and forces a scroll on the next update, so the new session starts streaming-to-bottom.

## Test plan

- [ ] Open Logs for device A, scroll up → close → open Logs for device B → lines stream live, view stays at bottom
- [ ] During a streaming session, scroll up to read history → new lines still pause auto-scroll (existing behaviour preserved)
- [ ] Same for the install / compile / validate command dialog