### PR TITLE
device card: fix button-row overflow in long-language locales

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -593,14 +593,13 @@ export class ESPHomeDeviceCard extends LitElement {
                       `
                     : nothing}
                 ${
-                  // Collapse Logs to icon-only when the row is at risk
-                  // of cramming. Cramming only happens when *both* an
-                  // accent action (Install/Update) and a Visit-web-UI
-                  // tile are competing for space alongside Edit; if
-                  // there's no accent action, the row has plenty of
-                  // room and the Logs label should stay visible so the
-                  // affordance reads at a glance.
-                  this.webUrl && (this.hasPendingChanges || this.hasUpdateAvailable)
+                  // Collapse Logs to icon-only when an accent action
+                  // (Install/Update) is present — Edit + accent + Logs
+                  // + kebab overflows the 300px-min card in long-language
+                  // locales like Dutch ("Bewerken"/"Installeren"/"Logboek").
+                  // Logs collapses first since the console icon reads
+                  // clearly without a label.
+                  this.hasPendingChanges || this.hasUpdateAvailable
                     ? html`<button
                         class="action-btn action-btn--ghost action-btn--tile"
                         @click=${() => this._emit("open-logs")}


### PR DESCRIPTION
## Problem

On the device cards, when an Install/Update button is shown alongside Edit + Logs + kebab, the row overflows the 300px-min card width in long-language locales (Dutch, German). The Edit button label gets truncated (e.g. "Bewerken" → "Bewerk").

The existing logic only collapsed Logs to an icon when *both* an accent action and a Visit-Web tile were present — but offline devices don't have a Visit-Web URL, so they kept the full Logs label and overflowed.

## Changes

- Collapse Logs to icon-only whenever Install/Update is shown, regardless of whether Visit-Web is present.