### PR TITLE
device table: show installed esphome version, not dashboard version

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -249,7 +249,7 @@ export class ESPHomeDeviceTable extends LitElement {
         friendly_name: d.friendly_name,
         ip: d.ip || d.address || "",
         platform: d.target_platform || "",
-        version: d.current_version || "",
+        version: d.deployed_version || "",
         comment: d.comment || "",
         config: d.configuration,
         hasPendingChanges: d.has_pending_changes === true,


### PR DESCRIPTION
## Problem
The ESPHome version column in the device list was showing the dashboard's bundled ESPHome version (what a fresh compile would produce) instead of the version actually installed on the device. This is misleading — every row showed the same number regardless of what each device was really running.

## Changes
- `src/components/dashboard/device-table.ts`: map the `version` column from `deployed_version` (mDNS-reported installed version) instead of `current_version` (dashboard-loaded version), matching the semantics already used by the device drawer.