### PR TITLE
release: pass --repo to gh release edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
         # token (esphome[bot]).
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh release edit "${{ inputs.version }}" --draft=false
+        run: gh release edit "${{ inputs.version }}" --draft=false --repo "${{ github.repository }}"
 
   bump-backend:
     name: Open bump PR on backend


### PR DESCRIPTION
# What does this implement/fix?

The `Publish GitHub release` job in `.github/workflows/release.yml` runs `gh release edit "$VERSION" --draft=false` without doing a checkout. `gh` falls back to inspecting the working directory's git config to figure out which repo to talk to, finds none, and exits with `fatal: not a git repository`. Pass `--repo "${{ github.repository }}"` so the command is self-contained and doesn't need a checkout.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes the failure observed on release run [25302636103](https://github.com/esphome/device-builder-frontend/actions/runs/25302636103) where the `Publish release` step failed with `fatal: not a git repository`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] `npm run lint` passes.
  - [ ] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).