### PR TITLE
Cancel the prior follow stream when the install dialog reopens

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -245,7 +245,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._lines = [];
     this._statusMessage = "";
     this._jobId = "";
-    this._streamId = "";
+    this._detachStream();
     this._dialog.open = true;
     this._resetAnsiLogScroll();
     this._start();
@@ -276,15 +276,35 @@ export class ESPHomeCommandDialog extends LitElement {
     this._lines = [];
     this._statusMessage = "";
     this._jobId = job.job_id;
-    this._streamId = "";
+    // Cancel any prior follow before starting a new one. Without
+    // this, every reopen of the dialog (clicking the busy spinner
+    // again while a job is still running) layered on a fresh
+    // ``firmwareFollowJob`` while the previous one was still pumping
+    // ``onOutput`` callbacks into ``this._lines`` — each new line
+    // appeared once per leaked subscription, so output duplicated
+    // five times after five clicks.
+    this._detachStream();
     this._dialog.open = true;
     this._resetAnsiLogScroll();
     this._followJob(job.job_id);
   }
 
   public close() {
-    this._streamId = "";
+    this._detachStream();
     this._dialog.open = false;
+  }
+
+  /**
+   * Tear down the active stream subscription, both client-side
+   * (drops the local handler so its closure stops appending to
+   * ``_lines``) and backend-side (the queued task can stop pushing
+   * lines for a job we're no longer watching). Safe to call when
+   * no stream is active.
+   */
+  private _detachStream() {
+    if (!this._streamId) return;
+    this._api.stopStream(this._streamId).catch(() => {});
+    this._streamId = "";
   }
 
   private get _title(): string {
@@ -350,7 +370,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // ─── Command execution ─────────────────────────────────────
 
   private async _start() {
-    this._streamId = "";
+    this._detachStream();
     this._jobId = "";
     this._state = "running";
     this._lines = [];
@@ -450,12 +470,12 @@ export class ESPHomeCommandDialog extends LitElement {
     }
     this._state = "error";
     this._statusMessage = this._localize("command.stopped");
-    this._streamId = "";
+    this._detachStream();
     this._jobId = "";
   }
 
   private _onDialogHide() {
-    this._streamId = "";
+    this._detachStream();
   }
 }
 

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -95,6 +95,14 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   }
 
   private _init(device: ConfiguredDevice) {
+    // Dispose any stream from a prior session before resetting state.
+    // ``_init`` re-runs on every ``installWebSerial`` call, including
+    // reopens after the user dismissed the previous run via the
+    // ``wa-dialog`` close button / Escape (which routes through
+    // ``_onClose`` and only flips ``_open``). Without this teardown a
+    // still-attached firmwareFollowJob from the prior compile would
+    // keep pushing lines into the new session's ``_logLines``.
+    this._detachStream();
     this._device = device;
     this._open = true;
     this._step = "installing";
@@ -106,8 +114,20 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._logsFullHeight = false;
     this._flashPercent = 0;
     this._jobId = "";
-    this._streamId = "";
     this._detected = null;
+  }
+
+  /**
+   * Tear down any active follow_job subscription, both client-side
+   * (drops the local handler so its closure stops appending to
+   * ``_logLines``) and backend-side. Safe when no stream is active.
+   * Used by every dialog-close path so a stale stream can't survive
+   * the next reopen.
+   */
+  private _detachStream() {
+    if (!this._streamId) return;
+    this._api.stopStream(this._streamId).catch(() => {});
+    this._streamId = "";
   }
 
   // ─── Styles ────────────────────────────────────────────
@@ -568,20 +588,20 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._open = false;
     this._device = null;
     this._jobId = "";
-    // Tear down any in-flight stream so its onOutput handler stops
-    // appending to ``_logLines`` after the dialog closes — otherwise
-    // a reopen of the dialog while the prior stream is still live
-    // would duplicate lines (the bug fixed for the command-dialog
-    // path; the install path has the same shape).
-    if (this._streamId) {
-      this._api.stopStream(this._streamId).catch(() => {});
-      this._streamId = "";
-    }
+    this._detachStream();
     this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
   }
 
+  /**
+   * ``wa-dialog``'s close button (header X) and Escape both fire
+   * ``wa-after-hide``, which routes here. Has to do the same stream
+   * teardown ``_close`` does — otherwise a header-X-then-reopen
+   * leaves the prior firmwareFollowJob attached, and lines from that
+   * subscription duplicate into the new session's log buffer.
+   */
   private _onClose() {
     this._open = false;
+    this._detachStream();
   }
 }
 

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -73,6 +73,17 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   private _device: ConfiguredDevice | null = null;
   private _jobId = "";
   private _streamId = "";
+
+  /**
+   * Reject hook for the in-flight ``_compileAndWait`` promise.
+   * ``_compileAndWait`` only settles from the firmwareFollowJob
+   * onResult / onError callbacks, but ``_detachStream`` removes the
+   * local handler in the API client so those callbacks can never
+   * fire after a teardown — without this hook the awaiter
+   * (``_startWebSerialInstall``) would hang forever and leak one
+   * pending install task per dialog reopen.
+   */
+  private _compileReject: ((err: Error) => void) | null = null;
   private _detected: DetectedChip | null = null;
 
   @query("wa-dialog")
@@ -113,21 +124,35 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._logsExpanded = false;
     this._logsFullHeight = false;
     this._flashPercent = 0;
-    this._jobId = "";
+    // ``_jobId`` is already cleared by ``_detachStream`` above; same
+    // for ``_streamId`` and ``_compileReject``.
     this._detected = null;
   }
 
   /**
    * Tear down any active follow_job subscription, both client-side
    * (drops the local handler so its closure stops appending to
-   * ``_logLines``) and backend-side. Safe when no stream is active.
-   * Used by every dialog-close path so a stale stream can't survive
-   * the next reopen.
+   * ``_logLines``) and backend-side. Settles a pending
+   * ``_compileAndWait`` promise so the parent flow doesn't hang
+   * waiting for callbacks that can no longer fire, and cancels the
+   * underlying firmware job so the backend stops doing work for a
+   * dialog the user has dismissed. Safe when no stream is active —
+   * every check is null-guarded.
    */
   private _detachStream() {
-    if (!this._streamId) return;
-    this._api.stopStream(this._streamId).catch(() => {});
-    this._streamId = "";
+    if (this._streamId) {
+      this._api.stopStream(this._streamId).catch(() => {});
+      this._streamId = "";
+    }
+    if (this._compileReject) {
+      const reject = this._compileReject;
+      this._compileReject = null;
+      reject(new Error("Install dialog dismissed"));
+    }
+    if (this._jobId) {
+      this._api.firmwareCancel(this._jobId).catch(() => {});
+      this._jobId = "";
+    }
   }
 
   // ─── Styles ────────────────────────────────────────────
@@ -539,6 +564,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   private _compileAndWait(configuration: string): Promise<void> {
     return new Promise(async (resolve, reject) => {
+      // Capture ``reject`` on the dialog so a mid-flight detach
+      // (header-X / Escape / reopen) can settle this promise. The
+      // followJob callbacks below clear the hook back to ``null``
+      // once they fire so a normal completion doesn't double-reject
+      // when the next teardown runs.
+      this._compileReject = reject;
       try {
         const job = await this._api.firmwareCompile(configuration);
         this._jobId = job.job_id;
@@ -553,16 +584,19 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
           onResult: (data) => {
             this._streamId = "";
             this._jobId = "";
+            this._compileReject = null;
             const result = data as unknown as { status: string };
             result.status === JobStatus.COMPLETED ? resolve() : reject(new Error("Compilation failed"));
           },
           onError: (error) => {
             this._streamId = "";
             this._jobId = "";
+            this._compileReject = null;
             reject(new Error(error));
           },
         });
       } catch (err) {
+        this._compileReject = null;
         reject(err);
       }
     });
@@ -587,7 +621,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   private _close() {
     this._open = false;
     this._device = null;
-    this._jobId = "";
+    // ``_detachStream`` clears ``_jobId`` itself (and cancels the
+    // backend job + settles any pending compile promise), so we
+    // don't bare-clear it here.
     this._detachStream();
     this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
   }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -568,7 +568,15 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._open = false;
     this._device = null;
     this._jobId = "";
-    this._streamId = "";
+    // Tear down any in-flight stream so its onOutput handler stops
+    // appending to ``_logLines`` after the dialog closes — otherwise
+    // a reopen of the dialog while the prior stream is still live
+    // would duplicate lines (the bug fixed for the command-dialog
+    // path; the install path has the same shape).
+    if (this._streamId) {
+      this._api.stopStream(this._streamId).catch(() => {});
+      this._streamId = "";
+    }
     this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -60,6 +60,15 @@ export class ESPHomeLogsDialog extends LitElement {
 
   private _streamId = "";
 
+  /**
+   * Cancel handle for an active Web Serial read loop. ``openPassive``
+   * runs the loop outside the WS-stream world, so it isn't covered by
+   * ``_streamId`` / ``stopStream`` — without an explicit hook the loop
+   * survived dialog closes and bled the previous device's output into
+   * the next session.
+   */
+  private _serialCancel: (() => void) | null = null;
+
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
@@ -376,7 +385,33 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   /** Open dialog without auto-starting streaming (for Web Serial feed). */
+  /**
+   * Register a cancel for the active Web Serial reader so the dialog
+   * can tear it down on close or when ``openPassive`` starts a new
+   * session. Caller (``streamSerialToDialog``) returns one cancel
+   * fn per loop; the dialog only ever holds one at a time and
+   * disposes the prior one when a new one is registered.
+   */
+  public setSerialCancel(cancel: () => void) {
+    this._stopSerial();
+    this._serialCancel = cancel;
+  }
+
+  private _stopSerial() {
+    if (this._serialCancel) {
+      const cancel = this._serialCancel;
+      this._serialCancel = null;
+      cancel();
+    }
+  }
+
   public openPassive() {
+    // Tear down any previous Web Serial read loop before kicking off
+    // the new session — without this the prior reader keeps shoving
+    // bytes into ``_lines`` and the new device's output is mixed
+    // with the old one's. Same shape as ``_detachStream`` in
+    // command-dialog.ts; different stream type, identical bug.
+    this._stopSerial();
     this._port = "";
     this._lines = [];
     this._streaming = true;
@@ -497,6 +532,12 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _stopStreaming(): Promise<void> {
+    // Stop both flavours of stream the dialog can carry: a backend
+    // ``logs`` WS subscription and a local Web Serial read loop.
+    // Closing one but not the other left passive sessions with a
+    // live reader still pushing bytes into ``_lines`` after the
+    // user hit Stop / Close.
+    this._stopSerial();
     const streamId = this._streamId;
     this._streaming = false;
     this._streamId = "";

--- a/src/pages/dashboard-actions.ts
+++ b/src/pages/dashboard-actions.ts
@@ -95,16 +95,38 @@ export async function fetchApiKey(
   }
 }
 
-export function streamSerialToDialog(port: any, dialog: any) {
+/**
+ * Pipe a Web Serial port into the logs dialog's line buffer.
+ *
+ * Returns a cancel function the dialog stores and calls on
+ * close / openPassive (to stop a previous session before starting
+ * a new one). Without that hook the read loop survived dialog
+ * closes and bled output from a previous serial port into the
+ * next session — a Copilot find on PR #68.
+ *
+ * The cancel:
+ *   * ``reader.cancel()`` releases the pending ``read()`` so the
+ *     loop's ``await`` settles and the loop exits via ``done``.
+ *   * ``reader.releaseLock()`` lets the decoder pipeline tear down
+ *     cleanly; otherwise a future getReader() call on the same
+ *     readable would throw.
+ */
+export function streamSerialToDialog(port: any, dialog: any): () => void {
   const decoder = new TextDecoderStream();
-  port.readable.pipeTo(decoder.writable);
+  port.readable.pipeTo(decoder.writable).catch(() => {
+    /* Pipe rejection happens when the reader is cancelled below;
+       swallow it so the unhandled promise rejection doesn't bubble
+       up into the console. */
+  });
   const reader = decoder.readable.getReader();
   let buffer = "";
+  let cancelled = false;
   const readLoop = async () => {
     try {
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
+        if (cancelled) break;
         buffer += value;
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -113,9 +135,22 @@ export function streamSerialToDialog(port: any, dialog: any) {
         }
       }
     } catch {
-      /* Port closed */
+      /* Port closed or reader cancelled — both are normal exits. */
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* Lock already released — ignore. */
+      }
     }
   };
   readLoop();
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    reader.cancel().catch(() => {
+      /* Already disposed — nothing to do. */
+    });
+  };
 }
 

--- a/src/pages/dashboard-actions.ts
+++ b/src/pages/dashboard-actions.ts
@@ -148,9 +148,22 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
   return () => {
     if (cancelled) return;
     cancelled = true;
-    reader.cancel().catch(() => {
-      /* Already disposed — nothing to do. */
-    });
+    // Cancel the reader first so its lock is released, then close
+    // the port. Without ``port.close()`` the browser keeps the OS
+    // handle open: every reopen of the passive logs viewer leaks
+    // another open port and eventually trips the per-tab Web Serial
+    // ceiling so the user can't reconnect to the same device until
+    // they refresh the page.
+    reader
+      .cancel()
+      .catch(() => {
+        /* Already disposed — nothing to do. */
+      })
+      .finally(() => {
+        port.close().catch(() => {
+          /* Port already closed (user pulled the cable, etc). */
+        });
+      });
   };
 }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -899,7 +899,8 @@ export class ESPHomePageDashboard extends LitElement {
         this._logsDialog.configuration = device.configuration;
         this._logsDialog.name = device.friendly_name || device.name;
         this._logsDialog.openPassive();
-        streamSerialToDialog(serialPort, this._logsDialog);
+        const cancelSerial = streamSerialToDialog(serialPort, this._logsDialog);
+        this._logsDialog.setSerialCancel(cancelSerial);
       } catch { /* User cancelled */ }
     }
   }


### PR DESCRIPTION
## Symptom

Clicking the busy spinner on a card while a job was still running reopened the install/progress dialog. The trailing log lines duplicated once per reopen — five clicks, five copies:

```
INFO Upload took 24.95 seconds, waiting for result...
INFO Upload took 24.95 seconds, waiting for result...
INFO Upload took 24.95 seconds, waiting for result...
INFO Upload took 24.95 seconds, waiting for result...
INFO Upload took 24.95 seconds, waiting for result...
INFO OTA successful
INFO OTA successful
INFO OTA successful
INFO OTA successful
INFO OTA successful
```

## Cause

`command-dialog.ts` had several sites that bared `this._streamId = ""` (in `open()`, `followJob()`, `close()`, `_onDialogHide()`, `_stop()`, `_start()`). That cleared the local id but never told the backend to cancel or asked the API client to drop the local handler. The previous `firmwareFollowJob`'s `onOutput` closure was bound to the dialog instance and kept appending to `this._lines` — each click layered another live subscription, so the same output came in N times.

## Fix

Extract a `_detachStream()` helper that:

- Calls `this._api.stopStream(this._streamId)` when set — that drops the local handler (so its closure stops appending) and tells the backend to cancel the queued streaming task.
- Zeros `_streamId`.

Use it at every site that previously bare-cleared `_streamId`, so a reopen always starts from a single live subscription.

Also applied the same fix to `firmware-install-dialog._close()` — same shape, less likely to be hit on the user's path but the bug is identical.

## Test plan

- [x] Lint clean.
- [x] All 124 existing tests pass.
- [ ] Reproduce the original report: click "Installing" on the card 5x while the job runs. Output should appear once per line, not five times.
- [ ] Reopen mid-stream still shows the live tail (the new follow's snapshot replay covers this — same as today).