### PR TITLE
section editor: friendly fallback for unknown components

### DIFF
--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -66,6 +66,13 @@ export const deviceSectionConfigStyles = css`
     color: var(--wa-color-text-normal);
   }
 
+  .section-subtitle {
+    margin: 0;
+    font-family: var(--wa-font-family-code);
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-text-quiet);
+  }
+
   .section-desc {
     margin: 0;
     font-size: var(--wa-font-size-xs);

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -157,6 +157,15 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @state()
   private _error = "";
 
+  /** Set when `getComponent` returns null for `sectionKey` — usually
+   *  a custom or external component the backend's catalog doesn't
+   *  describe. We fall back to a synthetic `_config` with no entries
+   *  so the existing YAML-only notice fires; the subtitle renders
+   *  the `domain.platform` so the user can see which key the
+   *  fallback applies to. */
+  @state()
+  private _isUnknown = false;
+
   @state()
   private _fieldErrors: Map<string, ValidationError> = new Map();
 
@@ -277,6 +286,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     this._loading = true;
     this._error = "";
     this._config = null;
+    this._isUnknown = false;
     this._dirty = false;
 
     try {
@@ -285,14 +295,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
       if (id !== this._loadId) return;
 
-      if (!component) {
-        this._error = this._localize("device.unknown_section", {
-          key: this.sectionKey,
-        });
-        this._loading = false;
-        return;
-      }
-
       // Use the live YAML the parent passes in; `fromLine` is
       // relative to that. A `_api.getConfig` re-fetch would
       // disagree with the user-visible YAML when the editor
@@ -300,18 +302,35 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       // different section than the one they clicked.
       const yaml = this.yaml;
 
-      if (id !== this._loadId) return;
-
-      this._config = {
-        section_key: this.sectionKey,
-        section_type: "core",
-        title: component.name,
-        description: component.description,
-        docs_url: component.docs_url,
-        icon: "",
-        image_url: component.image_url,
-        entries: component.config_entries,
-      };
+      if (!component) {
+        // Custom / external component the backend doesn't know
+        // about. Synthesise a config with no entries so the
+        // existing YAML-only notice fires — the section-header's
+        // subtitle surfaces the `domain.platform` so the user
+        // knows which key the fallback applies to.
+        this._config = {
+          section_key: this.sectionKey,
+          section_type: "core",
+          title: this._localize("device.custom_component_title"),
+          description: "",
+          docs_url: "",
+          icon: "",
+          image_url: "",
+          entries: [],
+        };
+        this._isUnknown = true;
+      } else {
+        this._config = {
+          section_key: this.sectionKey,
+          section_type: "core",
+          title: component.name,
+          description: component.description,
+          docs_url: component.docs_url,
+          icon: "",
+          image_url: component.image_url,
+          entries: component.config_entries,
+        };
+      }
       // Resolve `fromLine` against the live YAML — see
       // `_resolveSpliceContext` for the contract and the
       // documented asymmetry between this read path
@@ -398,18 +417,25 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
                 </a>`
               : nothing}
           </div>
-          <p class="section-desc">
-            ${renderMarkdown(this._config.description)}
-          </p>
+          ${this._isUnknown
+            ? html`<p class="section-subtitle">${this.sectionKey}</p>`
+            : nothing}
+          ${this._config.description
+            ? html`<p class="section-desc">
+                ${renderMarkdown(this._config.description)}
+              </p>`
+            : nothing}
         </div>
-        <div class="section-image">
-          <img
-            src=${this._config.image_url || "/assets/board/default.svg"}
-            alt=${this._config.title}
-            referrerpolicy="no-referrer"
-            @error=${this._onImageError}
-          />
-        </div>
+        ${this._isUnknown
+          ? nothing
+          : html`<div class="section-image">
+              <img
+                src=${this._config.image_url || "/assets/board/default.svg"}
+                alt=${this._config.title}
+                referrerpolicy="no-referrer"
+                @error=${this._onImageError}
+              />
+            </div>`}
       </div>
       ${yamlOnly
         ? html`<div class="yaml-only-notice" role="note">

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -305,13 +305,17 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       if (!component) {
         // Custom / external component the backend doesn't know
         // about. Synthesise a config with no entries so the
-        // existing YAML-only notice fires — the section-header's
-        // subtitle surfaces the `domain.platform` so the user
-        // knows which key the fallback applies to.
+        // existing YAML-only notice fires. We deliberately store
+        // `sectionKey` as the title rather than a localised
+        // "Custom component" label: the title flows into the
+        // delete confirm dialog and toast, so a generic label
+        // would make every prompt read the same when a device
+        // has multiple unknown sections. The header itself is
+        // re-localised live in render() — see _isUnknown branch.
         this._config = {
           section_key: this.sectionKey,
           section_type: "core",
-          title: this._localize("device.custom_component_title"),
+          title: this.sectionKey,
           description: "",
           docs_url: "",
           icon: "",
@@ -404,7 +408,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       <div class="section-header">
         <div class="section-header-info">
           <div class="section-header-title-row">
-            <h3 class="section-title">${this._config.title}</h3>
+            <h3 class="section-title">
+              ${this._isUnknown
+                ? this._localize("device.custom_component_title")
+                : this._config.title}
+            </h3>
             ${this._config.docs_url
               ? html`<a
                   class="docs-link"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -483,7 +483,7 @@
     "automation_action_label": "Then do",
     "adding": "Adding…",
     "saving": "Saving…",
-    "unknown_section": "Unknown section: {key}",
+    "custom_component_title": "Custom component",
     "load_config_error": "Failed to load section config",
     "yaml_only_section": "This section doesn't have a structured editor — edit it directly in the YAML pane on the right.",
     "show_yaml_editor": "Show YAML editor",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -398,7 +398,7 @@
     "automation_action_label": "Alors faire",
     "adding": "Ajout…",
     "saving": "Enregistrement…",
-    "unknown_section": "Section inconnue : {key}",
+    "custom_component_title": "Composant personnalisé",
     "load_config_error": "Échec du chargement de la configuration",
     "yaml_only_section": "Cette section n'a pas d'éditeur structuré — modifiez-la directement dans le volet YAML à droite.",
     "show_yaml_editor": "Afficher l'éditeur YAML",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -398,7 +398,7 @@
     "automation_action_label": "Dan doen",
     "adding": "Toevoegen…",
     "saving": "Opslaan…",
-    "unknown_section": "Onbekende sectie: {key}",
+    "custom_component_title": "Aangepast component",
     "load_config_error": "Laden van sectieconfiguratie mislukt",
     "yaml_only_section": "Deze sectie heeft geen gestructureerde editor — bewerk het rechts in de YAML-editor.",
     "show_yaml_editor": "YAML-editor tonen",


### PR DESCRIPTION
## Problem

When the navigator selects a section whose top-level key (or `domain.platform`) isn't in the backend's component catalog — typically a custom or external component — the section editor shouts a red "Unknown section: <key>" error. There's nothing actually wrong; we just can't generate a structured form for it. 


Closes [esphome/device-builder#290](https://github.com/esphome/device-builder/issues/290).

## Change

Synthesize a placeholder config when `getComponent` returns `null` so the section editor renders a soft fallback that reuses the existing YAML-only notice (the same one already shown for `packages`, etc.) instead of erroring out.

- Render header `Custom component` with the `domain.platform` as a monospaced subtitle, so the user can still see which section they clicked.
- Drop the section image for the fallback (no catalog entry → no illustration).
- Reuse the existing `.yaml-only-notice` to point the user at the YAML pane.
- Keep the delete button so users can still remove the section.
- Replace `device.unknown_section` with `device.custom_component_title` in `en` / `nl` / `fr` translations.