### PR TITLE
Wrap long ansi-log lines instead of forcing horizontal scroll

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -262,15 +262,18 @@ export class ESPHomeAnsiLog extends LitElement {
        instead of forcing the user onto an easily-missed horizontal
        scrollbar — PIO download URLs and full build paths routinely
        run past 200 chars and the install/log dialogs have no obvious
-       affordance for sideways scrolling. overflow-wrap: anywhere
-       breaks inside unbroken tokens (URLs, paths) so a single long
-       run can't push the line back into overflow. */
+       affordance for sideways scrolling. word-break: break-word +
+       overflow-wrap: anywhere is the same belt-and-suspenders pair
+       yaml-diff.ts uses — Safari historically honoured the former
+       earlier than the latter, so keeping both ensures unbroken
+       tokens (URLs, paths) wrap consistently across engines. */
     .log-line {
       margin: 0;
       padding: 0;
       border-radius: 2px;
       line-height: 18px;
       white-space: pre-wrap;
+      word-break: break-word;
       overflow-wrap: anywhere;
     }
 

--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -253,16 +253,25 @@ export class ESPHomeAnsiLog extends LitElement {
       tab-size: 4;
     }
 
-    /* white-space: pre lives on the line, not the container. On the
-       container Lit's html-template inter-element text nodes
+    /* white-space: pre-wrap lives on the line, not the container. On
+       the container Lit's html-template inter-element text nodes
        (whitespace between <div> and the interpolated children) render
-       as visible blank lines above the first real log line. */
+       as visible blank lines above the first real log line.
+
+       pre-wrap (vs plain pre) lets long lines wrap at the dialog edge
+       instead of forcing the user onto an easily-missed horizontal
+       scrollbar — PIO download URLs and full build paths routinely
+       run past 200 chars and the install/log dialogs have no obvious
+       affordance for sideways scrolling. overflow-wrap: anywhere
+       breaks inside unbroken tokens (URLs, paths) so a single long
+       run can't push the line back into overflow. */
     .log-line {
       margin: 0;
       padding: 0;
       border-radius: 2px;
       line-height: 18px;
-      white-space: pre;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
     }
 
     .log-line:hover {


### PR DESCRIPTION
## Summary

- Switch ``<esphome-ansi-log>`` per-line CSS from ``white-space: pre`` to ``pre-wrap`` so install / compile / logs dialog output wraps at the dialog edge instead of escaping onto a barely-visible horizontal scrollbar.
- Add ``overflow-wrap: anywhere`` so a single long token (PIO download URL, full build path) breaks inside itself instead of pushing the line back into overflow.

## Why

#73 widened the install dialog to 1300px to match logs, but on a 13" laptop the PIO ``Processing ... platform: https://github.com/.../platform-espressif32/releases/download/55.03.38-1/...`` line still ran off-screen with no obvious way to scroll right (``wa-dialog::part(body) { overflow: hidden }`` clips the inner scrollbar to a sliver flush against the toolbar). Wrapping is a strictly nicer affordance for terminal-style log viewing.

## Test plan

- [ ] ``npm run lint`` clean
- [ ] ``npm test`` (131/131 pass)
- [ ] Open the install dialog on a real device — long PIO download URLs and build paths wrap at the dialog edge end-to-end without horizontal scrolling.
- [ ] Indentation in stack traces / config dumps still aligns (the ``pre`` half of ``pre-wrap`` preserves leading whitespace).
- [ ] Logs dialog still wraps the same way — same component, so this rides for free.