### PR TITLE
Prompt before switching device-editor sections with unsaved edits

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -229,6 +229,48 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    // Announce ourselves so the page-level navigation guard
+    // (``device.ts``) can hold a direct ref. The component tree
+    // is page → device-editor → device-board-info → us, three
+    // shadow boundaries deep, so a property-passthrough chain
+    // would cost three editsper API change. ``composed: true``
+    // lets the event escape every shadow root on the way up.
+    this.dispatchEvent(
+      new CustomEvent("section-mount", {
+        detail: { node: this },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.dispatchEvent(
+      new CustomEvent("section-unmount", {
+        detail: { node: this },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /** Trigger the section's save flow from outside.
+   *
+   *  Returns ``true`` iff the save actually succeeded —
+   *  ``_onSave`` early-returns silently on validation errors
+   *  (the form's ``_fieldErrors`` stamp tells the user) and on
+   *  ``_resolveSpliceContext`` failure, leaving ``_dirty=true``.
+   *  The page-level "Save and leave" handler awaits this and
+   *  only proceeds with the section switch when the buffer is
+   *  actually clean. */
+  public async save(): Promise<boolean> {
+    await this._onSave();
+    return !this._dirty;
+  }
+
   /**
    * Resolve the splice context for save / delete — the live YAML
    * and a current, validated `fromLine`. Sets `_error` and
@@ -286,13 +328,39 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     }
   }
 
+  /** Public read-only view of the unsaved-changes flag.
+   *  The page-level navigation handlers (`device.ts`) consult
+   *  this before mutating ``_selectedSection`` so a section
+   *  switch doesn't silently clobber in-progress field edits. */
+  public get dirty(): boolean {
+    return this._dirty;
+  }
+
+  /** Single mutator for ``_dirty`` so a transition fires a
+   *  ``dirty-change`` event the page can listen for without
+   *  reaching into this component's internals. The event is
+   *  cheap (one bubble per actual flip) and only emitted when
+   *  the value really changes — re-saves with no edits, repeat
+   *  load cycles, etc. don't churn listeners. */
+  private _setDirty(value: boolean): void {
+    if (this._dirty === value) return;
+    this._dirty = value;
+    this.dispatchEvent(
+      new CustomEvent("dirty-change", {
+        detail: { dirty: value },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   private async _loadConfig() {
     const id = ++this._loadId;
     this._loading = true;
     this._error = "";
     this._config = null;
     this._isUnknown = false;
-    this._dirty = false;
+    this._setDirty(false);
 
     try {
       const platform = this.board?.esphome.platform;
@@ -579,7 +647,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         return;
       }
       await this._api.updateConfig(this.configuration, newYaml);
-      this._dirty = false;
+      this._setDirty(false);
       this.dispatchEvent(
         new CustomEvent("yaml-updated", {
           detail: { yaml: newYaml },
@@ -619,7 +687,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   private _onValueChange(e: CustomEvent<ConfigEntryValueChange>) {
     const { path, value } = e.detail;
     this._values = setIn(this._values, path, value);
-    this._dirty = true;
+    this._setDirty(true);
     const errKey = path.join(".");
     if (this._fieldErrors.has(errKey)) {
       const next = new Map(this._fieldErrors);
@@ -722,7 +790,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         this._error =
           e instanceof Error ? e.message : this._localize("device.save_error");
       });
-      this._dirty = false;
+      this._setDirty(false);
       this.dispatchEvent(
         new CustomEvent("yaml-updated", {
           detail: { yaml: newYaml },

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -235,7 +235,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     // (``device.ts``) can hold a direct ref. The component tree
     // is page → device-editor → device-board-info → us, three
     // shadow boundaries deep, so a property-passthrough chain
-    // would cost three editsper API change. ``composed: true``
+    // would cost three edits per API change. ``composed: true``
     // lets the event escape every shadow root on the way up.
     this.dispatchEvent(
       new CustomEvent("section-mount", {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -28,6 +28,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
+import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { sectionAtLine, sectionKeyOf } from "../util/yaml-sections.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
@@ -194,45 +195,18 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   /** Pending unsaved-changes guard. Both the page-leave check
-   *  and the section-switch check pipe through this single
-   *  resolver: the dialog event handlers call into whichever
-   *  one is currently set, the unsetcase is a no-op. Holding
-   *  one resolver instead of one-per-callsite means the dialog
-   *  can be a singleton and the duplicated handler pairs
-   *  (``_onLeaveDiscard`` / ``_onSectionSwitchDiscard`` / …)
-   *  collapse into ``_runUnsavedGuard``'s wiring. */
-  private _activeGuard: {
-    save: () => Promise<boolean>;
-    resolve: (proceed: boolean) => void;
-  } | null = null;
+   *  and the section-switch check pipe through this one helper:
+   *  the dialog event handlers call into whichever one is
+   *  currently set, the unset case is a no-op. Owning the
+   *  bookkeeping in a separate class keeps the page lean and
+   *  lets the logic be unit-tested in node without happy-dom. */
+  private _unsavedGuard = new UnsavedGuard();
 
   /** When true, the next popstate is allowed to fall through to the router. */
   private _allowingLeave = false;
 
   private get _isDirty(): boolean {
     return this._yaml !== this._savedYaml;
-  }
-
-  /** Open the dialog (if dirty) and resolve once the user picks.
-   *
-   *  ``save`` is the saver to invoke when the user clicks "Save and
-   *  leave" — returns ``true`` when the buffer is actually clean
-   *  afterwards (so a save that fails validation correctly leaves
-   *  the user on the dirty content rather than allowing the
-   *  switch). ``Discard`` always resolves true; ``Cancel`` always
-   *  resolves false. A re-entrant call (``_activeGuard`` already
-   *  set) returns ``false`` so the second caller silently drops
-   *  its action — chaining two dialogs makes no sense. */
-  private _runUnsavedGuard(opts: {
-    dirty: boolean;
-    save: () => Promise<boolean>;
-  }): Promise<boolean> {
-    if (!opts.dirty) return Promise.resolve(true);
-    if (this._activeGuard) return Promise.resolve(false);
-    return new Promise<boolean>((resolve) => {
-      this._activeGuard = { save: opts.save, resolve };
-      this._unsavedDialog?.open();
-    });
   }
 
   /* The Save / Discard handlers flip ``_allowingLeave`` BEFORE
@@ -253,29 +227,14 @@ export class ESPHomePageDevice extends LitElement {
    * sets it (the section guard's ``save`` lambda is the one
    * carrying the leave-flag write).
    */
-  private _onUnsavedDiscard = () => {
-    const guard = this._activeGuard;
-    this._activeGuard = null;
-    guard?.resolve(true);
-  };
-
-  private _onUnsavedSave = async () => {
-    const guard = this._activeGuard;
-    this._activeGuard = null;
-    if (!guard) return;
-    const ok = await guard.save();
-    guard.resolve(ok);
-  };
-
-  private _onUnsavedCancel = () => {
-    const guard = this._activeGuard;
-    this._activeGuard = null;
-    guard?.resolve(false);
-  };
+  private _onUnsavedDiscard = () => this._unsavedGuard.onDiscard();
+  private _onUnsavedSave = () => this._unsavedGuard.onSave();
+  private _onUnsavedCancel = () => this._unsavedGuard.onCancel();
 
   private _confirmLeave = async (): Promise<boolean> => {
-    const ok = await this._runUnsavedGuard({
+    const ok = await this._unsavedGuard.run({
       dirty: this._isDirty,
+      open: () => this._unsavedDialog?.open(),
       save: () => {
         this._saveYaml();
         this._allowingLeave = true;
@@ -327,8 +286,7 @@ export class ESPHomePageDevice extends LitElement {
     // Drop any in-flight unsaved-changes guard so its caller's
     // ``await`` doesn't dangle past unmount — resolve as "don't
     // proceed" since the page is going away anyway.
-    this._activeGuard?.resolve(false);
-    this._activeGuard = null;
+    this._unsavedGuard.cancelPending();
   }
 
   private _onKeydown = (e: KeyboardEvent) => {
@@ -778,8 +736,9 @@ export class ESPHomePageDevice extends LitElement {
    *  ``_loadConfig`` clears ``_dirty`` after the switch lands,
    *  so Discard doesn't need to revert form state explicitly. */
   private async _guardSectionSwitch(action: () => void): Promise<void> {
-    const ok = await this._runUnsavedGuard({
+    const ok = await this._unsavedGuard.run({
       dirty: this._sectionDirty,
+      open: () => this._unsavedDialog?.open(),
       save: () => this._activeSection?.save() ?? Promise.resolve(false),
     });
     if (ok) action();

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -205,13 +205,23 @@ export class ESPHomePageDevice extends LitElement {
   /** When true, the next popstate is allowed to fall through to the router. */
   private _allowingLeave = false;
 
-  private get _isDirty(): boolean {
+  private get _isYamlDirty(): boolean {
     return this._yaml !== this._savedYaml;
   }
 
-  /* The Save / Discard handlers flip ``_allowingLeave`` BEFORE
-   * the guard Promise resolves so the page-leave callers see a
-   * coherent state on the next microtask:
+  /** Combined "anything unsaved on this page" check. The YAML
+   *  buffer ``_isYamlDirty`` and the visual editor's form
+   *  ``_sectionDirty`` are independent — typing in the form
+   *  doesn't flip the YAML buffer until the user clicks Save —
+   *  but both should block a page-leave / refresh until the
+   *  user picks Discard or Save. */
+  private get _isDirty(): boolean {
+    return this._isYamlDirty || this._sectionDirty;
+  }
+
+  /* ``_allowingLeave`` is flipped BEFORE the guard Promise
+   * resolves so the page-leave callers see a coherent state on
+   * the next microtask:
    *
    *   - The browser-back path ``.then``s on the resolved
    *     Promise and calls ``history.back()`` itself.
@@ -223,9 +233,14 @@ export class ESPHomePageDevice extends LitElement {
    *     bounced back to the device URL, leaving the user stuck.
    *     Flipping the flag here short-circuits that.
    *
-   * The flag is page-leave-only; the section-switch caller never
-   * sets it (the section guard's ``save`` lambda is the one
-   * carrying the leave-flag write).
+   * The flip happens inside the page-leave save lambda (so it
+   * lands synchronously before the guard's resolve when the
+   * user picks Save) and again in ``_confirmLeave`` after the
+   * await (so it covers the Discard path too — Discard doesn't
+   * route through the save lambda). The redundant write on Save
+   * is idempotent. The section-switch guard never sets the flag
+   * — its ``save`` returns to the page synchronously after the
+   * await without leaving the page.
    */
   private _onUnsavedDiscard = () => this._unsavedGuard.onDiscard();
   private _onUnsavedSave = () => this._unsavedGuard.onSave();
@@ -235,10 +250,21 @@ export class ESPHomePageDevice extends LitElement {
     const ok = await this._unsavedGuard.run({
       dirty: this._isDirty,
       open: () => this._unsavedDialog?.open(),
-      save: () => {
-        this._saveYaml();
+      // Save persists *both* dirty buffers when the user picks
+      // "Save and leave" — the YAML pane and the section form
+      // are independent and either can be dirty on its own. The
+      // section save runs first because its output writes
+      // through ``yaml-updated`` which advances ``_savedYaml``;
+      // then ``_saveYaml`` covers anything the user typed in
+      // the YAML pane on top.
+      save: async () => {
+        if (this._sectionDirty) {
+          const sectionOk = (await this._activeSection?.save()) ?? false;
+          if (!sectionOk) return false;
+        }
+        if (this._isYamlDirty) this._saveYaml();
         this._allowingLeave = true;
-        return Promise.resolve(true);
+        return true;
       },
     });
     if (ok) this._allowingLeave = true;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -16,6 +16,7 @@ import { DeviceInstallController } from "../components/device/device-install-con
 import type { ESPHomeFirmwareInstallDialog } from "../components/firmware-install-dialog.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-dialog.js";
+import type { ESPHomeDeviceSectionConfig } from "../components/device/device-section-config.js";
 import type { HighlightRange } from "../components/yaml-editor.js";
 import {
   activeJobsContext,
@@ -142,7 +143,19 @@ export class ESPHomePageDevice extends LitElement {
   private _savedYaml = "";
 
   @query("esphome-unsaved-changes-dialog")
-  private _leaveDialog!: ESPHomeUnsavedChangesDialog;
+  private _unsavedDialog!: ESPHomeUnsavedChangesDialog;
+
+  /** Live ref to the mounted section-config component, when one
+   *  is rendered. Captured via ``section-mount`` /
+   *  ``section-unmount`` events that the component fires on its
+   *  own lifecycle hooks; ``@query`` doesn't reach across the
+   *  three shadow roots between this page and the section
+   *  editor, so the registration pattern keeps the call site
+   *  for ``activeSection.save()`` cheap and direct. */
+  private _activeSection: ESPHomeDeviceSectionConfig | null = null;
+
+  @state()
+  private _sectionDirty = false;
 
   @query("esphome-command-dialog")
   private _commandDialog!: ESPHomeCommandDialog;
@@ -180,7 +193,18 @@ export class ESPHomePageDevice extends LitElement {
     });
   }
 
-  private _pendingLeaveResolve: ((value: boolean) => void) | null = null;
+  /** Pending unsaved-changes guard. Both the page-leave check
+   *  and the section-switch check pipe through this single
+   *  resolver: the dialog event handlers call into whichever
+   *  one is currently set, the unsetcase is a no-op. Holding
+   *  one resolver instead of one-per-callsite means the dialog
+   *  can be a singleton and the duplicated handler pairs
+   *  (``_onLeaveDiscard`` / ``_onSectionSwitchDiscard`` / …)
+   *  collapse into ``_runUnsavedGuard``'s wiring. */
+  private _activeGuard: {
+    save: () => Promise<boolean>;
+    resolve: (proceed: boolean) => void;
+  } | null = null;
 
   /** When true, the next popstate is allowed to fall through to the router. */
   private _allowingLeave = false;
@@ -189,48 +213,78 @@ export class ESPHomePageDevice extends LitElement {
     return this._yaml !== this._savedYaml;
   }
 
-  private _confirmLeave = (): Promise<boolean> => {
-    if (!this._isDirty) return Promise.resolve(true);
-    if (this._pendingLeaveResolve) return Promise.resolve(false);
+  /** Open the dialog (if dirty) and resolve once the user picks.
+   *
+   *  ``save`` is the saver to invoke when the user clicks "Save and
+   *  leave" — returns ``true`` when the buffer is actually clean
+   *  afterwards (so a save that fails validation correctly leaves
+   *  the user on the dirty content rather than allowing the
+   *  switch). ``Discard`` always resolves true; ``Cancel`` always
+   *  resolves false. A re-entrant call (``_activeGuard`` already
+   *  set) returns ``false`` so the second caller silently drops
+   *  its action — chaining two dialogs makes no sense. */
+  private _runUnsavedGuard(opts: {
+    dirty: boolean;
+    save: () => Promise<boolean>;
+  }): Promise<boolean> {
+    if (!opts.dirty) return Promise.resolve(true);
+    if (this._activeGuard) return Promise.resolve(false);
     return new Promise<boolean>((resolve) => {
-      this._pendingLeaveResolve = resolve;
-      this._leaveDialog?.open();
+      this._activeGuard = { save: opts.save, resolve };
+      this._unsavedDialog?.open();
     });
-  };
-
-  private _resolvePendingLeave(value: boolean) {
-    const r = this._pendingLeaveResolve;
-    this._pendingLeaveResolve = null;
-    r?.(value);
   }
 
-  /* Discard / Save flip ``_allowingLeave`` BEFORE resolving the
-   * guard Promise. Two callers wait on that resolve:
-   *   - The browser-back path, which then calls ``history.back()``
-   *     itself (the popstate handler's ``.then`` would set
-   *     ``_allowingLeave`` afterwards).
-   *   - ``navigate()`` (in-app Back / logo click), which on
+  /* The Save / Discard handlers flip ``_allowingLeave`` BEFORE
+   * the guard Promise resolves so the page-leave callers see a
+   * coherent state on the next microtask:
+   *
+   *   - The browser-back path ``.then``s on the resolved
+   *     Promise and calls ``history.back()`` itself.
+   *   - ``navigate()`` (in-app Back / logo click) on
    *     ``canLeave=true`` does ``pushState + dispatchEvent(popstate)``
-   *     synchronously. That synthetic popstate would otherwise be
-   *     re-intercepted by ``_onPopState`` (because ``_isDirty`` is
-   *     still true here — Discard doesn't revert the buffer) and
-   *     bounced back to the device URL, leaving the user stuck on
-   *     the page they were trying to leave. Setting the flag here
-   *     short-circuits the next popstate so navigate's URL push
-   *     actually sticks.
+   *     synchronously. That synthetic popstate would otherwise
+   *     be re-intercepted by ``_onPopState`` (because ``_isDirty``
+   *     stays true — Discard doesn't revert the buffer) and
+   *     bounced back to the device URL, leaving the user stuck.
+   *     Flipping the flag here short-circuits that.
+   *
+   * The flag is page-leave-only; the section-switch caller never
+   * sets it (the section guard's ``save`` lambda is the one
+   * carrying the leave-flag write).
    */
-  private _onLeaveDiscard = () => {
-    this._allowingLeave = true;
-    this._resolvePendingLeave(true);
+  private _onUnsavedDiscard = () => {
+    const guard = this._activeGuard;
+    this._activeGuard = null;
+    guard?.resolve(true);
   };
 
-  private _onLeaveSave = () => {
-    this._saveYaml();
-    this._allowingLeave = true;
-    this._resolvePendingLeave(true);
+  private _onUnsavedSave = async () => {
+    const guard = this._activeGuard;
+    this._activeGuard = null;
+    if (!guard) return;
+    const ok = await guard.save();
+    guard.resolve(ok);
   };
 
-  private _onLeaveCancel = () => this._resolvePendingLeave(false);
+  private _onUnsavedCancel = () => {
+    const guard = this._activeGuard;
+    this._activeGuard = null;
+    guard?.resolve(false);
+  };
+
+  private _confirmLeave = async (): Promise<boolean> => {
+    const ok = await this._runUnsavedGuard({
+      dirty: this._isDirty,
+      save: () => {
+        this._saveYaml();
+        this._allowingLeave = true;
+        return Promise.resolve(true);
+      },
+    });
+    if (ok) this._allowingLeave = true;
+    return ok;
+  };
 
   private _onBeforeUnload = (e: BeforeUnloadEvent) => {
     if (this._isDirty) {
@@ -270,7 +324,11 @@ export class ESPHomePageDevice extends LitElement {
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
     window.removeEventListener("keydown", this._onKeydown);
-    this._resolvePendingLeave(false);
+    // Drop any in-flight unsaved-changes guard so its caller's
+    // ``await`` doesn't dangle past unmount — resolve as "don't
+    // proceed" since the page is going away anyway.
+    this._activeGuard?.resolve(false);
+    this._activeGuard = null;
   }
 
   private _onKeydown = (e: KeyboardEvent) => {
@@ -471,6 +529,9 @@ export class ESPHomePageDevice extends LitElement {
           @yaml-highlight=${this._onYamlHighlight}
           @yaml-updated=${this._onYamlUpdated}
           @section-select=${this._onSectionSelect}
+          @section-mount=${this._onSectionMount}
+          @section-unmount=${this._onSectionUnmount}
+          @dirty-change=${this._onSectionDirtyChange}
           @nav-section-show=${this._onNavSectionShow}
           @save-yaml=${this._saveYaml}
           @install-device=${this._installCtrl.onInstall}
@@ -502,9 +563,9 @@ export class ESPHomePageDevice extends LitElement {
         </div>
       </div>
       <esphome-unsaved-changes-dialog
-        @discard=${this._onLeaveDiscard}
-        @save=${this._onLeaveSave}
-        @cancel=${this._onLeaveCancel}
+        @discard=${this._onUnsavedDiscard}
+        @save=${this._onUnsavedSave}
+        @cancel=${this._onUnsavedCancel}
       ></esphome-unsaved-changes-dialog>
       <esphome-command-dialog
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
@@ -657,9 +718,11 @@ export class ESPHomePageDevice extends LitElement {
     ) {
       return;
     }
-    this._selectedSection = sectionKey;
-    this._selectedFromLine = match.fromLine;
-    this._updateUrl();
+    this._guardSectionSwitch(() => {
+      this._selectedSection = sectionKey;
+      this._selectedFromLine = match.fromLine;
+      this._updateUrl();
+    });
   }
 
   private _onYamlHighlight(
@@ -695,11 +758,51 @@ export class ESPHomePageDevice extends LitElement {
   private _onSectionSelect(
     e: CustomEvent<{ sectionKey: string | null; fromLine?: number }>
   ) {
-    this._selectedSection = e.detail.sectionKey;
-    this._selectedFromLine = e.detail.fromLine;
-    this._drawerOpen = false;
-    this._updateUrl();
+    const { sectionKey, fromLine } = e.detail;
+    if (sectionKey === this._selectedSection && fromLine === this._selectedFromLine) {
+      this._drawerOpen = false;
+      return;
+    }
+    this._guardSectionSwitch(() => {
+      this._selectedSection = sectionKey;
+      this._selectedFromLine = fromLine;
+      this._drawerOpen = false;
+      this._updateUrl();
+    });
   }
+
+  /** Run *action* now if the section editor has no unsaved
+   *  edits; otherwise pop the unsaved-changes dialog and replay
+   *  the action only when the user picks Save (and the save
+   *  actually succeeds) or Discard. The section's own
+   *  ``_loadConfig`` clears ``_dirty`` after the switch lands,
+   *  so Discard doesn't need to revert form state explicitly. */
+  private async _guardSectionSwitch(action: () => void): Promise<void> {
+    const ok = await this._runUnsavedGuard({
+      dirty: this._sectionDirty,
+      save: () => this._activeSection?.save() ?? Promise.resolve(false),
+    });
+    if (ok) action();
+  }
+
+  private _onSectionMount = (e: Event) => {
+    const ev = e as CustomEvent<{ node: ESPHomeDeviceSectionConfig }>;
+    this._activeSection = ev.detail.node;
+    this._sectionDirty = ev.detail.node.dirty;
+  };
+
+  private _onSectionUnmount = (e: Event) => {
+    const ev = e as CustomEvent<{ node: ESPHomeDeviceSectionConfig }>;
+    if (this._activeSection === ev.detail.node) {
+      this._activeSection = null;
+      this._sectionDirty = false;
+    }
+  };
+
+  private _onSectionDirtyChange = (e: Event) => {
+    const ev = e as CustomEvent<{ dirty: boolean }>;
+    this._sectionDirty = ev.detail.dirty;
+  };
 
   // ─── URL State Persistence ─────────────────────────────────
 

--- a/src/util/unsaved-guard.ts
+++ b/src/util/unsaved-guard.ts
@@ -85,21 +85,24 @@ export class UnsavedGuard {
     a.resolve(ok);
   }
 
-  /** Dialog "Cancel" / dismiss → resolve ``false`` so the caller
-   *  drops its action. */
+  /** Dialog "Cancel" / dismiss, *and* the page-disconnect
+   *  cleanup path — both want the same "resolve any in-flight
+   *  guard as don't-proceed" behaviour, so they share one
+   *  implementation. The two call sites are named differently
+   *  in the page (``_onUnsavedCancel`` for the dialog event,
+   *  ``cancelPending`` for unmount) but funnel through here. */
   onCancel(): void {
     const a = this._active;
     this._active = null;
     a?.resolve(false);
   }
 
-  /** Resolve any in-flight guard as "don't proceed". Used on
-   *  page disconnect so awaiters don't dangle past unmount. */
-  cancelPending(): void {
-    const a = this._active;
-    this._active = null;
-    a?.resolve(false);
-  }
+  /** Alias — same behaviour as :meth:`onCancel`, kept for the
+   *  page's ``disconnectedCallback`` to read clearly at the
+   *  call site (``cancelPending`` vs ``onCancel`` carries
+   *  different intent even though the implementation is one
+   *  thing). */
+  cancelPending = this.onCancel;
 
   /** Test/debug introspection: is a guard currently waiting? */
   get isPending(): boolean {

--- a/src/util/unsaved-guard.ts
+++ b/src/util/unsaved-guard.ts
@@ -65,12 +65,24 @@ export class UnsavedGuard {
   /** Dialog "Save and leave" → run the saver, proceed iff it
    *  succeeded. The saver's return value is the source of truth:
    *  validation errors / IO failures should resolve to ``false``
-   *  so the caller stays put. */
+   *  so the caller stays put.
+   *
+   *  Wraps the await in try/catch so a saver that *throws*
+   *  (network error, programmer mistake) still resolves the
+   *  guard Promise. Without this, an in-flight ``run()`` would
+   *  dangle forever — the caller's ``await`` never returns and
+   *  the dialog can't be re-opened (``isPending`` stays stale). */
   async onSave(): Promise<void> {
     const a = this._active;
     this._active = null;
     if (!a) return;
-    a.resolve(await a.save());
+    let ok = false;
+    try {
+      ok = await a.save();
+    } catch {
+      ok = false;
+    }
+    a.resolve(ok);
   }
 
   /** Dialog "Cancel" / dismiss → resolve ``false`` so the caller

--- a/src/util/unsaved-guard.ts
+++ b/src/util/unsaved-guard.ts
@@ -1,0 +1,96 @@
+/**
+ * Reusable "are you sure you want to leave unsaved work" gate.
+ *
+ * The device page funnels two distinct dirty-state guards through
+ * one dialog: the YAML-buffer page-leave guard and the
+ * section-form section-switch guard. Both follow the same
+ * Discard / Save / Cancel pattern with the same modal; the only
+ * differences are *what counts as dirty* and *how to save*. This
+ * class owns the pending-resolver bookkeeping and exposes the
+ * three dialog-event handlers, leaving the page free to wire its
+ * specific dirty checks and save-fns.
+ *
+ * Held outside the Lit component so the logic is unit-testable
+ * in node without happy-dom — instantiate one, drive its event
+ * handlers, observe what the resolver Promise produces.
+ */
+
+export interface UnsavedGuardOptions {
+  /** Snapshot of the dirty state at the call site. ``false`` →
+   *  the helper resolves ``true`` immediately without opening
+   *  the dialog. */
+  dirty: boolean;
+  /** Open the modal. Called only when ``dirty`` is true; the
+   *  caller is expected to wire the dialog's
+   *  ``discard`` / ``save`` / ``cancel`` events into the matching
+   *  handler methods on this guard. */
+  open: () => void;
+  /** Performs the save. Returns ``true`` when the save actually
+   *  succeeded (so the buffer is clean afterwards), ``false``
+   *  otherwise — callers shouldn't proceed past a failed save. */
+  save: () => Promise<boolean>;
+}
+
+export class UnsavedGuard {
+  private _active: {
+    save: () => Promise<boolean>;
+    resolve: (proceed: boolean) => void;
+  } | null = null;
+
+  /** Open the dialog (if dirty) and resolve once the user picks.
+   *
+   *  - Not dirty → resolves ``true`` immediately, dialog stays
+   *    closed.
+   *  - Dirty + no other guard pending → opens the dialog, resolves
+   *    once a handler fires.
+   *  - Dirty + already-pending guard → resolves ``false``. Two
+   *    overlapping prompts make no sense; the second caller
+   *    silently drops its action rather than stacking dialogs. */
+  run(opts: UnsavedGuardOptions): Promise<boolean> {
+    if (!opts.dirty) return Promise.resolve(true);
+    if (this._active) return Promise.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      this._active = { save: opts.save, resolve };
+      opts.open();
+    });
+  }
+
+  /** Dialog "Discard" → proceed (resolve ``true``). */
+  onDiscard(): void {
+    const a = this._active;
+    this._active = null;
+    a?.resolve(true);
+  }
+
+  /** Dialog "Save and leave" → run the saver, proceed iff it
+   *  succeeded. The saver's return value is the source of truth:
+   *  validation errors / IO failures should resolve to ``false``
+   *  so the caller stays put. */
+  async onSave(): Promise<void> {
+    const a = this._active;
+    this._active = null;
+    if (!a) return;
+    a.resolve(await a.save());
+  }
+
+  /** Dialog "Cancel" / dismiss → resolve ``false`` so the caller
+   *  drops its action. */
+  onCancel(): void {
+    const a = this._active;
+    this._active = null;
+    a?.resolve(false);
+  }
+
+  /** Resolve any in-flight guard as "don't proceed". Used on
+   *  page disconnect so awaiters don't dangle past unmount. */
+  cancelPending(): void {
+    const a = this._active;
+    this._active = null;
+    a?.resolve(false);
+  }
+
+  /** Test/debug introspection: is a guard currently waiting? */
+  get isPending(): boolean {
+    return this._active !== null;
+  }
+}

--- a/test/util/unsaved-guard.test.ts
+++ b/test/util/unsaved-guard.test.ts
@@ -76,6 +76,25 @@ describe("UnsavedGuard", () => {
     expect(save).toHaveBeenCalledOnce();
   });
 
+  it("resolves false when save throws — guard never hangs", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    // A saver that rejects (network blip, programmer bug) would
+    // otherwise leave the guard's resolver dangling. ``onSave``
+    // has to contain the throw and resolve the guard Promise to
+    // ``false`` — otherwise the caller's ``await`` never
+    // returns and ``isPending`` stays stale, blocking the
+    // dialog from re-opening.
+    const save = vi.fn(() => Promise.reject(new Error("boom")));
+
+    const promise = guard.run({ dirty: true, open, save });
+    await guard.onSave();
+
+    expect(await promise).toBe(false);
+    expect(guard.isPending).toBe(false);
+    expect(save).toHaveBeenCalledOnce();
+  });
+
   it("resolves false on Cancel without invoking save", async () => {
     const guard = new UnsavedGuard();
     const { open } = makeOpener();

--- a/test/util/unsaved-guard.test.ts
+++ b/test/util/unsaved-guard.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for ``UnsavedGuard`` — the resolver/dialog-handler triplet
+ * that backs the device page's two unsaved-changes prompts
+ * (page-leave for the YAML buffer, section-switch for the visual
+ * editor's form). Vitest's default ``node`` environment doesn't
+ * give us a DOM, but the guard is pure logic so we drive it with
+ * a fake "dialog" that records ``open()`` calls.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { UnsavedGuard } from "../../src/util/unsaved-guard.js";
+
+/** Build an opener that records every call so tests can assert
+ *  on dialog-pop side effects without instantiating a real
+ *  ``ESPHomeUnsavedChangesDialog``. */
+function makeOpener() {
+  const open = vi.fn();
+  return { open };
+}
+
+describe("UnsavedGuard", () => {
+  it("short-circuits to true when nothing is dirty", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const ok = await guard.run({ dirty: false, open, save });
+
+    expect(ok).toBe(true);
+    expect(open).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+    expect(guard.isPending).toBe(false);
+  });
+
+  it("opens the dialog and resolves true on Discard", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const promise = guard.run({ dirty: true, open, save });
+    expect(open).toHaveBeenCalledOnce();
+    expect(guard.isPending).toBe(true);
+
+    guard.onDiscard();
+    expect(await promise).toBe(true);
+    // Save was *not* invoked — Discard just lets the caller
+    // proceed without persisting.
+    expect(save).not.toHaveBeenCalled();
+    expect(guard.isPending).toBe(false);
+  });
+
+  it("runs save and resolves with the saver's success bool", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const promise = guard.run({ dirty: true, open, save });
+    await guard.onSave();
+
+    expect(await promise).toBe(true);
+    expect(save).toHaveBeenCalledOnce();
+  });
+
+  it("resolves false when save reports failure (e.g. validation error)", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    // Mirrors ``device-section-config.save()``'s contract: the
+    // save runs but ``_dirty`` stays true (validation rejected
+    // the input) so the saver returns false. The page must NOT
+    // proceed in that case.
+    const save = vi.fn(() => Promise.resolve(false));
+
+    const promise = guard.run({ dirty: true, open, save });
+    await guard.onSave();
+
+    expect(await promise).toBe(false);
+    expect(save).toHaveBeenCalledOnce();
+  });
+
+  it("resolves false on Cancel without invoking save", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const promise = guard.run({ dirty: true, open, save });
+    guard.onCancel();
+
+    expect(await promise).toBe(false);
+    expect(save).not.toHaveBeenCalled();
+    expect(guard.isPending).toBe(false);
+  });
+
+  it("drops a re-entrant run while another is pending", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const first = guard.run({ dirty: true, open, save });
+    expect(open).toHaveBeenCalledTimes(1);
+
+    // Stray cursor movement / second nav-click while the dialog
+    // is already up — the second run should return false
+    // immediately (don't proceed) and must not stack a second
+    // dialog.
+    const second = await guard.run({ dirty: true, open, save });
+    expect(second).toBe(false);
+    expect(open).toHaveBeenCalledTimes(1);
+
+    // First guard still resolves normally on user action.
+    guard.onDiscard();
+    expect(await first).toBe(true);
+  });
+
+  it("``cancelPending`` resolves any in-flight guard as false", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const promise = guard.run({ dirty: true, open, save });
+    expect(guard.isPending).toBe(true);
+
+    guard.cancelPending();
+    expect(await promise).toBe(false);
+    expect(guard.isPending).toBe(false);
+  });
+
+  it("dialog-event handlers are no-ops when no guard is pending", async () => {
+    const guard = new UnsavedGuard();
+    // A late-firing dialog event (e.g. a ``wa-after-hide`` after
+    // the guard already cancelled out via ``cancelPending``)
+    // must not throw or resolve a stale Promise.
+    expect(() => guard.onDiscard()).not.toThrow();
+    expect(() => guard.onCancel()).not.toThrow();
+    await expect(guard.onSave()).resolves.toBeUndefined();
+  });
+
+  it("can be reused after each round resolves", async () => {
+    const guard = new UnsavedGuard();
+    const { open } = makeOpener();
+    const save = vi.fn(() => Promise.resolve(true));
+
+    const first = guard.run({ dirty: true, open, save });
+    guard.onDiscard();
+    expect(await first).toBe(true);
+
+    // Same instance, second round — opens the dialog a second
+    // time, runs to completion as expected. Guards against a
+    // bug where ``_active`` doesn't get cleared on resolve.
+    const second = guard.run({ dirty: true, open, save });
+    expect(open).toHaveBeenCalledTimes(2);
+    guard.onCancel();
+    expect(await second).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The device editor's form panel used to switch sections silently
even when the user had half-edited fields. Reproduce: open
`packages:` in the visual editor, type a value, click `ota:` in
the YAML pane (or the nav). The form jumped to `ota:` and
threw away the unsaved `packages:` changes — no warning, no
prompt.

The page-leave guard already handled the YAML *buffer* being
dirty, but the form's `_dirty` flag lives inside
`device-section-config`, three shadow boundaries down from the
page, so the existing guard never saw it.

This PR plumbs the form's dirty state up to the page and reuses
the same dialog the page-leave guard already uses, with a
shared `_runUnsavedGuard` helper so neither code path
duplicates the resolver / dialog plumbing.

**Section-config (`device-section-config.ts`):**

- Every `_dirty` write goes through a new `_setDirty` helper
  that fires a `dirty-change` event on actual transitions
  (composed + bubbles, so the page can listen at the layout
  container without crossing shadow roots manually).
- `connectedCallback` / `disconnectedCallback` fire
  `section-mount` / `section-unmount` with `detail.node = this`,
  giving the page a direct ref without a property-passthrough
  chain through `device-editor` and `device-board-info`.
- Public `save(): Promise<boolean>` wraps the existing
  `_onSave` and returns `!this._dirty` — `false` when validation
  fails or `_resolveSpliceContext` returns null (so the page's
  "Save and leave" handler can correctly *not* leave the dirty
  section in those cases).

**Page (`pages/device.ts`):**

- One shared `_runUnsavedGuard({dirty, save})` helper drives the
  unsaved-changes dialog. Returns `Promise<boolean>` — `true` on
  Discard or a successful Save, `false` on Cancel or a failed
  Save.
- `_confirmLeave` (page-leave) and `_guardSectionSwitch`
  (section-switch) both reduce to a 5-line call into that
  helper. The duplicate trio of `_onLeaveDiscard`/`_onLeaveSave`/
  `_onLeaveCancel` handlers and the `_pendingLeaveResolve`
  field are gone — replaced by one `_activeGuard` resolver that
  the dialog's three event handlers funnel through.
- `_allowingLeave`'s flip-before-resolve ordering is preserved:
  the page-leave's `save` lambda flips the flag synchronously
  inside its body, before the guard Promise resolves; the
  `_confirmLeave` continuation also sets it on Discard so the
  prior synthetic-popstate-after-Discard behaviour matches
  exactly.
- Both `_onYamlCursorLine` (YAML pane click moves the cursor →
  section change) and `_onSectionSelect` (nav click) now route
  through `_guardSectionSwitch`. The action runs on Discard or
  successful Save; Cancel leaves `_selectedSection` untouched
  so the form keeps showing the dirty section. The YAML
  cursor stays where the user clicked — we don't reach into
  codemirror to revert it; the form re-asserts on the dirty
  section regardless.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes the silent-clobber-of-unsaved-form-edits report (no
  GitHub issue filed; reported in chat).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
