### PR TITLE
Add __ESPHOME_BASE_HREF__ placeholder for backend per-request injection

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const rspack = require("@rspack/core");
 
@@ -92,8 +93,21 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
         require(path.resolve(ROOT_DIR, "package.json")).version
       ),
     }),
+    // The source ``public/index.html`` carries an
+    // ``__ESPHOME_BASE_HREF__`` placeholder that the backend
+    // substitutes per-request with the deployment prefix
+    // (esphome/device-builder serves index.html and rewrites it).
+    // The rspack dev server doesn't go through that backend, so we
+    // pre-substitute the placeholder to ``"/"`` at build time for
+    // dev. Prod builds emit the placeholder verbatim — the backend
+    // is the substituter.
     new rspack.HtmlRspackPlugin({
-      template: path.resolve(PUBLIC_DIR, "index.html"),
+      templateContent: fs
+        .readFileSync(path.resolve(PUBLIC_DIR, "index.html"), "utf-8")
+        .replace(
+          /__ESPHOME_BASE_HREF__/g,
+          isProdBuild ? "__ESPHOME_BASE_HREF__" : "/",
+        ),
       inject: "body",
     }),
     new rspack.CopyRspackPlugin({

--- a/public/index.html
+++ b/public/index.html
@@ -80,15 +80,29 @@
     />
     <title>ESPHome</title>
     <!-- Backend rewrites ``__ESPHOME_BASE_HREF__`` per-request to
-         the deployment prefix (``/``, ``/api/hassio_ingress/...``,
-         a reverse-proxy subpath, etc.). All relative URLs below
-         — including the deferred app bundle that rspack emits
-         with ``publicPath: "auto"`` — resolve against this base,
-         so a hard-reload of a deep SPA URL like ``/device/<id>``
-         doesn't ask the server for ``/device/app.<hash>.js``
-         (which the SPA fallback would answer with HTML and the
-         browser would white-screen on). The placeholder is the
-         contract the backend's ``_shell_html`` substitutes. -->
+         the deployment prefix; values MUST end with a trailing
+         slash so a relative URL like ``app.HASH.js`` resolves
+         against the prefix-as-directory:
+             ``/`` (direct deploy)
+             ``/api/hassio_ingress/<token>/`` (HA add-on)
+             ``/dashboard/`` (reverse-proxy subpath)
+         A trailing-slash-less ``/api/hassio_ingress/<token>``
+         would resolve ``app.HASH.js`` to
+         ``/api/hassio_ingress/app.HASH.js`` and break loading.
+         All relative URLs below — including the deferred app
+         bundle that rspack emits with ``publicPath: "auto"`` —
+         resolve against this base, so a hard-reload of a deep
+         SPA URL like ``/device/<id>`` doesn't ask the server for
+         ``/device/app.<hash>.js`` (which the SPA fallback would
+         answer with HTML and the browser would white-screen on).
+         The placeholder is the contract the backend's
+         ``_shell_html`` substitutes — see esphome/device-builder's
+         ``_resolve_base_href`` for the canonical implementation
+         (always returns leading + trailing slashes). The rspack
+         dev server pre-substitutes the placeholder to ``"/"`` at
+         build time (``build-scripts/rspack.cjs``); only the prod
+         wheel ships with the literal placeholder for the backend
+         to fill. -->
     <base href="__ESPHOME_BASE_HREF__" />
     <!-- Favicon href is set at runtime from entrypoint.ts via
          ``withBase("/assets/logo/esphome.svg")`` so it resolves

--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,17 @@
       content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>ESPHome</title>
+    <!-- Backend rewrites ``__ESPHOME_BASE_HREF__`` per-request to
+         the deployment prefix (``/``, ``/api/hassio_ingress/...``,
+         a reverse-proxy subpath, etc.). All relative URLs below
+         — including the deferred app bundle that rspack emits
+         with ``publicPath: "auto"`` — resolve against this base,
+         so a hard-reload of a deep SPA URL like ``/device/<id>``
+         doesn't ask the server for ``/device/app.<hash>.js``
+         (which the SPA fallback would answer with HTML and the
+         browser would white-screen on). The placeholder is the
+         contract the backend's ``_shell_html`` substitutes. -->
+    <base href="__ESPHOME_BASE_HREF__" />
     <!-- Favicon href is set at runtime from entrypoint.ts via
          ``withBase("/assets/logo/esphome.svg")`` so it resolves
          correctly under any mount point — including HA ingress


### PR DESCRIPTION
# What does this implement/fix?

The bundle's entry script ships with a relative `src` (rspack `publicPath: "auto"`, for HA-ingress / reverse-proxy subpath support, added in #189). Without an explicit `<base href>`, hard-reload of a deep SPA URL like `/device/<id>` resolves the script against the route path → server's SPA fallback returns `index.html` → browser parses HTML as JS → `Uncaught SyntaxError: Unexpected token '<'` → white screen.

This PR adds a single `<base href="__ESPHOME_BASE_HREF__" />` placeholder at the top of `<head>`. The companion backend PR (esphome/device-builder#371) substitutes the placeholder per-request with the deployment prefix:

- `X-Forwarded-Prefix` header when present (reverse-proxy convention)
- otherwise strips the SPA route tail (`/device/<id>`, `/secrets`) off `request.path` to recover the mount-point prefix
- `lru_cache(maxsize=8)` on the rendered shell — substitution is paid once per distinct prefix.

CSP-clean: no inline scripts (the existing `default-src 'self'` blocks them anyway). The `<base href>` is constrained by the existing `base-uri 'self'` directive, so a hostile `X-Forwarded-Prefix` can't escape same-origin.

A frontend wheel without the placeholder raises `RuntimeError` at backend app construction so version drift surfaces loudly rather than as a runtime white-screen.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes the "white screen on hard-reload of `/device/<id>?line=...`" regression introduced in #189

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (729/729).
  - [ ] Tests have been added to verify that the new code works (where applicable).
