### PR TITLE
icon picker: render selected icon on form open (#289)

### DIFF
--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -387,6 +387,13 @@ export class ESPHomeMdiIconPicker extends LitElement {
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._escape.set(this._open);
+    // When the picker is mounted (or assigned a value) with an icon
+    // already selected, kick off the catalog load so the trigger button
+    // can render the SVG. Otherwise the form would open showing only a
+    // placeholder until the user clicks the dropdown.
+    if (changed.has("value") && !this._loaded && normalizeName(this.value)) {
+      void this._ensureCatalogLoaded();
+    }
   }
 
   /* Esc binds to ``document`` (not ``window``) and the callback uses
@@ -421,12 +428,15 @@ export class ESPHomeMdiIconPicker extends LitElement {
   private async _openPanel() {
     this._open = true;
     this.setAttribute("open", "");
-    if (!this._loaded) {
-      this._catalog = await loadCatalog();
-      this._loaded = true;
-    }
+    await this._ensureCatalogLoaded();
     await this.updateComplete;
     this._searchInput?.focus();
+  }
+
+  private async _ensureCatalogLoaded() {
+    if (this._loaded) return;
+    this._catalog = await loadCatalog();
+    this._loaded = true;
   }
 
   private _close() {


### PR DESCRIPTION
The icon picker only loaded its `@mdi/js` catalog when the dropdown was first opened. Forms that opened with an icon already selected therefore showed an empty placeholder in the trigger button until the user clicked it — see [esphome/device-builder#289](https://github.com/esphome/device-builder/issues/289).

## Changes
- Load the catalog from `willUpdate` whenever the picker is mounted (or assigned) with a non-empty value, so the trigger SVG renders immediately.
- Extract the load-once logic into a single `_ensureCatalogLoaded()` helper used by both the new pre-load path and the existing dropdown-open path.
- Empty pickers still defer the load until first interaction; the global catalog promise keeps subsequent picker instances instant.