### PR TITLE
config-entry-form: render description + help link on nested groups

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -115,6 +115,7 @@ export const configEntryFormStyles = css`
   .nested-toggle {
     display: flex;
     flex: 1;
+    min-width: 0;
     align-items: center;
     gap: var(--wa-space-2xs);
     background: none;
@@ -144,6 +145,8 @@ export const configEntryFormStyles = css`
 
   .nested-title {
     flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .nested-platform {

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -106,8 +106,15 @@ export const configEntryFormStyles = css`
     border-radius: var(--wa-border-radius-m);
   }
 
+  .nested-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+  }
+
   .nested-toggle {
-    display: inline-flex;
+    display: flex;
+    flex: 1;
     align-items: center;
     gap: var(--wa-space-2xs);
     background: none;
@@ -119,6 +126,12 @@ export const configEntryFormStyles = css`
     color: var(--wa-color-text-normal);
     cursor: pointer;
     text-align: left;
+  }
+
+  .nested-desc {
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+    margin: 0;
   }
 
   .nested-toggle:hover {

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -21,6 +21,7 @@ import {
   placeholderForFloatWithUnit,
   serializeFloatWithUnit,
 } from "../../util/float-with-unit.js";
+import { renderMarkdown } from "../../util/markdown.js";
 import { isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   effectiveDisabled,
@@ -623,20 +624,28 @@ export function renderNestedField(
   );
   return html`
     <div class="nested-group" data-field-key=${path.join(".")}>
-      <button
-        type="button"
-        class="nested-toggle"
-        @click=${() => ctx.toggleNested(key)}
-      >
-        <wa-icon
-          library="mdi"
-          name=${isOpen ? "chevron-up" : "chevron-down"}
-        ></wa-icon>
-        <span class="nested-title">${labelFor(entry, ctx)}</span>
-        ${entry.platform_type
-          ? html`<span class="nested-platform">${entry.platform_type}</span>`
-          : nothing}
-      </button>
+      <div class="nested-header">
+        <button
+          type="button"
+          class="nested-toggle"
+          @click=${() => ctx.toggleNested(key)}
+        >
+          <wa-icon
+            library="mdi"
+            name=${isOpen ? "chevron-up" : "chevron-down"}
+          ></wa-icon>
+          <span class="nested-title">${labelFor(entry, ctx)}</span>
+          ${entry.platform_type
+            ? html`<span class="nested-platform">${entry.platform_type}</span>`
+            : nothing}
+        </button>
+        ${renderHelpLink(entry, ctx)}
+      </div>
+      ${entry.description
+        ? html`<p class="nested-desc">
+            ${renderMarkdown(entry.description)}
+          </p>`
+        : nothing}
       ${isOpen
         ? html`<div class="nested-fields">
             ${renderableChildren.map((child) =>

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -628,6 +628,7 @@ export function renderNestedField(
         <button
           type="button"
           class="nested-toggle"
+          aria-expanded=${isOpen}
           @click=${() => ctx.toggleNested(key)}
         >
           <wa-icon


### PR DESCRIPTION
## Problem

Nested parent entries (e.g. `api.encryption`, `wifi.ap`) only rendered the toggle title. The same entry's `description` and `help_link` — which leaf fields and the top-level component header both render — were dropped, so the parent row carried less information than its children.

## Changes

- `renderNestedField` wraps the toggle in a `.nested-header` row that also renders the help-link icon (when `entry.help_link` is set), and emits a markdown `.nested-desc` paragraph below it (when `entry.description` is set).
- Added `.nested-header` (flex row) and `.nested-desc` (small/quiet typography) styles. `.nested-toggle` switched from `inline-flex` to `display: flex; flex: 1` so it grows next to the help link without pushing it off the row.