### PR TITLE
layout: add version footer

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -52,6 +52,7 @@ import {
   integrationDocsContext,
   isHaIngressContext,
   localizeContext,
+  serverVersionContext,
   versionContext,
   yamlDiffButtonContext,
 } from "../context/index.js";
@@ -156,6 +157,10 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: versionContext })
   @state()
   private _version = "";
+
+  @provide({ context: serverVersionContext })
+  @state()
+  private _serverVersion = "";
 
   @provide({ context: darkModeContext })
   @state()
@@ -378,6 +383,7 @@ export class ESPHomeApp extends LitElement {
     // sends backend commands has to wait for ``api.ready``.
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
+      this._serverVersion = info.server_version;
       this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
       this._apiConnected = true;
       // ``api.ready`` resolves when the connection is usable — either

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -3,11 +3,10 @@ import { mdiArrowCollapseRight, mdiArrowLeft } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { isHaIngressContext, localizeContext, versionContext } from "../context/index.js";
+import { isHaIngressContext, localizeContext, serverVersionContext, versionContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import pkg from "../../package.json";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -31,6 +30,10 @@ export class ESPHomeLayout extends LitElement {
   @consume({ context: versionContext, subscribe: true })
   @state()
   private _esphomeVersion = "";
+
+  @consume({ context: serverVersionContext, subscribe: true })
+  @state()
+  private _serverVersion = "";
 
   @state()
   private _path = window.location.pathname;
@@ -239,7 +242,7 @@ export class ESPHomeLayout extends LitElement {
       </div>
       <slot></slot>
       <div class="app-footer">
-        <span>ESPHome Device Builder v${pkg.version}</span>
+        ${this._serverVersion ? html`<span>ESPHome Device Builder v${this._serverVersion}</span>` : nothing}
         ${this._esphomeVersion ? html`<span>ESPHome v${this._esphomeVersion}</span>` : nothing}
       </div>
     `;

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -3,10 +3,11 @@ import { mdiArrowCollapseRight, mdiArrowLeft } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { isHaIngressContext, localizeContext } from "../context/index.js";
+import { isHaIngressContext, localizeContext, versionContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import pkg from "../../package.json";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -26,6 +27,10 @@ export class ESPHomeLayout extends LitElement {
   @consume({ context: isHaIngressContext, subscribe: true })
   @state()
   private _isHaIngress = false;
+
+  @consume({ context: versionContext, subscribe: true })
+  @state()
+  private _esphomeVersion = "";
 
   @state()
   private _path = window.location.pathname;
@@ -168,6 +173,22 @@ export class ESPHomeLayout extends LitElement {
           display: none;
         }
       }
+
+      .app-footer {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--wa-space-m);
+        font-size: 10px;
+        color: var(--wa-color-text-quiet);
+        opacity: 0.5;
+        pointer-events: none;
+      }
     `,
   ];
 
@@ -217,6 +238,10 @@ export class ESPHomeLayout extends LitElement {
         <esphome-header-actions></esphome-header-actions>
       </div>
       <slot></slot>
+      <div class="app-footer">
+        <span>ESPHome Device Builder v${pkg.version}</span>
+        ${this._esphomeVersion ? html`<span>ESPHome v${this._esphomeVersion}</span>` : nothing}
+      </div>
     `;
   }
 }

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -25,6 +25,9 @@ export const importableDevicesContext = createContext<AdoptableDevice[]>(
 /** Context for the ESPHome version string. */
 export const versionContext = createContext<string>(Symbol("esphome-version"));
 
+/** Context for the Device Builder server version string. */
+export const serverVersionContext = createContext<string>(Symbol("esphome-server-version"));
+
 /** Context for dark mode state. */
 export const darkModeContext = createContext<boolean>(Symbol("esphome-dark-mode"));
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -3,6 +3,7 @@ export {
   devicesContext,
   importableDevicesContext,
   versionContext,
+  serverVersionContext,
   darkModeContext,
   localizeContext,
   devicesLoadedContext,


### PR DESCRIPTION
There was no way to quickly verify which builder or ESPHome version was running without digging into settings or server info. A tiny, unobtrusive footer makes this immediately visible.

- Added a fixed 20px footer to `esphome-layout` showing the builder version (from `package.json`) and ESPHome version (from `versionContext`)
- Footer is non-interactive (`pointer-events: none`), muted, and does not affect page layout or scroll behaviour