### PR TITLE
section editor: keep filled advanced fields visible without toggle

### DIFF
--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -53,8 +53,12 @@ export interface RenderFilterOptions {
  * True when ``entry`` carries a value the user has set (typically
  * loaded from YAML). For leaves, any non-``undefined`` value counts
  * — the YAML parser only adds a key to ``values`` when it's
- * actually present in the document, and the serializer drops empty
- * scalars on save, so the round-trip stays consistent.
+ * actually present in the document, so "present in ``values``"
+ * is the visibility signal we want. Note this is a visibility
+ * predicate, not a serialization predicate: an explicit empty
+ * scalar (``key: ""``) or null may render once and then be
+ * dropped on save by ``serializeYamlValues``, which is fine —
+ * the next reload will hide the field.
  *
  * For NESTED entries, recurse into the sub-dict and report true if
  * any descendant leaf is set; an advanced group with at least one

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -40,10 +40,41 @@ export const ALWAYS_SHOWN_KEYS: ReadonlySet<string> = new Set(["name"]);
 export interface RenderFilterOptions {
   /** When true, drop non-required leaves (except ALWAYS_SHOWN_KEYS). */
   requiredOnly: boolean;
-  /** When false, drop entries marked ``advanced``. */
+  /** When false, drop entries marked ``advanced`` UNLESS they (or
+   *  a descendant) carry a YAML-supplied value. Pre-filled advanced
+   *  fields stay visible without forcing the user through the toggle;
+   *  clearing them in YAML lets them collapse back. */
   showAdvanced: boolean;
   /** Pass-through to ``isEntryVisible`` for cross-component checks. */
   presentComponents?: Set<string>;
+}
+
+/**
+ * True when ``entry`` carries a value the user has set (typically
+ * loaded from YAML). For leaves, any non-``undefined`` value counts
+ * — the YAML parser only adds a key to ``values`` when it's
+ * actually present in the document, and the serializer drops empty
+ * scalars on save, so the round-trip stays consistent.
+ *
+ * For NESTED entries, recurse into the sub-dict and report true if
+ * any descendant leaf is set; an advanced group with at least one
+ * filled child needs to render so the child is reachable.
+ */
+function hasMaterialValue(
+  entry: ConfigEntry,
+  values: Record<string, unknown>,
+): boolean {
+  const value = values[entry.key];
+  if (entry.type === ConfigEntryType.NESTED) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const childValues = value as Record<string, unknown>;
+    return (entry.config_entries ?? []).some((child) =>
+      hasMaterialValue(child, childValues),
+    );
+  }
+  return value !== undefined;
 }
 
 export function filterRenderable(
@@ -54,7 +85,13 @@ export function filterRenderable(
   const out: ConfigEntry[] = [];
   for (const entry of entries) {
     if (!isEntryVisible(entry, values, opts.presentComponents)) continue;
-    if (entry.advanced && !opts.showAdvanced) continue;
+    if (
+      entry.advanced &&
+      !opts.showAdvanced &&
+      !hasMaterialValue(entry, values)
+    ) {
+      continue;
+    }
     if (entry.type === ConfigEntryType.NESTED) {
       const child = values[entry.key];
       const childValues =

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -52,6 +52,95 @@ describe("filterRenderable", () => {
     expect(withAdv.map((e) => e.key)).toEqual(["a", "b"]);
   });
 
+  it("keeps advanced leaves whose YAML value is set, even with showAdvanced off", () => {
+    const entries = [
+      makeEntry({ key: "tx_power", advanced: true }),
+      makeEntry({ key: "fast_connect", advanced: true }),
+      makeEntry({ key: "ssid", required: true }),
+    ];
+    const out = filterRenderable(entries, { tx_power: "20dB", ssid: "x" }, {
+      requiredOnly: false,
+      showAdvanced: false,
+    });
+    // `tx_power` survives because YAML supplied a value;
+    // `fast_connect` stays hidden because it isn't filled.
+    expect(out.map((e) => e.key)).toEqual(["tx_power", "ssid"]);
+  });
+
+  it("treats explicit falsy values (false, 0, '') as set on advanced leaves", () => {
+    const entries = [
+      makeEntry({ key: "use_address", advanced: true }),
+      makeEntry({ key: "channel", advanced: true }),
+      makeEntry({ key: "comment", advanced: true }),
+    ];
+    const out = filterRenderable(
+      entries,
+      { use_address: false, channel: 0, comment: "" },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(out.map((e) => e.key)).toEqual([
+      "use_address",
+      "channel",
+      "comment",
+    ]);
+  });
+
+  it("keeps an advanced NESTED group when any descendant has a value", () => {
+    const entries = [
+      makeEntry({
+        key: "manual_ip",
+        type: ConfigEntryType.NESTED,
+        advanced: true,
+        config_entries: [
+          makeEntry({ key: "static_ip" }),
+          makeEntry({ key: "gateway" }),
+        ],
+      }),
+    ];
+    const filled = filterRenderable(
+      entries,
+      { manual_ip: { static_ip: "10.0.0.5" } },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(filled.map((e) => e.key)).toEqual(["manual_ip"]);
+    const empty = filterRenderable(entries, {}, {
+      requiredOnly: false,
+      showAdvanced: false,
+    });
+    expect(empty.map((e) => e.key)).toEqual([]);
+  });
+
+  it("surfaces an advanced leaf nested inside a non-advanced group when filled", () => {
+    const entries = [
+      makeEntry({
+        key: "ota",
+        type: ConfigEntryType.NESTED,
+        config_entries: [
+          makeEntry({ key: "platform", required: true }),
+          makeEntry({ key: "password", advanced: true }),
+        ],
+      }),
+    ];
+    const filled = filterRenderable(
+      entries,
+      { ota: { platform: "esphome", password: "secret" } },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(filled.map((e) => e.key)).toEqual(["ota"]);
+    const filledChildren = filterRenderable(
+      entries[0].config_entries!,
+      { platform: "esphome", password: "secret" },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(filledChildren.map((e) => e.key)).toEqual(["platform", "password"]);
+    const emptyChildren = filterRenderable(
+      entries[0].config_entries!,
+      { platform: "esphome" },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(emptyChildren.map((e) => e.key)).toEqual(["platform"]);
+  });
+
   it("drops non-required leaves in required-only mode (except ALWAYS_SHOWN_KEYS)", () => {
     const entries = [
       makeEntry({ key: "freq" }), // optional, not allowlisted


### PR DESCRIPTION
## Problem

Advanced component fields are hidden behind the **Show advanced settings** toggle. If the YAML already supplies values for those fields, the user has to flip the toggle to see (or even know about) them. From a glance the form looks like it's missing what the YAML actually contains.

## Changes

- `filterRenderable` now keeps an advanced entry visible when its YAML value is set, regardless of the toggle.
- For advanced NESTED groups, recurse into the sub-dict — the group renders if any descendant is filled.
- Clearing the value from YAML lets the field collapse back into the advanced section on the next reload.
- Added unit tests covering filled leaves, falsy values (`false` / `0` / `""`), advanced NESTED groups, and advanced leaves inside non-advanced groups.