### PR TITLE
device-drawer: collapse version + hash rows when in sync

### DIFF
--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -413,18 +413,31 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
               <span>${this._localize(statusKey)}</span>
             </div>`
           : nothing}
-        ${this._row(
-          "tag-multiple",
-          this._localize("dashboard.drawer_current_version"),
-          local,
-          true,
-        )}
-        ${this._row(
-          "upload",
-          this._localize("dashboard.drawer_deployed_version"),
-          deployed,
-          true,
-        )}
+        ${matches
+          ? // In sync — collapse the two identical rows into one.
+            // Showing "Current Version: 2026.5.0-dev" and
+            // "Deployed Version: 2026.5.0-dev" stacked is redundant
+            // and wastes drawer height.
+            this._row(
+              "tag-multiple",
+              this._localize("dashboard.drawer_version"),
+              local,
+              true,
+            )
+          : html`
+              ${this._row(
+                "tag-multiple",
+                this._localize("dashboard.drawer_current_version"),
+                local,
+                true,
+              )}
+              ${this._row(
+                "upload",
+                this._localize("dashboard.drawer_deployed_version"),
+                deployed,
+                true,
+              )}
+            `}
       </div>
     `;
   }
@@ -470,18 +483,32 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
               <span>${this._localize(statusKey)}</span>
             </div>`
           : nothing}
-        ${this._row(
-          "fingerprint",
-          this._localize("dashboard.drawer_config_hash_local"),
-          expected,
-          true,
-        )}
-        ${this._row(
-          "fingerprint",
-          this._localize("dashboard.drawer_config_hash_deployed"),
-          deployed,
-          true,
-        )}
+        ${matches
+          ? // In sync — show the hash once instead of twice. The
+            // two-row form is reserved for the diagnostic "Local
+            // vs Deployed" comparison; once they match the
+            // distinction is meaningless and just doubles the
+            // drawer height.
+            this._row(
+              "fingerprint",
+              this._localize("dashboard.drawer_config_hash_value"),
+              expected,
+              true,
+            )
+          : html`
+              ${this._row(
+                "fingerprint",
+                this._localize("dashboard.drawer_config_hash_local"),
+                expected,
+                true,
+              )}
+              ${this._row(
+                "fingerprint",
+                this._localize("dashboard.drawer_config_hash_deployed"),
+                deployed,
+                true,
+              )}
+            `}
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -203,6 +203,7 @@
     "drawer_config_hash_title": "Config Hash",
     "drawer_config_hash_local": "Local",
     "drawer_config_hash_deployed": "Deployed",
+    "drawer_config_hash_value": "Hash",
     "drawer_config_hash_in_sync": "In sync",
     "drawer_config_hash_out_of_sync": "Out of sync — flash to update",
     "drawer_version_in_sync": "In sync",


### PR DESCRIPTION
## Summary

When the version (`current_version === deployed_version`) or the config hash (`expected_config_hash === deployed_config_hash`) is in sync, the drawer was showing the same value stacked on two consecutive rows — "Current Version: 2026.5.0-dev" above "Deployed Version: 2026.5.0-dev", same for the hash pair. The two-row layout is the diagnostic for the *out-of-sync* case; once the values match the distinction is meaningless and just doubles the drawer height.

When matched, render one row labelled "Version" / "Hash" with the value once. The "In sync" pill already communicates the comparison result.

Out-of-sync rendering unchanged — both rows still render with their "Current / Deployed" and "Local / Deployed" labels so the user can read which side is stale.

## Test plan

- [x] `npx tsc --noEmit && npm test -- --run` — 636 green, no test changes needed (DOM-rendering of the drawer isn't pinned in vitest's node env).
- [ ] Manual: device drawer with version + hash both in sync → single row each, no "Current/Deployed" label.
- [ ] Manual: out-of-sync state still shows the labelled two-row diagnostic.