### PR TITLE
Dispatch release workflow instead of calling it (PyPI Trusted Publishing)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-and-release:
@@ -74,11 +74,26 @@ jobs:
   trigger-release:
     needs: check-and-release
     if: needs.check-and-release.outputs.should_release == 'true'
-    permissions:
-      contents: read    # ceiling for release.yml's checkout + gh release view
-      id-token: write   # ceiling for release.yml's PyPI Trusted Publishing
-    uses: ./.github/workflows/release.yml
-    with:
-      version: ${{ needs.check-and-release.outputs.version }}
-    secrets:
-      ESPHOME_GITHUB_APP_PRIVATE_KEY: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      # Dispatch via an app token rather than calling release.yml as a
+      # reusable workflow: PyPI Trusted Publishing matches on the OIDC
+      # `workflow` claim, which is the *caller* under workflow_call.
+      # Dispatching gives release.yml its own run so the claim matches.
+      # The default GITHUB_TOKEN can't trigger workflows, so use the app.
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ needs.check-and-release.outputs.version }}
+        run: |
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f version="$VERSION"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -95,5 +95,5 @@ jobs:
         run: |
           gh workflow run release.yml \
             --repo "${{ github.repository }}" \
-            --ref "${{ github.ref_name }}" \
+            --ref "${{ github.sha }}" \
             -f version="$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,6 @@ on:
         description: "Version number (e.g. 0.2.0)"
         required: true
         type: string
-  workflow_call:
-    inputs:
-      version:
-        description: "Version number (e.g. 0.2.0)"
-        required: true
-        type: string
-    secrets:
-      ESPHOME_GITHUB_APP_PRIVATE_KEY:
-        required: true
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
     name: Build wheel and attach to release
     needs: create-release
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read    # actions/checkout uses the implicit GITHUB_TOKEN
       id-token: write   # OIDC for PyPI Trusted Publishing


### PR DESCRIPTION
# What does this implement/fix?

Flips the auto-release → release linkage so PyPI Trusted Publishing accepts the publish.

PyPI Trusted Publishing matches on the OIDC `workflow` claim, which under `workflow_call` is the *caller* (`auto-release.yml`), not `release.yml` — so the configured trusted publisher (set to `release.yml`) rejects the upload. Switching `auto-release.yml` to dispatch `release.yml` via `gh workflow run` gives it its own run, and the OIDC `workflow` claim matches.

Changes:

- `release.yml`: dropped the `workflow_call` trigger; it is now `workflow_dispatch`-only.
- `auto-release.yml`: replaced the reusable-workflow `uses:` with a job that mints an app token (the default `GITHUB_TOKEN` cannot trigger workflow runs) and runs `gh workflow run release.yml -f version=...`.
- Tightened the top-level `permissions` from `contents: write` to `contents: read` since we no longer need to act as a permission ceiling for a called workflow.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] `npm run lint` passes.
  - [ ] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).