### PR TITLE
webserial: map detected chip description to ESPHome variant

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -16,6 +16,7 @@ import type { ConfiguredDevice } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { chipNameToVariant } from "../util/chip-variant.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
   connectToPort,
@@ -50,10 +51,6 @@ type InstallStep =
   | "done"
   | "download-ready"
   | "error";
-
-function normalizeChipName(name: string): string {
-  return name.split("(")[0].trim().toLowerCase().replace(/-/g, "");
-}
 
 @customElement("esphome-firmware-install-dialog")
 export class ESPHomeFirmwareInstallDialog extends LitElement {
@@ -594,7 +591,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     // the board catalog (same approach the wizard uses), and only
     // strict-compare when we got authoritative info back.
     this._statusMessage = this._localize("firmware.status_verifying");
-    const detectedNorm = normalizeChipName(detected.chipName);
+    const detectedVariant = chipNameToVariant(detected.chipName);
     let expected = device.target_platform;
     let hasAuthoritativeVariant = false;
     if (device.board_id) {
@@ -617,7 +614,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       "[Web Serial] Detected chip:",
       detected.chipName,
       "→",
-      detectedNorm,
+      detectedVariant,
       "| Expected:",
       expected,
       "→",
@@ -628,8 +625,8 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (
       expectedNorm &&
       expectedNorm !== "unknown" &&
-      detectedNorm !== expectedNorm &&
-      !(expectedIsCoarseEsp32 && detectedNorm.startsWith("esp32"))
+      detectedVariant !== expectedNorm &&
+      !(expectedIsCoarseEsp32 && detectedVariant.startsWith("esp32"))
     ) {
       try {
         await disconnect(detected.transport);

--- a/src/util/chip-variant.ts
+++ b/src/util/chip-variant.ts
@@ -1,0 +1,33 @@
+/**
+ * Map a detected chip description (from esptool-js) to its ESPHome
+ * variant string.
+ *
+ * esptool-js returns specific descriptions like ``ESP32-PICO-D4``,
+ * ``ESP32-D0WD``, or ``ESP32-S3-PICO-1``. ESPHome groups all
+ * non-sub-variant ESP32 chips under the plain ``esp32`` variant; sub
+ * variants (S2/S3, C2/C3/C5/C6/C61, H2, P4) are their own variants and
+ * must be matched exactly. ESP8266 has no sub-variants.
+ *
+ * Sub-variant prefixes are listed longest-first so e.g. ``esp32c61``
+ * isn't swallowed by ``esp32c6``.
+ */
+export function chipNameToVariant(name: string): string {
+  const n = name.split("(")[0].trim().toLowerCase().replace(/-/g, "");
+  const subVariants = [
+    "esp32c61",
+    "esp32c2",
+    "esp32c3",
+    "esp32c5",
+    "esp32c6",
+    "esp32h2",
+    "esp32p4",
+    "esp32s2",
+    "esp32s3",
+    "esp8266",
+  ];
+  for (const v of subVariants) {
+    if (n.startsWith(v)) return v;
+  }
+  if (n.startsWith("esp32")) return "esp32";
+  return n;
+}

--- a/test/util/chip-variant.test.ts
+++ b/test/util/chip-variant.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { chipNameToVariant } from "../../src/util/chip-variant.js";
+
+describe("chipNameToVariant", () => {
+  it("maps plain ESP32 to esp32", () => {
+    expect(chipNameToVariant("ESP32")).toBe("esp32");
+  });
+
+  it("maps ESP32-PICO-D4 to esp32 (the bug from #284)", () => {
+    expect(chipNameToVariant("ESP32-PICO-D4")).toBe("esp32");
+  });
+
+  it("maps ESP32-D0WD variants to esp32", () => {
+    expect(chipNameToVariant("ESP32-D0WD")).toBe("esp32");
+    expect(chipNameToVariant("ESP32-D0WDQ6")).toBe("esp32");
+    expect(chipNameToVariant("ESP32-U4WDH")).toBe("esp32");
+  });
+
+  it("maps PICO-V3 variants to esp32", () => {
+    expect(chipNameToVariant("ESP32-PICO-V3")).toBe("esp32");
+    expect(chipNameToVariant("ESP32-PICO-V3-02")).toBe("esp32");
+  });
+
+  it("maps each ESP32 sub-variant to its own variant", () => {
+    expect(chipNameToVariant("ESP32-S2")).toBe("esp32s2");
+    expect(chipNameToVariant("ESP32-S3")).toBe("esp32s3");
+    expect(chipNameToVariant("ESP32-C2")).toBe("esp32c2");
+    expect(chipNameToVariant("ESP32-C3")).toBe("esp32c3");
+    expect(chipNameToVariant("ESP32-C5")).toBe("esp32c5");
+    expect(chipNameToVariant("ESP32-C6")).toBe("esp32c6");
+    expect(chipNameToVariant("ESP32-C61")).toBe("esp32c61");
+    expect(chipNameToVariant("ESP32-H2")).toBe("esp32h2");
+    expect(chipNameToVariant("ESP32-P4")).toBe("esp32p4");
+  });
+
+  it("does not let esp32c6 swallow esp32c61", () => {
+    // Order in the prefix list matters: c61 must be checked before c6.
+    expect(chipNameToVariant("ESP32-C61")).toBe("esp32c61");
+    expect(chipNameToVariant("ESP32-C6")).toBe("esp32c6");
+  });
+
+  it("maps sub-variant packages to the sub-variant family", () => {
+    expect(chipNameToVariant("ESP32-S3-PICO-1")).toBe("esp32s3");
+    expect(chipNameToVariant("ESP32-S2FH4")).toBe("esp32s2");
+    expect(chipNameToVariant("ESP32-S2FN4R2")).toBe("esp32s2");
+  });
+
+  it("maps ESP8266 chips to esp8266", () => {
+    expect(chipNameToVariant("ESP8266")).toBe("esp8266");
+    expect(chipNameToVariant("ESP8266EX")).toBe("esp8266");
+  });
+
+  it("strips parenthetical revision info", () => {
+    expect(chipNameToVariant("ESP32-PICO-D4 (revision 1)")).toBe("esp32");
+    expect(chipNameToVariant("ESP32 (revision 3)")).toBe("esp32");
+  });
+
+  it("returns the normalized input for unknown chips", () => {
+    expect(chipNameToVariant("RP2040")).toBe("rp2040");
+    expect(chipNameToVariant("Unknown-Chip")).toBe("unknownchip");
+  });
+});


### PR DESCRIPTION
## Problem

WebSerial install fails on perfectly valid devices because esptool-js returns specific chip descriptions like `ESP32-PICO-D4`, `ESP32-D0WD`, or `ESP32-S3-PICO-1`, but ESPHome groups all non-sub-variant ESP32 chips under the plain `esp32` variant. The old normalizer just stripped dashes and produced `esp32picod4`, which never matched the authoritative `esp32` variant from the board catalog — so a regular ESP32 board with a PICO-D4 chip got rejected with a false mismatch.

Fixes esphome/device-builder#284

## Changes

- Add `src/util/chip-variant.ts` with `chipNameToVariant()` that maps any esptool-js chip description to its ESPHome variant. Sub-variants (S2/S3, C2/C3/C5/C6/C61, H2, P4) match exactly; everything else ESP32-prefixed falls through to `esp32`. ESP8266 maps to `esp8266`. Sub-variant prefixes are listed longest-first so `esp32c61` isn't swallowed by `esp32c6`.
- Use the new mapper in `firmware-install-dialog._startWebSerialInstall()` instead of the in-file `normalizeChipName`.
- Add `test/util/chip-variant.test.ts` covering the bug case, every sub-variant, the `c61` vs `c6` ordering, package suffixes, ESP8266, and revision strings.