### PR TITLE
device-section-config: validate save against the render schema, not the catalog

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -668,8 +668,25 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private async _onSave() {
     if (!this._config) return;
-    const errors = validateEntries(
+    // Validate against the *render* schema, not the raw catalog.
+    // For sections in ``MAP_SECTIONS`` (substitutions / packages /
+    // …) the catalog ships an irrelevant flat schema (9 specific
+    // fields for ``packages:``, one bogus ``string`` for
+    // ``substitutions:``) that does not match what the user
+    // actually edits in the form. ``resolveSectionEntries``
+    // produces the synthesised user-keyed-MAP shape; validating
+    // against the catalog instead would (e.g.) reject a
+    // ``packages:`` save because the catalog's required ``url``
+    // field isn't present in the user-named row, and the form
+    // would silently bail (Save click "does nothing") because
+    // ``_fieldErrors`` lives on entries the renderer never
+    // surfaces. Use the same entries the form rendered.
+    const renderEntries = resolveSectionEntries(
+      this.sectionKey,
       this._config.entries,
+    );
+    const errors = validateEntries(
+      renderEntries,
       this._values,
       this._presentComponents,
     );

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -19,6 +19,7 @@ import {
   resolveSectionEntries,
 } from "../../src/util/section-entry-overrides.js";
 import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
+import { validateEntries } from "../../src/util/config-validation.js";
 
 describe("MAP_SECTIONS", () => {
   it("contains 'substitutions'", () => {
@@ -140,5 +141,107 @@ describe("device-section-config wiring", () => {
       expr.includes("this._config.entries"),
       "form's .entries binds to the raw catalog entries — substitutions override is bypassed",
     ).toBe(false);
+  });
+
+  it("routes _onSave's validateEntries through the resolver, not the catalog", async () => {
+    // Regression pin for the "Save click does nothing" bug on
+    // ``packages:`` (and the latent equivalent on
+    // ``substitutions:``). The form rendered the resolver's
+    // user-keyed MAP shape, but ``_onSave`` validated against the
+    // catalog's flat schema — whose required fields (``url`` etc.
+    // for packages) were absent from the user-named rows, so
+    // ``_fieldErrors`` filled up and the save bailed silently.
+    // ``validateEntries`` must see the same entries the form
+    // rendered.
+    // @ts-expect-error — node-only module, types excluded from tsconfig
+    const fs = await import("node:fs");
+    // @ts-expect-error — node-only module, types excluded from tsconfig
+    const path = await import("node:path");
+    // @ts-expect-error — node-only module, types excluded from tsconfig
+    const url = await import("node:url");
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const sourcePath = path.resolve(
+      here,
+      "../../src/components/device/device-section-config.ts",
+    );
+    const src = fs.readFileSync(sourcePath, "utf-8");
+
+    const validateCall = /validateEntries\s*\(\s*([^,)]+)\s*,/;
+    const match = src.match(validateCall);
+    expect(match, "validateEntries call not found").not.toBeNull();
+    const firstArg = match![1].trim();
+    expect(
+      firstArg.includes("renderEntries") ||
+        firstArg.includes("resolveSectionEntries"),
+      `validateEntries' first arg is '${firstArg}', not the resolver's output`,
+    ).toBe(true);
+    expect(
+      firstArg === "this._config.entries",
+      "validateEntries reads the raw catalog — MAP-section saves silently bail on the catalog's required fields",
+    ).toBe(false);
+  });
+});
+
+describe("save validation contract", () => {
+  // ``_onSave`` must validate against the *render* schema. Pin
+  // the contract directly: a packages-shaped catalog (some
+  // required fields the user-keyed rows don't carry) produces
+  // errors when validated raw, but no errors once routed through
+  // ``resolveSectionEntries`` for a MAP section. Same shape that
+  // bit ``substitutions`` latently and ``packages`` visibly.
+  it("validateEntries against the resolver's output accepts user-keyed values that the raw catalog would reject", () => {
+    const packagesShapedCatalog: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "url",
+        type: ConfigEntryType.STRING,
+        required: true,
+      }),
+      makeConfigEntry({
+        key: "ref",
+        type: ConfigEntryType.STRING,
+        required: false,
+      }),
+    ];
+    const userKeyedValues: Record<string, unknown> = {
+      ApolloAutomation: "github://example/repo",
+      new_1: "github://example/other",
+    };
+
+    // Buggy path (validate against catalog): ``url`` reports
+    // required, so ``_fieldErrors`` populates and the save bails.
+    const rawErrors = validateEntries(
+      packagesShapedCatalog,
+      userKeyedValues,
+    );
+    expect(rawErrors.has("url")).toBe(true);
+
+    // Fixed path (validate against resolver output): the single
+    // user-keyed MAP entry isn't required, so no errors and the
+    // save proceeds.
+    const resolved = resolveSectionEntries(
+      "substitutions",
+      packagesShapedCatalog,
+    );
+    const resolvedErrors = validateEntries(resolved, userKeyedValues);
+    expect(resolvedErrors.size).toBe(0);
+  });
+
+  it("non-MAP sections still see catalog requirements (the resolver is a pass-through)", () => {
+    // Sanity check: the fix doesn't accidentally suppress
+    // validation for non-MAP sections. For ``wifi`` the resolver
+    // hands the catalog back unchanged, so a missing required
+    // ``ssid`` still errors.
+    const wifiCatalog: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "ssid",
+        type: ConfigEntryType.STRING,
+        required: true,
+      }),
+    ];
+    const errors = validateEntries(
+      resolveSectionEntries("wifi", wifiCatalog),
+      {},
+    );
+    expect(errors.has("ssid")).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

When a section in `MAP_SECTIONS` (today: `substitutions:`; once
#173 lands: `packages:` too) is saved from the visual editor,
`_onSave` was validating the user's values against
`this._config.entries` — the raw catalog. The catalog for those
sections is a flat schema unrelated to the user-keyed shape the
form actually renders:

- `substitutions:` ships one optional `string` field, so the
  catalog mismatch was latent (no required fields → no errors → no
  visible bug).
- `packages:` ships nine fields including required ones (`url`,
  …), so validating user-keyed rows like
  `ApolloAutomation.PLT-1: github://…` produced a
  `validation.required` error at `url`. `_fieldErrors` filled,
  `_onSave` silently bailed at the early-return, and the user saw
  the Save button do nothing.

Route `_onSave`'s `validateEntries` through
`resolveSectionEntries(this.sectionKey, this._config.entries)`
instead — the same shape the form rendered. For MAP sections that
yields the synthesised user-keyed MAP entry (no required catalog
fields to trip over). For every other section the resolver is a
pass-through, so `wifi`/`api`/etc. still validate against their
real requirements.

Reported in the visual editor against the `packages:` section on
the #173 branch; same fix proactively covers `substitutions:`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [x] Tests have been added to verify that the new code works (where applicable).

## Tests

`test/util/section-entry-overrides.test.ts` gains:

- A unit test pinning the contract: the same packages-shaped
  catalog produces a `url`-required error when validated raw, but
  zero errors once routed through `resolveSectionEntries` for a
  MAP section.
- A sanity test pinning that non-MAP sections (`wifi`) still see
  their catalog requirements — the fix doesn't accidentally
  suppress validation everywhere.
- A source-scan wiring test pinning that `_onSave`'s
  `validateEntries` first arg references the resolver output
  (`renderEntries` / `resolveSectionEntries(...)`), not
  `this._config.entries`. Mirrors the existing `.entries` form
  binding scan so a future refactor can't silently re-introduce
  the bug.
