### PR TITLE
Add bottom margin to the drawer's status banner

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -163,7 +163,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
         align-items: center;
         gap: var(--wa-space-s);
         padding: var(--wa-space-m) var(--wa-space-l);
-        margin: var(--wa-space-m) var(--wa-space-l) 0;
+        /* Symmetric vertical margin so the banner doesn't collapse
+           against the device-info section that follows. The body
+           below has its own padding, but with a 0 bottom-margin
+           here the first row's icon ended up clipped against the
+           banner's rounded bottom edge. */
+        margin: var(--wa-space-m) var(--wa-space-l);
         border-radius: var(--wa-border-radius-l);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);


### PR DESCRIPTION
## Summary

Tiny fix. The right-side device drawer's status banner ("Device Online") had `margin: var(--wa-space-m) var(--wa-space-l) 0` — top + sides, zero bottom — so the banner sat flush against the first row of the device-info section below it. The leading row's icon (ESP32C3 chip) ended up half-clipped against the banner's rounded bottom edge.

Symmetric vertical margin so the banner has breathing room against both the dividing border above and the content below.

## Test plan

- [x] Open the right drawer for any device — Device Online banner has visible space above and below
- [x] First device-info row (chip / ESP32 model) renders fully, no clipping against the banner