### PR TITLE
Disable drawer Build Size broom button while a build is in flight

### DIFF
--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -138,6 +138,16 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   @property({ type: Boolean, attribute: "drawer-open" })
   drawerOpen = true;
 
+  /** True while a firmware job is in flight for this device.
+   *  Gates the destructive in-content actions (the Build Size
+   *  row's broom button) so the user can't supersede a running
+   *  build by accident — the backend rejects ``firmware/clean``
+   *  in that state too, but disabling the affordance up front
+   *  avoids the round-trip and the resulting toast. Forwarded
+   *  from the parent ``<esphome-device-drawer>``. */
+  @property({ type: Boolean, reflect: true })
+  busy = false;
+
   /** Latest reachability snapshot pushed by the backend over the
    *  per-device WS subscription. ``null`` until the initial event
    *  arrives or after the subscription tears down. */
@@ -919,9 +929,12 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
             <button
               class="build-size-clean"
               type="button"
-              title=${this._localize("dashboard.action_clean_build")}
+              ?disabled=${this.busy}
+              title=${this.busy
+                ? this._localize("dashboard.action_clean_build_busy")
+                : this._localize("dashboard.action_clean_build")}
               aria-label=${this._localize("dashboard.action_clean_build")}
-              @click=${() => this._emitCleanBuild(d)}
+              @click=${() => (this.busy ? null : this._emitCleanBuild(d))}
             >
               <wa-icon library="mdi" name="broom"></wa-icon>
             </button>

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -351,6 +351,19 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           transparent 88%
         );
       }
+      /* Disabled state uses aria-disabled rather than the native
+         disabled attribute so the button stays focusable and the
+         title tooltip remains discoverable on hover — disabled
+         native buttons hide both, which would silently drop the
+         "wait for the current build…" explanation. The click
+         handler is gated separately on the busy property. */
+      .build-size-clean--disabled,
+      .build-size-clean--disabled:hover {
+        color: var(--wa-color-text-quiet);
+        background: none;
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
       .build-size-clean wa-icon {
         font-size: 14px;
       }
@@ -927,9 +940,11 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           <div class="value build-size-value">
             <span>${formatFileSize(d.build_size_bytes)}</span>
             <button
-              class="build-size-clean"
+              class="build-size-clean ${this.busy
+                ? "build-size-clean--disabled"
+                : ""}"
               type="button"
-              ?disabled=${this.busy}
+              aria-disabled=${this.busy ? "true" : "false"}
               title=${this.busy
                 ? this._localize("dashboard.action_clean_build_busy")
                 : this._localize("dashboard.action_clean_build")}

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -933,7 +933,9 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
               title=${this.busy
                 ? this._localize("dashboard.action_clean_build_busy")
                 : this._localize("dashboard.action_clean_build")}
-              aria-label=${this._localize("dashboard.action_clean_build")}
+              aria-label=${this.busy
+                ? this._localize("dashboard.action_clean_build_busy")
+                : this._localize("dashboard.action_clean_build")}
               @click=${() => (this.busy ? null : this._emitCleanBuild(d))}
             >
               <wa-icon library="mdi" name="broom"></wa-icon>

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -358,6 +358,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
           <esphome-device-drawer-content
             .device=${device}
             ?drawer-open=${this.open}
+            ?busy=${this.busy}
           ></esphome-device-drawer-content>
         </div>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -98,6 +98,7 @@
     "action_download_yaml": "Download YAML",
     "action_rename": "Rename hostname",
     "action_clean_build": "Clean build files",
+    "action_clean_build_busy": "Wait for the current build to finish before cleaning",
     "action_download_elf": "Download ELF file",
     "action_visit_web_ui": "Visit web UI",
     "action_validate_success": "\"{name}\" configuration is valid",


### PR DESCRIPTION
# What does this implement/fix?

The device drawer's **Build Size** row carries a broom-icon button that fires `clean-build`. The table-row kebab menu's "Clean build files" already gates on `?busy`, but the drawer's broom button missed the gate — so a user could click it while a compile / install was running mid-flight, and the backend's `_enqueue` supersede path quietly cancelled the running job to run the clean instead. That's exactly the worst case for an in-flight install: cancelled OTA, build artifacts wiped, no clear feedback to the user.

Forward the parent `<esphome-device-drawer>`'s `busy` prop to `<esphome-device-drawer-content>`, and gate the broom button on it: `?disabled` while busy, with the tooltip swapping to "Wait for the current build to finish before cleaning" so the user has a clear reason.

Companion backend PR: **esphome/device-builder#351** — rejects `firmware/clean` server-side when an active `COMPILE` / `UPLOAD` / `INSTALL` / `RENAME` job exists for the same configuration. Defense in depth; cancelling the request client-side just avoids the round-trip and the resulting toast.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes the "managed to clean while build in progress" report (no GitHub issue filed; reported in chat)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (699/699).
  - [x] Tests have been added to verify that the new code works (where applicable).
