### PR TITLE
Add web.esphome.io fallback to install firmware dialog

### DIFF
--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -1,9 +1,6 @@
 import { type ReactiveController, type ReactiveControllerHost } from "lit";
 import { DeviceState, type ConfiguredDevice } from "../../api/types.js";
-import type {
-  CommandType,
-  ESPHomeCommandDialog,
-} from "../command-dialog.js";
+import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 
 export interface DeviceInstallControllerHost extends ReactiveControllerHost {
@@ -51,9 +48,7 @@ export class DeviceInstallController implements ReactiveController {
     this._host.requestUpdate();
   };
 
-  onInstallMethodSelect = (
-    e: CustomEvent<{ method: string; port?: string }>
-  ) => {
+  onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) => {
     const device = this._host.device;
     this.installMethodOpen = false;
     this._host.requestUpdate();
@@ -65,14 +60,12 @@ export class DeviceInstallController implements ReactiveController {
       this._openCommand(device, "install", port!);
     } else if (method === "web-serial") {
       this._host.firmwareDialog?.installWebSerial(device);
+    } else if (method === "web-download") {
+      this._host.firmwareDialog?.installWebDownload(device);
     }
   };
 
-  private _openCommand(
-    device: ConfiguredDevice,
-    type: CommandType,
-    port?: string
-  ) {
+  private _openCommand(device: ConfiguredDevice, type: CommandType, port?: string) {
     const dialog = this._host.commandDialog;
     if (!dialog) return;
     dialog.configuration = device.configuration;

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -41,7 +41,15 @@ registerMdiIcons({
   close: mdiClose,
 });
 
-type InstallStep = "connecting" | "queued" | "installing" | "compiling" | "flashing" | "done" | "error";
+type InstallStep =
+  | "connecting"
+  | "queued"
+  | "installing"
+  | "compiling"
+  | "flashing"
+  | "done"
+  | "download-ready"
+  | "error";
 
 function normalizeChipName(name: string): string {
   return name.split("(")[0].trim().toLowerCase().replace(/-/g, "");
@@ -69,6 +77,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() private _logsExpanded = false;
   @state() private _logsFullHeight = false;
   @state() private _flashPercent = 0;
+  @state() private _downloadedFilename = "";
 
   private _device: ConfiguredDevice | null = null;
   private _jobId = "";
@@ -105,6 +114,21 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._startWebSerialInstall();
   }
 
+  /**
+   * Compile the firmware on the server, download the resulting binary
+   * to the user's machine, and show instructions to flash it via
+   * web.esphome.io. Used as the fallback path when neither OTA nor
+   * Web Serial is available (e.g. dashboard served over HTTP and the
+   * device is offline / first-flash).
+   */
+  installWebDownload(device: ConfiguredDevice) {
+    this._init(device);
+    this._step = "queued";
+    this._statusMessage = this._localize("firmware.status_queued");
+    this._dialog.open = true;
+    this._startWebDownload();
+  }
+
   private _init(device: ConfiguredDevice) {
     // Dispose any stream from a prior session before resetting state.
     // ``_init`` re-runs on every ``installWebSerial`` call, including
@@ -117,13 +141,16 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._device = device;
     this._open = true;
     this._step = "installing";
-    this._title = this._localize("firmware.install_title", { name: device.friendly_name || device.name });
+    this._title = this._localize("firmware.install_title", {
+      name: device.friendly_name || device.name,
+    });
     this._statusMessage = "";
     this._errorMessage = "";
     this._logLines = [];
     this._logsExpanded = false;
     this._logsFullHeight = false;
     this._flashPercent = 0;
+    this._downloadedFilename = "";
     // ``_jobId`` is already cleared by ``_detachStream`` above; same
     // for ``_streamId`` and ``_compileReject``.
     this._detected = null;
@@ -175,8 +202,13 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         --term-error: #c72e2e;
       }
 
-      wa-dialog { --width: 520px; transition: width 0.2s; }
-      :host([expanded]) wa-dialog { --width: min(900px, 90vw); }
+      wa-dialog {
+        --width: 520px;
+        transition: width 0.2s;
+      }
+      :host([expanded]) wa-dialog {
+        --width: min(900px, 90vw);
+      }
 
       wa-dialog::part(header) {
         background: var(--esphome-primary);
@@ -190,14 +222,21 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         font-weight: var(--wa-font-weight-bold);
       }
       wa-dialog::part(close-button__base) {
-        background: transparent; border: none; box-shadow: none;
-        padding: 0; min-width: unset; min-height: unset;
-        color: var(--esphome-on-primary); cursor: pointer;
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        min-width: unset;
+        min-height: unset;
+        color: var(--esphome-on-primary);
+        cursor: pointer;
       }
       wa-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);
       }
-      wa-dialog::part(footer) { display: none; }
+      wa-dialog::part(footer) {
+        display: none;
+      }
 
       .status {
         display: flex;
@@ -217,8 +256,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       .status-icon {
         font-size: 42px;
       }
-      .status-icon--success { color: var(--esphome-success); }
-      .status-icon--error { color: var(--esphome-error); }
+      .status-icon--success {
+        color: var(--esphome-success);
+      }
+      .status-icon--error {
+        color: var(--esphome-error);
+      }
 
       .status-text {
         font-size: var(--wa-font-size-m);
@@ -231,6 +274,21 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         color: var(--wa-color-text-quiet);
         max-width: 380px;
         line-height: 1.5;
+      }
+
+      .instructions {
+        margin: var(--wa-space-m) 0 0;
+        padding-left: var(--wa-space-l);
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-normal);
+        line-height: 1.6;
+      }
+      .instructions li + li {
+        margin-top: var(--wa-space-2xs);
+      }
+
+      a.btn {
+        text-decoration: none;
       }
 
       .progress-bar {
@@ -262,8 +320,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         color: var(--wa-color-text-quiet);
         cursor: pointer;
       }
-      .logs-toggle:hover { color: var(--wa-color-text-normal); }
-      .logs-toggle wa-icon { font-size: 16px; }
+      .logs-toggle:hover {
+        color: var(--wa-color-text-normal);
+      }
+      .logs-toggle wa-icon {
+        font-size: 16px;
+      }
 
       .logs-header {
         display: flex;
@@ -281,7 +343,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         color: var(--wa-color-text-quiet);
         cursor: pointer;
       }
-      .expand-btn:hover { color: var(--wa-color-text-normal); }
+      .expand-btn:hover {
+        color: var(--wa-color-text-normal);
+      }
 
       .logs-container {
         margin-top: var(--wa-space-s);
@@ -297,7 +361,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       .logs-container--full esphome-ansi-log {
         --log-height: 50vh;
       }
-      esphome-ansi-log::part(container) { border-radius: 0; }
+      esphome-ansi-log::part(container) {
+        border-radius: 0;
+      }
 
       .footer {
         display: flex;
@@ -346,14 +412,8 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
-        label=${this._title}
-        ?open=${this._open}
-        @wa-after-hide=${this._onClose}
-      >
-        ${this._renderStatus()}
-        ${this._renderProgress()}
-        ${this._renderLogs()}
+      <wa-dialog label=${this._title} ?open=${this._open} @wa-after-hide=${this._onClose}>
+        ${this._renderStatus()} ${this._renderProgress()} ${this._renderLogs()}
         ${this._renderFooter()}
       </wa-dialog>
     `;
@@ -363,15 +423,46 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (this._step === "done") {
       return html`
         <div class="status">
-          <wa-icon class="status-icon status-icon--success" library="mdi" name="check-circle"></wa-icon>
+          <wa-icon
+            class="status-icon status-icon--success"
+            library="mdi"
+            name="check-circle"
+          ></wa-icon>
           <span class="status-text">${this._statusMessage}</span>
         </div>
+      `;
+    }
+    if (this._step === "download-ready") {
+      const filename = this._downloadedFilename;
+      return html`
+        <div class="status">
+          <wa-icon
+            class="status-icon status-icon--success"
+            library="mdi"
+            name="check-circle"
+          ></wa-icon>
+          <span class="status-text"
+            >${this._localize("firmware.web_download_done_title")}</span
+          >
+          <span class="status-detail"
+            >${this._localize("firmware.web_download_done_body", { filename })}</span
+          >
+        </div>
+        <ol class="instructions">
+          <li>${this._localize("firmware.web_download_step_open")}</li>
+          <li>${this._localize("firmware.web_download_step_connect")}</li>
+          <li>${this._localize("firmware.web_download_step_install", { filename })}</li>
+        </ol>
       `;
     }
     if (this._step === "error") {
       return html`
         <div class="status">
-          <wa-icon class="status-icon status-icon--error" library="mdi" name="alert-circle"></wa-icon>
+          <wa-icon
+            class="status-icon status-icon--error"
+            library="mdi"
+            name="alert-circle"
+          ></wa-icon>
           <span class="status-text">${this._statusMessage}</span>
           <span class="status-detail">${this._errorMessage}</span>
         </div>
@@ -398,31 +489,81 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (this._logLines.length === 0) return nothing;
     return html`
       <div class="logs-header">
-        <button class="logs-toggle" @click=${() => { this._logsExpanded = !this._logsExpanded; }}>
-          <wa-icon library="mdi" name=${this._logsExpanded ? "chevron-up" : "chevron-down"}></wa-icon>
-          ${this._logsExpanded ? this._localize("firmware.hide_details") : this._localize("firmware.show_details")}
+        <button
+          class="logs-toggle"
+          @click=${() => {
+            this._logsExpanded = !this._logsExpanded;
+          }}
+        >
+          <wa-icon
+            library="mdi"
+            name=${this._logsExpanded ? "chevron-up" : "chevron-down"}
+          ></wa-icon>
+          ${this._logsExpanded
+            ? this._localize("firmware.hide_details")
+            : this._localize("firmware.show_details")}
         </button>
         ${this._logsExpanded
-          ? html`<button class="expand-btn" @click=${() => { this._logsFullHeight = !this._logsFullHeight; }}>
-              <wa-icon library="mdi" name=${this._logsFullHeight ? "arrow-collapse" : "arrow-expand"}></wa-icon>
+          ? html`<button
+              class="expand-btn"
+              @click=${() => {
+                this._logsFullHeight = !this._logsFullHeight;
+              }}
+            >
+              <wa-icon
+                library="mdi"
+                name=${this._logsFullHeight ? "arrow-collapse" : "arrow-expand"}
+              ></wa-icon>
             </button>`
           : nothing}
       </div>
       ${this._logsExpanded
-        ? html`<div class="logs-container ${this._logsFullHeight ? "logs-container--full" : ""}">
-            <esphome-ansi-log .lines=${this._logLines} ?light=${!this._darkMode}></esphome-ansi-log>
+        ? html`<div
+            class="logs-container ${this._logsFullHeight ? "logs-container--full" : ""}"
+          >
+            <esphome-ansi-log
+              .lines=${this._logLines}
+              ?light=${!this._darkMode}
+            ></esphome-ansi-log>
           </div>`
         : nothing}
     `;
   }
 
   private _renderFooter() {
-    const isRunning = this._step !== "done" && this._step !== "error";
+    const isRunning =
+      this._step !== "done" && this._step !== "error" && this._step !== "download-ready";
+    if (isRunning) {
+      return html`
+        <div class="footer">
+          <button class="btn btn--ghost" @click=${this._cancel}>
+            ${this._localize("command.stop")}
+          </button>
+        </div>
+      `;
+    }
+    if (this._step === "download-ready") {
+      return html`
+        <div class="footer">
+          <button class="btn btn--ghost" @click=${this._close}>
+            ${this._localize("command.close")}
+          </button>
+          <a
+            class="btn btn--primary"
+            href="https://web.esphome.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ${this._localize("firmware.web_download_open_button")}
+          </a>
+        </div>
+      `;
+    }
     return html`
       <div class="footer">
-        ${isRunning
-          ? html`<button class="btn btn--ghost" @click=${this._cancel}>${this._localize("command.stop")}</button>`
-          : html`<button class="btn btn--primary" @click=${this._close}>${this._localize("command.close")}</button>`}
+        <button class="btn btn--primary" @click=${this._close}>
+          ${this._localize("command.close")}
+        </button>
       </div>
     `;
   }
@@ -471,12 +612,18 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     const expectedNorm = expected ? expected.toLowerCase().replace(/-/g, "") : "";
     // Without a resolved variant, "esp32" can stand in for any ESP32
     // family chip — don't reject the install in that case.
-    const expectedIsCoarseEsp32 =
-      !hasAuthoritativeVariant && expectedNorm === "esp32";
+    const expectedIsCoarseEsp32 = !hasAuthoritativeVariant && expectedNorm === "esp32";
     console.debug(
-      "[Web Serial] Detected chip:", detected.chipName, "→", detectedNorm,
-      "| Expected:", expected, "→", expectedNorm,
-      "| authoritative:", hasAuthoritativeVariant,
+      "[Web Serial] Detected chip:",
+      detected.chipName,
+      "→",
+      detectedNorm,
+      "| Expected:",
+      expected,
+      "→",
+      expectedNorm,
+      "| authoritative:",
+      hasAuthoritativeVariant
     );
     if (
       expectedNorm &&
@@ -484,13 +631,26 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       detectedNorm !== expectedNorm &&
       !(expectedIsCoarseEsp32 && detectedNorm.startsWith("esp32"))
     ) {
-      try { await disconnect(detected.transport); } catch { /* ignore */ }
-      this._fail(this._localize("firmware.chip_mismatch", { detected: detected.chipName, expected }));
+      try {
+        await disconnect(detected.transport);
+      } catch {
+        /* ignore */
+      }
+      this._fail(
+        this._localize("firmware.chip_mismatch", {
+          detected: detected.chipName,
+          expected,
+        })
+      );
       return;
     }
 
     // Disconnect during compile — we'll reconnect to flash
-    try { await disconnect(detected.transport); } catch { /* ignore */ }
+    try {
+      await disconnect(detected.transport);
+    } catch {
+      /* ignore */
+    }
 
     // 3. Compile
     this._step = "queued";
@@ -544,10 +704,18 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       console.error("[Web Serial] Flash error:", err);
       // If progress reached 100%, treat as success (device may have reset during verification)
       if (this._flashPercent >= 100) {
-        console.debug("[Web Serial] Flash reached 100%, treating as success despite error");
+        console.debug(
+          "[Web Serial] Flash reached 100%, treating as success despite error"
+        );
       } else {
-        try { await disconnect(flashDetected.transport); } catch { /* ignore */ }
-        this._fail(err instanceof Error ? err.message : this._localize("firmware.flash_failed"));
+        try {
+          await disconnect(flashDetected.transport);
+        } catch {
+          /* ignore */
+        }
+        this._fail(
+          err instanceof Error ? err.message : this._localize("firmware.flash_failed")
+        );
         return;
       }
     }
@@ -556,10 +724,53 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = this._localize("firmware.status_resetting");
     try {
       await resetAndDisconnect(flashDetected.loader, flashDetected.transport);
-    } catch { /* ignore reset errors */ }
+    } catch {
+      /* ignore reset errors */
+    }
 
     this._statusMessage = this._localize("firmware.status_done");
     this._step = "done";
+  }
+
+  // ─── Web Download (compile + save .bin for web.esphome.io) ─────
+
+  private async _startWebDownload() {
+    const device = this._device;
+    if (!device) return;
+
+    try {
+      await this._compileAndWait(device.configuration);
+    } catch {
+      this._fail(this._localize("firmware.compile_failed"));
+      return;
+    }
+
+    this._statusMessage = this._localize("firmware.status_downloading");
+    try {
+      const binaries = await this._api.firmwareGetBinaries(device.configuration);
+      const factory = binaries.find((b) => b.file.includes("factory"));
+      const binary = factory || binaries[0];
+      if (!binary) {
+        this._fail(this._localize("serial.no_firmware"));
+        return;
+      }
+      const result = await this._api.firmwareDownload(device.configuration, binary.file);
+      const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
+      const blob = new Blob([bytes], { type: "application/octet-stream" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = result.filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      this._downloadedFilename = result.filename;
+    } catch {
+      this._fail(this._localize("firmware.download_failed"));
+      return;
+    }
+
+    this._step = "download-ready";
+    this._statusMessage = "";
   }
 
   private _compileAndWait(configuration: string): Promise<void> {
@@ -586,7 +797,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
             this._jobId = "";
             this._compileReject = null;
             const result = data as unknown as { status: string };
-            result.status === JobStatus.COMPLETED ? resolve() : reject(new Error("Compilation failed"));
+            result.status === JobStatus.COMPLETED
+              ? resolve()
+              : reject(new Error("Compilation failed"));
           },
           onError: (error) => {
             this._streamId = "";
@@ -613,7 +826,11 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   private async _cancel() {
     if (this._jobId) {
-      try { await this._api.firmwareCancel(this._jobId); } catch { /* ignore */ }
+      try {
+        await this._api.firmwareCancel(this._jobId);
+      } catch {
+        /* ignore */
+      }
     }
     this._close();
   }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -748,13 +748,16 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = this._localize("firmware.status_downloading");
     try {
       const binaries = await this._api.firmwareGetBinaries(device.configuration);
+      // web.esphome.io flashes the uploaded file at offset 0x0, so we
+      // need a factory image that includes the bootloader + partition
+      // table. The plain firmware.bin (app-only at 0x10000) would
+      // brick the device if flashed this way.
       const factory = binaries.find((b) => b.file.includes("factory"));
-      const binary = factory || binaries[0];
-      if (!binary) {
-        this._fail(this._localize("serial.no_firmware"));
+      if (!factory) {
+        this._fail(this._localize("firmware.no_factory_binary"));
         return;
       }
-      const result = await this._api.firmwareDownload(device.configuration, binary.file);
+      const result = await this._api.firmwareDownload(device.configuration, factory.file);
       const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
       const blob = new Blob([bytes], { type: "application/octet-stream" });
       const url = URL.createObjectURL(blob);

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowLeft, mdiSerialPort, mdiUsb, mdiWifi } from "@mdi/js";
+import { mdiArrowLeft, mdiCloudDownload, mdiSerialPort, mdiUsb, mdiWifi } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
@@ -19,6 +19,7 @@ registerMdiIcons({
   wifi: mdiWifi,
   usb: mdiUsb,
   "serial-port": mdiSerialPort,
+  "cloud-download": mdiCloudDownload,
 });
 
 type DialogView = "method" | "port-select";
@@ -218,6 +219,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   private _renderMethodList() {
     const isOnline = this.deviceState === DeviceState.ONLINE;
     const hasWebSerial = this._supportsWebSerial;
+    const showWebDownload = !hasWebSerial && !isOnline;
 
     return html`
       <div class="list">
@@ -227,8 +229,12 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         >
           <wa-icon library="mdi" name="wifi"></wa-icon>
           <div class="info">
-            <span class="title">${this._localize("dashboard.install_method_network")}</span>
-            <span class="desc">${this._localize("dashboard.install_method_network_desc")}</span>
+            <span class="title"
+              >${this._localize("dashboard.install_method_network")}</span
+            >
+            <span class="desc"
+              >${this._localize("dashboard.install_method_network_desc")}</span
+            >
           </div>
         </div>
         <div
@@ -237,19 +243,42 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         >
           <wa-icon library="mdi" name="usb"></wa-icon>
           <div class="info">
-            <span class="title">${this._localize("dashboard.install_method_usb_local")}</span>
-            <span class="desc">${hasWebSerial
-              ? this._localize("dashboard.install_method_usb_local_desc")
-              : this._localize("dashboard.install_method_usb_local_unsupported")}</span>
+            <span class="title"
+              >${this._localize("dashboard.install_method_usb_local")}</span
+            >
+            <span class="desc"
+              >${hasWebSerial
+                ? this._localize("dashboard.install_method_usb_local_desc")
+                : this._localize("dashboard.install_method_usb_local_unsupported")}</span
+            >
           </div>
         </div>
         <div class="option" @click=${this._onServerSerial}>
           <wa-icon library="mdi" name="serial-port"></wa-icon>
           <div class="info">
-            <span class="title">${this._localize("dashboard.install_method_usb_server")}</span>
-            <span class="desc">${this._localize("dashboard.install_method_usb_server_desc")}</span>
+            <span class="title"
+              >${this._localize("dashboard.install_method_usb_server")}</span
+            >
+            <span class="desc"
+              >${this._localize("dashboard.install_method_usb_server_desc")}</span
+            >
           </div>
         </div>
+        ${showWebDownload
+          ? html`
+              <div class="option" @click=${() => this._selectMethod("web-download")}>
+                <wa-icon library="mdi" name="cloud-download"></wa-icon>
+                <div class="info">
+                  <span class="title"
+                    >${this._localize("dashboard.install_method_web_download")}</span
+                  >
+                  <span class="desc"
+                    >${this._localize("dashboard.install_method_web_download_desc")}</span
+                  >
+                </div>
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -265,12 +294,19 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     }
 
     return html`
-      <button class="back-btn" @click=${() => { this._view = "method"; }}>
+      <button
+        class="back-btn"
+        @click=${() => {
+          this._view = "method";
+        }}
+      >
         <wa-icon library="mdi" name="arrow-left"></wa-icon>
         ${this._localize("dashboard.install_method_back")}
       </button>
       ${this._ports.length === 0
-        ? html`<div class="empty">${this._localize("dashboard.install_method_no_ports")}</div>`
+        ? html`<div class="empty">
+            ${this._localize("dashboard.install_method_no_ports")}
+          </div>`
         : html`
             <div class="list">
               ${this._ports.map(
@@ -282,7 +318,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
                       ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
                     </div>
                   </div>
-                `,
+                `
               )}
             </div>
           `}
@@ -306,7 +342,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         detail: { method },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -316,14 +352,12 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         detail: { method: "server-serial", port },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
   private _onClose() {
-    this.dispatchEvent(
-      new CustomEvent("close", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
   }
 }
 

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -219,7 +219,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   private _renderMethodList() {
     const isOnline = this.deviceState === DeviceState.ONLINE;
     const hasWebSerial = this._supportsWebSerial;
-    const showWebDownload = !hasWebSerial && !isOnline;
+    const showWebDownload = this.mode === "install" && !hasWebSerial && !isOnline;
 
     return html`
       <div class="list">

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1062,6 +1062,8 @@ export class ESPHomePageDashboard extends LitElement {
         this._openCommand(device, "install", port!);
       } else if (method === "web-serial") {
         this._firmwareDialog.installWebSerial(device);
+      } else if (method === "web-download") {
+        this._firmwareDialog.installWebDownload(device);
       }
     }
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -132,6 +132,8 @@
     "install_method_usb_local_unsupported": "Requires a browser with Web Serial support (e.g. Chrome)",
     "install_method_usb_server": "Plug into computer running ESPHome Dashboard",
     "install_method_usb_server_desc": "For devices connected via USB to the server",
+    "install_method_web_download": "Download firmware to flash via web.esphome.io",
+    "install_method_web_download_desc": "Compile here, then flash from a computer that can use Web Serial",
     "install": "Install",
     "install_method_select_port": "Select a serial port",
     "install_method_no_ports": "No serial ports found. Make sure the device is connected to the server.",
@@ -280,7 +282,13 @@
     "validate_success": "Configuration is valid!",
     "validate_failed": "Validation failed.",
     "show_details": "Show details",
-    "hide_details": "Hide details"
+    "hide_details": "Hide details",
+    "web_download_done_title": "Firmware ready to flash",
+    "web_download_done_body": "Saved as {filename}. Open web.esphome.io on a computer that can connect to your device via USB and flash the file.",
+    "web_download_step_open": "Open web.esphome.io",
+    "web_download_step_connect": "Click Connect and pick your device's serial port",
+    "web_download_step_install": "Choose Install and select the downloaded {filename}",
+    "web_download_open_button": "Open web.esphome.io"
   },
   "serial": {
     "title": "USB Device",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -275,6 +275,7 @@
     "install_failed": "Installation failed.",
     "compile_failed": "Compilation failed.",
     "download_failed": "Failed to download firmware.",
+    "no_factory_binary": "No factory binary available for this device. web.esphome.io needs a factory image to flash at offset 0x0.",
     "flash_failed": "Failed to flash firmware to device.",
     "chip_mismatch": "Chip mismatch: detected {detected} but device expects {expected}.",
     "validate_title": "Validate — {name}",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -171,6 +171,8 @@
     "install_method_usb_local_unsupported": "Nécessite un navigateur compatible Web Serial (ex. Chrome)",
     "install_method_usb_server": "Brancher sur l'ordinateur exécutant le tableau de bord ESPHome",
     "install_method_usb_server_desc": "Pour les appareils connectés via USB au serveur",
+    "install_method_web_download": "Télécharger le firmware pour le flasher via web.esphome.io",
+    "install_method_web_download_desc": "Compilez ici, puis flashez depuis un ordinateur qui prend en charge Web Serial",
     "install": "Installer",
     "install_method_select_port": "Sélectionnez un port série",
     "install_method_no_ports": "Aucun port série trouvé. Assurez-vous que l'appareil est connecté au serveur.",
@@ -511,7 +513,13 @@
     "validate_success": "La configuration est valide !",
     "validate_failed": "Échec de la validation.",
     "show_details": "Afficher les détails",
-    "hide_details": "Masquer les détails"
+    "hide_details": "Masquer les détails",
+    "web_download_done_title": "Firmware prêt à flasher",
+    "web_download_done_body": "Enregistré sous {filename}. Ouvrez web.esphome.io sur un ordinateur capable de se connecter à votre appareil via USB et flashez le fichier.",
+    "web_download_step_open": "Ouvrez web.esphome.io",
+    "web_download_step_connect": "Cliquez sur Connect et choisissez le port série de votre appareil",
+    "web_download_step_install": "Choisissez Install et sélectionnez le fichier téléchargé {filename}",
+    "web_download_open_button": "Ouvrir web.esphome.io"
   },
   "validation": {
     "required": "Ce champ est requis",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -506,6 +506,7 @@
     "install_failed": "Échec de l'installation.",
     "compile_failed": "Échec de la compilation.",
     "download_failed": "Échec du téléchargement du firmware.",
+    "no_factory_binary": "Aucun binaire factory disponible pour cet appareil. web.esphome.io a besoin d'une image factory pour flasher à l'offset 0x0.",
     "flash_failed": "Échec du flashage du firmware sur l'appareil.",
     "chip_mismatch": "Puce incompatible : détecté {detected} mais l'appareil attend {expected}.",
     "validate_title": "Validation — {name}",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -171,6 +171,8 @@
     "install_method_usb_local_unsupported": "Vereist een browser met Web Serial-ondersteuning (bijv. Chrome)",
     "install_method_usb_server": "Aansluiten op de computer met ESPHome Dashboard",
     "install_method_usb_server_desc": "Voor apparaten die via USB op de server zijn aangesloten",
+    "install_method_web_download": "Download firmware om te flashen via web.esphome.io",
+    "install_method_web_download_desc": "Compileer hier en flash daarna vanaf een computer die Web Serial ondersteunt",
     "install": "Installeren",
     "install_method_select_port": "Selecteer een seriële poort",
     "install_method_no_ports": "Geen seriële poorten gevonden. Zorg dat het apparaat op de server is aangesloten.",
@@ -511,7 +513,13 @@
     "validate_success": "Configuratie is geldig!",
     "validate_failed": "Validatie mislukt.",
     "show_details": "Details tonen",
-    "hide_details": "Details verbergen"
+    "hide_details": "Details verbergen",
+    "web_download_done_title": "Firmware klaar om te flashen",
+    "web_download_done_body": "Opgeslagen als {filename}. Open web.esphome.io op een computer die via USB met je apparaat kan verbinden en flash het bestand.",
+    "web_download_step_open": "Open web.esphome.io",
+    "web_download_step_connect": "Klik op Connect en kies de seriële poort van je apparaat",
+    "web_download_step_install": "Kies Install en selecteer het gedownloade bestand {filename}",
+    "web_download_open_button": "Open web.esphome.io"
   },
   "validation": {
     "required": "Dit veld is verplicht",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -506,6 +506,7 @@
     "install_failed": "Installatie mislukt.",
     "compile_failed": "Compilatie mislukt.",
     "download_failed": "Firmware downloaden mislukt.",
+    "no_factory_binary": "Geen factory binary beschikbaar voor dit apparaat. web.esphome.io heeft een factory image nodig om te flashen op offset 0x0.",
     "flash_failed": "Firmware flashen naar apparaat mislukt.",
     "chip_mismatch": "Chip-verschil: {detected} gedetecteerd maar apparaat verwacht {expected}.",
     "validate_title": "Valideren — {name}",


### PR DESCRIPTION
## Problem

Web Serial only works in a secure context (HTTPS or localhost). When the dashboard is served over plain HTTP — common in self-hosted LAN setups — `navigator.serial` is unavailable. If the device is also offline (typical first-flash state), the only remaining install method is plugging the device into the dashboard host, which often isn't physically practical.

## Solution

Add a fourth install option that compiles the firmware on the server, downloads the binary to the user's machine, and instructs them to flash it via [web.esphome.io](https://web.esphome.io) — the same browser flasher hosted on a secure context where Web Serial works. The option only appears when both Web Serial and OTA are unavailable.

## Changes

- New 4th option in `install-method-dialog`, conditionally rendered when `!hasWebSerial && !isOnline`, with a `cloud-download` icon
- New `installWebDownload(device)` flow in `firmware-install-dialog`: reuses the existing compile + binary-fetch pipeline, triggers a Blob download for the factory `.bin`, then switches to a "ready to flash" view with numbered steps and an "Open web.esphome.io" link
- Routed `web-download` method through `device-install-controller`
- Added localization keys to `en.json`, `nl.json`, and `fr.json`