### PR TITLE
Render every announced device IP in the drawer

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -82,8 +82,16 @@ export interface ConfiguredDevice {
   target_platform: string;
   /** mDNS hostname from StorageJSON (e.g. "my_device.local"). */
   address: string;
-  /** Resolved IPv4 address from mDNS — empty until the device is seen online. */
+  /** Primary resolved address — IPv4 when the device announces one,
+   *  else the first scoped IPv6. Empty until the device is seen
+   *  online. Drives ICMP probes, the OTA address cache, and the
+   *  table's IP column. */
   ip: string;
+  /** Every IP currently announced by the device (IPv4 first, then
+   *  any scoped IPv6 entries). Empty until mDNS resolves the device;
+   *  populated alongside ``ip`` so the drawer can surface every
+   *  address a multi-homed device claims. */
+  ip_addresses: string[];
   web_port: number | null;
   current_version: string;
   deployed_version: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -90,8 +90,9 @@ export interface ConfiguredDevice {
   /** Every IP currently announced by the device (IPv4 first, then
    *  any scoped IPv6 entries). Empty until mDNS resolves the device;
    *  populated alongside ``ip`` so the drawer can surface every
-   *  address a multi-homed device claims. */
-  ip_addresses: string[];
+   *  address a multi-homed device claims. Optional because older
+   *  backends omit the field entirely — guard before reading. */
+  ip_addresses?: string[];
   web_port: number | null;
   current_version: string;
   deployed_version: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -88,11 +88,10 @@ export interface ConfiguredDevice {
    *  table's IP column. */
   ip: string;
   /** Every IP currently announced by the device (IPv4 first, then
-   *  any scoped IPv6 entries). Empty until mDNS resolves the device;
-   *  populated alongside ``ip`` so the drawer can surface every
-   *  address a multi-homed device claims. Optional because older
-   *  backends omit the field entirely — guard before reading. */
-  ip_addresses?: string[];
+   *  any scoped IPv6 entries). Empty array until mDNS resolves the
+   *  device; populated alongside ``ip`` so the drawer can surface
+   *  every address a multi-homed device claims. */
+  ip_addresses: string[];
   web_port: number | null;
   current_version: string;
   deployed_version: string;

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -157,10 +157,10 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         font-style: italic;
       }
 
-      /* Vertical list for the IP-address row when a device announces
-         more than one address. Each entry sits on its own line so the
-         drawer doesn't truncate scoped IPv6 entries (which carry a
-         "%scope" suffix and easily overflow the row width). */
+      /* Stack each IP on its own line when a device announces more
+         than one address. Without this, .value's word-break would
+         wrap a long scoped IPv6 ("%scope" suffix and all) into the
+         next address mid-token, making the list hard to read. */
       .ip-list {
         display: flex;
         flex-direction: column;
@@ -565,13 +565,12 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
      than one address (a dual-stack host with both V4 and a scoped
      IPv6) the row stacks each entry on its own line; with a single
      address (or none) it falls back to the same shape as every
-     other row. ``ip_addresses`` is the canonical multi-IP list;
-     ``ip`` and ``address`` keep the row populated for older API
-     responses and pre-mDNS state. */
+     other row. ``ip_addresses`` is the canonical multi-IP list and
+     ``ip`` is its primary; ``address`` (the mDNS hostname) keeps
+     the row populated when the device hasn't been resolved yet. */
   private _renderIpRow(d: ConfiguredDevice) {
     const label = this._localize("dashboard.drawer_ip_address");
-    const ips =
-      d.ip_addresses && d.ip_addresses.length > 0 ? d.ip_addresses : d.ip ? [d.ip] : [];
+    const ips = d.ip_addresses?.length ? d.ip_addresses : d.ip ? [d.ip] : [];
     if (ips.length <= 1) {
       return this._row("ip-network-outline", label, ips[0] || d.address, true);
     }

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -21,10 +21,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { ConfiguredDevice } from "../../api/types.js";
-import {
-  integrationDocsContext,
-  localizeContext,
-} from "../../context/index.js";
+import { integrationDocsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -101,8 +98,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         letter-spacing: 0.06em;
         margin: 0 0 var(--wa-space-s);
         padding-bottom: var(--wa-space-xs);
-        border-bottom: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       }
 
       .row {
@@ -124,11 +120,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         width: 32px;
         height: 32px;
         border-radius: var(--wa-border-radius-m);
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 90%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
         flex-shrink: 0;
         margin-top: 2px;
       }
@@ -156,14 +148,23 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       }
 
       .value.mono {
-        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-          monospace;
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
         font-size: var(--wa-font-size-xs);
       }
 
       .value.muted {
         color: var(--wa-color-text-quiet);
         font-style: italic;
+      }
+
+      /* Vertical list for the IP-address row when a device announces
+         more than one address. Each entry sits on its own line so the
+         drawer doesn't truncate scoped IPv6 entries (which carry a
+         "%scope" suffix and easily overflow the row width). */
+      .ip-list {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
       }
 
       .tags-wrap {
@@ -332,25 +333,39 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         : nothing}
       <div class="section">
         <h4 class="section-title">${this._localize("dashboard.drawer_device_info")}</h4>
-        ${this._row("information-outline", this._localize("dashboard.drawer_name"), d.friendly_name || d.name)}
-        ${this._row("ip-network-outline", this._localize("dashboard.drawer_ip_address"), d.ip || d.address, true)}
-        ${this._row("memory", this._localize("dashboard.drawer_platform"), d.target_platform)}
+        ${this._row(
+          "information-outline",
+          this._localize("dashboard.drawer_name"),
+          d.friendly_name || d.name
+        )}
+        ${this._renderIpRow(d)}
+        ${this._row(
+          "memory",
+          this._localize("dashboard.drawer_platform"),
+          d.target_platform
+        )}
       </div>
 
       ${this._renderVersionSection(d)}
 
       <div class="section">
         <h4 class="section-title">${this._localize("dashboard.drawer_configuration")}</h4>
-        ${this._row("file-document-outline", this._localize("dashboard.drawer_config_file"), d.configuration, true)}
+        ${this._row(
+          "file-document-outline",
+          this._localize("dashboard.drawer_config_file"),
+          d.configuration,
+          true
+        )}
         ${this._row("text-short", this._localize("dashboard.drawer_comment"), d.comment)}
       </div>
 
       ${this._renderConfigHashSection(d)}
-
       ${d.loaded_integrations && d.loaded_integrations.length > 0
         ? html`
             <div class="section">
-              <h4 class="section-title">${this._localize("dashboard.drawer_loaded_integrations")}</h4>
+              <h4 class="section-title">
+                ${this._localize("dashboard.drawer_loaded_integrations")}
+              </h4>
               <div class="tags-wrap">
                 ${d.loaded_integrations.map((i) => {
                   const url = this._integrationDocs[i];
@@ -395,7 +410,9 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const statusKey = matches
       ? "dashboard.drawer_version_in_sync"
       : "dashboard.drawer_version_out_of_sync";
-    const statusCls = matches ? "sync-status sync-status--match" : "sync-status sync-status--diff";
+    const statusCls = matches
+      ? "sync-status sync-status--match"
+      : "sync-status sync-status--diff";
     // Suppress the badge entirely when the device hasn't reported a
     // version yet (no mDNS announce). Comparing against an empty
     // string would always read "out of sync" — meaningless noise on
@@ -414,13 +431,13 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           "tag-multiple",
           this._localize("dashboard.drawer_current_version"),
           local,
-          true,
+          true
         )}
         ${this._row(
           "upload",
           this._localize("dashboard.drawer_deployed_version"),
           deployed,
-          true,
+          true
         )}
       </div>
     `;
@@ -448,7 +465,9 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const statusKey = matches
       ? "dashboard.drawer_config_hash_in_sync"
       : "dashboard.drawer_config_hash_out_of_sync";
-    const statusCls = matches ? "sync-status sync-status--match" : "sync-status sync-status--diff";
+    const statusCls = matches
+      ? "sync-status sync-status--match"
+      : "sync-status sync-status--diff";
     // Match the version section's gating: only show the pill when
     // both sides are populated. A device that has compiled but
     // hasn't broadcast yet (or vice versa) doesn't have enough data
@@ -471,19 +490,21 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           "fingerprint",
           this._localize("dashboard.drawer_config_hash_local"),
           expected,
-          true,
+          true
         )}
         ${this._row(
           "fingerprint",
           this._localize("dashboard.drawer_config_hash_deployed"),
           deployed,
-          true,
+          true
         )}
       </div>
     `;
   }
 
-  private _renderEncryptionBadge(state: "active" | "plaintext" | "pending" | "mismatch" | "none") {
+  private _renderEncryptionBadge(
+    state: "active" | "plaintext" | "pending" | "mismatch" | "none"
+  ) {
     /* The four-state mapping for the drawer's coloured pill. The
        ``getEncryptionVisual`` helper carries the icon + tooltip
        choices for the icon-only views (card, table); the drawer adds
@@ -534,6 +555,35 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           <div class="label">${label}</div>
           <div class="value ${mono ? "mono" : ""} ${empty ? "muted" : ""}">
             ${value || "\u2014"}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  /* Render the IP-address row. When the device has announced more
+     than one address (a dual-stack host with both V4 and a scoped
+     IPv6) the row stacks each entry on its own line; with a single
+     address (or none) it falls back to the same shape as every
+     other row. ``ip_addresses`` is the canonical multi-IP list;
+     ``ip`` and ``address`` keep the row populated for older API
+     responses and pre-mDNS state. */
+  private _renderIpRow(d: ConfiguredDevice) {
+    const label = this._localize("dashboard.drawer_ip_address");
+    const ips =
+      d.ip_addresses && d.ip_addresses.length > 0 ? d.ip_addresses : d.ip ? [d.ip] : [];
+    if (ips.length <= 1) {
+      return this._row("ip-network-outline", label, ips[0] || d.address, true);
+    }
+    return html`
+      <div class="row">
+        <div class="icon">
+          <wa-icon library="mdi" name="ip-network-outline"></wa-icon>
+        </div>
+        <div class="content">
+          <div class="label">${label}</div>
+          <div class="value mono ip-list">
+            ${ips.map((ip) => html`<span>${ip}</span>`)}
           </div>
         </div>
       </div>

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -570,7 +570,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
      the row populated when the device hasn't been resolved yet. */
   private _renderIpRow(d: ConfiguredDevice) {
     const label = this._localize("dashboard.drawer_ip_address");
-    const ips = d.ip_addresses?.length ? d.ip_addresses : d.ip ? [d.ip] : [];
+    const ips = d.ip_addresses.length > 0 ? d.ip_addresses : d.ip ? [d.ip] : [];
     if (ips.length <= 1) {
       return this._row("ip-network-outline", label, ips[0] || d.address, true);
     }

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -213,7 +213,8 @@ export class ESPHomeDeviceTable extends LitElement {
     // Match against every announced IP — a dual-stack device's IPv6
     // address is just as legitimate a search target as its IPv4, and
     // the row's ``ip`` only carries the V4 primary.
-    const allIps = d._device.ip_addresses?.length ? d._device.ip_addresses : [d.ip];
+    const allIps =
+      d._device.ip_addresses.length > 0 ? d._device.ip_addresses : [d.ip];
     return (
       (d.friendly_name || d.name).toLowerCase().includes(q) ||
       d.config.toLowerCase().includes(q) ||

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -210,10 +210,14 @@ export class ESPHomeDeviceTable extends LitElement {
     const q = (filterValue as string).trim().toLowerCase();
     if (!q) return true;
     const d: DeviceRow = row.original;
+    // Match against every announced IP — a dual-stack device's IPv6
+    // address is just as legitimate a search target as its IPv4, and
+    // the row's ``ip`` only carries the V4 primary.
+    const allIps = d._device.ip_addresses?.length ? d._device.ip_addresses : [d.ip];
     return (
       (d.friendly_name || d.name).toLowerCase().includes(q) ||
       d.config.toLowerCase().includes(q) ||
-      d.ip.toLowerCase().includes(q) ||
+      allIps.some((ip) => ip.toLowerCase().includes(q)) ||
       d.platform.toLowerCase().includes(q)
     );
   };
@@ -227,7 +231,10 @@ export class ESPHomeDeviceTable extends LitElement {
     }
     if (changed.has("initialColumnVisibility") && this.initialColumnVisibility !== null) {
       // Merge defaults so columns the user hasn't explicitly toggled stay hidden.
-      this._columnVisibility = { ...DEFAULT_HIDDEN_COLUMNS, ...this.initialColumnVisibility };
+      this._columnVisibility = {
+        ...DEFAULT_HIDDEN_COLUMNS,
+        ...this.initialColumnVisibility,
+      };
     }
     if (changed.has("initialPageSize")) {
       this._pageSize = this.initialPageSize;
@@ -430,7 +437,9 @@ export class ESPHomeDeviceTable extends LitElement {
                       : sorted === "desc"
                         ? "descending"
                         : "none"}
-                    class="${canSort ? "sortable" : ""} ${sorted ? "sorted" : ""} col-${header.column.id}"
+                    class="${canSort ? "sortable" : ""} ${sorted
+                      ? "sorted"
+                      : ""} col-${header.column.id}"
                     style="width:${header.getSize()}px"
                     @click=${canSort ? () => header.column.toggleSorting() : nothing}
                   >
@@ -473,10 +482,8 @@ export class ESPHomeDeviceTable extends LitElement {
                   data-configuration=${row.original.config}
                   class=${classMap({
                     selected:
-                      this.selectMode &&
-                      this.selectedDevices.has(row.original.config),
-                    highlight:
-                      this.highlightConfiguration === row.original.config,
+                      this.selectMode && this.selectedDevices.has(row.original.config),
+                    highlight: this.highlightConfiguration === row.original.config,
                   })}
                   @click=${() =>
                     this.selectMode
@@ -575,7 +582,7 @@ export class ESPHomeDeviceTable extends LitElement {
     const root = this.shadowRoot;
     if (!root) return;
     const row = root.querySelector<HTMLElement>(
-      `tr[data-configuration="${CSS.escape(configuration)}"]`,
+      `tr[data-configuration="${CSS.escape(configuration)}"]`
     );
     row?.scrollIntoView({ behavior: "instant", block: "center" });
   }

--- a/src/util/web-ui-url.ts
+++ b/src/util/web-ui-url.ts
@@ -27,6 +27,23 @@ export function safeWebUiUrl(url: string): string {
 }
 
 /**
+ * Wrap *host* in the URL-host shape — IPv6 literals get the
+ * RFC 3986 brackets and a percent-encoded zone-id separator
+ * (``fe80::1%en0`` → ``[fe80::1%25en0]``); IPv4 literals and
+ * hostnames pass through unchanged. Without this, ``new URL`` in
+ * ``safeWebUiUrl`` rejected raw IPv6 hosts entirely and the
+ * Visit-Web-UI link disappeared for V6-only devices. Global IPv6
+ * literals now produce a usable link; scoped (link-local) ones are
+ * still rejected downstream because WHATWG ``new URL`` doesn't
+ * accept zone IDs at all — that's the right outcome since browsers
+ * can't route link-local without an OS interface scope anyway.
+ */
+function _wrapHost(host: string): string {
+  if (!host.includes(":")) return host;
+  return `[${host.replace("%", "%25")}]`;
+}
+
+/**
  * Build the device's web-UI URL, or return ``""`` when the YAML didn't
  * expose a ``web_server`` port or we don't have a host to point at.
  *
@@ -41,6 +58,6 @@ export function buildWebUiUrl(device: ConfiguredDevice): string {
   const host = device.address || device.ip;
   if (!host) return "";
   return safeWebUiUrl(
-    `http://${host}${device.web_port === 80 ? "" : `:${device.web_port}`}`,
+    `http://${_wrapHost(host)}${device.web_port === 80 ? "" : `:${device.web_port}`}`,
   );
 }

--- a/src/util/web-ui-url.ts
+++ b/src/util/web-ui-url.ts
@@ -40,7 +40,12 @@ export function safeWebUiUrl(url: string): string {
  */
 function _wrapHost(host: string): string {
   if (!host.includes(":")) return host;
-  return `[${host.replace("%", "%25")}]`;
+  // ``replaceAll`` (not ``replace``) so a malformed input with more
+  // than one ``%`` can't leak an unencoded one through — valid IPv6
+  // only has the single zone-id separator, but defensive escaping
+  // costs nothing and silences CodeQL's "incomplete string escaping"
+  // rule.
+  return `[${host.replaceAll("%", "%25")}]`;
 }
 
 /**

--- a/test/util/web-ui-url.test.ts
+++ b/test/util/web-ui-url.test.ts
@@ -12,6 +12,7 @@ const _baseDevice = {
   target_platform: "esp32",
   address: "kitchen.local",
   ip: "",
+  ip_addresses: [],
   web_port: null,
   current_version: "",
   deployed_version: "",
@@ -33,9 +34,7 @@ function _device(overrides: Partial<ConfiguredDevice> = {}): ConfiguredDevice {
 describe("safeWebUiUrl", () => {
   it("accepts http URLs", () => {
     expect(safeWebUiUrl("http://kitchen.local")).toBe("http://kitchen.local");
-    expect(safeWebUiUrl("http://kitchen.local:8080")).toBe(
-      "http://kitchen.local:8080",
-    );
+    expect(safeWebUiUrl("http://kitchen.local:8080")).toBe("http://kitchen.local:8080");
   });
 
   it("accepts https URLs", () => {
@@ -76,38 +75,36 @@ describe("buildWebUiUrl", () => {
   });
 
   it("returns empty string when neither address nor ip is set", () => {
-    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "" }))).toBe(
-      "",
-    );
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "" }))).toBe("");
   });
 
   it("uses the mDNS address when present", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local"
+    );
   });
 
   it("falls back to ip when address is empty", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "", ip: "10.0.0.5" })),
-    ).toBe("http://10.0.0.5");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "10.0.0.5" }))).toBe(
+      "http://10.0.0.5"
+    );
   });
 
   it("omits the port when it's the default 80", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local"
+    );
   });
 
   it("includes a non-default port", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local:8080");
+    expect(buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local:8080"
+    );
   });
 
   it("includes ports below 80 verbatim", () => {
     expect(buildWebUiUrl(_device({ web_port: 22, address: "host" }))).toBe(
-      "http://host:22",
+      "http://host:22"
     );
   });
 });

--- a/test/util/web-ui-url.test.ts
+++ b/test/util/web-ui-url.test.ts
@@ -107,4 +107,32 @@ describe("buildWebUiUrl", () => {
       "http://host:22"
     );
   });
+
+  it("brackets a global IPv6 literal", () => {
+    expect(
+      buildWebUiUrl(_device({ web_port: 80, address: "", ip: "2001:db8::1" }))
+    ).toBe("http://[2001:db8::1]");
+  });
+
+  it("returns empty for a scoped IPv6 literal — browsers can't navigate it", () => {
+    // ``_wrapHost`` brackets and percent-encodes the zone-id, but
+    // WHATWG ``new URL`` (and every browser) rejects IPv6 zone IDs
+    // outright. Hiding the link is the right UX: a link that 404s
+    // on click is worse than no link.
+    expect(
+      buildWebUiUrl(_device({ web_port: 80, address: "", ip: "fe80::1%en0" }))
+    ).toBe("");
+  });
+
+  it("brackets IPv6 with a non-default port", () => {
+    expect(
+      buildWebUiUrl(_device({ web_port: 8080, address: "", ip: "2001:db8::1" }))
+    ).toBe("http://[2001:db8::1]:8080");
+  });
+
+  it("leaves IPv4 literals unbracketed", () => {
+    expect(
+      buildWebUiUrl(_device({ web_port: 80, address: "", ip: "192.168.1.42" }))
+    ).toBe("http://192.168.1.42");
+  });
 });


### PR DESCRIPTION
## Problem

The drawer's IP-Address row only showed `device.ip` — a single IPv4 — even though dual-stack devices announce additional IPv6 addresses on mDNS. With the backend [PR #294](https://github.com/esphome/device-builder/pull/294) exposing `ip_addresses` (every IP from the mDNS broadcast), the frontend can now surface the full set so V6 addresses aren't hidden from users.

## Changes

- Add `ip_addresses: string[]` to the `ConfiguredDevice` type.
- Drawer renders multiple IPs stacked on their own lines (monospace); falls back to the existing single-row shape when there's only one (or none).
- Table search filter now matches against every announced IP — a search for an IPv6 fragment surfaces the right row even though the table column still shows the V4 primary.