### PR TITLE
Fix singular/plural in discovered devices banner

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -640,9 +640,12 @@ export class ESPHomePageDashboard extends LitElement {
           <div style="justify-content: center; display: flex; align-items: center">
             <wa-icon library="mdi" name="clipboard-text-search-outline"></wa-icon>
             <span
-              >${this._localize("dashboard.discovered_count", {
-                count: visible.length,
-              })}</span
+              >${this._localize(
+                visible.length === 1
+                  ? "dashboard.discovered_count_singular"
+                  : "dashboard.discovered_count_plural",
+                { count: visible.length },
+              )}</span
             >
           </div>
           <button

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2,7 +2,8 @@
   "dashboard": {
     "title": "ESPHome - Device Builder",
     "subtitle": "Create and make your smart devices and automations",
-    "discovered_count": "Discovered {count} device",
+    "discovered_count_singular": "Discovered {count} device",
+    "discovered_count_plural": "Discovered {count} devices",
     "discovered_status": "Discovered",
     "discovered_ignored": "Ignored",
     "show": "Show",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -2,7 +2,8 @@
   "dashboard": {
     "title": "ESPHome - Device Builder",
     "subtitle": "Créez et fabriquez vos appareils intelligents et automatisations",
-    "discovered_count": "{count} appareil détecté",
+    "discovered_count_singular": "{count} appareil détecté",
+    "discovered_count_plural": "{count} appareils détectés",
     "discovered_status": "Détecté",
     "discovered_ignored": "Ignoré",
     "show": "Afficher",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -2,7 +2,8 @@
   "dashboard": {
     "title": "ESPHome - Device Builder",
     "subtitle": "Maak en bouw uw slimme apparaten en automatiseringen",
-    "discovered_count": "{count} apparaat gevonden",
+    "discovered_count_singular": "{count} apparaat gevonden",
+    "discovered_count_plural": "{count} apparaten gevonden",
     "discovered_status": "Gevonden",
     "discovered_ignored": "Genegeerd",
     "show": "Tonen",

--- a/test/common/localize.test.ts
+++ b/test/common/localize.test.ts
@@ -25,8 +25,10 @@ describe("defaultLocalize", () => {
   });
 
   it("interpolates {variable} placeholders", () => {
-    const out = defaultLocalize("dashboard.discovered_count", { count: 3 });
-    expect(out).toBe("Discovered 3 device");
+    const out = defaultLocalize("dashboard.discovered_count_plural", {
+      count: 3,
+    });
+    expect(out).toBe("Discovered 3 devices");
   });
 
   it("interpolates multiple placeholders", () => {
@@ -38,7 +40,7 @@ describe("defaultLocalize", () => {
   });
 
   it("leaves unknown placeholders intact", () => {
-    const out = defaultLocalize("dashboard.discovered_count", {});
+    const out = defaultLocalize("dashboard.discovered_count_singular", {});
     expect(out).toBe("Discovered {count} device");
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The discovered-devices banner read "Discovered 4 device" — a single
`discovered_count` translation key was used regardless of count, so
the singular noun stuck no matter how many devices were found.

Split the key into singular and plural variants (matching the
existing `device_singular`/`device_plural` pattern) and pick the
right one based on count.

- `discovered_count` → `discovered_count_singular` /
  `discovered_count_plural` in `en.json`, `nl.json`, `fr.json`
- `_renderBanner` in `dashboard.ts` selects the key by
  `visible.length === 1`
- Updated unit tests in `test/common/localize.test.ts` to use the
  new keys

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
