### PR TITLE
table-row-menu: keep Install in kebab when inline shows Update

### DIFF
--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -83,9 +83,10 @@ export class ESPHomeTableRowMenu extends LitElement {
   hasPending = false;
 
   /** Mirrors ``ConfiguredDevice.update_available`` for the open
-   *  device. The inline Update button takes precedence over Install
-   *  when this is true; the kebab's Install entry hides for the same
-   *  reason as ``hasPending``. */
+   *  device. The inline button takes the "Update" shape when this
+   *  is true (forces an OTA push); the kebab's Install entry stays
+   *  visible in that case so the user can still pick serial / web-
+   *  flasher path even though OTA is offered inline. */
   @property({ type: Boolean, attribute: "has-update", reflect: true })
   hasUpdate = false;
 
@@ -195,18 +196,24 @@ export class ESPHomeTableRowMenu extends LitElement {
          pairing is obvious at a glance; breakpoints are off-by-one
          from the inline rules so the transition pixel never has both
          copies hidden:
-           menu-item--install  (only when has-pending)  inline > 820px
+           menu-item--install  (when has-pending and NOT has-update)
+                                                        inline > 820px
            menu-item--logs                              inline > 920px
-           menu-item--visit-web                         inline > 1024px */
+           menu-item--visit-web                         inline > 1024px
+
+         When 'has-update' is set the inline button shows "Update"
+         (forces an OTA push). The kebab Install entry stays visible
+         in that case — it's the alternate "install via serial /
+         web-flasher" path the user reaches when their device is
+         tethered for boot-log capture, etc. — so the dedupe rule
+         only fires on 'has-pending' without 'has-update'. */
       :host([card-mode]) .menu-item--logs,
       :host([card-mode]) .menu-item--visit-web,
-      :host([card-mode][has-pending]) .menu-item--install,
-      :host([card-mode][has-update]) .menu-item--install {
+      :host([card-mode][has-pending]:not([has-update])) .menu-item--install {
         display: none;
       }
       @media (min-width: 821px) {
-        :host(:not([card-mode])[has-pending]) .menu-item--install,
-        :host(:not([card-mode])[has-update]) .menu-item--install {
+        :host(:not([card-mode])[has-pending]:not([has-update])) .menu-item--install {
           display: none;
         }
       }
@@ -236,21 +243,13 @@ export class ESPHomeTableRowMenu extends LitElement {
           <wa-icon library="mdi" name="check-decagram"></wa-icon>
           ${this._localize("dashboard.action_validate")}
         </div>
-        ${this.hasUpdate
-          ? html`<div
-              class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
-              @click=${this.busy ? undefined : () => this._emit("update-device")}
-            >
-              <wa-icon library="mdi" name="upload"></wa-icon>
-              ${this._localize("dashboard.update")}
-            </div>`
-          : html`<div
-              class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
-              @click=${this.busy ? undefined : () => this._emit("install-device")}
-            >
-              <wa-icon library="mdi" name="upload"></wa-icon>
-              ${this._localize("dashboard.action_install")}
-            </div>`}
+        <div
+          class="menu-item menu-item--install ${this.busy ? "menu-item--disabled" : ""}"
+          @click=${this.busy ? undefined : () => this._emit("install-device")}
+        >
+          <wa-icon library="mdi" name="upload"></wa-icon>
+          ${this._localize("dashboard.action_install")}
+        </div>
         <div class="menu-item menu-item--logs" @click=${() => this._emit("open-logs")}>
           <wa-icon library="mdi" name="console"></wa-icon>
           ${this._localize("dashboard.drawer_logs")}


### PR DESCRIPTION
## Summary

Restores the kebab menu's **Install** entry on rows where the inline button has morphed to **Update** (an `update_available` device, online and OTA-reachable). The kebab Install was the alternate "install via serial / web-flasher" path users want when their device is tethered to their computer for boot-log capture, or when they want to pick a flash method instead of being forced into OTA.

## Repro

1. Open the dashboard with a device that's online and has an update available (`update_available === true`).
2. Inline action button reads "Update".
3. Open the kebab — Install is missing. The only flash path is the inline OTA Update.

## Fix

Two changes in `src/components/dashboard/table-row-menu.ts`:

- **Template**: stop morphing the kebab entry to "Update" when `hasUpdate` is set. The kebab always shows **Install** with the `install-device` action; the inline button owns the "Update" OTA-force-push affordance.
- **CSS dedupe**: only hide `.menu-item--install` when `has-pending` is set AND `has-update` is NOT — so the entry stays visible whenever the inline button is "Update". Card-mode and the `>821px` table breakpoint both updated.

After: with an update-available device, the row shows inline **Update** AND kebab **Install** — same as a non-online dirty device shows inline **Install** AND no kebab Install (still deduped).

Discussed in #esphome-dev: jesserockz pointed out forcing OTA on online devices breaks the serial-tethered flow; marcelveldt confirmed the kebab Install was the prior remedy; bdraco filed this as the regression.

## Test plan

- [x] Lint: tsc clean
- [x] Tests: 372 pass
- [ ] Live: device with `update_available`, online → inline reads "Update", kebab still has "Install"
- [ ] Live: device dirty (pending), offline / not OTA-reachable → inline "Install", kebab Install hidden via dedupe (above 821px / card-mode)
- [ ] Live: clean device, no update → no inline button, kebab still has "Install" (always-available path)