### PR TITLE
yaml-editor: auto-indent on Enter (issue #134 partial)

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -11,7 +11,7 @@ import { basicSetup, EditorView } from "codemirror";
 import { EditorState } from "@codemirror/state";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import { apiContext, darkModeContext } from "../context/index.js";
-import { esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { createBackendYamlLinter } from "../util/yaml-lint-backend.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import type { YamlSection } from "../util/yaml-sections.js";
@@ -99,7 +99,7 @@ export class ESPHomeYamlEditor extends LitElement {
     const extensions = [
       basicSetup,
       esphomeYaml(),
-      indentUnit.of("  "),
+      indentUnit.of(ESPHOME_YAML_INDENT),
       keymap.of([indentWithTab]),
       highlightField,
       EditorView.theme({

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -10,7 +10,11 @@
  */
 import { parser as yamlParser } from "@lezer/yaml";
 import { cppLanguage } from "@codemirror/lang-cpp";
-import { LRLanguage, LanguageSupport } from "@codemirror/language";
+import {
+  LRLanguage,
+  LanguageSupport,
+  indentService,
+} from "@codemirror/language";
 import { parseMixed } from "@lezer/common";
 import type { SyntaxNodeRef, Input } from "@lezer/common";
 
@@ -80,8 +84,51 @@ export const esphomeYamlLanguage = LRLanguage.define({
 });
 
 /**
+ * YAML auto-indent service. Mirrors the legacy esphome dashboard's
+ * Monaco rule (``beforeText: /:\s*$/`` → ``IndentAction.Indent``)
+ * plus list-item continuation handling: pressing Enter under a
+ * line that ends with ``:`` opens a child block (indent + 2), and
+ * continuation lines inside a ``- item`` list are aligned to the
+ * dash's content column (``dash + 2``) so siblings of the first
+ * key in a list item land at the right depth automatically.
+ *
+ * Without this the new editor required the user to manually
+ * Tab/space every nested line — a real regression from the
+ * legacy editor (issue #134).
+ *
+ * Walks back over blank lines to find the nearest non-blank
+ * predecessor so a stray blank between sections doesn't reset
+ * indent to 0.
+ */
+const yamlIndentService = indentService.of((context, pos) => {
+  const currentLineNumber = context.state.doc.lineAt(pos).number;
+  for (let n = currentLineNumber - 1; n >= 1; n--) {
+    const text = context.state.doc.line(n).text;
+    if (!text.trim()) continue;
+    // A line of the form ``  - <something>``: the natural
+    // continuation column is the dash's position + 2 (one space
+    // for the dash, one for the gap), not the dash's leading
+    // whitespace. Without this, a continuation under
+    // ``  - platform: gpio`` would land at column 2 instead of 4.
+    const dashMatch = text.match(/^( *)-\s/);
+    const baseIndent = dashMatch
+      ? dashMatch[1].length + 2
+      : (text.match(/^( *)/)?.[1].length ?? 0);
+    // Trailing-colon line opens a child block. Strip a trailing
+    // ``# comment`` first so ``key:  # note`` still triggers
+    // (ESPHome configs sprinkle inline comments freely).
+    const noComment = text.replace(/\s+#.*$/, "");
+    if (/:\s*$/.test(noComment)) {
+      return baseIndent + 2;
+    }
+    return baseIndent;
+  }
+  return null;
+});
+
+/**
  * Language support bundle for ESPHome YAML.
  */
 export function esphomeYaml(): LanguageSupport {
-  return new LanguageSupport(esphomeYamlLanguage);
+  return new LanguageSupport(esphomeYamlLanguage, [yamlIndentService]);
 }

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -101,25 +101,32 @@ export const esphomeYamlLanguage = LRLanguage.define({
  * indent to 0.
  */
 const yamlIndentService = indentService.of((context, pos) => {
+  // ``context.unit`` is the editor's configured indent width (the
+  // ``indentUnit`` facet, in columns). Deriving the step from it
+  // means the service tracks any future change to the editor's
+  // indent configuration instead of hard-coding ``+ 2``. The dash
+  // continuation also uses ``unit`` because YAML's ``- key`` is
+  // exactly one indent step deeper than the dash's column.
+  const step = context.unit;
   const currentLineNumber = context.state.doc.lineAt(pos).number;
   for (let n = currentLineNumber - 1; n >= 1; n--) {
     const text = context.state.doc.line(n).text;
     if (!text.trim()) continue;
     // A line of the form ``  - <something>``: the natural
-    // continuation column is the dash's position + 2 (one space
-    // for the dash, one for the gap), not the dash's leading
-    // whitespace. Without this, a continuation under
-    // ``  - platform: gpio`` would land at column 2 instead of 4.
+    // continuation column is one indent step past the dash's column,
+    // not the dash's leading whitespace. Without this, a
+    // continuation under ``  - platform: gpio`` would land at
+    // column 2 instead of 4.
     const dashMatch = text.match(/^( *)-\s/);
     const baseIndent = dashMatch
-      ? dashMatch[1].length + 2
+      ? dashMatch[1].length + step
       : (text.match(/^( *)/)?.[1].length ?? 0);
     // Trailing-colon line opens a child block. Strip a trailing
     // ``# comment`` first so ``key:  # note`` still triggers
     // (ESPHome configs sprinkle inline comments freely).
     const noComment = text.replace(/\s+#.*$/, "");
     if (/:\s*$/.test(noComment)) {
-      return baseIndent + 2;
+      return baseIndent + step;
     }
     return baseIndent;
   }

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -21,6 +21,14 @@ import type { SyntaxNodeRef, Input } from "@lezer/common";
 const LAMBDA_TAG = "!lambda";
 
 /**
+ * Single source of truth for ESPHome YAML's indent width. Two
+ * spaces matches the legacy dashboard and the upstream ESPHome
+ * code style. Exported so consumers (the editor, tests) share
+ * the same unit and the indent service derives ``step`` from it.
+ */
+export const ESPHOME_YAML_INDENT = "  ";
+
+/**
  * Mixed parser wrapper: when we encounter a Tagged node whose Tag is
  * `!lambda`, overlay the C++ parser on the value content.
  */
@@ -125,7 +133,15 @@ const yamlIndentService = indentService.of((context, pos) => {
     // ``# comment`` first so ``key:  # note`` still triggers
     // (ESPHome configs sprinkle inline comments freely).
     const noComment = text.replace(/\s+#.*$/, "");
-    if (/:\s*$/.test(noComment)) {
+    // Two block-opener shapes:
+    //   1. ``key:`` — plain mapping → child indent + step
+    //   2. ``key: |-`` / ``key: >+`` / ``lambda: |`` etc. — YAML
+    //      block-scalar header. The next line is the scalar's
+    //      content, which lives one step deeper than the key.
+    //      Crucial for ESPHome's ``lambda: |-`` and ``!lambda |-``
+    //      patterns, which would otherwise force the user to
+    //      hand-indent every line of C++.
+    if (/:\s*$/.test(noComment) || /:\s*[|>][+-]?\s*$/.test(noComment)) {
       return baseIndent + step;
     }
     return baseIndent;

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
-import {
-  IndentContext,
-  getIndentation,
-  indentService,
-  syntaxTree,
-} from "@codemirror/language";
+import { getIndentation } from "@codemirror/language";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 
 /**
@@ -101,11 +96,3 @@ describe("esphome-yaml language extension shape", () => {
   });
 });
 
-// Suppress unused-import lint: the imports are part of the public
-// CM6 API surface and exercising them via getIndentation keeps this
-// test honest. ``IndentContext`` / ``indentService`` / ``syntaxTree``
-// are referenced at type level in case a future test wants to inspect
-// them more directly.
-void IndentContext;
-void indentService;
-void syntaxTree;

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
-import { getIndentation } from "@codemirror/language";
-import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { getIndentation, indentUnit } from "@codemirror/language";
+import {
+  ESPHOME_YAML_INDENT,
+  esphomeYaml,
+} from "../../src/util/esphome-yaml-lang.js";
 
 /**
  * The indent service mirrors the legacy esphome dashboard's Monaco
@@ -15,9 +18,12 @@ import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
  * directly) keeps the test resilient to internal API changes.
  */
 function indentAt(yaml: string): number | null {
+  // Pin ``indentUnit`` to ``ESPHOME_YAML_INDENT`` — same shared
+  // constant the editor wires up — so assertions below are
+  // deterministic and don't drift with CodeMirror's default.
   const state = EditorState.create({
     doc: yaml,
-    extensions: [esphomeYaml()],
+    extensions: [indentUnit.of(ESPHOME_YAML_INDENT), esphomeYaml()],
   });
   // Indent the LAST line of the doc — that's what gets recomputed
   // when the user presses Enter at the end of a content line.
@@ -77,6 +83,16 @@ describe("esphome-yaml indent service", () => {
     // → indent 0. (Yes, that's malformed YAML; we still want the
     // editor to behave gracefully.)
     expect(indentAt("esphome: test\n")).toBe(0);
+  });
+
+  it("indents +step after a block-scalar header", () => {
+    // ``lambda: |-`` opens a block scalar; the next line is its
+    // content and should land one step deeper than the key.
+    // Mirrors the ESPHome ``lambda: |-`` / ``!lambda |-`` shape
+    // — without this users have to hand-indent every C++ line.
+    expect(indentAt("on_boot:\n  - lambda: |-\n")).toBe(6);
+    expect(indentAt("foo:\n  bar: >+\n")).toBe(4);
+    expect(indentAt("foo:\n  bar: |\n")).toBe(4);
   });
 });
 

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import {
+  IndentContext,
+  getIndentation,
+  indentService,
+  syntaxTree,
+} from "@codemirror/language";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+
+/**
+ * The indent service mirrors the legacy esphome dashboard's Monaco
+ * rule (`beforeText: /:\s*$/` → Indent) plus list-item continuation
+ * handling. Pin both the trailing-colon and dash-continuation paths
+ * so a future refactor can't quietly drop them.
+ *
+ * `getIndentation` is CodeMirror's official entry point for asking
+ * the registered indent services for the indent of a given position
+ * — using it (rather than reaching into the service callback
+ * directly) keeps the test resilient to internal API changes.
+ */
+function indentAt(yaml: string): number | null {
+  const state = EditorState.create({
+    doc: yaml,
+    extensions: [esphomeYaml()],
+  });
+  // Indent the LAST line of the doc — that's what gets recomputed
+  // when the user presses Enter at the end of a content line.
+  const lastLine = state.doc.line(state.doc.lines);
+  return getIndentation(state, lastLine.from);
+}
+
+describe("esphome-yaml indent service", () => {
+  it("indents +2 after a trailing-colon block opener", () => {
+    // After `esphome:`, the next line should sit at indent 2.
+    expect(indentAt("esphome:\n")).toBe(2);
+  });
+
+  it("continues at parent indent for content lines", () => {
+    // After `name: test`, the next line should match `name:`'s indent
+    // (2 — sibling key under `esphome:`), not jump deeper.
+    expect(indentAt("esphome:\n  name: test\n")).toBe(2);
+  });
+
+  it("indents +2 after nested trailing-colon", () => {
+    // `esphome:` → indent 2. `on_boot:` at indent 2 → next line at
+    // indent 4. Confirms the rule fires regardless of nesting depth.
+    expect(indentAt("esphome:\n  on_boot:\n")).toBe(4);
+  });
+
+  it("aligns continuation lines under a list-item dash", () => {
+    // `  - platform: template` → siblings of `platform` should land
+    // at column 4 (dash position 2 + 2). Without this, the next line
+    // would default to column 2 and look like a new list item.
+    expect(indentAt("button:\n  - platform: template\n")).toBe(4);
+  });
+
+  it("combines list-item continuation with trailing-colon", () => {
+    // `  - on_press:` → next line at column 6 (dash + 2 + 2 for the
+    // colon child block). Mirrors the user's expected shape:
+    //   button:
+    //     - on_press:
+    //         then:
+    expect(indentAt("button:\n  - on_press:\n")).toBe(6);
+  });
+
+  it("walks back over blank lines to the last non-blank", () => {
+    // A blank line between sections shouldn't reset indent — the
+    // editor should still honour the last meaningful predecessor.
+    expect(indentAt("esphome:\n  on_boot:\n\n")).toBe(4);
+  });
+
+  it("strips inline trailing comments before checking trailing colon", () => {
+    // `key:  # note` is still a block opener — the legacy dashboard
+    // didn't strip comments and would've missed this. Pinning the
+    // strip avoids regressing.
+    expect(indentAt("esphome:  # device-wide config\n")).toBe(2);
+  });
+
+  it("returns 0 for top-level content lines", () => {
+    // After `esphome: test`, the next line is a top-level sibling
+    // → indent 0. (Yes, that's malformed YAML; we still want the
+    // editor to behave gracefully.)
+    expect(indentAt("esphome: test\n")).toBe(0);
+  });
+});
+
+describe("esphome-yaml language extension shape", () => {
+  it("ships an indent service in the support bundle", () => {
+    // Cheap structural check — surfaces a regression if someone
+    // refactors the export and forgets to pass the indent service
+    // along to LanguageSupport.
+    const support = esphomeYaml();
+    expect(support).toBeTruthy();
+    expect(support.support).toBeDefined();
+    // The support bundle includes our indentService.of(...) plus
+    // whatever the language carries; both are Extension values, so
+    // a positive length is enough confirmation.
+    const flat = ([] as unknown[]).concat(support.support as unknown[]);
+    expect(flat.length).toBeGreaterThan(0);
+  });
+});
+
+// Suppress unused-import lint: the imports are part of the public
+// CM6 API surface and exercising them via getIndentation keeps this
+// test honest. ``IndentContext`` / ``indentService`` / ``syntaxTree``
+// are referenced at type level in case a future test wants to inspect
+// them more directly.
+void IndentContext;
+void indentService;
+void syntaxTree;


### PR DESCRIPTION
Closes one of the three regressions tracked in #134.

## What this fixes

Pressing Enter in the YAML pane returned the cursor to column 0 — users had to manually space/tab every nested line. The legacy esphome dashboard handled this with a single Monaco rule (`onEnterRules: { beforeText: /:\s*$/, action: Indent }`).

Ported to CodeMirror 6 via `indentService`. Two cases covered:

- **Trailing colon opens a child block** → indent +2 from the parent's column. Inline trailing comments are stripped first so `esphome:  # device-wide` still triggers.
- **List-item continuation** → siblings of the first key in a `- item` align to the dash's *content* column (`dash + 2`), not the dash's leading whitespace. Without this, the line under `  - platform: template` would default to column 2 and look like a new list item instead of a sibling key.

Walks back over blank lines so a stray blank between sections doesn't reset indent to 0.

## What's NOT in this PR

Issue #134 also flags two completion gaps:

- Typing `o` under `esphome:` doesn't suggest `on_boot` (or other triggers).
- Typing `l` inside a `then:` body doesn't suggest `logger.log` (or other actions).

Both depend on the backend schema sync (`script/sync_components.py`) exposing triggers and actions through the catalog's `config_entries` shape. The legacy dashboard fetched the full versioned schema bundle (`https://schema.esphome.io/<version>`) and walked it client-side via a sophisticated handler (`completions-handler.ts` in the legacy repo). The new dashboard's catalog-driven completion has the right shape but the data may not be flowing through. Out of scope for this purely client-side change; tracked in the same issue.

## Tests (+9)

`test/util/esphome-yaml-lang.test.ts`:

- Trailing-colon block opener
- Content lines continue at parent indent
- Nested trailing-colon depth
- List-item dash continuation
- Combined dash + trailing-colon (`- on_press:` → +4 from dash)
- Walks back over blank lines
- Strips inline `# comment` before checking trailing colon
- Top-level content lines return 0
- `esphomeYaml()` ships the indent service in its support bundle

All 383 tests pass; tsc clean.

## Test plan

- [x] Unit: 383/383 (+9 new)
- [x] Lint: `tsc --noEmit` clean
- [ ] Live: type `esphome:` then Enter → cursor at column 2
- [ ] Live: type `on_boot:` under that → Enter → cursor at column 4
- [ ] Live: type `then:` under `on_boot` → Enter → cursor at column 6
- [ ] Live: under `button:`, type `  - platform: template` Enter → cursor at column 4 (sibling of `platform`)