### PR TITLE
Parse YAML section keys with dots, hyphens, and URL-style chars

### DIFF
--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -27,9 +27,10 @@ import {
  * without dropping the row.
  *
  * Quoted keys (``"foo:bar":`` etc.) and other exotic forms aren't
- * matched here; they fall through to the form-editor's
- * "complex value" placeholder by virtue of not parsing — see
- * issue tracker for upstream support if needed.
+ * matched here; lines using them are skipped by the minimal parser
+ * and therefore won't appear in the returned values map or today's
+ * MAP editor. Supporting them would require a different parsing
+ * strategy; see issue tracker for upstream support if needed.
  */
 const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -15,12 +15,23 @@ import {
 } from "./yaml-serialize.js";
 
 /**
- * Identifier alphabet ESPHome accepts for top-level / nested config
- * keys. Centralised so the parse and write paths stay in lockstep —
- * if the schema ever broadens (e.g. hyphenated or namespaced keys),
- * both sides change at one site instead of drifting silently.
+ * Identifier alphabet for plain-scalar YAML keys the parser will
+ * accept. The leading character stays strict (``[a-zA-Z_]``) so
+ * list-item dashes, comment lines, and YAML anchors / aliases
+ * (``&foo``, ``*foo``) can't masquerade as keys. The body is
+ * permissive — anything that isn't whitespace, ``:`` (separator),
+ * or ``#`` (comment) — so URL- and path-derived names that
+ * user-keyed sections like ``packages:`` and ``substitutions:``
+ * accept (``ApolloAutomation.R-PRO-1-ETH``, ``vendor/lib@v1``,
+ * ``com.example.thing``) round-trip through the form editor
+ * without dropping the row.
+ *
+ * Quoted keys (``"foo:bar":`` etc.) and other exotic forms aren't
+ * matched here; they fall through to the form-editor's
+ * "complex value" placeholder by virtue of not parsing — see
+ * issue tracker for upstream support if needed.
  */
-const KEY_PATTERN = "[a-zA-Z_][a-zA-Z0-9_]*";
+const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
 
 /**
  * Match the inline-key form on a YAML list-item line

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -62,6 +62,45 @@ describe("test helper: nthListItemLine", () => {
   });
 });
 
+describe("parseYamlSectionValues — permissive key alphabet", () => {
+  it("captures dotted / hyphenated keys (URL-style package names)", () => {
+    // ``packages:`` accepts URL-derived names like
+    // ``ApolloAutomation.R-PRO-1-ETH:`` (issue surfaced in the
+    // form editor where the row vanished because the strict
+    // ``[a-zA-Z_][a-zA-Z0-9_]*`` regex rejected the dot + hyphen
+    // and the parser silently dropped the line). The MAP-fallback
+    // editor uses ``parseYamlSectionValues`` to populate row
+    // values; if the parser drops the line, the form shows
+    // "No entries yet" while the YAML clearly has one.
+    const yaml =
+      "packages:\n" +
+      "  ApolloAutomation.R-PRO-1-ETH: github://ApolloAutomation/R_PRO-1/Integrations/ESPHome/R_PRO-1_ETH.yaml\n";
+    const values = parseYamlSectionValues(yaml, "packages");
+    expect(values["ApolloAutomation.R-PRO-1-ETH"]).toBe(
+      "github://ApolloAutomation/R_PRO-1/Integrations/ESPHome/R_PRO-1_ETH.yaml",
+    );
+  });
+
+  it("captures path- and namespaced-style keys", () => {
+    const yaml =
+      "packages:\n" +
+      "  vendor/lib@v1.2.3: ./local/path.yaml\n" +
+      "  com.example.thing: github://example/thing\n";
+    const values = parseYamlSectionValues(yaml, "packages");
+    expect(values["vendor/lib@v1.2.3"]).toBe("./local/path.yaml");
+    expect(values["com.example.thing"]).toBe("github://example/thing");
+  });
+
+  it("still rejects keys that start with a list-item dash or hash", () => {
+    // The leading-character constraint stays strict so a stray
+    // ``- `` (list item) or ``# `` (comment) at the section indent
+    // doesn't masquerade as a key.
+    const yaml = "packages:\n  - not_a_key: value\n  # commented: out\n";
+    const values = parseYamlSectionValues(yaml, "packages");
+    expect(values).toEqual({});
+  });
+});
+
 describe("parseYamlSectionValues — prototype pollution defense", () => {
   // YAML keys like `__proto__` / `constructor` / `prototype`
   // would otherwise hit the corresponding setter on


### PR DESCRIPTION
# What does this implement/fix?

`packages:` form editor was showing "No entries yet — click + to add one" even when the YAML clearly contained one. Reproduced with:

```yaml
packages:
  ApolloAutomation.R-PRO-1-ETH: github://ApolloAutomation/R_PRO-1/Integrations/ESPHome/R_PRO-1_ETH.yaml
```

Root cause: `parseYamlSectionValues` used a strict `KEY_PATTERN = "[a-zA-Z_][a-zA-Z0-9_]*"` for child keys, which silently dropped any line whose key wasn't a plain identifier. URL- and path-derived names that user-keyed sections like `packages:` accept (dotted, hyphenated, slash-separated, etc.) all rejected. The MAP fallback editor relies on this parser to populate rows, so the entry was missing from `_values` and the form rendered as empty.

Broadens the body alphabet to `[^\s:#]*` — anything that isn't whitespace, the YAML `:` separator, or a comment marker `#`. The leading character stays strict (`[a-zA-Z_]`) so list-item dashes, comment lines, and YAML anchor / alias forms (`&foo`, `*foo`) can't masquerade as keys.

Three regression tests:
- Dotted + hyphenated keys (the reported case).
- Path- and namespaced-style keys (`vendor/lib@v1.2.3`, `com.example.thing`).
- Negative case: leading dash or hash still rejects.

**Out of scope for this PR (follow-up if needed):** quoted keys (`"foo:bar":`) and other genuinely exotic YAML forms still slip through the regex and would still be silently dropped. A robust fix would need either a real YAML library or a "raw lines" fallback in the parser that surfaces unparseable rows with the per-row "edit in YAML" placeholder. No real-world cases reported yet, so leaving that as a follow-up.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced from #173 follow-up testing (`packages` MAP fallback wasn't displaying URL-style package keys).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (667/667).
  - [x] Tests have been added to verify that the new code works (where applicable).
