### PR TITLE
Fix web-download flow for ESP8266 devices

### DIFF
--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -29,6 +29,10 @@ export class DeviceInstallController implements ReactiveController {
     return this._host.device?.state ?? DeviceState.UNKNOWN;
   }
 
+  get deviceTargetPlatform(): string {
+    return this._host.device?.target_platform ?? "";
+  }
+
   /** "Install" entry point — opens the install-method picker. */
   onInstall = () => {
     if (!this._host.device) return;

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -759,7 +759,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         binaries.find((b) => b.file === "firmware.factory.bin") ??
         binaries.find((b) => b.file === "firmware.bin");
       if (!flashable) {
-        this._fail(this._localize("firmware.no_factory_binary"));
+        this._fail(this._localize("firmware.no_flashable_binary"));
         return;
       }
       const result = await this._api.firmwareDownload(

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -748,16 +748,24 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = this._localize("firmware.status_downloading");
     try {
       const binaries = await this._api.firmwareGetBinaries(device.configuration);
-      // web.esphome.io flashes the uploaded file at offset 0x0, so we
-      // need a factory image that includes the bootloader + partition
-      // table. The plain firmware.bin (app-only at 0x10000) would
-      // brick the device if flashed this way.
-      const factory = binaries.find((b) => b.file.includes("factory"));
-      if (!factory) {
+      // web.esphome.io flashes the uploaded file at 0x0, so we need a
+      // self-contained image. Per ESPHome's get_download_types(): ESP32
+      // returns "firmware.factory.bin" (bootloader + partitions + app);
+      // ESP8266 returns just "firmware.bin" which is itself the full
+      // image (no bootloader/partition split on ESP8266). RP2040 / nrf52
+      // / libretiny return .uf2 files which web.esphome.io can't flash —
+      // reject those with a clear error.
+      const flashable =
+        binaries.find((b) => b.file === "firmware.factory.bin") ??
+        binaries.find((b) => b.file === "firmware.bin");
+      if (!flashable) {
         this._fail(this._localize("firmware.no_factory_binary"));
         return;
       }
-      const result = await this._api.firmwareDownload(device.configuration, factory.file);
+      const result = await this._api.firmwareDownload(
+        device.configuration,
+        flashable.file
+      );
       const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
       const blob = new Blob([bytes], { type: "application/octet-stream" });
       const url = URL.createObjectURL(blob);

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -40,6 +40,9 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   deviceState: DeviceState = DeviceState.UNKNOWN;
 
   @property()
+  deviceTargetPlatform = "";
+
+  @property()
   mode: "install" | "logs" = "install";
 
   @state() private _view: DialogView = "method";
@@ -48,6 +51,17 @@ export class ESPHomeInstallMethodDialog extends LitElement {
 
   private get _supportsWebSerial(): boolean {
     return "serial" in navigator;
+  }
+
+  /**
+   * web.esphome.io / esp-web-tools only supports ESP32 (all variants)
+   * and ESP8266. UF2 platforms (RP2040, nrf52, libretiny) ship a
+   * different binary format that the browser flasher can't handle, so
+   * we hide the option entirely for those.
+   */
+  private get _supportsWebDownload(): boolean {
+    const p = this.deviceTargetPlatform.toLowerCase();
+    return p.startsWith("esp32") || p === "esp8266";
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
@@ -219,7 +233,8 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   private _renderMethodList() {
     const isOnline = this.deviceState === DeviceState.ONLINE;
     const hasWebSerial = this._supportsWebSerial;
-    const showWebDownload = this.mode === "install" && !hasWebSerial && !isOnline;
+    const showWebDownload =
+      this.mode === "install" && !hasWebSerial && !isOnline && this._supportsWebDownload;
 
     return html`
       <div class="list">

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -746,6 +746,7 @@ export class ESPHomePageDashboard extends LitElement {
       <esphome-install-method-dialog
         ?open=${this._installMethodOpen}
         .deviceState=${this._installMethodDevice?.state ?? DeviceState.UNKNOWN}
+        .deviceTargetPlatform=${this._installMethodDevice?.target_platform ?? ""}
         .mode=${this._installMethodMode}
         @close=${() => { this._installMethodOpen = false; }}
         @select-method=${this._onInstallMethodSelect}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -447,6 +447,7 @@ export class ESPHomePageDevice extends LitElement {
       <esphome-install-method-dialog
         ?open=${this._installCtrl.installMethodOpen}
         .deviceState=${this._installCtrl.deviceState}
+        .deviceTargetPlatform=${this._installCtrl.deviceTargetPlatform}
         @close=${this._installCtrl.onInstallMethodClose}
         @select-method=${this._installCtrl.onInstallMethodSelect}
       ></esphome-install-method-dialog>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -275,7 +275,7 @@
     "install_failed": "Installation failed.",
     "compile_failed": "Compilation failed.",
     "download_failed": "Failed to download firmware.",
-    "no_factory_binary": "No flashable binary available for this device. web.esphome.io supports ESP32 and ESP8266 only.",
+    "no_flashable_binary": "No flashable binary available for this device. web.esphome.io supports ESP32 and ESP8266 only.",
     "flash_failed": "Failed to flash firmware to device.",
     "chip_mismatch": "Chip mismatch: detected {detected} but device expects {expected}.",
     "validate_title": "Validate — {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -275,7 +275,7 @@
     "install_failed": "Installation failed.",
     "compile_failed": "Compilation failed.",
     "download_failed": "Failed to download firmware.",
-    "no_factory_binary": "No factory binary available for this device. web.esphome.io needs a factory image to flash at offset 0x0.",
+    "no_factory_binary": "No flashable binary available for this device. web.esphome.io supports ESP32 and ESP8266 only.",
     "flash_failed": "Failed to flash firmware to device.",
     "chip_mismatch": "Chip mismatch: detected {detected} but device expects {expected}.",
     "validate_title": "Validate — {name}",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -506,7 +506,7 @@
     "install_failed": "Échec de l'installation.",
     "compile_failed": "Échec de la compilation.",
     "download_failed": "Échec du téléchargement du firmware.",
-    "no_factory_binary": "Aucun binaire flashable disponible pour cet appareil. web.esphome.io ne prend en charge que ESP32 et ESP8266.",
+    "no_flashable_binary": "Aucun binaire flashable disponible pour cet appareil. web.esphome.io ne prend en charge que ESP32 et ESP8266.",
     "flash_failed": "Échec du flashage du firmware sur l'appareil.",
     "chip_mismatch": "Puce incompatible : détecté {detected} mais l'appareil attend {expected}.",
     "validate_title": "Validation — {name}",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -506,7 +506,7 @@
     "install_failed": "Échec de l'installation.",
     "compile_failed": "Échec de la compilation.",
     "download_failed": "Échec du téléchargement du firmware.",
-    "no_factory_binary": "Aucun binaire factory disponible pour cet appareil. web.esphome.io a besoin d'une image factory pour flasher à l'offset 0x0.",
+    "no_factory_binary": "Aucun binaire flashable disponible pour cet appareil. web.esphome.io ne prend en charge que ESP32 et ESP8266.",
     "flash_failed": "Échec du flashage du firmware sur l'appareil.",
     "chip_mismatch": "Puce incompatible : détecté {detected} mais l'appareil attend {expected}.",
     "validate_title": "Validation — {name}",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -506,7 +506,7 @@
     "install_failed": "Installatie mislukt.",
     "compile_failed": "Compilatie mislukt.",
     "download_failed": "Firmware downloaden mislukt.",
-    "no_factory_binary": "Geen geschikte binary beschikbaar voor dit apparaat. web.esphome.io ondersteunt alleen ESP32 en ESP8266.",
+    "no_flashable_binary": "Geen geschikte binary beschikbaar voor dit apparaat. web.esphome.io ondersteunt alleen ESP32 en ESP8266.",
     "flash_failed": "Firmware flashen naar apparaat mislukt.",
     "chip_mismatch": "Chip-verschil: {detected} gedetecteerd maar apparaat verwacht {expected}.",
     "validate_title": "Valideren — {name}",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -506,7 +506,7 @@
     "install_failed": "Installatie mislukt.",
     "compile_failed": "Compilatie mislukt.",
     "download_failed": "Firmware downloaden mislukt.",
-    "no_factory_binary": "Geen factory binary beschikbaar voor dit apparaat. web.esphome.io heeft een factory image nodig om te flashen op offset 0x0.",
+    "no_factory_binary": "Geen geschikte binary beschikbaar voor dit apparaat. web.esphome.io ondersteunt alleen ESP32 en ESP8266.",
     "flash_failed": "Firmware flashen naar apparaat mislukt.",
     "chip_mismatch": "Chip-verschil: {detected} gedetecteerd maar apparaat verwacht {expected}.",
     "validate_title": "Valideren — {name}",


### PR DESCRIPTION
## Problem

The web.esphome.io download flow added in [#92](https://github.com/esphome/device-builder-frontend/pull/92) assumed every platform produces a binary with "factory" in the name. That's only true for ESP32 — ESP8266 returns just `firmware.bin` (single-image platform, no separate bootloader; the file itself is the full image at 0x0). So flashing a fresh ESP8266 from an HTTP-only dashboard hit a "no factory binary" error even though `firmware.bin` would have worked.

## Changes

- Pick `firmware.factory.bin` (ESP32) or fall back to `firmware.bin` (ESP8266)
- Reject UF2 platforms (RP2040 / nrf52 / libretiny) — web.esphome.io can't flash those
- Update the error message to say "supports ESP32 and ESP8266 only" instead of mentioning offsets