### PR TITLE
bulk-action: fall back to localized "Unknown error" when backend omits one

### DIFF
--- a/src/pages/dashboard-actions.ts
+++ b/src/pages/dashboard-actions.ts
@@ -175,11 +175,17 @@ async function runBulkAction(
   const devicesByConfiguration = new Map(
     devices.map((d) => [d.configuration, d] as const),
   );
+  const fallbackError = localize("dashboard.bulk_failure_unknown_error");
   for (const result of failed) {
     const device = devicesByConfiguration.get(result.configuration);
     const name = device ? device.friendly_name || device.name : result.configuration;
+    // Fall back to a localized "Unknown error" string when the
+    // backend's per-row result didn't include one — without this
+    // the failure toasts read like ``Failed to archive "kitchen": ``
+    // (dangling colon) because ``action_archive_failed`` /
+    // ``action_unarchive_failed`` interpolate ``{error}`` directly.
     toast.error(
-      localize(copy.failureKey, { name, error: result.error ?? "" }),
+      localize(copy.failureKey, { name, error: result.error || fallbackError }),
       { richColors: true },
     );
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -86,6 +86,7 @@
     "archive_all_none": "No devices selected to archive",
     "archive_bulk_success": "{count} device(s) archived",
     "archive_bulk_failed": "Bulk archive failed",
+    "bulk_failure_unknown_error": "Unknown error",
     "update_device_success": "\"{name}\" updated successfully",
     "update_device_failed": "\"{name}\" update failed",
     "delete_failed": "Failed to delete \"{name}\"",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -53,6 +53,7 @@
     "delete_all_none": "Aucun appareil sélectionné à supprimer",
     "delete_bulk_success": "{count} appareil(s) supprimé(s)",
     "delete_bulk_failed": "Échec de la suppression en lot",
+    "bulk_failure_unknown_error": "Erreur inconnue",
     "update_device_success": "\"{name}\" mis à jour avec succès",
     "update_device_failed": "Échec de la mise à jour de \"{name}\"",
     "delete_failed": "Échec de la suppression de \"{name}\"",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -53,6 +53,7 @@
     "delete_all_none": "Geen apparaten geselecteerd om te verwijderen",
     "delete_bulk_success": "{count} apparaat/apparaten verwijderd",
     "delete_bulk_failed": "Bulkverwijdering mislukt",
+    "bulk_failure_unknown_error": "Onbekende fout",
     "update_device_success": "\"{name}\" succesvol bijgewerkt",
     "update_device_failed": "Bijwerken van \"{name}\" mislukt",
     "delete_failed": "Verwijderen van \"{name}\" mislukt",


### PR DESCRIPTION
# What does this implement/fix?

PR #164's late Copilot review (landed after merge) flagged that `runBulkAction`'s failure toast was producing dangling-colon strings when the backend's per-row `BulkActionResult` didn't carry an `error` field.

The current shape:

```ts
toast.error(localize(copy.failureKey, { name, error: result.error ?? "" }), …);
```

Where `copy.failureKey` is one of `dashboard.action_archive_failed` ("Failed to archive \"{name}\": {error}") or `dashboard.action_unarchive_failed` (same shape). When `result.error` is absent the user sees:

> Failed to archive "kitchen":

with no reason and a trailing colon. Substitutes a localized `dashboard.bulk_failure_unknown_error` ("Unknown error" / "Erreur inconnue" / "Onbekende fout") whenever the backend didn't supply a per-row error string. `delete_failed` doesn't interpolate `{error}` so its path stays well-formed either way; the fix is correct for both bulk action flows.

Localized in `en` / `fr` / `nl`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to: esphome/device-builder-frontend#164 (the original bulk-archive PR; Copilot flagged the dangling-colon shape after that PR landed)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable) — `runBulkAction` doesn't have unit-test scaffolding (precedent matches the original PR); the failing-toast path is exercised manually.
