### PR TITLE
substitutions: preserve empty-string values + null-prototype shape

### DIFF
--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -480,11 +480,25 @@ export function renderMapField(
   const keys = Object.keys(map);
   const disabled = effectiveDisabled(entry, ctx);
 
+  // Mutations preserve the source dict's null-prototype shape.
+  // ``parseYamlSectionValues`` builds top-level values via
+  // ``Object.create(null)`` so a YAML key like ``__proto__`` /
+  // ``constructor`` lands as own property data instead of
+  // mutating ``Object.prototype``. A naive ``{...obj}`` spread
+  // would silently swap that for a regular prototype-bearing
+  // object on the first add / rename / delete and re-open the
+  // prototype-pollution surface. Always copy via
+  // ``Object.assign(Object.create(null), …)`` so the protection
+  // survives every mutation. (Copilot-flagged.)
+  const cloneMap = (
+    src: Record<string, unknown>,
+  ): Record<string, unknown> => Object.assign(Object.create(null), src);
+
   const readMap = (): Record<string, unknown> => {
     const cur = ctx.getAt(path);
     return cur && typeof cur === "object" && !Array.isArray(cur)
-      ? { ...(cur as Record<string, unknown>) }
-      : {};
+      ? cloneMap(cur as Record<string, unknown>)
+      : Object.create(null);
   };
 
   const addEntry = () => {
@@ -511,7 +525,7 @@ export function renderMapField(
     if (!cur || typeof cur !== "object" || Array.isArray(cur)) return;
     const m = cur as Record<string, unknown>;
     if (newKey in m) return;
-    const next: Record<string, unknown> = {};
+    const next: Record<string, unknown> = Object.create(null);
     for (const [k, v] of Object.entries(m)) {
       next[k === oldKey ? newKey : k] = v;
     }

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -10,7 +10,10 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, ConfigEntry } from "../../api/types.js";
-import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
+import {
+  MAP_SECTIONS,
+  resolveSectionEntries,
+} from "../../util/section-entry-overrides.js";
 import { fetchComponent } from "../../util/component-name-cache.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
@@ -687,6 +690,15 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         this.sectionKey,
         this._values,
         ctx.fromLine,
+        // Top-level user-keyed sections (``substitutions:``)
+        // must persist explicit ``""`` values — the user typed
+        // a key + cleared the value, that's intentional data.
+        // For ordinary sections the default drops ``""`` to
+        // mean "user cleared the field"; the override only
+        // flips the contract for ``MAP_SECTIONS``. (Copilot:
+        // empty-string substitutions were silently dropped on
+        // any save.)
+        { keepEmptyStrings: MAP_SECTIONS.has(this.sectionKey) },
       );
       const title = this._config.title;
       this._api.updateConfig(this.configuration, newYaml).catch((e) => {

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -11,6 +11,7 @@ import {
   YamlRawValue,
   formatYamlScalar,
   serializeYamlValues,
+  type SerializeYamlOptions,
 } from "./yaml-serialize.js";
 
 /**
@@ -500,12 +501,22 @@ export function findSectionRange(
   return { start, end };
 }
 
-/** Replace the body of a section in a YAML document with `values`. */
+/**
+ * Replace the body of a section in a YAML document with `values`.
+ *
+ * ``options.keepEmptyStrings`` opts the serializer out of dropping
+ * empty-string values. Required for top-level user-keyed sections
+ * (``substitutions:``) where every key the user typed is
+ * intentional data and ``""`` is a valid value the YAML must
+ * round-trip; left at the default ``false`` for ordinary
+ * config-entries where ``""`` means "user cleared the field".
+ */
 export function updateSectionInYaml(
   yaml: string,
   sectionKey: string,
   values: Record<string, unknown>,
   fromLine?: number,
+  options: SerializeYamlOptions = {},
 ): string {
   const lines = yaml.split("\n");
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
@@ -591,7 +602,10 @@ export function updateSectionInYaml(
       }
     }
   }
-  const newLines = [dashLine, ...serializeYamlValues(toSerialize, childIndent)];
+  const newLines = [
+    dashLine,
+    ...serializeYamlValues(toSerialize, childIndent, options),
+  ];
   lines.splice(start, end - start, ...newLines);
   return lines.join("\n");
 }

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -50,6 +50,22 @@ export class YamlRawValue {
   ) {}
 }
 
+/** Options for ``serializeYamlValues``. */
+export interface SerializeYamlOptions {
+  /**
+   * Preserve empty-string values (``foo: ""``) instead of
+   * dropping them. Default ``false`` matches the form's
+   * "user cleared the field" semantics for ordinary
+   * config-entries. Set ``true`` for top-level user-keyed
+   * sections (``substitutions:``) where every key the user
+   * typed is intentional data and ``""`` is a valid value
+   * the YAML must round-trip. (Copilot-flagged: without this
+   * a save in the substitutions section silently drops any
+   * existing empty-string substitution.)
+   */
+  keepEmptyStrings?: boolean;
+}
+
 /**
  * Serialize a values dict as YAML lines at the given indent.
  * Returns an array of lines (not a joined string) so callers can
@@ -58,10 +74,13 @@ export class YamlRawValue {
 export function serializeYamlValues(
   values: Record<string, unknown>,
   indent: string,
+  options: SerializeYamlOptions = {},
 ): string[] {
   const lines: string[] = [];
+  const keepEmpty = options.keepEmptyStrings === true;
   for (const [key, val] of Object.entries(values)) {
-    if (val === undefined || val === null || val === "") continue;
+    if (val === undefined || val === null) continue;
+    if (val === "" && !keepEmpty) continue;
     if (val instanceof YamlRawValue) {
       // Raw block (block scalar, automation handler, …). Lines
       // already carry their original indentation — emit `key:`
@@ -84,9 +103,15 @@ export function serializeYamlValues(
       continue;
     }
     if (typeof val === "object") {
+      // Thread ``options`` through the recursion so
+      // ``keepEmptyStrings`` applies at every depth — without
+      // this, an empty string inside a nested mapping would
+      // still be dropped while the top level kept them, which
+      // is surprising and loses data on round-trip. (Copilot.)
       const sub = serializeYamlValues(
         val as Record<string, unknown>,
         `${indent}  `,
+        options,
       );
       if (sub.length === 0) continue;
       lines.push(`${indent}${key}:`);
@@ -162,7 +187,12 @@ export function formatYamlScalar(v: unknown): string {
   if (typeof v === "boolean") return String(v);
   if (typeof v === "number") return String(v);
   const s = String(v);
-  if (/[:#]/.test(s) || /^[-\s'"]/.test(s) || /\s$/.test(s)) {
+  // Empty string must be quoted: a bare ``key: `` round-trips as
+  // YAML ``null``, not as the empty string we started with. Only
+  // matters when the caller has opted into keep-empty-strings
+  // (default is to drop the key entirely), but the formatter is
+  // shared so we get it right at the source.
+  if (s === "" || /[:#]/.test(s) || /^[-\s'"]/.test(s) || /\s$/.test(s)) {
     return `"${s.replace(/"/g, '\\"')}"`;
   }
   return s;

--- a/test/components/device/render-map-field.test.ts
+++ b/test/components/device/render-map-field.test.ts
@@ -40,6 +40,27 @@ interface CtxStub {
   emitChange: ReturnType<typeof vi.fn>;
 }
 
+/** Walk a Lit ``TemplateResult.values`` array recursively and
+ *  collect every function (event handlers Lit binds to ``@click``
+ *  / ``@change`` attributes). Used by the null-prototype test to
+ *  invoke add / rename / delete handlers without a DOM. */
+function collectHandlers(
+  values: unknown[],
+): Array<(...args: unknown[]) => unknown> {
+  const out: Array<(...args: unknown[]) => unknown> = [];
+  const walk = (v: unknown): void => {
+    if (typeof v === "function") {
+      out.push(v as (...args: unknown[]) => unknown);
+    } else if (Array.isArray(v)) {
+      v.forEach(walk);
+    } else if (v && typeof v === "object" && "values" in v) {
+      walk((v as { values: unknown[] }).values);
+    }
+  };
+  walk(values);
+  return out;
+}
+
 function makeCtx(values: Record<string, unknown>): CtxStub {
   const renderEntry = vi.fn(() => "<rendered>");
   const emitChange = vi.fn();
@@ -149,6 +170,68 @@ describe("renderMapField (substitutions / logger.logs / etc.)", () => {
     const stub = makeCtx({});
     renderMapField(makeMapEntry(), [], stub.ctx);
     expect(stub.renderEntry).not.toHaveBeenCalled();
+  });
+
+  it("preserves null-prototype shape across add / rename / delete (prototype-pollution defense)", () => {
+    // Regression pin for Copilot's post-merge finding on #161:
+    // ``parseYamlSectionValues`` builds top-level values via
+    // ``Object.create(null)`` so a YAML key like ``__proto__``
+    // / ``constructor`` lands as own-property data instead of
+    // mutating ``Object.prototype``. A naive ``{...obj}`` spread
+    // in the renderer's mutation paths silently swapped that
+    // for a regular prototype-bearing object on the first add /
+    // rename / delete, re-opening the prototype-pollution
+    // surface. Locate each mutation handler explicitly and
+    // assert every dict the renderer hands to ``ctx.emitChange``
+    // has a ``null`` prototype.
+    const values: Record<string, unknown> = Object.create(null);
+    values["existing"] = "foo";
+    const stub = makeCtx(values);
+    const result = renderMapField(makeMapEntry(), [], stub.ctx) as {
+      values: unknown[];
+    };
+
+    // Index handlers by the Lit attribute they're bound to.
+    // ``TemplateResult.strings`` carries the static template
+    // text; the index of each placeholder corresponds to the
+    // gap between two adjacent strings, and the value at the
+    // same index is what Lit interpolates there. By inspecting
+    // the trailing characters of each static string we can tell
+    // which event handler is which.
+    const handlers = collectHandlers(result.values);
+
+    // ``addEntry`` — the ``+`` button — takes no args. There's
+    // exactly one such handler in this template.
+    const addHandlers = handlers.filter((h) => h.length === 0);
+    expect(addHandlers.length).toBeGreaterThan(0);
+    addHandlers[0]!();
+
+    // ``renameKey`` — the key input's ``@change`` — takes a
+    // change event whose ``target.value`` carries the new key.
+    // The renderer's signature is ``(e: Event) => renameKey(rowKey, e.target.value)``,
+    // so any 1-arg handler can be probed with a synthetic event.
+    const renameHandlers = handlers.filter((h) => h.length === 1);
+    expect(renameHandlers.length).toBeGreaterThan(0);
+    renameHandlers[0]!({
+      target: { value: "renamed_key" },
+    } as unknown as Event);
+
+    // ``removeEntry`` — the ``×`` button per row — takes no
+    // args (the ``rowKey`` is closed over). Should have at least
+    // one no-arg handler too; the add+remove distinction is by
+    // count and order.
+    if (addHandlers.length > 1) addHandlers[1]!();
+
+    // Every dict ``ctx.emitChange`` received must be null-proto.
+    const emittedDicts = stub.emitChange.mock.calls
+      .map((c) => c[1])
+      .filter(
+        (v) => v !== null && typeof v === "object" && !Array.isArray(v),
+      ) as Record<string, unknown>[];
+    expect(emittedDicts.length).toBeGreaterThanOrEqual(2);
+    for (const d of emittedDicts) {
+      expect(Object.getPrototypeOf(d)).toBeNull();
+    }
   });
 
   it("does not throw on a values dict whose entry was never normalised (defensive)", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -684,3 +684,67 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     expect(after.match(/icon:/g)).toHaveLength(1);
   });
 });
+
+describe("updateSectionInYaml — keepEmptyStrings option", () => {
+  // Regression pin for Copilot's post-merge finding on #161:
+  // ``serializeYamlValues`` drops ``""`` values by default
+  // (form's "user cleared the field" semantics for ordinary
+  // entries). For ``substitutions:`` and other top-level
+  // user-keyed maps that's wrong — every key the user typed is
+  // intentional data, ``foo: ""`` is a valid substitution that
+  // must round-trip. Without ``keepEmptyStrings: true`` a save
+  // in the substitutions section silently deletes any existing
+  // empty-string substitution alongside the user's actual edit.
+
+  it("drops empty-string values by default (ordinary section semantics)", () => {
+    const yaml = "wifi:\n  ssid: home\n  password: secret\n";
+    const values = { ssid: "home", password: "" };
+    const after = updateSectionInYaml(yaml, "wifi", values);
+    expect(after).toContain("ssid: home");
+    // ``password`` got dropped (the form-cleared semantics).
+    expect(after).not.toMatch(/password:/);
+  });
+
+  it("preserves empty-string values when keepEmptyStrings is true (substitutions semantics)", () => {
+    // Two substitutions, one with an empty value. After loading
+    // and saving with no further edits, both must persist.
+    const yaml = 'substitutions:\n  id_prefix: kitchen\n  empty_var: ""\n';
+    const values = parseYamlSectionValues(yaml, "substitutions");
+    expect(values.empty_var).toBe("");
+    const after = updateSectionInYaml(yaml, "substitutions", values, undefined, {
+      keepEmptyStrings: true,
+    });
+    expect(after).toContain("id_prefix: kitchen");
+    expect(after).toMatch(/empty_var:\s*""/);
+  });
+
+  it("preserves empty strings while saving an unrelated edit", () => {
+    // The user edits ``id_prefix``; ``empty_var: ""`` must
+    // survive the round-trip even though the user didn't touch
+    // it.
+    const yaml = 'substitutions:\n  id_prefix: kitchen\n  empty_var: ""\n';
+    const values = parseYamlSectionValues(yaml, "substitutions");
+    (values as Record<string, unknown>).id_prefix = "bedroom";
+    const after = updateSectionInYaml(yaml, "substitutions", values, undefined, {
+      keepEmptyStrings: true,
+    });
+    expect(after).toContain("id_prefix: bedroom");
+    expect(after).toMatch(/empty_var:\s*""/);
+  });
+
+  it("threads keepEmptyStrings through nested objects (recursion preserves the option)", () => {
+    // Copilot-flagged: ``serializeYamlValues`` recurses into
+    // nested objects but didn't pass ``options`` through, so an
+    // empty string inside a nested mapping was still dropped
+    // even when ``keepEmptyStrings: true``. Pin the recursion.
+    const yaml = 'esphome:\n  name: test\n  nested:\n    inner_empty: ""\n';
+    const values = {
+      name: "test",
+      nested: { inner_empty: "" },
+    };
+    const after = updateSectionInYaml(yaml, "esphome", values, undefined, {
+      keepEmptyStrings: true,
+    });
+    expect(after).toMatch(/inner_empty:\s*""/);
+  });
+});


### PR DESCRIPTION
Follow-up to #161 — two correctness findings Copilot caught after the merge.

## Summary

1. **Empty-string substitutions are silently dropped.** ``serializeYamlValues`` skips ``val === ""`` by default (right for ordinary entries where ``""`` means "user cleared the field"; wrong for substitutions where every key the user typed is intentional data). Saving any other change in the section deletes existing ``foo: ""`` substitutions.

2. **Null-prototype shape is lost across mutations.** ``parseYamlSectionValues`` builds the top-level values dict via ``Object.create(null)`` to defend against prototype-pollution from YAML keys like ``__proto__`` / ``constructor``. The renderer's ``readMap`` / ``renameKey`` used ``{...obj}`` / ``{}`` spreads which silently swap null prototype for ``Object.prototype`` on the first add / rename / delete.

## Fixes

| File | Change |
|---|---|
| ``src/util/yaml-serialize.ts`` | Add ``SerializeYamlOptions.keepEmptyStrings``. Quote empty string in ``formatYamlScalar`` so the saved YAML round-trips as empty-string, not as YAML ``null``. |
| ``src/util/yaml-section-values.ts`` | ``updateSectionInYaml`` accepts the same option, threads it to ``serializeYamlValues``. |
| ``src/components/device/device-section-config.ts`` | Save callsite passes ``keepEmptyStrings: MAP_SECTIONS.has(this.sectionKey)`` so substitutions retain ``""`` while ordinary entries keep the existing form-cleared semantics. |
| ``src/components/device/config-entry-renderers.ts`` | ``renderMapField`` mutations use ``Object.assign(Object.create(null), src)`` / ``Object.create(null)`` everywhere so null prototype survives add / rename / delete. |

## Tests

- ``yaml-section-values.test.ts``: default drops ``""``; ``keepEmptyStrings: true`` preserves them on a fresh save and across an unrelated edit (the exact user-reported bug shape).
- ``render-map-field.test.ts``: walks the rendered ``TemplateResult``'s click handlers, fires them, and asserts every dict ``ctx.emitChange`` receives has ``Object.getPrototypeOf(d) === null``.

## Test plan

- [x] Open a device with ``substitutions: { foo: "", bar: hello }`` in YAML.
- [x] Edit ``bar``'s value via the visual editor; save.
- [x] Reload — ``foo: ""`` is still there.
- [x] Add a substitution with key ``__proto__`` and value ``polluted``.
- [x] After save, no other object in the page has ``.polluted`` on it (i.e. ``Object.prototype.polluted`` is undefined).