### PR TITLE
Address second-round Copilot review on merged PR #96

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -448,6 +448,11 @@ export class ESPHomeAdoptDialog extends LitElement {
       // derivation the dashboard's ``_onAdopted`` handler uses so
       // both the welcome-banner flag (consumed on first device-editor
       // mount) and the highlight signal key off the same string.
+      // Pre-rename flag survives a rename only if the user opens
+      // the editor first — if they rename before opening, the rename
+      // flow drops the flag (see ``clearJustCreated`` call in
+      // ``_executeRename``); they've already engaged with the device
+      // so the welcome banner would just be noise.
       markJustCreated(`${name}.yaml`);
       this.close();
       this.dispatchEvent(

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -32,6 +32,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
+import { clearJustCreated } from "../util/just-created.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -233,10 +234,15 @@ export class ESPHomePageDashboard extends LitElement {
        before opening the device editor. The user typically lands
        here when they hit the back button to leave the editor — at
        which point we want their freshly-created device to flash and
-       scroll into view, the same way an adopted device does. */
+       scroll into view, the same way an adopted device does.
+       ``_tryConsumePendingScroll`` covers the "device is already
+       in ``_devices`` at mount time" case (WS pushed it while the
+       user was in the editor); ``updated()`` handles the
+       "arrives later" case. */
     const pending = consumePendingHighlight();
     if (pending !== null) {
       this._highlightFreshDevice(pending);
+      this._tryConsumePendingScroll();
     }
   }
 
@@ -847,30 +853,61 @@ export class ESPHomePageDashboard extends LitElement {
          ``_devices`` change is what fires this branch.
        - YAML-import / wizard return: ``connectedCallback`` reads the
          pending-highlight ``sessionStorage`` flag *after* the host
-         is back on the dashboard. By that point the WS may already
-         have pushed the device into ``_devices`` (e.g. the user
-         spent time in the editor). There's no future ``_devices``
-         change to wait for, so check on the very first ``updated``
-         tick after mount too — ``changed.size === 0`` indicates
-         the post-connect render. */
+         is back on the dashboard. The WS may already have pushed
+         the device into ``_devices`` while the user was in the
+         editor — that case is handled directly in
+         ``connectedCallback`` (``_tryConsumePendingScroll``); this
+         branch only needs to fire when the device arrives *after*
+         the dashboard mounts.
+
+       Earlier versions used ``changed.size === 0`` as a "first
+       render after mount" signal, but ``connectedCallback``
+       mutates ``_showIgnored`` from localStorage so the first
+       ``updated()`` call has ``changed.size > 0`` whenever that
+       toggle is on — the post-mount scroll silently stopped firing.
+       The direct call from ``connectedCallback`` removes that
+       brittle dependency. */
     if (
       this._pendingAdoptScroll !== null &&
-      (changed.has("_devices") || changed.size === 0) &&
+      changed.has("_devices") &&
       this._devices.some((d) => d.configuration === this._pendingAdoptScroll)
     ) {
       const target = this._pendingAdoptScroll;
       this._pendingAdoptScroll = null;
-      /* Wait two animation frames before scrolling. On the render
-         where the device first appears, the card's children
-         (wa-icon, status badge, etc.) are still mounting and the
-         row's height isn't final, so a same-tick ``scrollIntoView``
-         calculates against a too-short layout and stops short. Two
-         rAFs are enough for Lit's children to commit and for the
-         browser to settle the grid track sizes. */
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => this._scrollAdoptedIntoView(target)),
-      );
+      this._scheduleScrollIntoView(target);
     }
+  }
+
+  /** Try to scroll a pending-highlight target into view *now* if the
+   *  matching device is already in ``_devices``.
+   *
+   *  Called from ``connectedCallback`` after consuming the
+   *  ``sessionStorage`` flag — by the time the dashboard re-mounts
+   *  on back-navigation from the editor, the WS may already have
+   *  pushed the freshly-created device into ``_devices`` and there's
+   *  no future ``_devices`` change for ``updated()`` to react to.
+   *  When the device isn't there yet, leave ``_pendingAdoptScroll``
+   *  armed so ``updated()`` fires the scroll on the first
+   *  ``_devices`` change. */
+  private _tryConsumePendingScroll(): void {
+    if (this._pendingAdoptScroll === null) return;
+    const target = this._pendingAdoptScroll;
+    if (!this._devices.some((d) => d.configuration === target)) return;
+    this._pendingAdoptScroll = null;
+    this._scheduleScrollIntoView(target);
+  }
+
+  /** Wait two animation frames before scrolling. On the render
+   *  where the device first appears, the card's children (wa-icon,
+   *  status badge, etc.) are still mounting and the row's height
+   *  isn't final, so a same-tick ``scrollIntoView`` calculates
+   *  against a too-short layout and stops short. Two rAFs are
+   *  enough for Lit's children to commit and for the browser to
+   *  settle the grid track sizes. */
+  private _scheduleScrollIntoView(configuration: string): void {
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => this._scrollAdoptedIntoView(configuration)),
+    );
   }
 
   private _scrollAdoptedIntoView(configuration: string): void {
@@ -940,6 +977,12 @@ export class ESPHomePageDashboard extends LitElement {
       toast.error(this._localize("dashboard.action_rename_failed", { name: device.name }), { richColors: true });
       return;
     }
+    /* Drop any pending welcome-banner flag — if the user just
+       adopted / created the device and renamed it before opening
+       the editor, the stored configuration string is now stale
+       (the file lives at the renamed path) and the banner is moot
+       anyway: the user has already engaged with the device. */
+    clearJustCreated();
     if (response.job) {
       /* Validated configs route through the firmware queue — the
          compile + OTA install runs there and we follow it in the

--- a/src/util/just-created.ts
+++ b/src/util/just-created.ts
@@ -33,3 +33,20 @@ export function consumeJustCreated(configuration: string): boolean {
   }
   return false;
 }
+
+/** Drop any pending just-created flag.
+ *
+ * Called from flows that imply the user has already engaged with
+ * the device (rename, archive, etc.) — at that point the welcome
+ * banner is moot and the stored configuration string would be
+ * stale anyway (rename changes the filename the device-page mount
+ * would key off). Cheaper than tracking the rename and rewriting
+ * the stored value.
+ */
+export function clearJustCreated(): void {
+  try {
+    sessionStorage.removeItem(KEY);
+  } catch {
+    // Ignore — see comment in markJustCreated.
+  }
+}

--- a/test/util/just-created.test.ts
+++ b/test/util/just-created.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearJustCreated,
+  consumeJustCreated,
+  markJustCreated,
+} from "../../src/util/just-created.js";
+
+describe("just-created", () => {
+  // The vitest config runs in the ``node`` environment which has no
+  // ``sessionStorage``. Stub it with a tiny in-memory Map per-test so
+  // we don't need to pull in jsdom for two methods. Same shape as
+  // ``pending-highlight.test.ts``.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false from consume when nothing is marked", () => {
+    expect(consumeJustCreated("kitchen.yaml")).toBe(false);
+  });
+
+  it("returns true exactly once and clears the flag", () => {
+    markJustCreated("kitchen.yaml");
+    expect(consumeJustCreated("kitchen.yaml")).toBe(true);
+    // Second consume on the same key — the welcome banner should
+    // only fire once, so the flag has to be gone.
+    expect(consumeJustCreated("kitchen.yaml")).toBe(false);
+  });
+
+  it("returns false when consume keys don't match the marked value", () => {
+    // Pin the strict equality: a wizard for ``kitchen.yaml`` musn't
+    // accidentally fire the banner for ``kitchen-2.yaml`` even
+    // though the names share a prefix.
+    markJustCreated("kitchen.yaml");
+    expect(consumeJustCreated("kitchen-2.yaml")).toBe(false);
+    // The original mark survives a non-matching consume — only the
+    // exact-match consume clears it.
+    expect(consumeJustCreated("kitchen.yaml")).toBe(true);
+  });
+
+  it("clearJustCreated drops a pending mark unconditionally", () => {
+    // Used by the rename flow: the pre-rename flag points at the
+    // old filename, which the device-page mount can no longer
+    // match. Drop it rather than try to rewrite, since the user's
+    // already engaged with the device.
+    markJustCreated("kitchen.yaml");
+    clearJustCreated();
+    expect(consumeJustCreated("kitchen.yaml")).toBe(false);
+  });
+
+  it("clearJustCreated is a no-op when nothing is marked", () => {
+    // Rename can fire on devices that were never just-created
+    // (existing device renamed to something else); the clear has
+    // to tolerate that without throwing.
+    expect(() => clearJustCreated()).not.toThrow();
+    expect(consumeJustCreated("anything.yaml")).toBe(false);
+  });
+
+  it("tolerates sessionStorage failures across all entry points", () => {
+    // Private-mode browsers and sandboxed iframes can throw on
+    // every ``sessionStorage`` access. The helpers swallow these
+    // — the welcome banner is decoration, not worth blowing up
+    // the wizard / rename / device-mount over.
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+      clear: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => markJustCreated("kitchen.yaml")).not.toThrow();
+    expect(consumeJustCreated("kitchen.yaml")).toBe(false);
+    expect(() => clearJustCreated()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to the merged PR #96. Copilot left two more comments on the second review pass that arrived after #96 had landed.

## 1. Brittle `changed.size === 0` signal
\`connectedCallback\` mutates \`_showIgnored\` from localStorage, so for users with the "Show ignored discoveries" toggle on, the first \`updated()\` after connect has \`changed.size > 0\` — the post-mount scroll branch silently stopped firing. Pending-highlight got consumed but the new device never scrolled into view.

**Fix:** replace the heuristic with an explicit \`_tryConsumePendingScroll\` call from \`connectedCallback\`. If the freshly-arrived device is already in \`_devices\` at mount time (WS pushed it while the user was in the editor), scroll directly. Otherwise leave \`_pendingAdoptScroll\` armed so \`updated()\` fires the scroll on the first \`_devices\` change. \`updated()\` no longer depends on \`changed.size\`.

## 2. Welcome banner missed after rename
Adopted devices can be renamed from the dashboard before the user ever opens the editor. The wizard / adopt flows arm \`markJustCreated(<name>.yaml)\`; after a rename, the on-disk configuration is \`<new-name>.yaml\` and the device-page's \`consumeJustCreated(this.id)\` no longer matches — the welcome banner silently disappears.

**Fix:** added \`clearJustCreated()\` to the just-created helper and call it from \`_executeRename\` right after the API call succeeds. Renaming implies the user has already engaged with the device, so the welcome banner is moot at that point — drop the stale flag rather than try to rewrite it to the new filename. The adopt-dialog still arms the flag (right behaviour for users who *don't* rename first); the rename flow now keeps the sessionStorage in sync.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run test\` — 182 passed
- [x] Manual: adopt a device, click back, observe scroll-into-view (was broken with the toggle on); also adopt → rename → open editor: no welcome banner (vs. previously: silently no banner because of stale flag).