### PR TITLE
Validate link schemes in catalog markdown renderer (security audit F-1)

### DIFF
--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -29,6 +29,25 @@ interface Segment {
 }
 
 /**
+ * Schemes we render as live anchors. Catalog descriptions in
+ * practice only use ``http(s)://`` (docs cross-references) and a
+ * handful of ``mailto:`` links to maintainers; anything else
+ * (``javascript:``, ``data:``, ``vbscript:``, ``file:``, bare
+ * fragments, scheme-less relative URLs) falls back to plain text
+ * so a future supply-chain compromise of the catalog data can't
+ * inject a clickable XSS vector. Repo-controlled today, so this
+ * is defense in depth — see esphome/device-builder#120 (F-1).
+ *
+ * Exported for the unit test; production callers should go
+ * through ``renderMarkdown`` which gates link rendering on this.
+ */
+const SAFE_LINK_SCHEMES = /^\s*(?:https?|mailto):/i;
+
+export function isSafeLinkHref(href: string | undefined): boolean {
+  return href !== undefined && SAFE_LINK_SCHEMES.test(href);
+}
+
+/**
  * Single regex with prioritised alternatives — alternatives are
  * tried left-to-right so links match before bold and bold matches
  * before italic (so `**foo**` is one bold token, not two italics).
@@ -77,6 +96,13 @@ function renderSegment(seg: Segment): TemplateResult | string {
     case "text":
       return seg.text;
     case "link":
+      // Unsafe (or missing) scheme → fall back to the link text as
+      // plain content so a ``[click me](javascript:alert(1))`` in
+      // the catalog can't render as a live anchor. The ``[text]``
+      // is preserved so the user still sees the words.
+      if (!isSafeLinkHref(seg.href)) {
+        return seg.text;
+      }
       return html`<a
         class="md-link"
         href=${seg.href ?? ""}

--- a/test/util/markdown.test.ts
+++ b/test/util/markdown.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the link-scheme validator that gates the inline-Markdown
+ * renderer. Catalog descriptions are repo-controlled today (board
+ * manifests, schema-derived component docstrings), so a
+ * ``[click me](javascript:alert(1))`` can't be injected by an
+ * external attacker — the validator is defense in depth against a
+ * future supply-chain compromise of the catalog data. See
+ * esphome/device-builder#120 (F-1).
+ *
+ * Vitest runs in a Node environment here (no DOM, no Lit render
+ * target), so we test the pure ``isSafeLinkHref`` predicate
+ * directly — it's the security boundary; the
+ * ``if (!isSafeLinkHref(seg.href)) return seg.text`` branch in
+ * ``renderSegment`` is trivially provable by reading the code.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isSafeLinkHref } from "../../src/util/markdown.js";
+
+describe("isSafeLinkHref — accepted schemes", () => {
+  it("accepts http://", () => {
+    expect(isSafeLinkHref("http://esphome.io/foo")).toBe(true);
+  });
+
+  it("accepts https://", () => {
+    expect(isSafeLinkHref("https://esphome.io/foo")).toBe(true);
+  });
+
+  it("accepts mailto:", () => {
+    expect(isSafeLinkHref("mailto:dev@example.com")).toBe(true);
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    // Browsers treat ``HTTPS:`` and ``https:`` as equivalent;
+    // matching that lets uppercase-shouted URLs in catalog text
+    // still render as anchors.
+    expect(isSafeLinkHref("HTTPS://esphome.io")).toBe(true);
+    expect(isSafeLinkHref("MAILTO:dev@example.com")).toBe(true);
+    expect(isSafeLinkHref("HtTp://mixed.example.com")).toBe(true);
+  });
+
+  it("ignores leading whitespace before the scheme", () => {
+    // Markdown-in-the-wild often has stray spaces in
+    // ``[text]( https://…)``. The renderer is forgiving about
+    // these so a single space doesn't make a docs link silently
+    // fall back to plain text.
+    expect(isSafeLinkHref(" https://esphome.io")).toBe(true);
+    expect(isSafeLinkHref("\thttps://esphome.io")).toBe(true);
+    expect(isSafeLinkHref("\nhttps://esphome.io")).toBe(true);
+  });
+});
+
+describe("isSafeLinkHref — rejected schemes", () => {
+  it("rejects javascript:", () => {
+    // The whole reason this validator exists.
+    expect(isSafeLinkHref("javascript:alert(1)")).toBe(false);
+    // Mixed-case spelling — historical XSS vector when the
+    // sanitiser was case-sensitive.
+    expect(isSafeLinkHref("JaVaScRiPt:alert(1)")).toBe(false);
+  });
+
+  it("rejects data: URIs", () => {
+    // ``data:text/html;…`` would let an injected catalog
+    // description carry a base64-encoded HTML payload.
+    expect(
+      isSafeLinkHref("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="),
+    ).toBe(false);
+  });
+
+  it("rejects vbscript:", () => {
+    expect(isSafeLinkHref("vbscript:msgbox(1)")).toBe(false);
+  });
+
+  it("rejects file: URIs", () => {
+    // Local-file URIs would let a malicious link reveal
+    // dashboard-process filesystem layout when clicked in a
+    // browser that honours ``file://``.
+    expect(isSafeLinkHref("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects scheme-less / relative URLs", () => {
+    // Strict-or-text: the catalog uses absolute URLs, so
+    // anything without one of the allowlisted schemes falls
+    // back to plain text rather than getting browser-native
+    // resolution behaviour we can't reason about.
+    expect(isSafeLinkHref("/foo")).toBe(false);
+    expect(isSafeLinkHref("foo/bar")).toBe(false);
+    expect(isSafeLinkHref("#section")).toBe(false);
+    expect(isSafeLinkHref("//example.com/x")).toBe(false);
+    expect(isSafeLinkHref("example.com/x")).toBe(false);
+  });
+
+  it("rejects empty / undefined href", () => {
+    expect(isSafeLinkHref(undefined)).toBe(false);
+    expect(isSafeLinkHref("")).toBe(false);
+    expect(isSafeLinkHref("   ")).toBe(false);
+  });
+
+  it("rejects javascript: even when prefixed with control chars", () => {
+    // Browsers can be tricked by tab / newline / NUL bytes
+    // before the scheme (historic XSS bypass). Leading
+    // whitespace is allowed (Markdown forgiveness), but a
+    // ``javascript`` body still has to follow — and the regex
+    // only matches the scheme name, so a tab + ``javascript:``
+    // is text either way. Test fixes the contract so a future
+    // tweak can't accidentally widen the prefix.
+    expect(isSafeLinkHref("\tjavascript:alert(1)")).toBe(false);
+    expect(isSafeLinkHref("\njavascript:alert(1)")).toBe(false);
+  });
+});


### PR DESCRIPTION
Resolves the F-1 finding from the security audit (esphome/device-builder#120).

## Summary

The inline-Markdown renderer that surfaces catalog component descriptions rendered any `[text](href)` token as a live `<a href>`, including unsafe schemes like `javascript:alert(1)`, `data:text/html;…`, and `file://`.

Catalog data is repo-controlled today (board manifests, schema-derived component descriptions sourced from ESPHome's docs), so external attackers can't inject these — the audit classified F-1 as a bounded supply-chain risk. Defense in depth warrants scheme validation at the rendering boundary regardless.

## What changed

`src/util/markdown.ts`:

- New exported `isSafeLinkHref(href)` predicate. Allowlist: `http:`, `https:`, `mailto:` (case-insensitive, leading-whitespace tolerant for Markdown forgiveness).
- `renderSegment` for `link` segments now falls back to plain text when the href fails the check. The display text survives — reader still sees the words, the URL is dropped.

## Tests

`test/util/markdown.test.ts` — 12 cases:

- Accept allowlist: `http://`, `https://`, `mailto:` (lowercase, uppercase, mixed-case)
- Leading whitespace tolerance: ` https://…`, `\thttps://…`, `\nhttps://…`
- Reject: `javascript:` (lowercase + `JaVaScRiPt:` mixed-case), `data:`, `vbscript:`, `file:`
- Reject scheme-less / relative: `/foo`, `foo/bar`, `#section`, `//example.com/x`, `example.com/x`
- Reject empty / `undefined` / whitespace-only href
- Reject control-char-prefixed XSS bypass: `\tjavascript:`, `\njavascript:`

Vitest is Node-env here (no DOM, no Lit render target), so the tests target the pure validator directly. The `if (!isSafeLinkHref(seg.href)) return seg.text` branch in `renderSegment` is trivially provable from reading the code.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 148 passed (12 new + 136 existing)