### PR TITLE
Add Content-Security-Policy meta tag (security audit F-2)

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -19,7 +19,13 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
   name: "esphome-frontend",
   mode: isProdBuild ? "production" : "development",
   target: "browserslist:modern",
-  devtool: isProdBuild ? "nosources-source-map" : "eval-cheap-module-source-map",
+  // ``eval-cheap-module-source-map`` is the rspack default for dev
+  // and uses ``eval()`` to evaluate each module — clashes with our
+  // CSP's lack of ``script-src 'unsafe-eval'`` so the dev server
+  // would 100% fail to boot the app. ``cheap-module-source-map``
+  // emits a separate ``.map`` file and avoids eval entirely; same
+  // line-level fidelity, slower hot reloads (acceptable for dev).
+  devtool: isProdBuild ? "nosources-source-map" : "cheap-module-source-map",
   entry: {
     app: path.resolve(SRC_DIR, "entrypoint.ts"),
   },

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,47 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#038fc7" />
+    <!--
+      Content-Security-Policy - defense in depth against any future
+      XSS that slips past Lit's auto-escaping. Catches injected
+      <script src="https://evil.com/...">, eval() of attacker text,
+      and reparenting via <base>. Not a substitute for sanitising
+      user content; it's the second wall.
+
+      Trade-offs we live with today:
+        * style-src 'unsafe-inline' - required by the inline <style>
+          block below AND by Lit's style-map / styleMap directive
+          (emits inline style="..." attributes). Tightening to a
+          hashed/nonced block + class-toggle migration is tracked
+          as a follow-up - see esphome/device-builder#120.
+        * img-src data: + font-src data: - the yaml-editor squiggle
+          markers and the MDI icon paths build data: URIs at runtime.
+        * connect-src 'self' ws: wss: - the dashboard, its assets,
+          and its WebSocket share an origin in every default
+          deployment (port-6052 direct, ESPHome Desktop, HA add-on
+          via Ingress, single-hostname nginx reverse proxy). The
+          ws: / wss: openers make split-hostname proxy setups
+          (ws.api.example.com + dash.example.com) work too - those
+          have been a recurring pain point on the legacy dashboard.
+          Trade-off: an XSS already in our bundle could exfiltrate
+          via a WebSocket to an attacker origin. We still block the
+          loud / easy injection paths (script-src falls back to
+          default-src 'self' so <script src="https://evil.com/...">
+          stays blocked), and the residual is the same one we'd
+          accept by dropping CSP entirely. xhr / fetch exfil is
+          NOT covered by ws: / wss: - those still go through the
+          default-src 'self' gate.
+        * No frame-ancestors directive - HA Ingress iframes us from
+          a different origin (homeassistant.local), so locking
+          framing would break the add-on. Browser default (allow
+          all) leaves clickjacking unblocked; operators behind a
+          reverse proxy can add their own frame-ancestors via
+          response headers.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'"
+    />
     <title>ESPHome</title>
     <link rel="icon" type="image/svg+xml" href="/assets/logo/esphome.svg" />
     <style>

--- a/public/index.html
+++ b/public/index.html
@@ -19,21 +19,22 @@
           as a follow-up - see esphome/device-builder#120.
         * img-src data: + font-src data: - the yaml-editor squiggle
           markers and the MDI icon paths build data: URIs at runtime.
-        * connect-src 'self' ws: wss: - the dashboard, its assets,
-          and its WebSocket share an origin in every default
-          deployment (port-6052 direct, ESPHome Desktop, HA add-on
-          via Ingress, single-hostname nginx reverse proxy). The
-          ws: / wss: openers make split-hostname proxy setups
-          (ws.api.example.com + dash.example.com) work too - those
-          have been a recurring pain point on the legacy dashboard.
-          Trade-off: an XSS already in our bundle could exfiltrate
-          via a WebSocket to an attacker origin. We still block the
-          loud / easy injection paths (script-src falls back to
-          default-src 'self' so <script src="https://evil.com/...">
-          stays blocked), and the residual is the same one we'd
-          accept by dropping CSP entirely. xhr / fetch exfil is
-          NOT covered by ws: / wss: - those still go through the
-          default-src 'self' gate.
+        * connect-src 'self' ws: wss: data: - the dashboard, its
+          assets, and its WebSocket share an origin in every
+          default deployment (port-6052 direct, ESPHome Desktop,
+          HA add-on via Ingress, single-hostname nginx reverse
+          proxy). The ws: / wss: openers make split-hostname proxy
+          setups (ws.api.example.com + dash.example.com) work too -
+          those have been a recurring pain point on the legacy
+          dashboard. data: is needed because WebAwesome's icon
+          resolver fetches MDI path SVGs we register at runtime
+          via fetch() against a data: URI we built ourselves;
+          connect-src gates fetch destinations and the data: URI
+          isn't 'self'. Trade-off: an XSS already in our bundle
+          could exfiltrate via a WebSocket to an attacker origin.
+          We still block the loud / easy injection paths
+          (script-src falls back to default-src 'self' so
+          <script src="https://evil.com/..."> stays blocked).
         * No frame-ancestors directive - HA Ingress iframes us from
           a different origin (homeassistant.local), so locking
           framing would break the add-on. Browser default (allow
@@ -43,7 +44,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data:; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome</title>
     <link rel="icon" type="image/svg+xml" href="/assets/logo/esphome.svg" />

--- a/public/index.html
+++ b/public/index.html
@@ -12,29 +12,52 @@
       user content; it's the second wall.
 
       Trade-offs we live with today:
-        * style-src 'unsafe-inline' - required by the inline <style>
-          block below AND by Lit's style-map / styleMap directive
-          (emits inline style="..." attributes). Tightening to a
-          hashed/nonced block + class-toggle migration is tracked
-          as a follow-up - see esphome/device-builder#120.
-        * img-src data: + font-src data: - the yaml-editor squiggle
-          markers and the MDI icon paths build data: URIs at runtime.
-        * connect-src 'self' ws: wss: data: - the dashboard, its
-          assets, and its WebSocket share an origin in every
-          default deployment (port-6052 direct, ESPHome Desktop,
-          HA add-on via Ingress, single-hostname nginx reverse
-          proxy). The ws: / wss: openers make split-hostname proxy
-          setups (ws.api.example.com + dash.example.com) work too -
+        * style-src 'unsafe-inline' - required by three things in
+          our bundle today:
+            - The inline <style> block below in this index.html.
+            - Lit's style-map / styleMap directive emits inline
+              style="..." attributes; CSP style-src covers those.
+            - styles/apply-theme.ts builds <style> elements at
+              runtime via document.createElement("style") and
+              appends them to the document for the active theme;
+              one component (table-row-menu.ts) also assigns
+              element.style.cssText. Both are inline styles per
+              CSP, even though the markup never appears in the
+              source HTML.
+          Tightening (drop 'unsafe-inline', hash the static block,
+          migrate style-map and the theme injector to constructable
+          stylesheets) is tracked as a follow-up - see
+          esphome/device-builder#120.
+        * img-src 'self' data: https: - the yaml-editor squiggle
+          markers and MDI icon paths build data: URIs at runtime;
+          board catalog images come from vendor CDNs (espressif,
+          m5stack, olimex, shopify, etc.) so the img-src has to
+          allow https: globally. Images can't execute code, so the
+          worst-case loosening is letting an XSS load tracking
+          pixels - acceptable for a local dashboard.
+        * font-src data: - same data:-URI shape as the icons.
+        * connect-src 'self' ws: wss: data: - explicit connect-src
+          governs fetch / XHR / WebSocket / EventSource / Beacon
+          (default-src is NOT consulted once connect-src is set).
+          The dashboard's WS is always built same-origin
+          (api/esphome-api.ts: `${protocol}//${location.host}/ws`),
+          so 'self' alone would cover the default deployments
+          (port-6052 direct, ESPHome Desktop, HA add-on via
+          Ingress, single-hostname nginx reverse proxy). The
+          ws: / wss: openers are a deliberate compromise to keep
+          split-hostname proxy setups (ws.api.example.com +
+          dash.example.com) working without operator intervention -
           those have been a recurring pain point on the legacy
-          dashboard. data: is needed because WebAwesome's icon
-          resolver fetches MDI path SVGs we register at runtime
-          via fetch() against a data: URI we built ourselves;
-          connect-src gates fetch destinations and the data: URI
-          isn't 'self'. Trade-off: an XSS already in our bundle
-          could exfiltrate via a WebSocket to an attacker origin.
-          We still block the loud / easy injection paths
-          (script-src falls back to default-src 'self' so
-          <script src="https://evil.com/..."> stays blocked).
+          dashboard. Trade-off: an XSS in our bundle could
+          exfiltrate via a WebSocket to an attacker origin. fetch
+          and XHR over http(s) stay restricted to 'self' by the
+          same connect-src rule (the ws:/wss:/data: scheme openers
+          don't widen the http(s) origin allowlist). data: is
+          needed because WebAwesome's icon resolver fetches MDI
+          path SVGs we register at runtime via fetch() against a
+          data: URI we build ourselves. Loud injection paths
+          stay blocked - script-src falls back to default-src
+          'self' so <script src="https://evil.com/..."> can't load.
         * No frame-ancestors directive - HA Ingress iframes us from
           a different origin (homeassistant.local), so locking
           framing would break the add-on. Browser default (allow
@@ -44,7 +67,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data:; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome</title>
     <link rel="icon" type="image/svg+xml" href="/assets/logo/esphome.svg" />


### PR DESCRIPTION
Resolves the F-2 finding from the security audit (esphome/device-builder#120).

## Summary

Adds a `<meta http-equiv="Content-Security-Policy">` tag to `public/index.html`. Defense in depth against any future XSS that slips past Lit's auto-escaping — catches injected `<script src="https://evil.com/...">`, `eval()` of attacker text, and reparenting via `<base>`.

```
default-src 'self';
img-src 'self' data: https:;
style-src 'self' 'unsafe-inline';
font-src 'self' data:;
connect-src 'self' ws: wss: data:;
object-src 'none';
base-uri 'self';
form-action 'self'
```

## Calibration — keep every default deployment shape working

| Shape | Status |
|---|---|
| Direct (port 6052) | ✓ same-origin everything |
| ESPHome Desktop | ✓ same-origin |
| HA add-on (Ingress, common case) | ✓ everything served under `homeassistant.local:8123` |
| Single-hostname nginx reverse proxy | ✓ same origin for HTML / WS / assets |
| **Split-hostname reverse proxy** (`wss://api.dash.example.com/ws` + HTML on `dash.example.com`) | ✓ — `connect-src 'self' ws: wss:` opens the WS path so this recurring legacy-dashboard footgun doesn't repeat |

## Why each opener

- **`img-src https:`** — board catalog images come from vendor CDNs (espressif, m5stack, olimex, shopify, etc.). Without `https:` the catalog renders empty image slots. Images can't execute code; worst-case loosening is letting an XSS load tracking pixels.
- **`img-src data:`** + **`font-src data:`** — yaml-editor squiggle markers and MDI icon path data render as runtime `data:image/svg+xml;...` URIs.
- **`connect-src ws: wss:`** — split-hostname reverse-proxy compatibility. WS URL is always same-origin in our code (`api/esphome-api.ts`), so default deploys don't need this; the openers exist purely for split-hostname operators.
- **`connect-src data:`** — WebAwesome's icon resolver `fetch()`es the `data:` URI we register MDI path SVGs under.
- **`style-src 'unsafe-inline'`** — required by:
  - The inline `<style>` block in `index.html`
  - Lit's `style-map` / `styleMap` directive (emits inline `style="…"` attributes)
  - `styles/apply-theme.ts` builds runtime `<style>` elements via `document.createElement("style")`
  - `components/dashboard/table-row-menu.ts` assigns `element.style.cssText`
  - Tightening (drop `'unsafe-inline'`, hash the static block, migrate `style-map` and the theme injector to constructable stylesheets) is tracked as a follow-up in #120.

## What's not included

- **No `frame-ancestors`** — HA Ingress iframes us from `homeassistant.local`. Locking framing would break the add-on. Browser default leaves clickjacking unblocked; reverse-proxy operators can add their own response-header CSP.
- **No `'unsafe-eval'`** in `script-src` — required the dev devtool switch (rspack's default `eval-cheap-module-source-map` uses `eval()` per-module and wouldn't load under CSP). Dev is now on `cheap-module-source-map`; production was already on `nosources-source-map`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 159 passed
- [x] `npm run build` — clean (only the pre-existing asset-size warnings); meta-tag survives into output `index.html` verbatim
- [x] `npm run dev` boots without `eval` violations after the devtool switch
- [ ] Manual: load dashboard via direct port-6052 → board images render, icons render, no CSP violations
- [ ] Manual: load via HA Ingress → ditto