### PR TITLE
Add preview badge and feedback survey/Discord links

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -154,6 +154,23 @@ export class ESPHomeLayout extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-xs);
+      }
+
+      .preview-badge {
+        font-size: 9px;
+        font-weight: var(--wa-font-weight-bold);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 2px 6px;
+        border-radius: var(--wa-border-radius-s);
+        background: color-mix(in srgb, var(--esphome-on-primary), transparent 80%);
+        color: var(--esphome-on-primary);
+        border: 1px solid color-mix(in srgb, var(--esphome-on-primary), transparent 60%);
+        line-height: 1;
+        flex-shrink: 0;
       }
 
       .header-text p {
@@ -235,7 +252,10 @@ export class ESPHomeLayout extends LitElement {
           </button>
         </div>
         <div class="header-text">
-          <h1>${this._localize("dashboard.title")}</h1>
+          <h1>
+            <span>${this._localize("dashboard.title")}</span>
+            <span class="preview-badge">${this._localize("layout.preview_badge")}</span>
+          </h1>
           <p>${this._localize("dashboard.subtitle")}</p>
         </div>
         <div class="header-spacer"></div>

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -1,6 +1,8 @@
 import { consume } from "@lit/context";
 import {
   mdiBugOutline,
+  mdiClipboardListOutline,
+  mdiForumOutline,
   mdiLightbulbOutline,
   mdiMagnify,
   mdiOpenInNew,
@@ -17,10 +19,18 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   "bug-outline": mdiBugOutline,
+  "clipboard-list-outline": mdiClipboardListOutline,
+  "forum-outline": mdiForumOutline,
   "lightbulb-outline": mdiLightbulbOutline,
   magnify: mdiMagnify,
   "open-in-new": mdiOpenInNew,
 });
+
+const SURVEY_LINK = {
+  icon: "clipboard-list-outline",
+  labelKey: "feedback.survey",
+  href: "https://usabi.li/do/3wv9cloipto9/wadwk6",
+} as const;
 
 const LINKS = [
   {
@@ -42,6 +52,11 @@ const LINKS = [
     icon: "lightbulb-outline",
     labelKey: "feedback.new_feature",
     href: "https://github.com/orgs/esphome/discussions/new?category=builder-features-or-enhancements",
+  },
+  {
+    icon: "forum-outline",
+    labelKey: "feedback.discord",
+    href: "https://discord.gg/Rf2jWGVjaK",
   },
 ] as const;
 
@@ -136,6 +151,28 @@ export class ESPHomeFeedbackDialog extends LitElement {
         color: var(--wa-color-text-quiet);
         flex-shrink: 0;
       }
+
+      .link.featured {
+        background: var(--esphome-primary);
+        border-color: var(--esphome-primary);
+        color: var(--esphome-on-primary);
+        margin-bottom: var(--wa-space-s);
+      }
+
+      .link.featured:hover {
+        background: color-mix(in srgb, var(--esphome-primary), black 12%);
+        border-color: color-mix(in srgb, var(--esphome-primary), black 12%);
+      }
+
+      .link.featured .link-icon,
+      .link.featured .link-external,
+      .link.featured:hover .link-icon {
+        color: var(--esphome-on-primary);
+      }
+
+      .link.featured .link-label {
+        font-weight: var(--wa-font-weight-bold);
+      }
     `,
   ];
 
@@ -155,6 +192,21 @@ export class ESPHomeFeedbackDialog extends LitElement {
       >
         <p class="description">${this._localize("feedback.description")}</p>
         <div class="links">
+          <a
+            class="link featured"
+            href=${SURVEY_LINK.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            @click=${this.close}
+          >
+            <wa-icon class="link-icon" library="mdi" name=${SURVEY_LINK.icon}></wa-icon>
+            <span class="link-label">${this._localize(SURVEY_LINK.labelKey)}</span>
+            <wa-icon
+              class="link-external"
+              library="mdi"
+              name="open-in-new"
+            ></wa-icon>
+          </a>
           ${LINKS.map(
             (link) => html`
               <a

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -620,15 +620,18 @@
     "editor": "Editor",
     "yaml_diff_button": "YAML diff button",
     "header_actions_label": "Dashboard actions",
-    "more_options_with_count": "More options ({count} firmware task(s) active)"
+    "more_options_with_count": "More options ({count} firmware task(s) active)",
+    "preview_badge": "Preview"
   },
   "feedback": {
     "title": "Found a bug? Have an idea?",
     "description": "Help us improve ESPHome Device Builder by reporting issues or sharing your ideas.",
+    "survey": "Join feedback survey",
     "browse_issues": "Browse open issues",
     "new_issue": "Report a new issue",
     "browse_features": "Browse feature requests",
-    "new_feature": "Request a new feature"
+    "new_feature": "Request a new feature",
+    "discord": "Chat on the ESPHome Discord"
   },
   "command_palette": {
     "placeholder": "Type a command — or / to search YAML content",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -516,15 +516,18 @@
     "editor": "Éditeur",
     "yaml_diff_button": "Bouton de diff YAML",
     "header_actions_label": "Actions du tableau de bord",
-    "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))"
+    "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))",
+    "preview_badge": "Aperçu"
   },
   "feedback": {
     "title": "Un bug ? Une idée ?",
     "description": "Aidez-nous à améliorer ESPHome Device Builder en signalant des problèmes ou en partageant vos idées.",
+    "survey": "Participer au questionnaire",
     "browse_issues": "Parcourir les problèmes ouverts",
     "new_issue": "Signaler un nouveau problème",
     "browse_features": "Parcourir les demandes de fonctionnalités",
-    "new_feature": "Demander une nouvelle fonctionnalité"
+    "new_feature": "Demander une nouvelle fonctionnalité",
+    "discord": "Discuter sur le Discord ESPHome"
   },
   "auth": {
     "connecting": "Connexion…",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -516,15 +516,18 @@
     "editor": "Editor",
     "yaml_diff_button": "YAML-diff-knop",
     "header_actions_label": "Dashboardacties",
-    "more_options_with_count": "Meer opties ({count} firmwaretaken actief)"
+    "more_options_with_count": "Meer opties ({count} firmwaretaken actief)",
+    "preview_badge": "Preview"
   },
   "feedback": {
     "title": "Probleem of idee?",
     "description": "Help ons ESPHome Device Builder te verbeteren door problemen te melden of ideeën te delen.",
+    "survey": "Doe mee aan de feedback-enquête",
     "browse_issues": "Open problemen bekijken",
     "new_issue": "Nieuw probleem melden",
     "browse_features": "Functieverzoeken bekijken",
-    "new_feature": "Nieuwe functie aanvragen"
+    "new_feature": "Nieuwe functie aanvragen",
+    "discord": "Chat op de ESPHome Discord"
   },
   "auth": {
     "connecting": "Verbinden…",


### PR DESCRIPTION
# What does this implement/fix?

Getting ready for the public preview of the new device builder UI. This adds a small "Preview" marker to the header and surfaces two extra channels in the help dialog so early users can give feedback or jump into the Discord chat.

- Add `Preview` badge next to the title in the header
- Add highlighted `Join feedback survey` link at the top of the feedback dialog (temporary, points at the usability survey for the new UX/UI)
- Add `Chat on the ESPHome Discord` link at the bottom of the feedback dialog
- Translate new strings for `en`, `fr`, and `nl`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
