### PR TITLE
section editor: preserve block scalars and sub-dict list items

### DIFF
--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -7,7 +7,11 @@
  * read and write — not as a general YAML parser.
  */
 
-import { formatYamlScalar, serializeYamlValues } from "./yaml-serialize.js";
+import {
+  YamlRawValue,
+  formatYamlScalar,
+  serializeYamlValues,
+} from "./yaml-serialize.js";
 
 /**
  * Identifier alphabet ESPHome accepts for top-level / nested config
@@ -44,6 +48,28 @@ const LIST_ITEM_INLINE_KEY_RE = new RegExp(
  * round-trip path, so this is the only realistic source.
  */
 export const LIST_ITEM_START_RE = /^\s+-(\s|$)/;
+
+/**
+ * Block-scalar header on a YAML line: `key: |`, `key: |-`, `key: >`,
+ * `key: >+`, optionally followed by a comment. The minimal parser
+ * doesn't model block scalars; their presence is the canonical
+ * "this value can't be round-tripped through `Record<string, unknown>`"
+ * signal that triggers raw-line preservation.
+ */
+const BLOCK_SCALAR_RE = /:\s*[|>][-+]?\s*(?:#.*)?$/;
+
+/**
+ * Match a list item whose value is a key-style sub-dict header
+ * (`- then:`, `- lambda:`). The dash + key + colon shape is the
+ * other "complex list item" signal alongside block scalars — the
+ * follow-up lines under such a header carry the actual content,
+ * which the simple `string[]` representation would silently drop.
+ *
+ * Allows zero trailing whitespace after the colon (header-only
+ * line) AND content after it (`- lambda: |-`); both forms are
+ * complex.
+ */
+const LIST_ITEM_DICT_KEY_RE = /^\s+-\s+[a-zA-Z_][a-zA-Z0-9_]*:(?:\s|$)/;
 
 const childRegexFor = (indent: string) =>
   new RegExp(`^${indent}(${KEY_PATTERN}):\\s*(.*)$`);
@@ -95,6 +121,62 @@ const collectBlockListItems = (
     items.push(stripQuotes(m[1].trim()));
   }
   return { items, endIdx: j };
+};
+
+/**
+ * Scan forward from `startIdx` and return the 0-indexed line that
+ * ends the value-block sitting underneath a key at `keyIndent`.
+ * The block consists of every subsequent line that's either blank
+ * or indented strictly deeper than `keyIndent`; the first
+ * non-blank line at `keyIndent` (sibling key) or shallower
+ * (back-out) terminates it. EOF is also a valid terminator.
+ *
+ * Used by the raw-preservation path so we know which slice of the
+ * document to capture verbatim when a key's value contains a
+ * block scalar or sub-dict list items the minimal parser can't
+ * round-trip.
+ */
+const _findValueBlockEnd = (
+  lines: string[],
+  startIdx: number,
+  keyIndent: string,
+): number => {
+  for (let i = startIdx; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    const lead = lines[i].match(/^[ \t]*/)![0];
+    if (lead.length <= keyIndent.length) return i;
+  }
+  return lines.length;
+};
+
+/**
+ * Detect whether the value-block in `[startIdx, endIdx)` carries
+ * shapes the minimal parser can't round-trip. Two signals:
+ *
+ *   1. A block-scalar header (`key: |`, `key: >-`) on any line.
+ *      Block scalars span multiple physical lines, and the
+ *      `string` parser would only capture the header.
+ *   2. A list-item whose first token is a key-style header
+ *      (`- then:`, `- lambda:` without inline value). The
+ *      follow-up indented lines carry the actual content; the
+ *      `string[]` parser would silently drop them.
+ *
+ * Either signal triggers raw-line preservation for the whole
+ * block. False negatives here regress to the previous mangling
+ * behaviour, so the regexes are deliberately permissive.
+ */
+const _isComplexBlock = (
+  lines: string[],
+  startIdx: number,
+  endIdx: number,
+): boolean => {
+  for (let i = startIdx; i < endIdx; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (BLOCK_SCALAR_RE.test(line)) return true;
+    if (LIST_ITEM_DICT_KEY_RE.test(line)) return true;
+  }
+  return false;
 };
 
 /**
@@ -164,12 +246,24 @@ export function parseYamlSectionValues(
 
   const listItemPrefix = `${childIndent}  - `;
   const listItemRegex = listItemRegexFor(childIndent);
+  // For list-item-rooted sections: only sibling dashes at the
+  // SAME indentation as the leading dash terminate the section.
+  // A nested list inside a value (`on_press:` → `      - lambda:`)
+  // has a deeper dash indent — treating it as a sibling would
+  // cut the section short and leave the nested content stranded
+  // outside the splice range, which is what mangled saves of
+  // template-button automations.
+  const siblingDashIndent = isListItem
+    ? (lines[startIdx].match(/^(\s*)-/) ?? ["", ""])[1].length
+    : -1;
 
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
     if (isListItem) {
-      if (LIST_ITEM_START_RE.test(line) || /^[a-zA-Z]/.test(line)) break;
+      const dashMatch = line.match(/^(\s*)-(\s|$)/);
+      if (dashMatch && dashMatch[1].length === siblingDashIndent) break;
+      if (/^[a-zA-Z]/.test(line)) break;
     } else if (/^[a-zA-Z]/.test(line)) {
       break;
     }
@@ -186,6 +280,23 @@ export function parseYamlSectionValues(
       const peekLine = lines[peek];
 
       if (peekLine.startsWith(listItemPrefix)) {
+        // Find the full extent of this key's value-block first
+        // (the slice that ends at the next sibling key at
+        // childIndent or back-out). Scanning the whole block is
+        // necessary because complexity can hide on a follow-up
+        // body line — `      - lambda: |-` looks parseable on
+        // its own; the next-line `          some_code();` body
+        // is what triggers raw-mode.
+        const blockEnd = _findValueBlockEnd(lines, i + 1, childIndent);
+        if (_isComplexBlock(lines, i + 1, blockEnd)) {
+          // Slice with `lines.slice(i + 1, blockEnd)` to capture
+          // the lines verbatim (with trailing blank lines
+          // trimmed by `_findValueBlockEnd`'s "next non-blank
+          // line at keyIndent or shallower" terminator).
+          values[key] = new YamlRawValue(lines.slice(i + 1, blockEnd));
+          i = blockEnd - 1;
+          continue;
+        }
         const { items, endIdx } = collectBlockListItems(
           lines,
           i + 1,
@@ -253,6 +364,15 @@ function parseNestedBlock(
       let peek = i + 1;
       while (peek < lines.length && lines[peek].trim() === "") peek++;
       if (peek < lines.length && lines[peek].startsWith(listItemPrefix)) {
+        // Same complex-block detection as the top-level parser:
+        // block scalars or sub-dict list items under a key get
+        // captured raw rather than mangled into `string[]`.
+        const blockEnd = _findValueBlockEnd(lines, i + 1, indent);
+        if (_isComplexBlock(lines, i + 1, blockEnd)) {
+          values[key] = new YamlRawValue(lines.slice(i + 1, blockEnd));
+          i = blockEnd;
+          continue;
+        }
         const { items, endIdx } = collectBlockListItems(
           lines,
           i + 1,
@@ -284,7 +404,21 @@ function parseNestedBlock(
   return { values, endIdx: i };
 }
 
-/** Find the 0-indexed line range [start, end) for a section. */
+/**
+ * Find the 0-indexed line range [start, end) for a section.
+ *
+ * For list-item-rooted sections, termination is on a sibling dash
+ * at the SAME indent as the leading dash (or a top-level key) —
+ * NOT just any indented dash. A nested list inside the section's
+ * value (e.g. an automation list under `on_press:` whose dashes
+ * sit deeper than the section's leading dash) is part of the
+ * section, not a sibling, and clipping the range there leaves the
+ * nested content outside the splice — which then survives the
+ * save and re-appears as duplicate stale lines under the new
+ * serialized output. That regression was visible as a template
+ * button's `on_press` lambda body persisting verbatim after the
+ * form-side save mangled the on_press header.
+ */
 export function findSectionRange(
   lines: string[],
   sectionKey: string,
@@ -294,10 +428,18 @@ export function findSectionRange(
   if (start < 0) return { start: -1, end: -1 };
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
+  const siblingDashIndent = isListItem
+    ? (lines[start].match(/^(\s*)-/) ?? ["", ""])[1].length
+    : -1;
   let end = lines.length;
   for (let i = start + 1; i < lines.length; i++) {
     if (isListItem) {
-      if (LIST_ITEM_START_RE.test(lines[i]) || /^[a-zA-Z]/.test(lines[i])) {
+      const dashMatch = lines[i].match(/^(\s*)-(\s|$)/);
+      if (dashMatch && dashMatch[1].length === siblingDashIndent) {
+        end = i;
+        break;
+      }
+      if (/^[a-zA-Z]/.test(lines[i])) {
         end = i;
         break;
       }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -55,21 +55,44 @@ export const LIST_ITEM_START_RE = /^\s+-(\s|$)/;
  * doesn't model block scalars; their presence is the canonical
  * "this value can't be round-tripped through `Record<string, unknown>`"
  * signal that triggers raw-line preservation.
+ *
+ * Anchored at the start with `^[^"']*:` so the `:` we match is the
+ * key/value delimiter, not a `:` sitting inside a quoted string
+ * value (`name: "weird: |"`). False positives are merely
+ * conservative (they over-trigger raw mode, which is lossless),
+ * but the anchor avoids the surprise of raw-mode kicking in on a
+ * value the parser could otherwise round-trip.
  */
-const BLOCK_SCALAR_RE = /:\s*[|>][-+]?\s*(?:#.*)?$/;
+const BLOCK_SCALAR_RE = /^[^"']*:\s*[|>][-+]?\s*(?:#.*)?$/;
+
+/**
+ * Match an inline block-scalar marker — the part AFTER the colon
+ * on a `key: |-` line, captured by the parser as `raw`. Used to
+ * detect the direct-block-scalar shape (a key whose value is a
+ * block scalar header rather than a list of items).
+ */
+const BLOCK_SCALAR_INLINE_RE = /^[|>][-+]?$/;
 
 /**
  * Match a list item whose value is a key-style sub-dict header
- * (`- then:`, `- lambda:`). The dash + key + colon shape is the
+ * (`- then:`, `- lambda:`, `- logger.log: pressed`,
+ * `- switch.turn_on: relay`). The dash + key + colon shape is the
  * other "complex list item" signal alongside block scalars — the
  * follow-up lines under such a header carry the actual content,
  * which the simple `string[]` representation would silently drop.
+ *
+ * Key allows dots (and digits / underscores after the leading
+ * letter) so dotted action names like `logger.log` /
+ * `switch.turn_on` register as dict-style items. The simpler
+ * bare-identifier form let those automations through as plain
+ * scalars, which the serializer then quoted (`- "logger.log:
+ * pressed"`), corrupting the YAML type.
  *
  * Allows zero trailing whitespace after the colon (header-only
  * line) AND content after it (`- lambda: |-`); both forms are
  * complex.
  */
-const LIST_ITEM_DICT_KEY_RE = /^\s+-\s+[a-zA-Z_][a-zA-Z0-9_]*:(?:\s|$)/;
+const LIST_ITEM_DICT_KEY_RE = /^\s+-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
 
 const childRegexFor = (indent: string) =>
   new RegExp(`^${indent}(${KEY_PATTERN}):\\s*(.*)$`);
@@ -124,59 +147,56 @@ const collectBlockListItems = (
 };
 
 /**
- * Scan forward from `startIdx` and return the 0-indexed line that
- * ends the value-block sitting underneath a key at `keyIndent`.
- * The block consists of every subsequent line that's either blank
- * or indented strictly deeper than `keyIndent`; the first
- * non-blank line at `keyIndent` (sibling key) or shallower
- * (back-out) terminates it. EOF is also a valid terminator.
- *
- * Used by the raw-preservation path so we know which slice of the
- * document to capture verbatim when a key's value contains a
- * block scalar or sub-dict list items the minimal parser can't
+ * Scan forward from `startIdx` once, returning both the 0-indexed
+ * line that ends the value-block under a key at `keyIndent` AND
+ * whether the block carries shapes the minimal parser can't
  * round-trip.
- */
-const _findValueBlockEnd = (
-  lines: string[],
-  startIdx: number,
-  keyIndent: string,
-): number => {
-  for (let i = startIdx; i < lines.length; i++) {
-    if (lines[i].trim() === "") continue;
-    const lead = lines[i].match(/^[ \t]*/)![0];
-    if (lead.length <= keyIndent.length) return i;
-  }
-  return lines.length;
-};
-
-/**
- * Detect whether the value-block in `[startIdx, endIdx)` carries
- * shapes the minimal parser can't round-trip. Two signals:
  *
+ * Block extent: every subsequent line that's either blank or
+ * indented strictly deeper than `keyIndent`. The first non-blank
+ * line at `keyIndent` (sibling key) or shallower (back-out)
+ * terminates it; EOF is also a valid terminator.
+ *
+ * Complexity signals:
  *   1. A block-scalar header (`key: |`, `key: >-`) on any line.
  *      Block scalars span multiple physical lines, and the
  *      `string` parser would only capture the header.
  *   2. A list-item whose first token is a key-style header
- *      (`- then:`, `- lambda:` without inline value). The
+ *      (`- then:`, `- lambda:`, `- logger.log: pressed`). The
  *      follow-up indented lines carry the actual content; the
  *      `string[]` parser would silently drop them.
- *
  * Either signal triggers raw-line preservation for the whole
- * block. False negatives here regress to the previous mangling
- * behaviour, so the regexes are deliberately permissive.
+ * block. False negatives regress to the previous mangling
+ * behaviour, so the regexes are deliberately permissive — false
+ * positives merely over-preserve.
+ *
+ * Indent comparison is on space-only leading whitespace. ESPHome's
+ * emitter never produces tabs and the parser's `LIST_ITEM_START_RE`
+ * / `childRegexFor` already assume spaces, so a tab here is a sign
+ * of YAML the rest of the parser also won't handle correctly.
+ *
+ * Single pass (rather than separate `_findValueBlockEnd` +
+ * `_isComplexBlock` walks) so a section with many top-level keys
+ * and 100+ line value-blocks doesn't pay 2x the line scans.
  */
-const _isComplexBlock = (
+const _scanValueBlock = (
   lines: string[],
   startIdx: number,
-  endIdx: number,
-): boolean => {
-  for (let i = startIdx; i < endIdx; i++) {
+  keyIndent: string,
+): { endIdx: number; isComplex: boolean } => {
+  let isComplex = false;
+  for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
-    if (BLOCK_SCALAR_RE.test(line)) return true;
-    if (LIST_ITEM_DICT_KEY_RE.test(line)) return true;
+    const lead = line.match(/^ */)![0];
+    if (lead.length <= keyIndent.length) return { endIdx: i, isComplex };
+    if (!isComplex) {
+      if (BLOCK_SCALAR_RE.test(line) || LIST_ITEM_DICT_KEY_RE.test(line)) {
+        isComplex = true;
+      }
+    }
   }
-  return false;
+  return { endIdx: lines.length, isComplex };
 };
 
 /**
@@ -273,6 +293,21 @@ export function parseYamlSectionValues(
     const key = match[1];
     const raw = match[2].trim();
 
+    // Direct block scalar: `key: |-` (or `|`, `>`, `>-`, `|+`,
+    // `>+`). The header sits on this line; the body lines are
+    // indented underneath. Without this branch the parser would
+    // store `raw` as a literal string `"|-"` and drop the body —
+    // the serializer would then quote `|-` (it starts with `-`)
+    // and emit `key: "|-"`, corrupting any inline lambda /
+    // multi-line scalar field. Capture the body lines as raw
+    // and replay the inline header on serialize.
+    if (BLOCK_SCALAR_INLINE_RE.test(raw)) {
+      const { endIdx } = _scanValueBlock(lines, i + 1, childIndent);
+      values[key] = new YamlRawValue(lines.slice(i + 1, endIdx), raw);
+      i = endIdx - 1;
+      continue;
+    }
+
     if (raw === "") {
       let peek = i + 1;
       while (peek < lines.length && lines[peek].trim() === "") peek++;
@@ -280,24 +315,26 @@ export function parseYamlSectionValues(
       const peekLine = lines[peek];
 
       if (peekLine.startsWith(listItemPrefix)) {
-        // Find the full extent of this key's value-block first
-        // (the slice that ends at the next sibling key at
-        // childIndent or back-out). Scanning the whole block is
-        // necessary because complexity can hide on a follow-up
-        // body line — `      - lambda: |-` looks parseable on
-        // its own; the next-line `          some_code();` body
-        // is what triggers raw-mode.
-        const blockEnd = _findValueBlockEnd(lines, i + 1, childIndent);
-        if (_isComplexBlock(lines, i + 1, blockEnd)) {
-          // Slice with `lines.slice(i + 1, blockEnd)` to capture
+        // Find the full extent of this key's value-block AND its
+        // complexity in a single forward scan. Complexity can
+        // hide on a follow-up body line — `      - lambda: |-`
+        // looks parseable on its own; the next-line
+        // `          some_code();` body is what triggers raw-mode.
+        const { endIdx, isComplex } = _scanValueBlock(
+          lines,
+          i + 1,
+          childIndent,
+        );
+        if (isComplex) {
+          // Slice with `lines.slice(i + 1, endIdx)` to capture
           // the lines verbatim (with trailing blank lines
-          // trimmed by `_findValueBlockEnd`'s "next non-blank
-          // line at keyIndent or shallower" terminator).
-          values[key] = new YamlRawValue(lines.slice(i + 1, blockEnd));
-          i = blockEnd - 1;
+          // trimmed by `_scanValueBlock`'s "next non-blank line
+          // at keyIndent or shallower" terminator).
+          values[key] = new YamlRawValue(lines.slice(i + 1, endIdx));
+          i = endIdx - 1;
           continue;
         }
-        const { items, endIdx } = collectBlockListItems(
+        const { items, endIdx: listEndIdx } = collectBlockListItems(
           lines,
           i + 1,
           listItemPrefix,
@@ -305,7 +342,7 @@ export function parseYamlSectionValues(
         );
         if (items.length > 0) {
           values[key] = items;
-          i = endIdx - 1;
+          i = listEndIdx - 1;
         }
         continue;
       }
@@ -360,6 +397,18 @@ function parseNestedBlock(
     const key = match[1];
     const raw = match[2].trim();
 
+    // Direct block scalar at nested indent (same shape as the
+    // top-level parser's branch — see comment there). A nested
+    // field written as `key: |-` followed by indented body has
+    // to round-trip via `YamlRawValue`; otherwise the body is
+    // dropped and `raw` survives as a stray `"|-"` string.
+    if (BLOCK_SCALAR_INLINE_RE.test(raw)) {
+      const { endIdx } = _scanValueBlock(lines, i + 1, indent);
+      values[key] = new YamlRawValue(lines.slice(i + 1, endIdx), raw);
+      i = endIdx;
+      continue;
+    }
+
     if (raw === "") {
       let peek = i + 1;
       while (peek < lines.length && lines[peek].trim() === "") peek++;
@@ -367,20 +416,20 @@ function parseNestedBlock(
         // Same complex-block detection as the top-level parser:
         // block scalars or sub-dict list items under a key get
         // captured raw rather than mangled into `string[]`.
-        const blockEnd = _findValueBlockEnd(lines, i + 1, indent);
-        if (_isComplexBlock(lines, i + 1, blockEnd)) {
-          values[key] = new YamlRawValue(lines.slice(i + 1, blockEnd));
-          i = blockEnd;
+        const { endIdx, isComplex } = _scanValueBlock(lines, i + 1, indent);
+        if (isComplex) {
+          values[key] = new YamlRawValue(lines.slice(i + 1, endIdx));
+          i = endIdx;
           continue;
         }
-        const { items, endIdx } = collectBlockListItems(
+        const { items, endIdx: listEndIdx } = collectBlockListItems(
           lines,
           i + 1,
           listItemPrefix,
           listItemRegex,
         );
         values[key] = items;
-        i = endIdx;
+        i = listEndIdx;
         continue;
       }
       const deeper = `${indent}  `;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -20,12 +20,22 @@
  * shape that round-trips byte-for-byte but doesn't fit
  * `string | string[] | Record<string, unknown>`.
  *
- * The instance carries the original lines verbatim (with their
- * leading whitespace), and the serializer pastes them back under a
- * fresh `key:` header without trying to re-render the contents. This
- * lets the form edit fields it understands (a button's `name`,
- * `icon`, `device_class`) without mangling the automation block it
- * doesn't.
+ * The instance carries the original body lines verbatim (with their
+ * leading whitespace). The serializer pastes them back under the
+ * `key:` header — optionally suffixed with `inlineHeader` (the
+ * `|-` / `>+` marker that has to sit on the SAME line as `key:`,
+ * not on its own line). The form edits fields it understands (a
+ * button's `name`, `icon`, `device_class`) without mangling the
+ * automation block it doesn't.
+ *
+ * Two shapes:
+ *   1. List-rooted block (`on_press:` → `- lambda: ...` → body):
+ *      `inlineHeader` is undefined, `lines` includes the dash row
+ *      and everything underneath.
+ *   2. Direct block scalar (`lambda: |-` → body):
+ *      `inlineHeader = "|-"`, `lines` is the body only. The
+ *      serializer emits `key: |-` and then the body, preserving
+ *      the YAML's required header-on-same-line shape.
  *
  * Class identity (rather than a sentinel property) so a YAML key
  * called `__raw` or similar can't accidentally trigger raw-mode on
@@ -34,7 +44,10 @@
  * survives form mutations.
  */
 export class YamlRawValue {
-  constructor(public readonly lines: readonly string[]) {}
+  constructor(
+    public readonly lines: readonly string[],
+    public readonly inlineHeader?: string,
+  ) {}
 }
 
 /**
@@ -52,11 +65,13 @@ export function serializeYamlValues(
     if (val instanceof YamlRawValue) {
       // Raw block (block scalar, automation handler, …). Lines
       // already carry their original indentation — emit `key:`
-      // and paste them back unchanged. `instanceof` check before
+      // (with the inline `|-` / `>+` marker when present) and
+      // paste them back unchanged. `instanceof` check before
       // the generic `typeof === "object"` branch so the class
       // identity wins over the plain-object handling below.
-      if (val.lines.length === 0) continue;
-      lines.push(`${indent}${key}:`);
+      if (val.lines.length === 0 && !val.inlineHeader) continue;
+      const header = val.inlineHeader ? ` ${val.inlineHeader}` : "";
+      lines.push(`${indent}${key}:${header}`);
       lines.push(...val.lines);
       continue;
     }

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -4,13 +4,38 @@
  * `serializeYamlValues` is used by the section editor (to write a
  * section back into the device YAML) and by the add-component dialog
  * (to render a live preview). It handles scalars, arrays of scalars,
- * and nested objects; empty/null/undefined values are skipped.
+ * nested objects, and `YamlRawValue` opaque blocks; empty/null/undefined
+ * values are skipped.
  *
  * `parseTopLevelComponents` walks the YAML to find every top-level
  * key (e.g. `wifi:`, `mqtt:`, `output:`). Both forms use it to
  * evaluate `depends_on_component` predicates and component-level
  * dependency checks against the user's current configuration.
  */
+
+/**
+ * Opaque wrapper for a section-value block the parser couldn't fully
+ * model — block scalars (`lambda: |-`), automation handlers with
+ * sub-dict list items (`on_press:` → `- then:` → ...), or any other
+ * shape that round-trips byte-for-byte but doesn't fit
+ * `string | string[] | Record<string, unknown>`.
+ *
+ * The instance carries the original lines verbatim (with their
+ * leading whitespace), and the serializer pastes them back under a
+ * fresh `key:` header without trying to re-render the contents. This
+ * lets the form edit fields it understands (a button's `name`,
+ * `icon`, `device_class`) without mangling the automation block it
+ * doesn't.
+ *
+ * Class identity (rather than a sentinel property) so a YAML key
+ * called `__raw` or similar can't accidentally trigger raw-mode on
+ * round-trip. ``setIn`` (used by the form) copies values by
+ * reference through ``{...obj}`` spread, so the class identity
+ * survives form mutations.
+ */
+export class YamlRawValue {
+  constructor(public readonly lines: readonly string[]) {}
+}
 
 /**
  * Serialize a values dict as YAML lines at the given indent.
@@ -24,6 +49,17 @@ export function serializeYamlValues(
   const lines: string[] = [];
   for (const [key, val] of Object.entries(values)) {
     if (val === undefined || val === null || val === "") continue;
+    if (val instanceof YamlRawValue) {
+      // Raw block (block scalar, automation handler, …). Lines
+      // already carry their original indentation — emit `key:`
+      // and paste them back unchanged. `instanceof` check before
+      // the generic `typeof === "object"` branch so the class
+      // identity wins over the plain-object handling below.
+      if (val.lines.length === 0) continue;
+      lines.push(`${indent}${key}:`);
+      lines.push(...val.lines);
+      continue;
+    }
     if (Array.isArray(val)) {
       if (val.length === 0) continue;
       lines.push(`${indent}${key}:`);

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -491,7 +491,41 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
       values,
       2,
     );
-    expect(after).toContain("    on_press:\n      - lambda: |-\n          some_code(1, 2);");
+    expect(after).toContain(
+      "    on_press:\n      - lambda: |-\n          some_code(1, 2);",
+    );
+    // Tighten the byte-stable contract: no duplicated section
+    // headers (regression check — early findSectionRange bug
+    // had on_press: appearing twice in the output).
+    expect(after.match(/on_press:/g)).toHaveLength(1);
+    expect(after.match(/lambda:/g)).toHaveLength(1);
+  });
+
+  it("overrides raw preservation when the form writes a new value to that key", () => {
+    // Contract pin: YamlRawValue is the parser's "I can't model
+    // this, paste it back unchanged" sentinel. If the form does
+    // get a real value into that key (a hypothetical edit field
+    // on `on_press`, or the user clearing the field), the
+    // form's value wins and serializer emits it normally —
+    // raw-preservation is a parser-side default, not a sticky
+    // protection.
+    const yaml = `button:
+  - platform: template
+    name: My Button
+    on_press:
+      - lambda: |-
+          some_code();
+`;
+    const values = parseYamlSectionValues(yaml, "button.template", 2);
+    // Form replaces the on_press value with a plain string
+    // (artificial — the real form doesn't expose on_press —
+    // but documents the override semantics).
+    (values as Record<string, unknown>).on_press = "new_value";
+    const after = updateSectionInYaml(yaml, "button.template", values, 2);
+    // Raw block is gone, replaced by the form's string.
+    expect(after).toContain("on_press: new_value");
+    expect(after).not.toContain("- lambda: |-");
+    expect(after).not.toContain("some_code()");
   });
 
   it("findSectionRange does not stop at a nested list inside a value", () => {
@@ -530,6 +564,79 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     expect(after).toContain("          - logger.log: pressed");
     expect(after).toContain("name: Door");
     expect(after).not.toContain('- "then:"');
+  });
+
+  it("preserves a direct block scalar (`lambda: |-`) on a top-level key", () => {
+    // Direct block scalar — value sits on the SAME line as the
+    // key, body underneath. Without raw-preservation the parser
+    // captured `raw = "|-"` as a literal string and dropped the
+    // body; the serializer then quoted `"|-"` (starts with `-`)
+    // producing `lambda: "|-"` and corrupting the field.
+    const yaml = `lambda:
+  lambda: |-
+    return some_value;
+  other_field: hello
+`;
+    // The fixture's first line `lambda:` is a top-level key whose
+    // value is a dict with a NESTED `lambda: |-` field.
+    const values = parseYamlSectionValues(yaml, "lambda");
+    // The nested block is preserved as YamlRawValue under the
+    // outer dict's `lambda` key.
+    expect(values.other_field).toBe("hello");
+    // Now save the section unchanged and verify the block scalar
+    // round-trips byte-for-byte.
+    const after = updateSectionInYaml(yaml, "lambda", values);
+    expect(after).toContain("lambda: |-");
+    expect(after).toContain("    return some_value;");
+    expect(after).not.toContain('lambda: "|-"');
+  });
+
+  it("preserves a direct block scalar at the top level of a list-item section", () => {
+    // The repro Copilot flagged: a list-item section whose body
+    // includes a direct block scalar field (not wrapped in a
+    // list under a key). Editing a sibling field on save would
+    // otherwise drop the block scalar's body.
+    const yaml = `script:
+  - id: my_script
+    then:
+      - logger.log: hello
+    inline_code: |-
+      some_function();
+      another_line;
+`;
+    const values = parseYamlSectionValues(yaml, "script", 2);
+    expect(values.id).toBe("my_script");
+    // Form-side: rename the script
+    (values as Record<string, unknown>).id = "renamed_script";
+    const after = updateSectionInYaml(yaml, "script", values, 2);
+    expect(after).toContain("inline_code: |-");
+    expect(after).toContain("      some_function();");
+    expect(after).toContain("      another_line;");
+    expect(after).toContain("id: renamed_script");
+    expect(after).not.toContain('inline_code: "|-"');
+  });
+
+  it("preserves dotted-key automation actions (`- logger.log:`, `- switch.turn_on:`)", () => {
+    // Pre-fix `LIST_ITEM_DICT_KEY_RE` only matched bare
+    // identifiers, so `- logger.log: pressed` was treated as a
+    // plain string and re-emitted as `- "logger.log: pressed"`,
+    // corrupting the automation.
+    const yaml = `binary_sensor:
+  - platform: gpio
+    pin: D1
+    on_press:
+      - logger.log: pressed
+      - switch.turn_on: relay_id
+`;
+    const values = parseYamlSectionValues(yaml, "binary_sensor.gpio", 2);
+    (values as Record<string, unknown>).name = "Door";
+    const after = updateSectionInYaml(yaml, "binary_sensor.gpio", values, 2);
+    // Both dotted-key items survive without quoting
+    expect(after).toContain("- logger.log: pressed");
+    expect(after).toContain("- switch.turn_on: relay_id");
+    expect(after).not.toContain('- "logger.log: pressed"');
+    expect(after).not.toContain('- "switch.turn_on: relay_id"');
+    expect(after).toContain("name: Door");
   });
 
   it("multi-button list: edits to one item don't disturb siblings", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -414,3 +414,166 @@ describe("removeSectionFromYaml — multi-item list", () => {
     expect(after).not.toContain("platform: esphome");
   });
 });
+
+describe("parseYamlSectionValues / updateSectionInYaml — block scalars and complex automations", () => {
+  // Reduced repro of the user-reported bug: opening a template
+  // button section in the visual editor and adding an icon mangled
+  // the `on_press: - lambda: |-` block into `- "lambda: |-"` and
+  // left the lambda body line stranded after the new icon row.
+  // Two compounding causes:
+  //   1. `findSectionRange` terminated the section at the indented
+  //      `      - lambda: |-` thinking it was a sibling list item
+  //      — it's actually nested inside the on_press value — so the
+  //      splice didn't cover the lambda body line.
+  //   2. The minimal parser/serializer can't represent block
+  //      scalars; `on_press` came back as `["lambda: |-"]` and
+  //      re-serialized as `- "lambda: |-"` (quoted because the
+  //      string contains `:`).
+  // Fix: track the section's leading-dash indent (only sibling
+  // dashes at the same indent terminate); detect block-scalar /
+  // sub-dict-list shapes and round-trip them via `YamlRawValue`.
+
+  const TEMPLATE_BUTTON_YAML = `button:
+  - platform: template
+    name: My Button
+    on_press:
+      - lambda: |-
+          some_code(1, 2);
+`;
+
+  it("preserves a list item's block-scalar lambda body across save", () => {
+    // This is the exact user-reported flow: parse → form adds
+    // `icon` → save. The lambda body must be intact and the
+    // on_press list must NOT have been re-serialized as a
+    // quoted string.
+    const values = parseYamlSectionValues(
+      TEMPLATE_BUTTON_YAML,
+      "button.template",
+      2,
+    );
+    expect(values.platform).toBe("template");
+    expect(values.name).toBe("My Button");
+    // Form-side: user adds an icon
+    (values as Record<string, unknown>).icon = "mdi:account";
+    const after = updateSectionInYaml(
+      TEMPLATE_BUTTON_YAML,
+      "button.template",
+      values,
+      2,
+    );
+
+    // Block scalar lambda is intact
+    expect(after).toContain("- lambda: |-");
+    expect(after).toContain("          some_code(1, 2);");
+    // No mangled quoted-string version
+    expect(after).not.toContain('- "lambda: |-"');
+    // The new icon was added
+    expect(after).toContain('icon: "mdi:account"');
+    // Exactly one on_press: line — not duplicated by the splice
+    expect(after.match(/on_press:/g)).toHaveLength(1);
+    // Exactly one lambda: line (only the original block scalar
+    // header), not the original-plus-mangled-copy
+    expect(after.match(/lambda:/g)).toHaveLength(1);
+  });
+
+  it("preserves the on_press list when the form leaves it untouched", () => {
+    // Sanity round-trip: parse + write WITHOUT the form changing
+    // anything must produce a byte-equivalent (modulo trailing
+    // newline handling) result for the section.
+    const values = parseYamlSectionValues(
+      TEMPLATE_BUTTON_YAML,
+      "button.template",
+      2,
+    );
+    const after = updateSectionInYaml(
+      TEMPLATE_BUTTON_YAML,
+      "button.template",
+      values,
+      2,
+    );
+    expect(after).toContain("    on_press:\n      - lambda: |-\n          some_code(1, 2);");
+  });
+
+  it("findSectionRange does not stop at a nested list inside a value", () => {
+    // Direct test for cause #1: parseYamlSectionValues exposes
+    // the same section-range walk via its outer break loop. If
+    // the loop bailed at `      - lambda: |-`, `name` would be
+    // captured but `on_press` wouldn't — so the presence of
+    // both keys in the parse output proves the walk crossed
+    // the nested dash.
+    const values = parseYamlSectionValues(
+      TEMPLATE_BUTTON_YAML,
+      "button.template",
+      2,
+    );
+    expect(Object.keys(values).sort()).toEqual(
+      ["name", "on_press", "platform"].sort(),
+    );
+  });
+
+  it("preserves sub-dict list items (`- then:` style automations)", () => {
+    // Automations frequently use `- then:` headers with their
+    // own indented body. The simple `string[]` parser would
+    // capture only "then:" and drop the body — same class of
+    // bug as the lambda block scalar.
+    const yaml = `binary_sensor:
+  - platform: gpio
+    pin: D1
+    on_press:
+      - then:
+          - logger.log: pressed
+`;
+    const values = parseYamlSectionValues(yaml, "binary_sensor.gpio", 2);
+    (values as Record<string, unknown>).name = "Door";
+    const after = updateSectionInYaml(yaml, "binary_sensor.gpio", values, 2);
+    expect(after).toContain("- then:");
+    expect(after).toContain("          - logger.log: pressed");
+    expect(after).toContain("name: Door");
+    expect(after).not.toContain('- "then:"');
+  });
+
+  it("multi-button list: edits to one item don't disturb siblings", () => {
+    // The PR description's full scenario — multiple template
+    // buttons, only one is edited. Sibling buttons (above and
+    // below) keep their lambda blocks intact.
+    const yaml = `button:
+  - platform: template
+    name: Button A
+    on_press:
+      - lambda: |-
+          do_a();
+  - platform: template
+    name: Button B
+    on_press:
+      - lambda: |-
+          do_b();
+  - platform: template
+    name: Button C
+    on_press:
+      - lambda: |-
+          do_c();
+`;
+    // Edit the middle button (line 7 = `  - platform: template`
+    // for Button B).
+    const values = parseYamlSectionValues(yaml, "button.template", 7);
+    expect(values.name).toBe("Button B");
+    (values as Record<string, unknown>).icon = "mdi:account";
+    const after = updateSectionInYaml(yaml, "button.template", values, 7);
+    // All three lambda bodies still present
+    expect(after).toContain("do_a();");
+    expect(after).toContain("do_b();");
+    expect(after).toContain("do_c();");
+    // Exactly three lambda headers — the splice didn't duplicate
+    // or drop any
+    expect(after.match(/- lambda: \|-/g)).toHaveLength(3);
+    // Icon landed on the right button
+    const lines = after.split("\n");
+    const bIdx = lines.findIndex((l) => l.includes("name: Button B"));
+    const buttonBSlice = lines
+      .slice(bIdx, bIdx + 6)
+      .join("\n");
+    expect(buttonBSlice).toContain('icon: "mdi:account"');
+    // Sanity: only Button B got the icon (siblings stayed clean)
+    expect(after.match(/icon:/g)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Saving a template button's `icon` via the visual editor mangled the rest of the section. Two compounding parser/serializer bugs:

### Repro

Starting YAML (a button with a `lambda` automation):
```yaml
button:
  - platform: template
    name: Benchmark Noise Encrypt 1000B
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(1000, 500);
```

User opens the section in the visual editor, adds `icon: mdi:account`, saves. Result:

```yaml
button:
  - platform: template
    name: Benchmark Noise Encrypt 1000B
    on_press:
      - "lambda: |-"
    icon: "mdi:account"
      - lambda: |-
          noise_encrypt_benchmark(1000, 500);
```

The on_press header is now a quoted string, the lambda body is duplicated, and the icon line sits between the two copies.

### Root cause

1. **`findSectionRange` terminated on any indented dash.** The section is a list-item rooted at `  - platform: template` (indent 2). The walker bailed at `      - lambda: |-` (indent 6) thinking it was a sibling list item — it's nested inside the on_press value. So the splice range only covered the first three lines; the lambda body survived the splice and re-appeared after the new serialized output.

2. **The minimal parser can't represent block scalars.** `on_press` came back as `["lambda: |-"]` (just the header captured, body dropped). On re-serialize, `formatYamlScalar` quoted the string because it contains `:`, producing `- "lambda: |-"`.

### Fix

- Track the leading-dash indent for list-item-rooted sections; only terminate on a sibling dash at the **same** indent (or a top-level key at column 0). Nested list-items inside the section's value stay inside the range.
- Detect complex value-blocks via two signals: a block-scalar header on any line (`key: |`, `key: |-`, `key: >`, `key: >-`), or a list-item whose first token is a key-style header (`- then:`, `- lambda:`). Capture those blocks as a new `YamlRawValue` opaque wrapper carrying the original lines verbatim.
- Serializer recognises `YamlRawValue` and pastes the raw lines back under a fresh `key:` header. The form edits fields it understands; opaque blocks survive byte-for-byte.

### Tests (+6)

- Lambda block scalar preserved through icon-add save (the exact user-reported flow)
- No-op round-trip: parse → write without form changes is byte-stable for the section
- `findSectionRange` walk crosses a nested list inside a value (proves cause #1 is fixed)
- Sub-dict list items (`- then:` style automations) round-trip cleanly
- Multi-button list: editing the middle button leaves siblings' lambda bodies untouched, with exactly one icon landing on the right item

## Test plan

- [x] Unit: 354 tests pass (was 348, +6 new)
- [x] Lint: tsc clean
- [ ] Live: open a template button with `on_press: - lambda: |-`, add an icon, save → YAML diff shows only the icon line added; lambda body intact
- [ ] Live: same flow on an automation with `- then:` style handler → automation block preserved