### PR TITLE
Cancel in-progress test runs on new pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 env:
   NODE_VERSION: "22.x"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-and-lint:
     name: Test and Lint


### PR DESCRIPTION
## Summary

Adds a `concurrency` group to the Test and Lint workflow keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so a fresh push to a branch or PR cancels any still-running test job for the same ref.