### PR TITLE
Keep the Logs label visible on cards without an Install / Update button

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -592,22 +592,31 @@ export class ESPHomeDeviceCard extends LitElement {
                         </button>
                       `
                     : nothing}
-                ${this.webUrl
-                  ? html`<button
-                      class="action-btn action-btn--ghost action-btn--tile"
-                      @click=${() => this._emit("open-logs")}
-                      aria-label=${this._localize("dashboard.drawer_logs")}
-                      title=${this._localize("dashboard.drawer_logs")}
-                    >
-                      <wa-icon library="mdi" name="console"></wa-icon>
-                    </button>`
-                  : html`<button
-                      class="action-btn action-btn--ghost"
-                      @click=${() => this._emit("open-logs")}
-                    >
-                      <wa-icon library="mdi" name="console"></wa-icon>
-                      ${this._localize("dashboard.drawer_logs")}
-                    </button>`}
+                ${
+                  // Collapse Logs to icon-only when the row is at risk
+                  // of cramming. Cramming only happens when *both* an
+                  // accent action (Install/Update) and a Visit-web-UI
+                  // tile are competing for space alongside Edit; if
+                  // there's no accent action, the row has plenty of
+                  // room and the Logs label should stay visible so the
+                  // affordance reads at a glance.
+                  this.webUrl && (this.hasPendingChanges || this.hasUpdateAvailable)
+                    ? html`<button
+                        class="action-btn action-btn--ghost action-btn--tile"
+                        @click=${() => this._emit("open-logs")}
+                        aria-label=${this._localize("dashboard.drawer_logs")}
+                        title=${this._localize("dashboard.drawer_logs")}
+                      >
+                        <wa-icon library="mdi" name="console"></wa-icon>
+                      </button>`
+                    : html`<button
+                        class="action-btn action-btn--ghost"
+                        @click=${() => this._emit("open-logs")}
+                      >
+                        <wa-icon library="mdi" name="console"></wa-icon>
+                        ${this._localize("dashboard.drawer_logs")}
+                      </button>`
+                }
                 ${this.webUrl
                   ? html`<a
                       class="action-btn action-btn--ghost action-btn--tile"


### PR DESCRIPTION
## Summary

Tighten the Logs-button collapse condition on the device card from \`webUrl\` to \`webUrl AND (hasPendingChanges OR hasUpdateAvailable)\` — only collapse to icon-only when an accent button (Install / Update) is also competing for space alongside Edit + Visit web UI.

## Why

The earlier collapse landed because four buttons in a four-up grid (Edit + Install + Logs + Visit) was cramming on retina laptops. But on cards with no pending changes and no update available there's no accent button, leaving the row with just three controls and plenty of room. Collapsing Logs to icon-only there makes the affordance harder to spot at a glance and reads inconsistent with Edit, which always shows its label.

## Test plan

- [ ] \`npm run lint\` clean
- [ ] \`npm test\` (135/135 pass)
- [ ] Manual: device that's online, in sync, web_server enabled — Logs shows full text alongside Edit + Visit tile.
- [ ] Manual: device with pending changes + web_server — Logs still collapses to icon-only (the original 4-button cramming case).
- [ ] Manual: device without web_server — Logs always shows full text (unchanged).