### PR TITLE
Select all in filtered view: only select visible devices

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -571,13 +571,6 @@ export class ESPHomeDeviceTable extends LitElement {
     );
   }
 
-  /** Configurations currently visible in the table after applying the
-   *  active search filter (across all pages). Used by the dashboard's
-   *  floating select-bar so "Select all" honors the search. */
-  public getVisibleConfigurations(): string[] {
-    return this._visibleConfigs.slice();
-  }
-
   /** Scroll the row matching *configuration* into view.
    *
    *  Exposed so the dashboard can highlight a freshly-adopted device

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -152,6 +152,7 @@ export class ESPHomeDeviceTable extends LitElement {
 
   private _tableController = new TableController<DeviceRow>(this);
   private _rows: DeviceRow[] = [];
+  private _visibleConfigs: string[] = [];
   private _columns: ColumnDef<DeviceRow>[] = [];
   private _prevLocalize: LocalizeFunc | null = null;
 
@@ -293,6 +294,9 @@ export class ESPHomeDeviceTable extends LitElement {
     });
 
     const rows = table.getRowModel().rows;
+    this._visibleConfigs = table
+      .getFilteredRowModel()
+      .rows.map((r) => r.original.config);
     const pgState = table.getState().pagination;
     const toggleCols: ToggleableColumn[] = table
       .getAllColumns()
@@ -546,7 +550,8 @@ export class ESPHomeDeviceTable extends LitElement {
 
   private get _allSelected(): boolean {
     return (
-      this._rows.length > 0 && this._rows.every((r) => this.selectedDevices.has(r.config))
+      this._visibleConfigs.length > 0 &&
+      this._visibleConfigs.every((cfg) => this.selectedDevices.has(cfg))
     );
   }
 
@@ -559,10 +564,18 @@ export class ESPHomeDeviceTable extends LitElement {
   private _onToggleAll() {
     this.dispatchEvent(
       new CustomEvent(this._allSelected ? "deselect-all" : "select-all", {
+        detail: this._visibleConfigs.slice(),
         bubbles: true,
         composed: true,
       })
     );
+  }
+
+  /** Configurations currently visible in the table after applying the
+   *  active search filter (across all pages). Used by the dashboard's
+   *  floating select-bar so "Select all" honors the search. */
+  public getVisibleConfigurations(): string[] {
+    return this._visibleConfigs.slice();
   }
 
   /** Scroll the row matching *configuration* into view.

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -20,8 +20,12 @@ export class ESPHomeSelectBar extends LitElement {
   @property({ type: Number, attribute: "selected-count" })
   selectedCount = 0;
 
-  @property({ type: Number, attribute: "total-count" })
-  totalCount = 0;
+  /** True when every currently-visible (filtered) device is in the
+   *  parent's selection. Drives the toggle button between "Select all"
+   *  and "Deselect all" so it reflects the filtered scope rather than
+   *  the full device list. */
+  @property({ type: Boolean, attribute: "all-visible-selected" })
+  allVisibleSelected = false;
 
 
   static styles = [
@@ -144,8 +148,7 @@ export class ESPHomeSelectBar extends LitElement {
   ];
 
   protected render() {
-    const allSelected =
-      this.selectedCount === this.totalCount && this.totalCount > 0;
+    const allSelected = this.allVisibleSelected;
 
     return html`
       <div class="select-bar">

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -367,29 +367,55 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   /** Configurations currently visible to the user given the active
-   *  view and search query. Card view applies the filter inline; table
-   *  view delegates so the broader column-aware filter is honored. The
-   *  floating select-bar uses this so "Select all" matches what's on
-   *  screen instead of selecting filtered-out devices. */
+   *  view and search query. Card view searches name + configuration;
+   *  table view also matches address / IP / platform to mirror the
+   *  device-table's global filter. Used so "Select all" — header
+   *  checkbox or floating select-bar — only ever touches devices the
+   *  user can actually see. */
   private _currentlyVisibleConfigurations(): string[] {
-    if (this._view === DashboardView.TABLE) {
-      const table = this.shadowRoot?.querySelector("esphome-device-table") as
-        | (HTMLElement & { getVisibleConfigurations?: () => string[] })
-        | null;
-      if (table?.getVisibleConfigurations) {
-        return table.getVisibleConfigurations();
-      }
-    }
     const q = this._search.trim().toLowerCase();
     const sorted = this._sortedDevices;
-    const filtered = q
-      ? sorted.filter(
-          (d) =>
-            (d.friendly_name || d.name).toLowerCase().includes(q) ||
-            d.configuration.toLowerCase().includes(q)
-        )
-      : sorted;
-    return filtered.map((d) => d.configuration);
+    if (!q) return sorted.map((d) => d.configuration);
+    const isTable = this._view === DashboardView.TABLE;
+    return sorted
+      .filter((d) => {
+        const name = d.friendly_name || d.name;
+        if (name.toLowerCase().includes(q)) return true;
+        if (d.configuration.toLowerCase().includes(q)) return true;
+        if (!isTable) return false;
+        return (
+          d.address.toLowerCase().includes(q) ||
+          d.ip_addresses.some((ip) => ip.toLowerCase().includes(q)) ||
+          d.target_platform.toLowerCase().includes(q)
+        );
+      })
+      .map((d) => d.configuration);
+  }
+
+  private get _allVisibleSelected(): boolean {
+    const visible = this._currentlyVisibleConfigurations();
+    return (
+      visible.length > 0 && visible.every((c) => this._selectedDevices.has(c))
+    );
+  }
+
+  /** Add the given configurations to the current selection without
+   *  touching unrelated entries — preserves picks the user made under
+   *  a previous filter. Empty input is a no-op. */
+  private _addToSelection(configurations: string[]) {
+    if (configurations.length === 0) return;
+    const next = new Set(this._selectedDevices);
+    for (const c of configurations) next.add(c);
+    this._selectedDevices = next;
+  }
+
+  /** Remove the given configurations from the current selection
+   *  without touching the rest. Empty input is a no-op. */
+  private _removeFromSelection(configurations: string[]) {
+    if (configurations.length === 0) return;
+    const next = new Set(this._selectedDevices);
+    for (const c of configurations) next.delete(c);
+    this._selectedDevices = next;
   }
 
   private get _visibleImportableDevices(): AdoptableDevice[] {
@@ -640,12 +666,10 @@ export class ESPHomePageDashboard extends LitElement {
         @show-progress=${(e: CustomEvent<ConfiguredDevice>) =>
           this._showJobProgress(e.detail)}
         @toggle-select=${(e: CustomEvent<string>) => this._toggleDevice(e.detail)}
-        @select-all=${(e: CustomEvent<string[]>) => {
-          this._selectedDevices = new Set(e.detail);
-        }}
-        @deselect-all=${() => {
-          this._selectedDevices = new Set();
-        }}
+        @select-all=${(e: CustomEvent<string[]>) =>
+          this._addToSelection(e.detail)}
+        @deselect-all=${(e: CustomEvent<string[]>) =>
+          this._removeFromSelection(e.detail)}
         @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}
         @update-device=${(e: CustomEvent<ConfiguredDevice>) =>
           this._openCommand(e.detail, "install")}
@@ -760,13 +784,11 @@ export class ESPHomePageDashboard extends LitElement {
       return html`
         <esphome-select-bar
           selected-count=${this._selectedDevices.size}
-          total-count=${this._devices.length}
-          @select-all=${() => {
-            this._selectedDevices = new Set(this._currentlyVisibleConfigurations());
-          }}
-          @deselect-all=${() => {
-            this._selectedDevices = new Set();
-          }}
+          ?all-visible-selected=${this._allVisibleSelected}
+          @select-all=${() =>
+            this._addToSelection(this._currentlyVisibleConfigurations())}
+          @deselect-all=${() =>
+            this._removeFromSelection(this._currentlyVisibleConfigurations())}
           @cancel=${() => {
             this._selectMode = false;
             this._selectedDevices = new Set();

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -366,6 +366,32 @@ export class ESPHomePageDashboard extends LitElement {
     return sorted;
   }
 
+  /** Configurations currently visible to the user given the active
+   *  view and search query. Card view applies the filter inline; table
+   *  view delegates so the broader column-aware filter is honored. The
+   *  floating select-bar uses this so "Select all" matches what's on
+   *  screen instead of selecting filtered-out devices. */
+  private _currentlyVisibleConfigurations(): string[] {
+    if (this._view === DashboardView.TABLE) {
+      const table = this.shadowRoot?.querySelector("esphome-device-table") as
+        | (HTMLElement & { getVisibleConfigurations?: () => string[] })
+        | null;
+      if (table?.getVisibleConfigurations) {
+        return table.getVisibleConfigurations();
+      }
+    }
+    const q = this._search.trim().toLowerCase();
+    const sorted = this._sortedDevices;
+    const filtered = q
+      ? sorted.filter(
+          (d) =>
+            (d.friendly_name || d.name).toLowerCase().includes(q) ||
+            d.configuration.toLowerCase().includes(q)
+        )
+      : sorted;
+    return filtered.map((d) => d.configuration);
+  }
+
   private get _visibleImportableDevices(): AdoptableDevice[] {
     /* Hide ignored discoveries by default — the user already said
        "don't show me this", so a fresh page load shouldn't put them
@@ -614,8 +640,8 @@ export class ESPHomePageDashboard extends LitElement {
         @show-progress=${(e: CustomEvent<ConfiguredDevice>) =>
           this._showJobProgress(e.detail)}
         @toggle-select=${(e: CustomEvent<string>) => this._toggleDevice(e.detail)}
-        @select-all=${() => {
-          this._selectedDevices = new Set(this._devices.map((d) => d.configuration));
+        @select-all=${(e: CustomEvent<string[]>) => {
+          this._selectedDevices = new Set(e.detail);
         }}
         @deselect-all=${() => {
           this._selectedDevices = new Set();
@@ -736,7 +762,7 @@ export class ESPHomePageDashboard extends LitElement {
           selected-count=${this._selectedDevices.size}
           total-count=${this._devices.length}
           @select-all=${() => {
-            this._selectedDevices = new Set(this._devices.map((d) => d.configuration));
+            this._selectedDevices = new Set(this._currentlyVisibleConfigurations());
           }}
           @deselect-all=${() => {
             this._selectedDevices = new Set();


### PR DESCRIPTION
## Problem

In a filtered view, clicking "Select all" (table header checkbox or the floating select-bar) selected **every** device, not just the ones matching the active search.

Closes [esphome/device-builder#310](https://github.com/esphome/device-builder/issues/310).

## Changes

- `device-table`: header checkbox `select-all` event now carries the configurations of the rows currently visible after the global filter; the "all selected" indicator is also based on visible rows so the checkbox state matches what the user sees.
- `device-table`: exposes `getVisibleConfigurations()` so the dashboard's floating select-bar can ask the table for its filtered subset.
- `dashboard`: `select-all` from the table consumes the event detail; the floating select-bar resolves visible configs against the active view (card filter inline, table via the new method).