### PR TITLE
Show Update label when an ESPHome version update is available

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -364,14 +364,25 @@ export class ESPHomeDeviceDrawer extends LitElement {
             <wa-icon library="mdi" name="pencil"></wa-icon>
             ${this._localize("dashboard.drawer_edit")}
           </button>
-          <button
-            class="action action--accent"
-            ?disabled=${this.busy}
-            @click=${() => this._emitAction("update-device")}
-          >
-            <wa-icon library="mdi" name="upload"></wa-icon>
-            ${this._localize("dashboard.drawer_update")}
-          </button>
+          ${device.update_available
+            ? html`<button
+                class="action action--accent"
+                ?disabled=${this.busy}
+                @click=${() => this._emitAction("update-device")}
+              >
+                <wa-icon library="mdi" name="upload"></wa-icon>
+                ${this._localize("dashboard.drawer_update")}
+              </button>`
+            : device.has_pending_changes === true
+              ? html`<button
+                  class="action action--accent"
+                  ?disabled=${this.busy}
+                  @click=${() => this._emitAction("install-device")}
+                >
+                  <wa-icon library="mdi" name="upload"></wa-icon>
+                  ${this._localize("dashboard.install")}
+                </button>`
+              : nothing}
           <button
             class="action action--ghost"
             ?disabled=${this.busy}

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -329,6 +329,7 @@ export class ESPHomeDeviceTable extends LitElement {
         .position=${this._contextMenuPos}
         ?anchor-right=${this._contextMenuAnchorRight}
         ?has-pending=${this._contextMenuDevice?.has_pending_changes === true}
+        ?has-update=${this._contextMenuDevice?.update_available === true}
         ?busy=${this._contextMenuDevice ? this.activeJobs.has(this._contextMenuDevice.configuration) : false}
         @menu-close=${this._closeContextMenu}
         @edit-device=${(e: CustomEvent) => {

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -189,8 +189,12 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
       cell: (info) => {
         const row = info.row.original;
         const device = row._device;
-        const showInstall = row.hasPendingChanges;
-        const showUpdate = !row.hasPendingChanges && row.hasUpdateAvailable;
+        /* Update wins over install when both flags are set: an
+           available newer ESPHome version is the more pressing nudge,
+           and OTA-update will pick up any pending YAML changes as a
+           free side-effect. Mirrors the legacy dashboard. */
+        const showUpdate = row.hasUpdateAvailable;
+        const showInstall = !showUpdate && row.hasPendingChanges;
         const visitUrl = buildWebUiUrl(device);
         const showVisit = visitUrl !== "";
         // Priority order (highest → lowest, last to drop on narrow

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -78,6 +78,13 @@ export class ESPHomeTableRowMenu extends LitElement {
   @property({ type: Boolean, attribute: "has-pending", reflect: true })
   hasPending = false;
 
+  /** Mirrors ``ConfiguredDevice.update_available`` for the open
+   *  device. The inline Update button takes precedence over Install
+   *  when this is true; the kebab's Install entry hides for the same
+   *  reason as ``hasPending``. */
+  @property({ type: Boolean, attribute: "has-update", reflect: true })
+  hasUpdate = false;
+
   @query(".menu")
   private _menuEl!: HTMLDivElement;
 
@@ -189,11 +196,13 @@ export class ESPHomeTableRowMenu extends LitElement {
            menu-item--visit-web                         inline > 1024px */
       :host([card-mode]) .menu-item--logs,
       :host([card-mode]) .menu-item--visit-web,
-      :host([card-mode][has-pending]) .menu-item--install {
+      :host([card-mode][has-pending]) .menu-item--install,
+      :host([card-mode][has-update]) .menu-item--install {
         display: none;
       }
       @media (min-width: 821px) {
-        :host(:not([card-mode])[has-pending]) .menu-item--install {
+        :host(:not([card-mode])[has-pending]) .menu-item--install,
+        :host(:not([card-mode])[has-update]) .menu-item--install {
           display: none;
         }
       }

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -232,10 +232,21 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="check-decagram"></wa-icon>
           ${this._localize("dashboard.action_validate")}
         </div>
-        <div class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("install-device")}>
-          <wa-icon library="mdi" name="upload"></wa-icon>
-          ${this._localize("dashboard.action_install")}
-        </div>
+        ${this.hasUpdate
+          ? html`<div
+              class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
+              @click=${this.busy ? undefined : () => this._emit("update-device")}
+            >
+              <wa-icon library="mdi" name="upload"></wa-icon>
+              ${this._localize("dashboard.update")}
+            </div>`
+          : html`<div
+              class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
+              @click=${this.busy ? undefined : () => this._emit("install-device")}
+            >
+              <wa-icon library="mdi" name="upload"></wa-icon>
+              ${this._localize("dashboard.action_install")}
+            </div>`}
         <div class="menu-item menu-item--logs ${this.busy ? "menu-item--disabled" : ""}" @click=${this.busy ? undefined : () => this._emit("open-logs")}>
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -569,26 +569,26 @@ export class ESPHomeDeviceCard extends LitElement {
                   <wa-icon library="mdi" name="pencil"></wa-icon>
                   ${this._localize("dashboard.edit")}
                 </button>
-                ${this.hasPendingChanges
+                ${this.hasUpdateAvailable
                   ? html`
                       <button
                         class="action-btn action-btn--accent"
                         ?disabled=${this.busy}
-                        @click=${() => this._emit("install-device")}
+                        @click=${() => this._emit("update-device")}
                       >
                         <wa-icon library="mdi" name="upload"></wa-icon>
-                        ${this._localize("dashboard.install")}
+                        ${this._localize("dashboard.update")}
                       </button>
                     `
-                  : this.hasUpdateAvailable
+                  : this.hasPendingChanges
                     ? html`
                         <button
                           class="action-btn action-btn--accent"
                           ?disabled=${this.busy}
-                          @click=${() => this._emit("update-device")}
+                          @click=${() => this._emit("install-device")}
                         >
                           <wa-icon library="mdi" name="upload"></wa-icon>
-                          ${this._localize("dashboard.update")}
+                          ${this._localize("dashboard.install")}
                         </button>
                       `
                     : nothing}

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -254,27 +254,27 @@ export class ESPHomeDeviceEditor extends LitElement {
         </header>
         <div class="card-body">
           <div class="editor-floating-actions">
-            ${this.hasPendingChanges
+            ${this.hasUpdateAvailable
               ? html`<button
                   type="button"
                   class="install-fab"
                   ?disabled=${this.busy}
-                  @click=${this._onInstall}
-                  title=${this._localize("dashboard.install")}
+                  @click=${this._onUpdate}
+                  title=${this._localize("dashboard.update")}
                 >
                   <wa-icon library="mdi" name="upload"></wa-icon>
-                  ${this._localize("dashboard.install")}
+                  ${this._localize("dashboard.update")}
                 </button>`
-              : this.hasUpdateAvailable
+              : this.hasPendingChanges
                 ? html`<button
                     type="button"
                     class="install-fab"
                     ?disabled=${this.busy}
-                    @click=${this._onUpdate}
-                    title=${this._localize("dashboard.update")}
+                    @click=${this._onInstall}
+                    title=${this._localize("dashboard.install")}
                   >
                     <wa-icon library="mdi" name="upload"></wa-icon>
-                    ${this._localize("dashboard.update")}
+                    ${this._localize("dashboard.install")}
                   </button>`
                 : nothing}
             <button

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -553,6 +553,7 @@ export class ESPHomePageDashboard extends LitElement {
         .position=${this._cardContextPosition}
         card-mode
         ?has-pending=${this._cardContextDevice?.has_pending_changes === true}
+        ?has-update=${this._cardContextDevice?.update_available === true}
         ?busy=${this._cardContextDevice ? this._activeJobs.has(this._cardContextDevice.configuration) : false}
         @menu-close=${() => { this._cardContextDevice = null; this._cardContextPosition = null; }}
         @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -541,6 +541,7 @@ export class ESPHomePageDashboard extends LitElement {
         @drawer-close=${() => { this._drawerOpen = false; }}
         @edit-device=${(e: CustomEvent) => { this._drawerOpen = false; editDevice(e.detail); }}
         @update-device=${(e: CustomEvent<ConfiguredDevice>) => { this._drawerOpen = false; this._openCommand(e.detail, "install"); }}
+        @install-device=${(e: CustomEvent<ConfiguredDevice>) => { this._drawerOpen = false; this._openInstallMethod(e.detail); }}
         @open-logs=${(e: CustomEvent) => { this._drawerOpen = false; this._openLogs(e.detail); }}
       ></esphome-device-drawer>
     `;


### PR DESCRIPTION
## Summary

Legacy dashboard parity. When the blue update-available dot is showing on a device, the button should read "Update" — even if there are also pending local YAML changes. The new dashboard was showing "Install" in the combined case because the `hasPendingChanges` branch came first.

Flips the precedence in every place the Install/Update button is rendered:

- `device-card` template
- `device-editor` floating action button
- `table-columns` cell action
- `table-row-menu` kebab — now also takes a `has-update` reflect attribute so the card-mode dedupe hides the kebab Install entry whenever the inline Update button is showing

Click handlers stay as before: Update emits `update-device` (direct OTA, fast path), Install emits `install-device` (asks the install method dialog). So users with OTA already set up keep the one-click update flow.

## Test plan

- [ ] Device with only update available (blue dot) → button reads "Update", click flashes via OTA
- [ ] Device with only pending changes (orange dot) → button reads "Install", click opens install method dialog
- [ ] Device with both flags → button reads "Update" (matches legacy)
- [ ] Kebab menu doesn't show a duplicate Install entry in any of the three states
- [ ] Table view inline cell shows the same precedence
- [ ] Device editor floating action button matches