### PR TITLE
Bump CI Node version from 22.x to 24.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
-  NODE_VERSION: "22.x"
+  NODE_VERSION: "24.x"
   BACKEND_REPO: esphome/device-builder
   PACKAGE_NAME: esphome-device-builder-frontend
   WHEEL_NAME: esphome_device_builder_frontend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: "22.x"
+  NODE_VERSION: "24.x"
 
 jobs:
   test-and-lint:


### PR DESCRIPTION
## Summary

- Bumps `NODE_VERSION` from `22.x` to `24.x` in both `.github/workflows/test.yml` and `.github/workflows/release.yml`.
- Verified locally on Node 24.15.0: `npm ci`, `npm run lint` (tsc --noEmit), `npm test` (218 passed), and `npm run build` all succeed cleanly. Build only emits the pre-existing bundle-size warnings, unrelated to Node version.