### PR TITLE
Highlight + scroll to a freshly-created device on dashboard return

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -8,6 +8,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
+import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -443,6 +444,11 @@ export class ESPHomeAdoptDialog extends LitElement {
       if (friendlyName) args.friendly_name = friendlyName;
       if (this._encryption) args.encryption = "true";
       await this._api.importDevice(args);
+      // Configuration filenames are ``<name>.yaml``; mirror the same
+      // derivation the dashboard's ``_onAdopted`` handler uses so
+      // both the welcome-banner flag (consumed on first device-editor
+      // mount) and the highlight signal key off the same string.
+      markJustCreated(`${name}.yaml`);
       this.close();
       this.dispatchEvent(
         new CustomEvent("adopted", {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -9,6 +9,7 @@ import { localizeContext, apiContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { friendlyNameSlugify } from "../../util/friendly-name-slugify.js";
 import { markJustCreated } from "../../util/just-created.js";
+import { markPendingHighlight } from "../../util/pending-highlight.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { safeUploadFilename } from "../../util/safe-upload-filename.js";
 
@@ -266,17 +267,26 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     }
   }
 
-  /** Close the dialog and navigate to the new device's editor.
+  /** Run the post-``createDevice`` UX shared by all three wizard paths.
    *
-   * Centralised so the three creation paths can't drift apart on
-   * the navigation contract (``markJustCreated`` arms the editor's
-   * one-shot welcome banner; ``encodeURIComponent`` keeps spaces /
-   * Unicode safe in the URL — ``app-shell``'s router render decodes
-   * the param on the receiving side so ``this.id`` stays the raw
-   * filename for ``configuration`` comparison).
+   * - ``markJustCreated`` arms the device editor's one-shot welcome
+   *   banner (consumed on first mount).
+   * - ``markPendingHighlight`` arms the dashboard's one-shot
+   *   highlight + scroll for the next time the user lands back on
+   *   ``/`` (e.g. after closing the editor with the back button).
+   * - Then close the dialog and navigate to the device editor.
+   *   ``encodeURIComponent`` keeps spaces / Unicode safe in the URL
+   *   — ``app-shell``'s router render decodes the param on the
+   *   receiving side so ``this.id`` stays the raw filename for
+   *   ``configuration`` comparison.
+   *
+   * Centralised so the three creation paths can't drift on which
+   * one-shot signals they arm — every path opens the editor and
+   * arms both flags.
    */
   private _navigateToCreated(configuration: string): void {
     markJustCreated(configuration);
+    markPendingHighlight(configuration);
     this.close();
     window.history.pushState(
       {},

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -838,21 +838,24 @@ export class ESPHomePageDashboard extends LitElement {
     this._highlightFreshDevice(`${e.detail.name}.yaml`);
   };
 
-  private _onYamlImported = (e: CustomEvent<{ configuration: string }>) => {
-    /* Wizard's YAML-import path closes the dialog and lands the user
-       back on the dashboard (unlike basic / empty creation, which
-       navigates to the device editor for further setup). Re-use the
-       adopt flow's highlight + scroll machinery so the new device
-       lights up the same way a freshly-adopted one does. */
-    this._highlightFreshDevice(e.detail.configuration);
-  };
-
   private _pendingAdoptScroll: string | null = null;
 
   protected updated(changed: PropertyValues): void {
+    /* Two distinct triggers land here:
+       - Adopt flow: pending-scroll is set synchronously while the
+         device is still propagating from the WS; the matching
+         ``_devices`` change is what fires this branch.
+       - YAML-import / wizard return: ``connectedCallback`` reads the
+         pending-highlight ``sessionStorage`` flag *after* the host
+         is back on the dashboard. By that point the WS may already
+         have pushed the device into ``_devices`` (e.g. the user
+         spent time in the editor). There's no future ``_devices``
+         change to wait for, so check on the very first ``updated``
+         tick after mount too — ``changed.size === 0`` indicates
+         the post-connect render. */
     if (
       this._pendingAdoptScroll !== null &&
-      changed.has("_devices") &&
+      (changed.has("_devices") || changed.size === 0) &&
       this._devices.some((d) => d.configuration === this._pendingAdoptScroll)
     ) {
       const target = this._pendingAdoptScroll;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -32,6 +32,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
+import { consumePendingHighlight } from "../util/pending-highlight.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
   archiveDevice,
@@ -228,6 +229,15 @@ export class ESPHomePageDashboard extends LitElement {
       "esphome-show-archived-dialog",
       this._onShowArchivedDialog,
     );
+    /* Consume the one-shot pending-highlight signal the wizard arms
+       before opening the device editor. The user typically lands
+       here when they hit the back button to leave the editor — at
+       which point we want their freshly-created device to flash and
+       scroll into view, the same way an adopted device does. */
+    const pending = consumePendingHighlight();
+    if (pending !== null) {
+      this._highlightFreshDevice(pending);
+    }
   }
 
   private async _loadPreferences() {
@@ -798,21 +808,18 @@ export class ESPHomePageDashboard extends LitElement {
     }
   }
 
-  private _onAdopted = (e: CustomEvent<{ name: string; friendlyName: string }>) => {
-    /* Configuration filenames are ``<name>.yaml`` — that's how the
-       adopt dialog asks the backend to write the file (see
-       ``import_device``), so the filename is deterministic from the
-       submitted name. Driving the highlight off the configuration
-       string lets us light up either the card or the table row,
-       both of which key on ``device.configuration``. */
-    const configuration = `${e.detail.name}.yaml`;
+  /** Light up + queue a scroll for a freshly-arrived configuration.
+
+      Drives the highlight off the configuration string so it matches
+      either the card view or the table row, both of which key on
+      ``device.configuration``. The actual scroll happens in
+      ``updated()`` once the matching device shows up in
+      ``_devices`` — the WS DEVICE_ADDED event lags the triggering
+      dialog event, especially on mobile where the round-trip is
+      slower, so scrolling now would hit a layout that doesn't have
+      the new card yet. */
+  private _highlightFreshDevice(configuration: string): void {
     this._recentlyAdopted = configuration;
-    /* Mark this configuration as scroll-pending. The actual scroll
-       happens in ``updated()`` once the matching device shows up in
-       ``_devices`` — the WS DEVICE_ADDED event lags the dialog's
-       ``adopted`` event, especially on mobile where the round-trip
-       is slower, so a scroll fired right now hits a layout that
-       doesn't have the new card yet. */
     this._pendingAdoptScroll = configuration;
     if (this._adoptHighlightTimer !== null) {
       clearTimeout(this._adoptHighlightTimer);
@@ -821,6 +828,23 @@ export class ESPHomePageDashboard extends LitElement {
       this._recentlyAdopted = null;
       this._adoptHighlightTimer = null;
     }, 4000);
+  }
+
+  private _onAdopted = (e: CustomEvent<{ name: string; friendlyName: string }>) => {
+    /* Configuration filenames are ``<name>.yaml`` — that's how the
+       adopt dialog asks the backend to write the file (see
+       ``import_device``), so the filename is deterministic from the
+       submitted name. */
+    this._highlightFreshDevice(`${e.detail.name}.yaml`);
+  };
+
+  private _onYamlImported = (e: CustomEvent<{ configuration: string }>) => {
+    /* Wizard's YAML-import path closes the dialog and lands the user
+       back on the dashboard (unlike basic / empty creation, which
+       navigates to the device editor for further setup). Re-use the
+       adopt flow's highlight + scroll machinery so the new device
+       lights up the same way a freshly-adopted one does. */
+    this._highlightFreshDevice(e.detail.configuration);
   };
 
   private _pendingAdoptScroll: string | null = null;

--- a/src/util/pending-highlight.ts
+++ b/src/util/pending-highlight.ts
@@ -1,0 +1,46 @@
+/**
+ * One-shot "highlight this configuration on the dashboard's next mount"
+ * signal.
+ *
+ * The wizard navigates to ``/device/<configuration>`` after creating a
+ * device so the user lands in the editor. When they close the editor
+ * (back button / Esc / browser nav) the router re-mounts the
+ * dashboard, and we want the just-created card / row to light up the
+ * same way the discovery / adopt flow lights up.
+ *
+ * The signal lives in ``sessionStorage`` so it survives the popstate
+ * route change but stays scoped to the active tab — a different tab
+ * landing on the dashboard shouldn't see a stranger's import flash.
+ */
+
+const KEY = "esphome.pending-dashboard-highlight";
+
+/** Mark *configuration* to be highlighted on the dashboard's next mount.
+ *
+ * Safe to call right before navigating away — the storage write
+ * survives the route change. Calling repeatedly overwrites; only
+ * the most recent target lights up.
+ */
+export function markPendingHighlight(configuration: string): void {
+  try {
+    sessionStorage.setItem(KEY, configuration);
+  } catch {
+    // sessionStorage can fail in private mode / sandboxed iframes —
+    // not worth blowing up the wizard over a missing flash.
+  }
+}
+
+/** Atomically read + clear the flag. Returns the stored configuration
+ *  string, or ``null`` when nothing's pending. */
+export function consumePendingHighlight(): string | null {
+  try {
+    const stored = sessionStorage.getItem(KEY);
+    if (stored !== null) {
+      sessionStorage.removeItem(KEY);
+      return stored;
+    }
+  } catch {
+    // Ignore — see comment in markPendingHighlight.
+  }
+  return null;
+}

--- a/test/util/pending-highlight.test.ts
+++ b/test/util/pending-highlight.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  consumePendingHighlight,
+  markPendingHighlight,
+} from "../../src/util/pending-highlight.js";
+
+describe("pending-highlight", () => {
+  // The vitest config runs in the ``node`` environment which has no
+  // ``sessionStorage``. The helper just calls ``getItem`` /
+  // ``setItem`` / ``removeItem`` so a tiny in-memory Map stand-in is
+  // enough — we don't need to pull in jsdom for two methods.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when nothing is pending", () => {
+    expect(consumePendingHighlight()).toBeNull();
+  });
+
+  it("round-trips a configuration string", () => {
+    markPendingHighlight("kitchen.yaml");
+    expect(consumePendingHighlight()).toBe("kitchen.yaml");
+  });
+
+  it("clears the flag after consumption (one-shot)", () => {
+    markPendingHighlight("kitchen.yaml");
+    consumePendingHighlight();
+    // Second consume on an empty bucket — the highlight only fires
+    // on the dashboard's next mount, not every mount thereafter.
+    expect(consumePendingHighlight()).toBeNull();
+  });
+
+  it("overwrites prior pending values", () => {
+    // If the user creates two devices in quick succession only the
+    // most recent lights up; that's deliberate so they don't see a
+    // stale flash from the previous import.
+    markPendingHighlight("first.yaml");
+    markPendingHighlight("second.yaml");
+    expect(consumePendingHighlight()).toBe("second.yaml");
+  });
+});


### PR DESCRIPTION
## Summary

The wizard's three creation paths (basic / empty / upload) all navigate to \`/device/<configuration>\` to drop the user into the editor for further setup. When the user closes the editor (back button / Esc), they land back on the dashboard — but until now the new device was just one row among many. Match the discovery / adopt flow's UX: light up the new card / row and scroll it into view so the user can confirm at a glance that their new device is registered.

## Mechanism

A \`pending-highlight\` one-shot signal in \`sessionStorage\` — twin of the existing \`just-created\` flag (which arms the device-editor's welcome banner). The wizard sets it right before navigating; the dashboard's \`connectedCallback\` reads + clears it on mount and routes through the same \`_recentlyAdopted\` + \`_pendingAdoptScroll\` machinery the adopt flow uses.

## Changes

- **\`src/util/pending-highlight.ts\`** (new): \`markPendingHighlight\` / \`consumePendingHighlight\` pair. sessionStorage so the flag survives popstate but stays scoped to the active tab.
- **\`create-config-dialog\`**: extract the post-create UX (markJustCreated + markPendingHighlight + close + nav) into a single \`_navigateToCreated\` helper. All three creation paths arm both one-shot flags and navigate identically.
- **\`adopt-dialog\`**: also call \`markJustCreated\` on the adopted configuration so the welcome banner fires the first time the user opens an adopted device's editor (matches the wizard paths). No \`markPendingHighlight\` here — adopt's dashboard highlight already runs synchronously via the \`adopted\` event while the user is still on the dashboard.
- **\`dashboard\`**: extract the highlight-and-queue-scroll bookkeeping into \`_highlightFreshDevice\` (was duplicated in \`_onAdopted\`); call it from \`connectedCallback\` when \`consumePendingHighlight\` returns a hit.

## Test plan

- [x] 4 new tests pin the round-trip / one-shot / overwrite semantics of \`pending-highlight\`. \`sessionStorage\` is stubbed via \`vi.stubGlobal\` since the project's vitest config runs in the \`node\` environment.
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 178 passed (174 + 4)
- [x] Manual: create a device through each wizard path, close the editor, confirm the new card flashes + scrolls.

> Stacked on #95 — base set to \`fix-upload-strips-underscores\` so the diff is just this feature.