### PR TITLE
Hide Connect your board button when Web Serial is unavailable

### DIFF
--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -427,10 +427,16 @@ export class ESPHomeWizardStepBoard extends LitElement {
       </div>
 
       <div class="helper-row">
-        <button class="connect-board-btn" type="button" @click=${this._connectBoard}>
-          <wa-icon library="mdi" name="usb-port"></wa-icon>
-          ${this._localize("wizard.connect_your_board")}
-        </button>
+        ${isWebSerialSupported()
+          ? html`<button
+              class="connect-board-btn"
+              type="button"
+              @click=${this._connectBoard}
+            >
+              <wa-icon library="mdi" name="usb-port"></wa-icon>
+              ${this._localize("wizard.connect_your_board")}
+            </button>`
+          : nothing}
         <button class="helper-link" type="button">
           ${this._localize("wizard.dont_know_board")}
         </button>


### PR DESCRIPTION
## Problem

In the new-device wizard's board selector, the **Connect your board** button is shown to every visitor, but it relies on `navigator.serial` (Web Serial API) which is only available in Chromium-based browsers. In Firefox, Safari, and on iOS the button does nothing when clicked — a confusing dead end.

## Changes

- Wrap the **Connect your board** button in an `isWebSerialSupported()` check so it only renders when the browser actually supports Web Serial.
- The neighbouring **I don't know what board I have** link is unaffected and still shows for everyone.