### PR TITLE
Sync advanced settings toggle with per-section state

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -578,7 +578,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
             ${hasAdvanced
               ? html`<div class="advanced-toggle-row">
                   <wa-switch
-                    ?checked=${showAdvanced}
+                    .checked=${showAdvanced}
                     @change=${(e: Event) =>
                       this._setShowAdvanced(
                         (


### PR DESCRIPTION
## Problem

When viewing a section/component (e.g. WiFi) and toggling **Show advanced settings** ON, navigating to another section (e.g. Native API) leaves the toggle visually ON while the advanced fields are hidden — toggle and content fall out of sync.

`_advancedShownSections` is correctly per-section, but the `wa-switch` component caches its checked state internally (`_checked` + `valueHasChanged`). When Lit removed the boolean `checked` attribute on section change, the cached state stayed, so the visual switch position no longer matched the rendered fields.

## Changes

- `src/components/device/device-section-config.ts`: bind the advanced-toggle as a property (`.checked`) instead of a boolean attribute (`?checked`), so the wa-switch's setter runs on every section change and stays in sync with `_advancedShownSections`.

Fixes [esphome/device-builder#359](https://github.com/esphome/device-builder/issues/359).