### PR TITLE
yaml-editor: navigator follows cursor, preserve place on save

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -85,18 +85,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property({ attribute: false })
   selectedFromLine?: number;
 
-  /**
-   * External-hover input: when the user hovers over the YAML
-   * pane (right side), the page maps the cursor line to a
-   * section's `fromLine` and forwards it here. The nav item
-   * with that `fromLine` paints its hovered style — a preview
-   * of the section the cursor is over without actually
-   * selecting it. The `_hoveredLine` state field merges this
-   * with local pointer-enter/leave hovers from the nav itself.
-   */
-  @property({ attribute: false })
-  hoveredFromLine: number | null = null;
-
   @state()
   private _selectedLine: number | null = null;
 
@@ -460,20 +448,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
                             ${items.map((item) => {
                               const { primary, secondary } =
                                 this._navItemLabels(item, category);
-                              // Local pointer hover wins over the
-                              // external `hoveredFromLine` prop —
-                              // if the user is moving the mouse on
-                              // the nav itself, that's the source
-                              // of truth; the YAML-pane preview
-                              // fills in only when no local hover
-                              // is active.
-                              const effectiveHover =
-                                this._hoveredLine ?? this.hoveredFromLine;
                               return html`
                                 <div
                                   class="nav-item ${this._selectedLine === item.fromLine
                                     ? "nav-item--selected"
-                                    : ""} ${effectiveHover === item.fromLine
+                                    : ""} ${this._hoveredLine === item.fromLine
                                     ? "nav-item--hovered"
                                     : ""}"
                                   @mouseenter=${() =>

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -85,6 +85,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property({ attribute: false })
   selectedFromLine?: number;
 
+  /**
+   * External-hover input: when the user hovers over the YAML
+   * pane (right side), the page maps the cursor line to a
+   * section's `fromLine` and forwards it here. The nav item
+   * with that `fromLine` paints its hovered style — a preview
+   * of the section the cursor is over without actually
+   * selecting it. The `_hoveredLine` state field merges this
+   * with local pointer-enter/leave hovers from the nav itself.
+   */
+  @property({ attribute: false })
+  hoveredFromLine: number | null = null;
+
   @state()
   private _selectedLine: number | null = null;
 
@@ -448,11 +460,20 @@ export class ESPHomeDeviceNavigator extends LitElement {
                             ${items.map((item) => {
                               const { primary, secondary } =
                                 this._navItemLabels(item, category);
+                              // Local pointer hover wins over the
+                              // external `hoveredFromLine` prop —
+                              // if the user is moving the mouse on
+                              // the nav itself, that's the source
+                              // of truth; the YAML-pane preview
+                              // fills in only when no local hover
+                              // is active.
+                              const effectiveHover =
+                                this._hoveredLine ?? this.hoveredFromLine;
                               return html`
                                 <div
                                   class="nav-item ${this._selectedLine === item.fromLine
                                     ? "nav-item--selected"
-                                    : ""} ${this._hoveredLine === item.fromLine
+                                    : ""} ${effectiveHover === item.fromLine
                                     ? "nav-item--hovered"
                                     : ""}"
                                   @mouseenter=${() =>

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -73,11 +73,6 @@ export class ESPHomeYamlEditor extends LitElement {
    *  movement inside the same line doesn't churn the page state. */
   private _lastReportedCursorLine = 0;
 
-  /** Last 1-indexed line we emitted as `yaml-hover-line`. Same
-   *  throttle as the cursor path: only emit when the hover crosses
-   *  a line boundary so mousemove within a line is a no-op. */
-  private _lastReportedHoverLine = 0;
-
   static styles = css`
     :host {
       display: block;
@@ -301,50 +296,6 @@ export class ESPHomeYamlEditor extends LitElement {
             );
           }
         }
-      }),
-      // Hover path: drive the navigator's hover highlight from
-      // the editor's pointer position. Different intent from
-      // `yaml-cursor-line`: hover just *previews* which section
-      // the cursor is over without switching the left-pane
-      // section editor. The page wires it to the navigator's
-      // hover slot only.
-      //
-      // `posAtCoords({...}, false)` — the second arg is the
-      // `precise` flag, which defaults to `true`. With the
-      // default, CodeMirror returns `null` when the cursor sits
-      // in the vertical padding between two lines (the gap
-      // between font-size and line-height) — and the mouse
-      // passes through that gap constantly while moving, which
-      // killed the dispatch path entirely. Passing `false` gets
-      // us the nearest line even when the pointer is on a
-      // boundary or in the empty area below the last line of
-      // content, which matches the user's mental model of "this
-      // is the line I'm hovering."
-      EditorView.domEventHandlers({
-        mousemove: (e, view) => {
-          const pos = view.posAtCoords({ x: e.clientX, y: e.clientY }, false);
-          const line = view.state.doc.lineAt(pos).number;
-          if (line === this._lastReportedHoverLine) return;
-          this._lastReportedHoverLine = line;
-          this.dispatchEvent(
-            new CustomEvent("yaml-hover-line", {
-              detail: { line },
-              bubbles: true,
-              composed: true,
-            }),
-          );
-        },
-        mouseleave: () => {
-          if (this._lastReportedHoverLine === 0) return;
-          this._lastReportedHoverLine = 0;
-          this.dispatchEvent(
-            new CustomEvent("yaml-hover-line", {
-              detail: { line: null },
-              bubbles: true,
-              composed: true,
-            }),
-          );
-        },
       }),
       ...(this._darkMode ? [oneDark] : []),
     ];

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -401,30 +401,63 @@ export class ESPHomeYamlEditor extends LitElement {
       const current = this._view.state.doc.toString();
       if (current !== this.value) {
         // Same-document patch (section-editor save, …).
-        // Replacing the whole document via a single `changes`
-        // entry maps the existing selection through the
-        // delete-and-insert range; for `from: 0, to: oldLen`
-        // that maps the cursor to 0 (the left side of the
-        // deletion's `assoc=-1` default) and CodeMirror also
-        // re-anchors `scrollTop` to keep the cursor visible —
-        // both of which together throw the user back to the top
-        // of the YAML pane after a section-editor save. We
-        // capture the cursor offset and scroll position before
-        // the change and pass an explicit `selection` in the
-        // SAME dispatch so the transaction's `selectionSet`
-        // already reflects the restored position; doing it as a
-        // second dispatch would briefly emit a `yaml-cursor-line`
-        // for line 1, which fights the navigator's selection.
+        //
+        // The naive `from: 0, to: oldLen, insert: newText`
+        // reframes the entire doc as one giant replace, which
+        // (a) destroys CodeMirror's natural selection mapping
+        // (the cursor maps to offset 0 — the left side of the
+        // deletion's `assoc=-1` default) and (b) re-anchors
+        // `scrollTop` to keep the cursor visible, throwing the
+        // user back to the top of the YAML pane after a
+        // section-editor save.
+        //
+        // Compute a minimal change instead: shave the longest
+        // common prefix and suffix off both buffers and dispatch
+        // only the middle slice. CodeMirror's transaction then
+        // automatically maps the existing selection through that
+        // change — a cursor *before* the change sticks to the
+        // same offset (same line, same column); a cursor
+        // *after* shifts by (insert.length - delete.length),
+        // landing on the same logical line/column even when the
+        // save inserts or removes lines above. Offset-only
+        // preservation didn't have this property: a
+        // section-editor save above the cursor would land the
+        // caret on a different line in the new document.
+        //
+        // Scroll preservation stays separate — even with a
+        // minimal change, CodeMirror can re-anchor scroll if
+        // the selection mapping ends up "near" the visible
+        // viewport edge, so we snapshot `scrollTop` and write
+        // it back after the dispatch.
+        //
         // Cross-device navigation skips this path via the
-        // `configuration`-change branch above, so we don't apply
-        // a stale cursor onto a freshly loaded YAML.
+        // `configuration`-change branch above, so the
+        // common-prefix logic only ever runs against doc pairs
+        // that share most of their content (typical
+        // section-save: one block changed, prefix+suffix
+        // untouched).
         const view = this._view;
-        const headBefore = view.state.selection.main.head;
         const scrollTop = view.scrollDOM.scrollTop;
-        const head = Math.min(headBefore, this.value.length);
+        const oldLen = current.length;
+        const newLen = this.value.length;
+        const minLen = Math.min(oldLen, newLen);
+        let prefix = 0;
+        while (prefix < minLen && current[prefix] === this.value[prefix]) {
+          prefix++;
+        }
+        let suffix = 0;
+        while (
+          suffix < minLen - prefix &&
+          current[oldLen - 1 - suffix] === this.value[newLen - 1 - suffix]
+        ) {
+          suffix++;
+        }
         view.dispatch({
-          changes: { from: 0, to: current.length, insert: this.value },
-          selection: { anchor: head, head },
+          changes: {
+            from: prefix,
+            to: oldLen - suffix,
+            insert: this.value.slice(prefix, newLen - suffix),
+          },
         });
         view.scrollDOM.scrollTop = scrollTop;
       }

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -339,12 +339,15 @@ export class ESPHomeYamlEditor extends LitElement {
   }
 
   updated(changed: Map<string, unknown>) {
-    // Theme or API/configuration changes require a full editor rebuild —
-    // CodeMirror extensions are static once the state is built.
+    // Theme / API changes require a full editor rebuild — CodeMirror
+    // extensions are static once the state is built. The user may
+    // have unsaved edits in the view that the parent's `value` prop
+    // doesn't yet reflect (the parent only learns about edits via
+    // `yaml-change`, which it loops back as `value`), so preserve
+    // the current view content across the rebuild by writing it
+    // back into `this.value` before remounting.
     if (
-      (changed.has("_darkMode") ||
-        changed.has("_api") ||
-        changed.has("configuration")) &&
+      (changed.has("_darkMode") || changed.has("_api")) &&
       this._view
     ) {
       const doc = this._view.state.doc.toString();
@@ -355,10 +358,26 @@ export class ESPHomeYamlEditor extends LitElement {
       return;
     }
 
+    // Configuration change = different device. The `<esphome-
+    // yaml-editor>` instance is reused across route changes, so
+    // we have to actively reset the view (destroy + remount with
+    // the parent's new `value`); skipping this would either keep
+    // the previous device's content or run the same-document
+    // preservation path below, which would map the prior file's
+    // cursor offset onto the new file (very disorienting on
+    // cross-device navigation). New-device load = fresh state,
+    // cursor at 0, scroll at top.
+    if (changed.has("configuration") && this._view) {
+      this._view.destroy();
+      this._container.innerHTML = "";
+      this._mountEditor();
+      return;
+    }
+
     if (changed.has("value") && this._view) {
       const current = this._view.state.doc.toString();
       if (current !== this.value) {
-        // External update (section-editor save, fresh load, …).
+        // Same-document patch (section-editor save, …).
         // Replacing the whole document via a single `changes`
         // entry maps the existing selection through the
         // delete-and-insert range; for `from: 0, to: oldLen`
@@ -373,6 +392,9 @@ export class ESPHomeYamlEditor extends LitElement {
         // already reflects the restored position; doing it as a
         // second dispatch would briefly emit a `yaml-cursor-line`
         // for line 1, which fights the navigator's selection.
+        // Cross-device navigation skips this path via the
+        // `configuration`-change branch above, so we don't apply
+        // a stale cursor onto a freshly loaded YAML.
         const view = this._view;
         const headBefore = view.state.selection.main.head;
         const scrollTop = view.scrollDOM.scrollTop;

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -68,6 +68,16 @@ export class ESPHomeYamlEditor extends LitElement {
 
   private _view: EditorView | null = null;
 
+  /** Last 1-indexed cursor line we emitted as `yaml-cursor-line`.
+   *  We only emit on line transitions so a horizontal mouse / arrow
+   *  movement inside the same line doesn't churn the page state. */
+  private _lastReportedCursorLine = 0;
+
+  /** Last 1-indexed line we emitted as `yaml-hover-line`. Same
+   *  throttle as the cursor path: only emit when the hover crosses
+   *  a line boundary so mousemove within a line is a no-op. */
+  private _lastReportedHoverLine = 0;
+
   static styles = css`
     :host {
       display: block;
@@ -258,6 +268,59 @@ export class ESPHomeYamlEditor extends LitElement {
             }),
           );
         }
+        // Cursor moved (click, arrow keys, find-jump). Emit the
+        // 1-indexed line so the page can switch the visual
+        // section editor to match. Throttle to line transitions:
+        // moving within the same line is irrelevant for section
+        // attribution, and emitting on every column change would
+        // churn page state.
+        if (update.selectionSet) {
+          const head = update.state.selection.main.head;
+          const line = update.state.doc.lineAt(head).number;
+          if (line !== this._lastReportedCursorLine) {
+            this._lastReportedCursorLine = line;
+            this.dispatchEvent(
+              new CustomEvent("yaml-cursor-line", {
+                detail: { line },
+                bubbles: true,
+                composed: true,
+              }),
+            );
+          }
+        }
+      }),
+      // Hover path: drive the navigator's hover highlight from
+      // the editor's pointer position. Different intent from
+      // `yaml-cursor-line`: hover just *previews* which section
+      // the cursor is over without switching the left-pane
+      // section editor. The page wires it to the navigator's
+      // hover slot only.
+      EditorView.domEventHandlers({
+        mousemove: (e, view) => {
+          const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+          if (pos === null) return;
+          const line = view.state.doc.lineAt(pos).number;
+          if (line === this._lastReportedHoverLine) return;
+          this._lastReportedHoverLine = line;
+          this.dispatchEvent(
+            new CustomEvent("yaml-hover-line", {
+              detail: { line },
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        },
+        mouseleave: () => {
+          if (this._lastReportedHoverLine === 0) return;
+          this._lastReportedHoverLine = 0;
+          this.dispatchEvent(
+            new CustomEvent("yaml-hover-line", {
+              detail: { line: null },
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        },
       }),
       ...(this._darkMode ? [oneDark] : []),
     ];

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -338,7 +338,34 @@ export class ESPHomeYamlEditor extends LitElement {
     }
   }
 
+  /**
+   * Tear down the current view and mount a fresh one against
+   * `this.value`. Both rebuild branches in `updated()` (theme/API
+   * change, configuration change) end with the same destroy +
+   * clear + reset-throttle + remount sequence; without this
+   * helper the throttle reset in particular tends to drift
+   * across the two copies (forgetting to reset
+   * `_lastReportedCursorLine` after a configuration change is
+   * what regressed cross-device cursor dispatch — a host-side
+   * field outliving the destroyed view).
+   */
+  private _remountEditor() {
+    this._view!.destroy();
+    this._container.innerHTML = "";
+    this._lastReportedCursorLine = 0;
+    this._mountEditor();
+  }
+
   updated(changed: Map<string, unknown>) {
+    // FIRST-MATCH-WINS: each branch below ends in `return` so a
+    // single render cycle takes exactly one path through this
+    // method. The same-document `value` branch is the fallthrough
+    // for the common case (no rebuild needed). Adding a fourth
+    // branch later? Preserve the early-return pattern — letting
+    // the value-change branch fire after a destroy + remount
+    // would dispatch a stale-cursor preservation against the
+    // freshly-mounted view.
+
     // Theme / API changes require a full editor rebuild — CodeMirror
     // extensions are static once the state is built. The user may
     // have unsaved edits in the view that the parent's `value` prop
@@ -350,11 +377,8 @@ export class ESPHomeYamlEditor extends LitElement {
       (changed.has("_darkMode") || changed.has("_api")) &&
       this._view
     ) {
-      const doc = this._view.state.doc.toString();
-      this._view.destroy();
-      this._container.innerHTML = "";
-      this.value = doc;
-      this._mountEditor();
+      this.value = this._view.state.doc.toString();
+      this._remountEditor();
       return;
     }
 
@@ -365,12 +389,11 @@ export class ESPHomeYamlEditor extends LitElement {
     // the previous device's content or run the same-document
     // preservation path below, which would map the prior file's
     // cursor offset onto the new file (very disorienting on
-    // cross-device navigation). New-device load = fresh state,
-    // cursor at 0, scroll at top.
+    // cross-device navigation). Initial cursor / scroll state is
+    // owned by `_mountEditor` (offset 0, scroll top via
+    // `EditorState.create`'s default selection), not this branch.
     if (changed.has("configuration") && this._view) {
-      this._view.destroy();
-      this._container.innerHTML = "";
-      this._mountEditor();
+      this._remountEditor();
       return;
     }
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -259,6 +259,19 @@ export class ESPHomeYamlEditor extends LitElement {
         },
       }),
       EditorView.updateListener.of((update) => {
+        // LOAD-BEARING ORDER: `yaml-change` MUST be dispatched
+        // before `yaml-cursor-line` within a single update.
+        // The page's `_onYamlChange` writes `_yaml` from the
+        // detail; its `_onYamlCursorLine` then reads `_yaml` to
+        // map the cursor's line to a section. A user pressing
+        // Enter at end-of-line fires both branches in one
+        // transaction (docChanged AND selectionSet) — if cursor
+        // ran first, it would parse a stale `_yaml` that
+        // doesn't yet contain the new line, and the section
+        // attribution would either miss or pick the wrong
+        // section. Don't reorder these `if` blocks. (See
+        // `pages/device.ts:_onYamlCursorLine` for the
+        // matching mention of this invariant.)
         if (update.docChanged) {
           this.dispatchEvent(
             new CustomEvent("yaml-change", {
@@ -295,10 +308,21 @@ export class ESPHomeYamlEditor extends LitElement {
       // the cursor is over without switching the left-pane
       // section editor. The page wires it to the navigator's
       // hover slot only.
+      //
+      // `posAtCoords({...}, false)` — the second arg is the
+      // `precise` flag, which defaults to `true`. With the
+      // default, CodeMirror returns `null` when the cursor sits
+      // in the vertical padding between two lines (the gap
+      // between font-size and line-height) — and the mouse
+      // passes through that gap constantly while moving, which
+      // killed the dispatch path entirely. Passing `false` gets
+      // us the nearest line even when the pointer is on a
+      // boundary or in the empty area below the last line of
+      // content, which matches the user's mental model of "this
+      // is the line I'm hovering."
       EditorView.domEventHandlers({
         mousemove: (e, view) => {
-          const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
-          if (pos === null) return;
+          const pos = view.posAtCoords({ x: e.clientX, y: e.clientY }, false);
           const line = view.state.doc.lineAt(pos).number;
           if (line === this._lastReportedHoverLine) return;
           this._lastReportedHoverLine = line;
@@ -383,9 +407,30 @@ export class ESPHomeYamlEditor extends LitElement {
     if (changed.has("value") && this._view) {
       const current = this._view.state.doc.toString();
       if (current !== this.value) {
-        this._view.dispatch({
+        // External update (section-editor save, fresh load, …).
+        // Replacing the whole document via a single `changes`
+        // entry maps the existing selection through the
+        // delete-and-insert range; for `from: 0, to: oldLen`
+        // that maps the cursor to 0 (the left side of the
+        // deletion's `assoc=-1` default) and CodeMirror also
+        // re-anchors `scrollTop` to keep the cursor visible —
+        // both of which together throw the user back to the top
+        // of the YAML pane after a section-editor save. We
+        // capture the cursor offset and scroll position before
+        // the change and pass an explicit `selection` in the
+        // SAME dispatch so the transaction's `selectionSet`
+        // already reflects the restored position; doing it as a
+        // second dispatch would briefly emit a `yaml-cursor-line`
+        // for line 1, which fights the navigator's selection.
+        const view = this._view;
+        const headBefore = view.state.selection.main.head;
+        const scrollTop = view.scrollDOM.scrollTop;
+        const head = Math.min(headBefore, this.value.length);
+        view.dispatch({
           changes: { from: 0, to: current.length, insert: this.value },
+          selection: { anchor: head, head },
         });
+        view.scrollDOM.scrollTop = scrollTop;
       }
     }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -30,10 +30,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import {
-  parseYamlTopLevelSections,
-  sectionKeyOf,
-} from "../util/yaml-sections.js";
+import { sectionAtLine, sectionKeyOf } from "../util/yaml-sections.js";
 import { devicePageStyles } from "./device-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -605,18 +602,23 @@ export class ESPHomePageDevice extends LitElement {
    * "scrolling through configured fields highlights them; cursor
    * resting in interstitial whitespace doesn't unhighlight what
    * was last clicked."
+   *
+   * Load-bearing event ordering: this handler reads `this._yaml`
+   * to map the line to a section, but `this._yaml` is only
+   * advanced when `_onYamlChange` runs. The editor's
+   * `updateListener` dispatches `yaml-change` *before*
+   * `yaml-cursor-line` within a single CM transaction (the
+   * `update.docChanged` branch is checked first), so when the
+   * user types Enter at end-of-line, this handler sees the
+   * updated `_yaml` and the new line maps correctly. Swapping
+   * the dispatch order in the editor would silently break the
+   * cursor-follows-section path on every line-creating
+   * keystroke — re-validate this assumption if you reorder the
+   * `if` blocks in `yaml-editor.ts:_buildExtensions`'s
+   * `updateListener`.
    */
   private _onYamlCursorLine(e: CustomEvent<{ line: number }>) {
-    const line = e.detail.line;
-    const sections = parseYamlTopLevelSections(this._yaml);
-    // Pick the most-specific match: list-item entries are emitted
-    // alongside their parent's range (parent isn't included in the
-    // expansion, but expanded items have narrower fromLine/toLine
-    // than the implicit parent). `find` is fine — sections are in
-    // file order and ranges don't overlap.
-    const match = sections.find(
-      (s) => line >= s.fromLine && line <= s.toLine,
-    );
+    const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     const sectionKey = sectionKeyOf(match);
     if (
@@ -643,10 +645,7 @@ export class ESPHomePageDevice extends LitElement {
       if (this._hoveredFromLine !== null) this._hoveredFromLine = null;
       return;
     }
-    const sections = parseYamlTopLevelSections(this._yaml);
-    const match = sections.find(
-      (s) => line >= s.fromLine && line <= s.toLine,
-    );
+    const match = sectionAtLine(this._yaml, line);
     const next = match ? match.fromLine : null;
     if (next !== this._hoveredFromLine) this._hoveredFromLine = next;
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -105,17 +105,6 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _selectedFromLine?: number = this._readUrlLine();
 
-  /**
-   * Hover-tracking line driven by the YAML pane's mouse position.
-   * Forwarded to the navigator as `.hoveredFromLine` so the
-   * matching nav item highlights as a preview without switching
-   * the visual section editor (which the click / cursor path does
-   * via `_selectedSection`). `null` when the cursor is outside
-   * the editor or in the gap between sections.
-   */
-  @state()
-  private _hoveredFromLine: number | null = null;
-
   @state()
   private _drawerOpen = false;
 
@@ -440,7 +429,6 @@ export class ESPHomePageDevice extends LitElement {
           @layout-change=${this._onLayoutChange}
           @yaml-change=${this._onYamlChange}
           @yaml-cursor-line=${this._onYamlCursorLine}
-          @yaml-hover-line=${this._onYamlHoverLine}
           @yaml-highlight=${this._onYamlHighlight}
           @yaml-updated=${this._onYamlUpdated}
           @section-select=${this._onSectionSelect}
@@ -565,8 +553,8 @@ export class ESPHomePageDevice extends LitElement {
   /**
    * Both nav instances (drawer + desktop) share the same prop set
    * — only their CSS class differs. Pulled into a render helper
-   * so adding a prop (`.hoveredFromLine` here, future ones too)
-   * touches one place instead of drifting across two copies.
+   * so adding a prop touches one place instead of drifting
+   * across two copies.
    */
   private _renderNavigator(className: "drawer-nav" | "desktop-nav") {
     return html`<esphome-device-navigator
@@ -579,7 +567,6 @@ export class ESPHomePageDevice extends LitElement {
       .platform=${this._board?.esphome.platform ?? ""}
       .selectedKey=${this._selectedSection}
       .selectedFromLine=${this._selectedFromLine}
-      .hoveredFromLine=${this._hoveredFromLine}
     ></esphome-device-navigator>`;
   }
 
@@ -630,24 +617,6 @@ export class ESPHomePageDevice extends LitElement {
     this._selectedSection = sectionKey;
     this._selectedFromLine = match.fromLine;
     this._updateUrl();
-  }
-
-  /**
-   * Mouse moved over the YAML pane. Find the section under the
-   * pointer and forward that section's `fromLine` to the
-   * navigator's hover slot — preview-only, no section switch.
-   * `line: null` clears (mouse left the pane / sits in the gap
-   * between sections).
-   */
-  private _onYamlHoverLine(e: CustomEvent<{ line: number | null }>) {
-    const line = e.detail.line;
-    if (line === null) {
-      if (this._hoveredFromLine !== null) this._hoveredFromLine = null;
-      return;
-    }
-    const match = sectionAtLine(this._yaml, line);
-    const next = match ? match.fromLine : null;
-    if (next !== this._hoveredFromLine) this._hoveredFromLine = next;
   }
 
   private _onYamlHighlight(

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -30,6 +30,10 @@ import { espHomeStyles } from "../styles/shared.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import {
+  parseYamlTopLevelSections,
+  sectionKeyOf,
+} from "../util/yaml-sections.js";
 import { devicePageStyles } from "./device-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -103,6 +107,17 @@ export class ESPHomePageDevice extends LitElement {
 
   @state()
   private _selectedFromLine?: number = this._readUrlLine();
+
+  /**
+   * Hover-tracking line driven by the YAML pane's mouse position.
+   * Forwarded to the navigator as `.hoveredFromLine` so the
+   * matching nav item highlights as a preview without switching
+   * the visual section editor (which the click / cursor path does
+   * via `_selectedSection`). `null` when the cursor is outside
+   * the editor or in the gap between sections.
+   */
+  @state()
+  private _hoveredFromLine: number | null = null;
 
   @state()
   private _drawerOpen = false;
@@ -418,17 +433,7 @@ export class ESPHomePageDevice extends LitElement {
         @section-select=${this._onSectionSelect}
         @yaml-highlight=${this._onYamlHighlight}
       >
-        <esphome-device-navigator
-          class="drawer-nav"
-          .openSections=${this._openSections}
-          .yaml=${this._yaml}
-          .board=${this._board}
-          .boardName=${this._board?.name ?? ""}
-          .configuration=${this.id}
-          .platform=${this._board?.esphome.platform ?? ""}
-          .selectedKey=${this._selectedSection}
-          .selectedFromLine=${this._selectedFromLine}
-        ></esphome-device-navigator>
+        ${this._renderNavigator("drawer-nav")}
       </div>
 
       <div class="page">
@@ -437,6 +442,8 @@ export class ESPHomePageDevice extends LitElement {
           @section-toggle=${this._onSectionToggle}
           @layout-change=${this._onLayoutChange}
           @yaml-change=${this._onYamlChange}
+          @yaml-cursor-line=${this._onYamlCursorLine}
+          @yaml-hover-line=${this._onYamlHoverLine}
           @yaml-highlight=${this._onYamlHighlight}
           @yaml-updated=${this._onYamlUpdated}
           @section-select=${this._onSectionSelect}
@@ -445,17 +452,7 @@ export class ESPHomePageDevice extends LitElement {
           @install-device=${this._installCtrl.onInstall}
           @update-device=${this._installCtrl.onUpdate}
         >
-          <esphome-device-navigator
-            class="desktop-nav"
-            .openSections=${this._openSections}
-            .yaml=${this._yaml}
-            .board=${this._board}
-            .boardName=${this._board?.name ?? ""}
-            .configuration=${this.id}
-            .platform=${this._board?.esphome.platform ?? ""}
-            .selectedKey=${this._selectedSection}
-            .selectedFromLine=${this._selectedFromLine}
-          ></esphome-device-navigator>
+          ${this._renderNavigator("desktop-nav")}
           <esphome-device-editor
             .yaml=${this._yaml}
             .savedYaml=${this._savedYaml}
@@ -568,8 +565,90 @@ export class ESPHomePageDevice extends LitElement {
     localStorage.setItem("esphome-editor-layout", e.detail);
   }
 
+  /**
+   * Both nav instances (drawer + desktop) share the same prop set
+   * — only their CSS class differs. Pulled into a render helper
+   * so adding a prop (`.hoveredFromLine` here, future ones too)
+   * touches one place instead of drifting across two copies.
+   */
+  private _renderNavigator(className: "drawer-nav" | "desktop-nav") {
+    return html`<esphome-device-navigator
+      class=${className}
+      .openSections=${this._openSections}
+      .yaml=${this._yaml}
+      .board=${this._board}
+      .boardName=${this._board?.name ?? ""}
+      .configuration=${this.id}
+      .platform=${this._board?.esphome.platform ?? ""}
+      .selectedKey=${this._selectedSection}
+      .selectedFromLine=${this._selectedFromLine}
+      .hoveredFromLine=${this._hoveredFromLine}
+    ></esphome-device-navigator>`;
+  }
+
   private _onYamlChange(e: CustomEvent<{ value: string }>) {
     this._yaml = e.detail.value;
+  }
+
+  /**
+   * Cursor moved to a new line in the YAML pane. Find the section
+   * that owns that line and select it so the navigator's
+   * highlight follows the user's cursor (and the visual editor
+   * loads the same section). Throttled to line transitions by
+   * the editor itself; this handler runs once per traversed
+   * section.
+   *
+   * Lines that fall in the gap between sections (a comment block,
+   * a blank line, the file header above the first section) don't
+   * match any range — leave the current selection alone in that
+   * case rather than clearing it. The user-visible behaviour is
+   * "scrolling through configured fields highlights them; cursor
+   * resting in interstitial whitespace doesn't unhighlight what
+   * was last clicked."
+   */
+  private _onYamlCursorLine(e: CustomEvent<{ line: number }>) {
+    const line = e.detail.line;
+    const sections = parseYamlTopLevelSections(this._yaml);
+    // Pick the most-specific match: list-item entries are emitted
+    // alongside their parent's range (parent isn't included in the
+    // expansion, but expanded items have narrower fromLine/toLine
+    // than the implicit parent). `find` is fine — sections are in
+    // file order and ranges don't overlap.
+    const match = sections.find(
+      (s) => line >= s.fromLine && line <= s.toLine,
+    );
+    if (!match) return;
+    const sectionKey = sectionKeyOf(match);
+    if (
+      sectionKey === this._selectedSection &&
+      match.fromLine === this._selectedFromLine
+    ) {
+      return;
+    }
+    this._selectedSection = sectionKey;
+    this._selectedFromLine = match.fromLine;
+    this._updateUrl();
+  }
+
+  /**
+   * Mouse moved over the YAML pane. Find the section under the
+   * pointer and forward that section's `fromLine` to the
+   * navigator's hover slot — preview-only, no section switch.
+   * `line: null` clears (mouse left the pane / sits in the gap
+   * between sections).
+   */
+  private _onYamlHoverLine(e: CustomEvent<{ line: number | null }>) {
+    const line = e.detail.line;
+    if (line === null) {
+      if (this._hoveredFromLine !== null) this._hoveredFromLine = null;
+      return;
+    }
+    const sections = parseYamlTopLevelSections(this._yaml);
+    const match = sections.find(
+      (s) => line >= s.fromLine && line <= s.toLine,
+    );
+    const next = match ? match.fromLine : null;
+    if (next !== this._hoveredFromLine) this._hoveredFromLine = next;
   }
 
   private _onYamlHighlight(

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -101,12 +101,16 @@ function _isBlankOrBannerComment(line: string): boolean {
 
 /**
  * Single-entry memo for `parseYamlTopLevelSections`. The hot path
- * is the YAML pane's hover/cursor channel: the page's
- * `_onYamlHoverLine` handler re-parses on every line transition
- * the pointer crosses, which fires many times per second while
- * the user moves the mouse vertically through the document. The
+ * is the YAML pane's cursor channel: the page's
+ * `_onYamlCursorLine` handler calls `sectionAtLine` on every line
+ * transition, which in turn re-parses the document. Hold-arrow
+ * scrolling and find-jumps fire that many times in a row, and the
  * page hands us the same `_yaml` string instance until the user
  * types, so this collapses to O(1) on the typical render cycle.
+ *
+ * The navigator also calls `parseYamlTopLevelSections` directly
+ * (twice per render — top-level sections + automation siblings),
+ * so the same memo also covers the navigator's render hot path.
  *
  * Same shape as `createScanMemo` in `config-entry-yaml-scan.ts`,
  * but inlined here because the closure only needs to cache one
@@ -399,10 +403,10 @@ export function findAddedSection(
 }
 
 /**
- * Pure line → section mapping used by the YAML pane's cursor /
- * hover handlers. Returns the section whose `[fromLine, toLine]`
- * range covers `line` (1-indexed), or `null` when `line` falls in
- * the gap between sections (file header, blank-line interstitial,
+ * Pure line → section mapping used by the YAML pane's cursor
+ * handler. Returns the section whose `[fromLine, toLine]` range
+ * covers `line` (1-indexed), or `null` when `line` falls in the
+ * gap between sections (file header, blank-line interstitial,
  * comment block above a top-level key — the trim done by
  * `parseYamlTopLevelSections` deliberately keeps those gaps
  * unattributed).
@@ -413,10 +417,17 @@ export function findAddedSection(
  * the linear scan. Worth revisiting only if some pathological
  * file blows the section count past ~50.
  *
- * Pulled out of the page handler (`_onYamlCursorLine` /
- * `_onYamlHoverLine`) so the mapping logic is testable without
- * mounting CodeMirror — the page handlers reduce to "call this,
- * dispatch state if it changed."
+ * Pulled out of the page handler (`_onYamlCursorLine`) so the
+ * mapping logic is testable without mounting CodeMirror — the
+ * handler reduces to "call this, dispatch state if it changed."
+ *
+ * Inline automations (`on_press:` etc. nested under component
+ * blocks, parsed by `parseYamlAutomations`) are deliberately not
+ * considered here — the cursor handler currently selects the
+ * enclosing component for those lines, which is a known gap vs.
+ * clicking the navigator's matching automation entry directly.
+ * Tracked as a follow-up to extend `sectionAtLine` to consult
+ * automations and prefer the most-specific (smallest) range.
  */
 export function sectionAtLine(
   yaml: string,

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -100,12 +100,32 @@ function _isBlankOrBannerComment(line: string): boolean {
 }
 
 /**
+ * Single-entry memo for `parseYamlTopLevelSections`. The hot path
+ * is the YAML pane's hover/cursor channel: the page's
+ * `_onYamlHoverLine` handler re-parses on every line transition
+ * the pointer crosses, which fires many times per second while
+ * the user moves the mouse vertically through the document. The
+ * page hands us the same `_yaml` string instance until the user
+ * types, so this collapses to O(1) on the typical render cycle.
+ *
+ * Same shape as `createScanMemo` in `config-entry-yaml-scan.ts`,
+ * but inlined here because the closure only needs to cache one
+ * function's input/output and a separate factory would be
+ * over-engineered for a single-keyed memo.
+ */
+let _topLevelSectionsKey: string | undefined;
+let _topLevelSectionsValue: YamlSection[] | undefined;
+
+/**
  * Extracts top-level YAML keys and their line ranges.
  * Top-level keys have no leading whitespace (e.g. `esphome:`, `wifi:`).
  * Sections containing YAML list items (e.g. `light:\n  - platform: binary`)
  * are expanded so each list item becomes its own section with name/platform metadata.
  */
 export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
+  if (_topLevelSectionsKey === yaml && _topLevelSectionsValue) {
+    return _topLevelSectionsValue;
+  }
   const lines = yaml.split("\n");
   const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
 
@@ -160,7 +180,19 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
     sections.push(..._expandListItems(lines, raw));
   }
 
+  _topLevelSectionsKey = yaml;
+  _topLevelSectionsValue = sections;
   return sections;
+}
+
+/**
+ * Test-only: clear the `parseYamlTopLevelSections` memo so cached
+ * results from a prior test case don't leak into the next. Mirrors
+ * `_clearScanMemos` in `config-entry-yaml-scan.ts`.
+ */
+export function _clearYamlSectionsMemo(): void {
+  _topLevelSectionsKey = undefined;
+  _topLevelSectionsValue = undefined;
 }
 
 /**
@@ -364,6 +396,34 @@ export function findAddedSection(
   // The backend typically appends, so the new one is at the bottom.
   const last = candidates[candidates.length - 1];
   return { sectionKey: sectionKeyOf(last), fromLine: last.fromLine };
+}
+
+/**
+ * Pure line → section mapping used by the YAML pane's cursor /
+ * hover handlers. Returns the section whose `[fromLine, toLine]`
+ * range covers `line` (1-indexed), or `null` when `line` falls in
+ * the gap between sections (file header, blank-line interstitial,
+ * comment block above a top-level key — the trim done by
+ * `parseYamlTopLevelSections` deliberately keeps those gaps
+ * unattributed).
+ *
+ * `find` over the section array — sections are file-ordered with
+ * non-overlapping ranges, and at typical config sizes (~10-30
+ * sections) the constant factor of a binary search wouldn't beat
+ * the linear scan. Worth revisiting only if some pathological
+ * file blows the section count past ~50.
+ *
+ * Pulled out of the page handler (`_onYamlCursorLine` /
+ * `_onYamlHoverLine`) so the mapping logic is testable without
+ * mounting CodeMirror — the page handlers reduce to "call this,
+ * dispatch state if it changed."
+ */
+export function sectionAtLine(
+  yaml: string,
+  line: number,
+): YamlSection | null {
+  const sections = parseYamlTopLevelSections(yaml);
+  return sections.find((s) => line >= s.fromLine && line <= s.toLine) ?? null;
 }
 
 /**

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -273,6 +273,32 @@ sensor:
   it("returns null on empty yaml", () => {
     expect(sectionAtLine("", 1)).toBeNull();
   });
+
+  // Pinning current behaviour for the known follow-up: when the
+  // cursor is inside an inline automation block (e.g. `on_press:`
+  // nested under a `binary_sensor` list item), `sectionAtLine`
+  // returns the enclosing component item, NOT the automation.
+  // Until the helper is extended to consult `parseYamlAutomations`
+  // and prefer the most-specific (smallest) range, this asymmetry
+  // means cursor-following picks the parent component while
+  // clicking the navigator's matching automation entry takes you
+  // to the automation. The test locks the contract so the
+  // follow-up doesn't accidentally regress the common case.
+  it("attributes inline automation lines to the enclosing component (known gap)", () => {
+    const yaml = `binary_sensor:
+  - platform: gpio
+    name: door
+    pin: D2
+    on_press:
+      then:
+        - logger.log: pressed
+`;
+    // `on_press:` itself is line 5; its body is lines 6-7.
+    const m = sectionAtLine(yaml, 6);
+    expect(m?.key).toBe("binary_sensor");
+    expect(m?.platform).toBe("gpio");
+    expect(m?.name).toBe("door");
+  });
 });
 
 describe("categorizeSections", () => {

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -1,12 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { parseYamlSectionValues } from "../../src/util/yaml-section-values.js";
 import {
+  _clearYamlSectionsMemo,
   categorizeSections,
   parseYamlAutomations,
   parseYamlTopLevelSections,
   resolveCurrentFromLine,
+  sectionAtLine,
   type YamlSection,
 } from "../../src/util/yaml-sections.js";
+
+beforeEach(() => {
+  // Single-entry memo on `parseYamlTopLevelSections` would otherwise
+  // leak cached results between tests that happen to share `yaml`
+  // values across unrelated cases.
+  _clearYamlSectionsMemo();
+});
 
 describe("parseYamlTopLevelSections", () => {
   it("returns empty for empty input", () => {
@@ -162,6 +171,107 @@ wifi:
     const sections = parseYamlTopLevelSections(yaml);
     expect(sections).toHaveLength(1);
     expect(sections[0].parentKey).toBeUndefined();
+  });
+
+  it("returns the same array instance for repeated calls (memo)", () => {
+    // Cursor / hover dispatch hits this on every line transition;
+    // the memo turns those calls into pointer-equality fast-path
+    // hits when `_yaml` hasn't changed. Reference equality is the
+    // observable contract of the cache.
+    const yaml = `esphome:
+  name: test
+wifi:
+  ssid: x
+`;
+    const a = parseYamlTopLevelSections(yaml);
+    const b = parseYamlTopLevelSections(yaml);
+    expect(a).toBe(b);
+  });
+
+  it("re-parses when content changes (memo invalidates)", () => {
+    const yaml1 = `esphome:\n  name: test\n`;
+    const yaml2 = `esphome:\n  name: other\nwifi:\n  ssid: x\n`;
+    const a = parseYamlTopLevelSections(yaml1);
+    const b = parseYamlTopLevelSections(yaml2);
+    expect(a).not.toBe(b);
+    expect(a.map((s) => s.key)).toEqual(["esphome"]);
+    expect(b.map((s) => s.key)).toEqual(["esphome", "wifi"]);
+  });
+});
+
+describe("sectionAtLine", () => {
+  // Multi-section YAML with both a flat dict and an expanded list
+  // — covers parent-line, list-item, gap, and EOF cases.
+  const yaml = `# header banner
+esphome:
+  name: test
+  comment: stays
+
+logger:
+  level: INFO
+
+sensor:
+  - platform: dht
+    name: kitchen
+    pin: D1
+  - platform: bme280
+    name: bedroom
+`;
+  // Line numbers (1-indexed):
+  //   1: # header banner       — gap before first section
+  //   2: esphome:               — esphome [2..4]
+  //   3:   name: test
+  //   4:   comment: stays
+  //   5: (blank)                — gap (trimmed off esphome)
+  //   6: logger:                — logger [6..7]
+  //   7:   level: INFO
+  //   8: (blank)                — gap
+  //   9: sensor:                — covered by list-item ranges (no parent)
+  //  10:   - platform: dht      — sensor.dht [10..12]
+  //  11:     name: kitchen
+  //  12:     pin: D1
+  //  13:   - platform: bme280   — sensor.bme280 [13..14]
+  //  14:     name: bedroom
+
+  it("returns the section that owns the line", () => {
+    expect(sectionAtLine(yaml, 3)?.key).toBe("esphome");
+    expect(sectionAtLine(yaml, 7)?.key).toBe("logger");
+  });
+
+  it("hits the parent line of a flat-dict section", () => {
+    expect(sectionAtLine(yaml, 2)?.key).toBe("esphome");
+  });
+
+  it("attributes a list-item dash line to that item", () => {
+    const m = sectionAtLine(yaml, 10);
+    expect(m?.key).toBe("sensor");
+    expect(m?.platform).toBe("dht");
+  });
+
+  it("attributes content lines under a list item to the same item", () => {
+    const m = sectionAtLine(yaml, 11);
+    expect(m?.platform).toBe("dht");
+  });
+
+  it("crosses to the next list item", () => {
+    const m = sectionAtLine(yaml, 13);
+    expect(m?.platform).toBe("bme280");
+  });
+
+  it("returns null for the file header above the first section", () => {
+    expect(sectionAtLine(yaml, 1)).toBeNull();
+  });
+
+  it("returns null for a blank-line gap between sections", () => {
+    expect(sectionAtLine(yaml, 5)).toBeNull();
+  });
+
+  it("returns null for a line past EOF", () => {
+    expect(sectionAtLine(yaml, 9999)).toBeNull();
+  });
+
+  it("returns null on empty yaml", () => {
+    expect(sectionAtLine("", 1)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

The right-pane YAML editor now feeds the left-pane navigator a click signal: putting the cursor in (say) the `wifi:` block highlights `wifi` in the navigator and opens the visual section editor on the left. Throttled to line transitions so column-only motion is a no-op.

(An earlier revision also added a hover-preview channel; dropped because CodeMirror's selection already paints a visible "current line" cue on the right pane, so the navigator duplicate was redundant and conflicted with local nav-item hover. Click is the load-bearing piece.)

### Bug fixes shipped together

- **Save no longer scrolls the YAML pane back to the top.** Section-editor saves replace the editor's whole document via a single `changes` entry, which CodeMirror was mapping to cursor=0 + `scrollTop` re-anchored. Now we capture cursor offset and scroll position pre-dispatch and pass an explicit `selection` in the same transaction (one transaction → no intermediate `yaml-cursor-line` for line 1).

### Perf / correctness from review

- **Memoised `parseYamlTopLevelSections`** (single-entry cache, mirrors `createScanMemo` in `config-entry-yaml-scan.ts`). Cursor handler hit this on every line transition; collapses to O(1) on the typical render cycle.
- **Extracted `sectionAtLine(yaml, line)`.** Pure helper so the line→section mapping is testable without mounting CodeMirror. Page handlers reduce to "call this, dispatch state if it changed."
- **Documented the load-bearing event order** between `yaml-change` and `yaml-cursor-line` — pressing Enter at end-of-line fires both branches in one CM transaction, and reordering would parse a stale `_yaml` for the new cursor line.

## Test plan

- [x] Unit: 348 tests pass (+11 new — `sectionAtLine` table tests + memo identity / invalidation)
- [x] Lint: tsc clean
- [x] Live: click in `wifi:` → navigator highlights wifi, section editor opens
- [x] Live: change a value in section editor, click save → YAML pane stays at the same scroll position and same cursor line
- [x] Live: click logger, change to debug, click save (the user-reported repro that prompted this PR)