### PR TITLE
Show "queued — waiting for X" overlay in command dialog

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -24,6 +24,7 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -177,7 +178,17 @@ export class ESPHomeCommandDialog extends LitElement {
         min-height: 300px;
         max-height: 70vh;
         overflow: hidden;
+      }
+      /* Wrapper that owns the queued overlay's positioning context.
+         Anchoring on this (rather than .content) means the overlay
+         covers only the log area — the toolbar / banner stay
+         interactive even on narrow viewports where their height
+         doesn't match the previous hard-coded offset. */
+      .log-area {
         position: relative;
+        flex: 1;
+        min-height: 0;
+        display: flex;
       }
       esphome-ansi-log {
         flex: 1;
@@ -192,7 +203,7 @@ export class ESPHomeCommandDialog extends LitElement {
          the "View firmware tasks" button gives them a quick out. */
       .queued-overlay {
         position: absolute;
-        inset: 0 0 var(--queued-toolbar-offset, 36px) 0;
+        inset: 0;
         background: var(--term-bg);
         display: flex;
         flex-direction: column;
@@ -383,8 +394,10 @@ export class ESPHomeCommandDialog extends LitElement {
     return html`
       <wa-dialog label=${this._title} light-dismiss @wa-after-hide=${this._onDialogHide}>
         <div class="content">
-          <esphome-ansi-log .lines=${this._lines} ?light=${!this._darkMode}></esphome-ansi-log>
-          ${this._renderQueuedOverlay()}
+          <div class="log-area">
+            <esphome-ansi-log .lines=${this._lines} ?light=${!this._darkMode}></esphome-ansi-log>
+            ${this._renderQueuedOverlay()}
+          </div>
           ${this._renderBanner()}
           ${this._renderToolbar()}
         </div>
@@ -411,13 +424,7 @@ export class ESPHomeCommandDialog extends LitElement {
   }
 
   private _jobDisplayName(job: FirmwareJob): string {
-    if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
-      return this._localize("firmware_jobs.build_env_label");
-    }
-    const device = this._devices.find(
-      (d) => d.configuration === job.configuration,
-    );
-    return device?.friendly_name || device?.name || job.configuration;
+    return firmwareJobDisplayName(job, this._devices, this._localize);
   }
 
   private _renderQueuedOverlay() {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -3,8 +3,10 @@ import {
   mdiAlertCircle,
   mdiCheckCircle,
   mdiClose,
+  mdiPlaylistCheck,
   mdiRefresh,
   mdiStop,
+  mdiTimerSand,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -13,7 +15,14 @@ import { JobStatus, JobType } from "../api/types.js";
 import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeAnsiLog } from "./ansi-log.js";
-import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import type { ConfiguredDevice } from "../api/types.js";
+import {
+  apiContext,
+  darkModeContext,
+  devicesContext,
+  firmwareJobsContext,
+  localizeContext,
+} from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -27,6 +36,8 @@ registerMdiIcons({
   refresh: mdiRefresh,
   "check-circle": mdiCheckCircle,
   "alert-circle": mdiAlertCircle,
+  "playlist-check": mdiPlaylistCheck,
+  "timer-sand": mdiTimerSand,
 });
 
 export type CommandType = "install" | "compile" | "validate" | "clean" | "reset";
@@ -52,6 +63,20 @@ export class ESPHomeCommandDialog extends LitElement {
 
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
+
+  /** Live snapshot of every backend firmware job, keyed by job_id.
+   *  Drives the "queued — another task is running" overlay so we can
+   *  tell the user the current dialog is waiting in line instead of
+   *  silently sitting on an empty log. */
+  @consume({ context: firmwareJobsContext, subscribe: true })
+  @state()
+  private _jobs: Map<string, FirmwareJob> = new Map();
+
+  /** Configured devices — used to resolve the running job's friendly
+   *  name for the queued-overlay's "waiting for: <device>" hint. */
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  private _devices: ConfiguredDevice[] = [];
 
   @property()
   configuration = "";
@@ -152,6 +177,7 @@ export class ESPHomeCommandDialog extends LitElement {
         min-height: 300px;
         max-height: 70vh;
         overflow: hidden;
+        position: relative;
       }
       esphome-ansi-log {
         flex: 1;
@@ -159,6 +185,48 @@ export class ESPHomeCommandDialog extends LitElement {
         --log-height: 100%;
       }
       esphome-ansi-log::part(container) { border-radius: 0; }
+
+      /* Queued-overlay — covers the empty log area while the job is
+         waiting in line behind another firmware task. The dialog
+         deliberately doesn't auto-close so the user can keep watching;
+         the "View firmware tasks" button gives them a quick out. */
+      .queued-overlay {
+        position: absolute;
+        inset: 0 0 var(--queued-toolbar-offset, 36px) 0;
+        background: var(--term-bg);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 24px;
+        text-align: center;
+        font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+        color: var(--term-fg);
+        z-index: 1;
+      }
+      .queued-overlay wa-icon[name="timer-sand"] {
+        font-size: 48px;
+        color: var(--term-accent);
+        animation: queued-pulse 2s ease-in-out infinite;
+      }
+      @keyframes queued-pulse {
+        0%, 100% { opacity: 0.7; }
+        50% { opacity: 1; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .queued-overlay wa-icon[name="timer-sand"] { animation: none; }
+      }
+      .queued-title {
+        font-size: 16px;
+        font-weight: 700;
+      }
+      .queued-message {
+        font-size: 13px;
+        color: var(--term-fg-muted);
+        max-width: 420px;
+        line-height: 1.5;
+      }
 
       .status-banner {
         display: flex;
@@ -296,11 +364,78 @@ export class ESPHomeCommandDialog extends LitElement {
       <wa-dialog label=${this._title} light-dismiss @wa-after-hide=${this._onDialogHide}>
         <div class="content">
           <esphome-ansi-log .lines=${this._lines} ?light=${!this._darkMode}></esphome-ansi-log>
+          ${this._renderQueuedOverlay()}
           ${this._renderBanner()}
           ${this._renderToolbar()}
         </div>
       </wa-dialog>
     `;
+  }
+
+  /** True when this dialog is following a job that's still in the
+   *  queue — backend serialises firmware work, so an Install kicked
+   *  off while another job is running sits at QUEUED until its turn. */
+  private get _isQueued(): boolean {
+    if (!this._jobId) return false;
+    return this._jobs.get(this._jobId)?.status === JobStatus.QUEUED;
+  }
+
+  /** The job currently holding the firmware queue, if any. Used to
+   *  tell the user *which* device they're waiting on so they can
+   *  decide whether to cancel the in-flight task. */
+  private get _runningJob(): FirmwareJob | null {
+    for (const job of this._jobs.values()) {
+      if (job.status === JobStatus.RUNNING) return job;
+    }
+    return null;
+  }
+
+  private _jobDisplayName(job: FirmwareJob): string {
+    if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
+      return this._localize("firmware_jobs.build_env_label");
+    }
+    const device = this._devices.find(
+      (d) => d.configuration === job.configuration,
+    );
+    return device?.friendly_name || device?.name || job.configuration;
+  }
+
+  private _renderQueuedOverlay() {
+    if (!this._isQueued) return nothing;
+    const running = this._runningJob;
+    return html`
+      <div class="queued-overlay" role="status" aria-live="polite">
+        <wa-icon library="mdi" name="timer-sand"></wa-icon>
+        <div class="queued-title">
+          ${this._localize("command.queued_title")}
+        </div>
+        <div class="queued-message">
+          ${running
+            ? this._localize("command.queued_waiting_for", {
+                name: this._jobDisplayName(running),
+              })
+            : this._localize("command.queued_message")}
+        </div>
+        <button class="term-btn term-btn--start" @click=${this._openFirmwareJobs}>
+          <wa-icon library="mdi" name="playlist-check"></wa-icon>
+          ${this._localize("command.queued_view_all")}
+        </button>
+      </div>
+    `;
+  }
+
+  private _openFirmwareJobs() {
+    /* Closing the command dialog frees the user to interact with the
+       firmware-tasks list (cancel the running job, see the full
+       queue, etc.) — the dialog's follow_job stream will reattach if
+       they click back into this device's job from the tasks list. */
+    this.close();
+    this.dispatchEvent(
+      new CustomEvent("open-firmware-jobs", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private _renderBanner() {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -92,6 +92,14 @@ export class ESPHomeCommandDialog extends LitElement {
 
   /** Active job ID (for cancel). Not used for validate. */
   private _jobId = "";
+  /** Latest known status of the followed job. Primed from the
+   *  ``firmware/install`` (etc.) response so the queued overlay can
+   *  render immediately on open instead of waiting for the matching
+   *  ``job_queued`` event to land in ``firmwareJobsContext``. The
+   *  context value takes precedence once it arrives — see
+   *  ``_isQueued`` below. */
+  @state()
+  private _jobStatus: JobStatus | null = null;
   /** Stream message ID (for both validate streaming and follow_job streaming). */
   private _streamId = "";
   /** Install target port — "OTA" for network, an actual port for server-serial. */
@@ -324,6 +332,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._lines = [];
     this._statusMessage = "";
     this._jobId = "";
+    this._jobStatus = null;
     this._detachStream();
     this._dialog.open = true;
     this._resetAnsiLogScroll();
@@ -355,6 +364,10 @@ export class ESPHomeCommandDialog extends LitElement {
     this._lines = [];
     this._statusMessage = "";
     this._jobId = job.job_id;
+    /* Prime from the job we were handed so the queued overlay can
+       render on the very first paint instead of after the next
+       context update. */
+    this._jobStatus = job.status;
     // Cancel any prior follow before starting a new one. Without
     // this, every reopen of the dialog (clicking the busy spinner
     // again while a job is still running) layered on a fresh
@@ -410,7 +423,12 @@ export class ESPHomeCommandDialog extends LitElement {
    *  off while another job is running sits at QUEUED until its turn. */
   private get _isQueued(): boolean {
     if (!this._jobId) return false;
-    return this._jobs.get(this._jobId)?.status === JobStatus.QUEUED;
+    /* Context wins once it has the entry — the backend may transition
+       the job (e.g. QUEUED → RUNNING) before we'd see it locally.
+       The locally-primed ``_jobStatus`` only fills the gap before the
+       first context update. */
+    const ctxStatus = this._jobs.get(this._jobId)?.status;
+    return (ctxStatus ?? this._jobStatus) === JobStatus.QUEUED;
   }
 
   /** The job currently holding the firmware queue, if any. Used to
@@ -573,6 +591,11 @@ export class ESPHomeCommandDialog extends LitElement {
     }
 
     this._jobId = job.job_id;
+    /* Prime status from the API response so the queued overlay shows
+       up immediately. The matching ``job_queued`` event will lands in
+       ``firmwareJobsContext`` shortly after and the getter will
+       prefer that live value going forward. */
+    this._jobStatus = job.status;
     this._followJob(job.job_id);
   }
 

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -30,6 +30,7 @@ import {
   formatAbsoluteTime,
   formatRelativeTime,
 } from "../util/format-job-time.js";
+import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -677,11 +678,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   };
 
   private _jobDisplayName(job: FirmwareJob): string {
-    if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
-      return this._localize("firmware_jobs.build_env_label");
-    }
-    const device = this._devices.find((d) => d.configuration === job.configuration);
-    return device?.friendly_name || device?.name || job.configuration;
+    return firmwareJobDisplayName(job, this._devices, this._localize);
   }
 
   private _openJob(job: FirmwareJob) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -207,7 +207,11 @@
     "clean_success": "Build files cleaned.",
     "clean_failed": "Clean failed.",
     "reset_success": "Build environment reset. The next compile will redownload the toolchain.",
-    "reset_failed": "Failed to reset the build environment."
+    "reset_failed": "Failed to reset the build environment.",
+    "queued_title": "Waiting in queue",
+    "queued_message": "Another firmware task is running. This task will start when it finishes.",
+    "queued_waiting_for": "Waiting for {name} to finish.",
+    "queued_view_all": "View firmware tasks"
   },
   "firmware": {
     "install_title": "Install — {name}",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -192,7 +192,11 @@
     "clean_success": "Fichiers de compilation nettoyés.",
     "clean_failed": "Échec du nettoyage.",
     "reset_success": "Environnement de compilation réinitialisé. La prochaine compilation retéléchargera la chaîne d'outils.",
-    "reset_failed": "Échec de la réinitialisation de l'environnement de compilation."
+    "reset_failed": "Échec de la réinitialisation de l'environnement de compilation.",
+    "queued_title": "En file d'attente",
+    "queued_message": "Une autre tâche firmware est en cours. Celle-ci démarrera à la fin.",
+    "queued_waiting_for": "En attente de {name}.",
+    "queued_view_all": "Voir les tâches firmware"
   },
   "serial": {
     "title": "Appareil USB",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -192,7 +192,11 @@
     "clean_success": "Bouwbestanden opgeschoond.",
     "clean_failed": "Opschonen mislukt.",
     "reset_success": "Bouw-omgeving gereset. De volgende compilatie downloadt de toolchain opnieuw.",
-    "reset_failed": "Resetten van de bouw-omgeving mislukt."
+    "reset_failed": "Resetten van de bouw-omgeving mislukt.",
+    "queued_title": "In wachtrij",
+    "queued_message": "Er draait al een andere firmwaretaak. Deze start zodra die klaar is.",
+    "queued_waiting_for": "Wachten tot {name} klaar is.",
+    "queued_view_all": "Firmwaretaken bekijken"
   },
   "serial": {
     "title": "USB-apparaat",

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -1,0 +1,28 @@
+import { JobType } from "../api/types.js";
+import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
+import type { LocalizeFunc } from "../common/localize.js";
+
+/**
+ * Resolve the human-readable label for a firmware job.
+ *
+ * Used by both the firmware-tasks dialog and the command dialog's
+ * queued overlay so the same job is named the same way everywhere
+ * (e.g. switching from ``configuration`` to ``friendly_name`` won't
+ * accidentally drift between surfaces).
+ *
+ * - ``RESET_BUILD_ENV`` jobs (and any job without a ``configuration``)
+ *   render as the localized "build environment" label.
+ * - Otherwise prefer the configured device's friendly name → fall
+ *   back to ``name`` → fall back to the raw configuration filename.
+ */
+export function firmwareJobDisplayName(
+  job: FirmwareJob,
+  devices: ConfiguredDevice[],
+  localize: LocalizeFunc,
+): string {
+  if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
+    return localize("firmware_jobs.build_env_label");
+  }
+  const device = devices.find((d) => d.configuration === job.configuration);
+  return device?.friendly_name || device?.name || job.configuration;
+}


### PR DESCRIPTION
## Summary

Repro: kick off Install on device A, then click Install on device B while A is still installing.

Today: B's command dialog opens immediately on top of an empty terminal. The job is sitting at QUEUED waiting for A to finish, but the UI gives no indication of that — users assume something's broken.

This adds a queued overlay over the empty log area with:

- A pulsing timer-sand icon so the waiting state is visible at a glance
- A **live** "Waiting for *Device A* to finish." line that resolves the currently-running job through `firmwareJobsContext` + `devicesContext` and updates the moment that job changes — the queue advances visibly without anyone reopening anything
- A "View firmware tasks" button that closes this dialog and opens the firmware-tasks list (cancel the in-flight job, see the full queue, etc.)

When the followed job flips to RUNNING the overlay falls away and the normal streaming log + toolbar take over.

## Test plan

- [ ] Start Install on A, immediately click Install on B → B's dialog shows the timer-sand overlay with "Waiting for *A* to finish."
- [ ] When A completes and B starts → overlay disappears, B's log streams as normal
- [ ] "View firmware tasks" closes the command dialog and opens the firmware-tasks dialog
- [ ] If A is cancelled while B is queued, the overlay still shows (B is still waiting because the queue advances synchronously) and updates the moment the next runner starts
- [ ] Reduced-motion users get a static icon (no pulse animation)