### PR TITLE
device-navigator: show resolved catalog names

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -10,17 +10,24 @@ import {
 } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { localizeContext } from "../../context/index.js";
+import { apiContext, localizeContext } from "../../context/index.js";
 import { AUTOMATIONS_ENABLED } from "../../feature-flags.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import {
+  fetchComponent,
+  getCachedComponent,
+  subscribeComponentCache,
+} from "../../util/component-name-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   type YamlSection,
   categorizeSections,
   parseYamlAutomations,
   parseYamlTopLevelSections,
+  sectionKeyOf,
 } from "../../util/yaml-sections.js";
 import type { HighlightRange } from "../yaml-editor.js";
 
@@ -47,6 +54,19 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  private _api?: ESPHomeAPI;
+
+  /**
+   * Bumped whenever a fresh entry lands in the component-name cache,
+   * which forces a re-render so resolved labels appear without
+   * needing the user to interact with the navigator.
+   */
+  @state()
+  private _cacheTick = 0;
+
+  private _unsubscribeCache?: () => void;
 
   @property({ attribute: false })
   openSections: Set<number> = new Set();
@@ -286,7 +306,30 @@ export class ESPHomeDeviceNavigator extends LitElement {
     `,
   ];
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Re-render when any other navigator (or this one on a previous
+    // mount) fills in a catalog entry we're showing — keeps labels
+    // live across device switches without a manual refresh.
+    this._unsubscribeCache = subscribeComponentCache(() => {
+      this._cacheTick++;
+    });
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubscribeCache?.();
+    this._unsubscribeCache = undefined;
+  }
+
   protected willUpdate(changedProperties: Map<string, unknown>) {
+    if (
+      (changedProperties.has("yaml") || changedProperties.has("platform")) &&
+      this.yaml
+    ) {
+      this._kickoffNameResolves();
+    }
+
     // Sync `_selectedLine`/`_selectedRange` whenever the externally-
     // controlled selection changes (URL restore, "go to component"
     // events from the dialog, YAML edits that shift line numbers).
@@ -313,17 +356,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
       // Try fromLine first (exact match), fall back to key/platform
       // match (handles the case where the YAML shifted under us, e.g.
       // the user just added a component before the selected one).
-      const matchByKey = (s: YamlSection) => {
-        if (!s.platform) return s.key === this.selectedKey;
-        const candidate = s.platform.startsWith(`${s.key}.`)
-          ? s.platform
-          : `${s.key}.${s.platform}`;
-        return candidate === this.selectedKey;
-      };
       const match =
         (this.selectedFromLine !== undefined
           ? allSections.find((s) => s.fromLine === this.selectedFromLine)
-          : undefined) ?? allSections.find(matchByKey);
+          : undefined) ??
+        allSections.find((s) => sectionKeyOf(s) === this.selectedKey);
       if (match) {
         this._selectedLine = match.fromLine;
         this._selectedRange = {
@@ -518,34 +555,51 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   /**
-   * Decide what to show on the two lines of a nav item. Same shape
-   * for core, components, and automations:
+   * Fire-and-forget catalog lookups for any sections whose name we
+   * haven't cached yet. Resolved entries land in the shared cache;
+   * the subscription bumps `_cacheTick` to trigger a re-render.
+   * Automations are skipped — their keys are free-form strings
+   * (`<component> → on_press`), not catalog ids.
+   */
+  private _kickoffNameResolves(): void {
+    if (!this._api) return;
+    const sections = parseYamlTopLevelSections(this.yaml);
+    const { core, components } = categorizeSections(sections);
+    const platform = this.platform || undefined;
+    for (const item of [...core, ...components]) {
+      const id = sectionKeyOf(item);
+      if (getCachedComponent(id, platform) !== undefined) continue;
+      void fetchComponent(this._api, id, platform).catch(() => {
+        // Swallow — the navigator falls back to the raw id when no
+        // catalog entry is available, so a transient backend hiccup
+        // shouldn't surface as an error here.
+      });
+    }
+  }
+
+  /**
+   * Decide what to show on the two lines of a nav item.
    *
-   *   line 1 (primary)   <domain>.<platform> when this is a list
-   *                      item under a platform domain (e.g.
-   *                      `sensor.dht`, `time.homeassistant`),
-   *                      otherwise just the domain key (`wifi`,
-   *                      `api`, `uart`).
+   *   line 1 (primary)   the catalog's friendly name (e.g.
+   *                      "GPIO Binary Sensor") once resolved.
+   *                      Falls back to <domain>.<platform> (or just
+   *                      the domain for core keys like `wifi`) until
+   *                      the cache is populated, or when no catalog
+   *                      entry exists (typically: automations).
    *   line 2 (secondary) the user-supplied `name:` if present, else
    *                      the `id:`. Hidden when neither is set or
    *                      when it's identical to the primary.
-   *
-   * Putting the domain on the first line keeps the navigator scanable
-   * — you can tell at a glance what kind of thing each entry is —
-   * while the user-friendly label sits underneath as the personal
-   * identifier.
    */
   private _navItemLabels(
     item: YamlSection,
-    _category: "core" | "component" | "automation",
+    category: "core" | "component" | "automation",
   ): { primary: string; secondary?: string } {
-    let primary: string;
-    if (item.platform) {
-      primary = item.platform.startsWith(`${item.key}.`)
-        ? item.platform
-        : `${item.key}.${item.platform}`;
-    } else {
-      primary = item.key;
+    const raw = sectionKeyOf(item);
+
+    let primary = raw;
+    if (category !== "automation") {
+      const cached = getCachedComponent(raw, this.platform || undefined);
+      if (cached?.name) primary = cached.name;
     }
 
     const named = item.name || item.id;
@@ -566,20 +620,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
 
   private _onItemClick(item: YamlSection) {
     const { fromLine, toLine } = item;
-    // Component IDs in the catalog are namespaced as `parent.platform` for
-    // platform-based components (e.g. `switch.template`, `binary_sensor.gpio`).
-    // Top-level components use just their key (e.g. `wifi`, `api`).
-    // Guard: if the platform value already starts with the parent key (e.g.
-    // a malformed YAML or a stale value), don't double-prefix it.
-    let sectionKey: string;
-    if (item.platform) {
-      const platform = item.platform;
-      sectionKey = platform.startsWith(`${item.key}.`)
-        ? platform
-        : `${item.key}.${platform}`;
-    } else {
-      sectionKey = item.key;
-    }
+    const sectionKey = sectionKeyOf(item);
 
     if (this._selectedLine === fromLine) {
       this.selectedKey = null;

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -1,0 +1,101 @@
+import type { ESPHomeAPI } from "../api/index.js";
+import type { ComponentCatalogEntry } from "../api/types.js";
+
+/**
+ * Session-scoped cache of component catalog entries, keyed by
+ * `componentId|platform|boardId`. Used by the device navigator to
+ * resolve raw `domain.platform` ids (e.g. `binary_sensor.gpio`) into
+ * friendly catalog names (e.g. "GPIO Binary Sensor") without
+ * re-fetching across renders, devices, or navigations.
+ *
+ * The backend catalog is loaded from a static JSON file at startup
+ * and is immutable for the lifetime of the process, so cache entries
+ * never need invalidation. `null` is cached too (catalog miss) to
+ * avoid re-fetching unknown ids; transport errors are not cached so
+ * the next call retries.
+ *
+ * Concurrent fetches for the same key share a single in-flight
+ * promise, so a navigator that mounts and dispatches N parallel
+ * resolves only triggers N unique backend calls.
+ */
+
+type CacheValue = ComponentCatalogEntry | null;
+
+const _cache = new Map<string, CacheValue>();
+const _inflight = new Map<string, Promise<CacheValue>>();
+const _listeners = new Set<() => void>();
+
+function _key(componentId: string, platform?: string, boardId?: string): string {
+  return `${componentId}|${platform ?? ""}|${boardId ?? ""}`;
+}
+
+/**
+ * Synchronous read. Returns the cached entry (or `null` for a known
+ * catalog miss), or `undefined` when this key has never been fetched.
+ * Callers typically use this from render and fall back to the raw id
+ * when the result is `undefined` or `null`.
+ */
+export function getCachedComponent(
+  componentId: string,
+  platform?: string,
+  boardId?: string,
+): CacheValue | undefined {
+  return _cache.get(_key(componentId, platform, boardId));
+}
+
+/**
+ * Fetch a component, populating the cache. Subsequent calls with the
+ * same key return the cached value (or join the in-flight promise).
+ * Notifies subscribers once after a fresh entry lands so reactive
+ * consumers can re-render.
+ */
+export function fetchComponent(
+  api: ESPHomeAPI,
+  componentId: string,
+  platform?: string,
+  boardId?: string,
+): Promise<CacheValue> {
+  const key = _key(componentId, platform, boardId);
+  if (_cache.has(key)) return Promise.resolve(_cache.get(key) ?? null);
+
+  const existing = _inflight.get(key);
+  if (existing) return existing;
+
+  const promise = api
+    .getComponent(componentId, platform, boardId)
+    .then((entry) => {
+      _cache.set(key, entry ?? null);
+      _inflight.delete(key);
+      _notify();
+      return entry ?? null;
+    })
+    .catch((err) => {
+      _inflight.delete(key);
+      throw err;
+    });
+
+  _inflight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Subscribe to cache updates. Returns an unsubscribe function.
+ * Listeners fire once per fresh entry; failed fetches do not fire.
+ */
+export function subscribeComponentCache(listener: () => void): () => void {
+  _listeners.add(listener);
+  return () => {
+    _listeners.delete(listener);
+  };
+}
+
+function _notify(): void {
+  for (const listener of _listeners) listener();
+}
+
+/** Test-only: drop all cached entries and pending promises. */
+export function _clearComponentCache(): void {
+  _cache.clear();
+  _inflight.clear();
+  _listeners.clear();
+}

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -90,7 +90,17 @@ export function subscribeComponentCache(listener: () => void): () => void {
 }
 
 function _notify(): void {
-  for (const listener of _listeners) listener();
+  // Isolate each listener: a throwing subscriber would otherwise
+  // reject `fetchComponent`'s promise (the cache is already populated
+  // at this point, so the rejection is misleading) and skip later
+  // listeners that haven't been notified yet.
+  for (const listener of _listeners) {
+    try {
+      listener();
+    } catch (err) {
+      console.error("component-name-cache listener threw", err);
+    }
+  }
 }
 
 /** Test-only: drop all cached entries and pending promises. */

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -118,6 +118,28 @@ describe("component-name-cache", () => {
     expect(second?.name).toBe("WiFi");
   });
 
+  it("isolates listener exceptions from the fetch promise and other listeners", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const goodA = vi.fn();
+    const goodB = vi.fn();
+    const bad = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    subscribeComponentCache(goodA);
+    subscribeComponentCache(bad);
+    subscribeComponentCache(goodB);
+
+    const { api } = mockApi(() => entry("wifi", "WiFi"));
+    const result = await fetchComponent(api, "wifi");
+
+    expect(result?.name).toBe("WiFi");
+    expect(goodA).toHaveBeenCalledTimes(1);
+    expect(goodB).toHaveBeenCalledTimes(1);
+    expect(bad).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
   it("notifies subscribers exactly once per fresh entry", async () => {
     const listener = vi.fn();
     const unsubscribe = subscribeComponentCache(listener);

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { ComponentCatalogEntry } from "../../src/api/types.js";
+import {
+  _clearComponentCache,
+  fetchComponent,
+  getCachedComponent,
+  subscribeComponentCache,
+} from "../../src/util/component-name-cache.js";
+
+const entry = (id: string, name: string): ComponentCatalogEntry =>
+  ({
+    id,
+    name,
+    description: "",
+    category: "core" as ComponentCatalogEntry["category"],
+    docs_url: "",
+    image_url: "",
+    dependencies: [],
+    multi_conf: false,
+    supported_platforms: [],
+    config_entries: [],
+  }) as ComponentCatalogEntry;
+
+const mockApi = (
+  impl: (id: string, platform?: string, boardId?: string) =>
+    | Promise<ComponentCatalogEntry | null>
+    | ComponentCatalogEntry
+    | null,
+): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
+  const getComponent = vi.fn((id: string, platform?: string, boardId?: string) =>
+    Promise.resolve(impl(id, platform, boardId)),
+  );
+  return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
+};
+
+describe("component-name-cache", () => {
+  afterEach(() => {
+    _clearComponentCache();
+  });
+
+  it("fetches uncached components and caches the result", async () => {
+    const { api, getComponent } = mockApi(() => entry("wifi", "WiFi"));
+
+    expect(getCachedComponent("wifi")).toBeUndefined();
+    const got = await fetchComponent(api, "wifi");
+
+    expect(got?.name).toBe("WiFi");
+    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getCachedComponent("wifi")?.name).toBe("WiFi");
+
+    // Second call hits the cache, no extra backend round-trip.
+    await fetchComponent(api, "wifi");
+    expect(getComponent).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent in-flight calls for the same key", async () => {
+    let resolve!: (v: ComponentCatalogEntry) => void;
+    const { api, getComponent } = mockApi(
+      () => new Promise<ComponentCatalogEntry>((r) => (resolve = r)),
+    );
+
+    const a = fetchComponent(api, "binary_sensor.gpio", "esp32");
+    const b = fetchComponent(api, "binary_sensor.gpio", "esp32");
+    const c = fetchComponent(api, "binary_sensor.gpio", "esp32");
+
+    expect(getComponent).toHaveBeenCalledTimes(1);
+    resolve(entry("binary_sensor.gpio", "GPIO Binary Sensor"));
+
+    await expect(a).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
+    await expect(b).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
+    await expect(c).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
+    expect(getComponent).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys cache entries by component id, platform, and board id", async () => {
+    const { api, getComponent } = mockApi((id, platform) =>
+      entry(id, `${id}|${platform ?? ""}`),
+    );
+
+    await fetchComponent(api, "sensor.dht", "esp32");
+    await fetchComponent(api, "sensor.dht", "esp8266");
+    await fetchComponent(api, "sensor.dht");
+
+    expect(getComponent).toHaveBeenCalledTimes(3);
+    expect(getCachedComponent("sensor.dht", "esp32")?.name).toBe(
+      "sensor.dht|esp32",
+    );
+    expect(getCachedComponent("sensor.dht", "esp8266")?.name).toBe(
+      "sensor.dht|esp8266",
+    );
+    expect(getCachedComponent("sensor.dht")?.name).toBe("sensor.dht|");
+  });
+
+  it("caches null (catalog miss) so unknown ids aren't re-fetched", async () => {
+    const { api, getComponent } = mockApi(() => null);
+
+    const first = await fetchComponent(api, "nonsense.id");
+    expect(first).toBeNull();
+    expect(getCachedComponent("nonsense.id")).toBeNull();
+
+    await fetchComponent(api, "nonsense.id");
+    expect(getComponent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache transport errors (allows retry)", async () => {
+    let attempts = 0;
+    const { api } = mockApi(() => {
+      attempts++;
+      if (attempts === 1) return Promise.reject(new Error("network down"));
+      return entry("wifi", "WiFi");
+    });
+
+    await expect(fetchComponent(api, "wifi")).rejects.toThrow("network down");
+    expect(getCachedComponent("wifi")).toBeUndefined();
+
+    const second = await fetchComponent(api, "wifi");
+    expect(second?.name).toBe("WiFi");
+  });
+
+  it("notifies subscribers exactly once per fresh entry", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeComponentCache(listener);
+
+    const { api } = mockApi(() => entry("api", "API"));
+    await fetchComponent(api, "api");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Cached read shouldn't notify again.
+    await fetchComponent(api, "api");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    const { api: api2 } = mockApi(() => entry("logger", "Logger"));
+    await fetchComponent(api2, "logger");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

The device navigator's left-pane list shows components by their raw YAML id (e.g. `binary_sensor.gpio`, `output.gpio`, `light.binary`). That's accurate but not friendly — at a glance you can't tell what each component actually is without reading the YAML.

This PR resolves each id against the component catalog and shows the friendly name (e.g. "GPIO Binary Sensor") on the primary line, keeping the user-supplied `name:` / `id:` from YAML on the secondary line.

## Changes

- New `src/util/component-name-cache.ts`: session-scoped cache around `getComponent`, keyed by `componentId|platform|boardId`. Dedupes concurrent in-flight calls, caches catalog misses (`null`), notifies subscribers when fresh entries land.
- `device-navigator`: consumes `apiContext`, kicks off lookups for core + component sections on YAML / platform changes, re-renders via cache subscription. Falls back to the raw id while the lookup is pending or when no catalog entry exists (e.g. inline automations).
- Replaces two open-coded copies of the `<key>.<platform>` builder with the existing `sectionKeyOf` helper.
- Unit tests for the cache (dedup, key separation, null caching, error retry, listener semantics).

No backend changes — `components/get_component` is already an O(1) in-memory lookup so a batch endpoint would have been premature.


<img width="938" height="628" alt="image" src="https://github.com/user-attachments/assets/9d7dcda8-0bc1-4e1f-b379-1a0418e26e3b" />



<img width="696" height="648" alt="image" src="https://github.com/user-attachments/assets/059b12e8-e0de-4934-98e3-2c34923a5955" />

