### PR TITLE
Revert release dispatch ref back to ref_name

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -95,5 +95,5 @@ jobs:
         run: |
           gh workflow run release.yml \
             --repo "${{ github.repository }}" \
-            --ref "${{ github.sha }}" \
+            --ref "${{ github.ref_name }}" \
             -f version="$VERSION"


### PR DESCRIPTION
# What does this implement/fix?

Reverts the Copilot autofix from #108 that switched the `gh workflow run release.yml --ref` argument from `github.ref_name` to `github.sha`.

The `workflow_dispatch` API (`POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches`) only accepts a **branch or tag name** in `ref`, not a commit SHA. Passing the SHA 422s with `No ref found for: <sha>`, which is what the most recent auto-release run hit.

`release.yml` pins the build via the tag it creates in `create-release` (`build-and-attach` checks out `ref: \${{ inputs.version }}`), so dispatching from the branch name is sufficient — the dispatch ref doesn't determine what gets built.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] \`npm run lint\` passes.
  - [ ] \`npm run test\` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).