### PR TITLE
Let GitHub create the release tag at publish time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
-# Tags the version, drafts release notes, builds the Python wheel
-# containing the prebuilt frontend, attaches the wheel + sdist to
-# the draft release, publishes the wheel to PyPI, then flips the
-# GitHub release to public, and finally opens / updates a single
-# bump PR on the backend repo so it picks up the new PyPI version.
+# Drafts release notes, builds the Python wheel containing the
+# prebuilt frontend, attaches the wheel + sdist to the draft
+# release, publishes the wheel to PyPI, then flips the GitHub
+# release to public (which creates the tag at the target SHA),
+# and finally opens / updates a single bump PR on the backend
+# repo so it picks up the new PyPI version.
 
 on:
   workflow_dispatch:
@@ -24,7 +25,7 @@ permissions: {}
 
 jobs:
   create-release:
-    name: Tag and draft release
+    name: Draft release
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token
@@ -39,19 +40,13 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Create and push tag
-        run: |
-          git config user.name "esphome[bot]"
-          git config user.email "115708604+esphome[bot]@users.noreply.github.com"
-          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}"
-          git push origin "${{ inputs.version }}"
-
       - name: Generate release notes
         uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
         with:
           config-name: release-drafter.yml
           version: ${{ inputs.version }}
           tag: ${{ inputs.version }}
+          commitish: ${{ github.sha }}
           publish: false
           prerelease: false
         env:
@@ -75,7 +70,10 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.version }}
+          # Tag doesn't exist yet — it's created when the draft release
+          # is published. Build from the SHA the workflow ran on, which
+          # is also what release-drafter targets via commitish.
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,14 @@ env:
 
 permissions: {}
 
+# Only one release run at a time, ever. A second run queues
+# behind the first rather than cancelling it — cancelling
+# mid-publish could leave PyPI and the GitHub release in
+# inconsistent states.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   create-release:
     name: Draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Verify tag does not already exist
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.version }} already exists on origin. Bump the version or delete the existing tag."
+            exit 1
+          fi
+
       - name: Generate release notes
         uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
         with:


### PR DESCRIPTION
# What does this implement/fix?

Drops the manual `git tag` / `git push` step from the release workflow. The draft release is created against the workflow's commit SHA via release-drafter's `commitish` input, and the tag is materialised by GitHub when the draft is flipped to public (the existing `gh release edit --draft=false` step). No upfront tag push, so a re-run after a partial failure never collides with an already-existing tag.

The build job's checkout switches from `ref: ${{ inputs.version }}` (the tag — which no longer exists at build time) to `ref: ${{ github.sha }}`, which is the same SHA release-drafter targets, so the wheel content matches what the published release tags.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] `npm run lint` passes.
  - [ ] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).