### PR TITLE
Auto-enlarge firmware install dialog when showing logs

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -81,7 +81,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() private _failedDuringCompile = false;
   @state() private _logLines: string[] = [];
   @state() private _logsExpanded = false;
-  @state() private _logsFullHeight = false;
   @state() private _flashPercent = 0;
   @state() private _downloadedFilename = "";
   /** Auto-flip to the logs dialog after a successful Web Serial
@@ -203,7 +202,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._errorMessage = "";
     this._logLines = [];
     this._logsExpanded = false;
-    this._logsFullHeight = false;
     this._flashPercent = 0;
     this._downloadedFilename = "";
     this._showLogsAfterInstall = true;
@@ -425,20 +423,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         justify-content: space-between;
       }
 
-      .expand-btn {
-        display: inline-flex;
-        align-items: center;
-        padding: 0;
-        background: none;
-        border: none;
-        font-size: 16px;
-        color: var(--wa-color-text-quiet);
-        cursor: pointer;
-      }
-      .expand-btn:hover {
-        color: var(--wa-color-text-normal);
-      }
-
       .logs-container {
         margin-top: var(--wa-space-s);
         border: 1px solid var(--term-border);
@@ -447,12 +431,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       }
 
       esphome-ansi-log {
-        --log-height: 200px;
-      }
-
-      .logs-container--full esphome-ansi-log {
         --log-height: 50vh;
       }
+
       esphome-ansi-log::part(container) {
         border-radius: 0;
       }
@@ -507,8 +488,8 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (changedProperties.has("_darkMode")) {
       this.toggleAttribute("light", !this._darkMode);
     }
-    if (changedProperties.has("_logsFullHeight")) {
-      this.toggleAttribute("expanded", this._logsFullHeight);
+    if (changedProperties.has("_logsExpanded")) {
+      this.toggleAttribute("expanded", this._logsExpanded);
     }
   }
 
@@ -665,24 +646,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
             ? this._localize("firmware.hide_details")
             : this._localize("firmware.show_details")}
         </button>
-        ${this._logsExpanded
-          ? html`<button
-              class="expand-btn"
-              @click=${() => {
-                this._logsFullHeight = !this._logsFullHeight;
-              }}
-            >
-              <wa-icon
-                library="mdi"
-                name=${this._logsFullHeight ? "arrow-collapse" : "arrow-expand"}
-              ></wa-icon>
-            </button>`
-          : nothing}
       </div>
       ${this._logsExpanded
-        ? html`<div
-            class="logs-container ${this._logsFullHeight ? "logs-container--full" : ""}"
-          >
+        ? html`<div class="logs-container">
             <esphome-ansi-log
               .lines=${this._logLines}
               ?light=${!this._darkMode}


### PR DESCRIPTION
# What does this implement/fix?

The Web Serial install dialog used to hide logs behind a *Show details* toggle, then show them in a tiny 200px window with a second *Enlarge* button to grow the dialog. Two clicks for what should be one — and the small intermediate state was barely usable.

Now showing details immediately enlarges the dialog and renders logs at 50vh.

Changes:

- Drop the `_logsFullHeight` state and the expand/collapse button from `firmware-install-dialog`.
- Tie the dialog's `expanded` attribute to `_logsExpanded` directly.
- Remove the `.logs-container--full` CSS modifier; logs always render at 50vh when shown.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
