### PR TITLE
Confirm before deleting a single device

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -118,6 +118,13 @@ export class ESPHomePageDashboard extends LitElement {
   @state() private _drawerDevice: ConfiguredDevice | null = null;
   @state() private _cardContextDevice: ConfiguredDevice | null = null;
   @state() private _cardContextPosition: { x: number; y: number } | null = null;
+  /** Single device queued for delete confirmation. ``null`` means
+   *  the shared confirm dialog is in bulk-delete mode (driven by
+   *  ``_selectedDevices``). The state-keyed mode-switch lets us
+   *  reuse one ``esphome-confirm-dialog`` instance for both the
+   *  per-device kebab Delete and the select-mode bulk Delete
+   *  without juggling two dialog elements. */
+  @state() private _pendingDelete: ConfiguredDevice | null = null;
   /** Configuration filename of the most recently adopted device.
    *  Drives a short-lived ``highlight`` attribute on the matching
    *  device card / row so the user can spot the freshly-imported
@@ -516,7 +523,7 @@ export class ESPHomePageDashboard extends LitElement {
         @rename-device=${(e: CustomEvent<ConfiguredDevice>) => this._openRename(e.detail)}
         @clean-build=${(e: CustomEvent<ConfiguredDevice>) => this._openCommand(e.detail, "clean")}
         @download-elf=${(e: CustomEvent<ConfiguredDevice>) => this._downloadFirmware(e.detail)}
-        @delete-device=${(e: CustomEvent<ConfiguredDevice>) => deleteDevice(e.detail, this._api, this._devices, this._localize)}
+        @delete-device=${(e: CustomEvent<ConfiguredDevice>) => this._confirmDeleteSingle(e.detail)}
         @enter-select-mode=${(e: CustomEvent<string>) => this._onEnterSelectMode(e.detail)}
       >
         <div slot="toolbar" class="toolbar-row">
@@ -567,7 +574,7 @@ export class ESPHomePageDashboard extends LitElement {
         @rename-device=${(e: CustomEvent<ConfiguredDevice>) => this._openRename(e.detail)}
         @clean-build=${(e: CustomEvent<ConfiguredDevice>) => this._openCommand(e.detail, "clean")}
         @download-elf=${(e: CustomEvent<ConfiguredDevice>) => this._downloadFirmware(e.detail)}
-        @delete-device=${(e: CustomEvent<ConfiguredDevice>) => deleteDevice(e.detail, this._api, this._devices, this._localize)}
+        @delete-device=${(e: CustomEvent<ConfiguredDevice>) => this._confirmDeleteSingle(e.detail)}
         @enter-select=${(e: CustomEvent<ConfiguredDevice>) => this._onEnterSelectMode(e.detail.configuration)}
       ></esphome-table-row-menu>
     `;
@@ -601,13 +608,27 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   private _renderDialogs() {
+    /* One confirm-dialog instance covers both flows (per-device
+       kebab Delete and select-mode bulk Delete) — ``_pendingDelete``
+       drives the copy and the ``@confirm`` router. Picking up the
+       device's friendly name keeps the prompt readable when the
+       technical hostname is something like
+       ``athom-rgbcw-bulb-998181``. */
+    const pendingName = this._pendingDelete
+      ? this._pendingDelete.friendly_name || this._pendingDelete.name
+      : "";
     return html`
       <esphome-confirm-dialog
-        heading=${this._localize("dashboard.delete_selected_title")}
-        message=${this._localize("dashboard.delete_selected_desc", { count: this._selectedDevices.size })}
+        heading=${this._pendingDelete
+          ? this._localize("dashboard.delete_single_title")
+          : this._localize("dashboard.delete_selected_title")}
+        message=${this._pendingDelete
+          ? this._localize("dashboard.delete_single_desc", { name: pendingName })
+          : this._localize("dashboard.delete_selected_desc", { count: this._selectedDevices.size })}
         confirm-label=${this._localize("dashboard.delete_selected_confirm")}
         destructive
-        @confirm=${this._executeDeleteSelected}
+        @confirm=${this._executeDelete}
+        @cancel=${() => { this._pendingDelete = null; }}
       ></esphome-confirm-dialog>
       <esphome-rename-device-dialog
         @rename-confirm=${this._executeRename}
@@ -977,10 +998,29 @@ export class ESPHomePageDashboard extends LitElement {
       toast.info(this._localize("dashboard.delete_all_none"), { richColors: true });
       return;
     }
+    /* Bulk-delete path — ``_pendingDelete`` stays null so the
+       confirm dialog shows the bulk copy ("Delete N device(s)"). */
+    this._pendingDelete = null;
     this._confirmDialog.open();
   }
 
-  private _executeDeleteSelected() {
+  private _confirmDeleteSingle(device: ConfiguredDevice) {
+    /* Per-device kebab Delete — set ``_pendingDelete`` so the
+       confirm dialog shows the single-device copy and routes to the
+       single-device path. Earlier this skipped the dialog entirely
+       and went straight to ``deleteDevice`` — there's no undo, so a
+       missed click on the kebab silently nuked the YAML. */
+    this._pendingDelete = device;
+    this._confirmDialog.open();
+  }
+
+  private _executeDelete() {
+    if (this._pendingDelete) {
+      const target = this._pendingDelete;
+      this._pendingDelete = null;
+      deleteDevice(target, this._api, this._devices, this._localize);
+      return;
+    }
     const selected = [...this._selectedDevices];
     this._selectMode = false;
     this._selectedDevices = new Set();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -71,6 +71,8 @@
     "delete_selected_title": "Delete devices",
     "delete_selected_desc": "Are you sure you want to delete {count} device(s)? This will remove their configuration files and cannot be undone.",
     "delete_selected_confirm": "Delete",
+    "delete_single_title": "Delete device",
+    "delete_single_desc": "Are you sure you want to delete \"{name}\"? This will remove its configuration files and cannot be undone.",
     "delete_all_none": "No devices selected to delete",
     "delete_bulk_success": "{count} device(s) deleted",
     "delete_bulk_failed": "Bulk delete failed",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -47,6 +47,8 @@
     "delete_selected_title": "Supprimer les appareils",
     "delete_selected_desc": "Êtes-vous sûr de vouloir supprimer {count} appareil(s) ? Cela supprimera leurs fichiers de configuration et ne pourra pas être annulé.",
     "delete_selected_confirm": "Supprimer",
+    "delete_single_title": "Supprimer l'appareil",
+    "delete_single_desc": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cela supprimera ses fichiers de configuration et ne pourra pas être annulé.",
     "delete_all_none": "Aucun appareil sélectionné à supprimer",
     "delete_bulk_success": "{count} appareil(s) supprimé(s)",
     "delete_bulk_failed": "Échec de la suppression en lot",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -47,6 +47,8 @@
     "delete_selected_title": "Apparaten verwijderen",
     "delete_selected_desc": "Weet u zeker dat u {count} apparaat/apparaten wilt verwijderen? Dit verwijdert hun configuratiebestanden en kan niet ongedaan worden gemaakt.",
     "delete_selected_confirm": "Verwijderen",
+    "delete_single_title": "Apparaat verwijderen",
+    "delete_single_desc": "Weet u zeker dat u \"{name}\" wilt verwijderen? Dit verwijdert de configuratiebestanden en kan niet ongedaan worden gemaakt.",
     "delete_all_none": "Geen apparaten geselecteerd om te verwijderen",
     "delete_bulk_success": "{count} apparaat/apparaten verwijderd",
     "delete_bulk_failed": "Bulkverwijdering mislukt",


### PR DESCRIPTION
## Summary

The per-device Delete action (kebab menu, table-row context menu) went straight to `deleteDevice` with no prompt. There's no undo on the dashboard — a missed click on the wrong row silently removed the YAML, the storage sidecar, and any compile output for that device. The bulk-select Delete already gated on a confirm dialog; this brings the per-device path in line.

### Approach

The shared `esphome-confirm-dialog` instance switches its copy via a new `_pendingDelete` state:
- Set when a single device is queued → dialog reads "Delete device" + "Are you sure you want to delete *Apollo PLT-1*?".
- `null` when the bulk-delete flow opens it → existing "Delete devices / Delete N device(s)?" copy.

`@confirm` routes to either `deleteDevice` or `deleteBulkDevices` based on which mode is active. `@cancel` clears `_pendingDelete` so a stale state doesn't linger if the dialog is reopened later.

The single-device prompt picks up the device's friendly name when present, so the message reads as a sentence even when the technical hostname is something like `athom-rgbcw-bulb-998181`.

## Test plan

- [ ] Click Delete on a single device's kebab → confirm dialog opens with "Delete device" + the device's name. Cancel keeps the device. Confirm removes it.
- [ ] Select multiple devices, click bulk Delete → existing "Delete N device(s)" prompt still works.
- [ ] After cancelling a single-device delete, opening bulk Delete still shows the bulk copy (no leaked state).
- [ ] After confirming, opening bulk Delete still shows the bulk copy.