### PR TITLE
Add auth support for password-protected backends

### DIFF
--- a/build-scripts/dev-server.cjs
+++ b/build-scripts/dev-server.cjs
@@ -4,6 +4,15 @@ const rspack = require("@rspack/core");
 
 const config = createRspackConfig({ isProdBuild: false });
 
+// Honor PORT from the environment so harnesses (including Claude
+// Code's preview tool) can run a parallel dev server on a free port
+// when the default is already in use. Falls back to the rspack
+// config's hardcoded port when PORT isn't set.
+const envPort = parseInt(process.env.PORT, 10);
+if (Number.isFinite(envPort) && envPort > 0) {
+  config.devServer.port = envPort;
+}
+
 const compiler = rspack.rspack(config);
 const server = new RspackDevServer(config.devServer, compiler);
 

--- a/src/api/api-error.ts
+++ b/src/api/api-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Error thrown by the WebSocket client when the backend responds with
+ * an ErrorMessage. Carries the structured ``error_code`` + ``details``
+ * fields so callers can distinguish e.g. ``not_authenticated`` from
+ * ``rate_limited`` without string-matching the formatted message.
+ *
+ * The ``message`` is intentionally kept identical to the prior
+ * ``new Error(`${code}: ${details}`)`` shape so existing string-match
+ * tests / log scrapers continue to work.
+ */
+export class APIError extends Error {
+  errorCode: string;
+  details: string;
+
+  constructor(errorCode: string, details: string | undefined) {
+    super(`${errorCode}: ${details ?? ""}`);
+    this.name = "APIError";
+    this.errorCode = errorCode;
+    this.details = details ?? "";
+  }
+}

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -133,7 +133,14 @@ export class ESPHomeAPI {
     return this._readyPromise;
   }
 
+  /** Replace ``ready`` with a fresh pending promise — but only when
+   *  the previous one was already resolved. This keeps the same
+   *  pending promise alive across the ``connect()`` → ``_onClose``
+   *  → reconnect chain so callers that attached ``.then(...)`` during
+   *  the disconnected window aren't stranded when the reconnect's
+   *  ``connect()`` runs. */
   private _resetReady(): void {
+    if (this._readyResolve !== null) return;
     this._readyPromise = new Promise<void>((resolve) => {
       this._readyResolve = resolve;
     });
@@ -302,13 +309,19 @@ export class ESPHomeAPI {
       return;
     }
 
-    const stored = getStoredToken();
-    if (!stored) {
+    // Prefer the localStorage copy (it's "the most recent token we
+    // know about" since ``setStoredToken`` runs on every successful
+    // login), but fall back to the in-memory ``_authToken`` so private
+    // mode / sandboxed iframes — where ``setStoredToken`` is silently
+    // a no-op — don't drop the user back to the login form on every
+    // reconnect.
+    const token = getStoredToken() ?? this._authToken;
+    if (!token) {
       this.onAuthRequired?.();
       return;
     }
 
-    void this._tryStoredTokenLogin(stored);
+    void this._tryStoredTokenLogin(token);
   }
 
   private async _tryStoredTokenLogin(token: string): Promise<void> {
@@ -327,6 +340,12 @@ export class ESPHomeAPI {
     const wasConnected = this._connected;
     this._connected = false;
     this._ws = null;
+
+    // Park ``ready`` until the next successful connect+auth. Without
+    // this, anyone awaiting it during the reconnect-backoff window
+    // would resume against a closed socket and immediately hit
+    // "WebSocket not connected".
+    this._resetReady();
 
     // Reject all pending requests
     for (const [, pending] of this._pendingRequests) {

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -6,6 +6,12 @@
  * Streaming commands (compile, upload, logs, validate, clean) receive
  * EventMessages with "output" and "result" events.
  */
+import { APIError } from "./api-error.js";
+import {
+  clearStoredToken,
+  getStoredToken,
+  setStoredToken,
+} from "../util/auth-token.js";
 import type {
   AddComponentResponse,
   ArchivedDevice,
@@ -31,6 +37,40 @@ import type {
   UserPreferences,
   WizardResponse,
 } from "./types.js";
+
+interface AuthLoginResult {
+  token: string;
+  expires_at: number;
+}
+
+/** Mask sensitive auth fields when logging — tokens / passwords show
+ *  up in support tickets via attached browser console logs. The
+ *  formatted command/result still has shape, just no secret values. */
+function redactForLog(payload: unknown): unknown {
+  if (payload === null || typeof payload !== "object") return payload;
+  const obj = payload as Record<string, unknown>;
+  const command = typeof obj.command === "string" ? obj.command : null;
+  const isAuth =
+    (command !== null && command.startsWith("auth")) ||
+    "token" in obj ||
+    "password" in obj;
+  if (!isAuth) return payload;
+  const clone: Record<string, unknown> = { ...obj };
+  if (clone.args && typeof clone.args === "object") {
+    const args = clone.args as Record<string, unknown>;
+    const safeArgs: Record<string, unknown> = { ...args };
+    if ("token" in safeArgs) safeArgs.token = "<redacted>";
+    if ("password" in safeArgs) safeArgs.password = "<redacted>";
+    clone.args = safeArgs;
+  }
+  if (clone.result && typeof clone.result === "object") {
+    const result = clone.result as Record<string, unknown>;
+    if ("token" in result) {
+      clone.result = { ...result, token: "<redacted>" };
+    }
+  }
+  return clone;
+}
 
 type PendingRequest = {
   resolve: (result: unknown) => void;
@@ -59,9 +99,23 @@ export class ESPHomeAPI {
     reject: (error: Error) => void;
   } | null = null;
 
+  // Auth state. ``_authToken`` mirrors the value last accepted by the
+  // server (or pulled from localStorage on (re)connect). ``_ready`` is
+  // a deferred promise resolved either when the server replies
+  // ``requires_auth: false``, or after a successful auth/login —
+  // components that need to issue commands at startup ``await api.ready``
+  // to avoid racing the auth gate.
+  private _authToken: string | null = null;
+  private _readyPromise: Promise<void> = Promise.resolve();
+  private _readyResolve: (() => void) | null = null;
+
   // Callbacks for connection state changes
   onConnected?: (info: ServerInfoMessage) => void;
   onDisconnected?: () => void;
+  /** Fired when the server requires auth and we don't have a usable
+   *  stored token (or the stored token was rejected). The app shell
+   *  uses this to surface the login form. */
+  onAuthRequired?: () => void;
 
   get connected(): boolean {
     return this._connected;
@@ -69,6 +123,27 @@ export class ESPHomeAPI {
 
   get serverInfo(): ServerInfoMessage | null {
     return this._serverInfo;
+  }
+
+  /** Resolves once the connection is fully ready to issue commands —
+   *  i.e. ``requires_auth: false`` was reported, or auth/login
+   *  succeeded. Components that need to fetch data on startup should
+   *  ``await api.ready`` before calling other commands. */
+  get ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
+  private _resetReady(): void {
+    this._readyPromise = new Promise<void>((resolve) => {
+      this._readyResolve = resolve;
+    });
+  }
+
+  private _markReady(): void {
+    if (this._readyResolve) {
+      this._readyResolve();
+      this._readyResolve = null;
+    }
   }
 
   // ─── Connection Management ────────────────────────────────
@@ -81,6 +156,11 @@ export class ESPHomeAPI {
     if (this._connected && this._serverInfo) {
       return Promise.resolve(this._serverInfo);
     }
+
+    // Every connect attempt has its own readiness window — pre-auth
+    // commands shouldn't accidentally observe a still-resolved promise
+    // from a previous (now-closed) connection.
+    this._resetReady();
 
     return new Promise((resolve, reject) => {
       this._connectPromise = { resolve, reject };
@@ -124,7 +204,7 @@ export class ESPHomeAPI {
     let data: Record<string, unknown>;
     try {
       data = JSON.parse(event.data);
-      console.debug("[RECEIVED]", data);
+      console.debug("[RECEIVED]", redactForLog(data));
     } catch {
       console.error("Invalid JSON from WebSocket");
       return;
@@ -140,6 +220,7 @@ export class ESPHomeAPI {
         this._connectPromise = null;
       }
       this.onConnected?.(this._serverInfo);
+      this._handlePostServerInfo(this._serverInfo);
       return;
     }
 
@@ -152,7 +233,7 @@ export class ESPHomeAPI {
       const pending = this._pendingRequests.get(messageId);
       if (pending) {
         this._pendingRequests.delete(messageId);
-        pending.reject(new Error(`${err.error_code}: ${err.details || ""}`));
+        pending.reject(new APIError(err.error_code, err.details));
       }
       const stream = this._streamHandlers.get(messageId);
       if (stream) {
@@ -195,6 +276,50 @@ export class ESPHomeAPI {
         pending.resolve(result.result);
       }
       return;
+    }
+  }
+
+  /**
+   * Run the auth dance immediately after the ServerInfoMessage lands.
+   *
+   * - If the server says ``requires_auth: false`` (no password
+   *   configured, or the request came in via the trusted HA-ingress
+   *   site) → mark the connection ready, no further work needed.
+   * - If a stored token exists → try ``auth/login {token}``. On
+   *   success the server returns a fresh token + sliding expiry; we
+   *   persist it and mark ready. On any error the stored token is
+   *   dropped and ``onAuthRequired`` fires so the app shell can
+   *   surface the login form.
+   * - If no stored token exists → fire ``onAuthRequired`` directly.
+   *
+   * Runs on every (re)connect, so a mid-session reconnect with a
+   * still-valid token is transparent and a revoked token correctly
+   * surfaces the login form.
+   */
+  private _handlePostServerInfo(info: ServerInfoMessage): void {
+    if (!info.requires_auth) {
+      this._markReady();
+      return;
+    }
+
+    const stored = getStoredToken();
+    if (!stored) {
+      this.onAuthRequired?.();
+      return;
+    }
+
+    void this._tryStoredTokenLogin(stored);
+  }
+
+  private async _tryStoredTokenLogin(token: string): Promise<void> {
+    try {
+      await this.login({ token });
+    } catch {
+      // Stored token rejected — wipe it and surface the login form.
+      // The login() method already cleared in-memory + storage on the
+      // not_authenticated path; rate-limited / unexpected errors land
+      // here too, and the user retries with credentials.
+      this.onAuthRequired?.();
     }
   }
 
@@ -276,7 +401,7 @@ export class ESPHomeAPI {
           reject(error);
         },
       });
-      console.debug("[SENDING]", msg);
+      console.debug("[SENDING]", redactForLog(msg));
       this._ws!.send(JSON.stringify(msg));
     });
   }
@@ -302,6 +427,68 @@ export class ESPHomeAPI {
     this._ws.send(JSON.stringify(msg));
 
     return messageId;
+  }
+
+  // ─── Auth ─────────────────────────────────────────────────
+
+  /**
+   * Authenticate the current connection.
+   *
+   * Two paths, mirroring the backend ``auth/login`` contract:
+   * - Username + password (interactive sign-in form).
+   * - Token replay (silent re-auth on (re)connect using a token
+   *   persisted from a previous successful login).
+   *
+   * On success the returned token is persisted to localStorage and
+   * cached on the API client so the next reconnect can replay it
+   * silently. ``ready`` resolves so any callers awaiting it (the app
+   * shell's ``_postAuth`` flow) can proceed.
+   *
+   * On ``not_authenticated`` the stored token is cleared — no point
+   * trying it again. Other errors (rate limited, transport, ...)
+   * leave storage untouched so the user can retry once the limit
+   * window passes or the network recovers.
+   */
+  async login(
+    credentials: { username: string; password: string } | { token: string },
+  ): Promise<AuthLoginResult> {
+    try {
+      const result = await this.sendCommand<AuthLoginResult>(
+        "auth/login",
+        credentials as unknown as Record<string, unknown>,
+      );
+      this._authToken = result.token;
+      setStoredToken(result.token, result.expires_at);
+      this._markReady();
+      return result;
+    } catch (err) {
+      if (err instanceof APIError && err.errorCode === "not_authenticated") {
+        this._authToken = null;
+        clearStoredToken();
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Revoke the current session and drop the stored token.
+   *
+   * The backend closes the socket immediately after responding, which
+   * triggers our auto-reconnect — the new connection will land on
+   * ``requires_auth: true`` with no usable token, so the app shell
+   * surfaces the login form. We don't proactively close here; letting
+   * the backend drive the close keeps the flow simple.
+   */
+  async logout(): Promise<void> {
+    try {
+      await this.sendCommand("auth/logout");
+    } finally {
+      // Always wipe local state — even if the request failed (e.g.
+      // network blip), the user's intent is "log me out". On
+      // reconnect they'll be prompted to sign in again.
+      this._authToken = null;
+      clearStoredToken();
+    }
   }
 
   // ─── Event Subscription ────────────────────────────────────

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export { ESPHomeAPI } from "./esphome-api.js";
+export { APIError } from "./api-error.js";
 export type * from "./types.js";

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -52,6 +52,8 @@ export enum ErrorCode {
   INVALID_ARGS = "invalid_args",
   NOT_FOUND = "not_found",
   INTERNAL_ERROR = "internal_error",
+  NOT_AUTHENTICATED = "not_authenticated",
+  RATE_LIMITED = "rate_limited",
 }
 
 // ─── Paged Responses ─────────────────────────────────────────

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -213,6 +213,15 @@ export class ESPHomeApp extends LitElement {
   @state()
   private _rateLimitedUntil = 0;
 
+  // Tracks the WebSocket connection independently from the auth gate.
+  // We deliberately *do not* flip ``_authState`` on disconnect — that
+  // would unmount the routed app on every transient blip and lose
+  // page-local state like the device editor's unsaved YAML buffer.
+  // Components that care (currently just the login form's submit
+  // button) read this directly.
+  @state()
+  private _apiConnected = false;
+
   // ─── Router ──────────────────────────────────────────────
 
   private _router = new Router(this, [
@@ -373,6 +382,7 @@ export class ESPHomeApp extends LitElement {
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
       this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
+      this._apiConnected = true;
       // ``api.ready`` resolves when the connection is usable — either
       // ``requires_auth: false``, or a stored token replay succeeds.
       // If neither path takes, ``onAuthRequired`` fires below and the
@@ -389,13 +399,12 @@ export class ESPHomeApp extends LitElement {
 
     this._api.onDisconnected = () => {
       console.warn("WebSocket disconnected, will auto-reconnect...");
-      // While the socket is down, hide the dashboard behind the
-      // connecting spinner. Either the auto-reconnect's serverinfo
-      // marks ready again (transparent), or onAuthRequired flips us
-      // to needs-login.
-      if (this._authState === "authed") {
-        this._authState = "connecting";
-      }
+      // Don't touch ``_authState`` — keeping the routed app mounted
+      // during transparent reconnects preserves page-local state like
+      // the device editor's unsaved YAML buffer. The login form (when
+      // visible) reads ``_apiConnected`` to disable submit while the
+      // socket is down.
+      this._apiConnected = false;
     };
 
     // Connect to WebSocket
@@ -707,6 +716,7 @@ export class ESPHomeApp extends LitElement {
       return html`
         <esphome-login
           ?submitting=${this._authState === "authing"}
+          ?disconnected=${!this._apiConnected}
           .error=${this._authError}
           rate-limited-until=${this._rateLimitedUntil}
           @submit-credentials=${this._onLoginSubmit}
@@ -754,6 +764,15 @@ export class ESPHomeApp extends LitElement {
       // ``authed``. Nothing else to do here.
     } catch (err) {
       this._authState = "needs-login";
+      if (!this._apiConnected) {
+        // Socket dropped mid-login. The form is already showing
+        // "Reconnecting…" via the ``disconnected`` prop; surfacing a
+        // stale "sign-in failed" toast on top of that would just be
+        // noise — the auto-reconnect will land and the user can retry.
+        this._authError = null;
+        this._rateLimitedUntil = 0;
+        return;
+      }
       if (err instanceof APIError) {
         if (err.errorCode === ErrorCode.NOT_AUTHENTICATED) {
           this._authError = this._localize("auth.invalid_credentials");

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -12,10 +12,11 @@ import { provide } from "@lit/context";
 import { css, html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
-import { ESPHomeAPI } from "../api/index.js";
+import { APIError, ESPHomeAPI } from "../api/index.js";
 import {
   DeviceEventType,
   DeviceState,
+  ErrorCode,
   JobStatus,
   JobType,
   Theme,
@@ -100,10 +101,23 @@ const RECENT_JOB_TTL_MS_ATTENTION = 30_000;
 import "../pages/dashboard.js";
 import "./command-palette.js";
 import "./esphome-layout.js";
+import "./esphome-login.js";
 import "./firmware-jobs-dialog.js";
 import type { ESPHomeFirmwareJobsDialog } from "./firmware-jobs-dialog.js";
 import "./settings-dialog.js";
 import type { ESPHomeSettingsDialog } from "./settings-dialog.js";
+
+type AuthState = "connecting" | "needs-login" | "authing" | "authed";
+
+/** Parse the "try again in Xs" hint out of the backend's rate-limit
+ *  details string. Returns 0 when no number is present so the caller
+ *  can fall back to a generic "try again later" message. */
+function parseRateLimitSeconds(details: string): number {
+  const match = /in\s+(\d+)\s*s/.exec(details);
+  if (!match) return 0;
+  const n = Number(match[1]);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
 
 /** Decode the ``:id`` path param for the device route, falling back to
  *  the raw value when the URL contains a malformed ``%`` sequence.
@@ -184,6 +198,21 @@ export class ESPHomeApp extends LitElement {
   @state()
   private _integrationDocs: Record<string, string> = {};
 
+  // ─── Auth gate ───────────────────────────────────────────
+  // Drives whether we render the connecting spinner, the login form,
+  // or the actual app. Starts at "connecting" until the first
+  // serverinfo lands; the API client either marks ``ready`` immediately
+  // (no auth required) or fires ``onAuthRequired`` so we surface
+  // ``<esphome-login>``.
+  @state()
+  private _authState: AuthState = "connecting";
+
+  @state()
+  private _authError: string | null = null;
+
+  @state()
+  private _rateLimitedUntil = 0;
+
   // ─── Router ──────────────────────────────────────────────
 
   private _router = new Router(this, [
@@ -236,6 +265,32 @@ export class ESPHomeApp extends LitElement {
         width: 100vw;
         overflow-y: auto;
         background: var(--wa-color-surface-default, #f8f9fa);
+      }
+
+      .auth-status-screen {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 100%;
+        gap: var(--wa-space-m);
+        color: var(--wa-color-text-quiet);
+        font-size: var(--wa-font-size-s);
+      }
+
+      .auth-spinner {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 3px solid color-mix(in srgb, var(--esphome-primary), transparent 80%);
+        border-top-color: var(--esphome-primary);
+        animation: auth-spin 0.9s linear infinite;
+      }
+
+      @keyframes auth-spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     `,
   ];
@@ -312,29 +367,54 @@ export class ESPHomeApp extends LitElement {
       this._localize = ((key: string, ..._args: unknown[]) => key) as LocalizeFunc;
     }
 
-    // Set up connection callbacks
+    // Set up connection callbacks. ServerInfo is safe to consume
+    // pre-auth (it's the auth-gate input itself), but anything that
+    // sends backend commands has to wait for ``api.ready``.
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
       this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
-      this._subscribeToEvents();
-      this._subscribeToFollowJobs();
-      this._loadIntegrationDocs();
+      // ``api.ready`` resolves when the connection is usable — either
+      // ``requires_auth: false``, or a stored token replay succeeds.
+      // If neither path takes, ``onAuthRequired`` fires below and the
+      // app shell flips to ``needs-login``; this await stays parked
+      // until the user signs in, then resumes the post-auth setup.
+      void this._api.ready.then(() => this._afterAuthenticated());
+    };
+
+    this._api.onAuthRequired = () => {
+      this._authState = "needs-login";
+      this._authError = null;
+      this._rateLimitedUntil = 0;
     };
 
     this._api.onDisconnected = () => {
       console.warn("WebSocket disconnected, will auto-reconnect...");
+      // While the socket is down, hide the dashboard behind the
+      // connecting spinner. Either the auto-reconnect's serverinfo
+      // marks ready again (transparent), or onAuthRequired flips us
+      // to needs-login.
+      if (this._authState === "authed") {
+        this._authState = "connecting";
+      }
     };
 
     // Connect to WebSocket
     try {
-      const info = await this._api.connect();
-      this._version = info.esphome_version;
-      this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
-      // Sync theme from backend once connected
-      this._loadThemePreference();
+      await this._api.connect();
     } catch (err) {
       console.error("Failed to connect to WebSocket:", err);
     }
+  }
+
+  /** Runs once auth has succeeded for the current connection (or
+   *  immediately when no auth is required). Idempotent across reconnects. */
+  private async _afterAuthenticated() {
+    this._authState = "authed";
+    this._authError = null;
+    this._subscribeToEvents();
+    this._subscribeToFollowJobs();
+    this._loadIntegrationDocs();
+    this._loadThemePreference();
   }
 
   /**
@@ -614,6 +694,26 @@ export class ESPHomeApp extends LitElement {
   private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
 
   protected render() {
+    if (this._authState === "connecting") {
+      return html`
+        <div class="auth-status-screen">
+          <div class="auth-spinner" aria-hidden="true"></div>
+          <p>${this._localize("auth.connecting")}</p>
+        </div>
+      `;
+    }
+
+    if (this._authState === "needs-login" || this._authState === "authing") {
+      return html`
+        <esphome-login
+          ?submitting=${this._authState === "authing"}
+          .error=${this._authError}
+          rate-limited-until=${this._rateLimitedUntil}
+          @submit-credentials=${this._onLoginSubmit}
+        ></esphome-login>
+      `;
+    }
+
     return html`
       <esphome-layout
         @set-theme=${this._onSetTheme}
@@ -638,6 +738,46 @@ export class ESPHomeApp extends LitElement {
         @firmware-history-cleared=${this._onFirmwareHistoryCleared}
       ></esphome-firmware-jobs-dialog>
     `;
+  }
+
+  private async _onLoginSubmit(
+    e: CustomEvent<{ username: string; password: string }>,
+  ) {
+    if (this._authState === "authing") return;
+    this._authState = "authing";
+    this._authError = null;
+    try {
+      await this._api.login(e.detail);
+      // ``api.login`` already resolved ``api.ready`` — the
+      // ``onConnected.then`` chain in ``_init`` will pick that up and
+      // call ``_afterAuthenticated`` which flips the state to
+      // ``authed``. Nothing else to do here.
+    } catch (err) {
+      this._authState = "needs-login";
+      if (err instanceof APIError) {
+        if (err.errorCode === ErrorCode.NOT_AUTHENTICATED) {
+          this._authError = this._localize("auth.invalid_credentials");
+          this._rateLimitedUntil = 0;
+          return;
+        }
+        if (err.errorCode === ErrorCode.RATE_LIMITED) {
+          const seconds = parseRateLimitSeconds(err.details);
+          if (seconds > 0) {
+            this._rateLimitedUntil = Date.now() + seconds * 1000;
+            this._authError = this._localize("auth.rate_limited", {
+              seconds,
+            });
+          } else {
+            this._rateLimitedUntil = 0;
+            this._authError = this._localize("auth.rate_limited_generic");
+          }
+          return;
+        }
+      }
+      console.error("Unexpected sign-in error:", err);
+      this._authError = this._localize("auth.unexpected_error");
+      this._rateLimitedUntil = 0;
+    }
   }
 
   private _onSetTheme(e: CustomEvent<string>) {

--- a/src/components/esphome-login.ts
+++ b/src/components/esphome-login.ts
@@ -24,6 +24,13 @@ export class ESPHomeLogin extends LitElement {
   @property({ type: Boolean })
   submitting = false;
 
+  /** True when the WebSocket is currently down (reconnect in flight).
+   *  Disables submit so we don't fire dead requests, and swaps the
+   *  button copy for a "reconnecting…" hint. Inputs stay enabled so
+   *  the user can keep typing while waiting. */
+  @property({ type: Boolean })
+  disconnected = false;
+
   /** Already-localized error string. ``null`` hides the error region. */
   @property({ type: String })
   error: string | null = null;
@@ -170,12 +177,17 @@ export class ESPHomeLogin extends LitElement {
       Math.ceil((this.rateLimitedUntil - this._now) / 1000),
     );
     const rateLimited = secondsLeft > 0;
-    const submitDisabled = this.submitting || rateLimited;
-    const submitLabel = this.submitting
-      ? this._localize("auth.submitting")
-      : rateLimited
-        ? this._localize("auth.rate_limited", { seconds: secondsLeft })
-        : this._localize("auth.submit");
+    const submitDisabled = this.submitting || rateLimited || this.disconnected;
+    // Disconnected wins over the other states because submitting one
+    // wouldn't go anywhere — the user sees the form is alive but
+    // queued behind the reconnect.
+    const submitLabel = this.disconnected
+      ? this._localize("auth.connecting")
+      : this.submitting
+        ? this._localize("auth.submitting")
+        : rateLimited
+          ? this._localize("auth.rate_limited", { seconds: secondsLeft })
+          : this._localize("auth.submit");
 
     return html`
       <div class="card">
@@ -234,6 +246,7 @@ export class ESPHomeLogin extends LitElement {
   private _onSubmit = (e: SubmitEvent) => {
     e.preventDefault();
     if (this.submitting) return;
+    if (this.disconnected) return;
     if (this.rateLimitedUntil > Date.now()) return;
     this.dispatchEvent(
       new CustomEvent("submit-credentials", {

--- a/src/components/esphome-login.ts
+++ b/src/components/esphome-login.ts
@@ -1,0 +1,252 @@
+/**
+ * Full-screen login page — rendered by the app shell when the server
+ * reports ``requires_auth: true`` and we don't have a usable token.
+ *
+ * Owns only the form state + a rate-limit countdown timer; auth flow
+ * (validate / store token / advance to dashboard) lives on the parent
+ * which dispatches to ``esphome-api``.
+ */
+import { consume } from "@lit/context";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import { localizeContext } from "../context/index.js";
+import { inputStyles } from "../styles/inputs.js";
+import { espHomeStyles } from "../styles/shared.js";
+
+@customElement("esphome-login")
+export class ESPHomeLogin extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  /** True while the parent's submit handler is awaiting auth/login. */
+  @property({ type: Boolean })
+  submitting = false;
+
+  /** Already-localized error string. ``null`` hides the error region. */
+  @property({ type: String })
+  error: string | null = null;
+
+  /** Unix-ms timestamp until which the submit button stays disabled
+   *  (rate-limit lockout). ``0`` = no lockout. */
+  @property({ type: Number, attribute: "rate-limited-until" })
+  rateLimitedUntil = 0;
+
+  @state()
+  private _username = "";
+
+  @state()
+  private _password = "";
+
+  @state()
+  private _now = Date.now();
+
+  @query("input[name='username']")
+  private _usernameInput!: HTMLInputElement;
+
+  private _tick: ReturnType<typeof setInterval> | null = null;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Re-render every second while a rate-limit countdown is active
+    // so the disabled-button copy ticks down. The interval is harmless
+    // when no countdown is set (1Hz is cheap), but we still gate it
+    // to avoid lingering work when not needed.
+    this._tick = setInterval(() => {
+      this._now = Date.now();
+    }, 1000);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._tick !== null) {
+      clearInterval(this._tick);
+      this._tick = null;
+    }
+  }
+
+  protected firstUpdated(): void {
+    // Drop focus into the username field on mount — the form is the
+    // only thing on screen, so autofocusing matches user expectation
+    // and shortcuts password-manager flows.
+    this._usernameInput?.focus();
+  }
+
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    css`
+      :host {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: center;
+        padding: var(--wa-space-l);
+        min-height: 100%;
+      }
+
+      .card {
+        width: 100%;
+        max-width: 380px;
+        background: var(--wa-color-surface-raised);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        border-radius: var(--wa-border-radius-l);
+        padding: var(--wa-space-xl);
+        box-shadow: var(--wa-shadow-m);
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-l);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: var(--wa-font-size-xl);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+      }
+
+      p.subtitle {
+        margin: 0;
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-quiet);
+        line-height: 1.5;
+      }
+
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-m);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      label {
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+      }
+
+      .error {
+        font-size: var(--wa-font-size-s);
+        color: var(--esphome-error);
+        background: color-mix(in srgb, var(--esphome-error), transparent 90%);
+        border-radius: var(--wa-border-radius-m);
+        padding: var(--wa-space-s) var(--wa-space-m);
+      }
+
+      button[type="submit"] {
+        margin-top: var(--wa-space-s);
+        background: var(--esphome-primary);
+        color: var(--esphome-on-primary);
+        border: none;
+        border-radius: var(--wa-border-radius-m);
+        padding: 10px 18px;
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-bold);
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.12s;
+      }
+
+      button[type="submit"]:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+      }
+
+      button[type="submit"]:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    `,
+  ];
+
+  protected render() {
+    const secondsLeft = Math.max(
+      0,
+      Math.ceil((this.rateLimitedUntil - this._now) / 1000),
+    );
+    const rateLimited = secondsLeft > 0;
+    const submitDisabled = this.submitting || rateLimited;
+    const submitLabel = this.submitting
+      ? this._localize("auth.submitting")
+      : rateLimited
+        ? this._localize("auth.rate_limited", { seconds: secondsLeft })
+        : this._localize("auth.submit");
+
+    return html`
+      <div class="card">
+        <div>
+          <h1>${this._localize("auth.sign_in")}</h1>
+          <p class="subtitle">${this._localize("auth.description")}</p>
+        </div>
+        <form @submit=${this._onSubmit}>
+          <div class="field">
+            <label for="login-username">
+              ${this._localize("auth.username")}
+            </label>
+            <input
+              id="login-username"
+              name="username"
+              type="text"
+              autocomplete="username"
+              .value=${this._username}
+              ?disabled=${this.submitting}
+              @input=${this._onUsernameInput}
+            />
+          </div>
+          <div class="field">
+            <label for="login-password">
+              ${this._localize("auth.password")}
+            </label>
+            <input
+              id="login-password"
+              name="password"
+              type="password"
+              autocomplete="current-password"
+              .value=${this._password}
+              ?disabled=${this.submitting}
+              @input=${this._onPasswordInput}
+            />
+          </div>
+          ${this.error
+            ? html`<div class="error" role="alert">${this.error}</div>`
+            : nothing}
+          <button type="submit" ?disabled=${submitDisabled}>
+            ${submitLabel}
+          </button>
+        </form>
+      </div>
+    `;
+  }
+
+  private _onUsernameInput = (e: InputEvent) => {
+    this._username = (e.target as HTMLInputElement).value;
+  };
+
+  private _onPasswordInput = (e: InputEvent) => {
+    this._password = (e.target as HTMLInputElement).value;
+  };
+
+  private _onSubmit = (e: SubmitEvent) => {
+    e.preventDefault();
+    if (this.submitting) return;
+    if (this.rateLimitedUntil > Date.now()) return;
+    this.dispatchEvent(
+      new CustomEvent("submit-credentials", {
+        detail: { username: this._username, password: this._password },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-login": ESPHomeLogin;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -594,6 +594,19 @@
     "save_error": "Failed to save secrets",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n"
   },
+  "auth": {
+    "connecting": "Connecting…",
+    "sign_in": "Sign in",
+    "description": "Sign in to manage your ESPHome devices.",
+    "username": "Username",
+    "password": "Password",
+    "submit": "Sign in",
+    "submitting": "Signing in…",
+    "invalid_credentials": "Invalid username or password.",
+    "rate_limited": "Too many failed attempts. Try again in {seconds}s.",
+    "rate_limited_generic": "Too many failed attempts. Try again later.",
+    "unexpected_error": "Sign-in failed. Please try again."
+  },
   "firmware_jobs": {
     "menu_item": "Firmware tasks",
     "menu_item_with_count": "Firmware tasks ({count} active)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -478,6 +478,19 @@
     "header_actions_label": "Actions du tableau de bord",
     "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))"
   },
+  "auth": {
+    "connecting": "Connexion…",
+    "sign_in": "Connexion",
+    "description": "Connectez-vous pour gérer vos appareils ESPHome.",
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe",
+    "submit": "Se connecter",
+    "submitting": "Connexion…",
+    "invalid_credentials": "Nom d'utilisateur ou mot de passe invalide.",
+    "rate_limited": "Trop de tentatives échouées. Réessayez dans {seconds}s.",
+    "rate_limited_generic": "Trop de tentatives échouées. Réessayez plus tard.",
+    "unexpected_error": "Échec de la connexion. Veuillez réessayer."
+  },
   "firmware_jobs": {
     "menu_item": "Tâches firmware",
     "menu_item_with_count": "Tâches firmware ({count} active(s))"

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -478,6 +478,19 @@
     "header_actions_label": "Dashboardacties",
     "more_options_with_count": "Meer opties ({count} firmwaretaken actief)"
   },
+  "auth": {
+    "connecting": "Verbinden…",
+    "sign_in": "Inloggen",
+    "description": "Log in om je ESPHome-apparaten te beheren.",
+    "username": "Gebruikersnaam",
+    "password": "Wachtwoord",
+    "submit": "Inloggen",
+    "submitting": "Bezig met inloggen…",
+    "invalid_credentials": "Ongeldige gebruikersnaam of wachtwoord.",
+    "rate_limited": "Te veel mislukte pogingen. Probeer het over {seconds}s opnieuw.",
+    "rate_limited_generic": "Te veel mislukte pogingen. Probeer het later opnieuw.",
+    "unexpected_error": "Inloggen mislukt. Probeer het opnieuw."
+  },
   "firmware_jobs": {
     "menu_item": "Firmwaretaken",
     "menu_item_with_count": "Firmwaretaken ({count} actief)"

--- a/src/util/auth-token.ts
+++ b/src/util/auth-token.ts
@@ -1,0 +1,58 @@
+/**
+ * Persistent storage for the dashboard auth token.
+ *
+ * The backend hands out an opaque token after a successful
+ * username/password login (``auth/login``). Storing it in localStorage
+ * lets a returning browser skip the password form and re-authenticate
+ * silently — the API client sends the stored token on (re)connect, and
+ * only falls back to the login UI when the server rejects with
+ * ``not_authenticated``.
+ *
+ * ``expires_at`` is kept for diagnostic purposes only. The backend
+ * auto-refreshes the expiry on every authenticated message (sliding
+ * 30-day window), so client-side expiry checks are unreliable thanks
+ * to clock skew — we always send the stored token if present and let
+ * the server reject if it's actually invalid.
+ */
+
+const KEY = "esphome.auth-token";
+
+interface StoredAuthToken {
+  token: string;
+  expires_at: number;
+}
+
+/** Read the stored token, or null when no usable token is present. */
+export function getStoredToken(): string | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredAuthToken;
+    if (typeof parsed?.token !== "string" || !parsed.token) return null;
+    return parsed.token;
+  } catch {
+    // Private mode / sandboxed iframes / corrupted JSON — treat as
+    // no stored token, the user can sign in again.
+    return null;
+  }
+}
+
+/** Persist a freshly-issued token + its expires_at (unix seconds). */
+export function setStoredToken(token: string, expiresAt: number): void {
+  try {
+    const value: StoredAuthToken = { token, expires_at: expiresAt };
+    localStorage.setItem(KEY, JSON.stringify(value));
+  } catch {
+    // No-op — see comment in getStoredToken. The session still
+    // works for this tab via the in-memory token on the API client.
+  }
+}
+
+/** Drop the stored token (logout, or after the server rejects it). */
+export function clearStoredToken(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    // Ignore — see comment in getStoredToken.
+  }
+}

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -701,6 +701,102 @@ describe("ESPHomeAPI — auth", () => {
     expect(localStorage.getItem("esphome.auth-token")).toBeNull();
   });
 
+  it("falls back to the in-memory token when localStorage writes silently fail", async () => {
+    // Private-mode browsers / sandboxed iframes throw on every
+    // localStorage access. ``login()`` still keeps a copy in
+    // ``_authToken`` so reconnects within the same tab can replay it
+    // without dropping the user back to the form.
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+      clear: () => {},
+    });
+
+    const api = new ESPHomeAPI();
+    const onAuthRequired = vi.fn();
+    api.onAuthRequired = onAuthRequired;
+
+    // First connect: server requires auth, no stored token → form.
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+    expect(onAuthRequired).toHaveBeenCalledTimes(1);
+
+    // User signs in. setStoredToken throws but is swallowed; the API
+    // client caches the token in memory.
+    const loginPromise = api.login({ username: "admin", password: "hunter2" });
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      result: { token: "in-mem-tok", expires_at: 1_900_000_000 },
+    });
+    await loginPromise;
+
+    // Socket drops, reconnect. The stored-token lookup misses (private
+    // mode) but the in-memory cache carries the session forward.
+    ws.close();
+
+    const reconnect = api.connect();
+    const ws2 = MockWebSocket.latest();
+    ws2.open();
+    ws2.receive(serverInfoAuthRequired);
+    await reconnect;
+
+    const replay = ws2.sentAs<{
+      command: string;
+      args: Record<string, unknown>;
+      message_id: string;
+    }>(0);
+    expect(replay.command).toBe("auth/login");
+    expect(replay.args).toEqual({ token: "in-mem-tok" });
+
+    // No second prompt — onAuthRequired was only called for the first
+    // (pre-login) connect.
+    expect(onAuthRequired).toHaveBeenCalledTimes(1);
+  });
+
+  it("ready parks until the next successful connect+auth after a disconnect", async () => {
+    // Without this contract, any caller that awaits ``api.ready``
+    // during the reconnect-backoff window resumes against the closed
+    // socket and immediately hits "WebSocket not connected".
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfo);
+    await pending;
+    await api.ready; // resolves immediately — no auth required.
+
+    // Drop the socket. ``ready`` should now be a fresh pending
+    // promise — anyone awaiting it parks until the reconnect lands.
+    ws.close();
+
+    let resolved = false;
+    void api.ready.then(() => {
+      resolved = true;
+    });
+    // Yield twice so any spurious resolution would have flushed.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // Reconnect; ``ready`` resolves only after the new serverinfo.
+    const second = api.connect();
+    const ws2 = MockWebSocket.latest();
+    ws2.open();
+    ws2.receive(serverInfo);
+    await second;
+    await api.ready;
+    expect(resolved).toBe(true);
+  });
+
   it("logout clears the stored token even when the request fails", async () => {
     // The intent of ``logout`` is "sign me out of this browser" — a
     // backend hiccup (network blip, internal_error) shouldn't strand

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -670,7 +670,7 @@ describe("ESPHomeAPI — auth", () => {
     }
   });
 
-  it("logout clears the stored token even if the request fails", async () => {
+  it("logout clears the stored token on success", async () => {
     stubLocalStorage({
       "esphome.auth-token": JSON.stringify({
         token: "tok",
@@ -698,6 +698,46 @@ describe("ESPHomeAPI — auth", () => {
     ws.receive({ message_id: sent.message_id, result: { logged_out: true } });
     await logoutPromise;
 
+    expect(localStorage.getItem("esphome.auth-token")).toBeNull();
+  });
+
+  it("logout clears the stored token even when the request fails", async () => {
+    // The intent of ``logout`` is "sign me out of this browser" — a
+    // backend hiccup (network blip, internal_error) shouldn't strand
+    // the token in localStorage where the next reconnect would
+    // happily replay it. The ``finally`` block in ``logout()`` is the
+    // contract we're pinning here.
+    stubLocalStorage({
+      "esphome.auth-token": JSON.stringify({
+        token: "tok",
+        expires_at: 1_700_000_000,
+      }),
+    });
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    const replay = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: replay.message_id,
+      result: { token: "tok", expires_at: 1_800_000_000 },
+    });
+    await api.ready;
+
+    const logoutPromise = api.logout();
+    const sent = ws.sentAs<{ command: string; message_id: string }>(1);
+    expect(sent.command).toBe("auth/logout");
+    ws.receive({
+      message_id: sent.message_id,
+      error_code: "internal_error",
+      details: "boom",
+    });
+
+    await expect(logoutPromise).rejects.toBeInstanceOf(APIError);
+    // Local state cleared regardless of the rejection.
     expect(localStorage.getItem("esphome.auth-token")).toBeNull();
   });
 });

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -6,6 +6,7 @@ import {
   it,
   vi,
 } from "vitest";
+import { APIError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import {
   MockWebSocket,
@@ -20,6 +21,22 @@ const serverInfo = {
   ha_addon: false,
   requires_auth: false,
 };
+
+const serverInfoAuthRequired = {
+  ...serverInfo,
+  requires_auth: true,
+};
+
+function stubLocalStorage(initial?: Record<string, string>): Map<string, string> {
+  const store = new Map<string, string>(Object.entries(initial ?? {}));
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+  });
+  return store;
+}
 
 async function connect(api: ESPHomeAPI): Promise<MockWebSocket> {
   const pending = api.connect();
@@ -139,13 +156,28 @@ describe("ESPHomeAPI — sendCommand", () => {
     expect(sent.args).toBeUndefined();
   });
 
-  it("rejects with the error_code + details on ErrorMessage", async () => {
+  it("rejects with an APIError carrying error_code + details", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     const pending = api.sendCommand("boom");
     const { message_id } = ws.sentAs<{ message_id: string }>(0);
     ws.receive({ message_id, error_code: "not_found", details: "no such cmd" });
+    // Existing string-match contract preserved for log scrapers.
     await expect(pending).rejects.toThrow(/not_found.*no such cmd/);
+
+    // Structured fields available on the error so callers can branch
+    // on error_code without re-parsing the message.
+    const second = api.sendCommand("boom2");
+    const id2 = ws.sentAs<{ message_id: string }>(1).message_id;
+    ws.receive({ message_id: id2, error_code: "not_found", details: "gone" });
+    try {
+      await second;
+      throw new Error("should have rejected");
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      expect((err as APIError).errorCode).toBe("not_found");
+      expect((err as APIError).details).toBe("gone");
+    }
   });
 
   it("rejects when no response arrives before the timeout", async () => {
@@ -447,5 +479,225 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
     expect(sent.command).toBe("config/set_preferences");
     expect(sent.args).toEqual({ theme: "dark" });
+  });
+});
+
+describe("ESPHomeAPI — auth", () => {
+  beforeEach(() => {
+    installMockWebSocket();
+    stubLocalStorage();
+  });
+  afterEach(() => {
+    uninstallMockWebSocket();
+    vi.unstubAllGlobals();
+  });
+
+  it("ready resolves immediately when requires_auth is false", async () => {
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfo);
+    await pending;
+    // No login needed — the trusted-ingress / no-password case.
+    await expect(api.ready).resolves.toBeUndefined();
+  });
+
+  it("fires onAuthRequired when requires_auth is true and no token is stored", async () => {
+    const api = new ESPHomeAPI();
+    const onAuthRequired = vi.fn();
+    api.onAuthRequired = onAuthRequired;
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+    expect(onAuthRequired).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-replays a stored token when requires_auth is true", async () => {
+    stubLocalStorage({
+      "esphome.auth-token": JSON.stringify({
+        token: "stored-tok",
+        expires_at: 1_700_000_000,
+      }),
+    });
+    const api = new ESPHomeAPI();
+    const onAuthRequired = vi.fn();
+    api.onAuthRequired = onAuthRequired;
+
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    // The auto-replay sends auth/login {token}.
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.command).toBe("auth/login");
+    expect(sent.args).toEqual({ token: "stored-tok" });
+
+    // Server accepts; ready resolves and onAuthRequired never fires.
+    ws.receive({
+      message_id: sent.message_id,
+      result: { token: "fresh-tok", expires_at: 1_800_000_000 },
+    });
+    await expect(api.ready).resolves.toBeUndefined();
+    expect(onAuthRequired).not.toHaveBeenCalled();
+
+    // Fresh token persisted for the next reconnect.
+    expect(localStorage.getItem("esphome.auth-token")).toBe(
+      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 }),
+    );
+  });
+
+  it("clears the stored token + fires onAuthRequired when the replay is rejected", async () => {
+    stubLocalStorage({
+      "esphome.auth-token": JSON.stringify({
+        token: "stale-tok",
+        expires_at: 1_700_000_000,
+      }),
+    });
+    const api = new ESPHomeAPI();
+    const onAuthRequired = vi.fn();
+    api.onAuthRequired = onAuthRequired;
+
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      error_code: "not_authenticated",
+      details: "Invalid or expired token",
+    });
+
+    // The stored token is wiped — no point trying it again.
+    await vi.waitFor(() => {
+      expect(onAuthRequired).toHaveBeenCalledTimes(1);
+    });
+    expect(localStorage.getItem("esphome.auth-token")).toBeNull();
+  });
+
+  it("login(credentials) sends username/password and persists the token", async () => {
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    const loginPromise = api.login({ username: "admin", password: "hunter2" });
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.command).toBe("auth/login");
+    expect(sent.args).toEqual({ username: "admin", password: "hunter2" });
+
+    ws.receive({
+      message_id: sent.message_id,
+      result: { token: "new-tok", expires_at: 1_900_000_000 },
+    });
+
+    await expect(loginPromise).resolves.toEqual({
+      token: "new-tok",
+      expires_at: 1_900_000_000,
+    });
+    await expect(api.ready).resolves.toBeUndefined();
+    expect(localStorage.getItem("esphome.auth-token")).toBe(
+      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 }),
+    );
+  });
+
+  it("login surfaces APIError with not_authenticated for bad credentials", async () => {
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    const loginPromise = api.login({ username: "admin", password: "wrong" });
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      error_code: "not_authenticated",
+      details: "Invalid credentials",
+    });
+
+    await expect(loginPromise).rejects.toBeInstanceOf(APIError);
+    try {
+      await loginPromise;
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      expect((err as APIError).errorCode).toBe("not_authenticated");
+      expect((err as APIError).details).toBe("Invalid credentials");
+    }
+  });
+
+  it("login surfaces APIError with rate_limited including the details string", async () => {
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    const loginPromise = api.login({ username: "admin", password: "wrong" });
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      error_code: "rate_limited",
+      details: "Too many failed attempts; try again in 42s",
+    });
+
+    try {
+      await loginPromise;
+      throw new Error("should have rejected");
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      expect((err as APIError).errorCode).toBe("rate_limited");
+      expect((err as APIError).details).toContain("42s");
+    }
+  });
+
+  it("logout clears the stored token even if the request fails", async () => {
+    stubLocalStorage({
+      "esphome.auth-token": JSON.stringify({
+        token: "tok",
+        expires_at: 1_700_000_000,
+      }),
+    });
+    const api = new ESPHomeAPI();
+    const pending = api.connect();
+    const ws = MockWebSocket.latest();
+    ws.open();
+    ws.receive(serverInfoAuthRequired);
+    await pending;
+
+    // Drain the auto-replay so the next sentAs call sees logout.
+    const replay = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: replay.message_id,
+      result: { token: "tok", expires_at: 1_800_000_000 },
+    });
+    await api.ready;
+
+    const logoutPromise = api.logout();
+    const sent = ws.sentAs<{ command: string; message_id: string }>(1);
+    expect(sent.command).toBe("auth/logout");
+    ws.receive({ message_id: sent.message_id, result: { logged_out: true } });
+    await logoutPromise;
+
+    expect(localStorage.getItem("esphome.auth-token")).toBeNull();
   });
 });

--- a/test/util/auth-token.test.ts
+++ b/test/util/auth-token.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStoredToken,
+  getStoredToken,
+  setStoredToken,
+} from "../../src/util/auth-token.js";
+
+describe("auth-token", () => {
+  // Mirrors the just-created.test.ts pattern: vitest runs in node, so
+  // localStorage has to be stubbed per-test.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getStoredToken()).toBeNull();
+  });
+
+  it("round-trips a token through set/get", () => {
+    setStoredToken("abc123", 1_700_000_000);
+    expect(getStoredToken()).toBe("abc123");
+  });
+
+  it("clearStoredToken drops a previously-stored token", () => {
+    setStoredToken("abc123", 1_700_000_000);
+    clearStoredToken();
+    expect(getStoredToken()).toBeNull();
+  });
+
+  it("ignores malformed JSON in storage", () => {
+    // Simulate stale data from a prior version that wrote the bare
+    // token instead of the {token, expires_at} envelope.
+    localStorage.setItem("esphome.auth-token", "not json {");
+    expect(getStoredToken()).toBeNull();
+  });
+
+  it("ignores values without a token field", () => {
+    localStorage.setItem("esphome.auth-token", JSON.stringify({}));
+    expect(getStoredToken()).toBeNull();
+  });
+
+  it("treats an empty token string as no token", () => {
+    localStorage.setItem(
+      "esphome.auth-token",
+      JSON.stringify({ token: "", expires_at: 0 }),
+    );
+    expect(getStoredToken()).toBeNull();
+  });
+
+  it("tolerates localStorage failures across all entry points", () => {
+    // Private-mode browsers and sandboxed iframes can throw on every
+    // localStorage access. The helpers swallow these — auth still
+    // works (in-memory token on the API client carries the session).
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+      clear: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => setStoredToken("abc", 1)).not.toThrow();
+    expect(getStoredToken()).toBeNull();
+    expect(() => clearStoredToken()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

The frontend ignored the `requires_auth` flag in `serverinfo`. When the backend was started with `--username/--password`, every command after connect was rejected with `not_authenticated` and the dashboard rendered an empty, broken state — there was no UI to sign in.

When running as a Home Assistant add-on through the trusted ingress site the backend already reports `requires_auth: false`, so no client-side ingress check is needed — honoring `requires_auth` is sufficient.

## Changes

- New `auth-token` util — persists `{token, expires_at}` in `localStorage` (`esphome.auth-token`), tolerant of private-mode failures.
- `ESPHomeAPI`:
  - New `login()` / `logout()` methods, plus an `onAuthRequired` callback and a `ready` promise that resolves once auth is settled.
  - On every (re)connect: if `requires_auth: true`, silently replay the stored token; on rejection clear it and fire `onAuthRequired`.
  - All errors now reject as `APIError` (carries `errorCode` + `details`) so callers can branch on `not_authenticated` / `rate_limited` without string-matching.
  - Console-debug logs redact `token` / `password` fields from `auth/*` traffic.
- `app-shell` state machine: `connecting → needs-login → authing → authed`. Subscriptions, integration-docs, and theme prefs only fire after auth succeeds. Reconnects are transparent when the stored token still works, otherwise the login form re-appears mid-session without losing the URL.
- New `<esphome-login>` component — full-screen card with username/password, autofocus, error banner, and a live rate-limit countdown derived from the backend's `try again in Xs` hint.
- Translations for `auth.*` added in `en` / `fr` / `nl`.
- `dev-server.cjs` now honors `PORT` from the env so a parallel preview can run on a free port when 5173 is taken.
- Tests cover token storage, structured `APIError`, auto-replay, replay rejection wiping the stored token, login success/failure paths (including `rate_limited` details), and logout always clearing local state.