### PR TITLE
Bump command-dialog default width to match the logs dialog

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -141,7 +141,16 @@ export class ESPHomeCommandDialog extends LitElement {
         --term-success: #3d7a28;
       }
 
-      wa-dialog { --width: min(900px, 90vw); }
+      /* Match the logs-dialog width — same body content (ANSI-coloured
+         terminal output from esphome's --dashboard mode), same wrap
+         budget. 900 wrapped routinely on retina laptops where the
+         timestamp + [C][module:NNN] prefix eats more horizontal real
+         estate than expected; 1300 fits the common case end-to-end on
+         a 13-inch laptop and leaves long-tail lines (multi-component
+         config dumps, stack traces) to the user's browser scrollbar.
+         min(..., 94vw) keeps the dialog from kissing the viewport
+         edges on smaller screens. */
+      wa-dialog { --width: min(1300px, 94vw); }
       /* Header matches the device-editor's title bar
          (--esphome-primary background with --esphome-on-primary
          text) so Validate / Install / Clean dialogs read as part


### PR DESCRIPTION
## Summary

Same fix the logs dialog already shipped twice (PR #67 for the latest), applied to the install / compile / validate / clean dialog.

`command-dialog` has the same body content as `logs-dialog` — ANSI-coloured terminal output from `esphome --dashboard` — and the same wrap budget. The logs dialog was widened from 900 → 1100 → 1200 → **1300px / 94vw** as users kept hitting the wrap on retina laptops where the timestamp + `[C][module:NNN]` prefix eats more horizontal real estate than the original measurement allowed for. The command dialog never picked up those bumps and was still at `min(900px, 90vw)` — so install / compile output wraps even though logs no longer does.

This PR moves command-dialog to the same `min(1300px, 94vw)` value, with a comment cross-referencing the logs-dialog history so the next person knows the two files intentionally share the same number.

## Test plan

- [x] Lint clean.
- [x] All 131 existing tests pass.
- [ ] Visual: install / compile / validate dialog on a 13" / 14" / 15" laptop fits typical `[C][module:NNN]` log lines end-to-end without wrap. Long-tail lines (config dumps, stack traces) still wrap; the dialog body's overflow handles them.