### PR TITLE
Show pending lock when YAML adds encryption but device hasn't been flashed

### DIFF
--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -37,30 +37,34 @@ export type EncryptionState =
 export function getEncryptionState(d: EncryptionInputs): EncryptionState {
   if (!d.api_enabled) return "none";
   if (!d.api_encrypted) return "plaintext";
-  /* Pending changes always pin the indicator to "pending", even
-     when mDNS hasn't reported anything yet. After Take Control the
-     dashboard creates a YAML with ``api: encryption: …`` but the
-     running firmware is still the vendor image with no encryption,
-     so ``api_encrypted=true`` plus ``has_pending_changes=true`` is
-     the "you need to flash to actually get encryption" state.
-     Trusting the YAML there (the previous behaviour) showed a
-     green lock the moment the YAML was saved, which read as
-     "encryption active" while the device was still happily
-     answering plaintext on the wire. */
-  if (d.has_pending_changes) return "pending";
   const observed = d.api_encryption_active;
-  /* mDNS not seen yet: trust the YAML. ``observed == null`` (loose
-     equality) catches both ``null`` and ``undefined`` — the latter
-     can sneak in from older backends or cached WS payloads that
-     predate the field. */
-  if (observed == null) return "active";
-  /* TXT absent → device is running plaintext API. With no pending
-     changes to explain it, the firmware on the device disagrees
-     with the YAML — real mismatch, probably a failed flash or a
-     device flashed elsewhere. */
-  if (observed === "") return "mismatch";
-  /* TXT present (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``). */
-  return "active";
+  /* mDNS confirms encryption is *actually* running on the device
+     (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``). Truth on the
+     wire trumps everything else — a YAML edit elsewhere
+     (whitespace, comment, sensor tweak) doesn't disable the
+     encryption that's already live, so the indicator stays green
+     even when ``has_pending_changes`` is set. */
+  if (observed) return "active";
+  /* From here ``observed`` is either ``""`` (mDNS seen, TXT
+     absent — device is plaintext) or ``null`` / ``undefined``
+     (mDNS not seen yet). In both cases the running firmware is
+     not confirmed-encrypted, so a pending-changes flag is the
+     "Take Control just added encryption to the YAML, but the
+     vendor image on the device hasn't been replaced yet" path —
+     show "pending" to nudge the user toward Install. */
+  if (d.has_pending_changes) return "pending";
+  /* No pending changes:
+       - ``observed == null`` → mDNS hasn't reported. Trust the
+         YAML; the device is presumed encrypted until proven
+         otherwise. ``observed == null`` (loose equality) covers
+         ``null`` and ``undefined`` — the latter can sneak in
+         from older backends or cached WS payloads that predate
+         the field.
+       - ``observed === ""`` → mDNS confirmed plaintext. The
+         firmware on the device disagrees with the YAML and there
+         is no pending compile to explain it: real mismatch,
+         probably a failed flash or a device flashed elsewhere. */
+  return observed == null ? "active" : "mismatch";
 }
 
 export interface EncryptionVisual {

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -37,18 +37,28 @@ export type EncryptionState =
 export function getEncryptionState(d: EncryptionInputs): EncryptionState {
   if (!d.api_enabled) return "none";
   if (!d.api_encrypted) return "plaintext";
+  /* Pending changes always pin the indicator to "pending", even
+     when mDNS hasn't reported anything yet. After Take Control the
+     dashboard creates a YAML with ``api: encryption: …`` but the
+     running firmware is still the vendor image with no encryption,
+     so ``api_encrypted=true`` plus ``has_pending_changes=true`` is
+     the "you need to flash to actually get encryption" state.
+     Trusting the YAML there (the previous behaviour) showed a
+     green lock the moment the YAML was saved, which read as
+     "encryption active" while the device was still happily
+     answering plaintext on the wire. */
+  if (d.has_pending_changes) return "pending";
   const observed = d.api_encryption_active;
   /* mDNS not seen yet: trust the YAML. ``observed == null`` (loose
      equality) catches both ``null`` and ``undefined`` — the latter
      can sneak in from older backends or cached WS payloads that
      predate the field. */
   if (observed == null) return "active";
-  /* TXT absent → device is running plaintext API. If the user has
-     unflashed changes, they probably know — surface "pending" so the
-     indicator nudges toward Install. Otherwise it's a real mismatch. */
-  if (observed === "") {
-    return d.has_pending_changes ? "pending" : "mismatch";
-  }
+  /* TXT absent → device is running plaintext API. With no pending
+     changes to explain it, the firmware on the device disagrees
+     with the YAML — real mismatch, probably a failed flash or a
+     device flashed elsewhere. */
+  if (observed === "") return "mismatch";
   /* TXT present (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``). */
   return "active";
 }

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -49,22 +49,39 @@ describe("getEncryptionState", () => {
     ).toBe("active");
   });
 
-  it("returns 'pending' on pending changes regardless of mDNS state", () => {
+  it("returns 'pending' on pending changes when mDNS hasn't confirmed encryption", () => {
     /* Take Control adds ``api: encryption: …`` to the YAML before
        the user has flashed. The running firmware is still the
        vendor image with no encryption, so the indicator must read
-       "pending" — even when mDNS hasn't observed the device yet
-       (the previous behaviour fell through to "active" via the
-       null/undefined path and showed a green lock for an
-       unencrypted device). All three mDNS states collapse to
-       "pending" once ``has_pending_changes`` is set. */
-    for (const observed of [null, "", "Noise_NNpsk0_25519_ChaChaPoly_SHA256"]) {
+       "pending" — both for the brand-new ``null`` case (mDNS
+       hasn't observed the device yet) and the ``""`` case (mDNS
+       confirms the device is broadcasting plaintext). The
+       previous behaviour fell through to "active" via the null
+       path and showed a green lock for an unencrypted device. */
+    for (const observed of [null, ""]) {
       expect(
         getEncryptionState(
           inputs({ api_encryption_active: observed, has_pending_changes: true }),
         ),
       ).toBe("pending");
     }
+  });
+
+  it("stays 'active' when mDNS confirms encryption even with pending changes", () => {
+    /* Comment / whitespace / unrelated YAML edit on a device that
+       is already running encrypted firmware — the running
+       firmware still answers Noise on the wire, so encryption is
+       live. ``has_pending_changes`` here means "YAML differs from
+       last compile", not "encryption is about to change". Truth
+       on the wire wins. */
+    expect(
+      getEncryptionState(
+        inputs({
+          api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+          has_pending_changes: true,
+        }),
+      ),
+    ).toBe("active");
   });
 
   it("returns 'mismatch' when YAML encrypted, mDNS reports plaintext, no pending changes", () => {

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -29,7 +29,7 @@ describe("getEncryptionState", () => {
     expect(getEncryptionState(inputs({ api_encrypted: false }))).toBe("plaintext");
   });
 
-  it("returns 'active' when YAML encrypted and mDNS not seen yet", () => {
+  it("returns 'active' when YAML encrypted, in sync, and mDNS not seen yet", () => {
     expect(getEncryptionState(inputs({ api_encryption_active: null }))).toBe("active");
   });
 
@@ -49,12 +49,22 @@ describe("getEncryptionState", () => {
     ).toBe("active");
   });
 
-  it("returns 'pending' when YAML encrypted, mDNS reports plaintext, and changes are pending", () => {
-    expect(
-      getEncryptionState(
-        inputs({ api_encryption_active: "", has_pending_changes: true }),
-      ),
-    ).toBe("pending");
+  it("returns 'pending' on pending changes regardless of mDNS state", () => {
+    /* Take Control adds ``api: encryption: …`` to the YAML before
+       the user has flashed. The running firmware is still the
+       vendor image with no encryption, so the indicator must read
+       "pending" — even when mDNS hasn't observed the device yet
+       (the previous behaviour fell through to "active" via the
+       null/undefined path and showed a green lock for an
+       unencrypted device). All three mDNS states collapse to
+       "pending" once ``has_pending_changes`` is set. */
+    for (const observed of [null, "", "Noise_NNpsk0_25519_ChaChaPoly_SHA256"]) {
+      expect(
+        getEncryptionState(
+          inputs({ api_encryption_active: observed, has_pending_changes: true }),
+        ),
+      ).toBe("pending");
+    }
   });
 
   it("returns 'mismatch' when YAML encrypted, mDNS reports plaintext, no pending changes", () => {


### PR DESCRIPTION
## Summary

Reorder ``getEncryptionState`` so ``has_pending_changes`` always wins over the mDNS observation. After Take Control adds ``api: encryption: …`` to a YAML, the indicator now reads "pending" instead of falsely showing the green active lock for a device that's still running unencrypted vendor firmware.

## Why

Reproduction: Take Control on a discovered device, accept the default "Enable API encryption" toggle. The dashboard writes a YAML with encryption immediately, and the new card showed a green filled-lock — even though the running firmware was the vendor image answering plaintext on the wire.

The previous helper short-circuited to ``"active"`` whenever ``api_encryption_active == null`` (mDNS not seen yet), trusting the YAML. Right after Take Control the mDNS broadcast for the configured device's *new* name is genuinely null for several seconds, plenty of time to mis-render. Trusting YAML over the install state turns the indicator into a status of intent, not reality.

The new ordering: ``has_pending_changes`` collapses every observed-value path to "pending". The "mismatch" state now means specifically "no pending changes, YAML wants encryption, device says plaintext" — flashed-elsewhere / failed-OTA territory.

## Test plan

- [ ] ``npm run lint`` clean
- [ ] ``npm test`` (135/135 pass — updated case parametrises all three observed values under ``has_pending_changes=true``)
- [ ] Manual: Take Control on a vendor device with encryption toggle on → card shows orange "pending" lock until install completes; flashes to green after the device reports back via mDNS.
- [ ] Manual: existing in-sync encrypted device → still green (regression check).