### PR TITLE
Add close X to toasts so they don't block Save / Install buttons

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -363,7 +363,20 @@ export class ESPHomeApp extends LitElement {
 
   private async _init() {
     toast.config({
-      toastOptions: { position: "bottom-right", richColors: true, duration: 4000 },
+      toastOptions: {
+        position: "bottom-right",
+        richColors: true,
+        duration: 4000,
+        // The bottom-right toast can land on top of the device
+        // editor's Save / Install buttons (issue #171). The X
+        // gives the user a guaranteed dismissal that doesn't
+        // depend on swipe — which mouse users discover late and
+        // touchpad users may struggle with — and isn't gated on
+        // the 4s auto-close timer. UX team may swap this for a
+        // different placement later; the close affordance stays
+        // useful regardless of where the toast moves.
+        closeButton: true,
+      },
     });
     this._initDarkMode();
     try {


### PR DESCRIPTION
# What does this implement/fix?

The bottom-right toast lands on top of the device editor's Save / Install buttons (issue #171). The default sonner-js toast has no visible close affordance and relies on swipe-to-dismiss — which mouse users discover late, and which doesn't help when the toast itself is the obstacle for 4 seconds.

Set `closeButton: true` on the global toast config in `app-shell.ts` so every toast renders an X. Single one-line behaviour change; the existing position / duration / richColors stay as-is.

UX team may want to revisit placement later (e.g. move toasts above the action buttons, or shorten the duration); the X is useful regardless of where the toast ends up. Leaving issue #171 open so Steven / UX can land a follow-up improvement on top.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- addresses #171 (intentionally not "fixes" — leaving the issue open for the UX-team revisit)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (680/680).
  - [x] Tests have been added to verify that the new code works (where applicable).
