### PR TITLE
command-dialog: re-pin log to bottom when status banner appears

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -435,6 +435,21 @@ export class ESPHomeCommandDialog extends LitElement {
     if (changedProperties.has("_darkMode")) {
       this.toggleAttribute("light", !this._darkMode);
     }
+    /* When a job ends, the success/error banner takes ~56px of flex
+       space below the log. The log container shrinks, scrollTop is
+       preserved, and the bottom of the log slides out of view —
+       which also trips ansi-log's _isUserScrolled latch and disables
+       auto-scroll for any trailing lines. Re-pin to the new bottom
+       and clear the latch on the running → terminal transition. */
+    if (changedProperties.has("_state")) {
+      const prev = changedProperties.get("_state") as CommandState | null;
+      if (
+        prev === "running" &&
+        (this._state === "success" || this._state === "error")
+      ) {
+        this._resetAnsiLogScroll();
+      }
+    }
   }
 
   public open(type: CommandType, options?: { port?: string }) {


### PR DESCRIPTION
# What does this implement/fix?

When a queued job ends, `_renderBanner` inserts a ~56px success/error
row into the dialog's flex column below the log. The log container's
`clientHeight` drops by that amount but `scrollTop` is preserved, so
the bottom of the output slides out of view. Worse, the induced
scroll change fires `ansi-log`'s `_handleScroll`, which sees
`scrollHeight - scrollTop - clientHeight ≈ 56 > 40` and latches
`_isUserScrolled = true` — so any trailing line that arrives after
the banner (or a re-attached follow-up stream) won't auto-scroll
either.

Detect the `running → terminal` transition in `willUpdate` and call
the existing `_resetAnsiLogScroll()` helper. That schedules a
`scrollToBottom()` after the next `updateComplete`, which both
re-pins the log to the new bottom and clears `_isUserScrolled` so
auto-scroll re-engages.

The same helper is already used by `open()` and the secrets-toggle
restart (`command-dialog.ts:466`) for the same reason — this
extends it to the one remaining transition that breaks the latch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a — discovered while testing OTA install end-to-end.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).