### PR TITLE
Collapse the Logs button to icon-only when the Visit Web UI button is shown

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -586,11 +586,15 @@ export class ESPHomeDeviceCard extends LitElement {
                       `
                     : nothing}
                 <button
-                  class="action-btn action-btn--ghost"
+                  class="action-btn action-btn--ghost ${this.webUrl ? "action-btn--tile" : ""}"
                   @click=${() => this._emit("open-logs")}
+                  aria-label=${this._localize("dashboard.drawer_logs")}
+                  title=${this._localize("dashboard.drawer_logs")}
                 >
                   <wa-icon library="mdi" name="console"></wa-icon>
-                  ${this._localize("dashboard.drawer_logs")}
+                  ${this.webUrl
+                    ? nothing
+                    : this._localize("dashboard.drawer_logs")}
                 </button>
                 ${this.webUrl
                   ? html`<a

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -585,17 +585,22 @@ export class ESPHomeDeviceCard extends LitElement {
                         </button>
                       `
                     : nothing}
-                <button
-                  class="action-btn action-btn--ghost ${this.webUrl ? "action-btn--tile" : ""}"
-                  @click=${() => this._emit("open-logs")}
-                  aria-label=${this._localize("dashboard.drawer_logs")}
-                  title=${this._localize("dashboard.drawer_logs")}
-                >
-                  <wa-icon library="mdi" name="console"></wa-icon>
-                  ${this.webUrl
-                    ? nothing
-                    : this._localize("dashboard.drawer_logs")}
-                </button>
+                ${this.webUrl
+                  ? html`<button
+                      class="action-btn action-btn--ghost action-btn--tile"
+                      @click=${() => this._emit("open-logs")}
+                      aria-label=${this._localize("dashboard.drawer_logs")}
+                      title=${this._localize("dashboard.drawer_logs")}
+                    >
+                      <wa-icon library="mdi" name="console"></wa-icon>
+                    </button>`
+                  : html`<button
+                      class="action-btn action-btn--ghost"
+                      @click=${() => this._emit("open-logs")}
+                    >
+                      <wa-icon library="mdi" name="console"></wa-icon>
+                      ${this._localize("dashboard.drawer_logs")}
+                    </button>`}
                 ${this.webUrl
                   ? html`<a
                       class="action-btn action-btn--ghost action-btn--tile"


### PR DESCRIPTION
## Symptom

In a four-up card grid (and on tighter desktop viewports generally), cards that expose a **Visit Web UI** button — i.e. devices with `web_server:` in their YAML, so the backend reports a non-null `web_port` — have one extra button-width to fit on the row. Edit + Install + Logs + Visit + kebab squeezed the labelled buttons into truncation territory, so the row read as a smoosh of icons with cropped text.

## Fix

When `webUrl` is set, drop the **Logs** label and render the button icon-only (same `--tile` shape Visit already uses). Edit and Install keep their labels — they're more frequent and the label carries weight beyond the icon — and Logs is the right one to collapse because the `console` icon is already used elsewhere in the dashboard for the same action. `aria-label` and `title` carry the accessible name so screen readers and hover tooltips still say "Logs".

When there's no Visit button (no `web_server` block), the row keeps the old layout — the extra horizontal real estate goes to the labelled Logs button as before.

## Test plan

- [x] Lint clean.
- [x] All 124 existing tests pass.
- [ ] Visual on a 4-up card grid: cards with Visit button — Edit + Install labelled, Logs icon-only, Visit icon, kebab. No truncation.
- [ ] Cards without Visit button — unchanged from today (Edit + Install + labelled Logs + kebab).
- [ ] Hover the icon-only Logs button: tooltip says "Logs".