### PR TITLE
Extract _lintFailureMessage's reducer to a unit-tested helper

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -39,6 +39,7 @@ import {
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../util/yaml-section-values.js";
+import { lintFailureMessageFromResponse } from "../../util/lint-failure-message.js";
 import { resolveCurrentFromLine } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
 import { isYamlOnlySection } from "./yaml-only-sections.js";
@@ -836,28 +837,16 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     } catch {
       return null;
     }
-    // Two distinct empty-string cases to keep apart:
-    //   1. No errors at all — return null, ``_onSave`` proceeds.
-    //   2. Errors reported but the first one's ``message`` is
-    //      whitespace-only — the backend flagged a problem we
-    //      can't render verbatim, but proceeding would silently
-    //      ignore a real validation failure. Fall back to a
-    //      generic localised label so ``_onSave`` blocks AND
-    //      the user gets a visible error.
-    // Without case 2, ``_onSave`` would update the YAML on the
-    // backend's own "this is invalid" response just because the
-    // message string happened to trim away to nothing.
-    const validation = res.validation_errors?.[0];
-    if (validation) {
-      const msg = validation.message?.trim();
-      return msg || this._localize("device.section_save_error");
-    }
-    const yaml = res.yaml_errors?.[0];
-    if (yaml) {
-      const msg = yaml.message?.trim();
-      return msg || this._localize("device.section_save_error");
-    }
-    return null;
+    // Pure response→message reduction lives in
+    // ``util/lint-failure-message.ts`` so the empty-trim
+    // fallback contract is unit-testable in node without
+    // standing up a Lit component. The localised label is the
+    // fallback when the backend reports an error whose
+    // ``message`` trims to empty.
+    return lintFailureMessageFromResponse(
+      res,
+      this._localize("device.section_save_error"),
+    );
   }
 }
 

--- a/src/util/lint-failure-message.ts
+++ b/src/util/lint-failure-message.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure response → display-message reducer for ``editor/validate_yaml``.
+ *
+ * Lifted out of ``device-section-config`` so the empty-message
+ * fallback contract is unit-testable in node without spinning up
+ * a Lit component. Two shapes the device editor needs to keep
+ * apart:
+ *
+ *   - No errors at all → ``null`` so ``_onSave`` proceeds.
+ *   - Error reported but the first one's ``message`` is
+ *     empty / whitespace → return the caller's *fallback* so
+ *     ``_onSave`` blocks AND the user sees something rendered.
+ *     Without the fallback, an empty trim would coalesce to
+ *     ``null`` and let the save through despite the backend
+ *     reporting a validation error.
+ *
+ * The caller (``_lintFailureMessage`` in
+ * ``device-section-config.ts``) supplies its localized
+ * ``device.section_save_error`` as the fallback — kept as a
+ * parameter rather than baked in so the helper has no
+ * dependency on Lit's ``LocalizeFunc`` context plumbing.
+ */
+import type { EditorValidateResponse } from "../api/types.js";
+
+export function lintFailureMessageFromResponse(
+  res: EditorValidateResponse,
+  fallback: string,
+): string | null {
+  const validation = res.validation_errors?.[0];
+  if (validation) {
+    const msg = validation.message?.trim();
+    return msg || fallback;
+  }
+  const yaml = res.yaml_errors?.[0];
+  if (yaml) {
+    const msg = yaml.message?.trim();
+    return msg || fallback;
+  }
+  return null;
+}

--- a/test/util/lint-failure-message.test.ts
+++ b/test/util/lint-failure-message.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for ``lintFailureMessageFromResponse`` — the pure
+ * response → display-message reducer the device editor uses
+ * to decide whether to bail on save.
+ *
+ * Two empty-string cases the device editor's ``_onSave`` flow
+ * has to keep apart, both pinned here:
+ *
+ *   - No errors → ``null`` (save proceeds).
+ *   - Error reported but message is empty/whitespace → fall back
+ *     to the caller-supplied label so ``_onSave`` blocks AND
+ *     the rendered error ``<p>`` shows something.
+ */
+import { describe, expect, it } from "vitest";
+import type { EditorValidateResponse } from "../../src/api/types.js";
+import { lintFailureMessageFromResponse } from "../../src/util/lint-failure-message.js";
+
+const FALLBACK = "Failed to save section";
+
+function res(overrides: Partial<EditorValidateResponse> = {}): EditorValidateResponse {
+  return {
+    yaml_errors: [],
+    validation_errors: [],
+    ...overrides,
+  };
+}
+
+describe("lintFailureMessageFromResponse", () => {
+  it("returns null when both error arrays are empty", () => {
+    expect(lintFailureMessageFromResponse(res(), FALLBACK)).toBe(null);
+  });
+
+  it("returns the validation message when present and non-empty", () => {
+    const out = lintFailureMessageFromResponse(
+      res({
+        validation_errors: [
+          { message: "Invalid foo bar" } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe("Invalid foo bar");
+  });
+
+  it("trims surrounding whitespace from a real validation message", () => {
+    const out = lintFailureMessageFromResponse(
+      res({
+        validation_errors: [
+          { message: "  Invalid foo bar\n" } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    // No leading / trailing whitespace bleeds into the rendered
+    // ``<p>`` — keeps the error block tidy regardless of how
+    // ESPHome formats its messages.
+    expect(out).toBe("Invalid foo bar");
+  });
+
+  it("falls back to the caller-supplied label when validation message trims empty", () => {
+    // Critical bail-vs-proceed pivot: the backend reported a
+    // validation_error, but the message string was just
+    // whitespace. Without the fallback the helper would return
+    // ``null`` and ``_onSave`` would proceed past a real
+    // validation failure. Fallback keeps the save blocked.
+    const out = lintFailureMessageFromResponse(
+      res({
+        validation_errors: [
+          { message: "   \n\t  " } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe(FALLBACK);
+  });
+
+  it("falls back to the caller-supplied label when validation message is undefined", () => {
+    // Same bail behaviour for the missing-message shape (e.g.
+    // a future backend response that only carries a code +
+    // location and forgets the human label).
+    const out = lintFailureMessageFromResponse(
+      res({
+        validation_errors: [
+          { message: undefined as unknown as string } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe(FALLBACK);
+  });
+
+  it("returns the yaml_errors message when no validation errors", () => {
+    // Validation errors take priority — but yaml-syntax errors
+    // are also a real failure and should bail.
+    const out = lintFailureMessageFromResponse(
+      res({
+        yaml_errors: [
+          { message: "Unexpected token" } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe("Unexpected token");
+  });
+
+  it("falls back when yaml_errors message trims empty", () => {
+    const out = lintFailureMessageFromResponse(
+      res({
+        yaml_errors: [
+          { message: "  " } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe(FALLBACK);
+  });
+
+  it("validation errors win over yaml errors", () => {
+    // Both populated — pin priority so a regression that
+    // swapped the order would surface.
+    const out = lintFailureMessageFromResponse(
+      res({
+        validation_errors: [
+          { message: "validation wins" } as never,
+        ],
+        yaml_errors: [
+          { message: "yaml loses" } as never,
+        ],
+      }),
+      FALLBACK,
+    );
+    expect(out).toBe("validation wins");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #173. The Lit method `_lintFailureMessage` in
`device-section-config.ts` does two separable things:

1. Call `validateYaml` over the API.
2. Reduce the `EditorValidateResponse` to `string | null` for
   `_onSave` to consume.

#173 inlined (2) — including the empty-trim fallback to
`device.section_save_error` that the latest Copilot review
asked for. That fallback's contract is the load-bearing bit:
without it, a backend-reported `validation_error` whose
`message` trims to empty would coalesce to `null` and let the
save proceed past a real failure.

This PR lifts (2) into `src/util/lint-failure-message.ts` as a
pure helper so the contract can be unit-tested in node without
spinning up the Lit component (vitest runs in the `node`
environment — no DOM, no custom-element registry). The Lit
method now just awaits the API call and forwards the response
to the helper with its localised label as the fallback. Same
runtime behaviour; the contract is just verified by direct
test rather than the existing source-grep wiring test.

**Tests** (`test/util/lint-failure-message.test.ts`, 8 cases):

- No errors → `null` (save proceeds).
- Real validation message → returned trimmed.
- Validation message that trims to empty → fallback so save
  blocks AND a visible error renders.
- Same fallback shape on `yaml_errors`.
- Validation errors take priority over yaml errors.
- Whitespace-only messages on both error arrays.
- Missing `message` field falls back too.

**Related issue or feature (if applicable):**

- follow-up to #173

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (699/699, +8 new).
  - [x] Tests have been added to verify that the new code works (where applicable).
