### PR TITLE
Add yamllint CI workflow

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,24 @@
+name: yamllint
+
+on:
+  pull_request:
+    paths:
+      - "**/*.yml"
+      - "**/*.yaml"
+      - ".yamllint"
+      - ".github/workflows/yamllint.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run yamllint
+        run: yamllint .

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/yamllint.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  # GitHub Actions workflows use `on:` as a key, which yamllint's
+  # default config flags as a truthy value.
+  truthy:
+    check-keys: false
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
# What does this implement/fix?

Adds a yamllint CI job that runs on pull requests touching any `.yml`/`.yaml` file (or the yamllint config/workflow itself). The job uses the yamllint preinstalled on `ubuntu-latest`, so it's just checkout + lint — no Python setup or pip install needed.

A `.yamllint` config is included that extends the default ruleset with practical tweaks: `truthy.check-keys: false` (GitHub workflows always use `on:` as a key), `line-length` raised to 120 chars at warning level, `document-start` disabled, and relaxed comment spacing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] \`npm run lint\` passes.
  - [x] \`npm run test\` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).