### PR TITLE
Tighten release workflow and switch backend pin to PyPI ==version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -81,5 +81,4 @@ jobs:
     with:
       version: ${{ needs.check-and-release.outputs.version }}
     secrets:
-      ESPHOME_GITHUB_APP_ID: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
       ESPHOME_GITHUB_APP_PRIVATE_KEY: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -75,8 +75,8 @@ jobs:
     needs: check-and-release
     if: needs.check-and-release.outputs.should_release == 'true'
     permissions:
-      contents: write
-      pull-requests: read
+      contents: read    # ceiling for release.yml's checkout + gh release view
+      id-token: write   # ceiling for release.yml's PyPI Trusted Publishing
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.check-and-release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,11 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          # Skip dists already on PyPI so a partial-failure rerun
+          # (e.g. release-edit failed after PyPI succeeded) doesn't
+          # blow up on the duplicate version.
+          skip-existing: true
 
       - name: Publish release
         run: gh release edit "${{ inputs.version }}" --draft=false
@@ -192,7 +197,13 @@ jobs:
           # correctly when this body is rendered on the backend repo's PR.
           notes = re.sub(r"(?<![\w/])#(\d+)\b", rf"{repo}#\1", notes)
           # Defuse @user mentions so the backend PR doesn't ping contributors.
-          notes = re.sub(r"(?<![\w@`])@([A-Za-z0-9][A-Za-z0-9-]*)", r"`@\1`", notes)
+          # The trailing lookahead skips scoped npm package refs like
+          # @home-assistant/webawesome that appear in PR titles.
+          notes = re.sub(
+              r"(?<![\w@`])@([A-Za-z0-9][A-Za-z0-9-]*)(?![A-Za-z0-9/-])",
+              r"`@\1`",
+              notes,
+          )
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write("body<<NOTES_EOF\n")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             device-builder
+            device-builder-frontend
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,7 @@ env:
   BACKEND_REPO: esphome/device-builder
   PACKAGE_NAME: esphome-device-builder-frontend
 
-permissions:
-  contents: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   create-release:
@@ -71,6 +69,9 @@ jobs:
     name: Build wheel and attach to release
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # actions/checkout uses the implicit GITHUB_TOKEN
+      id-token: write   # OIDC for PyPI Trusted Publishing
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 # Tags the version, drafts release notes, builds the Python wheel
 # containing the prebuilt frontend, attaches the wheel + sdist to
-# the GitHub release, and opens / updates a single bump PR on the
-# backend repo so it picks up the new wheel URL.
+# the draft release, publishes the wheel to PyPI, then flips the
+# GitHub release to public, and finally opens / updates a single
+# bump PR on the backend repo so it picks up the new PyPI version.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,8 @@ jobs:
     name: Open bump PR on backend
     needs: build-and-attach
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # GITHUB_TOKEN reads this repo's release body
     steps:
       - name: Create backend app token
         id: app-token
@@ -156,7 +158,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             device-builder
-            device-builder-frontend
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
@@ -172,7 +173,7 @@ jobs:
       - name: Get release notes
         id: notes
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
           python3 - <<'PY'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,13 +133,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
       - name: Publish release
         run: gh release edit "${{ inputs.version }}" --draft=false
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   bump-backend:
     name: Open bump PR on backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ on:
         required: true
         type: string
     secrets:
-      ESPHOME_GITHUB_APP_ID:
-        required: true
       ESPHOME_GITHUB_APP_PRIVATE_KEY:
         required: true
 
@@ -29,7 +27,6 @@ env:
   NODE_VERSION: "22.x"
   BACKEND_REPO: esphome/device-builder
   PACKAGE_NAME: esphome-device-builder-frontend
-  WHEEL_NAME: esphome_device_builder_frontend
 
 permissions:
   contents: write
@@ -39,17 +36,23 @@ jobs:
   create-release:
     name: Tag and draft release
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ inputs.version }}
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create and push tag
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "esphome[bot]"
+          git config user.email "115708604+esphome[bot]@users.noreply.github.com"
           git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
           git push origin "${{ inputs.version }}"
 
@@ -59,16 +62,23 @@ jobs:
           config-name: release-drafter.yml
           version: ${{ inputs.version }}
           tag: ${{ inputs.version }}
-          publish: true
+          publish: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   build-and-attach:
     name: Build wheel and attach to release
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.version }}
@@ -120,28 +130,26 @@ jobs:
       - name: Attach to release
         run: gh release upload "${{ inputs.version }}" dist/*.whl dist/*.tar.gz
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Publish release
+        run: gh release edit "${{ inputs.version }}" --draft=false
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   bump-backend:
     name: Open bump PR on backend
     needs: build-and-attach
     runs-on: ubuntu-latest
     steps:
-      - name: Validate GitHub App configuration
-        env:
-          GITHUB_APP_ID: ${{ secrets.ESPHOME_GITHUB_APP_ID || vars.ESPHOME_GITHUB_APP_ID }}
-        run: |
-          if [ -z "$GITHUB_APP_ID" ]; then
-            echo "::error::Missing GitHub App ID."
-            echo "::error::Set Actions secret or variable ESPHOME_GITHUB_APP_ID and ensure it is shared with this repository."
-            exit 1
-          fi
-
       - name: Create backend app token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID || vars.ESPHOME_GITHUB_APP_ID }}
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
@@ -160,25 +168,40 @@ jobs:
 
       - name: Get release notes
         id: notes
-        run: |
-          NOTES=$(gh release view "${{ inputs.version }}" \
-            --repo "${{ github.repository }}" \
-            --json body --jq '.body')
-          {
-            echo "body<<NOTES_EOF"
-            echo "$NOTES"
-            echo "NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          import subprocess
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          notes = subprocess.check_output(
+              ["gh", "release", "view", os.environ["VERSION"],
+               "--repo", repo,
+               "--json", "body", "--jq", ".body"],
+              text=True,
+          )
+          # Qualify bare #NNN refs with the source repo so they resolve
+          # correctly when this body is rendered on the backend repo's PR.
+          notes = re.sub(r"(?<![\w/])#(\d+)\b", rf"{repo}#\1", notes)
+          # Defuse @user mentions so the backend PR doesn't ping contributors.
+          notes = re.sub(r"(?<![\w@`])@([A-Za-z0-9][A-Za-z0-9-]*)", r"`@\1`", notes)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write("body<<NOTES_EOF\n")
+              f.write(notes)
+              if not notes.endswith("\n"):
+                  f.write("\n")
+              f.write("NOTES_EOF\n")
+          PY
 
       - name: Update backend pyproject.toml
         working-directory: backend
         env:
           VERSION: ${{ inputs.version }}
-          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
-          WHEEL_NAME: ${{ env.WHEEL_NAME }}
-          REPO: ${{ github.repository }}
         run: |
           python3 - <<'PY'
           import os
@@ -187,13 +210,7 @@ jobs:
 
           version = os.environ["VERSION"]
           package = os.environ["PACKAGE_NAME"]
-          wheel = os.environ["WHEEL_NAME"]
-          repo = os.environ["REPO"]
-          url = (
-              f"https://github.com/{repo}/releases/download/"
-              f"{version}/{wheel}-{version}-py3-none-any.whl"
-          )
-          dep = f'"{package} @ {url}"'
+          dep = f'"{package}=={version}"'
 
           path = Path("pyproject.toml")
           text = path.read_text()


### PR DESCRIPTION
# What does this implement/fix?

Polish for the release automation. Switches the backend dependency pin from a GitHub-release wheel URL to a plain PyPI `package==version`, reorders `build-and-attach` so PyPI publishing happens before the GitHub release goes public (so a PyPI failure leaves the release as a draft), tightens per-job permissions to the minimum each job needs, and post-processes release-notes copy before pasting into the backend bump PR so cross-repo refs/mentions don't mis-link or notify contributors.

Detail per area:

- **App-token plumbing.** All jobs in `release.yml` mint and use the `esphome[bot]` App token via `client-id` + `ESPHOME_GITHUB_APP_CLIENT_ID` (legacy `app-id` / `ESPHOME_GITHUB_APP_ID` plumbing dropped, `actions/create-github-app-token` bumped to v3.1.1). `auto-release.yml`'s caller-side secret pass-through is updated to match.
- **Per-job permissions.** Workflow `GITHUB_TOKEN` defaults to `permissions: {}` and only the jobs that need the implicit token get scopes:
  - `build-and-attach`: `contents: read` (for `actions/checkout`) + `id-token: write` (for `pypa/gh-action-pypi-publish` Trusted Publishing).
  - `bump-backend`: `contents: read` (so `gh release view` can read this repo's release body via the default token, instead of widening the App token's repo scope).
  - `create-release`: nothing — every operation uses the App token explicitly.
- **Caller-side ceiling.** `auto-release.yml`'s `trigger-release` job grants `contents: read` + `id-token: write` to match `release.yml`'s per-job ceilings — without this, the called workflow's OIDC token wouldn't mint and PyPI publishing would fail.
- **Release ordering.** `build-and-attach` now drafts → attaches wheel + sdist → publishes to PyPI → publishes the GitHub release. A PyPI failure leaves the release as a draft instead of going public against a wheel that never landed on PyPI.
- **Backend bump.** Backend `pyproject.toml` is rewritten to `package==version` instead of `package @ <wheel-url>`. The existing regex matches both forms, so the next release rewrites the URL line in place.
- **Release-notes copy.** Before pasting the release body into the backend PR description, qualify bare `#NNN` refs with the source repo (so they resolve to this repo's PRs/issues) and wrap `@user` mentions in backticks (so contributors aren't pinged from a PR on the backend repo).
- **Cleanup.** Drop redundant step-level env vars that re-declare workflow-level env (workflow `env:` is inherited automatically). The `Get release notes` step now runs Python so the regex rewrites are readable inline.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] \`npm run lint\` passes.
  - [ ] \`npm run test\` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).