### PR TITLE
Make add-component / add-config dialog X a comfortable hit target

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -143,7 +143,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
       wa-dialog::part(header) {
         background: var(--esphome-primary);
-        padding: 0 var(--wa-space-m);
+        /* Right padding is 0 so the close button sits flush with the
+           dialog's corner — the button is explicitly sized to a 40x40
+           square below to give the X a comfortable hit target right
+           where the user reaches for it. */
+        padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
@@ -158,7 +162,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
         background: transparent;
         border: none;
         box-shadow: none;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. */
         padding: 0;
+        width: 40px;
+        height: 40px;
         min-width: unset;
         min-height: unset;
         color: var(--esphome-on-primary);


### PR DESCRIPTION
## Summary

Same fix as #91, applied to \`add-component-dialog.ts\` — which also backs \`add-config-dialog.ts\`, the "Add configuration" wrapper that locks the catalog to \`core\`. The close X was inset by \`--wa-space-m\` of header padding and the icon's ~14px footprint left a small target.

- Drop the header's right padding so the close X sits flush with the dialog's corner.
- Size the button to a 40x40 square (matching the header height) so the entire upper-right region is clickable.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test\` — 159 passed
- [ ] Manual: open the device dashboard, hit + → "Add configuration" and "Add component"; click the X near the top-right corner — registers comfortably.