### PR TITLE
Mask values in secrets editor with reveal toggle

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -78,9 +78,9 @@ export class ESPHomeYamlEditor extends LitElement {
   /** When true, EVERY key/value pair is masked — used by the
    *  `secrets.yaml` editor, where the entire file is by definition
    *  a list of credentials and the per-key allowlist (password,
-   *  ota_password, encryption.key, …) doesn't apply. Read at
-   *  extension-construction time; remount the editor to change it
-   *  at runtime. */
+   *  ota_password, encryption.key, …) doesn't apply. Captured at
+   *  extension-construction time; runtime changes trigger an
+   *  editor remount via `updated()` (same path dark-mode uses). */
   @property({ type: Boolean }) maskAllValues = false;
 
   @query(".cm-wrap") private _container!: HTMLDivElement;
@@ -386,15 +386,19 @@ export class ESPHomeYamlEditor extends LitElement {
     // would dispatch a stale-cursor preservation against the
     // freshly-mounted view.
 
-    // Theme / API changes require a full editor rebuild — CodeMirror
-    // extensions are static once the state is built. The user may
-    // have unsaved edits in the view that the parent's `value` prop
-    // doesn't yet reflect (the parent only learns about edits via
-    // `yaml-change`, which it loops back as `value`), so preserve
-    // the current view content across the rebuild by writing it
-    // back into `this.value` before remounting.
+    // Theme / API / maskAllValues changes require a full editor
+    // rebuild — CodeMirror extensions are static once the state is
+    // built, and the mask-all flag is captured at extension
+    // construction time. The user may have unsaved edits in the
+    // view that the parent's `value` prop doesn't yet reflect (the
+    // parent only learns about edits via `yaml-change`, which it
+    // loops back as `value`), so preserve the current view content
+    // across the rebuild by writing it back into `this.value`
+    // before remounting.
     if (
-      (changed.has("_darkMode") || changed.has("_api")) &&
+      (changed.has("_darkMode") ||
+        changed.has("_api") ||
+        changed.has("maskAllValues")) &&
       this._view
     ) {
       this.value = this._view.state.doc.toString();

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -75,6 +75,14 @@ export class ESPHomeYamlEditor extends LitElement {
    *  `!secret`-tag handling — this only affects raw inline values. */
   @property({ type: Boolean }) revealSensitive = false;
 
+  /** When true, EVERY key/value pair is masked — used by the
+   *  `secrets.yaml` editor, where the entire file is by definition
+   *  a list of credentials and the per-key allowlist (password,
+   *  ota_password, encryption.key, …) doesn't apply. Read at
+   *  extension-construction time; remount the editor to change it
+   *  at runtime. */
+  @property({ type: Boolean }) maskAllValues = false;
+
   @query(".cm-wrap") private _container!: HTMLDivElement;
 
   private _view: EditorView | null = null;
@@ -113,7 +121,7 @@ export class ESPHomeYamlEditor extends LitElement {
       indentUnit.of(ESPHOME_YAML_INDENT),
       keymap.of([indentWithTab]),
       highlightField,
-      sensitiveValueMaskExtension(this.revealSensitive),
+      sensitiveValueMaskExtension(this.revealSensitive, this.maskAllValues),
       EditorView.theme({
         "&": { height: "100%" },
         ".cm-scroller": {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowLeft, mdiContentSave } from "@mdi/js";
+import { mdiArrowLeft, mdiContentSave, mdiEye, mdiEyeOff } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import toast from "sonner-js";
@@ -18,6 +18,8 @@ import "../components/yaml-editor.js";
 registerMdiIcons({
   "arrow-left": mdiArrowLeft,
   "content-save": mdiContentSave,
+  eye: mdiEye,
+  "eye-off": mdiEyeOff,
 });
 
 const SECRETS_FILE = "secrets.yaml";
@@ -42,6 +44,12 @@ export class ESPHomePageSecrets extends LitElement {
 
   @state()
   private _loaded = false;
+
+  // Mirrors the device editor's per-field reveal toggle. Default
+  // hidden so values render as bullets the moment the page paints —
+  // anyone glancing at the screen sees masks, not the raw secrets.
+  @state()
+  private _revealSensitive = false;
 
   async connectedCallback() {
     super.connectedCallback();
@@ -161,10 +169,46 @@ export class ESPHomePageSecrets extends LitElement {
         font-size: var(--wa-font-size-l);
         color: var(--esphome-primary);
       }
+
+      .reveal-toggle {
+        border: none;
+        background: transparent;
+        color: var(--esphome-primary);
+        padding: 6px 8px;
+        border-radius: var(--wa-border-radius-m);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: inherit;
+      }
+
+      .reveal-toggle:hover {
+        background: color-mix(
+          in srgb,
+          var(--esphome-primary),
+          transparent 90%
+        );
+      }
+
+      .reveal-toggle[aria-pressed="true"] {
+        background: color-mix(
+          in srgb,
+          var(--esphome-primary),
+          transparent 85%
+        );
+      }
+
+      .reveal-toggle wa-icon {
+        font-size: var(--wa-font-size-l);
+      }
     `,
   ];
 
   protected render() {
+    const revealLabel = this._localize(
+      this._revealSensitive ? "secrets.hide_values" : "secrets.reveal_values",
+    );
     return html`
       <div class="page">
         <div class="page-header">
@@ -175,6 +219,19 @@ export class ESPHomePageSecrets extends LitElement {
             <h1>${this._localize("secrets.title")}</h1>
             <p>${this._localize("secrets.desc")}</p>
           </div>
+          <button
+            type="button"
+            class="reveal-toggle"
+            aria-pressed=${this._revealSensitive}
+            aria-label=${revealLabel}
+            title=${revealLabel}
+            @click=${this._toggleRevealSensitive}
+          >
+            <wa-icon
+              library="mdi"
+              name=${this._revealSensitive ? "eye-off" : "eye"}
+            ></wa-icon>
+          </button>
         </div>
         <wa-divider></wa-divider>
         <div class="editor-card">
@@ -191,6 +248,8 @@ export class ESPHomePageSecrets extends LitElement {
           </button>
           <esphome-yaml-editor
             .value=${this._yaml}
+            .maskAllValues=${true}
+            .revealSensitive=${this._revealSensitive}
             @yaml-change=${(e: CustomEvent) => {
               this._yaml = e.detail.value;
             }}
@@ -198,6 +257,10 @@ export class ESPHomePageSecrets extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  private _toggleRevealSensitive() {
+    this._revealSensitive = !this._revealSensitive;
   }
 
   private _goBack() {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -663,6 +663,8 @@
     "saving": "Saving…",
     "saved": "Secrets saved",
     "save_error": "Failed to save secrets",
+    "reveal_values": "Reveal values",
+    "hide_values": "Hide values",
     "file_header": "# Secrets — store sensitive values here and reference them\n# in your device configurations using !secret <key>\n#\n# Example:\n#   wifi_ssid: \"your-network-name\"\n#   wifi_password: \"your-password\"\n"
   },
   "auth": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -529,6 +529,8 @@
     "saving": "Enregistrement…",
     "saved": "Secrets enregistrés",
     "save_error": "Échec de l'enregistrement des secrets",
+    "reveal_values": "Afficher les valeurs",
+    "hide_values": "Masquer les valeurs",
     "file_header": "# Secrets — stockez vos valeurs sensibles ici et référencez-les\n# dans vos configurations d'appareils avec !secret <clé>\n#\n# Exemple :\n#   wifi_ssid: \"nom-de-votre-réseau\"\n#   wifi_password: \"votre-mot-de-passe\"\n"
   },
   "firmware": {

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -529,6 +529,8 @@
     "saving": "Opslaan…",
     "saved": "Geheimen opgeslagen",
     "save_error": "Opslaan van geheimen mislukt",
+    "reveal_values": "Waarden tonen",
+    "hide_values": "Waarden verbergen",
     "file_header": "# Geheimen — sla gevoelige waarden hier op en verwijs ernaar\n# in uw apparaatconfiguraties met !secret <sleutel>\n#\n# Voorbeeld:\n#   wifi_ssid: \"uw-netwerknaam\"\n#   wifi_password: \"uw-wachtwoord\"\n"
   },
   "firmware": {

--- a/src/util/yaml-sensitive-mask.ts
+++ b/src/util/yaml-sensitive-mask.ts
@@ -33,7 +33,11 @@ export const setRevealSensitiveEffect = StateEffect.define<boolean>();
 
 const sensitiveMark = Decoration.mark({ class: "cm-esphome-sensitive-value" });
 
-function computeDecorations(state: EditorState, revealed: boolean): DecorationSet {
+function computeDecorations(
+  state: EditorState,
+  revealed: boolean,
+  maskAllValues: boolean,
+): DecorationSet {
   if (revealed) return Decoration.none;
   const doc = state.doc;
   // Pass ``EditorState.doc`` (CodeMirror's ``Text``) directly to
@@ -43,7 +47,7 @@ function computeDecorations(state: EditorState, revealed: boolean): DecorationSe
   // the editor's update listener already pays one ``toString()``
   // for the ``yaml-change`` dispatch and we don't want to double
   // that just to compute mask decorations.
-  const ranges = findSensitiveValueRanges(doc);
+  const ranges = findSensitiveValueRanges(doc, { maskAllValues });
   if (ranges.length === 0) return Decoration.none;
   const built: Range<Decoration>[] = [];
   for (const r of ranges) {
@@ -56,7 +60,10 @@ function computeDecorations(state: EditorState, revealed: boolean): DecorationSe
   return Decoration.set(built, true);
 }
 
-export function sensitiveValueMaskExtension(initialReveal = false): Extension {
+export function sensitiveValueMaskExtension(
+  initialReveal = false,
+  maskAllValues = false,
+): Extension {
   // Holds the current reveal flag so the field can short-circuit
   // when the user has the toolbar reveal button on.
   const revealedField = StateField.define<boolean>({
@@ -73,8 +80,15 @@ export function sensitiveValueMaskExtension(initialReveal = false): Extension {
   // flag flips. Living in a StateField (not a ViewPlugin) means the
   // decorations are part of the editor state and the initial doc
   // mounts already-masked — no flash of plaintext on load.
+  //
+  // ``maskAllValues`` is captured here at extension-construction
+  // time. The flag is set once by the host page (false everywhere
+  // except the secrets editor) and is not expected to toggle at
+  // runtime — a change would require rebuilding the editor (the
+  // same path dark-mode and configuration changes already use).
   const decoField = StateField.define<DecorationSet>({
-    create: (state) => computeDecorations(state, state.field(revealedField)),
+    create: (state) =>
+      computeDecorations(state, state.field(revealedField), maskAllValues),
     update(decos, tr) {
       const revealed = tr.state.field(revealedField);
       const revealedChanged = tr.effects.some((e) =>
@@ -83,7 +97,7 @@ export function sensitiveValueMaskExtension(initialReveal = false): Extension {
       if (!tr.docChanged && !revealedChanged) {
         return decos.map(tr.changes);
       }
-      return computeDecorations(tr.state, revealed);
+      return computeDecorations(tr.state, revealed, maskAllValues);
     },
     provide: (f) => EditorView.decorations.from(f),
   });

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -30,6 +30,13 @@ export interface SensitiveValueRange {
   valueTo: number;
 }
 
+export interface FindSensitiveValueRangesOptions {
+  /** When true, every key/value pair is treated as sensitive — used
+   *  for `secrets.yaml`, where the entire file is by definition a
+   *  list of credentials and the per-key allowlist doesn't apply. */
+  maskAllValues?: boolean;
+}
+
 // Keys whose values are always credentials regardless of where they
 // appear in the document. These names are stable across the ESPHome
 // catalog (api/ota/mqtt/wifi/web_server/http_request all spell their
@@ -118,7 +125,9 @@ function isLineSource(value: string | LineSource): value is LineSource {
 
 export function findSensitiveValueRanges(
   yaml: string | LineSource,
+  options: FindSensitiveValueRangesOptions = {},
 ): SensitiveValueRange[] {
+  const { maskAllValues = false } = options;
   const ranges: SensitiveValueRange[] = [];
   let lines: string[];
   if (isLineSource(yaml)) {
@@ -163,11 +172,16 @@ export function findSensitiveValueRanges(
       stack.pop();
     }
 
-    let sensitive = ALWAYS_SENSITIVE_KEYS.has(key);
-    if (!sensitive && stack.length > 0) {
-      const parent = stack[stack.length - 1].key;
-      const allowed = PARENT_SCOPED_SENSITIVE_KEYS[parent];
-      if (allowed && allowed.has(key)) sensitive = true;
+    let sensitive: boolean;
+    if (maskAllValues) {
+      sensitive = true;
+    } else {
+      sensitive = ALWAYS_SENSITIVE_KEYS.has(key);
+      if (!sensitive && stack.length > 0) {
+        const parent = stack[stack.length - 1].key;
+        const allowed = PARENT_SCOPED_SENSITIVE_KEYS[parent];
+        if (allowed && allowed.has(key)) sensitive = true;
+      }
     }
 
     stack.push({ indent, key });

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -64,7 +64,16 @@ const PARENT_SCOPED_SENSITIVE_KEYS: Record<string, Set<string>> = {
   encryption: new Set(["key"]),
 };
 
-const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_]*):(\s*)(.*)$/;
+// Plain-scalar key matcher. Permits hyphens and dots inside the
+// key so user-defined secret names like `wifi-password:` or
+// `mqtt.user:` are recognised — important for the secrets editor's
+// `maskAllValues` mode where every key/value pair is supposed to
+// be masked. The leading-character class stays restrictive
+// (`[a-zA-Z_]`) so we don't pick up numeric scalars or list
+// dashes as keys. Quoted keys (`"my key": …`) are still not
+// matched; they're rare enough in ESPHome configs and
+// `secrets.yaml` that we accept the limitation.
+const KEY_LINE = /^(\s*)(-\s+)?([a-zA-Z_][a-zA-Z0-9_.\-]*):(\s*)(.*)$/;
 // Block-scalar header tail: `|`, `>`, optional chomping indicator (`+`/`-`),
 // optional explicit indentation digit, optional trailing comment.
 const BLOCK_SCALAR_HEADER = /^[|>][+-]?\d*\s*(#.*)?$/;

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -359,5 +359,22 @@ wifi_password: should-be-skipped-without-flag
       // nothing here.
       expect(findSensitiveValueRanges(yaml)).toEqual([]);
     });
+
+    it("masks values for keys with hyphens and dots", () => {
+      // secrets.yaml has user-defined keys — kebab-case and
+      // dot.notation are both legal YAML. Without the broadened
+      // KEY_LINE matcher these lines wouldn't match the scanner
+      // and their values would slip through unmasked.
+      const yaml = `wifi-password: kebab-secret
+mqtt.user: dotted-user
+api-key.v2: mixed-secret
+`;
+      const ranges = findSensitiveValueRanges(yaml, { maskAllValues: true });
+      expect(valuesAt(yaml, ranges)).toEqual([
+        "kebab-secret",
+        "dotted-user",
+        "mixed-secret",
+      ]);
+    });
   });
 });

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -280,4 +280,84 @@ ota:
       `"with \\"escaped\\" inside"`,
     ]);
   });
+
+  describe("maskAllValues mode (secrets.yaml)", () => {
+    it("masks every key/value pair regardless of key name", () => {
+      // A typical secrets.yaml has user-defined keys (`wifi_ssid`,
+      // `api_key`, …) that aren't in the per-key allowlist. With
+      // maskAllValues every value is treated as a credential.
+      const yaml = `wifi_ssid: my-network
+wifi_password: mywifipass
+api_key: deadbeef
+fallback_hotspot_password: fallback123
+`;
+      const ranges = findSensitiveValueRanges(yaml, { maskAllValues: true });
+      expect(valuesAt(yaml, ranges)).toEqual([
+        "my-network",
+        "mywifipass",
+        "deadbeef",
+        "fallback123",
+      ]);
+    });
+
+    it("does not mask comments or comment-only lines", () => {
+      // The default file_header is all comments — those mustn't
+      // become bullets, the user needs to read the example.
+      const yaml = `# Secrets file
+# Example:
+#   wifi_ssid: "your-network"
+wifi_ssid: real-value
+`;
+      const ranges = findSensitiveValueRanges(yaml, { maskAllValues: true });
+      expect(valuesAt(yaml, ranges)).toEqual(["real-value"]);
+    });
+
+    it("strips trailing comments from the masked range", () => {
+      const yaml = `wifi_password: mywifipass  # set in deploy
+`;
+      const ranges = findSensitiveValueRanges(yaml, { maskAllValues: true });
+      expect(valuesAt(yaml, ranges)).toEqual(["mywifipass"]);
+    });
+
+    it("masks block-scalar bodies but not the header line", () => {
+      const yaml = `api_token: |
+  multi
+  line
+  secret
+`;
+      const ranges = findSensitiveValueRanges(yaml, { maskAllValues: true });
+      expect(valuesAt(yaml, ranges)).toEqual(["multi", "line", "secret"]);
+    });
+
+    it("does not mask !secret references (orthogonal indirection)", () => {
+      // Edge case: a user shouldn't write `!secret` inside
+      // secrets.yaml itself, but if they do we still skip it.
+      const yaml = `wifi_password: !secret real_password
+`;
+      expect(
+        findSensitiveValueRanges(yaml, { maskAllValues: true }),
+      ).toEqual([]);
+    });
+
+    it("ignores key-only lines with no inline value", () => {
+      const yaml = `wifi_ssid:
+api_key:
+`;
+      expect(
+        findSensitiveValueRanges(yaml, { maskAllValues: true }),
+      ).toEqual([]);
+    });
+
+    it("default mode is unaffected (no maskAllValues option)", () => {
+      // Defensive: confirm the default behaviour still scopes to the
+      // sensitive-key allowlist when the option is omitted.
+      const yaml = `wifi_ssid: my-network
+wifi_password: should-be-skipped-without-flag
+`;
+      // `wifi_password` is NOT in ALWAYS_SENSITIVE_KEYS — only
+      // `password` (without the prefix) is. So default mode masks
+      // nothing here.
+      expect(findSensitiveValueRanges(yaml)).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Values in the secrets editor were rendered as plain text — anyone glancing at someone's screen could read every credential at once. The device YAML editor already masks sensitive values with a reveal toggle; this brings the same UX to `secrets.yaml`, where every value is by definition a secret.

- Add a `maskAllValues` mode to the YAML sensitive-value scanner — bypasses the per-key allowlist and treats every `key: value` line as a credential. Comments, key-only lines, `!secret` references and block-scalar handling all carry over unchanged.
- Plumb the flag through `sensitiveValueMaskExtension` and the `<esphome-yaml-editor>` component (default `false`, so the device editor is unaffected).
- Set `maskAllValues=true` on the secrets page and add an eye / eye-off toggle in the page header to reveal/hide all values at once, mirroring the device editor pattern.
- Add `secrets.reveal_values` / `secrets.hide_values` in en/nl/fr.
- Cover the new mode with unit tests (comments, block scalars, `!secret` skip, default-mode regression).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [x] Tests have been added to verify that the new code works (where applicable).
