### PR TITLE
Make frontend deployment-base aware (HA ingress, reverse-proxy subpaths)

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -144,7 +144,15 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
     filename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
     chunkFilename: isProdBuild ? "[name].[contenthash].js" : "[name].js",
     path: OUTPUT_DIR,
-    publicPath: "/",
+    // ``auto`` makes the runtime derive the public path from
+    // ``document.currentScript.src`` and HtmlRspackPlugin emit the
+    // entry script with a relative href. That lets the bundle load
+    // from any mount point — bare ``/``, an HA ingress prefix like
+    // ``/api/hassio_ingress/<token>/``, or a reverse-proxy subpath
+    // — without rebuilding. ``src/util/base-path.ts`` reads the same
+    // signal to keep client-side routing, the WebSocket URL, and the
+    // ``/assets/...`` references in lockstep.
+    publicPath: "auto",
     clean: true,
     hashFunction: "xxhash64",
   },

--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,13 @@
       content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome</title>
-    <link rel="icon" type="image/svg+xml" href="assets/logo/esphome.svg" />
+    <!-- Favicon href is set at runtime from entrypoint.ts via
+         ``withBase("/assets/logo/esphome.svg")`` so it resolves
+         correctly under any mount point — including HA ingress
+         and direct deep links like ``/device/<id>`` (which the
+         SPA serves the same ``index.html`` for, so a static
+         document-relative URL would resolve against the route). -->
+    <link rel="icon" type="image/svg+xml" />
     <style>
       :root,
       .wa-light,

--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
       content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome</title>
-    <link rel="icon" type="image/svg+xml" href="/assets/logo/esphome.svg" />
+    <link rel="icon" type="image/svg+xml" href="assets/logo/esphome.svg" />
     <style>
       :root,
       .wa-light,

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -7,6 +7,7 @@
  * EventMessages with "output" and "result" events.
  */
 import { APIError } from "./api-error.js";
+import { BASE_PATH } from "../util/base-path.js";
 import { clearStoredToken, getStoredToken, setStoredToken } from "../util/auth-token.js";
 import type {
   AddComponentResponse,
@@ -190,7 +191,7 @@ export class ESPHomeAPI {
       this._intentionalDisconnect = false;
 
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const wsUrl = `${protocol}//${window.location.host}/ws`;
+      const wsUrl = `${protocol}//${window.location.host}${BASE_PATH}ws`;
 
       this._ws = new WebSocket(wsUrl);
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -57,6 +57,7 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { BASE_PATH, withBase } from "../util/base-path.js";
 import { isTerminalJobStatus } from "../util/firmware-job-status.js";
 
 // Mirrors the backend's `_PRIMARY_JOB_TYPES` retention pool — these
@@ -228,11 +229,11 @@ export class ESPHomeApp extends LitElement {
 
   private _router = new Router(this, [
     {
-      path: "/",
+      path: withBase("/"),
       render: () => html`<esphome-page-dashboard></esphome-page-dashboard>`,
     },
     {
-      path: "/secrets",
+      path: withBase("/secrets"),
       enter: async () => {
         await import("../pages/secrets.js");
         return true;
@@ -240,7 +241,7 @@ export class ESPHomeApp extends LitElement {
       render: () => html`<esphome-page-secrets></esphome-page-secrets>`,
     },
     {
-      path: "/device/:id",
+      path: withBase("/device/:id"),
       enter: async () => {
         await import("../pages/device.js");
         return true;
@@ -397,7 +398,7 @@ export class ESPHomeApp extends LitElement {
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
       this._serverVersion = info.server_version;
-      this._isHaIngress = info.ha_addon && window.location.pathname.includes("/ingress");
+      this._isHaIngress = info.ha_addon && BASE_PATH.includes("/ingress");
       this._apiConnected = true;
       // ``api.ready`` resolves when the connection is usable — either
       // ``requires_auth: false``, or a stored token replay succeeds.

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -21,6 +21,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 // Automation add-flow is gated on a backend that doesn't yet exist;
 // the navigator still shows the section but disables its action
 // button. See `feature-flags.ts` and the README "Status" section.
+import { withBase } from "../../util/base-path.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import type { ESPHomeAddAutomationDialog } from "./add-automation-dialog.js";
@@ -543,12 +544,12 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
 
   private _boardImageUrl(board: BoardCatalogEntry): string {
     if (board.images.length > 0) return board.images[0];
-    return "/assets/board/default.svg";
+    return withBase("/assets/board/default.svg");
   }
 
   private _onImageError(e: Event) {
     const img = e.target as HTMLImageElement;
-    const fallback = "/assets/board/default.svg";
+    const fallback = withBase("/assets/board/default.svg");
     if (img.src !== window.location.origin + fallback && !img.src.endsWith(fallback)) {
       img.src = fallback;
     }

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -18,6 +18,7 @@ import {
   KEEP_EMPTY_STRING_SECTIONS,
   resolveSectionEntries,
 } from "../../util/section-entry-overrides.js";
+import { withBase } from "../../util/base-path.js";
 import { fetchComponent } from "../../util/component-name-cache.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
@@ -447,7 +448,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   private _onImageError(e: Event) {
     const img = e.target as HTMLImageElement;
-    const fallback = "/assets/board/default.svg";
+    const fallback = withBase("/assets/board/default.svg");
     if (
       img.src !== window.location.origin + fallback &&
       !img.src.endsWith(fallback)
@@ -522,7 +523,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
           ? nothing
           : html`<div class="section-image">
               <img
-                src=${this._config.image_url || "/assets/board/default.svg"}
+                src=${this._config.image_url || withBase("/assets/board/default.svg")}
                 alt=${this._config.title}
                 referrerpolicy="no-referrer"
                 @error=${this._onImageError}

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -5,6 +5,7 @@ import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { isHaIngressContext, localizeContext, serverVersionContext, versionContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { stripBase, withBase } from "../util/base-path.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -36,10 +37,10 @@ export class ESPHomeLayout extends LitElement {
   private _serverVersion = "";
 
   @state()
-  private _path = window.location.pathname;
+  private _path = stripBase(window.location.pathname);
 
   private _onPopState = () => {
-    this._path = window.location.pathname;
+    this._path = stripBase(window.location.pathname);
   };
 
   connectedCallback() {
@@ -212,7 +213,7 @@ export class ESPHomeLayout extends LitElement {
                   title=${this._localize("layout.home_assistant")}
                 >
                   <wa-icon library="mdi" name="arrow-collapse-right"></wa-icon>
-                  <img src="/assets/logo/ha.svg" alt="Home Assistant" />
+                  <img src=${withBase("/assets/logo/ha.svg")} alt="Home Assistant" />
                 </wa-button>
                 <div class="header-separator"></div>
               `
@@ -230,7 +231,7 @@ export class ESPHomeLayout extends LitElement {
               `
             : nothing}
           <button class="header-logo" @click=${this._goHome}>
-            <img src="/assets/logo/esphome.svg" alt="ESPHome" />
+            <img src=${withBase("/assets/logo/esphome.svg")} alt="ESPHome" />
           </button>
         </div>
         <div class="header-text">

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,6 +7,7 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, apiContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { withBase } from "../../util/base-path.js";
 import { friendlyNameSlugify } from "../../util/friendly-name-slugify.js";
 import { markJustCreated } from "../../util/just-created.js";
 import { markPendingHighlight } from "../../util/pending-highlight.js";
@@ -291,7 +292,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     window.history.pushState(
       {},
       "",
-      `/device/${encodeURIComponent(configuration)}`,
+      withBase(`/device/${encodeURIComponent(configuration)}`),
     );
     window.dispatchEvent(new PopStateEvent("popstate"));
   }

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -14,6 +14,7 @@ import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { withBase } from "../../util/base-path.js";
 import { debounce } from "../../util/debounce.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -473,7 +474,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
 
   private _renderFeatured(board: BoardCatalogEntry) {
     const imageUrl =
-      board.images.length > 0 ? board.images[0] : "/assets/board/default.svg";
+      board.images.length > 0 ? board.images[0] : withBase("/assets/board/default.svg");
     return html`
       <div class="featured-card">
         <img class="featured-image" src=${imageUrl} alt=${board.name} />
@@ -513,7 +514,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
 
   private _renderBoardCard(board: BoardCatalogEntry, expanded: boolean) {
     const imageUrl =
-      board.images.length > 0 ? board.images[0] : "/assets/board/default.svg";
+      board.images.length > 0 ? board.images[0] : withBase("/assets/board/default.svg");
     return html`
       <article class="board-card ${expanded ? "board-card--expanded" : ""}">
         <div class="board-card-header">

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -7,6 +7,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { withBase } from "../../util/base-path.js";
 
 @customElement("esphome-wizard-step-setup")
 export class ESPHomeWizardStepSetup extends LitElement {
@@ -234,7 +235,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
               class="board-image"
               src=${board.images.length > 0
                 ? board.images[0]
-                : "/assets/board/default.svg"}
+                : withBase("/assets/board/default.svg")}
               alt=${board.name}
             />`
           : null}

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -17,5 +17,16 @@ if (typeof crypto !== "undefined" && !crypto.randomUUID) {
     ) as `${string}-${string}-${string}-${string}-${string}`;
 }
 
+import { withBase } from "./util/base-path.js";
+
+// Set the favicon href at runtime so it resolves under any mount
+// point. A static ``href="/assets/..."`` would 404 under an HA
+// ingress prefix; a document-relative ``href="assets/..."`` would
+// resolve against the current route on a deep link (the SPA serves
+// the same index.html for ``/device/<id>``, which would then look
+// for ``/device/assets/...``).
+const favicon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+if (favicon) favicon.href = withBase("/assets/logo/esphome.svg");
+
 import "./styles/apply-theme.js";
 import "./components/app-shell.js";

--- a/src/pages/dashboard-actions.ts
+++ b/src/pages/dashboard-actions.ts
@@ -6,9 +6,10 @@ import type {
   ConfiguredDevice,
 } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import { withBase } from "../util/base-path.js";
 
 export function editDevice(device: ConfiguredDevice) {
-  window.history.pushState({}, "", `/device/${device.configuration}`);
+  window.history.pushState({}, "", withBase(`/device/${device.configuration}`));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -25,6 +25,7 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { withBase } from "../util/base-path.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -285,7 +286,7 @@ export class ESPHomePageDevice extends LitElement {
     }
     if (!this._isDirty) return;
     e.stopImmediatePropagation();
-    window.history.pushState({}, "", `/device/${this.id}`);
+    window.history.pushState({}, "", withBase(`/device/${this.id}`));
     this._confirmLeave().then((canLeave) => {
       if (canLeave) {
         this._allowingLeave = true;

--- a/src/util/base-path.ts
+++ b/src/util/base-path.ts
@@ -1,0 +1,52 @@
+/**
+ * URL path prefix where this app is mounted, with a trailing slash.
+ * "/" for a standalone deployment, "/api/hassio_ingress/<token>/"
+ * under HA ingress, "/some/prefix/" behind a reverse proxy.
+ *
+ * Derived from the entry script's URL — rspack's ``publicPath:
+ * "auto"`` resolves chunk paths from ``document.currentScript.src``
+ * at runtime, and we use the same source so client-side routing,
+ * the WebSocket URL, and hard-coded asset references all line up
+ * with the path the bundle was actually served from. Capturing this
+ * before any ``pushState`` runs is what makes deep links work — once
+ * the SPA navigates, ``window.location.pathname`` no longer reflects
+ * the deployment base.
+ */
+const BASE_PATH: string = ((): string => {
+  // Node test environments (vitest with the default Node pool) have
+  // neither ``document`` nor ``window`` — guard so importing this
+  // module doesn't crash before any test body runs.
+  if (typeof document !== "undefined") {
+    const script = document.currentScript;
+    if (script instanceof HTMLScriptElement && script.src) {
+      try {
+        return new URL(script.src).pathname.replace(/[^/]*$/, "") || "/";
+      } catch {
+        // Fall through to the location-based fallback.
+      }
+    }
+  }
+  if (typeof window !== "undefined") {
+    const path = window.location.pathname;
+    return (path.endsWith("/") ? path : path.replace(/[^/]*$/, "")) || "/";
+  }
+  return "/";
+})();
+
+const BASE_NO_TRAIL = BASE_PATH === "/" ? "" : BASE_PATH.replace(/\/$/, "");
+
+export { BASE_PATH };
+
+/** Prefix an absolute path with the deployment base. Relative paths pass through unchanged. */
+export function withBase(path: string): string {
+  if (!path.startsWith("/")) return path;
+  return BASE_NO_TRAIL + path;
+}
+
+/** Strip the deployment base from a pathname. Returns "/" when the pathname equals the base. */
+export function stripBase(pathname: string): string {
+  if (BASE_NO_TRAIL === "" || !pathname.startsWith(BASE_NO_TRAIL)) {
+    return pathname;
+  }
+  return pathname.slice(BASE_NO_TRAIL.length) || "/";
+}

--- a/src/util/base-path.ts
+++ b/src/util/base-path.ts
@@ -45,8 +45,14 @@ export function withBase(path: string): string {
 
 /** Strip the deployment base from a pathname. Returns "/" when the pathname equals the base. */
 export function stripBase(pathname: string): string {
-  if (BASE_NO_TRAIL === "" || !pathname.startsWith(BASE_NO_TRAIL)) {
-    return pathname;
+  if (BASE_NO_TRAIL === "") return pathname;
+  // Require a path-segment boundary after the prefix so a base of
+  // "/foo" doesn't strip from "/foobar/...". The two valid forms
+  // are pathname === BASE_NO_TRAIL ("/foo") or pathname starts
+  // with BASE_PATH (the trailing-slash form, "/foo/...").
+  if (pathname === BASE_NO_TRAIL) return "/";
+  if (pathname.startsWith(BASE_PATH)) {
+    return pathname.slice(BASE_NO_TRAIL.length) || "/";
   }
-  return pathname.slice(BASE_NO_TRAIL.length) || "/";
+  return pathname;
 }

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -1,3 +1,5 @@
+import { withBase } from "./base-path.js";
+
 export type LeaveGuard = () => Promise<boolean>;
 
 let activeGuard: LeaveGuard | null = null;
@@ -11,6 +13,6 @@ export async function navigate(url: string): Promise<void> {
     const canLeave = await activeGuard();
     if (!canLeave) return;
   }
-  window.history.pushState({}, "", url);
+  window.history.pushState({}, "", withBase(url));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }

--- a/test/util/base-path.test.ts
+++ b/test/util/base-path.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the deployment-base helpers.
+ *
+ * ``base-path.ts`` derives ``BASE_PATH`` once at module load from
+ * ``document.currentScript.src`` (matching rspack's ``publicPath:
+ * "auto"`` resolution). Routing, the WebSocket URL, and the hard-
+ * coded ``/assets/...`` references all flow through ``withBase`` /
+ * ``stripBase``, so a regression here breaks every deployment mode
+ * that isn't a bare ``/`` mount — HA ingress, reverse-proxy
+ * subpaths, the lot.
+ *
+ * Each scenario fakes ``document`` / ``window`` on ``globalThis``
+ * and re-imports the module via ``vi.resetModules()`` so the
+ * top-level ``BASE_PATH`` IIFE re-runs against the new globals.
+ * The ``stripBase`` boundary case ("/foo" must NOT match
+ * "/foobar/...") is the one Copilot flagged on the original PR;
+ * pin it explicitly.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type Globals = Record<string, unknown>;
+
+function setGlobals(opts: {
+  scriptSrc?: string;
+  pathname?: string;
+}): void {
+  const g = globalThis as Globals;
+  // Fake HTMLScriptElement so the ``script instanceof HTMLScriptElement``
+  // guard in ``base-path.ts`` doesn't throw on the missing constructor.
+  class FakeScript {
+    src = "";
+  }
+  g.HTMLScriptElement = FakeScript;
+  if (opts.scriptSrc !== undefined) {
+    const script = new FakeScript();
+    script.src = opts.scriptSrc;
+    g.document = { currentScript: script };
+  } else {
+    g.document = { currentScript: null };
+  }
+  if (opts.pathname !== undefined) {
+    g.window = { location: { pathname: opts.pathname } };
+  }
+}
+
+function clearGlobals(): void {
+  const g = globalThis as Globals;
+  delete g.document;
+  delete g.window;
+  delete g.HTMLScriptElement;
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("../../src/util/base-path.js");
+}
+
+afterEach(() => {
+  clearGlobals();
+  vi.resetModules();
+});
+
+describe("BASE_PATH derivation", () => {
+  it("falls back to '/' when neither document nor window is available", async () => {
+    // No globals — the Node-test guard short-circuits both branches.
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/");
+  });
+
+  it("derives '/' from a root-mounted entry script", async () => {
+    setGlobals({ scriptSrc: "https://example.com/app.abc123.js" });
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/");
+  });
+
+  it("derives the HA ingress prefix from the entry script URL", async () => {
+    setGlobals({
+      scriptSrc:
+        "http://homeassistant.local:8123/api/hassio_ingress/TOKEN/app.abc123.js",
+    });
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/api/hassio_ingress/TOKEN/");
+  });
+
+  it("derives a reverse-proxy subpath from the entry script URL", async () => {
+    setGlobals({ scriptSrc: "https://example.com/some/prefix/app.abc123.js" });
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/some/prefix/");
+  });
+
+  it("falls back to window.location.pathname when no script is present", async () => {
+    // currentScript is null (e.g., async chunk loaded after document
+    // parse) but window.location is still available.
+    setGlobals({ pathname: "/some/prefix/" });
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/some/prefix/");
+  });
+
+  it("strips the trailing filename from a non-slash window.location.pathname fallback", async () => {
+    // Deep link like ``/some/prefix/device/abc`` with no script
+    // signal — the helper has to assume the last segment is a route
+    // and trim it. Imperfect but matches what we can know without
+    // the bundle's own URL.
+    setGlobals({ pathname: "/some/prefix/device/abc" });
+    const { BASE_PATH } = await loadModule();
+    expect(BASE_PATH).toBe("/some/prefix/device/");
+  });
+});
+
+describe("withBase", () => {
+  it("is a no-op for root-mounted deployments", async () => {
+    setGlobals({ scriptSrc: "https://example.com/app.js" });
+    const { withBase } = await loadModule();
+    expect(withBase("/")).toBe("/");
+    expect(withBase("/dashboard")).toBe("/dashboard");
+    expect(withBase("/device/abc")).toBe("/device/abc");
+  });
+
+  it("prefixes absolute paths with the deployment base", async () => {
+    setGlobals({ scriptSrc: "https://example.com/api/hassio_ingress/T/app.js" });
+    const { withBase } = await loadModule();
+    expect(withBase("/")).toBe("/api/hassio_ingress/T/");
+    expect(withBase("/dashboard")).toBe("/api/hassio_ingress/T/dashboard");
+    expect(withBase("/assets/logo/esphome.svg")).toBe(
+      "/api/hassio_ingress/T/assets/logo/esphome.svg",
+    );
+  });
+
+  it("passes relative paths through unchanged", async () => {
+    setGlobals({ scriptSrc: "https://example.com/some/prefix/app.js" });
+    const { withBase } = await loadModule();
+    expect(withBase("dashboard")).toBe("dashboard");
+    expect(withBase("./assets/foo.png")).toBe("./assets/foo.png");
+    expect(withBase("")).toBe("");
+  });
+});
+
+describe("stripBase", () => {
+  it("is a no-op for root-mounted deployments", async () => {
+    setGlobals({ scriptSrc: "https://example.com/app.js" });
+    const { stripBase } = await loadModule();
+    expect(stripBase("/")).toBe("/");
+    expect(stripBase("/dashboard")).toBe("/dashboard");
+    expect(stripBase("/device/abc")).toBe("/device/abc");
+  });
+
+  it("strips the deployment base from a prefixed pathname", async () => {
+    setGlobals({ scriptSrc: "https://example.com/some/prefix/app.js" });
+    const { stripBase } = await loadModule();
+    expect(stripBase("/some/prefix/")).toBe("/");
+    expect(stripBase("/some/prefix/dashboard")).toBe("/dashboard");
+    expect(stripBase("/some/prefix/device/abc")).toBe("/device/abc");
+  });
+
+  it("returns '/' when pathname equals the base without a trailing slash", async () => {
+    // Browser back / direct hit at the bare mount point — the path
+    // can be either ``/foo`` or ``/foo/`` depending on the redirect
+    // story; both should map to the app's "/" route.
+    setGlobals({ scriptSrc: "https://example.com/foo/app.js" });
+    const { stripBase } = await loadModule();
+    expect(stripBase("/foo")).toBe("/");
+    expect(stripBase("/foo/")).toBe("/");
+  });
+
+  it("does NOT strip from a pathname that merely shares a leading prefix", async () => {
+    // Regression for the Copilot-flagged boundary bug: ``startsWith``
+    // alone would have stripped ``/foo`` from ``/foobar/...``,
+    // breaking back-button comparisons on any deployment whose
+    // sibling routes happened to share a name prefix with the mount.
+    setGlobals({ scriptSrc: "https://example.com/foo/app.js" });
+    const { stripBase } = await loadModule();
+    expect(stripBase("/foobar")).toBe("/foobar");
+    expect(stripBase("/foobar/baz")).toBe("/foobar/baz");
+    expect(stripBase("/food")).toBe("/food");
+  });
+
+  it("returns the original pathname when there is no overlap with the base", async () => {
+    setGlobals({ scriptSrc: "https://example.com/some/prefix/app.js" });
+    const { stripBase } = await loadModule();
+    expect(stripBase("/other")).toBe("/other");
+    expect(stripBase("/")).toBe("/");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Makes the frontend work when served from a non-root URL — primarily Home Assistant ingress (e.g. `/api/hassio_ingress/<token>/`), but also any reverse-proxy subpath. Previously the built HTML hard-coded `<script src="/app.<hash>.js">`, so loading the dashboard through HA ingress 404'd before the app could boot:

```
GET http://homeassistant.local:8123/app.d63d0cfb81212854.js  → 404
```

Switches rspack's `publicPath` to `"auto"` so the entry script emits a relative URL, and adds a small `src/util/base-path.ts` helper that captures the deployment prefix from the entry script's own URL (the same signal rspack uses for async chunks). Every absolute path then routes through that helper:

- `@lit-labs/router` route patterns and every `pushState`/`navigate()` call
- The `/ws` WebSocket URL
- The favicon and the hard-coded `/assets/...` image references
- The `_isHaIngress` detection (now reads `BASE_PATH` instead of the live, post-pushState pathname)
- The back-button check in `esphome-layout` strips the base before comparing to `/`

Standalone deployments are unaffected — `BASE_PATH` resolves to `/` when there's no prefix, and `withBase("/foo")` is a no-op in that case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).