### PR TITLE
Clear draft release assets before re-uploading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,19 @@ jobs:
           rm -rf build *.egg-info
           python3 -m build --wheel --sdist
 
+      - name: Clear existing assets on draft release
+        # On a partial-failure rerun the draft release may already
+        # carry assets from the previous attempt. Strip them so the
+        # upload starts from a clean slate.
+        run: |
+          gh release view "${{ inputs.version }}" --json assets --jq '.assets[].name' \
+            | while IFS= read -r asset; do
+                [ -z "$asset" ] && continue
+                gh release delete-asset "${{ inputs.version }}" "$asset" --yes
+              done
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - name: Attach to release
         run: gh release upload "${{ inputs.version }}" dist/*.whl dist/*.tar.gz
         env:


### PR DESCRIPTION
# What does this implement/fix?

A partial-failure rerun of the release workflow could leave the draft release carrying assets from the previous attempt; the next upload step would then either error on duplicates or pile stale files alongside the new ones. This adds a step that enumerates assets on the draft release via `gh release view --json assets` and deletes each one with `gh release delete-asset --yes` before the upload, so every run starts from a clean slate.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] `npm run lint` passes.
  - [ ] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).