### PR TITLE
ci: enforce PR labels and align label set with backend

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,24 +13,32 @@ categories:
     labels:
       - breaking-change
 
-  - title: "🚀 Features and enhancements"
+  - title: "🚀 New features"
     labels:
-      - feature
-      - enhancement
       - new-feature
+      - enhancement
 
   - title: "🐛 Bug fixes"
     labels:
       - bugfix
-      - bug
 
-  - title: "🧰 Maintenance and dependency bumps"
+  - title: "🔄 Refactor"
+    labels:
+      - refactor
+
+  - title: "📚 Documentation"
+    labels:
+      - docs
+
+  - title: "🧹 Maintenance"
+    labels:
+      - maintenance
+
+  - title: "⬆️ Dependencies / CI"
     collapse-after: 5
     labels:
-      - ci
-      - documentation
-      - maintenance
       - dependencies
+      - ci
 
 template: |
   $CHANGES

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,30 @@
+---
+name: PR Labels
+
+# Every PR must carry exactly one of the labels release-drafter
+# knows how to slot into a release-notes section. Without this
+# guard a contributor can quietly skip labelling and their PR
+# disappears from the next changelog.
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+jobs:
+  pr_labels:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏷 Verify PR has a valid label
+        uses: ludeeus/action-require-labels@7ef0dba93830452589680da7cdea2e2c4c0f8dff  # 1.1.0
+        with:
+          labels: >-
+            breaking-change, bugfix, refactor, new-feature, enhancement,
+            maintenance, ci, dependencies, docs

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -17,6 +17,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pr_labels:
     name: Verify


### PR DESCRIPTION
## Problem

Backend enforces a label allowlist on every PR via `pr-labels.yaml` so release-drafter can slot each PR into the right changelog section. Frontend had no equivalent check, and its release-drafter labels diverged (`feature`, `bug`, `documentation` vs backend's `new-feature`, `bugfix`, `docs`), so changelogs across the two repos look inconsistent and PRs can land unlabelled.

## Changes

- Added `.github/workflows/pr-labels.yaml`, a verbatim copy of the backend's check requiring one of: `breaking-change, bugfix, refactor, new-feature, enhancement, maintenance, ci, dependencies, docs`.
- Updated `.github/release-drafter.yml` categories/labels to match the backend's set (added `refactor` and `docs` sections, dropped `feature`/`bug`/`documentation`).
- Synced the GitHub repo label set with backend (created the 6 missing labels, aligned colors/descriptions, removed the unused `bug` and `help wanted` defaults).