### PR TITLE
release: wait for PyPI to index before opening backend bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,35 @@ jobs:
     permissions:
       contents: read    # GITHUB_TOKEN reads this repo's release body
     steps:
+      - name: Wait for PyPI to index the new version
+        env:
+          PACKAGE: ${{ env.PACKAGE_NAME }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # PyPI's index is eventually consistent — ``publish-pypi``
+          # returns success when the artifact lands on storage, but
+          # the JSON / simple index served to ``pip install`` lags
+          # by ~30s–3min behind. Without a gate, the backend bump
+          # PR's CI fires before PyPI is serving the pin and fails
+          # with ``ResolutionImpossible``, requiring a manual
+          # re-run ~2 minutes later. Poll the JSON endpoint until
+          # the version is reachable.
+          #
+          # If the cap expires (rare PyPI incident), open the PR
+          # anyway with a warning — backend CI re-run is cheap, and
+          # blocking the release on a PyPI outage isn't worth it.
+          URL="https://pypi.org/pypi/$PACKAGE/$VERSION/json"
+          for i in $(seq 1 30); do
+            if curl -fsSL --max-time 10 -o /dev/null "$URL"; then
+              echo "PyPI is serving $PACKAGE==$VERSION (after $i attempt(s))."
+              exit 0
+            fi
+            echo "PyPI not yet serving $PACKAGE==$VERSION (attempt $i/30); sleeping 10s..."
+            sleep 10
+          done
+          echo "::warning::PyPI did not index $PACKAGE==$VERSION within 5 minutes — opening PR anyway; backend CI may need a manual re-run."
+
       - name: Create backend app token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,22 +264,51 @@ jobs:
           # by ~30s–3min behind. Without a gate, the backend bump
           # PR's CI fires before PyPI is serving the pin and fails
           # with ``ResolutionImpossible``, requiring a manual
-          # re-run ~2 minutes later. Poll the JSON endpoint until
-          # the version is reachable.
+          # re-run ~2 minutes later.
           #
-          # If the cap expires (rare PyPI incident), open the PR
-          # anyway with a warning — backend CI re-run is cheap, and
+          # Probe both endpoints — ``pip install`` resolves through
+          # the simple index, but the JSON endpoint is the cheapest
+          # "metadata reached the CDN edge" sentinel. Require both
+          # to succeed before declaring ready, since the two
+          # indexes can lag each other by a few seconds.
+          # (Copilot-flagged: a 200 on JSON alone doesn't guarantee
+          # the simple index has caught up, which is what ``pip``
+          # actually reads.)
+          #
+          # Cap the loop on wall-clock elapsed (5 minutes) rather
+          # than attempt count, so a slow ``curl --max-time 10``
+          # response can't double the deadline. (Copilot-flagged:
+          # 30 attempts × (curl 10s + sleep 10s) was up to 10 min,
+          # not the advertised 5.)
+          #
+          # If the deadline expires (rare PyPI incident), open the
+          # PR anyway with a warning — backend CI re-run is cheap,
           # blocking the release on a PyPI outage isn't worth it.
-          URL="https://pypi.org/pypi/$PACKAGE/$VERSION/json"
-          for i in $(seq 1 30); do
-            if curl -fsSL --max-time 10 -o /dev/null "$URL"; then
-              echo "PyPI is serving $PACKAGE==$VERSION (after $i attempt(s))."
+          JSON_URL="https://pypi.org/pypi/$PACKAGE/$VERSION/json"
+          SIMPLE_URL="https://pypi.org/simple/$PACKAGE/"
+          # Wheel filenames PEP 503-normalise hyphens to underscores;
+          # sdist filenames keep hyphens. Match either form, then
+          # require the literal version substring delimited by
+          # ``-`` (wheel) or ``.`` (sdist) so a future version that
+          # is a prefix of an unrelated string (e.g. ``0.1.2`` vs
+          # ``0.1.27``) doesn't false-positive.
+          PKG_RE="${PACKAGE//-/[-_]}"
+          VER_RE="${VERSION//./\\.}"
+          DEADLINE_SECS=300
+          START=$SECONDS
+          ATTEMPT=0
+          while (( SECONDS - START < DEADLINE_SECS )); do
+            ATTEMPT=$((ATTEMPT + 1))
+            if curl -fsSL --max-time 10 -o /dev/null "$JSON_URL" 2>/dev/null \
+               && curl -fsSL --max-time 10 "$SIMPLE_URL" 2>/dev/null \
+                  | grep -qE -- "${PKG_RE}-${VER_RE}[-.]"; then
+              echo "PyPI serving $PACKAGE==$VERSION on JSON + simple indexes (after $ATTEMPT attempt(s), $((SECONDS - START))s)."
               exit 0
             fi
-            echo "PyPI not yet serving $PACKAGE==$VERSION (attempt $i/30); sleeping 10s..."
+            echo "PyPI not yet ready (attempt $ATTEMPT, $((SECONDS - START))s elapsed); sleeping 10s..."
             sleep 10
           done
-          echo "::warning::PyPI did not index $PACKAGE==$VERSION within 5 minutes — opening PR anyway; backend CI may need a manual re-run."
+          echo "::warning::PyPI did not index $PACKAGE==$VERSION within ${DEADLINE_SECS}s — opening PR anyway; backend CI may need a manual re-run."
 
       - name: Create backend app token
         id: app-token


### PR DESCRIPTION
## Summary

Backend bump PR's CI runs `pip install` against the new
`esphome-device-builder-frontend==<ver>` pin, but PyPI's JSON / simple index
lags ~30s–3min behind `publish-pypi`'s success — the artifact is on storage
but `pip` can't see it yet. The bump PR's CI fails with
`ResolutionImpossible` and we manually re-run it ~2 minutes later.

## Change

Add a polling step at the top of the `bump-backend` job that probes
`https://pypi.org/pypi/<pkg>/<ver>/json` every 10s for up to 5 minutes:

- 200 → log the attempt count and proceed.
- All 30 attempts exhausted → emit `::warning::` and fall through anyway.
  Backend CI re-run is cheap; blocking the release on a PyPI outage isn't
  worth it.

## Why this placement

- Inside `bump-backend`, **before** `peter-evans/create-pull-request` pushes
  the branch — pushing the branch is what triggers the backend's auto-CI,
  so we want PyPI verified before the push, not after.
- Existing `bump-backend: needs: publish-release` chain preserves the order
  (`validate` → `build` → `publish-pypi` → `publish-release` →
  `bump-backend`), so the wait runs only after PyPI publish has succeeded.

## Injection / safety

- The version already passes `^[0-9]+\.[0-9]+\.[0-9]+$` via the `validate`
  job at the head of the chain; no metacharacters can survive.
- The value is passed through the `env:` block (`VERSION: ${{ inputs.version }}`)
  rather than interpolated directly into the shell `run:` source, matching
  the GitHub-recommended safe-substitution pattern used elsewhere in this
  workflow.
- All variable references are double-quoted; no `eval` / `bash -c` /
  command substitution against the variables.
- No new third-party actions added — pure `run:` shell.

## Test plan

- [x] Manually trigger a release run against a test version.
- [x] Workflow log shows `Wait for PyPI to index the new version` step
  emitting "PyPI is serving … (after N attempt(s))" before `bump-backend`'s
  PR-creation step fires.
- [x] Backend bump PR's CI finds the version on first run (no re-run
  needed).
- [x] Force a PyPI lag scenario (e.g., simulate by injecting a temporary
  fake URL): step emits the warning and the bump PR opens regardless.