### PR TITLE
Fix Discard button + visual editor / YAML save sync

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -556,13 +556,24 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _onYamlUpdated(e: CustomEvent<{ yaml: string }>) {
-    /* ``yaml-updated`` is fired by the visual-editor section save and
-     * the add-component dialog AFTER the new YAML has already been
-     * persisted to disk via ``api.updateConfig`` / ``api.addComponent``.
-     * Both ``_yaml`` (the in-memory buffer) and ``_savedYaml`` (the
-     * "what's on disk" reference for ``_isDirty``) advance together
-     * so the YAML editor's Save button doesn't latch on as if the
-     * user had unsaved changes after a successful section save. */
+    /* ``yaml-updated`` fires from the visual-editor section save,
+     * the add-component dialog, and the section-delete path. Two
+     * emitters (``add-component-dialog`` and the section-delete
+     * branch) ``await`` the API call before dispatching; the
+     * section-save path is intentionally optimistic — it kicks
+     * off ``api.updateConfig`` without awaiting and dispatches
+     * immediately so the form clears its dirty state without an
+     * extra round-trip. ``_savedYaml`` advances optimistically to
+     * match: it tracks "what we believe is on disk", consistent
+     * with the section component's own optimistic ``_dirty=false``.
+     * If the save fails, the section's existing error toast
+     * surfaces it; the parent's dirty state is the rare wrong
+     * follower of the optimistic flow.
+     *
+     * Without this, the YAML editor's Save button stayed enabled
+     * after a successful visual save because ``_isDirty`` (which
+     * compares ``_yaml`` vs ``_savedYaml``) latched true on the
+     * first ``yaml-updated``. */
     this._yaml = e.detail.yaml;
     this._savedYaml = e.detail.yaml;
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -172,10 +172,29 @@ export class ESPHomePageDevice extends LitElement {
     r?.(value);
   }
 
-  private _onLeaveDiscard = () => this._resolvePendingLeave(true);
+  /* Discard / Save flip ``_allowingLeave`` BEFORE resolving the
+   * guard Promise. Two callers wait on that resolve:
+   *   - The browser-back path, which then calls ``history.back()``
+   *     itself (the popstate handler's ``.then`` would set
+   *     ``_allowingLeave`` afterwards).
+   *   - ``navigate()`` (in-app Back / logo click), which on
+   *     ``canLeave=true`` does ``pushState + dispatchEvent(popstate)``
+   *     synchronously. That synthetic popstate would otherwise be
+   *     re-intercepted by ``_onPopState`` (because ``_isDirty`` is
+   *     still true here — Discard doesn't revert the buffer) and
+   *     bounced back to the device URL, leaving the user stuck on
+   *     the page they were trying to leave. Setting the flag here
+   *     short-circuits the next popstate so navigate's URL push
+   *     actually sticks.
+   */
+  private _onLeaveDiscard = () => {
+    this._allowingLeave = true;
+    this._resolvePendingLeave(true);
+  };
 
   private _onLeaveSave = () => {
     this._saveYaml();
+    this._allowingLeave = true;
     this._resolvePendingLeave(true);
   };
 
@@ -537,7 +556,15 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _onYamlUpdated(e: CustomEvent<{ yaml: string }>) {
+    /* ``yaml-updated`` is fired by the visual-editor section save and
+     * the add-component dialog AFTER the new YAML has already been
+     * persisted to disk via ``api.updateConfig`` / ``api.addComponent``.
+     * Both ``_yaml`` (the in-memory buffer) and ``_savedYaml`` (the
+     * "what's on disk" reference for ``_isDirty``) advance together
+     * so the YAML editor's Save button doesn't latch on as if the
+     * user had unsaved changes after a successful section save. */
     this._yaml = e.detail.yaml;
+    this._savedYaml = e.detail.yaml;
   }
 
   private _onSectionSelect(

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the leave-guard navigation primitives.
+ *
+ * The pattern: pages with unsaved-changes state register a guard
+ * via ``setLeaveGuard``; the in-app Back / logo / command-palette
+ * paths all funnel through ``navigate()``, which awaits the guard
+ * before pushing the new URL. The discard / save resolution races
+ * with that ``await``, so the contract has to hold:
+ *
+ *   1. ``navigate()`` calls the registered guard exactly once
+ *      before mutating history.
+ *   2. ``navigate()`` short-circuits without touching history when
+ *      the guard resolves ``false``.
+ *   3. ``navigate()`` proceeds to ``pushState`` + dispatch a
+ *      synthetic popstate when the guard resolves ``true``.
+ *   4. ``setLeaveGuard(null)`` removes the guard so subsequent
+ *      navigations are unconditional.
+ *   5. Without any guard registered, ``navigate()`` always
+ *      proceeds.
+ *
+ * The MasterOfNone bug (Discard does nothing on the in-app Back
+ * button while the visual editor's Save left ``_isDirty=true``)
+ * traced to the synthetic popstate that ``navigate()`` fires
+ * being re-intercepted by the device-page's popstate guard. The
+ * fix landed in ``pages/device.ts`` (``_onLeaveDiscard`` /
+ * ``_onLeaveSave`` flip ``_allowingLeave=true`` before resolving),
+ * but the tests here pin the underlying ``navigate`` contract so
+ * a future refactor that drops the synthetic popstate or skips
+ * the guard surfaces immediately.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { navigate, setLeaveGuard } from "../../src/util/navigation.js";
+
+/* The vitest config runs in the ``node`` environment, which has
+ * no ``window``. ``navigation.ts`` reaches for ``window.history``
+ * and ``window.dispatchEvent`` directly, so install a minimal
+ * stub on ``globalThis`` per-test. A full DOM (jsdom / happy-dom)
+ * would be overkill for this surface — the module pokes exactly
+ * three globals.
+ */
+
+describe("navigate", () => {
+  let pushStateSpy: ReturnType<typeof vi.fn>;
+  let dispatchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    pushStateSpy = vi.fn();
+    dispatchSpy = vi.fn();
+    // The vitest config runs in the ``node`` environment, which has
+    // no ``window``. ``navigation.ts`` reaches for ``window.history``
+    // and ``window.dispatchEvent`` directly, so install a minimal
+    // stub on ``globalThis`` per-test. A full DOM (jsdom / happy-dom)
+    // would be overkill for this surface — the module pokes exactly
+    // three globals.
+    (globalThis as Record<string, unknown>).window = {
+      history: { pushState: pushStateSpy },
+      dispatchEvent: dispatchSpy,
+    };
+    // ``new PopStateEvent("popstate")`` needs a constructor — stub
+    // it as ``Event`` (the test only checks the event's ``type``,
+    // not popstate-specific fields).
+    (globalThis as Record<string, unknown>).PopStateEvent = Event;
+  });
+
+  afterEach(() => {
+    setLeaveGuard(null);
+    delete (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).PopStateEvent;
+    vi.restoreAllMocks();
+  });
+
+  it("pushes state and dispatches popstate when no guard is set", async () => {
+    await navigate("/dashboard");
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+    const popstateCalls = dispatchSpy.mock.calls.filter(
+      (call) => (call[0] as Event).type === "popstate",
+    );
+    expect(popstateCalls).toHaveLength(1);
+  });
+
+  it("calls the registered guard exactly once before pushing state", async () => {
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+
+    await navigate("/dashboard");
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    // Push happens AFTER the guard resolves — pin the order so a
+    // refactor that fired pushState eagerly (and only consulted
+    // the guard for cancellation) can't slip through.
+    expect(guard.mock.invocationCallOrder[0]).toBeLessThan(
+      pushStateSpy.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("aborts navigation when the guard resolves false", async () => {
+    const guard = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(guard);
+
+    await navigate("/dashboard");
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    const popstateCalls = dispatchSpy.mock.calls.filter(
+      (call) => (call[0] as Event).type === "popstate",
+    );
+    expect(popstateCalls).toHaveLength(0);
+  });
+
+  it("proceeds when the guard resolves true (Discard path)", async () => {
+    // Mirrors the Discard-from-unsaved-changes-dialog flow: the
+    // page's guard opens a dialog, the user clicks Discard, the
+    // dialog resolves the Promise to true, and ``navigate`` then
+    // pushes the new URL synchronously. The device-page popstate
+    // listener is supposed to short-circuit on the synthetic
+    // popstate that follows (via ``_allowingLeave``), which is
+    // the bit the MasterOfNone bug missed.
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+
+    await navigate("/");
+
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+    const popstateCalls = dispatchSpy.mock.calls.filter(
+      (call) => (call[0] as Event).type === "popstate",
+    );
+    expect(popstateCalls).toHaveLength(1);
+  });
+
+  it("ignores a previously registered guard once cleared", async () => {
+    const guard = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(guard);
+    setLeaveGuard(null);
+
+    await navigate("/dashboard");
+
+    expect(guard).not.toHaveBeenCalled();
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+  });
+
+  it("uses the latest registered guard when multiple are set in sequence", async () => {
+    // Component lifecycle: a page mounts, registers its guard,
+    // then unmounts and a new page registers its own. Pin "latest
+    // wins" so a stale guard from a torn-down page can't block
+    // the new page's navigations.
+    const stale = vi.fn(() => Promise.resolve(false));
+    const fresh = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(stale);
+    setLeaveGuard(fresh);
+
+    await navigate("/");
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
+  });
+
+  it("awaits an asynchronous guard before pushing state", async () => {
+    // The dialog-driven discard flow resolves the guard's Promise
+    // *after* a microtask (user click → button handler →
+    // ``_resolvePendingLeave``). Pin that ``navigate`` actually
+    // awaits — without ``await activeGuard()`` it would push
+    // state before the user even sees the dialog.
+    let resolveGuard: ((v: boolean) => void) | undefined;
+    const guard = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveGuard = resolve;
+        }),
+    );
+    setLeaveGuard(guard);
+
+    const navPromise = navigate("/dashboard");
+    // Yield once so any synchronous push would already have fired.
+    await Promise.resolve();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+
+    resolveGuard?.(true);
+    await navPromise;
+
+    expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+  });
+});


### PR DESCRIPTION
Reported by MasterOfNone on esphome dev + device-builder beta5:

> Steps to reproduce: Edit a device, change a property (e.g. friendly_name), click Save in the visual editor — the YAML editor's "Save" button is enabled (out of sync). Click "Back" in the top-left corner, the unsaved-changes dialog opens, click "Discard" — nothing happens. Should revert and return to the device list.

Two related regressions in \`pages/device.ts\`:

### Bug 1: Visual save leaves \`_savedYaml\` stale
\`_onYamlUpdated\` advanced \`_yaml\` after a successful visual-editor section save (or add-component dialog) but left \`_savedYaml\` untouched, so \`_isDirty = (_yaml !== _savedYaml)\` latched on. The visual save already wrote the new YAML to disk via \`api.updateConfig\` / \`api.addComponent\`, so both halves of the dirty-state pair should advance together.

### Bug 2: Discard via in-app Back gets bounced
The in-app Back button (and logo / command-palette navigations) routes through \`navigate()\`, which on \`canLeave=true\` does \`pushState + dispatchEvent(popstate)\` synchronously. \`_onLeaveDiscard\` / \`_onLeaveSave\` only resolved the guard Promise — the synthetic popstate then fired before \`_isDirty\` had cleared, hit \`_onPopState\`, and got re-intercepted (because Discard doesn't revert the buffer) and bounced back to the device URL.

Fixed by flipping \`_allowingLeave = true\` BEFORE resolving the guard so the synthetic popstate short-circuits cleanly. The browser-Back path was unaffected — its own \`.then\` in the popstate handler already does the same flip.

### Tests
Adds \`test/util/navigation.test.ts\` to pin the leave-guard contract:
- \`navigate\` awaits the guard before pushing state.
- Short-circuits on \`false\` (Cancel path).
- Proceeds to \`pushState + popstate\` on \`true\` (Discard / Save path).
- Respects \`setLeaveGuard(null)\` clearing and "latest wins" replacement.

7 new tests, full suite (195 tests) passes locally.

## Test plan
- [x] \`npm test\` — 195/195 passing.
- [x] \`npm run lint\` — clean.
- [ ] Manual smoke: edit device → change friendly_name → visual Save → YAML Save button greys out → Back → Discard → returns to device list.