### PR TITLE
header: add feedback dialog with bug/feature links (closes esphome/backlog#120)

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -97,6 +97,8 @@ import "../pages/dashboard.js";
 import "./command-palette.js";
 import "./esphome-layout.js";
 import "./esphome-login.js";
+import "./feedback-dialog.js";
+import type { ESPHomeFeedbackDialog } from "./feedback-dialog.js";
 import "./firmware-jobs-dialog.js";
 import type { ESPHomeFirmwareJobsDialog } from "./firmware-jobs-dialog.js";
 import "./settings-dialog.js";
@@ -697,6 +699,9 @@ export class ESPHomeApp extends LitElement {
   @query("esphome-firmware-jobs-dialog")
   private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
 
+  @query("esphome-feedback-dialog")
+  private _feedbackDialog!: ESPHomeFeedbackDialog;
+
   protected render() {
     if (this._authState === "connecting") {
       return html`
@@ -727,6 +732,7 @@ export class ESPHomeApp extends LitElement {
         @open-settings=${this._onOpenSettings}
         @open-firmware-jobs=${this._onOpenFirmwareJobs}
         @open-reset-build-env=${this._onOpenResetBuildEnv}
+        @open-feedback=${this._onOpenFeedback}
       >
         ${this._router.outlet()}
       </esphome-layout>
@@ -743,6 +749,7 @@ export class ESPHomeApp extends LitElement {
       <esphome-firmware-jobs-dialog
         @firmware-history-cleared=${this._onFirmwareHistoryCleared}
       ></esphome-firmware-jobs-dialog>
+      <esphome-feedback-dialog></esphome-feedback-dialog>
     `;
   }
 
@@ -836,6 +843,10 @@ export class ESPHomeApp extends LitElement {
 
   private _onOpenResetBuildEnv() {
     this._firmwareJobsDialog?.openResetBuildEnv();
+  }
+
+  private _onOpenFeedback() {
+    this._feedbackDialog?.open();
   }
 
   /** Prune retained terminal jobs locally after the user clears

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -1,12 +1,14 @@
 import { consume } from "@lit/context";
 import {
   mdiArchiveOutline,
+  mdiBugOutline,
   mdiCheck,
   mdiCog,
   mdiCogRefresh,
   mdiDotsVertical,
   mdiEyeOutline,
   mdiKeyVariant,
+  mdiLightbulbOutline,
   mdiPlaylistCheck,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
@@ -24,12 +26,14 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   "archive-outline": mdiArchiveOutline,
+  "bug-outline": mdiBugOutline,
   check: mdiCheck,
   cog: mdiCog,
   "cog-refresh": mdiCogRefresh,
   "dots-vertical": mdiDotsVertical,
   "eye-outline": mdiEyeOutline,
   "key-variant": mdiKeyVariant,
+  "lightbulb-outline": mdiLightbulbOutline,
   "playlist-check": mdiPlaylistCheck,
 });
 
@@ -187,6 +191,15 @@ export class ESPHomeHeaderActions extends LitElement {
 
       .menu-item:hover {
         background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+      }
+
+      /* Anchor-based menu items (external links) get the browser's
+         rel="noopener noreferrer" enforcement instead of a flaky
+         window.open flag. Reset anchor defaults so they read as
+         regular menu rows. */
+      .menu-item--link {
+        text-decoration: none;
+        color: inherit;
       }
 
       .menu-item wa-icon {
@@ -381,6 +394,29 @@ export class ESPHomeHeaderActions extends LitElement {
                 <wa-icon library="mdi" name="cog"></wa-icon>
                 ${this._localize("layout.settings")}
               </div>
+              <div class="menu-divider" role="separator"></div>
+              <a
+                class="menu-item menu-item--link"
+                role="menuitem"
+                href="https://github.com/esphome/esphome/issues/new/choose"
+                target="_blank"
+                rel="noopener noreferrer"
+                @click=${this._close}
+              >
+                <wa-icon library="mdi" name="bug-outline"></wa-icon>
+                ${this._localize("layout.report_issue")}
+              </a>
+              <a
+                class="menu-item menu-item--link"
+                role="menuitem"
+                href="https://github.com/orgs/esphome/discussions/new/choose"
+                target="_blank"
+                rel="noopener noreferrer"
+                @click=${this._close}
+              >
+                <wa-icon library="mdi" name="lightbulb-outline"></wa-icon>
+                ${this._localize("layout.request_feature")}
+              </a>
             </div>
           `
         : nothing}

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -1,14 +1,13 @@
 import { consume } from "@lit/context";
 import {
   mdiArchiveOutline,
-  mdiBugOutline,
   mdiCheck,
   mdiCog,
   mdiCogRefresh,
+  mdiCommentQuestionOutline,
   mdiDotsVertical,
   mdiEyeOutline,
   mdiKeyVariant,
-  mdiLightbulbOutline,
   mdiPlaylistCheck,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
@@ -26,14 +25,13 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   "archive-outline": mdiArchiveOutline,
-  "bug-outline": mdiBugOutline,
   check: mdiCheck,
   cog: mdiCog,
   "cog-refresh": mdiCogRefresh,
+  "comment-question-outline": mdiCommentQuestionOutline,
   "dots-vertical": mdiDotsVertical,
   "eye-outline": mdiEyeOutline,
   "key-variant": mdiKeyVariant,
-  "lightbulb-outline": mdiLightbulbOutline,
   "playlist-check": mdiPlaylistCheck,
 });
 
@@ -191,15 +189,6 @@ export class ESPHomeHeaderActions extends LitElement {
 
       .menu-item:hover {
         background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
-      }
-
-      /* Anchor-based menu items (external links) get the browser's
-         rel="noopener noreferrer" enforcement instead of a flaky
-         window.open flag. Reset anchor defaults so they read as
-         regular menu rows. */
-      .menu-item--link {
-        text-decoration: none;
-        color: inherit;
       }
 
       .menu-item wa-icon {
@@ -395,28 +384,16 @@ export class ESPHomeHeaderActions extends LitElement {
                 ${this._localize("layout.settings")}
               </div>
               <div class="menu-divider" role="separator"></div>
-              <a
-                class="menu-item menu-item--link"
+              <div
+                class="menu-item"
                 role="menuitem"
-                href="https://github.com/esphome/esphome/issues/new/choose"
-                target="_blank"
-                rel="noopener noreferrer"
-                @click=${this._close}
+                tabindex="0"
+                @click=${this._openFeedback}
+                @keydown=${this._onMenuItemKeydown}
               >
-                <wa-icon library="mdi" name="bug-outline"></wa-icon>
-                ${this._localize("layout.report_issue")}
-              </a>
-              <a
-                class="menu-item menu-item--link"
-                role="menuitem"
-                href="https://github.com/orgs/esphome/discussions/new/choose"
-                target="_blank"
-                rel="noopener noreferrer"
-                @click=${this._close}
-              >
-                <wa-icon library="mdi" name="lightbulb-outline"></wa-icon>
-                ${this._localize("layout.request_feature")}
-              </a>
+                <wa-icon library="mdi" name="comment-question-outline"></wa-icon>
+                ${this._localize("layout.feedback_menu")}
+              </div>
             </div>
           `
         : nothing}
@@ -523,6 +500,16 @@ export class ESPHomeHeaderActions extends LitElement {
     this._close();
     this.dispatchEvent(
       new CustomEvent("open-settings", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _openFeedback() {
+    this._close();
+    this.dispatchEvent(
+      new CustomEvent("open-feedback", {
         bubbles: true,
         composed: true,
       }),

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -1,0 +1,187 @@
+import { consume } from "@lit/context";
+import {
+  mdiBugOutline,
+  mdiLightbulbOutline,
+  mdiMagnify,
+  mdiOpenInNew,
+} from "@mdi/js";
+import { LitElement, css, html } from "lit";
+import { customElement, query, state } from "lit/decorators.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import { localizeContext } from "../context/index.js";
+import { espHomeStyles } from "../styles/shared.js";
+import { registerMdiIcons } from "../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  "bug-outline": mdiBugOutline,
+  "lightbulb-outline": mdiLightbulbOutline,
+  magnify: mdiMagnify,
+  "open-in-new": mdiOpenInNew,
+});
+
+const LINKS = [
+  {
+    icon: "magnify",
+    labelKey: "feedback.browse_issues",
+    href: "https://github.com/esphome/device-builder/issues",
+  },
+  {
+    icon: "bug-outline",
+    labelKey: "feedback.new_issue",
+    href: "https://github.com/esphome/device-builder/issues/new?template=bug_report.yml",
+  },
+  {
+    icon: "magnify",
+    labelKey: "feedback.browse_features",
+    href: "https://github.com/orgs/esphome/discussions/categories/builder-features-or-enhancements?discussions_q=is%3Aopen+category%3A%22Builder+features+or+enhancements%22+sort%3Atop",
+  },
+  {
+    icon: "lightbulb-outline",
+    labelKey: "feedback.new_feature",
+    href: "https://github.com/orgs/esphome/discussions/new?category=builder-features-or-enhancements",
+  },
+] as const;
+
+@customElement("esphome-feedback-dialog")
+export class ESPHomeFeedbackDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @query("wa-dialog")
+  private _dialog!: HTMLElement & { open: boolean };
+
+  static styles = [
+    espHomeStyles,
+    css`
+      wa-dialog {
+        --width: 460px;
+      }
+
+      wa-dialog::part(header) {
+        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
+      }
+
+      wa-dialog::part(title) {
+        font-size: var(--wa-font-size-m);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+      }
+
+      wa-dialog::part(close-button__base) {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+      }
+
+      wa-dialog::part(body) {
+        padding: 0 var(--wa-space-l) var(--wa-space-l);
+      }
+
+      wa-dialog::part(footer) {
+        display: none;
+      }
+
+      .description {
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-quiet);
+        line-height: 1.5;
+        margin: 0 0 var(--wa-space-m);
+      }
+
+      .links {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+      }
+
+      .link {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-s);
+        padding: 10px var(--wa-space-m);
+        border-radius: var(--wa-border-radius-m);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-lowered);
+        color: var(--wa-color-text-normal);
+        font-size: var(--wa-font-size-s);
+        text-decoration: none;
+        transition: background 0.12s, border-color 0.12s;
+      }
+
+      .link:hover {
+        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+      }
+
+      .link:hover .link-icon {
+        color: var(--esphome-primary);
+      }
+
+      .link-icon {
+        font-size: 18px;
+        color: var(--wa-color-text-quiet);
+        flex-shrink: 0;
+      }
+
+      .link-label {
+        flex: 1;
+      }
+
+      .link-external {
+        font-size: 14px;
+        color: var(--wa-color-text-quiet);
+        flex-shrink: 0;
+      }
+    `,
+  ];
+
+  open() {
+    this._dialog.open = true;
+  }
+
+  close() {
+    this._dialog.open = false;
+  }
+
+  protected render() {
+    return html`
+      <wa-dialog
+        label=${this._localize("feedback.title")}
+        light-dismiss
+      >
+        <p class="description">${this._localize("feedback.description")}</p>
+        <div class="links">
+          ${LINKS.map(
+            (link) => html`
+              <a
+                class="link"
+                href=${link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                @click=${this.close}
+              >
+                <wa-icon class="link-icon" library="mdi" name=${link.icon}></wa-icon>
+                <span class="link-label">${this._localize(link.labelKey)}</span>
+                <wa-icon
+                  class="link-external"
+                  library="mdi"
+                  name="open-in-new"
+                ></wa-icon>
+              </a>
+            `,
+          )}
+        </div>
+      </wa-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-feedback-dialog": ESPHomeFeedbackDialog;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -566,14 +566,21 @@
     "show_ignored_discoveries": "Show ignored discoveries",
     "archived_devices": "Archived devices",
     "reset_build_env": "Reset build environment",
-    "report_issue": "Report an issue",
-    "request_feature": "Request a feature",
+    "feedback_menu": "Found a bug? Have an idea?",
     "back": "Back",
     "home_assistant": "Home Assistant",
     "editor": "Editor",
     "yaml_diff_button": "YAML diff button",
     "header_actions_label": "Dashboard actions",
     "more_options_with_count": "More options ({count} firmware task(s) active)"
+  },
+  "feedback": {
+    "title": "Found a bug? Have an idea?",
+    "description": "Help us improve ESPHome Device Builder by reporting issues or sharing your ideas.",
+    "browse_issues": "Browse open issues",
+    "new_issue": "Report a new issue",
+    "browse_features": "Browse feature requests",
+    "new_feature": "Request a new feature"
   },
   "command_palette": {
     "placeholder": "Type a command — or / to search YAML content",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -566,6 +566,8 @@
     "show_ignored_discoveries": "Show ignored discoveries",
     "archived_devices": "Archived devices",
     "reset_build_env": "Reset build environment",
+    "report_issue": "Report an issue",
+    "request_feature": "Request a feature",
     "back": "Back",
     "home_assistant": "Home Assistant",
     "editor": "Editor",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -480,6 +480,8 @@
     "show_ignored_discoveries": "Afficher les découvertes ignorées",
     "archived_devices": "Appareils archivés",
     "reset_build_env": "Réinitialiser l'environnement de compilation",
+    "report_issue": "Signaler un problème",
+    "request_feature": "Demander une fonctionnalité",
     "back": "Retour",
     "home_assistant": "Home Assistant",
     "editor": "Éditeur",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -480,14 +480,21 @@
     "show_ignored_discoveries": "Afficher les découvertes ignorées",
     "archived_devices": "Appareils archivés",
     "reset_build_env": "Réinitialiser l'environnement de compilation",
-    "report_issue": "Signaler un problème",
-    "request_feature": "Demander une fonctionnalité",
+    "feedback_menu": "Un bug ? Une idée ?",
     "back": "Retour",
     "home_assistant": "Home Assistant",
     "editor": "Éditeur",
     "yaml_diff_button": "Bouton de diff YAML",
     "header_actions_label": "Actions du tableau de bord",
     "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))"
+  },
+  "feedback": {
+    "title": "Un bug ? Une idée ?",
+    "description": "Aidez-nous à améliorer ESPHome Device Builder en signalant des problèmes ou en partageant vos idées.",
+    "browse_issues": "Parcourir les problèmes ouverts",
+    "new_issue": "Signaler un nouveau problème",
+    "browse_features": "Parcourir les demandes de fonctionnalités",
+    "new_feature": "Demander une nouvelle fonctionnalité"
   },
   "auth": {
     "connecting": "Connexion…",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -480,6 +480,8 @@
     "show_ignored_discoveries": "Genegeerde ontdekkingen tonen",
     "archived_devices": "Gearchiveerde apparaten",
     "reset_build_env": "Bouw-omgeving resetten",
+    "report_issue": "Probleem melden",
+    "request_feature": "Functie aanvragen",
     "back": "Terug",
     "home_assistant": "Home Assistant",
     "editor": "Editor",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -480,14 +480,21 @@
     "show_ignored_discoveries": "Genegeerde ontdekkingen tonen",
     "archived_devices": "Gearchiveerde apparaten",
     "reset_build_env": "Bouw-omgeving resetten",
-    "report_issue": "Probleem melden",
-    "request_feature": "Functie aanvragen",
+    "feedback_menu": "Probleem of idee?",
     "back": "Terug",
     "home_assistant": "Home Assistant",
     "editor": "Editor",
     "yaml_diff_button": "YAML-diff-knop",
     "header_actions_label": "Dashboardacties",
     "more_options_with_count": "Meer opties ({count} firmwaretaken actief)"
+  },
+  "feedback": {
+    "title": "Probleem of idee?",
+    "description": "Help ons ESPHome Device Builder te verbeteren door problemen te melden of ideeën te delen.",
+    "browse_issues": "Open problemen bekijken",
+    "new_issue": "Nieuw probleem melden",
+    "browse_features": "Functieverzoeken bekijken",
+    "new_feature": "Nieuwe functie aanvragen"
   },
   "auth": {
     "connecting": "Verbinden…",


### PR DESCRIPTION
Closes [esphome/backlog#120](https://github.com/esphome/backlog/issues/120). The dashboard previously had no in-product path for users to file bugs or share feature ideas — this adds a single overflow-menu entry that opens a small dialog with the four canonical links from the backlog ticket.

- Add `Found a bug? Have an idea?` item to the top-right kebab menu (separated by a divider)
- New `esphome-feedback-dialog` (`src/components/feedback-dialog.ts`) with four `<a target="_blank" rel="noopener noreferrer">` rows:
  - Browse open issues → `esphome/device-builder/issues`
  - Report a new issue → `esphome/device-builder/issues/new?template=bug_report.yml`
  - Browse feature requests → `esphome` discussions, `builder-features-or-enhancements` category
  - Request a new feature → new discussion in the same category
- Wire the dialog into `app-shell.ts` via the existing `open-*` event pattern (`@open-feedback`, `@query`, `_onOpenFeedback`)
- Translations added under a new `feedback.*` namespace for `en`, `nl`, `fr`
