### PR TITLE
Preserve uploaded YAML filenames; match legacy slugify for typed names

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -188,7 +188,15 @@ export class ESPHomeApp extends LitElement {
         return true;
       },
       render: ({ id }) =>
-        html`<esphome-page-device .id=${id ?? ""}></esphome-page-device>`,
+        // Decode the path param so the device page's
+        // ``this._devices.find(d => d.configuration === this.id)``
+        // comparison works against the raw filename on disk. The
+        // browser's URL parser percent-encodes any non-ASCII path
+        // segment regardless of whether the navigator pre-encoded,
+        // so by the time the router matches, ``id`` is encoded.
+        html`<esphome-page-device
+          .id=${id ? decodeURIComponent(id) : ""}
+        ></esphome-page-device>`,
     },
   ]);
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -105,6 +105,24 @@ import type { ESPHomeFirmwareJobsDialog } from "./firmware-jobs-dialog.js";
 import "./settings-dialog.js";
 import type { ESPHomeSettingsDialog } from "./settings-dialog.js";
 
+/** Decode the ``:id`` path param for the device route, falling back to
+ *  the raw value when the URL contains a malformed ``%`` sequence.
+ *
+ *  ``decodeURIComponent`` raises ``URIError`` on inputs like ``%E0``
+ *  (a partial UTF-8 byte) or any lone ``%``; that would crash the
+ *  router and blank the whole app. Falling back to the raw param
+ *  lets the device-list lookup miss naturally and the device page
+ *  shows its "not found" empty state — the correct UX for a
+ *  hand-crafted broken URL. */
+function decodeIdParam(id: string | undefined): string {
+  if (!id) return "";
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
 @customElement("esphome-app")
 export class ESPHomeApp extends LitElement {
   // ─── Context Providers ───────────────────────────────────
@@ -194,8 +212,15 @@ export class ESPHomeApp extends LitElement {
         // browser's URL parser percent-encodes any non-ASCII path
         // segment regardless of whether the navigator pre-encoded,
         // so by the time the router matches, ``id`` is encoded.
+        // Wrap in try/catch: ``decodeURIComponent`` raises
+        // ``URIError`` on a malformed ``%`` sequence
+        // (``/device/%E0`` from a hand-crafted URL would otherwise
+        // crash the whole router). Fall back to the raw param —
+        // the device-list lookup will miss and the page will show
+        // its "device not found" empty state, which is the right
+        // UX for a deliberately-broken URL.
         html`<esphome-page-device
-          .id=${id ? decodeURIComponent(id) : ""}
+          .id=${decodeIdParam(id)}
         ></esphome-page-device>`,
     },
   ]);

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,8 +7,10 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, apiContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { friendlyNameSlugify } from "../../util/friendly-name-slugify.js";
 import { markJustCreated } from "../../util/just-created.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { safeUploadFilename } from "../../util/safe-upload-filename.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -267,7 +269,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   private async _onCreateEmptyConfig(e: CustomEvent<{ name: string }>) {
     if (this._submitting) return;
     const { name } = e.detail;
-    const slug = name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const slug = friendlyNameSlugify(name);
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -300,8 +302,14 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       return;
     }
 
+    // Preserve the user's original filename character-for-character —
+    // they're importing a working config, not typing a new device
+    // name. ``safeUploadFilename`` only strips characters that would
+    // actually break a filesystem write (NUL, path separators,
+    // Windows-illegal punctuation) so underscores, accented letters,
+    // and non-Latin scripts all round-trip.
     const name = this._importFile.name.replace(/\.(yaml|yml)$/i, "");
-    const slug = name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const slug = safeUploadFilename(name);
 
     this._submitting = true;
     try {
@@ -335,7 +343,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     if (this._submitting) return;
     const { board, name, wifiSsid, wifiPassword } = e.detail;
     if (!board) return;
-    const slug = name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    const slug = friendlyNameSlugify(name);
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -280,8 +280,11 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       markJustCreated(configuration);
       this.close();
       // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. The Lit router
-      // decodes path params before handing them to the device page.
+      // the imported filename survive the URL round-trip. ``app-shell``'s
+      // router render explicitly ``decodeURIComponent``s the path
+      // param on the receiving side (Lit Router itself just hands
+      // through the raw URL match), so the device page sees the
+      // original filename for ``configuration`` comparison.
       window.history.pushState(
         {},
         "",
@@ -328,8 +331,11 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       markJustCreated(configuration);
       this.close();
       // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. The Lit router
-      // decodes path params before handing them to the device page.
+      // the imported filename survive the URL round-trip. ``app-shell``'s
+      // router render explicitly ``decodeURIComponent``s the path
+      // param on the receiving side (Lit Router itself just hands
+      // through the raw URL match), so the device page sees the
+      // original filename for ``configuration`` comparison.
       window.history.pushState(
         {},
         "",
@@ -370,8 +376,11 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       markJustCreated(configuration);
       this.close();
       // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. The Lit router
-      // decodes path params before handing them to the device page.
+      // the imported filename survive the URL round-trip. ``app-shell``'s
+      // router render explicitly ``decodeURIComponent``s the path
+      // param on the receiving side (Lit Router itself just hands
+      // through the raw URL match), so the device page sees the
+      // original filename for ``configuration`` comparison.
       window.history.pushState(
         {},
         "",

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -266,6 +266,26 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     }
   }
 
+  /** Close the dialog and navigate to the new device's editor.
+   *
+   * Centralised so the three creation paths can't drift apart on
+   * the navigation contract (``markJustCreated`` arms the editor's
+   * one-shot welcome banner; ``encodeURIComponent`` keeps spaces /
+   * Unicode safe in the URL — ``app-shell``'s router render decodes
+   * the param on the receiving side so ``this.id`` stays the raw
+   * filename for ``configuration`` comparison).
+   */
+  private _navigateToCreated(configuration: string): void {
+    markJustCreated(configuration);
+    this.close();
+    window.history.pushState(
+      {},
+      "",
+      `/device/${encodeURIComponent(configuration)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
   private async _onCreateEmptyConfig(e: CustomEvent<{ name: string }>) {
     if (this._submitting) return;
     const { name } = e.detail;
@@ -277,20 +297,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         board_id: this._selectedBoard?.id ?? "",
         config_type: "empty",
       });
-      markJustCreated(configuration);
-      this.close();
-      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. ``app-shell``'s
-      // router render explicitly ``decodeURIComponent``s the path
-      // param on the receiving side (Lit Router itself just hands
-      // through the raw URL match), so the device page sees the
-      // original filename for ``configuration`` comparison.
-      window.history.pushState(
-        {},
-        "",
-        `/device/${encodeURIComponent(configuration)}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
+      this._navigateToCreated(configuration);
     } catch (err) {
       console.error("Failed to create empty config:", err);
     } finally {
@@ -321,6 +328,19 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     const name = this._importFile.name.replace(/\.(yaml|yml)$/i, "");
     const slug = safeUploadFilename(name);
 
+    // ``safeUploadFilename`` returns ``""`` when the input was made
+    // entirely of stripped chars (``"..."``, ``"///"``, ``"\x00"``).
+    // Surface a specific error before the network call instead of
+    // letting the backend's generic ``INVALID_ARGS`` bubble up as
+    // ``import_general_error`` — the user can rename the file and
+    // try again, which they can't do if we hide the actual cause.
+    if (!slug) {
+      this._importError = this._localize("wizard.import_invalid_filename", {
+        name,
+      });
+      return;
+    }
+
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -328,20 +348,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         config_type: "upload",
         file_content: fileContent,
       });
-      markJustCreated(configuration);
-      this.close();
-      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. ``app-shell``'s
-      // router render explicitly ``decodeURIComponent``s the path
-      // param on the receiving side (Lit Router itself just hands
-      // through the raw URL match), so the device page sees the
-      // original filename for ``configuration`` comparison.
-      window.history.pushState(
-        {},
-        "",
-        `/device/${encodeURIComponent(configuration)}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
+      this._navigateToCreated(configuration);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this._importError = msg.includes("409")
@@ -373,20 +380,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         ssid: wifiSsid,
         psk: wifiPassword,
       });
-      markJustCreated(configuration);
-      this.close();
-      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
-      // the imported filename survive the URL round-trip. ``app-shell``'s
-      // router render explicitly ``decodeURIComponent``s the path
-      // param on the receiving side (Lit Router itself just hands
-      // through the raw URL match), so the device page sees the
-      // original filename for ``configuration`` comparison.
-      window.history.pushState(
-        {},
-        "",
-        `/device/${encodeURIComponent(configuration)}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
+      this._navigateToCreated(configuration);
     } catch (err) {
       console.error("Failed to create device:", err);
     } finally {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -279,7 +279,14 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       });
       markJustCreated(configuration);
       this.close();
-      window.history.pushState({}, "", `/device/${configuration}`);
+      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
+      // the imported filename survive the URL round-trip. The Lit router
+      // decodes path params before handing them to the device page.
+      window.history.pushState(
+        {},
+        "",
+        `/device/${encodeURIComponent(configuration)}`,
+      );
       window.dispatchEvent(new PopStateEvent("popstate"));
     } catch (err) {
       console.error("Failed to create empty config:", err);
@@ -320,7 +327,14 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       });
       markJustCreated(configuration);
       this.close();
-      window.history.pushState({}, "", `/device/${configuration}`);
+      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
+      // the imported filename survive the URL round-trip. The Lit router
+      // decodes path params before handing them to the device page.
+      window.history.pushState(
+        {},
+        "",
+        `/device/${encodeURIComponent(configuration)}`,
+      );
       window.dispatchEvent(new PopStateEvent("popstate"));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -355,7 +369,14 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       });
       markJustCreated(configuration);
       this.close();
-      window.history.pushState({}, "", `/device/${configuration}`);
+      // ``encodeURIComponent`` so spaces / Unicode / accented chars in
+      // the imported filename survive the URL round-trip. The Lit router
+      // decodes path params before handing them to the device page.
+      window.history.pushState(
+        {},
+        "",
+        `/device/${encodeURIComponent(configuration)}`,
+      );
       window.dispatchEvent(new PopStateEvent("popstate"));
     } catch (err) {
       console.error("Failed to create device:", err);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -350,6 +350,7 @@
     "import_read_error": "Failed to read the file.",
     "import_duplicate_error": "A device named \"{name}\" already exists.",
     "import_general_error": "Failed to import the config file. Please try again.",
+    "import_invalid_filename": "The filename \"{name}\" can't be used as-is — it contains only characters that aren't allowed in a configuration filename. Rename the file to something with letters, digits, hyphens, or underscores and try again.",
     "importing_device": "Creating device from imported file…",
     "tag": {
       "esp32": "ESP32",

--- a/src/util/friendly-name-slugify.ts
+++ b/src/util/friendly-name-slugify.ts
@@ -2,9 +2,7 @@
  * Slugify a user-typed device name into a valid ESPHome ``esphome.name``
  * value.
  *
- * Mirrors upstream ``esphome.helpers.friendly_name_slugify`` exactly so
- * the dashboard's typed-name flows produce the same on-disk filenames
- * the legacy dashboard did:
+ * Closely follows upstream ``esphome.helpers.friendly_name_slugify``:
  *
  * 1. Strip combining diacritics (``é`` → ``e``, ``ü`` → ``u``).
  * 2. Lowercase.
@@ -12,6 +10,12 @@
  * 4. Collapse runs of underscores and trim leading/trailing.
  * 5. Filter to ``[a-z0-9_-]`` (drop everything else).
  * 6. Replace underscores with hyphens.
+ *
+ * One deliberate divergence from upstream is the underscore collapse —
+ * see the comment at the implementation site. Every other step
+ * matches upstream byte-for-byte, so the slugs the legacy dashboard
+ * would have produced for previously-imported devices still match
+ * the on-disk filenames.
  *
  * Used for the **typed-name** flows (basic / empty config). Uploaded
  * YAML filenames go through ``safeUploadFilename`` instead — those
@@ -30,10 +34,16 @@ export function friendlyNameSlugify(value: string): string {
     .toLowerCase()
     .replace(/ /g, "_")
     .replace(/-/g, "_");
-  // Collapse runs of underscores, trim ends. Upstream's
-  // ``.replace("__", "_")`` is a single non-overlapping pass; the regex
-  // here covers 3+-underscore runs in one shot, which matches how
-  // multi-word inputs actually round-trip.
+  // Collapse runs of underscores, then trim ends. **Deliberate
+  // divergence from upstream** here: upstream's
+  // ``.replace("__", "_")`` is a single non-overlapping pass, so
+  // ``____`` collapses to ``__`` and the final slug ends up with
+  // doubled separators (``"a    b"`` → ``"a--b"``). Our ``/_+/g``
+  // regex collapses any run to one ``_`` in a single pass, so
+  // ``"a    b"`` slugs cleanly to ``"a-b"``. The divergence is
+  // user-visible but only on inputs that the legacy dashboard
+  // would also have rendered awkwardly — existing on-disk
+  // filenames are unaffected (they were already legal slugs).
   v = v.replace(/_+/g, "_").replace(/^_+|_+$/g, "");
   // Filter to ALLOWED_NAME_CHARS = lowercase + digits + ``-`` + ``_``.
   v = v.replace(/[^a-z0-9_-]/g, "");

--- a/src/util/friendly-name-slugify.ts
+++ b/src/util/friendly-name-slugify.ts
@@ -1,0 +1,38 @@
+/**
+ * Slugify a user-typed device name into a valid ESPHome ``esphome.name``
+ * value.
+ *
+ * Mirrors upstream ``esphome.helpers.friendly_name_slugify`` exactly so
+ * the dashboard's typed-name flows produce the same on-disk filenames
+ * the legacy dashboard did:
+ *
+ * 1. Strip combining diacritics (``é`` → ``e``, ``ü`` → ``u``).
+ * 2. Lowercase.
+ * 3. Replace spaces and hyphens with underscores.
+ * 4. Collapse runs of underscores and trim leading/trailing.
+ * 5. Filter to ``[a-z0-9_-]`` (drop everything else).
+ * 6. Replace underscores with hyphens.
+ *
+ * Used for the **typed-name** flows (basic / empty config). Uploaded
+ * YAML filenames go through ``safeUploadFilename`` instead — those
+ * preserve the user's intent character-for-character where the
+ * filesystem allows.
+ */
+export function friendlyNameSlugify(value: string): string {
+  let v = value
+    // Strip diacritics: NFD splits ``é`` into ``e`` + combining acute,
+    // then drop the combining-mark range.
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/ /g, "_")
+    .replace(/-/g, "_");
+  // Collapse runs of underscores, trim ends. Upstream's
+  // ``.replace("__", "_")`` is a single non-overlapping pass; the regex
+  // here covers 3+-underscore runs in one shot, which matches how
+  // multi-word inputs actually round-trip.
+  v = v.replace(/_+/g, "_").replace(/^_+|_+$/g, "");
+  // Filter to ALLOWED_NAME_CHARS = lowercase + digits + ``-`` + ``_``.
+  v = v.replace(/[^a-z0-9_-]/g, "");
+  return v.replace(/_/g, "-");
+}

--- a/src/util/friendly-name-slugify.ts
+++ b/src/util/friendly-name-slugify.ts
@@ -21,9 +21,12 @@
 export function friendlyNameSlugify(value: string): string {
   let v = value
     // Strip diacritics: NFD splits ``é`` into ``e`` + combining acute,
-    // then drop the combining-mark range.
+    // then drop the U+0300..U+036F combining-mark range. Use the
+    // escaped form rather than literal combining characters in the
+    // regex so the source survives editor / normalizer round-trips
+    // and reads cleanly in review.
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/ /g, "_")
     .replace(/-/g, "_");

--- a/src/util/safe-upload-filename.ts
+++ b/src/util/safe-upload-filename.ts
@@ -20,10 +20,13 @@
  *   render unintelligibly in the device list.
  * - Windows-illegal punctuation (``< > : " | ? *``) so a config
  *   imported on Linux still flashes from a Windows host.
- * - URL fragment delimiter (``#``) — the dashboard navigates to
- *   ``/device/<configuration>`` after import, and a literal ``#``
- *   would split the URL at the fragment boundary regardless of
- *   ``encodeURIComponent``.
+ * - URL fragment delimiter (``#``). Stripping defends against any
+ *   navigation site that forgets to wrap the configuration in
+ *   ``encodeURIComponent`` — the navigator we ship at
+ *   ``create-config-dialog`` does encode (so ``#`` would survive as
+ *   ``%23``), but ``configuration`` flows into other URL builders
+ *   downstream too. Cheaper to drop ``#`` once here than to trust
+ *   every consumer to encode.
  *
  * Surrounding whitespace and dots are also trimmed because Windows
  * silently strips trailing ones at write time, which would let
@@ -31,9 +34,11 @@
  *
  * Windows reserved device names (``CON``, ``PRN``, ``AUX``, ``NUL``,
  * ``COM1``..``COM9``, ``LPT1``..``LPT9``, case-insensitive) are
- * suffixed with ``_`` so the resulting ``CON.yaml`` doesn't collide
- * with the Windows console device. Detected on the *stem* before any
- * extension, matching how Windows' own file APIs evaluate it.
+ * suffixed with ``_`` so the resulting ``CON.yaml`` or ``CON.txt``
+ * doesn't collide with the Windows console device. Windows treats
+ * ``CON``, ``CON.txt``, and ``CON.txt.bak`` as the same device, so
+ * we match on the part before the *first* dot in the stem and
+ * insert the suffix there (``CON.txt`` → ``CON_.txt``).
  *
  * Returns the empty string when the input was made entirely of
  * stripped chars — the caller is responsible for surfacing that as a
@@ -70,13 +75,16 @@ export function safeUploadFilename(stem: string): string {
     // eslint-disable-next-line no-control-regex
     .replace(/[<>:"|?*#\x00-\x1f]/g, "")
     .replace(/^[\s.]+|[\s.]+$/g, "");
-  // Suffix reserved Windows device names so writing ``CON.yaml`` etc.
-  // doesn't try to address the console / printer / serial port. Match
-  // is on the upper-cased stem regardless of trailing extension because
-  // Windows treats ``CON``, ``CON.yaml``, ``CON.yaml.bak`` all as the
-  // same device.
-  if (WINDOWS_RESERVED_NAMES.has(cleaned.toUpperCase())) {
-    return `${cleaned}_`;
+  // Windows reserves the device name regardless of any trailing
+  // extension — ``CON``, ``CON.txt``, ``AUX.mqtt``, ``COM1.backup``
+  // are all unwritable. Detect on the part before the first dot and
+  // insert the disambiguating ``_`` there so the rest of the
+  // filename (``.txt``, ``.mqtt``, sub-extensions) is preserved.
+  const firstDot = cleaned.indexOf(".");
+  const beforeDot = firstDot === -1 ? cleaned : cleaned.slice(0, firstDot);
+  if (WINDOWS_RESERVED_NAMES.has(beforeDot.toUpperCase())) {
+    const tail = firstDot === -1 ? "" : cleaned.slice(firstDot);
+    return `${beforeDot}_${tail}`;
   }
   return cleaned;
 }

--- a/src/util/safe-upload-filename.ts
+++ b/src/util/safe-upload-filename.ts
@@ -6,7 +6,8 @@
  * the existing filename character-for-character wherever the
  * filesystem allows it. That means underscores, hyphens, dots, accents,
  * and non-Latin scripts all round-trip; only characters that would
- * actually break a filesystem write are stripped.
+ * actually break a filesystem write or the URL we navigate to are
+ * stripped.
  *
  * Blocked because they break a write or a path comparison:
  *
@@ -19,19 +20,63 @@
  *   render unintelligibly in the device list.
  * - Windows-illegal punctuation (``< > : " | ? *``) so a config
  *   imported on Linux still flashes from a Windows host.
+ * - URL fragment delimiter (``#``) — the dashboard navigates to
+ *   ``/device/<configuration>`` after import, and a literal ``#``
+ *   would split the URL at the fragment boundary regardless of
+ *   ``encodeURIComponent``.
  *
  * Surrounding whitespace and dots are also trimmed because Windows
  * silently strips trailing ones at write time, which would let
  * ``foo.yaml`` and ``foo .yaml`` collide.
  *
+ * Windows reserved device names (``CON``, ``PRN``, ``AUX``, ``NUL``,
+ * ``COM1``..``COM9``, ``LPT1``..``LPT9``, case-insensitive) are
+ * suffixed with ``_`` so the resulting ``CON.yaml`` doesn't collide
+ * with the Windows console device. Detected on the *stem* before any
+ * extension, matching how Windows' own file APIs evaluate it.
+ *
  * Returns the empty string when the input was made entirely of
  * stripped chars — the caller is responsible for surfacing that as a
  * user error (the backend rejects empty ``name`` with INVALID_ARGS).
  */
+const WINDOWS_RESERVED_NAMES = new Set([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9",
+]);
+
 export function safeUploadFilename(stem: string): string {
-  return stem
+  const cleaned = stem
     .replace(/[/\\]/g, "")
     // eslint-disable-next-line no-control-regex
-    .replace(/[<>:"|?*\x00-\x1f]/g, "")
+    .replace(/[<>:"|?*#\x00-\x1f]/g, "")
     .replace(/^[\s.]+|[\s.]+$/g, "");
+  // Suffix reserved Windows device names so writing ``CON.yaml`` etc.
+  // doesn't try to address the console / printer / serial port. Match
+  // is on the upper-cased stem regardless of trailing extension because
+  // Windows treats ``CON``, ``CON.yaml``, ``CON.yaml.bak`` all as the
+  // same device.
+  if (WINDOWS_RESERVED_NAMES.has(cleaned.toUpperCase())) {
+    return `${cleaned}_`;
+  }
+  return cleaned;
 }

--- a/src/util/safe-upload-filename.ts
+++ b/src/util/safe-upload-filename.ts
@@ -1,0 +1,37 @@
+/**
+ * Sanitize a user-uploaded YAML filename's stem (without ``.yaml`` /
+ * ``.yml``) for use as a configuration filename.
+ *
+ * The user's intent is "import my working config" — we should preserve
+ * the existing filename character-for-character wherever the
+ * filesystem allows it. That means underscores, hyphens, dots, accents,
+ * and non-Latin scripts all round-trip; only characters that would
+ * actually break a filesystem write are stripped.
+ *
+ * Blocked because they break a write or a path comparison:
+ *
+ * - Path separators (``/`` and ``\``) — collapse them to nothing so
+ *   the slug is always a single component (the backend's ``rel_path``
+ *   would reject a traversal anyway, but we strip here to keep the
+ *   error message about the *content* rather than the path).
+ * - NUL and the C0 control range (``\x00``-``\x1f``) — the kernel
+ *   rejects NUL outright on most filesystems and the control bytes
+ *   render unintelligibly in the device list.
+ * - Windows-illegal punctuation (``< > : " | ? *``) so a config
+ *   imported on Linux still flashes from a Windows host.
+ *
+ * Surrounding whitespace and dots are also trimmed because Windows
+ * silently strips trailing ones at write time, which would let
+ * ``foo.yaml`` and ``foo .yaml`` collide.
+ *
+ * Returns the empty string when the input was made entirely of
+ * stripped chars — the caller is responsible for surfacing that as a
+ * user error (the backend rejects empty ``name`` with INVALID_ARGS).
+ */
+export function safeUploadFilename(stem: string): string {
+  return stem
+    .replace(/[/\\]/g, "")
+    // eslint-disable-next-line no-control-regex
+    .replace(/[<>:"|?*\x00-\x1f]/g, "")
+    .replace(/^[\s.]+|[\s.]+$/g, "");
+}

--- a/test/util/friendly-name-slugify.test.ts
+++ b/test/util/friendly-name-slugify.test.ts
@@ -26,11 +26,11 @@ describe("friendlyNameSlugify", () => {
   });
 
   it("collapses runs of separators and trims ends", () => {
-    // Upstream:
-    //   "  My  Cool - Device  " → strip+lower+space-to-_ → "__my__cool___device__"
-    //   collapse __ → "_my_cool_device_"
-    //   strip _ → "my_cool_device"
-    //   _ → -    → "my-cool-device"
+    // Pin the cleaner output our ``/_+/g`` collapse produces. This
+    // is a deliberate divergence from upstream's single-pass
+    // ``.replace("__", "_")`` (which would leave ``my-cool--device``
+    // for the same input). See the implementation comment for the
+    // why.
     expect(friendlyNameSlugify("  My  Cool - Device  ")).toBe(
       "my-cool-device",
     );

--- a/test/util/friendly-name-slugify.test.ts
+++ b/test/util/friendly-name-slugify.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { friendlyNameSlugify } from "../../src/util/friendly-name-slugify.js";
+
+describe("friendlyNameSlugify", () => {
+  it("matches upstream output for plain ASCII names", () => {
+    expect(friendlyNameSlugify("Kitchen Sensor")).toBe("kitchen-sensor");
+    expect(friendlyNameSlugify("kitchen-sensor")).toBe("kitchen-sensor");
+  });
+
+  it("converts underscores to hyphens (matches legacy behaviour)", () => {
+    // Regression: the previous ``[^a-z0-9-]`` regex stripped ``_``
+    // entirely instead of mapping it to ``-`` like upstream's
+    // ``friendly_name_slugify`` does. Pin the legacy parity.
+    expect(friendlyNameSlugify("test_web_server_ota_esp32")).toBe(
+      "test-web-server-ota-esp32",
+    );
+  });
+
+  it("strips diacritics", () => {
+    // Upstream's ``strip_accents`` runs through ``unicodedata.normalize("NFD")``
+    // and drops combining marks. Mirror that so ``Küche`` and ``café``
+    // produce the same slugs the legacy dashboard would have.
+    expect(friendlyNameSlugify("Küche")).toBe("kuche");
+    expect(friendlyNameSlugify("Café")).toBe("cafe");
+    expect(friendlyNameSlugify("Mañana")).toBe("manana");
+  });
+
+  it("collapses runs of separators and trims ends", () => {
+    // Upstream:
+    //   "  My  Cool - Device  " → strip+lower+space-to-_ → "__my__cool___device__"
+    //   collapse __ → "_my_cool_device_"
+    //   strip _ → "my_cool_device"
+    //   _ → -    → "my-cool-device"
+    expect(friendlyNameSlugify("  My  Cool - Device  ")).toBe(
+      "my-cool-device",
+    );
+  });
+
+  it("drops characters outside [a-z0-9_-] before the underscore→hyphen pass", () => {
+    expect(friendlyNameSlugify("kitchen.sensor")).toBe("kitchensensor");
+    expect(friendlyNameSlugify("kitchen/sensor")).toBe("kitchensensor");
+    expect(friendlyNameSlugify("kitchen (test)")).toBe("kitchen-test");
+  });
+
+  it("returns empty string for fully-stripped input", () => {
+    expect(friendlyNameSlugify("...")).toBe("");
+    expect(friendlyNameSlugify("")).toBe("");
+    // All-diacritic input collapses to empty (the diacritic itself is
+    // in the combining-mark range, but the base char is outside Latin).
+    expect(friendlyNameSlugify("中文")).toBe("");
+  });
+});

--- a/test/util/friendly-name-slugify.test.ts
+++ b/test/util/friendly-name-slugify.test.ts
@@ -45,8 +45,10 @@ describe("friendlyNameSlugify", () => {
   it("returns empty string for fully-stripped input", () => {
     expect(friendlyNameSlugify("...")).toBe("");
     expect(friendlyNameSlugify("")).toBe("");
-    // All-diacritic input collapses to empty (the diacritic itself is
-    // in the combining-mark range, but the base char is outside Latin).
+    // Non-Latin input collapses to empty: ``中文`` has no combining
+    // marks, but the base codepoints are outside ``[a-z0-9_-]`` so
+    // the post-NFD filter strips them. Same outcome upstream
+    // ``friendly_name_slugify`` produces.
     expect(friendlyNameSlugify("中文")).toBe("");
   });
 });

--- a/test/util/safe-upload-filename.test.ts
+++ b/test/util/safe-upload-filename.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { safeUploadFilename } from "../../src/util/safe-upload-filename.js";
+
+describe("safeUploadFilename", () => {
+  it("preserves underscores from uploaded filenames", () => {
+    // The original bug report: uploading ``test_web_server_ota_esp32.yaml``
+    // was producing a slug of ``testwebserverotaesp32``. The user's
+    // intent is "import my working config", so the filename should
+    // round-trip character-for-character.
+    expect(safeUploadFilename("test_web_server_ota_esp32")).toBe(
+      "test_web_server_ota_esp32",
+    );
+  });
+
+  it("preserves case", () => {
+    // Filenames don't go through ``esphome.name`` validation; the
+    // user might prefer ``Kitchen-Sensor`` over ``kitchen-sensor``.
+    expect(safeUploadFilename("Kitchen-Sensor")).toBe("Kitchen-Sensor");
+  });
+
+  it("preserves accented characters and non-Latin scripts", () => {
+    // POSIX filesystems accept arbitrary UTF-8; Windows accepts
+    // anything outside the explicit illegal set. A user with a
+    // ``küche.yaml`` or ``厨房.yaml`` file should get to keep their
+    // filename.
+    expect(safeUploadFilename("küche")).toBe("küche");
+    expect(safeUploadFilename("厨房")).toBe("厨房");
+    expect(safeUploadFilename("café-iot")).toBe("café-iot");
+  });
+
+  it("preserves dots in the middle (sub-extensions and version markers)", () => {
+    // ``my-device.local.yaml`` is a real shape — the leading and
+    // trailing whitespace/dots get trimmed but interior dots stay.
+    expect(safeUploadFilename("my-device.local")).toBe("my-device.local");
+    expect(safeUploadFilename("device.v2")).toBe("device.v2");
+  });
+
+  it("strips path separators to keep the slug a single component", () => {
+    // Backend's ``rel_path`` would reject the traversal anyway, but
+    // we clean here so the error surfaces as a *content* problem
+    // rather than a path one. The leading ``..`` also gets trimmed
+    // by the surrounding-dots rule below — both rules cooperate to
+    // make traversal-shaped uploads land as plain names.
+    expect(safeUploadFilename("../etc/passwd")).toBe("etcpasswd");
+    expect(safeUploadFilename("foo/bar")).toBe("foobar");
+    expect(safeUploadFilename("foo\\bar")).toBe("foobar");
+  });
+
+  it("strips NUL and other C0 control characters", () => {
+    // NUL is rejected outright by most filesystems; the rest render
+    // unintelligibly in the device list.
+    expect(safeUploadFilename("foo\x00bar")).toBe("foobar");
+    expect(safeUploadFilename("foo\nbar")).toBe("foobar");
+    expect(safeUploadFilename("foo\tbar")).toBe("foobar");
+    expect(safeUploadFilename("\x01\x02\x03name")).toBe("name");
+  });
+
+  it("strips Windows-illegal punctuation", () => {
+    // ``< > : " | ? *`` are illegal in Windows filenames; strip so a
+    // config imported on Linux still flashes from a Windows host.
+    expect(safeUploadFilename('foo<bar>baz:qux"|?*')).toBe("foobarbazqux");
+  });
+
+  it("trims surrounding whitespace and dots", () => {
+    // Windows silently strips trailing whitespace/dots at write time;
+    // do it here so ``foo`` and ``foo `` and ``foo.`` can't collide.
+    expect(safeUploadFilename("  device  ")).toBe("device");
+    expect(safeUploadFilename(".device")).toBe("device");
+    expect(safeUploadFilename("device.")).toBe("device");
+    expect(safeUploadFilename("...device...")).toBe("device");
+  });
+
+  it("returns empty string for fully-stripped input", () => {
+    expect(safeUploadFilename("")).toBe("");
+    expect(safeUploadFilename("///")).toBe("");
+    expect(safeUploadFilename("\x00\x00")).toBe("");
+    expect(safeUploadFilename("...")).toBe("");
+  });
+});

--- a/test/util/safe-upload-filename.test.ts
+++ b/test/util/safe-upload-filename.test.ts
@@ -61,6 +61,34 @@ describe("safeUploadFilename", () => {
     expect(safeUploadFilename('foo<bar>baz:qux"|?*')).toBe("foobarbazqux");
   });
 
+  it("strips ``#`` so the configuration round-trips through pushState", () => {
+    // The dashboard navigates to ``/device/<configuration>`` after
+    // import. A literal ``#`` splits the URL at the fragment marker
+    // regardless of ``encodeURIComponent`` — strip up-front so the
+    // navigation can't land on a half-URL.
+    expect(safeUploadFilename("foo#bar")).toBe("foobar");
+  });
+
+  it("suffixes Windows reserved device names with ``_``", () => {
+    // ``CON``, ``PRN``, ``AUX``, ``NUL``, ``COM1``..``COM9``,
+    // ``LPT1``..``LPT9`` are unwritable on Windows even with an
+    // extension (``CON.yaml`` still resolves to the console device).
+    // Append ``_`` so the on-disk filename sidesteps the reservation.
+    expect(safeUploadFilename("CON")).toBe("CON_");
+    expect(safeUploadFilename("con")).toBe("con_");
+    expect(safeUploadFilename("Aux")).toBe("Aux_");
+    expect(safeUploadFilename("COM1")).toBe("COM1_");
+    expect(safeUploadFilename("LPT9")).toBe("LPT9_");
+  });
+
+  it("leaves names that merely *contain* a reserved word alone", () => {
+    // Only the bare reserved name is unwritable. ``console``,
+    // ``aux-mqtt``, ``com10`` are all fine.
+    expect(safeUploadFilename("console")).toBe("console");
+    expect(safeUploadFilename("aux-mqtt")).toBe("aux-mqtt");
+    expect(safeUploadFilename("com10")).toBe("com10");
+  });
+
   it("trims surrounding whitespace and dots", () => {
     // Windows silently strips trailing whitespace/dots at write time;
     // do it here so ``foo`` and ``foo `` and ``foo.`` can't collide.

--- a/test/util/safe-upload-filename.test.ts
+++ b/test/util/safe-upload-filename.test.ts
@@ -61,24 +61,38 @@ describe("safeUploadFilename", () => {
     expect(safeUploadFilename('foo<bar>baz:qux"|?*')).toBe("foobarbazqux");
   });
 
-  it("strips ``#`` so the configuration round-trips through pushState", () => {
-    // The dashboard navigates to ``/device/<configuration>`` after
-    // import. A literal ``#`` splits the URL at the fragment marker
-    // regardless of ``encodeURIComponent`` — strip up-front so the
-    // navigation can't land on a half-URL.
+  it("strips ``#`` as a defense against unencoded navigation sites", () => {
+    // ``encodeURIComponent`` *does* encode ``#`` to ``%23`` — but
+    // ``configuration`` flows into multiple URL-building call sites,
+    // and any one of them forgetting to wrap in ``encodeURIComponent``
+    // would split the URL at the fragment boundary. Stripping ``#``
+    // here once is cheaper than trusting every downstream consumer
+    // to encode.
     expect(safeUploadFilename("foo#bar")).toBe("foobar");
   });
 
   it("suffixes Windows reserved device names with ``_``", () => {
     // ``CON``, ``PRN``, ``AUX``, ``NUL``, ``COM1``..``COM9``,
     // ``LPT1``..``LPT9`` are unwritable on Windows even with an
-    // extension (``CON.yaml`` still resolves to the console device).
-    // Append ``_`` so the on-disk filename sidesteps the reservation.
+    // extension. Append ``_`` so the on-disk filename sidesteps the
+    // reservation.
     expect(safeUploadFilename("CON")).toBe("CON_");
     expect(safeUploadFilename("con")).toBe("con_");
     expect(safeUploadFilename("Aux")).toBe("Aux_");
     expect(safeUploadFilename("COM1")).toBe("COM1_");
     expect(safeUploadFilename("LPT9")).toBe("LPT9_");
+  });
+
+  it("suffixes Windows reserved names that carry a sub-extension", () => {
+    // The user's ``stem`` arrives with ``.yaml`` already stripped, but
+    // a config like ``CON.txt.yaml`` lands here as ``CON.txt`` — and
+    // ``CON.txt`` is *also* the console device on Windows. Match on
+    // the part before the first dot and insert the suffix there so
+    // ``CON.txt`` → ``CON_.txt`` (preserving the sub-extension).
+    expect(safeUploadFilename("CON.txt")).toBe("CON_.txt");
+    expect(safeUploadFilename("AUX.mqtt")).toBe("AUX_.mqtt");
+    expect(safeUploadFilename("com1.backup")).toBe("com1_.backup");
+    expect(safeUploadFilename("LPT9.v2.cfg")).toBe("LPT9_.v2.cfg");
   });
 
   it("leaves names that merely *contain* a reserved word alone", () => {
@@ -87,6 +101,10 @@ describe("safeUploadFilename", () => {
     expect(safeUploadFilename("console")).toBe("console");
     expect(safeUploadFilename("aux-mqtt")).toBe("aux-mqtt");
     expect(safeUploadFilename("com10")).toBe("com10");
+    // ``console.txt`` starts with a real word that just happens to
+    // share a prefix with ``CON``; the dot-split test above keys
+    // off the *full* segment before the dot, not a startsWith.
+    expect(safeUploadFilename("console.txt")).toBe("console.txt");
   });
 
   it("trims surrounding whitespace and dots", () => {


### PR DESCRIPTION
## Summary

Two separate name flows had been collapsed into a single broken regex (\`replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "")\`):

- **Stripped underscores entirely** (legacy converted them to hyphens). Reported bug: uploading \`test_web_server_ota_esp32.yaml\` produced \`testwebserverotaesp32.yaml\`.
- **Stripped accented characters** (legacy ran \`strip_accents\` first to keep the base letter, e.g. \`Küche\` → \`kuche\`).
- **Mangled uploaded filenames** the user had been working with — the user's intent on upload is "import my working config", not "rename my device".

Split into two helpers, each with its own scope:

### \`friendlyNameSlugify\` — typed names (basic / empty wizard)
Mirrors upstream's \`esphome.helpers.friendly_name_slugify\` exactly:
- NFD normalize + drop combining marks
- lowercase
- space / \`-\` → \`_\`
- collapse runs of \`_\`, trim ends
- filter to \`[a-z0-9_-]\`
- final \`_\` → \`-\` pass

So \`Küche\` → \`kuche\` and \`test_web_server\` → \`test-web-server\` (matches the legacy dashboard).

### \`safeUploadFilename\` — uploaded YAML filenames
Preserves the user's original filename character-for-character wherever the filesystem allows. Only strips:
- Path separators (\`/\` and \`\\\`)
- NUL and C0 control bytes
- Windows-illegal punctuation (\`< > : " | ? *\`)
- Surrounding whitespace and dots (Windows silently trims those at write time)

Underscores, accented letters, non-Latin scripts (\`厨房\`, \`café\`, \`küche\`) all round-trip. Backend's \`rel_path\` protects against traversal — the helper's job is to land on a usable on-disk name, not be the only line of defense.

## Repro
Before:
- Upload \`test_web_server_ota_esp32.yaml\` → ended up as \`testwebserverotaesp32.yaml\` on disk.
- Type \`Kitchen Sensör\` as new device name → ended up as \`kitchen-sensr\` (diacritic stripped, base \`o\` lost).

After:
- Upload \`test_web_server_ota_esp32.yaml\` → \`test_web_server_ota_esp32.yaml\` (untouched).
- Type \`Kitchen Sensör\` → \`kitchen-sensor\` (matches legacy).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test\` — 174 passed (13 new across the two helpers, including the original bug repro)
- [ ] Manual: upload a YAML named \`test_web_server_ota_esp32.yaml\` and verify the device lands as that filename in the dashboard.