### PR TITLE
Tighten labels: equal card heights, icon filter, regrouped toolbar

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -464,8 +464,9 @@ export class ESPHomeApp extends LitElement {
    *  the latest state — push events drive it day-to-day, but a
    *  reconnect crosses a window where events were dropped. A failure
    *  here is non-fatal: ``_labels`` stays at its previous value (or
-   *  empty on first load); device chips fall back to a neutral
-   *  "(unknown)" placeholder. */
+   *  empty on first load); chip renderers silently drop unknown ids
+   *  and the toolbar filter hides itself on an empty catalog, so the
+   *  missing data simply produces no visible UI. */
   private async _loadLabels() {
     try {
       this._labels = await this._api.listLabels();

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -162,17 +162,19 @@ export class ESPHomeDeviceCard extends LitElement {
       /* Always present so cards line up at equal height regardless
          of whether a particular device carries labels — without the
          reserved row, a single tagged device in the grid bumps every
-         neighbour out of column-baseline alignment. The min-height
-         matches one chip's natural height (chip line-height 1.4 +
-         padding) so an empty row leaves the same gap a single chip
-         would. */
+         neighbour out of column-baseline alignment. The reserved
+         vertical space (padding + min-height) matches a single-chip
+         row exactly: 21px chip height + 6px top + 6px bottom = 33px.
+         align-items:center keeps the chip(s) vertically centred so a
+         tag-overflow case doesn't drag the chip baseline off the
+         shared rhythm. */
       .device-card-labels {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
         gap: 4px;
-        padding: 0 var(--wa-space-m) var(--wa-space-s);
-        margin-top: -2px;
-        min-height: 22px;
+        padding: 6px var(--wa-space-m);
+        min-height: 21px;
       }
     `,
     css`

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -159,22 +159,18 @@ export class ESPHomeDeviceCard extends LitElement {
     espHomeStyles,
     labelChipStyles,
     css`
-      /* Always present so cards line up at equal height regardless
-         of whether a particular device carries labels — without the
-         reserved row, a single tagged device in the grid bumps every
-         neighbour out of column-baseline alignment. The reserved
-         vertical space (padding + min-height) matches a single-chip
-         row exactly: 21px chip height + 6px top + 6px bottom = 33px.
-         align-items:center keeps the chip(s) vertically centred so a
-         tag-overflow case doesn't drag the chip baseline off the
-         shared rhythm. */
+      /* Only rendered when the device carries labels; an untagged
+         device gets no chip row and the card collapses naturally.
+         Padding leans top-heavy (8px top vs 4px bottom) because the
+         actions row that follows already carries its own
+         var(--wa-space-s) of top padding, so a symmetric padding
+         here reads as more space below the chips than above. */
       .device-card-labels {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
         gap: 4px;
-        padding: 6px var(--wa-space-m);
-        min-height: 21px;
+        padding: 8px var(--wa-space-m) 4px;
       }
     `,
     css`
@@ -679,13 +675,14 @@ export class ESPHomeDeviceCard extends LitElement {
   /** Render the device's label chips just below the name / status
    *  header. Caps at 4 visible chips with a "+N" overflow chip so a
    *  heavily-tagged device doesn't blow out the card height; the
-   *  full set is reachable from the drawer. The container is always
-   *  rendered (with ``min-height``) so cards keep equal heights
-   *  whether a particular device carries labels or not. */
+   *  full set is reachable from the drawer. ``nothing`` when the
+   *  device carries no labels — the card collapses naturally so
+   *  untagged cards don't show an empty band. */
   private _renderLabels() {
     const labels = resolveLabelIds(this.labelIds, this._labelCatalog);
+    if (labels.length === 0) return nothing;
     return html`<div class="device-card-labels">
-      ${labels.length === 0 ? nothing : renderLabelChips(labels, { max: 4 })}
+      ${renderLabelChips(labels, { max: 4 })}
     </div>`;
   }
 

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -159,12 +159,20 @@ export class ESPHomeDeviceCard extends LitElement {
     espHomeStyles,
     labelChipStyles,
     css`
+      /* Always present so cards line up at equal height regardless
+         of whether a particular device carries labels — without the
+         reserved row, a single tagged device in the grid bumps every
+         neighbour out of column-baseline alignment. The min-height
+         matches one chip's natural height (chip line-height 1.4 +
+         padding) so an empty row leaves the same gap a single chip
+         would. */
       .device-card-labels {
         display: flex;
         flex-wrap: wrap;
         gap: 4px;
         padding: 0 var(--wa-space-m) var(--wa-space-s);
         margin-top: -2px;
+        min-height: 22px;
       }
     `,
     css`
@@ -669,14 +677,13 @@ export class ESPHomeDeviceCard extends LitElement {
   /** Render the device's label chips just below the name / status
    *  header. Caps at 4 visible chips with a "+N" overflow chip so a
    *  heavily-tagged device doesn't blow out the card height; the
-   *  full set is reachable from the drawer. ``nothing`` when the
-   *  device carries no labels — keeps the card visually unchanged
-   *  for the typical un-tagged device. */
+   *  full set is reachable from the drawer. The container is always
+   *  rendered (with ``min-height``) so cards keep equal heights
+   *  whether a particular device carries labels or not. */
   private _renderLabels() {
     const labels = resolveLabelIds(this.labelIds, this._labelCatalog);
-    if (labels.length === 0) return nothing;
     return html`<div class="device-card-labels">
-      ${renderLabelChips(labels, { max: 4 })}
+      ${labels.length === 0 ? nothing : renderLabelChips(labels, { max: 4 })}
     </div>`;
   }
 

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -75,10 +75,6 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   @property({ attribute: false })
   device!: ConfiguredDevice;
 
-  /** Whether the assignment dialog is currently open. */
-  @state()
-  private _dialogOpen = false;
-
   /** Substring filter applied to the catalog inside the dialog.
    *  Case-insensitive. */
   @state()
@@ -147,6 +143,13 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       .assigned-chip {
         position: relative;
         padding-right: 6px;
+        /* Override the shared label-chip 'overflow: hidden' so a
+           keyboard focus ring on the nested remove button isn't
+           clipped at the chip's rounded edge. The chip's own ellipsis
+           still works because the label text is truncated by the
+           inline 'title' and the chip's natural width (driven by
+           white-space:nowrap) — no overflow clip needed for that. */
+        overflow: visible;
       }
 
       .assigned-chip .remove-btn {
@@ -167,6 +170,12 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
       .assigned-chip .remove-btn:hover {
         opacity: 1;
+      }
+
+      .assigned-chip .remove-btn:focus-visible {
+        opacity: 1;
+        outline: 2px solid currentColor;
+        outline-offset: 1px;
       }
 
       .assigned-chip .remove-btn wa-icon {
@@ -390,13 +399,17 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     if (changed.has("device")) {
       // Reset transient state when the drawer swaps to a different
       // device; otherwise a half-typed "create" form would persist
-      // into the next device's editor.
-      this._dialogOpen = false;
+      // into the next device's editor and a still-pending save
+      // chained against the previous device would gate this one's
+      // ``_saving`` indicator until that promise settled.
+      if (this._dialog) this._dialog.open = false;
       this._filter = "";
       this._createOpen = false;
       this._newName = "";
       this._newColor = null;
       this._optimisticLabels = null;
+      this._saving = false;
+      this._saveChain = Promise.resolve();
     }
   }
 
@@ -635,7 +648,6 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   }
 
   private _openDialog = () => {
-    this._dialogOpen = true;
     this._filter = "";
     this._createOpen = false;
     this._newName = "";
@@ -644,7 +656,6 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   };
 
   private _onDialogClose = () => {
-    this._dialogOpen = false;
     this._filter = "";
     this._createOpen = false;
     this._newName = "";

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -14,7 +14,6 @@
 import { consume } from "@lit/context";
 import {
   mdiCheck,
-  mdiChevronDown,
   mdiTagMultipleOutline,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
@@ -34,7 +33,6 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   check: mdiCheck,
-  "chevron-down": mdiChevronDown,
   "tag-multiple-outline": mdiTagMultipleOutline,
 });
 
@@ -71,36 +69,54 @@ export class ESPHomeLabelsFilter extends LitElement {
         position: relative;
       }
 
+      /* Match the dashboard's other icon-button affordances
+         ('select-toggle-btn' + segmented 'view-toggle-btn'): 36px
+         square, neutral fill, primary fill when active. The active
+         count rides as a small badge in the upper-right corner so
+         the button stays icon-sized at any selection count. */
       .trigger {
+        position: relative;
         display: inline-flex;
         align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        background: var(--wa-color-surface-default);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        justify-content: center;
+        width: 36px;
+        height: 36px;
         border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-raised);
+        color: var(--wa-color-text-quiet);
         cursor: pointer;
-        white-space: nowrap;
+        transition:
+          background 0.12s,
+          color 0.12s,
+          border-color 0.12s;
+        padding: 0;
+        flex-shrink: 0;
       }
 
       .trigger:hover {
-        border-color: var(--wa-color-text-quiet);
+        background: var(--wa-color-surface-lowered);
+        color: var(--wa-color-text-normal);
       }
 
       .trigger--active {
+        background: var(--esphome-primary);
+        color: var(--esphome-on-primary);
         border-color: var(--esphome-primary);
-        color: var(--esphome-primary);
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+      }
+
+      .trigger--active:hover {
+        background: color-mix(in srgb, var(--esphome-primary), black 10%);
       }
 
       .trigger wa-icon {
-        font-size: 14px;
+        font-size: 18px;
       }
 
       .count-badge {
+        position: absolute;
+        top: -4px;
+        right: -4px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -108,10 +124,20 @@ export class ESPHomeLabelsFilter extends LitElement {
         height: 16px;
         padding: 0 4px;
         border-radius: 999px;
-        font-size: var(--wa-font-size-2xs);
+        font-size: 10px;
         font-weight: var(--wa-font-weight-bold);
+        line-height: 1;
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
+        border: 2px solid var(--wa-color-surface-default);
+      }
+
+      /* When the button itself is filled (active state), the badge
+         needs the inverse outline to stay distinct. */
+      .trigger--active .count-badge {
+        background: var(--wa-color-surface-default);
+        color: var(--esphome-primary);
+        border-color: var(--esphome-primary);
       }
 
       .popover {
@@ -230,18 +256,21 @@ export class ESPHomeLabelsFilter extends LitElement {
     if (this._catalog.length === 0) return nothing;
     const selectedSet = new Set(this.selected);
     const count = this.selected.length;
+    const label = this._localize("dashboard.filter_labels");
     return html`
       <button
         class="trigger ${count > 0 ? "trigger--active" : ""}"
         type="button"
+        title=${label}
+        aria-label=${label}
         aria-haspopup="true"
         aria-expanded=${this._open ? "true" : "false"}
         @click=${this._toggle}
       >
         <wa-icon library="mdi" name="tag-multiple-outline"></wa-icon>
-        <span>${this._localize("dashboard.filter_labels")}</span>
-        ${count > 0 ? html`<span class="count-badge">${count}</span>` : nothing}
-        <wa-icon library="mdi" name="chevron-down"></wa-icon>
+        ${count > 0
+          ? html`<span class="count-badge" aria-hidden="true">${count}</span>`
+          : nothing}
       </button>
       ${this._open ? this._renderPopover(selectedSet) : nothing}
     `;

--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -137,6 +137,23 @@ export const dashboardStyles = css`
     gap: var(--wa-space-s);
   }
 
+  /* Pushes the filter group to the right edge of the toolbar so
+     view-toggles (left of the spacer) and filter affordances
+     (right of the spacer) read as separate clusters. Collapses to
+     zero on viewports too narrow to afford it — the row wraps via
+     'flex-wrap' higher up if individual buttons overflow. */
+  .toolbar-spacer {
+    flex: 1 1 auto;
+    min-width: var(--wa-space-s);
+  }
+
+  .filter-group {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+    flex-shrink: 0;
+  }
+
   .search-wrap {
     max-width: 380px;
     flex: 1;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -458,6 +458,8 @@ export class ESPHomePageDashboard extends LitElement {
       <div class="toolbar">
         <div class="toolbar-row">
           ${this._renderSearchInput()} ${this._renderViewToggle()}
+          <span class="toolbar-spacer"></span>
+          ${this._renderFilterGroup()}
         </div>
         ${this._renderDiscoveryHint()}
         ${matchCount !== null
@@ -697,13 +699,11 @@ export class ESPHomePageDashboard extends LitElement {
     const yaml = this._yamlMode;
     const cardsLabel = this._localize("dashboard.view_cards");
     const tableLabel = this._localize("dashboard.view_table");
-    const yamlLabel = this._localize("yaml_search.switch_to_yaml");
-    // Three-way segmented control: device-list view (cards or
-    // table) plus a YAML-content-search mode. Only one button
-    // shows ``active`` at a time. Clicking cards / table while
-    // in YAML mode flips out of YAML and sets the chosen view;
-    // clicking ``{}`` flips into YAML mode and the underlying
-    // ``_view`` is preserved for when the user returns.
+    // Two-way segmented control for the device-list view. The YAML
+    // mode used to live here as a third segment but reads better
+    // grouped with the labels filter — it's a "narrow what's
+    // showing" affordance, not a "how is it laid out" choice. See
+    // ``_renderFilterGroup`` for the YAML-mode button.
     return html`
       <div
         class="view-toggle"
@@ -730,13 +730,30 @@ export class ESPHomePageDashboard extends LitElement {
         >
           <wa-icon library="mdi" name="table"></wa-icon>
         </button>
+      </div>
+    `;
+  }
+
+  /** Group the filtering affordances — labels filter + YAML-content
+   *  toggle — into one cluster sitting at the right of the toolbar.
+   *  Both narrow what the device list shows; pairing them visually
+   *  keeps the "how do I find a thing" tools together and away from
+   *  the view-mode toggle, which controls layout, not filtering. */
+  private _renderFilterGroup() {
+    const yaml = this._yamlMode;
+    const yamlLabel = this._localize(
+      yaml ? "yaml_search.switch_to_devices" : "yaml_search.switch_to_yaml",
+    );
+    return html`
+      <div class="filter-group">
+        ${this._renderLabelsFilter()}
         <button
-          class="view-toggle-btn ${yaml ? "active" : ""}"
+          class="select-toggle-btn ${yaml ? "active" : ""}"
           type="button"
           title=${yamlLabel}
           aria-label=${yamlLabel}
           aria-pressed=${yaml ? "true" : "false"}
-          @click=${() => this._setSearchMode(true)}
+          @click=${this._toggleSearchMode}
         >
           <wa-icon library="mdi" name="code-braces"></wa-icon>
         </button>
@@ -976,8 +993,10 @@ export class ESPHomePageDashboard extends LitElement {
     return html`
       <div class="toolbar">
         <div class="toolbar-row">
-          ${this._renderSearchInput()} ${this._renderLabelsFilter()}
-          ${this._renderSelectToggle()} ${this._renderViewToggle()}
+          ${this._renderSearchInput()} ${this._renderSelectToggle()}
+          ${this._renderViewToggle()}
+          <span class="toolbar-spacer"></span>
+          ${this._renderFilterGroup()}
         </div>
         ${this._renderDiscoveryHint()}
         <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
@@ -1164,8 +1183,10 @@ export class ESPHomePageDashboard extends LitElement {
       >
         <div slot="toolbar" class="toolbar-stack">
           <div class="toolbar-row">
-            ${this._renderSearchInput()} ${this._renderLabelsFilter()}
-            ${this._renderSelectToggle()} ${this._renderViewToggle()}
+            ${this._renderSearchInput()} ${this._renderSelectToggle()}
+            ${this._renderViewToggle()}
+            <span class="toolbar-spacer"></span>
+            ${this._renderFilterGroup()}
           </div>
           ${this._renderDiscoveryHint()}
         </div>

--- a/test/util/label-style.test.ts
+++ b/test/util/label-style.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  LABEL_COLOR_SWATCHES,
+  labelChipStyle,
+  labelChipStyleString,
+} from "../../src/util/label-style.js";
+
+const NEUTRAL_BG = "var(--wa-color-surface-lowered)";
+const NEUTRAL_FG = "var(--wa-color-text-quiet)";
+const NEUTRAL_BORDER = "var(--wa-color-surface-border)";
+
+describe("labelChipStyle", () => {
+  it("returns the neutral palette for null / undefined / empty input", () => {
+    for (const value of [null, undefined, ""]) {
+      const style = labelChipStyle(value);
+      expect(style.background).toBe(NEUTRAL_BG);
+      expect(style.color).toBe(NEUTRAL_FG);
+      expect(style.borderColor).toBe(NEUTRAL_BORDER);
+    }
+  });
+
+  it("falls back to neutral on malformed hex", () => {
+    // Missing leading #, 3-char shorthand, non-hex chars, trailing
+    // junk — the catalog stores ``#rrggbb`` lowercase but a hand-
+    // edited sidecar could surface anything.
+    for (const malformed of ["red", "#fff", "#abcz12", "#ffffff!", "#"]) {
+      expect(labelChipStyle(malformed).background).toBe(NEUTRAL_BG);
+    }
+  });
+
+  it("accepts uppercase hex (catalog lowercases on save, but defensive)", () => {
+    const style = labelChipStyle("#FF0000");
+    expect(style.background).toBe("#FF0000");
+  });
+
+  it("renders the supplied hex as the chip background", () => {
+    const style = labelChipStyle("#22c55e");
+    expect(style.background).toBe("#22c55e");
+    expect(style.borderColor).toContain("color-mix");
+    expect(style.borderColor).toContain("#22c55e");
+  });
+
+  it("picks dark text on light hues (yellow, cyan)", () => {
+    // Yellow / cyan / lime — luminance > 0.6, expect the dark
+    // foreground so the label stays legible against the bright fill.
+    expect(labelChipStyle("#eab308").color).toBe("#1a1a1a");
+    expect(labelChipStyle("#ffffff").color).toBe("#1a1a1a");
+    expect(labelChipStyle("#ffff00").color).toBe("#1a1a1a");
+  });
+
+  it("picks light text on dark hues (blue, red)", () => {
+    // Blues / reds / saturated pinks — luminance < 0.6, expect
+    // white text. These are exactly the kinds of GitHub-style
+    // labels where dark text would disappear into the background.
+    expect(labelChipStyle("#3b82f6").color).toBe("#ffffff");
+    expect(labelChipStyle("#ef4444").color).toBe("#ffffff");
+    expect(labelChipStyle("#000000").color).toBe("#ffffff");
+  });
+
+  it("threshold cutoff sits at luminance 0.6 (Rec. 601 weights)", () => {
+    // Just above the cutoff — Rec. 601 luminance for #cccccc is
+    // 0.8, comfortably in the "dark text" zone.
+    expect(labelChipStyle("#cccccc").color).toBe("#1a1a1a");
+    // Just below — #777777 lands at 0.467, well below 0.6.
+    expect(labelChipStyle("#777777").color).toBe("#ffffff");
+  });
+});
+
+describe("labelChipStyleString", () => {
+  it("emits a flat CSS-text string from the resolved style", () => {
+    const out = labelChipStyleString("#22c55e");
+    expect(out).toContain("background:#22c55e");
+    expect(out).toContain("color:#ffffff");
+    expect(out).toContain("border-color:");
+    // Each declaration ends with ``;`` joined together — a single
+    // attribute-style assignment, not a multi-line block.
+    expect(out.split("\n")).toHaveLength(1);
+  });
+
+  it("emits the neutral palette for nullish / malformed input", () => {
+    for (const value of [null, undefined, "", "not-a-color"]) {
+      const out = labelChipStyleString(value);
+      expect(out).toContain(`background:${NEUTRAL_BG}`);
+      expect(out).toContain(`color:${NEUTRAL_FG}`);
+    }
+  });
+});
+
+describe("LABEL_COLOR_SWATCHES", () => {
+  it("exposes a non-empty palette of valid #rrggbb hex strings", () => {
+    expect(LABEL_COLOR_SWATCHES.length).toBeGreaterThan(0);
+    for (const hex of LABEL_COLOR_SWATCHES) {
+      expect(hex).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it("every swatch resolves to a non-neutral chip style", () => {
+    for (const hex of LABEL_COLOR_SWATCHES) {
+      const style = labelChipStyle(hex);
+      expect(style.background).toBe(hex);
+      expect(style.background).not.toBe(NEUTRAL_BG);
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #193 covering layout polish + the Copilot review comments that landed after merge.

**Layout polish**

- Cards now reserve a min-height row for labels so tagged + untagged devices line up at equal height in the grid (no more single tagged card bumping its neighbours out of column-baseline alignment).
- The toolbar labels filter trigger is a 36×36 icon button (matching the select-toggle / view-toggle), with a corner badge for the active count instead of a wide `Labels (n) ⌄` pill.
- Pulled the YAML-content toggle out of the cards/list view-toggle and grouped it with the labels filter as a "filters" cluster on the right edge of the toolbar. Added a flex spacer between the view-toggle and that cluster so layout-mode and filter affordances read as separate things.

**Copilot follow-up review**

- `_loadLabels` doc no longer claims an `"(unknown)"` placeholder that doesn't exist.
- Editor resets `_saving` + `_saveChain` when the device prop changes so an in-flight save against the previous device can't gate the new one.
- Dropped dead `_dialogOpen` state — the `<wa-dialog>` open flag is the only source of truth.
- Visible focus ring on the chip remove button (overrode `overflow: hidden` on `.assigned-chip` so the outline isn't clipped at the chip's rounded edge).
- Added unit tests for `labelChipStyle` / `labelChipStyleString` / `LABEL_COLOR_SWATCHES` (luminance threshold, malformed-hex fallback, palette validity).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #193

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [x] Tests have been added to verify that the new code works (where applicable).
