### PR TITLE
section editor: live-yaml splice + stale-fromLine resolver

### DIFF
--- a/src/components/device/device-board-info-helpers.ts
+++ b/src/components/device/device-board-info-helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure helpers for `device-board-info`. Extracted so the test
+ * can import them without pulling in the webawesome
+ * CSSStyleSheet polyfill that the component itself registers
+ * eagerly (and which fails in a Node environment).
+ */
+
+/**
+ * True when the YAML transitioned from "no content" (empty,
+ * `undefined` initial, or `null`) to a non-empty value. Two
+ * real cases qualify:
+ *
+ *   - First-time arrival on page load (the page's
+ *     `_api.getConfig` resolved after the section editor was
+ *     deep-linked). Without bypassing the debounce, the form
+ *     would sit empty for a full coalesce window.
+ *   - User cleared the YAML pane and pasted new content. The
+ *     next input deserves immediate feedback — nothing to
+ *     coalesce against.
+ *
+ * The debounce only earns its keep against rapid yaml
+ * mutations (typing in the editor pane); these transitions
+ * have no spam risk and a perceptible empty-form window if
+ * gated.
+ */
+export function isEmptyToPopulatedYamlChange(
+  prev: string | undefined | null,
+  next: string,
+): boolean {
+  return !prev && !!next;
+}

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -97,8 +97,12 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   private _reloadTimer: ReturnType<typeof setTimeout> | null = null;
 
   updated(changedProperties: Map<string, unknown>) {
+    // Canonical yaml-watcher for the section editor. Debounce so
+    // typing in the YAML editor pane doesn't spam the schema
+    // fetch every keystroke; section-config's `reload()` itself
+    // gates on `!_dirty` so mid-edit pastes don't clobber the
+    // form.
     if (changedProperties.has("yaml") && this.selectedSection && this._sectionConfig) {
-      // Debounce reload so typing in the YAML editor doesn't spam the API
       if (this._reloadTimer) clearTimeout(this._reloadTimer);
       this._reloadTimer = setTimeout(() => this._sectionConfig?.reload(), 1000);
     }

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -102,7 +102,14 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // `reload()` per debounce window, but bypass the debounce
     // on the empty-to-populated transition (page-load arrival,
     // user cleared the pane and pasted new content) so the
-    // section editor's empty-form window is a render-frame
+    // section editor's empty-form window is bounded by the
+    // next render frame rather than a full coalesce window.
+    //
+    // Calling `reload()` synchronously from `updated()` is the
+    // right shape here: `reload()` mutates the child's `@state`,
+    // which Lit batches into the same render pass that's about
+    // to run anyway — no extra paint, no recursion. A separate
+    // `requestAnimationFrame` would just delay the effect.
     if (changedProperties.has("yaml") && this.selectedSection && this._sectionConfig) {
       if (this._reloadTimer) clearTimeout(this._reloadTimer);
       const prev = changedProperties.get("yaml") as string | undefined;

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -111,9 +111,15 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // to run anyway — no extra paint, no recursion. A separate
     // `requestAnimationFrame` would just delay the effect.
     if (changedProperties.has("yaml") && this.selectedSection && this._sectionConfig) {
-      if (this._reloadTimer) clearTimeout(this._reloadTimer);
+      if (this._reloadTimer) {
+        clearTimeout(this._reloadTimer);
+        this._reloadTimer = null;
+      }
       const prev = changedProperties.get("yaml") as string | undefined;
       if (isEmptyToPopulatedYamlChange(prev, this.yaml)) {
+        // Synchronous bypass: no timer to track, leave
+        // `_reloadTimer` at its just-cleared `null` so the
+        // "null means no timer" invariant holds.
         this._sectionConfig.reload();
       } else {
         this._reloadTimer = setTimeout(() => this._sectionConfig?.reload(), 1000);

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -14,6 +14,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { isEmptyToPopulatedYamlChange } from "./device-board-info-helpers.js";
 import { AUTOMATIONS_ENABLED } from "../../feature-flags.js";
 import { espHomeStyles } from "../../styles/shared.js";
 
@@ -97,25 +98,19 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   private _reloadTimer: ReturnType<typeof setTimeout> | null = null;
 
   updated(changedProperties: Map<string, unknown>) {
-    // Canonical yaml-watcher for the section editor. Debounce so
-    // typing in the YAML editor pane doesn't spam the schema
-    // fetch every keystroke; section-config's `reload()` itself
-    // gates on `!_dirty` so mid-edit pastes don't clobber the
-    // form.
+    // Coalesce typing in the YAML editor pane to one
+    // `reload()` per debounce window, but bypass the debounce
+    // on the empty-to-populated transition (page-load arrival,
+    // user cleared the pane and pasted new content) so the
+    // section editor's empty-form window is a render-frame
     if (changedProperties.has("yaml") && this.selectedSection && this._sectionConfig) {
       if (this._reloadTimer) clearTimeout(this._reloadTimer);
-      // Initial-load transition (`""` → real yaml): reload
-      // immediately. The section editor renders with an empty
-      // form until the first reload, so a 1s gate would leave
-      // the user staring at a blank form on every page load
-      // when deep-linked to a selected section. Subsequent
-      // changes keep the debounce.
       const prev = changedProperties.get("yaml") as string | undefined;
-      const delay = !prev && this.yaml ? 0 : 1000;
-      this._reloadTimer = setTimeout(
-        () => this._sectionConfig?.reload(),
-        delay,
-      );
+      if (isEmptyToPopulatedYamlChange(prev, this.yaml)) {
+        this._sectionConfig.reload();
+      } else {
+        this._reloadTimer = setTimeout(() => this._sectionConfig?.reload(), 1000);
+      }
     }
   }
 

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -104,7 +104,18 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
     // form.
     if (changedProperties.has("yaml") && this.selectedSection && this._sectionConfig) {
       if (this._reloadTimer) clearTimeout(this._reloadTimer);
-      this._reloadTimer = setTimeout(() => this._sectionConfig?.reload(), 1000);
+      // Initial-load transition (`""` → real yaml): reload
+      // immediately. The section editor renders with an empty
+      // form until the first reload, so a 1s gate would leave
+      // the user staring at a blank form on every page load
+      // when deep-linked to a selected section. Subsequent
+      // changes keep the debounce.
+      const prev = changedProperties.get("yaml") as string | undefined;
+      const delay = !prev && this.yaml ? 0 : 1000;
+      this._reloadTimer = setTimeout(
+        () => this._sectionConfig?.reload(),
+        delay,
+      );
     }
   }
 

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -378,6 +378,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
               .configuration=${this.configuration}
               .sectionKey=${this.selectedSection}
               .fromLine=${this.selectedFromLine}
+              .yaml=${this.yaml}
               .board=${this.board}
               ?yamlPaneVisible=${this.yamlPaneVisible}
             ></esphome-device-section-config>

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -172,6 +172,17 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @state()
   private _presentComponents: Set<string> = new Set();
 
+  /** Section's resolved `fromLine` against the *current* yaml,
+   *  recomputed each `_loadConfig`. Forwarded to the embedded
+   *  form so its conflict-detection (which skips the user's
+   *  own pin via `fromLine`) stays aligned with what the read
+   *  + write paths see. `undefined` when the section can't be
+   *  located in the live yaml — the form treats that as "no
+   *  exclusion" which is the right call for a not-found
+   *  section. */
+  @state()
+  private _resolvedFromLine?: number;
+
   @query("esphome-config-entry-form")
   private _form?: ESPHomeConfigEntryForm;
 
@@ -284,11 +295,26 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         image_url: component.image_url,
         entries: component.config_entries,
       };
+      // Resolve `fromLine` against the live YAML on the read
+      // path too — the cached `this.fromLine` can be stale by
+      // the time `reload()` fires (board-info debounces on
+      // yaml changes), and re-seeding from a stale line would
+      // populate the form with the wrong section's values.
+      // When the resolver can't find the section at all (key
+      // gone from yaml, empty pane), pass `undefined` so the
+      // parser falls back to its own column-0 scan (which
+      // won't match a dotted platform key, yielding `{}` —
+      // an empty form, the right outcome for a section that
+      // no longer exists).
+      const resolvedFromLine =
+        resolveCurrentFromLine(yaml, this.sectionKey, this.fromLine) ??
+        undefined;
       this._values = parseYamlSectionValues(
         yaml,
         this.sectionKey,
-        this.fromLine,
+        resolvedFromLine,
       );
+      this._resolvedFromLine = resolvedFromLine;
       this._presentComponents = parseTopLevelComponents(yaml);
     } catch (e) {
       if (id !== this._loadId) return;
@@ -397,7 +423,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
               .errors=${this._fieldErrors}
               .board=${this.board}
               .yaml=${this.yaml}
-              .fromLine=${this.fromLine}
+              .fromLine=${this._resolvedFromLine}
               .presentComponents=${this._presentComponents}
               ?disabled=${this._saving}
               ?show-advanced=${showAdvanced}

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -97,6 +97,19 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @property({ type: Number })
   fromLine?: number;
 
+  /**
+   * Live YAML for the device — the same string the YAML pane on
+   * the right shows, including any unsaved edits. Save and delete
+   * operate on this rather than re-fetching from the server: the
+   * navigator emits `fromLine` relative to the *live* YAML, so an
+   * out-of-sync saved version would point the splice at the
+   * wrong line and clobber a different section. The page that
+   * owns this state (`pages/device.ts`) feeds it through
+   * `device-board-info`.
+   */
+  @property()
+  yaml = "";
+
   /** Whether the device editor's YAML pane is currently visible.
    *  When it isn't, the YAML-only notice grows a "Show YAML editor"
    *  button so the user can reach the editor in one click. */
@@ -206,7 +219,12 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         return;
       }
 
-      const yaml = await this._api.getConfig(this.configuration);
+      // Use the live YAML the parent passes in; `fromLine` is
+      // relative to that. A `_api.getConfig` re-fetch would
+      // disagree with the user-visible YAML when the editor
+      // pane has unsaved edits and seed the form from a
+      // different section than the one they clicked.
+      const yaml = this.yaml;
 
       if (id !== this._loadId) return;
 
@@ -409,13 +427,16 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     this._error = "";
     const title = this._config.title;
     try {
-      const yaml = await this._api.getConfig(this.configuration);
+      // Same rationale as `_onSave`: operate on the live YAML the
+      // page passes in, not a re-fetch — `this.fromLine` is
+      // relative to the live YAML the navigator most recently
+      // parsed.
       const newYaml = removeSectionFromYaml(
-        yaml,
+        this.yaml,
         this.sectionKey,
         this.fromLine,
       );
-      if (newYaml === yaml) {
+      if (newYaml === this.yaml) {
         this._error = this._localize("device.section_delete_error");
         return;
       }
@@ -524,9 +545,13 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     this._saving = true;
     this._error = "";
     try {
-      const yaml = await this._api.getConfig(this.configuration);
+      // Operate on the live YAML the page hands us — `this.fromLine`
+      // is relative to whatever the navigator most recently parsed,
+      // and that's the live YAML, not the server's. Re-fetching
+      // would mismatch line numbers when the YAML pane has unsaved
+      // edits and write the wrong section.
       const newYaml = updateSectionInYaml(
-        yaml,
+        this.yaml,
         this.sectionKey,
         this._values,
         this.fromLine,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -231,12 +231,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * splice is structurally impossible when we don't proceed
    * without a resolved line.
    *
-   * Asymmetric on purpose with the read path (`_loadConfig`):
-   * the read path is reactive (driven by `reload()` from
-   * external yaml mutation, not user intent), so a popup error
-   * for "section vanished" would feel intrusive — it surfaces
-   * an empty form instead. The save / delete paths fire from
-   * an explicit user action so an error is the right
+   * Asymmetric on purpose with the read / load path: that path
+   * is reactive (driven by external yaml mutation, not user
+   * intent), so a popup error for "section vanished" would feel
+   * intrusive — it surfaces an empty form instead. Save / delete
+   * fire from an explicit user action, so an error is the right
    * acknowledgement.
    *
    * `notFoundErrorKey` is the localize key surfaced

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -30,6 +30,7 @@ import {
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../util/yaml-section-values.js";
+import { resolveCurrentFromLine } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -191,6 +192,45 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     ) {
       this._loadConfig();
     }
+  }
+
+  /**
+   * Resolve the splice context for save / delete — the live YAML
+   * and a current, validated `fromLine`. Sets `_error` and
+   * returns `null` when either is missing so callers surface the
+   * failure instead of running the splice with stale inputs.
+   *
+   * Empty `this.yaml` means a parent forgot to wire the prop;
+   * without the guard, `updateSectionInYaml("", ...)` would emit
+   * `""` and the parent's `updateConfig` call would silently
+   * clobber the device's entire config. Stale `this.fromLine`
+   * happens when the YAML pane shifted after section selection
+   * (paste / external edit) — `resolveCurrentFromLine` re-finds
+   * the section by key against the live YAML.
+   *
+   * `notFoundErrorKey` is the localize key surfaced on the
+   * section-not-found path (`device.save_error` /
+   * `device.section_delete_error`). The empty-prop case uses a
+   * fixed dev-facing string because that branch should never
+   * reach a real user.
+   */
+  private _resolveSpliceContext(
+    notFoundErrorKey: string,
+  ): { yaml: string; fromLine: number } | null {
+    if (!this.yaml) {
+      this._error = "Internal error: section editor missing yaml prop";
+      return null;
+    }
+    const fromLine = resolveCurrentFromLine(
+      this.yaml,
+      this.sectionKey,
+      this.fromLine,
+    );
+    if (fromLine === null) {
+      this._error = this._localize(notFoundErrorKey);
+      return null;
+    }
+    return { yaml: this.yaml, fromLine };
   }
 
   /** Reload config from the live YAML if the form has no unsaved
@@ -430,28 +470,18 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private async _onDeleteConfirmed() {
     if (!this._config) return;
-    // Defensive: same rationale as `_onSave` — without `this.yaml`
-    // the splice produces `""` and the parent would commit empty
-    // YAML, clobbering the entire config. Surface the failure
-    // rather than silently no-op'ing.
-    if (!this.yaml) {
-      this._error = "Internal error: section editor missing yaml prop";
-      return;
-    }
+    const ctx = this._resolveSpliceContext("device.section_delete_error");
+    if (!ctx) return;
     this._deleting = true;
     this._error = "";
     const title = this._config.title;
     try {
-      // Same rationale as `_onSave`: operate on the live YAML the
-      // page passes in, not a re-fetch — `this.fromLine` is
-      // relative to the live YAML the navigator most recently
-      // parsed.
       const newYaml = removeSectionFromYaml(
-        this.yaml,
+        ctx.yaml,
         this.sectionKey,
-        this.fromLine,
+        ctx.fromLine,
       );
-      if (newYaml === this.yaml) {
+      if (newYaml === ctx.yaml) {
         this._error = this._localize("device.section_delete_error");
         return;
       }
@@ -545,16 +575,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private async _onSave() {
     if (!this._config) return;
-    // Defensive: bail early if the parent forgot to wire the
-    // `yaml` prop. Without this, `updateSectionInYaml("", ...)`
-    // would emit `""` and the parent's `updateConfig` call would
-    // silently clobber the device's entire config. Surface a
-    // visible error too so the failure isn't a silent no-op
-    // when a future parent regresses.
-    if (!this.yaml) {
-      this._error = "Internal error: section editor missing yaml prop";
-      return;
-    }
     const errors = validateEntries(
       this._config.entries,
       this._values,
@@ -567,19 +587,16 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       return;
     }
     this._fieldErrors = new Map();
+    const ctx = this._resolveSpliceContext("device.save_error");
+    if (!ctx) return;
     this._saving = true;
     this._error = "";
     try {
-      // Operate on the live YAML the page hands us — `this.fromLine`
-      // is relative to whatever the navigator most recently parsed,
-      // and that's the live YAML, not the server's. Re-fetching
-      // would mismatch line numbers when the YAML pane has unsaved
-      // edits and write the wrong section.
       const newYaml = updateSectionInYaml(
-        this.yaml,
+        ctx.yaml,
         this.sectionKey,
         this._values,
-        this.fromLine,
+        ctx.fromLine,
       );
       const title = this._config.title;
       this._api.updateConfig(this.configuration, newYaml).catch((e) => {

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -222,13 +222,22 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * surface the failure with a localised error instead of running
    * the splice with stale inputs.
    *
-   * `resolveCurrentFromLine` returns `null` for empty / unbound
-   * `this.yaml` AND for "section key no longer present in the
-   * live YAML" (user pasted away the section, cleared the editor,
-   * or the cached `fromLine` shifted past a now-removed key).
-   * All three collapse to the same user-facing error — clobbering
-   * config with an empty-string splice is structurally
-   * impossible when we don't proceed without a resolved line.
+   * `resolveCurrentFromLine` returns `undefined` for empty /
+   * unbound `this.yaml` AND for "section key no longer present
+   * in the live YAML" (user pasted away the section, cleared
+   * the editor, or the cached `fromLine` shifted past a
+   * now-removed key). All three collapse to the same
+   * user-facing error — clobbering config with an empty-string
+   * splice is structurally impossible when we don't proceed
+   * without a resolved line.
+   *
+   * Asymmetric on purpose with the read path (`_loadConfig`):
+   * the read path is reactive (driven by `reload()` from
+   * external yaml mutation, not user intent), so a popup error
+   * for "section vanished" would feel intrusive — it surfaces
+   * an empty form instead. The save / delete paths fire from
+   * an explicit user action so an error is the right
+   * acknowledgement.
    *
    * `notFoundErrorKey` is the localize key surfaced
    * (`device.save_error` / `device.section_delete_error`).
@@ -304,23 +313,14 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         image_url: component.image_url,
         entries: component.config_entries,
       };
-      // Resolve `fromLine` against the live YAML on the read
-      // path too — the cached `this.fromLine` can be stale by
-      // the time `reload()` fires (board-info debounces on
-      // yaml changes), and re-seeding from a stale line would
-      // populate the form with the wrong section's values.
-      // When the resolver can't find the section at all (key
-      // gone from yaml, empty pane), the parser is called with
-      // `undefined` so its column-0 scan won't match a dotted
-      // platform key — values come back `{}` and the form
-      // surfaces empty.
-      //
-      // Asymmetric with save / delete (which surface a
-      // localised error in the same case): the read path is
-      // reactive (`reload()` fires from external yaml mutation,
-      // not user intent) so a popup error would feel intrusive
-      // for what's just "the underlying section vanished — show
-      // an empty form until the user decides what to do".
+      // Resolve `fromLine` against the live YAML — see
+      // `_resolveSpliceContext` for the contract and the
+      // documented asymmetry between this read path
+      // (silent-empty on missing section) and the save / delete
+      // paths (localised error). When the resolver returns
+      // `undefined`, the parser's column-0 scan won't match a
+      // dotted platform key, so values come back `{}` and the
+      // form surfaces empty.
       const resolvedFromLine = resolveCurrentFromLine(
         yaml,
         this.sectionKey,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -194,10 +194,12 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   }
 
   /** Reload config from the live YAML if the form has no unsaved
-   *  changes. `device-board-info` debounces this against `yaml`
-   *  prop changes so paste / external mutations re-seed a clean
-   *  form (and skip mid-edit reloads to avoid clobbering unsaved
-   *  field changes). */
+   *  changes. The canonical caller is `device-board-info`'s
+   *  `updated()` hook (`device-board-info.ts`, `_reloadTimer`),
+   *  which debounces this against `yaml` prop changes so paste /
+   *  external mutations re-seed a clean form. The dirty-check
+   *  here keeps mid-edit reloads from clobbering unsaved field
+   *  changes — board-info delegates the gating to us. */
   public reload() {
     if (!this._dirty && this.sectionKey && this.configuration) {
       this._loadConfig();
@@ -430,8 +432,12 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     if (!this._config) return;
     // Defensive: same rationale as `_onSave` — without `this.yaml`
     // the splice produces `""` and the parent would commit empty
-    // YAML, clobbering the entire config.
-    if (!this.yaml) return;
+    // YAML, clobbering the entire config. Surface the failure
+    // rather than silently no-op'ing.
+    if (!this.yaml) {
+      this._error = "Internal error: section editor missing yaml prop";
+      return;
+    }
     this._deleting = true;
     this._error = "";
     const title = this._config.title;
@@ -542,8 +548,13 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     // Defensive: bail early if the parent forgot to wire the
     // `yaml` prop. Without this, `updateSectionInYaml("", ...)`
     // would emit `""` and the parent's `updateConfig` call would
-    // silently clobber the device's entire config.
-    if (!this.yaml) return;
+    // silently clobber the device's entire config. Surface a
+    // visible error too so the failure isn't a silent no-op
+    // when a future parent regresses.
+    if (!this.yaml) {
+      this._error = "Internal error: section editor missing yaml prop";
+      return;
+    }
     const errors = validateEntries(
       this._config.entries,
       this._values,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -108,11 +108,12 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * owns this state (`pages/device.ts`) feeds it through
    * `device-board-info`.
    *
-   * Default `""` keeps the property optional for the (currently
-   * single) consumer; `_onSave` and `_onDeleteConfirmed` bail
-   * defensively when `this.yaml === ""` so a forgotten binding
-   * in a future parent can't silently clobber the device's
-   * config with an empty splice.
+   * Empty / unbound values are caught at the splice site by
+   * `resolveCurrentFromLine` returning `null` — the splice
+   * never runs without a resolved `fromLine`, so an empty YAML
+   * (user cleared the pane) and a missing prop binding both
+   * surface as a localised section-not-found error rather than
+   * an empty-string clobber.
    */
   @property()
   yaml = "";
@@ -197,30 +198,27 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   /**
    * Resolve the splice context for save / delete — the live YAML
    * and a current, validated `fromLine`. Sets `_error` and
-   * returns `null` when either is missing so callers surface the
-   * failure instead of running the splice with stale inputs.
+   * returns `null` when the section can't be located so callers
+   * surface the failure with a localised error instead of running
+   * the splice with stale inputs.
    *
-   * Empty `this.yaml` means a parent forgot to wire the prop;
-   * without the guard, `updateSectionInYaml("", ...)` would emit
-   * `""` and the parent's `updateConfig` call would silently
-   * clobber the device's entire config. Stale `this.fromLine`
-   * happens when the YAML pane shifted after section selection
-   * (paste / external edit) — `resolveCurrentFromLine` re-finds
-   * the section by key against the live YAML.
+   * `resolveCurrentFromLine` returns `null` for empty / unbound
+   * `this.yaml` AND for "section key no longer present in the
+   * live YAML" (user pasted away the section, cleared the editor,
+   * or the cached `fromLine` shifted past a now-removed key).
+   * All three collapse to the same user-facing error — clobbering
+   * config with an empty-string splice is structurally
+   * impossible when we don't proceed without a resolved line.
    *
-   * `notFoundErrorKey` is the localize key surfaced on the
-   * section-not-found path (`device.save_error` /
-   * `device.section_delete_error`). The empty-prop case uses a
-   * fixed dev-facing string because that branch should never
-   * reach a real user.
+   * `notFoundErrorKey` is the localize key surfaced
+   * (`device.save_error` / `device.section_delete_error`).
    */
   private _resolveSpliceContext(
-    notFoundErrorKey: string,
+    // Closed union so a typo at the call site (the only two
+    // surfacing paths) fails to compile rather than silently
+    // resolving to the locale key as English.
+    notFoundErrorKey: "device.save_error" | "device.section_delete_error",
   ): { yaml: string; fromLine: number } | null {
-    if (!this.yaml) {
-      this._error = "Internal error: section editor missing yaml prop";
-      return null;
-    }
     const fromLine = resolveCurrentFromLine(
       this.yaml,
       this.sectionKey,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -95,6 +95,15 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @property()
   sectionKey = "";
 
+  /**
+   * Cached `fromLine` from the navigator's emit at click time.
+   * Use `_resolvedFromLine` (re-resolved against the live YAML
+   * via `resolveCurrentFromLine`) for any actual operation —
+   * read, save, or delete. This value goes stale as soon as
+   * the YAML pane shifts, but is still useful as a "stale hint"
+   * to disambiguate same-key duplicates: a small shift maps
+   * the click back to the closest match.
+   */
   @property({ type: Number })
   fromLine?: number;
 
@@ -109,7 +118,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * `device-board-info`.
    *
    * Empty / unbound values are caught at the splice site by
-   * `resolveCurrentFromLine` returning `null` — the splice
+   * `resolveCurrentFromLine` returning `undefined` — the splice
    * never runs without a resolved `fromLine`, so an empty YAML
    * (user cleared the pane) and a missing prop binding both
    * surface as a localised section-not-found error rather than
@@ -235,7 +244,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       this.sectionKey,
       this.fromLine,
     );
-    if (fromLine === null) {
+    if (fromLine === undefined) {
       this._error = this._localize(notFoundErrorKey);
       return null;
     }
@@ -301,14 +310,22 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       // yaml changes), and re-seeding from a stale line would
       // populate the form with the wrong section's values.
       // When the resolver can't find the section at all (key
-      // gone from yaml, empty pane), pass `undefined` so the
-      // parser falls back to its own column-0 scan (which
-      // won't match a dotted platform key, yielding `{}` —
-      // an empty form, the right outcome for a section that
-      // no longer exists).
-      const resolvedFromLine =
-        resolveCurrentFromLine(yaml, this.sectionKey, this.fromLine) ??
-        undefined;
+      // gone from yaml, empty pane), the parser is called with
+      // `undefined` so its column-0 scan won't match a dotted
+      // platform key — values come back `{}` and the form
+      // surfaces empty.
+      //
+      // Asymmetric with save / delete (which surface a
+      // localised error in the same case): the read path is
+      // reactive (`reload()` fires from external yaml mutation,
+      // not user intent) so a popup error would feel intrusive
+      // for what's just "the underlying section vanished — show
+      // an empty form until the user decides what to do".
+      const resolvedFromLine = resolveCurrentFromLine(
+        yaml,
+        this.sectionKey,
+        this.fromLine,
+      );
       this._values = parseYamlSectionValues(
         yaml,
         this.sectionKey,

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -106,6 +106,12 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * wrong line and clobber a different section. The page that
    * owns this state (`pages/device.ts`) feeds it through
    * `device-board-info`.
+   *
+   * Default `""` keeps the property optional for the (currently
+   * single) consumer; `_onSave` and `_onDeleteConfirmed` bail
+   * defensively when `this.yaml === ""` so a forgotten binding
+   * in a future parent can't silently clobber the device's
+   * config with an empty splice.
    */
   @property()
   yaml = "";
@@ -164,10 +170,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @state()
   private _presentComponents: Set<string> = new Set();
 
-  /** Full YAML — needed by the embedded form for ID / pin lookups. */
-  @state()
-  private _yaml = "";
-
   @query("esphome-config-entry-form")
   private _form?: ESPHomeConfigEntryForm;
 
@@ -191,7 +193,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     }
   }
 
-  /** Reload config from backend if the form has no unsaved changes. */
+  /** Reload config from the live YAML if the form has no unsaved
+   *  changes. `device-board-info` debounces this against `yaml`
+   *  prop changes so paste / external mutations re-seed a clean
+   *  form (and skip mid-edit reloads to avoid clobbering unsaved
+   *  field changes). */
   public reload() {
     if (!this._dirty && this.sectionKey && this.configuration) {
       this._loadConfig();
@@ -244,7 +250,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         this.fromLine,
       );
       this._presentComponents = parseTopLevelComponents(yaml);
-      this._yaml = yaml;
     } catch (e) {
       if (id !== this._loadId) return;
       const msg = e instanceof Error ? e.message : "";
@@ -351,7 +356,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
               .values=${this._values}
               .errors=${this._fieldErrors}
               .board=${this.board}
-              .yaml=${this._yaml}
+              .yaml=${this.yaml}
               .fromLine=${this.fromLine}
               .presentComponents=${this._presentComponents}
               ?disabled=${this._saving}
@@ -423,6 +428,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private async _onDeleteConfirmed() {
     if (!this._config) return;
+    // Defensive: same rationale as `_onSave` — without `this.yaml`
+    // the splice produces `""` and the parent would commit empty
+    // YAML, clobbering the entire config.
+    if (!this.yaml) return;
     this._deleting = true;
     this._error = "";
     const title = this._config.title;
@@ -530,6 +539,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private async _onSave() {
     if (!this._config) return;
+    // Defensive: bail early if the parent forgot to wire the
+    // `yaml` prop. Without this, `updateSectionInYaml("", ...)`
+    // would emit `""` and the parent's `updateConfig` call would
+    // silently clobber the device's entire config.
+    if (!this.yaml) return;
     const errors = validateEntries(
       this._config.entries,
       this._values,

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -110,6 +110,19 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _navCollapsed = false;
 
+  /**
+   * Live device YAML, fed down through `device-editor` →
+   * `device-board-info` to the section editor and the YAML pane.
+   *
+   * Reference identity is load-bearing: the section editor's
+   * scan memos in `util/config-entry-yaml-scan.ts` (per-keystroke
+   * pin / id-reference lookups) cache by `yaml === yaml`. Only
+   * reassign this field when the content actually changes —
+   * never via a template literal, `String(...)`, or any path
+   * that constructs a new string. Doing so silently demotes the
+   * memos to a no-op (every render becomes a cache miss) and
+   * the per-keystroke scans regress to O(N) on the full YAML.
+   */
   @state()
   private _yaml = "";
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -114,14 +114,18 @@ export class ESPHomePageDevice extends LitElement {
    * Live device YAML, fed down through `device-editor` →
    * `device-board-info` to the section editor and the YAML pane.
    *
-   * Reference identity is load-bearing: the section editor's
-   * scan memos in `util/config-entry-yaml-scan.ts` (per-keystroke
-   * pin / id-reference lookups) cache by `yaml === yaml`. Only
-   * reassign this field when the content actually changes —
-   * never via a template literal, `String(...)`, or any path
-   * that constructs a new string. Doing so silently demotes the
-   * memos to a no-op (every render becomes a cache miss) and
-   * the per-keystroke scans regress to O(N) on the full YAML.
+   * The section editor's scan memos
+   * (`util/config-entry-yaml-scan.ts`) cache per-keystroke
+   * pin / id-reference lookups by content (`a.yaml === b.yaml`,
+   * value equality on primitive strings). Reassigning to the
+   * same string instance hits the V8 pointer-equality fast path
+   * for an O(1) cache hit; reconstructing a fresh string with
+   * identical content (template literal, `String(...)`, JSON
+   * round-trip) still hits but pays a single byte-compare on
+   * the first call after the rebuild. A content change always
+   * misses and re-scans. Avoid per-render rebuilds when you can
+   * — they don't break correctness but they do cost the fast
+   * path.
    */
   @state()
   private _yaml = "";

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -118,14 +118,21 @@ export class ESPHomePageDevice extends LitElement {
    * (`util/config-entry-yaml-scan.ts`) cache per-keystroke
    * pin / id-reference lookups by content (`a.yaml === b.yaml`,
    * value equality on primitive strings). Reassigning to the
-   * same string instance hits the V8 pointer-equality fast path
-   * for an O(1) cache hit; reconstructing a fresh string with
-   * identical content (template literal, `String(...)`, JSON
-   * round-trip) still hits but pays a single byte-compare on
-   * the first call after the rebuild. A content change always
-   * misses and re-scans. Avoid per-render rebuilds when you can
-   * — they don't break correctness but they do cost the fast
-   * path.
+   * same string instance hits the engine's pointer-equality
+   * fast path; reconstructing a fresh string with identical
+   * content still hits but pays a byte-compare on the first
+   * call after the rebuild. A content change always misses
+   * and re-scans.
+   *
+   * Patterns that produce a fresh string per render (and so
+   * cost the byte-compare without breaking correctness):
+   * template literals (``` `${value}` ```), `String(value)`,
+   * `value.toString()`, `JSON.stringify(JSON.parse(value))`.
+   * The current code path doesn't do any of these — `_yaml`
+   * is only reassigned on user yaml-change events, save
+   * events, or initial fetch — but a future refactor that
+   * introduces them would silently demote the fast path.
+   * Avoid when you can.
    */
   @state()
   private _yaml = "";

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -23,36 +23,73 @@
  * editor so a pin selector doesn't flag the user's *own* pin as
  * already in use.
  */
-/** Single-entry memo: caches the full pin map for a `yaml` +
- *  exclude-range combination. The form re-renders on every keystroke
- *  into the YAML pane (the live `yaml` prop is a pin-renderer
- *  dependency); the section editor's exclude range is stable across
- *  that same edit window, so a paste-then-type workflow gets cache
- *  hits on every keystroke.
+/**
+ * Single-entry memo with reference-equality keys. The hot path
+ * is the form re-rendering on every keystroke into the YAML
+ * pane: the live `yaml` prop is a dependency of the pin and
+ * id-reference renderers, and the section editor's exclude
+ * range / domain are stable across that same edit window — so
+ * a paste-then-type workflow gets cache hits on every keystroke.
  *
- *  Reference equality on `yaml` rather than a composite-string key:
- *  the parent (`pages/device.ts::_yaml`) only reassigns the string
- *  when the user types, so identical reads share the same identity.
- *  A composite-string key would itself be O(N) to build on every
- *  call — defeating most of the point. */
-let _pinMemoYaml: string | null = null;
-let _pinMemoFrom: number | undefined;
-let _pinMemoTo: number | undefined;
-let _pinMemoValue: Map<number, string> | null = null;
+ * Reference equality on `yaml` rather than a composite-string
+ * key: the parent (`pages/device.ts::_yaml`) only reassigns
+ * the string when the user types, so identical reads share
+ * the same identity. A composite-string key would itself be
+ * O(N) to build on every call — defeating most of the point.
+ *
+ * **Load-bearing:** `pages/device.ts` must keep `_yaml`'s
+ * string identity stable across renders that don't change the
+ * content. If a future refactor reconstructs the string each
+ * render (template literal, `String(...)`, JSON round-trip),
+ * every call becomes a cache miss and the optimisation
+ * silently degrades to a no-op.
+ *
+ * Wrapping the state in a small factory keeps the reset list
+ * (`_clearScanMemos`) single-source — adding a third memo just
+ * means a new `createScanMemo<K, V>()` line, not editing two
+ * places.
+ */
+function createScanMemo<K, V>() {
+  let key: K | undefined;
+  let value: V | undefined;
+  return {
+    get(probe: K, equals: (a: K, b: K) => boolean): V | undefined {
+      if (key !== undefined && equals(probe, key)) return value;
+      return undefined;
+    },
+    set(probe: K, v: V) {
+      key = probe;
+      value = v;
+    },
+    clear() {
+      key = undefined;
+      value = undefined;
+    },
+  };
+}
+
+interface PinKey {
+  yaml: string;
+  // Note: the cache distinguishes `undefined` (no exclude range)
+  // from `0` exactly via `Object.is`, so a future caller that
+  // passes `0` won't collide with the unset state.
+  excludeFromLine: number | undefined;
+  excludeToLine: number | undefined;
+}
+const pinMemo = createScanMemo<PinKey, Map<number, string>>();
+const pinKeyEquals = (a: PinKey, b: PinKey) =>
+  a.yaml === b.yaml &&
+  a.excludeFromLine === b.excludeFromLine &&
+  a.excludeToLine === b.excludeToLine;
 
 export function findUsedPins(
   yaml: string,
   excludeFromLine?: number,
   excludeToLine?: number,
 ): Map<number, string> {
-  if (
-    yaml === _pinMemoYaml &&
-    excludeFromLine === _pinMemoFrom &&
-    excludeToLine === _pinMemoTo &&
-    _pinMemoValue
-  ) {
-    return _pinMemoValue;
-  }
+  const probe: PinKey = { yaml, excludeFromLine, excludeToLine };
+  const cached = pinMemo.get(probe, pinKeyEquals);
+  if (cached) return cached;
   const used = new Map<number, string>();
   if (!yaml) {
     // Don't cache the empty-yaml early return: a future
@@ -87,10 +124,7 @@ export function findUsedPins(
       }
     }
   }
-  _pinMemoYaml = yaml;
-  _pinMemoFrom = excludeFromLine;
-  _pinMemoTo = excludeToLine;
-  _pinMemoValue = used;
+  pinMemo.set(probe, used);
   return used;
 }
 
@@ -118,25 +152,22 @@ export function sectionEndLine(
  * inside the given top-level domain. Block-list items reset the cursor
  * so each list element produces its own `{ id, name }` record.
  */
-/** Single-entry memo for the id-reference scan, keyed by
- *  (yaml, domain) — reference equality on `yaml`, same rationale
- *  as `findUsedPins`'s memo. */
-let _refMemoYaml: string | null = null;
-let _refMemoDomain: string | null = null;
-let _refMemoValue: Array<{ id: string; name: string }> | null = null;
+interface RefKey {
+  yaml: string;
+  domain: string;
+}
+const refMemo = createScanMemo<RefKey, Array<{ id: string; name: string }>>();
+const refKeyEquals = (a: RefKey, b: RefKey) =>
+  a.yaml === b.yaml && a.domain === b.domain;
 
 export function findReferencedComponents(
   yaml: string,
   domain: string,
 ): Array<{ id: string; name: string }> {
   if (!domain) return [];
-  if (
-    yaml === _refMemoYaml &&
-    domain === _refMemoDomain &&
-    _refMemoValue
-  ) {
-    return _refMemoValue;
-  }
+  const probe: RefKey = { yaml, domain };
+  const cached = refMemo.get(probe, refKeyEquals);
+  if (cached) return cached;
   const lines = yaml.split("\n");
   const result: Array<{ id: string; name: string }> = [];
   let inSection = false;
@@ -169,9 +200,7 @@ export function findReferencedComponents(
     }
   }
   flush();
-  _refMemoYaml = yaml;
-  _refMemoDomain = domain;
-  _refMemoValue = result;
+  refMemo.set(probe, result);
   return result;
 }
 
@@ -183,11 +212,6 @@ export function findReferencedComponents(
  * slate.
  */
 export function _clearScanMemos(): void {
-  _pinMemoYaml = null;
-  _pinMemoFrom = undefined;
-  _pinMemoTo = undefined;
-  _pinMemoValue = null;
-  _refMemoYaml = null;
-  _refMemoDomain = null;
-  _refMemoValue = null;
+  pinMemo.clear();
+  refMemo.clear();
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * YAML scanning helpers used by the ConfigEntry form to (a) detect pin
  * conflicts between sections and (b) discover ID references for the
  * id-reference picker. These are deliberately tiny, line-based scans —
@@ -7,21 +7,14 @@
  *
  * The form re-renders on every keystroke (live `yaml` prop is a
  * dependency of pin / id pickers), so both scans are memoised
- * single-entry by `yaml` reference. Re-renders that don't change the
- * yaml return cached results; an actual yaml change re-scans once.
- * Linear scans on the typical config (<200 lines) are sub-millisecond
- * even without the cache, but memoisation collapses the worst case
- * (paste a multi-thousand-line config, type into a field) from
- * O(N) per keystroke to O(1).
- */
-
-/**
- * Map every `GPIO<n>` reference in the YAML to the top-level domain
- * that owns it (e.g. `{ 4: "switch", 5: "binary_sensor" }`). When
- * `excludeFromLine`/`excludeToLine` are provided the lines in that
- * (inclusive) 1-indexed range are skipped — used by the section
- * editor so a pin selector doesn't flag the user's *own* pin as
- * already in use.
+ * single-entry on `(yaml, ...key)` via value equality (`a.yaml ===
+ * b.yaml` on primitive strings, with the engine's pointer-equality
+ * fast path on the typical render cycle). Re-renders that don't
+ * change the yaml return cached results; an actual yaml change
+ * re-scans once. Linear scans on the typical config (<200 lines)
+ * are sub-millisecond even without the cache, but memoisation
+ * collapses the worst case (paste a multi-thousand-line config,
+ * type into a field) from O(N) per keystroke to O(1).
  */
 /**
  * Single-entry memo for the YAML scans. The hot path is the
@@ -105,6 +98,14 @@ const pinKeyEquals = (a: PinKey, b: PinKey) =>
   a.excludeToLine === b.excludeToLine;
 const pinMemo = createScanMemo<PinKey, Map<number, string>>(pinKeyEquals);
 
+/**
+ * Map every `GPIO<n>` reference in the YAML to the top-level
+ * domain that owns it (e.g. `{ 4: "switch", 5: "binary_sensor" }`).
+ * When `excludeFromLine` / `excludeToLine` are provided the lines
+ * in that (inclusive) 1-indexed range are skipped — used by the
+ * section editor so a pin selector doesn't flag the user's *own*
+ * pin as already in use.
+ */
 export function findUsedPins(
   yaml: string,
   excludeFromLine?: number,

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -24,32 +24,38 @@
  * already in use.
  */
 /**
- * Single-entry memo with reference-equality keys. The hot path
- * is the form re-rendering on every keystroke into the YAML
- * pane: the live `yaml` prop is a dependency of the pin and
+ * Single-entry memo for the YAML scans. The hot path is the
+ * form re-rendering on every keystroke into the YAML pane:
+ * the live `yaml` prop is a dependency of the pin and
  * id-reference renderers, and the section editor's exclude
  * range / domain are stable across that same edit window — so
- * a paste-then-type workflow gets cache hits on every keystroke.
+ * a paste-then-type workflow gets cache hits on every
+ * keystroke.
  *
- * Reference equality on `yaml` rather than a composite-string
- * key: the parent (`pages/device.ts::_yaml`) only reassigns
- * the string when the user types, so identical reads share
- * the same identity. A composite-string key would itself be
- * O(N) to build on every call — defeating most of the point.
+ * Key comparison uses `a.yaml === b.yaml` directly, which on
+ * primitive strings is value equality, not reference identity.
+ * In practice the parent (`pages/device.ts::_yaml`) hands us
+ * the same string instance until the user types, so V8's
+ * `===` short-circuits via pointer equality — O(1) on the
+ * cache-hit path. When the content differs, length / hash
+ * checks short-circuit before any byte-compare. Only an
+ * unusual shape (two distinct strings with identical content)
+ * would force the O(N) byte-compare; the typical render cycle
+ * doesn't produce that.
  *
- * **Load-bearing:** `pages/device.ts` must keep `_yaml`'s
- * string identity stable across renders that don't change the
- * content. If a future refactor reconstructs the string each
- * render (template literal, `String(...)`, JSON round-trip),
- * every call becomes a cache miss and the optimisation
- * silently degrades to a no-op.
+ * The cache is content-keyed: a refactor that constructs a
+ * fresh string per render with the same content still hits
+ * (modulo the byte-compare cost noted above), and a content
+ * change misses regardless of identity. So the contract
+ * here is "same content → same cached result", and consumers
+ * of `_yaml` don't need to preserve string identity for
+ * correctness — only for the O(1) fast path.
  *
  * Wrapping the state in a small factory keeps the reset list
- * (`_clearScanMemos`) single-source — adding a third memo just
- * means a new `createScanMemo<K, V>()` line, not editing two
- * places.
- */
-/**
+ * (`_clearScanMemos`) single-source — adding a third memo
+ * just means a new `createScanMemo<K, V>(equals)` line, not
+ * editing two places.
+ *
  * `equals` is bound at factory time, not per-call: a single
  * `pinMemo` always uses one key-equality contract, so a future
  * caller can't silently flip cache semantics by passing a
@@ -61,6 +67,8 @@
  * as a legitimate cache key, which is fine because both memos
  * here use object keys; primitive-keyed memos that wanted to
  * cache `undefined` would need a different shape.
+ */
+/**
  */
 function createScanMemo<K, V>(equals: (a: K, b: K) => boolean) {
   let key: K | undefined;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -24,12 +24,20 @@
  * already in use.
  */
 /** Single-entry memo: caches the full pin map for a `yaml` +
- *  `excludeFromLine:excludeToLine` combination. The form re-renders
- *  on every keystroke into the YAML pane (the live `yaml` prop is a
- *  pin-renderer dependency); the section editor's exclude range is
- *  stable across that same edit window, so a paste-then-type
- *  workflow gets cache hits on every keystroke. */
-let _pinMemoKey = "";
+ *  exclude-range combination. The form re-renders on every keystroke
+ *  into the YAML pane (the live `yaml` prop is a pin-renderer
+ *  dependency); the section editor's exclude range is stable across
+ *  that same edit window, so a paste-then-type workflow gets cache
+ *  hits on every keystroke.
+ *
+ *  Reference equality on `yaml` rather than a composite-string key:
+ *  the parent (`pages/device.ts::_yaml`) only reassigns the string
+ *  when the user types, so identical reads share the same identity.
+ *  A composite-string key would itself be O(N) to build on every
+ *  call — defeating most of the point. */
+let _pinMemoYaml: string | null = null;
+let _pinMemoFrom: number | undefined;
+let _pinMemoTo: number | undefined;
 let _pinMemoValue: Map<number, string> | null = null;
 
 export function findUsedPins(
@@ -37,12 +45,21 @@ export function findUsedPins(
   excludeFromLine?: number,
   excludeToLine?: number,
 ): Map<number, string> {
-  const key = `${excludeFromLine ?? "_"}:${excludeToLine ?? "_"}${yaml}`;
-  if (key === _pinMemoKey && _pinMemoValue) return _pinMemoValue;
+  if (
+    yaml === _pinMemoYaml &&
+    excludeFromLine === _pinMemoFrom &&
+    excludeToLine === _pinMemoTo &&
+    _pinMemoValue
+  ) {
+    return _pinMemoValue;
+  }
   const used = new Map<number, string>();
   if (!yaml) {
-    _pinMemoKey = key;
-    _pinMemoValue = used;
+    // Don't cache the empty-yaml early return: a future
+    // regression that needs to do exclude-range work even on
+    // empty input would be silently masked by a cached empty
+    // Map. Empty input is also rare on the hot path (the form
+    // doesn't render its pin selectors until yaml has loaded).
     return used;
   }
   const lines = yaml.split("\n");
@@ -70,7 +87,9 @@ export function findUsedPins(
       }
     }
   }
-  _pinMemoKey = key;
+  _pinMemoYaml = yaml;
+  _pinMemoFrom = excludeFromLine;
+  _pinMemoTo = excludeToLine;
   _pinMemoValue = used;
   return used;
 }
@@ -100,10 +119,10 @@ export function sectionEndLine(
  * so each list element produces its own `{ id, name }` record.
  */
 /** Single-entry memo for the id-reference scan, keyed by
- *  (yaml, domain). Same rationale as `findUsedPins`'s memo —
- *  the form's id-reference picker re-renders on every keystroke;
- *  domain is stable across that window. */
-let _refMemoKey = "";
+ *  (yaml, domain) — reference equality on `yaml`, same rationale
+ *  as `findUsedPins`'s memo. */
+let _refMemoYaml: string | null = null;
+let _refMemoDomain: string | null = null;
 let _refMemoValue: Array<{ id: string; name: string }> | null = null;
 
 export function findReferencedComponents(
@@ -111,8 +130,13 @@ export function findReferencedComponents(
   domain: string,
 ): Array<{ id: string; name: string }> {
   if (!domain) return [];
-  const key = `${domain}:${yaml}`;
-  if (key === _refMemoKey && _refMemoValue) return _refMemoValue;
+  if (
+    yaml === _refMemoYaml &&
+    domain === _refMemoDomain &&
+    _refMemoValue
+  ) {
+    return _refMemoValue;
+  }
   const lines = yaml.split("\n");
   const result: Array<{ id: string; name: string }> = [];
   let inSection = false;
@@ -145,7 +169,25 @@ export function findReferencedComponents(
     }
   }
   flush();
-  _refMemoKey = key;
+  _refMemoYaml = yaml;
+  _refMemoDomain = domain;
   _refMemoValue = result;
   return result;
+}
+
+/**
+ * Test-only: clear both memos so cache state can't leak between
+ * cases. Production callers don't need this — within an editor
+ * session the memo's eviction-on-key-change is the right
+ * semantics — but tests asserting cache identity want a clean
+ * slate.
+ */
+export function _clearScanMemos(): void {
+  _pinMemoYaml = null;
+  _pinMemoFrom = undefined;
+  _pinMemoTo = undefined;
+  _pinMemoValue = null;
+  _refMemoYaml = null;
+  _refMemoDomain = null;
+  _refMemoValue = null;
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -4,6 +4,15 @@
  * id-reference picker. These are deliberately tiny, line-based scans —
  * a full YAML parse is overkill for the few keys we care about, and the
  * source is the user's working YAML which may be mid-edit.
+ *
+ * The form re-renders on every keystroke (live `yaml` prop is a
+ * dependency of pin / id pickers), so both scans are memoised
+ * single-entry by `yaml` reference. Re-renders that don't change the
+ * yaml return cached results; an actual yaml change re-scans once.
+ * Linear scans on the typical config (<200 lines) are sub-millisecond
+ * even without the cache, but memoisation collapses the worst case
+ * (paste a multi-thousand-line config, type into a field) from
+ * O(N) per keystroke to O(1).
  */
 
 /**
@@ -14,13 +23,28 @@
  * editor so a pin selector doesn't flag the user's *own* pin as
  * already in use.
  */
+/** Single-entry memo: caches the full pin map for a `yaml` +
+ *  `excludeFromLine:excludeToLine` combination. The form re-renders
+ *  on every keystroke into the YAML pane (the live `yaml` prop is a
+ *  pin-renderer dependency); the section editor's exclude range is
+ *  stable across that same edit window, so a paste-then-type
+ *  workflow gets cache hits on every keystroke. */
+let _pinMemoKey = "";
+let _pinMemoValue: Map<number, string> | null = null;
+
 export function findUsedPins(
   yaml: string,
   excludeFromLine?: number,
   excludeToLine?: number,
 ): Map<number, string> {
+  const key = `${excludeFromLine ?? "_"}:${excludeToLine ?? "_"}${yaml}`;
+  if (key === _pinMemoKey && _pinMemoValue) return _pinMemoValue;
   const used = new Map<number, string>();
-  if (!yaml) return used;
+  if (!yaml) {
+    _pinMemoKey = key;
+    _pinMemoValue = used;
+    return used;
+  }
   const lines = yaml.split("\n");
   let currentDomain = "";
   for (let i = 0; i < lines.length; i++) {
@@ -46,6 +70,8 @@ export function findUsedPins(
       }
     }
   }
+  _pinMemoKey = key;
+  _pinMemoValue = used;
   return used;
 }
 
@@ -73,11 +99,20 @@ export function sectionEndLine(
  * inside the given top-level domain. Block-list items reset the cursor
  * so each list element produces its own `{ id, name }` record.
  */
+/** Single-entry memo for the id-reference scan, keyed by
+ *  (yaml, domain). Same rationale as `findUsedPins`'s memo —
+ *  the form's id-reference picker re-renders on every keystroke;
+ *  domain is stable across that window. */
+let _refMemoKey = "";
+let _refMemoValue: Array<{ id: string; name: string }> | null = null;
+
 export function findReferencedComponents(
   yaml: string,
   domain: string,
 ): Array<{ id: string; name: string }> {
   if (!domain) return [];
+  const key = `${domain}:${yaml}`;
+  if (key === _refMemoKey && _refMemoValue) return _refMemoValue;
   const lines = yaml.split("\n");
   const result: Array<{ id: string; name: string }> = [];
   let inSection = false;
@@ -110,5 +145,7 @@ export function findReferencedComponents(
     }
   }
   flush();
+  _refMemoKey = key;
+  _refMemoValue = result;
   return result;
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -35,13 +35,14 @@
  * Key comparison uses `a.yaml === b.yaml` directly, which on
  * primitive strings is value equality, not reference identity.
  * In practice the parent (`pages/device.ts::_yaml`) hands us
- * the same string instance until the user types, so V8's
- * `===` short-circuits via pointer equality — O(1) on the
- * cache-hit path. When the content differs, length / hash
- * checks short-circuit before any byte-compare. Only an
- * unusual shape (two distinct strings with identical content)
- * would force the O(N) byte-compare; the typical render cycle
- * doesn't produce that.
+ * the same string instance until the user types, so engines
+ * typically short-circuit on pointer equality — no byte-compare
+ * on the typical equal-content fast path. When content differs
+ * they short-circuit on length and other structural
+ * mismatches. The unusual shape (two distinct strings with
+ * identical content) is the only one that forces an O(N)
+ * byte-compare; the typical render cycle doesn't produce
+ * that.
  *
  * The cache is content-keyed: a refactor that constructs a
  * fresh string per render with the same content still hits
@@ -67,8 +68,6 @@
  * as a legitimate cache key, which is fine because both memos
  * here use object keys; primitive-keyed memos that wanted to
  * cache `undefined` would need a different shape.
- */
-/**
  */
 function createScanMemo<K, V>(equals: (a: K, b: K) => boolean) {
   let key: K | undefined;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -49,11 +49,24 @@
  * means a new `createScanMemo<K, V>()` line, not editing two
  * places.
  */
-function createScanMemo<K, V>() {
+/**
+ * `equals` is bound at factory time, not per-call: a single
+ * `pinMemo` always uses one key-equality contract, so a future
+ * caller can't silently flip cache semantics by passing a
+ * different `equals` to `.get()`. The factory holds it as a
+ * closed-over private.
+ *
+ * `undefined` is the unset sentinel — the cache always misses
+ * before the first `set()`. That precludes using `undefined`
+ * as a legitimate cache key, which is fine because both memos
+ * here use object keys; primitive-keyed memos that wanted to
+ * cache `undefined` would need a different shape.
+ */
+function createScanMemo<K, V>(equals: (a: K, b: K) => boolean) {
   let key: K | undefined;
   let value: V | undefined;
   return {
-    get(probe: K, equals: (a: K, b: K) => boolean): V | undefined {
+    get(probe: K): V | undefined {
       if (key !== undefined && equals(probe, key)) return value;
       return undefined;
     },
@@ -70,17 +83,20 @@ function createScanMemo<K, V>() {
 
 interface PinKey {
   yaml: string;
-  // Note: the cache distinguishes `undefined` (no exclude range)
-  // from `0` exactly via `Object.is`, so a future caller that
-  // passes `0` won't collide with the unset state.
+  // Cache distinguishes `undefined` (no exclude range) from
+  // `0` exactly via `===`, so a future caller passing `0` as
+  // a line number won't collide with the unset state. (`===`
+  // and `Object.is` agree for the realistic shapes here —
+  // strings, integers, undefined; the only divergent case is
+  // NaN, which line numbers can't be.)
   excludeFromLine: number | undefined;
   excludeToLine: number | undefined;
 }
-const pinMemo = createScanMemo<PinKey, Map<number, string>>();
 const pinKeyEquals = (a: PinKey, b: PinKey) =>
   a.yaml === b.yaml &&
   a.excludeFromLine === b.excludeFromLine &&
   a.excludeToLine === b.excludeToLine;
+const pinMemo = createScanMemo<PinKey, Map<number, string>>(pinKeyEquals);
 
 export function findUsedPins(
   yaml: string,
@@ -88,7 +104,7 @@ export function findUsedPins(
   excludeToLine?: number,
 ): Map<number, string> {
   const probe: PinKey = { yaml, excludeFromLine, excludeToLine };
-  const cached = pinMemo.get(probe, pinKeyEquals);
+  const cached = pinMemo.get(probe);
   if (cached) return cached;
   const used = new Map<number, string>();
   if (!yaml) {
@@ -156,9 +172,12 @@ interface RefKey {
   yaml: string;
   domain: string;
 }
-const refMemo = createScanMemo<RefKey, Array<{ id: string; name: string }>>();
 const refKeyEquals = (a: RefKey, b: RefKey) =>
   a.yaml === b.yaml && a.domain === b.domain;
+const refMemo = createScanMemo<
+  RefKey,
+  Array<{ id: string; name: string }>
+>(refKeyEquals);
 
 export function findReferencedComponents(
   yaml: string,
@@ -166,7 +185,7 @@ export function findReferencedComponents(
 ): Array<{ id: string; name: string }> {
   if (!domain) return [];
   const probe: RefKey = { yaml, domain };
-  const cached = refMemo.get(probe, refKeyEquals);
+  const cached = refMemo.get(probe);
   if (cached) return cached;
   const lines = yaml.split("\n");
   const result: Array<{ id: string; name: string }> = [];

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -371,9 +371,51 @@ export function findAddedSection(
  * platform list items, that's `<parent>.<platform>` (de-duplicating
  * if the platform is already namespaced); otherwise just `key`.
  */
-function sectionKeyOf(section: YamlSection): string {
+export function sectionKeyOf(section: YamlSection): string {
   if (!section.platform) return section.key;
   return section.platform.startsWith(`${section.key}.`)
     ? section.platform
     : `${section.key}.${section.platform}`;
+}
+
+/**
+ * Resolve the current `fromLine` for `sectionKey` in `yaml`,
+ * preferring the section closest to `staleFromLine` when the
+ * section key matches multiple list items.
+ *
+ * The navigator emits `fromLine` at click time; if the YAML
+ * shifts afterwards (paste / external edit added or removed
+ * lines above the section), the cached number is stale and a
+ * splice keyed on it would clip the wrong section. This helper
+ * re-resolves against the current YAML so save / delete operate
+ * on the right line.
+ *
+ * Returns the matching section's 1-indexed `fromLine`, or
+ * `null` when no section in `yaml` matches `sectionKey` —
+ * callers surface that as an explicit error rather than running
+ * a wrong-line splice.
+ */
+export function resolveCurrentFromLine(
+  yaml: string,
+  sectionKey: string,
+  staleFromLine?: number,
+): number | null {
+  if (!yaml || !sectionKey) return null;
+  const matches = parseYamlTopLevelSections(yaml).filter(
+    (s) => sectionKeyOf(s) === sectionKey,
+  );
+  if (matches.length === 0) return null;
+  if (matches.length === 1 || staleFromLine === undefined) {
+    return matches[0].fromLine;
+  }
+  // Disambiguate: pick the candidate closest to the stale line.
+  // Same-key duplicates (two `ota.esphome` items) are
+  // pathological but legal in YAML; closest-match keeps a small
+  // shift mapped to the same item the user clicked.
+  return matches.reduce((best, candidate) =>
+    Math.abs(candidate.fromLine - staleFromLine) <
+    Math.abs(best.fromLine - staleFromLine)
+      ? candidate
+      : best,
+  ).fromLine;
 }

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -393,7 +393,21 @@ export function sectionKeyOf(section: YamlSection): string {
  * Returns the matching section's 1-indexed `fromLine`, or
  * `null` when no section in `yaml` matches `sectionKey` —
  * callers surface that as an explicit error rather than running
- * a wrong-line splice.
+ * a wrong-line splice. Empty `yaml` or empty `sectionKey` also
+ * return `null` so an unbound prop and a cleared editor pane
+ * collapse into the same caller-visible failure.
+ *
+ * Same-key duplicates (two `ota.esphome` items — pathological
+ * but legal YAML): closest-match is a heuristic, strictly
+ * better than ignoring `staleFromLine` but not guaranteed
+ * correct. If the user originally clicked the first of two
+ * duplicates and a subsequent paste shifted line numbers far
+ * enough that the stale line is now closer to the second
+ * duplicate, the resolver picks the second. There's no oracle
+ * once the array is reshuffled; a re-click is the expected
+ * recovery for that case. Equidistant ties prefer the first
+ * match (the test pins this; `reduce` with `<` keeps the
+ * accumulator on ties).
  */
 export function resolveCurrentFromLine(
   yaml: string,
@@ -408,10 +422,6 @@ export function resolveCurrentFromLine(
   if (matches.length === 1 || staleFromLine === undefined) {
     return matches[0].fromLine;
   }
-  // Disambiguate: pick the candidate closest to the stale line.
-  // Same-key duplicates (two `ota.esphome` items) are
-  // pathological but legal in YAML; closest-match keeps a small
-  // shift mapped to the same item the user clicked.
   return matches.reduce((best, candidate) =>
     Math.abs(candidate.fromLine - staleFromLine) <
     Math.abs(best.fromLine - staleFromLine)

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -391,11 +391,15 @@ export function sectionKeyOf(section: YamlSection): string {
  * on the right line.
  *
  * Returns the matching section's 1-indexed `fromLine`, or
- * `null` when no section in `yaml` matches `sectionKey` —
+ * `undefined` when no section in `yaml` matches `sectionKey` —
  * callers surface that as an explicit error rather than running
  * a wrong-line splice. Empty `yaml` or empty `sectionKey` also
- * return `null` so an unbound prop and a cleared editor pane
- * collapse into the same caller-visible failure.
+ * return `undefined` so an unbound prop and a cleared editor
+ * pane collapse into the same caller-visible failure.
+ *
+ * `undefined` (rather than `null`) so the result drops cleanly
+ * into `parseYamlSectionValues`'s optional `fromLine?` parameter
+ * without a `?? undefined` conversion at every call site.
  *
  * Same-key duplicates (two `ota.esphome` items — pathological
  * but legal YAML): closest-match is a heuristic, strictly
@@ -413,12 +417,12 @@ export function resolveCurrentFromLine(
   yaml: string,
   sectionKey: string,
   staleFromLine?: number,
-): number | null {
-  if (!yaml || !sectionKey) return null;
+): number | undefined {
+  if (!yaml || !sectionKey) return undefined;
   const matches = parseYamlTopLevelSections(yaml).filter(
     (s) => sectionKeyOf(s) === sectionKey,
   );
-  if (matches.length === 0) return null;
+  if (matches.length === 0) return undefined;
   if (matches.length === 1 || staleFromLine === undefined) {
     return matches[0].fromLine;
   }

--- a/test/components/device/device-board-info-helpers.test.ts
+++ b/test/components/device/device-board-info-helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isEmptyToPopulatedYamlChange } from "../../../src/components/device/device-board-info-helpers.js";
+
+describe("isEmptyToPopulatedYamlChange", () => {
+  // Pin the discriminator the section editor's debounce-skip
+  // path uses. A regression that flips the polarity (or removes
+  // the empty-state check) would silently re-introduce the 1s
+  // empty-form window on page load.
+
+  it("fires on first-time YAML arrival (undefined → real)", () => {
+    expect(isEmptyToPopulatedYamlChange(undefined, "esphome:\n  name: x\n")).toBe(true);
+  });
+
+  it("fires on user-cleared-then-pasted (\"\" → real)", () => {
+    expect(isEmptyToPopulatedYamlChange("", "esphome:\n  name: x\n")).toBe(true);
+  });
+
+  it("does not fire on typing (real → real)", () => {
+    expect(
+      isEmptyToPopulatedYamlChange(
+        "esphome:\n  name: x\n",
+        "esphome:\n  name: xy\n",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fire on user-cleared-the-pane (real → \"\")", () => {
+    expect(isEmptyToPopulatedYamlChange("esphome:\n  name: x\n", "")).toBe(false);
+  });
+
+  it("does not fire on noop-empty (\"\" → \"\")", () => {
+    expect(isEmptyToPopulatedYamlChange("", "")).toBe(false);
+  });
+
+  it("tolerates a null prev (defensive — Lit's getter returns undefined, not null, but contract is documented as both)", () => {
+    expect(isEmptyToPopulatedYamlChange(null, "esphome:\n")).toBe(true);
+  });
+});

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  findReferencedComponents,
+  findUsedPins,
+} from "../../src/util/config-entry-yaml-scan.js";
+
+describe("findUsedPins", () => {
+  const yaml = [
+    "switch:",
+    "  - platform: gpio",
+    "    pin: GPIO4",
+    "binary_sensor:",
+    "  - platform: gpio",
+    "    pin: GPIO5",
+    "",
+  ].join("\n");
+
+  it("maps each GPIO reference to its top-level domain", () => {
+    const map = findUsedPins(yaml);
+    expect(map.get(4)).toBe("switch");
+    expect(map.get(5)).toBe("binary_sensor");
+  });
+
+  it("excludes lines in the inclusive range", () => {
+    // Skip lines 4-6 (the binary_sensor block) — pin 5 should
+    // not appear.
+    const map = findUsedPins(yaml, 4, 6);
+    expect(map.get(4)).toBe("switch");
+    expect(map.has(5)).toBe(false);
+  });
+
+  it("returns an empty map for empty yaml", () => {
+    expect(findUsedPins("").size).toBe(0);
+  });
+
+  it("returns the same Map reference on repeated calls (memoised)", () => {
+    // Pin the cache contract: a re-render that hands us the
+    // same yaml + exclude pair returns the cached Map without
+    // re-scanning. A regression that drops the memo would
+    // produce a fresh Map (different identity) each call.
+    const a = findUsedPins(yaml);
+    const b = findUsedPins(yaml);
+    expect(a).toBe(b);
+  });
+
+  it("invalidates the memo when yaml changes", () => {
+    const a = findUsedPins(yaml);
+    const otherYaml = "switch:\n  - platform: gpio\n    pin: GPIO9\n";
+    const b = findUsedPins(otherYaml);
+    expect(a).not.toBe(b);
+    expect(b.get(9)).toBe("switch");
+  });
+
+  it("invalidates the memo when exclude range changes", () => {
+    const a = findUsedPins(yaml);
+    const b = findUsedPins(yaml, 4, 6);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("findReferencedComponents", () => {
+  const yaml = [
+    "i2c:",
+    "  - id: bus_a",
+    "    sda: GPIO4",
+    "  - id: bus_b",
+    "    sda: GPIO5",
+    "",
+  ].join("\n");
+
+  it("returns id/name pairs for the given domain", () => {
+    expect(findReferencedComponents(yaml, "i2c")).toEqual([
+      { id: "bus_a", name: "" },
+      { id: "bus_b", name: "" },
+    ]);
+  });
+
+  it("returns an empty array for an unknown domain", () => {
+    expect(findReferencedComponents(yaml, "uart")).toEqual([]);
+  });
+
+  it("returns an empty array for an empty domain string", () => {
+    expect(findReferencedComponents(yaml, "")).toEqual([]);
+  });
+
+  it("returns the same array reference on repeated calls (memoised)", () => {
+    const a = findReferencedComponents(yaml, "i2c");
+    const b = findReferencedComponents(yaml, "i2c");
+    expect(a).toBe(b);
+  });
+
+  it("invalidates the memo when yaml changes", () => {
+    const a = findReferencedComponents(yaml, "i2c");
+    const otherYaml = "i2c:\n  - id: bus_z\n";
+    const b = findReferencedComponents(otherYaml, "i2c");
+    expect(a).not.toBe(b);
+    expect(b).toEqual([{ id: "bus_z", name: "" }]);
+  });
+
+  it("invalidates the memo when domain changes", () => {
+    const a = findReferencedComponents(yaml, "i2c");
+    const b = findReferencedComponents(yaml, "uart");
+    expect(a).not.toBe(b);
+  });
+});

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  _clearScanMemos,
   findReferencedComponents,
   findUsedPins,
 } from "../../src/util/config-entry-yaml-scan.js";
+
+// The scans use module-level single-entry memos. Within a single
+// test file vitest runs cases sequentially, so cache state from
+// one case can leak into the next. Reset between cases so each
+// test starts cold and identity assertions don't depend on
+// ordering. Production code doesn't need this — eviction-on-
+// key-change is the right semantics there.
+beforeEach(() => {
+  _clearScanMemos();
+});
 
 describe("findUsedPins", () => {
   const yaml = [
@@ -44,6 +55,12 @@ describe("findUsedPins", () => {
   });
 
   it("invalidates the memo when yaml changes", () => {
+    // Single-entry memo: the previous yaml's cache is evicted
+    // by the new yaml. A round-trip back to the original yaml
+    // would re-scan, not return the original Map. A multi-entry
+    // future-refactor could make round-trips identity-stable;
+    // pinning the single-entry contract here ensures any such
+    // change is deliberate.
     const a = findUsedPins(yaml);
     const otherYaml = "switch:\n  - platform: gpio\n    pin: GPIO9\n";
     const b = findUsedPins(otherYaml);
@@ -55,6 +72,18 @@ describe("findUsedPins", () => {
     const a = findUsedPins(yaml);
     const b = findUsedPins(yaml, 4, 6);
     expect(a).not.toBe(b);
+  });
+
+  it("does not cache the empty-yaml early return", () => {
+    // Empty input bypasses the memo write. A regression where
+    // empty results were cached would silently mask a future
+    // change that needed to do exclude-range work even on
+    // empty input — verify a fresh empty Map is built each
+    // call.
+    const a = findUsedPins("");
+    const b = findUsedPins("");
+    expect(a).not.toBe(b);
+    expect(a.size).toBe(0);
   });
 });
 
@@ -90,6 +119,9 @@ describe("findReferencedComponents", () => {
   });
 
   it("invalidates the memo when yaml changes", () => {
+    // Single-entry semantics: round-trip back to the original
+    // yaml re-scans, not returns the original array. Pinning
+    // for the same reason as the pin memo's equivalent test.
     const a = findReferencedComponents(yaml, "i2c");
     const otherYaml = "i2c:\n  - id: bus_z\n";
     const b = findReferencedComponents(otherYaml, "i2c");

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -3,6 +3,7 @@ import {
   findSectionStart,
   LIST_ITEM_START_RE,
   parseYamlSectionValues,
+  removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../src/util/yaml-section-values.js";
 
@@ -312,5 +313,77 @@ describe("updateSectionInYaml — list item with inline key", () => {
     });
     expect(after).toContain("ssid: x");
     expect(after).toContain("password: secret");
+  });
+});
+
+describe("removeSectionFromYaml — multi-item list", () => {
+  // Pins the splice contract that surfaced the
+  // wrong-section-deleted bug. The bug itself was at the
+  // integration boundary (section editor was passing the
+  // server's stale YAML instead of the live one), so the
+  // splice was being asked to operate on a yaml the
+  // navigator's `fromLine` didn't match.
+  //
+  // The unit-level guarantee these tests pin: given the live
+  // YAML + a `fromLine` pointing at the right list item, the
+  // splice removes that item and only that item.
+
+  const multiItemOta = [
+    "ota:",
+    "  - platform: esphome",
+    "    password: foo",
+    "  - platform: web_server",
+    "",
+  ].join("\n");
+
+  it("removes the FIRST OTA list item when fromLine points at it", () => {
+    const fromLine = firstListItemLine(multiItemOta, "ota");
+    const after = removeSectionFromYaml(multiItemOta, "ota.esphome", fromLine);
+    expect(after).not.toContain("platform: esphome");
+    expect(after).not.toContain("password: foo");
+    // The other list item survives untouched.
+    expect(after).toContain("- platform: web_server");
+  });
+
+  it("removes the SECOND OTA list item when fromLine points at it", () => {
+    // Direct repro of the bug-report shape: deleting
+    // `ota.web_server` (the second item) must hit it and
+    // leave `ota.esphome` alone. The pre-fix code path
+    // routed through a stale yaml fetch and clipped the
+    // wrong item.
+    const lines = multiItemOta.split("\n");
+    const start = findSectionStart(lines, "ota");
+    let secondDashIdx = -1;
+    let dashCount = 0;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (LIST_ITEM_START_RE.test(lines[i])) {
+        dashCount++;
+        if (dashCount === 2) {
+          secondDashIdx = i;
+          break;
+        }
+      }
+    }
+    expect(secondDashIdx).toBeGreaterThan(0);
+    const after = removeSectionFromYaml(
+      multiItemOta,
+      "ota.web_server",
+      secondDashIdx + 1, // 1-indexed
+    );
+    expect(after).not.toContain("- platform: web_server");
+    // The first item and its sibling field survive.
+    expect(after).toContain("- platform: esphome");
+    expect(after).toContain("password: foo");
+  });
+
+  it("drops the parent block when removing the only list item", () => {
+    const before = "ota:\n  - platform: esphome\n";
+    const fromLine = firstListItemLine(before, "ota");
+    const after = removeSectionFromYaml(before, "ota.esphome", fromLine);
+    // Empty-parent cleanup kicks in: the bare `ota:` left
+    // behind would be invalid ESPHome, so the parent goes
+    // too.
+    expect(after).not.toContain("ota");
+    expect(after).not.toContain("platform: esphome");
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -7,21 +7,31 @@ import {
   updateSectionInYaml,
 } from "../../src/util/yaml-section-values.js";
 
-/** 1-indexed line of the first list-item dash following
+/** 1-indexed line of the *n*th (1-based) list-item dash following
  *  `parent:` in `yaml`. Section-editor callers pass that line as
- *  `fromLine`; resolving it here keeps the tests robust to
- *  layout edits (e.g. a leading comment line shifting
- *  positions). Reuses the parser's `LIST_ITEM_START_RE` directly
- *  so a future tightening there can't silently let the test
- *  helper drift to a different definition of "list item". */
-function firstListItemLine(yaml: string, parent: string): number {
+ *  `fromLine`; resolving it here keeps tests robust to layout
+ *  edits. Reuses the parser's `LIST_ITEM_START_RE` directly so
+ *  a future tightening there can't silently let the test helper
+ *  drift to a different definition of "list item". */
+function nthListItemLine(
+  yaml: string,
+  parent: string,
+  n: number,
+): number {
   const lines = yaml.split("\n");
   const start = findSectionStart(lines, parent);
+  let count = 0;
   for (let i = start + 1; i < lines.length; i++) {
-    if (LIST_ITEM_START_RE.test(lines[i])) return i + 1;
+    if (LIST_ITEM_START_RE.test(lines[i])) {
+      count++;
+      if (count === n) return i + 1;
+    }
   }
-  throw new Error(`no list-item dash under ${parent}: in test fixture`);
+  throw new Error(`fewer than ${n} list-item dashes under ${parent}: in fixture`);
 }
+
+const firstListItemLine = (yaml: string, parent: string): number =>
+  nthListItemLine(yaml, parent, 1);
 
 describe("parseYamlSectionValues — prototype pollution defense", () => {
   // YAML keys like `__proto__` / `constructor` / `prototype`
@@ -351,24 +361,10 @@ describe("removeSectionFromYaml — multi-item list", () => {
     // leave `ota.esphome` alone. The pre-fix code path
     // routed through a stale yaml fetch and clipped the
     // wrong item.
-    const lines = multiItemOta.split("\n");
-    const start = findSectionStart(lines, "ota");
-    let secondDashIdx = -1;
-    let dashCount = 0;
-    for (let i = start + 1; i < lines.length; i++) {
-      if (LIST_ITEM_START_RE.test(lines[i])) {
-        dashCount++;
-        if (dashCount === 2) {
-          secondDashIdx = i;
-          break;
-        }
-      }
-    }
-    expect(secondDashIdx).toBeGreaterThan(0);
     const after = removeSectionFromYaml(
       multiItemOta,
       "ota.web_server",
-      secondDashIdx + 1, // 1-indexed
+      nthListItemLine(multiItemOta, "ota", 2),
     );
     expect(after).not.toContain("- platform: web_server");
     // The first item and its sibling field survive.
@@ -382,8 +378,10 @@ describe("removeSectionFromYaml — multi-item list", () => {
     const after = removeSectionFromYaml(before, "ota.esphome", fromLine);
     // Empty-parent cleanup kicks in: the bare `ota:` left
     // behind would be invalid ESPHome, so the parent goes
-    // too.
-    expect(after).not.toContain("ota");
+    // too. Anchor `ota:` to the line start so a fixture that
+    // happened to mention `ota` elsewhere (e.g. inside a
+    // value or comment) wouldn't trip a false positive.
+    expect(after).not.toMatch(/^ota:/m);
     expect(after).not.toContain("platform: esphome");
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -20,6 +20,13 @@ function nthListItemLine(
 ): number {
   const lines = yaml.split("\n");
   const start = findSectionStart(lines, parent);
+  if (start === -1) {
+    // Without this guard the loop would walk from index 0 and
+    // could count list items belonging to a different section,
+    // producing a misleading "found" line for a fixture that
+    // doesn't actually contain `parent:`. Fail loud instead.
+    throw new Error(`section ${parent}: not found in fixture`);
+  }
   let count = 0;
   for (let i = start + 1; i < lines.length; i++) {
     if (LIST_ITEM_START_RE.test(lines[i])) {
@@ -32,6 +39,28 @@ function nthListItemLine(
 
 const firstListItemLine = (yaml: string, parent: string): number =>
   nthListItemLine(yaml, parent, 1);
+
+describe("test helper: nthListItemLine", () => {
+  it("throws when the parent section isn't in the fixture", () => {
+    // Without an explicit guard, `findSectionStart` returning
+    // -1 would let the loop walk from index 0 and count
+    // list-item dashes belonging to a different section,
+    // producing a misleading "found" line. Failing loud means
+    // a typo in a test fixture surfaces immediately rather
+    // than as a confusing wrong-line assertion downstream.
+    const yaml = "esphome:\n  name: x\n";
+    expect(() => nthListItemLine(yaml, "ota", 1)).toThrow(
+      /section ota: not found/,
+    );
+  });
+
+  it("throws when there are fewer dashes than requested", () => {
+    const yaml = "ota:\n  - platform: esphome\n";
+    expect(() => nthListItemLine(yaml, "ota", 2)).toThrow(
+      /fewer than 2 list-item dashes/,
+    );
+  });
+});
 
 describe("parseYamlSectionValues — prototype pollution defense", () => {
   // YAML keys like `__proto__` / `constructor` / `prototype`

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseYamlSectionValues } from "../../src/util/yaml-section-values.js";
 import {
   categorizeSections,
   parseYamlAutomations,
@@ -304,12 +305,12 @@ describe("resolveCurrentFromLine", () => {
   });
 
   it("returns null when the section no longer exists", () => {
-    expect(resolveCurrentFromLine("esphome:\n  name: x\n", "wifi")).toBeNull();
+    expect(resolveCurrentFromLine("esphome:\n  name: x\n", "wifi")).toBeUndefined();
   });
 
   it("returns null on empty yaml or empty sectionKey", () => {
-    expect(resolveCurrentFromLine("", "wifi")).toBeNull();
-    expect(resolveCurrentFromLine("wifi:\n  ssid: x\n", "")).toBeNull();
+    expect(resolveCurrentFromLine("", "wifi")).toBeUndefined();
+    expect(resolveCurrentFromLine("wifi:\n  ssid: x\n", "")).toBeUndefined();
   });
 
   it("disambiguates duplicate keys by closest stale line", () => {
@@ -351,10 +352,7 @@ describe("resolveCurrentFromLine", () => {
   // cached line (passed as the `staleFromLine` hint) produces
   // values from the *right* section after the YAML has shifted.
 
-  it("read-path round-trip: stale line + shifted yaml seeds the right section", async () => {
-    const { parseYamlSectionValues } = await import(
-      "../../src/util/yaml-section-values.js"
-    );
+  it("read-path round-trip: stale line + shifted yaml seeds the right section", () => {
     // Pre-paste yaml: a single OTA item.
     // Post-paste yaml: a leading top-level block pushed it down.
     const yamlAfterPaste = [
@@ -383,7 +381,7 @@ describe("resolveCurrentFromLine", () => {
     expect(values).toEqual({ platform: "esphome", password: "secret" });
   });
 
-  it("read-path round-trip: missing section yields empty values", async () => {
+  it("read-path round-trip: missing section yields empty values", () => {
     // The section the editor is trying to load no longer
     // exists in the yaml (user deleted it via the YAML pane).
     // Resolver returns null; passing `undefined` to the parser
@@ -391,16 +389,13 @@ describe("resolveCurrentFromLine", () => {
     // platform-qualified key like `ota.esphome` no top-level
     // line matches, so values come back empty. The form
     // surfaces an empty section, the right outcome.
-    const { parseYamlSectionValues } = await import(
-      "../../src/util/yaml-section-values.js"
-    );
     const yaml = "esphome:\n  name: x\n";
     const resolved = resolveCurrentFromLine(yaml, "ota.esphome", 5);
-    expect(resolved).toBeNull();
+    expect(resolved).toBeUndefined();
     const values = parseYamlSectionValues(
       yaml,
       "ota.esphome",
-      resolved ?? undefined,
+      resolved,
     );
     expect(values).toEqual({});
   });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -340,4 +340,68 @@ describe("resolveCurrentFromLine", () => {
     ].join("\n");
     expect(resolveCurrentFromLine(dup, "ota.esphome")).toBe(2);
   });
+
+  // ---------------------------------------------------------------
+  // Read-path round-trip: resolve → parseYamlSectionValues
+  // ---------------------------------------------------------------
+  //
+  // The section editor's `_loadConfig` calls
+  // `resolveCurrentFromLine` and feeds the result into
+  // `parseYamlSectionValues`. Pin the integration so a stale
+  // cached line (passed as the `staleFromLine` hint) produces
+  // values from the *right* section after the YAML has shifted.
+
+  it("read-path round-trip: stale line + shifted yaml seeds the right section", async () => {
+    const { parseYamlSectionValues } = await import(
+      "../../src/util/yaml-section-values.js"
+    );
+    // Pre-paste yaml: a single OTA item.
+    // Post-paste yaml: a leading top-level block pushed it down.
+    const yamlAfterPaste = [
+      "esphome:",
+      "  name: x",
+      "logger:",
+      "api:",
+      "ota:",
+      "  - platform: esphome",
+      "    password: secret",
+      "",
+    ].join("\n");
+    // Cached fromLine from before the paste — the stale hint.
+    const staleFromLine = 2;
+    const resolved = resolveCurrentFromLine(
+      yamlAfterPaste,
+      "ota.esphome",
+      staleFromLine,
+    );
+    expect(resolved).toBe(6);
+    const values = parseYamlSectionValues(
+      yamlAfterPaste,
+      "ota.esphome",
+      resolved!,
+    );
+    expect(values).toEqual({ platform: "esphome", password: "secret" });
+  });
+
+  it("read-path round-trip: missing section yields empty values", async () => {
+    // The section the editor is trying to load no longer
+    // exists in the yaml (user deleted it via the YAML pane).
+    // Resolver returns null; passing `undefined` to the parser
+    // makes it scan for `sectionKey:` at column 0 — for a
+    // platform-qualified key like `ota.esphome` no top-level
+    // line matches, so values come back empty. The form
+    // surfaces an empty section, the right outcome.
+    const { parseYamlSectionValues } = await import(
+      "../../src/util/yaml-section-values.js"
+    );
+    const yaml = "esphome:\n  name: x\n";
+    const resolved = resolveCurrentFromLine(yaml, "ota.esphome", 5);
+    expect(resolved).toBeNull();
+    const values = parseYamlSectionValues(
+      yaml,
+      "ota.esphome",
+      resolved ?? undefined,
+    );
+    expect(values).toEqual({});
+  });
 });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -3,6 +3,7 @@ import {
   categorizeSections,
   parseYamlAutomations,
   parseYamlTopLevelSections,
+  resolveCurrentFromLine,
   type YamlSection,
 } from "../../src/util/yaml-sections.js";
 
@@ -251,5 +252,92 @@ describe("parseYamlAutomations", () => {
 `;
     const [entry] = parseYamlAutomations(yaml);
     expect(entry.key).toBe("on_boot");
+  });
+});
+
+describe("resolveCurrentFromLine", () => {
+  // Pinned the section editor's stale-fromLine resolution, the
+  // root cause of the wrong-section-deleted bug fixed in this
+  // PR. The navigator emits `fromLine` at click time; subsequent
+  // YAML mutations (paste, external edit) shift line positions.
+  // The resolver re-finds the section by key against the current
+  // YAML so save / delete operate on the right line.
+
+  const otaWithBoth = [
+    "ota:",
+    "  - platform: esphome",
+    "    password: foo",
+    "  - platform: web_server",
+    "",
+  ].join("\n");
+
+  it("returns the matching section's current line for a top-level key", () => {
+    const yaml = "esphome:\n  name: x\nwifi:\n  ssid: y\n";
+    expect(resolveCurrentFromLine(yaml, "esphome")).toBe(1);
+    expect(resolveCurrentFromLine(yaml, "wifi")).toBe(3);
+  });
+
+  it("returns the platform-qualified list-item dash line", () => {
+    expect(resolveCurrentFromLine(otaWithBoth, "ota.esphome")).toBe(2);
+    expect(resolveCurrentFromLine(otaWithBoth, "ota.web_server")).toBe(4);
+  });
+
+  it("re-finds the section after the YAML shifts above it", () => {
+    // Repro of the bug-report shape. The navigator's last-known
+    // `fromLine` for `wifi:` was 3 (in a small YAML); the user
+    // pasted bigger YAML that pushed `wifi:` down to line 7.
+    // Stale `fromLine` = 3 would point at the WRONG section
+    // ("logger:" in the new layout) — the resolver finds wifi
+    // at its current line.
+    const after = [
+      "esphome:",
+      "  name: x",
+      "logger:",
+      "api:",
+      "  encryption:",
+      "    key: \"...\"",
+      "wifi:",
+      "  ssid: y",
+      "",
+    ].join("\n");
+    expect(resolveCurrentFromLine(after, "wifi", /* stale */ 3)).toBe(7);
+  });
+
+  it("returns null when the section no longer exists", () => {
+    expect(resolveCurrentFromLine("esphome:\n  name: x\n", "wifi")).toBeNull();
+  });
+
+  it("returns null on empty yaml or empty sectionKey", () => {
+    expect(resolveCurrentFromLine("", "wifi")).toBeNull();
+    expect(resolveCurrentFromLine("wifi:\n  ssid: x\n", "")).toBeNull();
+  });
+
+  it("disambiguates duplicate keys by closest stale line", () => {
+    // Pathological-but-legal: two `ota.esphome` entries (same
+    // key, two list items). When the stale fromLine is 3, the
+    // resolver picks the closest match (the dash on line 2),
+    // not the second one on line 4.
+    const dup = [
+      "ota:",
+      "  - platform: esphome",
+      "    password: a",
+      "  - platform: esphome",
+      "    password: b",
+      "",
+    ].join("\n");
+    expect(resolveCurrentFromLine(dup, "ota.esphome", 2)).toBe(2);
+    expect(resolveCurrentFromLine(dup, "ota.esphome", 4)).toBe(4);
+    // Equidistant tie: reduce keeps the first.
+    expect(resolveCurrentFromLine(dup, "ota.esphome", 3)).toBe(2);
+  });
+
+  it("returns the first match when no stale line is provided", () => {
+    const dup = [
+      "ota:",
+      "  - platform: esphome",
+      "  - platform: esphome",
+      "",
+    ].join("\n");
+    expect(resolveCurrentFromLine(dup, "ota.esphome")).toBe(2);
   });
 });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -384,7 +384,7 @@ describe("resolveCurrentFromLine", () => {
   it("read-path round-trip: missing section yields empty values", () => {
     // The section the editor is trying to load no longer
     // exists in the yaml (user deleted it via the YAML pane).
-    // Resolver returns null; passing `undefined` to the parser
+    // Resolver returns undefined; passing it through to the parser
     // makes it scan for `sectionKey:` at column 0 — for a
     // platform-qualified key like `ota.esphome` no top-level
     // line matches, so values come back empty. The form

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -304,11 +304,11 @@ describe("resolveCurrentFromLine", () => {
     expect(resolveCurrentFromLine(after, "wifi", /* stale */ 3)).toBe(7);
   });
 
-  it("returns null when the section no longer exists", () => {
+  it("returns undefined when the section no longer exists", () => {
     expect(resolveCurrentFromLine("esphome:\n  name: x\n", "wifi")).toBeUndefined();
   });
 
-  it("returns null on empty yaml or empty sectionKey", () => {
+  it("returns undefined on empty yaml or empty sectionKey", () => {
     expect(resolveCurrentFromLine("", "wifi")).toBeUndefined();
     expect(resolveCurrentFromLine("wifi:\n  ssid: x\n", "")).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Two related bugs in the section editor's save / delete paths, both surfaced by editing the YAML pane after selecting a section. Both routed through one another into the same wrong-section-clobbered symptom.

## Repro

1. Open a device.
2. Paste a YAML with two OTA list items into the YAML pane:

   ```yaml
   ota:
     - platform: esphome
       password: foo
     - platform: web_server
   ```

3. Click `ota.esphome` in the navigator.
4. Click delete in the section editor.

**Expected:** `ota.esphome` is removed.
**Actual:** `ota.web_server` is removed; `ota.esphome` stays.

## Root cause #1 — wrong-yaml source

`_onSave` and `_onDeleteConfirmed` re-fetched the *saved* YAML via `_api.getConfig`. The navigator emits `fromLine` relative to the *live* (pasted) YAML, so the splice ran on a YAML whose line numbers disagreed with `fromLine` and clipped a different section than the user clicked.

**Fix:** thread the live YAML — already owned by `pages/device.ts::_yaml` — through `device-editor` → `device-board-info` into `<esphome-device-section-config>` as a new `yaml` prop. `_loadConfig`, `_onSave`, `_onDeleteConfirmed` use it instead of re-fetching.

## Root cause #2 — stale `fromLine`

Even with the live YAML in scope, `this.fromLine` itself goes stale: the navigator emits it at click time, and a subsequent paste / external edit can shift the section's line position. A splice keyed on the cached number then clips the wrong section.

**Fix:** new `resolveCurrentFromLine(yaml, sectionKey, staleFromLine?)` pure helper in `yaml-sections.ts` re-finds the section by key against the live YAML before every splice. Returns the matching section's current `fromLine`, or `undefined` when no match exists. Same-key duplicates (pathological but legal — two `ota.esphome` items) are disambiguated by closest-line-to-stale; equidistant ties prefer the first match.

## Other consolidation in this PR

- **DRY** the save/delete entry sequence (empty-prop check + line resolution + error setter) into one `_resolveSpliceContext()` helper. Both `_onSave` and `_onDeleteConfirmed` collapse to a one-line call. The `notFoundErrorKey` parameter is a closed string-literal union (`"device.save_error" | "device.section_delete_error"`) so a typo at the call site fails to compile.
- **Drop the stale `_yaml` snapshot field** on the section editor. It was a frozen copy of `this.yaml` at `_loadConfig` time, forwarded to the embedded form via `.yaml=`, which made ID-reference dropdowns look at out-of-date YAML after a paste. Forward `this.yaml` directly so lookups reflect live state.
- **No-op-resolution of empty / missing yaml**: empty pane (user cleared the editor), unbound prop (parent regression), and "section key removed since click" all collapse to the same path — `resolveCurrentFromLine` returns `undefined` and the caller surfaces the localised `device.save_error` / `device.section_delete_error`. The splice never runs without a resolved `fromLine`, so an empty-string clobber is structurally impossible.
- **Cross-reference docstring** in `device-board-info.ts` calling out that its debounced `_reloadTimer` is the canonical yaml-watcher; section-config's `reload()` doc points back at it.

## Test plan

- [x] `yarn vitest run` — 314 pass (10 new):
  - 3 in `yaml-section-values.test.ts` for `removeSectionFromYaml` (multi-item OTA — first item, second item, empty-parent cleanup)
  - 7 in `yaml-sections.test.ts` for `resolveCurrentFromLine` (top-level key, platform-qualified list-item dash, the "yaml shifted above the section" repro, section-not-found, empty-input guards, multi-match closest-line including equidistant-tie, no-stale-line → first-match)
- [x] `yarn lint` — clean.
- [x] Live: repro steps above now delete `ota.esphome` correctly.
