### PR TITLE
Add pr-workflow Claude skill

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -68,40 +68,31 @@ side has landed.
 
 ## 6. Push and create the PR
 
+**Always read `.github/PULL_REQUEST_TEMPLATE.md` from the repo at
+PR-creation time and use it verbatim as the body** — do not
+reproduce, paraphrase, or trim the template anywhere else, or it
+will silently drift out of sync as the template evolves.
+
+When filling in the template:
+
+- Replace the `<!-- ... -->` prompt comments with the actual prose
+  for that section. Do not delete anything else.
+- **Leave all the checkboxes in place.** Do not remove rows you
+  aren't ticking — the human reviewer relies on the full list
+  being present.
+- Tick exactly one "Types of changes" box. For the Checklist
+  section, only tick boxes you have actually verified; leave the
+  rest as `- [ ]`.
+
 ```bash
 git push -u origin <branch-name>
+# Read .github/PULL_REQUEST_TEMPLATE.md, fill it in as above,
+# write the result to a temp file, then:
 gh pr create --repo esphome/device-builder-frontend --base main \
-  --label enhancement \
+  --label <release-notes-label> \
   --title "Imperative subject under 70 chars" \
-  --body "$(cat <<'EOF'
-# What does this implement/fix?
-
-<one paragraph: what changed and why>
-
-## Types of changes
-
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [x] Code quality improvements to existing code or addition of tests
-- [ ] Other
-
-**Related issue or feature (if applicable):**
-
-- fixes #<issue-number>
-
-## Checklist:
-  - [x] The code change is tested and works locally.
-  - [x] `npm run lint` passes.
-  - [x] `npm run test` passes.
-  - [x] Tests have been added to verify that the new code works (where applicable).
-EOF
-)"
+  --body-file /tmp/pr-body.md
 ```
-
-The keep-the-checklist-honest rule applies — only tick a box
-you've actually verified by running the command or inspecting the
-diff.
 
 ## 7. After the PR is open
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -30,11 +30,13 @@ abbreviate. If the template's "Types of changes" list looks
 narrower than the label set the workflow enforces (see step 3),
 prefer the workflow's canonical list when picking a label.
 
-## 3. Apply exactly one release-notes label
+## 3. Apply a release-notes label
 
 `.github/workflows/pr-labels.yaml` uses
 `ludeeus/action-require-labels` to require **at least one** of the
-release-drafter labels:
+release-drafter labels — it does not cap the number, but
+release-drafter slots a PR by its first matching label, so in
+practice apply just one:
 
 `breaking-change`, `bugfix`, `refactor`, `new-feature`,
 `enhancement`, `maintenance`, `ci`, `dependencies`, `docs`.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -85,6 +85,12 @@ When filling in the template:
 - Tick exactly one "Types of changes" box. For the Checklist
   section, only tick boxes you have actually verified; leave the
   rest as `- [ ]`.
+- **Do not escape characters from the template.** Backticks,
+  asterisks, angle brackets, etc. must be passed through verbatim
+  — escaping a backtick to `` \` `` corrupts inline code in the
+  rendered PR. The template is already valid Markdown; do not
+  rewrite it for shell quoting. Use `--body-file`, never
+  `--body "..."` with shell-escaping.
 
 ```bash
 git push -u origin <branch-name>

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pr-workflow
+description: Create pull requests for esphome/device-builder-frontend. Use when creating PRs, submitting changes, or preparing contributions.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# device-builder-frontend PR Workflow
+
+When creating a pull request for `esphome/device-builder-frontend`,
+follow these steps. The frontend ships prebuilt inside the
+`esphome/device-builder` Python wheel, so backend-visible changes
+(WS commands, model shapes, `ConfigEntryType` values) usually need
+a coordinated PR there too.
+
+## 1. Create branch from origin/main
+
+`origin` already points at `esphome/device-builder-frontend` —
+there is no fork in this workflow. Always re-fetch first:
+
+```bash
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+## 2. Read the PR template
+
+Before creating a PR, read `.github/PULL_REQUEST_TEMPLATE.md` for
+the required sections. Fill in **every** section — do not skip or
+abbreviate. If the template's "Types of changes" list looks
+narrower than the label set the workflow enforces (see step 3),
+prefer the workflow's canonical list when picking a label.
+
+## 3. Apply exactly one release-notes label
+
+`.github/workflows/pr-labels.yaml` uses
+`ludeeus/action-require-labels` to require **at least one** of the
+release-drafter labels:
+
+`breaking-change`, `bugfix`, `refactor`, `new-feature`,
+`enhancement`, `maintenance`, `ci`, `dependencies`, `docs`.
+
+Unlike the backend repo, this workflow does **not** auto-apply a
+label from a checkbox — you must pass the label explicitly when
+creating the PR (or apply it via the UI before CI runs):
+
+```bash
+gh pr create --label enhancement ...
+```
+
+Pick whichever label release-drafter would file the change under;
+if in doubt, look at the headings in `.github/release-drafter.yml`.
+
+## 4. Backend coordination
+
+If the change consumes a new WS command, event, model field, or
+`ConfigEntryType` from `esphome/device-builder`, link the companion
+backend PR in the description. Frontend PRs that depend on
+unmerged backend changes should stay in draft until the backend
+side has landed.
+
+## 5. Commit message conventions
+
+- **Imperative-mood subject line** — "Add X", not "Added X".
+- **No `Co-Authored-By: Claude` trailer.** Project preference
+  (matches the backend repo).
+- One logical change per commit. Run `npm run lint` and
+  `npm run test` locally before pushing.
+
+## 6. Push and create the PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --repo esphome/device-builder-frontend --base main \
+  --label enhancement \
+  --title "Imperative subject under 70 chars" \
+  --body "$(cat <<'EOF'
+# What does this implement/fix?
+
+<one paragraph: what changed and why>
+
+## Types of changes
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [x] Code quality improvements to existing code or addition of tests
+- [ ] Other
+
+**Related issue or feature (if applicable):**
+
+- fixes #<issue-number>
+
+## Checklist:
+  - [x] The code change is tested and works locally.
+  - [x] `npm run lint` passes.
+  - [x] `npm run test` passes.
+  - [x] Tests have been added to verify that the new code works (where applicable).
+EOF
+)"
+```
+
+The keep-the-checklist-honest rule applies — only tick a box
+you've actually verified by running the command or inspecting the
+diff.
+
+## 7. After the PR is open
+
+CI runs the test workflow and the label-verifier. If `pr-labels`
+fails, the PR is missing one of the canonical release-drafter
+labels — apply one via `gh pr edit --add-label <label>` rather
+than pushing an empty commit.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ build/
 .cache/
 *.tsbuildinfo
 .DS_Store
-.claude
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
# What does this implement/fix?

Adds a per-repo Claude skill at `.claude/skills/pr-workflow/SKILL.md`
that summarises this repo's PR conventions: branching from
`origin/main`, the release-notes label set required by
`.github/workflows/pr-labels.yaml` (this repo verifies a label
exists rather than auto-applying from a checkbox, so the skill
explicitly tells future PR runs to pass `--label <name>` to
`gh pr create`), backend-coordination expectations, and how to feed
the PR template to `gh pr create` without mangling it
(`--body-file`, never `--body "..."` shell-escaping).

Companion backend PR: esphome/device-builder#331.

`.gitignore` is tweaked from `.claude` to `.claude/*` plus a
`!.claude/skills/` negation so personal settings / `.DS_Store`
stay ignored but the shared skills directory is tracked.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other (documentation: contributor tooling)

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] `npm run lint` passes.
  - [ ] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
