### PR TITLE
Split release workflow into discrete jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" --silent 2>/dev/null; then
+          set -euo pipefail
+          # Capture both streams + exit code so we can distinguish a
+          # genuine "tag missing" 404 from any other failure (auth,
+          # rate limit, transient 5xx). A bare ``if gh api …`` would
+          # silently swallow those and let the workflow proceed.
+          set +e
+          output=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" 2>&1)
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
             echo "::error::Tag $VERSION already exists. Bump the version."
             exit 1
           fi
+
+          if grep -qi "HTTP 404\|Not Found" <<<"$output"; then
+            echo "Tag $VERSION does not exist; proceeding."
+            exit 0
+          fi
+
+          echo "::error::Failed to check whether tag $VERSION exists (gh api exit $status):"
+          echo "$output"
+          exit 1
 
   build:
     name: Build wheel and sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
             echo "::error::Tag '${{ inputs.version }}' already exists. Pick a new version."
             exit 1
           elif ! grep -q "HTTP 404" <<<"$err"; then
-            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists: $err"
+            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists."
+            echo "gh api stderr:"
+            echo "$err"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
 name: Release
 
-# Drafts release notes, builds the Python wheel containing the
-# prebuilt frontend, attaches the wheel + sdist to the draft
-# release, publishes the wheel to PyPI, then flips the GitHub
-# release to public (which creates the tag at the target SHA),
-# and finally opens / updates a single bump PR on the backend
-# repo so it picks up the new PyPI version.
+# Cuts a release. Validates the requested version, builds the
+# Python wheel + sdist (containing the prebuilt frontend), drafts
+# a GitHub release with assets attached, publishes the wheel to
+# PyPI, then flips the GitHub release to public (which creates
+# the tag at the recorded commitish), and finally opens / updates
+# a single bump PR on the backend repo so it picks up the new
+# PyPI version.
 
 on:
   workflow_dispatch:
@@ -32,63 +33,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  create-release:
-    name: Draft release
+  validate:
+    name: Validate version and tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # gh api reads git refs on this repo
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token }}
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' must be X.Y.Z."
+            exit 1
+          fi
+          echo "Version $VERSION is valid."
 
       - name: Verify tag does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ inputs.version }} already exists on origin. Bump the version or delete the existing tag."
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" --silent 2>/dev/null; then
+            echo "::error::Tag $VERSION already exists. Bump the version."
             exit 1
           fi
 
-      - name: Generate release notes
-        uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
-        with:
-          config-name: release-drafter.yml
-          version: ${{ inputs.version }}
-          tag: ${{ inputs.version }}
-          commitish: ${{ github.sha }}
-          publish: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-  build-and-attach:
-    name: Build wheel and attach to release
-    needs: create-release
+  build:
+    name: Build wheel and sdist
+    needs: validate
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read    # actions/checkout uses the implicit GITHUB_TOKEN
-      id-token: write   # OIDC for PyPI Trusted Publishing
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Tag doesn't exist yet — it's created when the draft release
           # is published. Build from the SHA the workflow ran on, which
           # is also what release-drafter targets via commitish.
           ref: ${{ github.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -134,6 +117,48 @@ jobs:
           rm -rf build *.egg-info
           python3 -m build --wheel --sdist
 
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  draft-release:
+    name: Draft GitHub release and attach assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Generate release notes (draft)
+        uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
+        with:
+          config-name: release-drafter.yml
+          version: ${{ inputs.version }}
+          tag: ${{ inputs.version }}
+          commitish: ${{ github.sha }}
+          publish: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
       - name: Clear existing assets on draft release
         # On a partial-failure rerun the draft release may already
         # carry assets from the previous attempt. Strip them so the
@@ -147,10 +172,26 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
-      - name: Attach to release
+      - name: Attach artifacts to draft release
         run: gh release upload "${{ inputs.version }}" dist/*.whl dist/*.tar.gz
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: draft-release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/esphome-device-builder-frontend/${{ inputs.version }}/
+    permissions:
+      id-token: write   # OIDC for PyPI Trusted Publishing
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -160,15 +201,39 @@ jobs:
           # blow up on the duplicate version.
           skip-existing: true
 
+  publish-release:
+    name: Publish GitHub release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    environment:
+      name: gh-release
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Publish release
-        run: gh release edit "${{ inputs.version }}" --draft=false
+        # Flipping draft → public causes GitHub to create the tag
+        # at the recorded ``commitish`` SHA, attributed to the app
+        # token (esphome[bot]).
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: gh release edit "${{ inputs.version }}" --draft=false
 
   bump-backend:
     name: Open bump PR on backend
-    needs: build-and-attach
+    needs: publish-release
     runs-on: ubuntu-latest
+    environment:
+      name: backend
+      url: ${{ steps.bump-pr.outputs.pull-request-url }}
     permissions:
       contents: read    # GITHUB_TOKEN reads this repo's release body
     steps:
@@ -267,6 +332,7 @@ jobs:
           PY
 
       - name: Open / update PR
+        id: bump-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
     name: Build wheel and sdist
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # actions/checkout uses the implicit GITHUB_TOKEN
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -127,6 +129,8 @@ jobs:
     name: Draft GitHub release and attach assets
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # actions/checkout uses the implicit GITHUB_TOKEN; release writes go via the app token
     steps:
       - name: Generate a token
         id: generate-token
@@ -208,6 +212,7 @@ jobs:
     environment:
       name: gh-release
       url: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+    permissions: {}   # all GitHub writes go via the app token
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,31 +53,20 @@ jobs:
       - name: Verify tag does not already exist
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          # Capture both streams + exit code so we can distinguish a
-          # genuine "tag missing" 404 from any other failure (auth,
-          # rate limit, transient 5xx). A bare ``if gh api …`` would
-          # silently swallow those and let the workflow proceed.
-          set +e
-          output=$(gh api "repos/${{ github.repository }}/git/ref/tags/$VERSION" 2>&1)
-          status=$?
-          set -e
-
-          if [ "$status" -eq 0 ]; then
-            echo "::error::Tag $VERSION already exists. Bump the version."
+          # `gh api` exits 0 on 2xx and non-zero on any other outcome
+          # (HTTP error or transport failure), so a bare exit-code check
+          # can't tell "tag doesn't exist" apart from "the network ate
+          # the request". Capture stderr and require an HTTP 404 before
+          # treating the tag as absent — anything else fails loudly.
+          if err=$(gh api "repos/${{ github.repository }}/git/refs/tags/${{ inputs.version }}" --silent 2>&1); then
+            echo "::error::Tag '${{ inputs.version }}' already exists. Pick a new version."
+            exit 1
+          elif ! grep -q "HTTP 404" <<<"$err"; then
+            echo "::error::Failed to check whether tag '${{ inputs.version }}' exists: $err"
             exit 1
           fi
-
-          if grep -qi "HTTP 404\|Not Found" <<<"$output"; then
-            echo "Tag $VERSION does not exist; proceeding."
-            exit 0
-          fi
-
-          echo "::error::Failed to check whether tag $VERSION exists (gh api exit $status):"
-          echo "$output"
-          exit 1
 
   build:
     name: Build wheel and sdist


### PR DESCRIPTION
# What does this implement/fix?

Restructures the release pipeline so each phase is a discrete job, mirroring the [backend-side overhaul](https://github.com/esphome/device-builder/pull/272). New job topology:

```
validate → build → draft-release → publish-pypi → publish-release → bump-backend
```

- **validate** — checks the version format (`X.Y.Z`) and confirms the tag does not already exist via `gh api`. No checkout needed.
- **build** — version-stamps `pyproject.toml` + `package.json`, builds the frontend bundle and Python wheel + sdist, then uploads `dist/` as an artifact. Drops the now-unneeded GitHub App token.
- **draft-release** — drafts the release with release-drafter (`publish: false`, `commitish: \${{ github.sha }}`), downloads the dist artifact, clears stale assets on partial-failure reruns, and attaches the wheel + sdist.
- **publish-pypi** — downloads the dist artifact and publishes to PyPI via Trusted Publishing. Carries the `pypi` deployment environment with a URL to the project page.
- **publish-release** — flips the draft release to public via `gh release edit --draft=false`, which creates the tag at the recorded commitish. Carries the `gh-release` deployment environment.
- **bump-backend** — now gated on `publish-release` so the bump PR only opens after the release is actually live. Carries a `backend` deployment environment whose URL resolves to the resulting bump-PR URL via `peter-evans/create-pull-request`'s `pull-request-url` output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] \`npm run lint\` passes.
  - [ ] \`npm run test\` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).