### PR TITLE
Fix featured-component bundle prefill and structured pin display

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -559,6 +559,22 @@ export class ESPHomeAddComponentDialog extends LitElement {
           this._submitError = this._localize("device.add_component_error");
           return;
         }
+        // Hand the just-added component's id to the next step's matching
+        // `references_component` field. Bundles are designed to chain —
+        // e.g. `Status LED (full setup)` adds an `output.gpio`, then a
+        // `light.binary` whose `output:` field has to point at it — and
+        // without this prefill the user has to re-pick the id they just
+        // typed in the previous step from a dropdown.
+        const justAddedId = e.detail.fields["id"];
+        const justAddedDomain = this._selected.category;
+        if (typeof justAddedId === "string" && justAddedDomain) {
+          this._prefillReference = {
+            domain: justAddedDomain,
+            id: justAddedId,
+          };
+        } else {
+          this._prefillReference = null;
+        }
         this._bundleQueue = remaining;
         this._bundleProgress = {
           ...this._bundleProgress,

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -452,14 +452,13 @@ export class ESPHomeAddComponentDialog extends LitElement {
       this._submitError = "";
       return;
     }
-    // Mid-bundle back is a cancel — drop the queue and return to the
-    // catalog. Already-added components stay in the YAML; we don't
-    // roll them back (consistent with the regular flow's no-rollback
-    // behaviour on errors).
-    if (this._bundleProgress) {
-      this._bundleQueue = [];
-      this._bundleProgress = null;
-    }
+    // Returning to the catalog (mid-bundle cancel or otherwise) —
+    // drop all detour state so a leftover `_prefillReference` from an
+    // abandoned bundle step can't leak into the next component the
+    // user selects. Already-added bundle components stay in the YAML;
+    // we don't roll them back (consistent with the regular flow's
+    // no-rollback behaviour on errors).
+    this._resetDetourState();
     this._selected = null;
     this._submitError = "";
   }

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -21,17 +21,25 @@ import {
 } from "./config-entry-renderers-shared.js";
 
 /**
- * Parse a `suggestions` value into a GPIO number. Featured manifests
- * write these as either bare ints (`12`) or string forms (`"GPIO12"`,
- * `"gpio12"`); the wire shape is `ConfigPrimitive`, so we accept both.
- * Returns `null` for anything we can't parse — the caller drops those
- * entries rather than letting a typo crash the renderer.
+ * Parse a pin reference into a GPIO number. Used both for the field's
+ * current value and for individual `suggestions` entries. Featured
+ * manifests write pins as bare ints (`12`), string forms (`"GPIO12"`,
+ * `"gpio12"`), or — for fields whose locked preset needs the long-form
+ * ESPHome pin block — an object like
+ * `{ number: 0, mode: { input: true, pullup: true }, inverted: true }`
+ * (Sonoff Basic's front-panel button is the canonical example: the pin
+ * is occupied + inverted + needs the internal pull-up, all baked into
+ * the preset). Returns `null` for anything we can't parse — the caller
+ * drops those entries rather than letting a typo blank the dropdown.
  */
-function parseSuggestionGpio(s: unknown): number | null {
+export function parsePinGpio(s: unknown): number | null {
   if (typeof s === "number" && Number.isFinite(s)) return s;
   if (typeof s === "string") {
     const m = s.match(/^\s*(?:GPIO)?(\d+)\s*$/i);
     if (m) return Number(m[1]);
+  }
+  if (s !== null && typeof s === "object" && !Array.isArray(s)) {
+    return parsePinGpio((s as Record<string, unknown>).number);
   }
   return null;
 }
@@ -97,11 +105,12 @@ export function renderPinField(
     return renderStringField(entry, "text", path, ctx);
   }
 
-  // Pin presets land as either bare ints (`12`) or `GPIOn` strings —
-  // the wa-option values are always the `GPIOn` form, so normalise
+  // Pin presets can land as bare ints (`12`), `GPIOn` strings, or the
+  // long-form pin block (`{ number: N, mode: {...}, inverted: ... }`).
+  // The wa-option values are always the `GPIOn` form, so normalise
   // before comparing or the disabled select renders blank.
   const rawValue = ctx.getAt(path);
-  const valueGpio = parseSuggestionGpio(rawValue);
+  const valueGpio = parsePinGpio(rawValue);
   const value =
     valueGpio !== null ? `GPIO${valueGpio}` : String(rawValue ?? "");
   const invalid = ctx.errorAt(path) !== null;
@@ -117,7 +126,7 @@ export function renderPinField(
   if (entry.suggestions && entry.suggestions.length > 0) {
     const allowed = new Set(
       entry.suggestions
-        .map(parseSuggestionGpio)
+        .map(parsePinGpio)
         .filter((g): g is number => g !== null),
     );
     if (allowed.size > 0) {

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parsePinGpio } from "../../../src/components/device/config-entry-pin-renderer.js";
+
+describe("parsePinGpio", () => {
+  it("accepts bare integers", () => {
+    expect(parsePinGpio(12)).toBe(12);
+    expect(parsePinGpio(0)).toBe(0);
+  });
+
+  it("accepts GPIO-prefixed strings, case-insensitively", () => {
+    expect(parsePinGpio("GPIO13")).toBe(13);
+    expect(parsePinGpio("gpio5")).toBe(5);
+    expect(parsePinGpio("  GPIO2  ")).toBe(2);
+  });
+
+  it("accepts plain numeric strings", () => {
+    expect(parsePinGpio("7")).toBe(7);
+    expect(parsePinGpio("0")).toBe(0);
+  });
+
+  it("extracts the GPIO from a long-form pin block", () => {
+    // The Sonoff Basic front-panel button preset locks the pin as a
+    // structured ESPHome pin block (number + mode + inverted). Without
+    // recognising the `number` field the dropdown rendered blank even
+    // though the underlying value was correct.
+    expect(
+      parsePinGpio({
+        number: 0,
+        mode: { input: true, pullup: true },
+        inverted: true,
+      }),
+    ).toBe(0);
+    expect(parsePinGpio({ number: 13 })).toBe(13);
+    expect(parsePinGpio({ number: "GPIO4" })).toBe(4);
+  });
+
+  it("returns null for unparseable values", () => {
+    expect(parsePinGpio(null)).toBeNull();
+    expect(parsePinGpio(undefined)).toBeNull();
+    expect(parsePinGpio("")).toBeNull();
+    expect(parsePinGpio("not a pin")).toBeNull();
+    expect(parsePinGpio({})).toBeNull();
+    expect(parsePinGpio({ number: "nope" })).toBeNull();
+    expect(parsePinGpio([])).toBeNull();
+    expect(parsePinGpio(Number.NaN)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
Two issues showed up on Sonoff Basic's featured components / bundles:

1. **Status LED (full setup) bundle** — step 2 (`light.binary` whose `output:` references the just-added `output.gpio`) rendered with the output dropdown blank, forcing the user to re-pick the id they had just typed in step 1.
2. **Front-Panel Button** featured component — the pin dropdown rendered empty/disabled even though the underlying preset (and the YAML it produced) was correct.

## Changes
- `add-component-dialog.ts`: when advancing a bundle step, carry the just-added component's id + category into `_prefillReference` so the next step's matching `references_component` field is populated automatically (same mechanism the dep-detour branch already uses).
- `config-entry-pin-renderer.ts`: extend the GPIO parser to accept the long-form ESPHome pin block (`{ number: N, mode: {...}, inverted: ... }`). Sonoff Basic's front-panel button locks `pin` to that structured form because GPIO0 needs `pullup` + `inverted`, and the parser was previously returning `null` for any non-primitive — leaving the locked dropdown with no selected option.
- Renamed the helper from `parseSuggestionGpio` → `parsePinGpio` to reflect that it parses both field values and suggestion entries, and added a unit test covering the new structured-pin case.