### PR TITLE
install-method-dialog: rework web-download row, add manual binary download

### DIFF
--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -74,6 +74,8 @@ export class DeviceInstallController implements ReactiveController {
       this._host.firmwareDialog?.installWebSerial(device);
     } else if (method === "web-download") {
       this._host.firmwareDialog?.installWebDownload(device);
+    } else if (method === "binary-download") {
+      this._host.firmwareDialog?.installBinaryDownload(device);
     }
   };
 

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -1012,7 +1012,16 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         binaries.find((b) => b.file === "firmware.bin") ??
         (isWebFlasher ? undefined : binaries[0]);
       if (!flashable) {
-        this._fail(this._localize("firmware.no_flashable_binary"));
+        // The web-flasher path can only handle ESP32 .factory.bin or
+        // ESP8266 .bin, so a missing match almost always means a UF2
+        // platform — surface that clearly. The manual path falls back
+        // to ``binaries[0]`` and only ends up here when nothing was
+        // produced at all, so use the more general "no binaries" copy.
+        this._fail(
+          this._localize(
+            isWebFlasher ? "firmware.no_flashable_binary" : "firmware.no_binaries"
+          )
+        );
         return;
       }
       const result = await this._api.firmwareDownload(

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -94,9 +94,17 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() private _showLogsAfterInstall = true;
   /** Which entry point opened the dialog. ``web-serial`` shows the
    *  show-logs-after-install toggle and dispatches the auto-flip on
-   *  success; ``web-download`` doesn't connect to a device so the
-   *  toggle is hidden and there's nothing to flip to. */
-  @state() private _installer: "web-serial" | "web-download" | null = null;
+   *  success; ``web-download`` and ``binary-download`` don't connect
+   *  to a device so the toggle is hidden and there's nothing to flip
+   *  to. The two download paths share most of the compile + save flow
+   *  but differ in the success-screen wording and footer (web-download
+   *  routes the user to web.esphome.io; binary-download leaves the
+   *  flashing tool to the user). */
+  @state() private _installer:
+    | "web-serial"
+    | "web-download"
+    | "binary-download"
+    | null = null;
 
   private _device: ConfiguredDevice | null = null;
   private _jobId = "";
@@ -147,7 +155,22 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._step = "queued";
     this._statusMessage = this._localize("firmware.status_queued");
     this._dialog.open = true;
-    this._startWebDownload();
+    this._startDownload();
+  }
+
+  /**
+   * Compile + download the binary and hand it off to the user without
+   * any opinion on how to flash it. Always available from the install
+   * picker so users can plug into esptool.py / picotool / a UF2 mass-
+   * storage flow without going through the web.esphome.io route.
+   */
+  installBinaryDownload(device: ConfiguredDevice) {
+    this._init(device);
+    this._installer = "binary-download";
+    this._step = "queued";
+    this._statusMessage = this._localize("firmware.status_queued");
+    this._dialog.open = true;
+    this._startDownload();
   }
 
   /**
@@ -515,6 +538,25 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     }
     if (this._step === "download-ready") {
       const filename = this._downloadedFilename;
+      // Manual binary download: just acknowledge the file and let the
+      // user flash it however they like — no web.esphome.io checklist.
+      if (this._installer === "binary-download") {
+        return html`
+          <div class="status">
+            <wa-icon
+              class="status-icon status-icon--success"
+              library="mdi"
+              name="check-circle"
+            ></wa-icon>
+            <span class="status-text"
+              >${this._localize("firmware.binary_download_done_title")}</span
+            >
+            <span class="status-detail"
+              >${this._localize("firmware.binary_download_done_body", { filename })}</span
+            >
+          </div>
+        `;
+      }
       return html`
         <div class="status">
           <wa-icon
@@ -679,6 +721,16 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       `;
     }
     if (this._step === "download-ready") {
+      // Manual binary download has no follow-up tool — just close.
+      if (this._installer === "binary-download") {
+        return html`
+          <div class="footer">
+            <button class="btn btn--primary" @click=${this._close}>
+              ${this._localize("command.close")}
+            </button>
+          </div>
+        `;
+      }
       return html`
         <div class="footer">
           <button class="btn btn--ghost" @click=${this._close}>
@@ -921,11 +973,21 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (handled) this._dialog.open = false;
   }
 
-  // ─── Web Download (compile + save .bin for web.esphome.io) ─────
+  // ─── Download flows (compile + save binary) ────────────────────
 
-  private async _startWebDownload() {
+  /**
+   * Shared compile + save path for both the web.esphome.io route and
+   * the manual binary download. Differs only in which binaries are
+   * eligible: web.esphome.io needs a self-contained image it can
+   * flash at 0x0 (ESP32 ``firmware.factory.bin`` or ESP8266
+   * ``firmware.bin``), while the manual route just gives the user
+   * whatever artefact the build produced — including .uf2 files for
+   * RP2040 / nrf52 / libretiny that the web flasher cannot handle.
+   */
+  private async _startDownload() {
     const device = this._device;
     if (!device) return;
+    const isWebFlasher = this._installer === "web-download";
 
     try {
       await this._compileAndWait(device.configuration);
@@ -938,16 +1000,17 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = this._localize("firmware.status_downloading");
     try {
       const binaries = await this._api.firmwareGetBinaries(device.configuration);
-      // web.esphome.io flashes the uploaded file at 0x0, so we need a
-      // self-contained image. Per ESPHome's get_download_types(): ESP32
-      // returns "firmware.factory.bin" (bootloader + partitions + app);
-      // ESP8266 returns just "firmware.bin" which is itself the full
-      // image (no bootloader/partition split on ESP8266). RP2040 / nrf52
-      // / libretiny return .uf2 files which web.esphome.io can't flash —
-      // reject those with a clear error.
+      // Per ESPHome's get_download_types(): ESP32 returns
+      // "firmware.factory.bin" (bootloader + partitions + app); ESP8266
+      // returns just "firmware.bin" which is itself the full image (no
+      // bootloader/partition split on ESP8266). For the web flasher we
+      // require one of those — anything else (UF2) is unusable. For the
+      // manual route we fall back to the first available binary so
+      // non-ESP platforms still get something flashable.
       const flashable =
         binaries.find((b) => b.file === "firmware.factory.bin") ??
-        binaries.find((b) => b.file === "firmware.bin");
+        binaries.find((b) => b.file === "firmware.bin") ??
+        (isWebFlasher ? undefined : binaries[0]);
       if (!flashable) {
         this._fail(this._localize("firmware.no_flashable_binary"));
         return;

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -4,6 +4,7 @@ import {
   mdiChevronDown,
   mdiChevronUp,
   mdiCloudDownload,
+  mdiDownload,
   mdiSerialPort,
   mdiUsb,
   mdiWifi,
@@ -31,6 +32,7 @@ registerMdiIcons({
   usb: mdiUsb,
   "serial-port": mdiSerialPort,
   "cloud-download": mdiCloudDownload,
+  download: mdiDownload,
 });
 
 type DialogView = "method" | "port-select";
@@ -330,6 +332,21 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         color: var(--wa-color-text-normal);
       }
 
+      /* Inline link inside an option's title (used by the web.esphome.io
+         row to render the host name as a clickable link). stopPropagation
+         on the link's click handler keeps the row's "start install" from
+         firing when the user just wants to preview the destination. */
+      .title .inline-link {
+        color: var(--esphome-primary);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+      }
+      .title .inline-link:hover,
+      .title .inline-link:focus-visible {
+        text-decoration-thickness: 2px;
+        outline: none;
+      }
+
       .desc {
         font-size: var(--wa-font-size-2xs);
         color: var(--wa-color-text-quiet);
@@ -400,28 +417,17 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   private _renderMethodList() {
     const isOnline = this.deviceState === DeviceState.ONLINE;
     const hasWebSerial = this._supportsWebSerial;
-    const showWebDownload =
+    // Web-download replaces (rather than supplements) the local USB row
+    // when the user can't use Web Serial here AND can't use OTA — the
+    // same situation that disabled the USB row before. Keeps the list
+    // short by not showing two USB options where only one is reachable.
+    const swapInWebDownload =
       this.mode === "install" && !hasWebSerial && !isOnline && this._supportsWebDownload;
 
     return html`
       <div class="list">
         ${this._renderOtaOption(isOnline)}
-        <div
-          class="option ${!hasWebSerial ? "option--disabled" : ""}"
-          @click=${hasWebSerial ? () => this._selectMethod("web-serial") : undefined}
-        >
-          <wa-icon library="mdi" name="usb"></wa-icon>
-          <div class="info">
-            <span class="title"
-              >${this._localize("dashboard.install_method_usb_local")}</span
-            >
-            <span class="desc"
-              >${hasWebSerial
-                ? this._localize("dashboard.install_method_usb_local_desc")
-                : this._localize("dashboard.install_method_usb_local_unsupported")}</span
-            >
-          </div>
-        </div>
+        ${swapInWebDownload ? this._renderWebDownloadOption() : this._renderWebSerialOption(hasWebSerial)}
         <div class="option" @click=${this._onServerSerial}>
           <wa-icon library="mdi" name="serial-port"></wa-icon>
           <div class="info">
@@ -433,21 +439,88 @@ export class ESPHomeInstallMethodDialog extends LitElement {
             >
           </div>
         </div>
-        ${showWebDownload
-          ? html`
-              <div class="option" @click=${() => this._selectMethod("web-download")}>
-                <wa-icon library="mdi" name="cloud-download"></wa-icon>
-                <div class="info">
-                  <span class="title"
-                    >${this._localize("dashboard.install_method_web_download")}</span
-                  >
-                  <span class="desc"
-                    >${this._localize("dashboard.install_method_web_download_desc")}</span
-                  >
-                </div>
-              </div>
-            `
-          : nothing}
+        ${this.mode === "install" ? this._renderManualDownloadOption() : nothing}
+      </div>
+    `;
+  }
+
+  private _renderWebSerialOption(hasWebSerial: boolean) {
+    return html`
+      <div
+        class="option ${!hasWebSerial ? "option--disabled" : ""}"
+        @click=${hasWebSerial ? () => this._selectMethod("web-serial") : undefined}
+      >
+        <wa-icon library="mdi" name="usb"></wa-icon>
+        <div class="info">
+          <span class="title"
+            >${this._localize("dashboard.install_method_usb_local")}</span
+          >
+          <span class="desc"
+            >${hasWebSerial
+              ? this._localize("dashboard.install_method_usb_local_desc")
+              : this._localize("dashboard.install_method_usb_local_unsupported")}</span
+          >
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * web.esphome.io fallback row. Renders the host name as an inline
+   * link inside the title so users can preview / right-click open the
+   * destination before committing to the compile + download. The link
+   * stops click propagation so opening it doesn't double-fire as a
+   * "start install" on the parent row.
+   *
+   * Translation splits on the ``{link}`` marker so other locales can
+   * place the URL anywhere within the sentence.
+   */
+  private _renderWebDownloadOption() {
+    const titleTemplate = this._localize("dashboard.install_method_web_download");
+    const linkText = this._localize("dashboard.install_method_web_download_link");
+    const [before, after = ""] = titleTemplate.split("{link}");
+    return html`
+      <div class="option" @click=${() => this._selectMethod("web-download")}>
+        <wa-icon library="mdi" name="cloud-download"></wa-icon>
+        <div class="info">
+          <span class="title"
+            >${before}<a
+              class="inline-link"
+              href="https://web.esphome.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              @click=${(e: MouseEvent) => e.stopPropagation()}
+              >${linkText}</a
+            >${after}</span
+          >
+          <span class="desc"
+            >${this._localize("dashboard.install_method_web_download_desc")}</span
+          >
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Manual binary download — always offered in install mode. Compiles
+   * here, hands the user the resulting binary, and leaves flashing to
+   * whatever tool they prefer (esptool.py, picotool, copy-to-MSC for
+   * UF2 platforms, etc). Distinct from the web-download row, which
+   * specifically routes the user through web.esphome.io and is gated
+   * to ESP32 / ESP8266.
+   */
+  private _renderManualDownloadOption() {
+    return html`
+      <div class="option" @click=${() => this._selectMethod("binary-download")}>
+        <wa-icon library="mdi" name="download"></wa-icon>
+        <div class="info">
+          <span class="title"
+            >${this._localize("dashboard.install_method_manual_download")}</span
+          >
+          <span class="desc"
+            >${this._localize("dashboard.install_method_manual_download_desc")}</span
+          >
+        </div>
       </div>
     `;
   }

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -473,25 +473,32 @@ export class ESPHomeInstallMethodDialog extends LitElement {
    * "start install" on the parent row.
    *
    * Translation splits on the ``{link}`` marker so other locales can
-   * place the URL anywhere within the sentence.
+   * place the URL anywhere within the sentence. Locales that don't
+   * include the marker (e.g. an older translation that already inlines
+   * the host name) fall back to rendering the title verbatim — without
+   * this guard the link would be appended after the existing inlined
+   * URL, producing duplicates like "... web.esphome.io web.esphome.io".
    */
   private _renderWebDownloadOption() {
     const titleTemplate = this._localize("dashboard.install_method_web_download");
     const linkText = this._localize("dashboard.install_method_web_download_link");
+    const hasMarker = titleTemplate.includes("{link}");
     const [before, after = ""] = titleTemplate.split("{link}");
     return html`
       <div class="option" @click=${() => this._selectMethod("web-download")}>
         <wa-icon library="mdi" name="cloud-download"></wa-icon>
         <div class="info">
           <span class="title"
-            >${before}<a
-              class="inline-link"
-              href="https://web.esphome.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              @click=${(e: MouseEvent) => e.stopPropagation()}
-              >${linkText}</a
-            >${after}</span
+            >${hasMarker
+              ? html`${before}<a
+                    class="inline-link"
+                    href="https://web.esphome.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    @click=${(e: MouseEvent) => e.stopPropagation()}
+                    >${linkText}</a
+                  >${after}`
+              : titleTemplate}</span
           >
           <span class="desc"
             >${this._localize("dashboard.install_method_web_download_desc")}</span

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1283,6 +1283,8 @@ export class ESPHomePageDashboard extends LitElement {
         this._firmwareDialog.installWebSerial(device);
       } else if (method === "web-download") {
         this._firmwareDialog.installWebDownload(device);
+      } else if (method === "binary-download") {
+        this._firmwareDialog.installBinaryDownload(device);
       }
     }
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -286,6 +286,7 @@
     "compile_failed": "Compilation failed.",
     "download_failed": "Failed to download firmware.",
     "no_flashable_binary": "No flashable binary available for this device. web.esphome.io supports ESP32 and ESP8266 only.",
+    "no_binaries": "No binaries were produced for this device. Make sure the build completed successfully.",
     "flash_failed": "Failed to flash firmware to device.",
     "chip_mismatch": "Chip mismatch: detected {detected} but device expects {expected}.",
     "validate_title": "Validate — {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -131,8 +131,11 @@
     "install_method_usb_local_unsupported": "Requires a browser with Web Serial support (e.g. Chrome)",
     "install_method_usb_server": "Plug into computer running ESPHome Dashboard",
     "install_method_usb_server_desc": "For devices connected via USB to the server",
-    "install_method_web_download": "Download firmware to flash via web.esphome.io",
-    "install_method_web_download_desc": "Compile here, then flash from a computer that can use Web Serial",
+    "install_method_web_download": "Flash on this computer via {link}",
+    "install_method_web_download_link": "web.esphome.io",
+    "install_method_web_download_desc": "Requires a browser with Web Serial support (e.g. Chrome)",
+    "install_method_manual_download": "Download firmware binary",
+    "install_method_manual_download_desc": "Compile here and download the binary, then flash it manually with your preferred tool",
     "install": "Install",
     "install_method_select_port": "Select a serial port",
     "install_method_no_ports": "No serial ports found. Make sure the device is connected to the server.",
@@ -296,7 +299,9 @@
     "web_download_step_open": "Open web.esphome.io",
     "web_download_step_connect": "Click Connect and pick your device's serial port",
     "web_download_step_install": "Choose Install and select the downloaded {filename}",
-    "web_download_open_button": "Open web.esphome.io"
+    "web_download_open_button": "Open web.esphome.io",
+    "binary_download_done_title": "Firmware binary downloaded",
+    "binary_download_done_body": "Saved as {filename}. Flash it to your device with your preferred tool."
   },
   "serial": {
     "title": "USB Device",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -171,8 +171,11 @@
     "install_method_usb_local_unsupported": "Nécessite un navigateur compatible Web Serial (ex. Chrome)",
     "install_method_usb_server": "Brancher sur l'ordinateur exécutant le tableau de bord ESPHome",
     "install_method_usb_server_desc": "Pour les appareils connectés via USB au serveur",
-    "install_method_web_download": "Télécharger le firmware pour le flasher via web.esphome.io",
-    "install_method_web_download_desc": "Compilez ici, puis flashez depuis un ordinateur qui prend en charge Web Serial",
+    "install_method_web_download": "Flasher sur cet ordinateur via {link}",
+    "install_method_web_download_link": "web.esphome.io",
+    "install_method_web_download_desc": "Nécessite un navigateur compatible Web Serial (ex. Chrome)",
+    "install_method_manual_download": "Télécharger le binaire du firmware",
+    "install_method_manual_download_desc": "Compilez ici et téléchargez le binaire, puis flashez-le manuellement avec votre outil préféré",
     "install": "Installer",
     "install_method_select_port": "Sélectionnez un port série",
     "install_method_no_ports": "Aucun port série trouvé. Assurez-vous que l'appareil est connecté au serveur.",
@@ -526,6 +529,7 @@
     "compile_failed": "Échec de la compilation.",
     "download_failed": "Échec du téléchargement du firmware.",
     "no_flashable_binary": "Aucun binaire flashable disponible pour cet appareil. web.esphome.io ne prend en charge que ESP32 et ESP8266.",
+    "no_binaries": "Aucun binaire n'a été produit pour cet appareil. Vérifiez que la compilation s'est terminée avec succès.",
     "flash_failed": "Échec du flashage du firmware sur l'appareil.",
     "chip_mismatch": "Puce incompatible : détecté {detected} mais l'appareil attend {expected}.",
     "validate_title": "Validation — {name}",
@@ -539,7 +543,9 @@
     "web_download_step_open": "Ouvrez web.esphome.io",
     "web_download_step_connect": "Cliquez sur Connect et choisissez le port série de votre appareil",
     "web_download_step_install": "Choisissez Install et sélectionnez le fichier téléchargé {filename}",
-    "web_download_open_button": "Ouvrir web.esphome.io"
+    "web_download_open_button": "Ouvrir web.esphome.io",
+    "binary_download_done_title": "Binaire du firmware téléchargé",
+    "binary_download_done_body": "Enregistré sous {filename}. Flashez-le sur votre appareil avec votre outil préféré."
   },
   "validation": {
     "required": "Ce champ est requis",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -171,8 +171,11 @@
     "install_method_usb_local_unsupported": "Vereist een browser met Web Serial-ondersteuning (bijv. Chrome)",
     "install_method_usb_server": "Aansluiten op de computer met ESPHome Dashboard",
     "install_method_usb_server_desc": "Voor apparaten die via USB op de server zijn aangesloten",
-    "install_method_web_download": "Download firmware om te flashen via web.esphome.io",
-    "install_method_web_download_desc": "Compileer hier en flash daarna vanaf een computer die Web Serial ondersteunt",
+    "install_method_web_download": "Flash op deze computer via {link}",
+    "install_method_web_download_link": "web.esphome.io",
+    "install_method_web_download_desc": "Vereist een browser met Web Serial-ondersteuning (bijv. Chrome)",
+    "install_method_manual_download": "Firmware-binary downloaden",
+    "install_method_manual_download_desc": "Compileer hier en download de binary, flash hem daarna handmatig met je eigen tool",
     "install": "Installeren",
     "install_method_select_port": "Selecteer een seriële poort",
     "install_method_no_ports": "Geen seriële poorten gevonden. Zorg dat het apparaat op de server is aangesloten.",
@@ -526,6 +529,7 @@
     "compile_failed": "Compilatie mislukt.",
     "download_failed": "Firmware downloaden mislukt.",
     "no_flashable_binary": "Geen geschikte binary beschikbaar voor dit apparaat. web.esphome.io ondersteunt alleen ESP32 en ESP8266.",
+    "no_binaries": "Er zijn geen binaries gegenereerd voor dit apparaat. Controleer of de build succesvol is voltooid.",
     "flash_failed": "Firmware flashen naar apparaat mislukt.",
     "chip_mismatch": "Chip-verschil: {detected} gedetecteerd maar apparaat verwacht {expected}.",
     "validate_title": "Valideren — {name}",
@@ -539,7 +543,9 @@
     "web_download_step_open": "Open web.esphome.io",
     "web_download_step_connect": "Klik op Connect en kies de seriële poort van je apparaat",
     "web_download_step_install": "Kies Install en selecteer het gedownloade bestand {filename}",
-    "web_download_open_button": "Open web.esphome.io"
+    "web_download_open_button": "Open web.esphome.io",
+    "binary_download_done_title": "Firmware-binary gedownload",
+    "binary_download_done_body": "Opgeslagen als {filename}. Flash hem naar je apparaat met je eigen tool."
   },
   "validation": {
     "required": "Dit veld is verplicht",


### PR DESCRIPTION
The install-method picker showed a disabled 'Plug into this computer' row whenever Web Serial wasn't available, and only revealed the web.esphome.io route as an extra option below it — leaving two USB rows where only one was actually reachable. There was also no path for users who want the binary to flash with their own tool.

## Changes

- Web-download row now **replaces** the local-USB row when Web Serial is unavailable and the device is offline (same condition that previously disabled the local-USB row).
- Web-download title rephrased to **'Flash on this computer via web.esphome.io'**, with the host name as an inline link. Description switched to **'Requires a browser with Web Serial support (e.g. Chrome)'** to match the existing local-USB unsupported wording.
- New always-visible **'Download firmware binary'** option that compiles + downloads the binary and lets the user flash it with their preferred tool (esptool.py, picotool, UF2 mass-storage, ...). Falls back to the first available binary so non-ESP platforms get a usable file too.