### PR TITLE
yaml/search: group results by device with code-snippet rendering

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -237,10 +237,24 @@ export interface DevicesResponse {
   importable: AdoptableDevice[];
 }
 
-/** A single matching line within a YAML file. */
+/** A single matching line within a YAML file.
+ *
+ *  ``before`` / ``after`` carry up to ``MAX_CONTEXT_LINES`` (10)
+ *  lines on each side of the matched line, sliced from the same
+ *  capped scan window the backend walks. The frontend renders a
+ *  code-snippet block that surfaces the surrounding key
+ *  (``device:`` / ``platform:`` / list-anchor lines) so a hit
+ *  deep inside a nested block reads as anchored config rather
+ *  than a free-floating value. Both default to ``[]`` for
+ *  matches at file edges.
+ */
 export interface YamlSearchMatch {
   line_number: number;
   line_text: string;
+  /** Up to ``context_lines`` lines preceding the match (file order). */
+  before: string[];
+  /** Up to ``context_lines`` lines following the match (file order). */
+  after: string[];
 }
 
 /**

--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -276,32 +276,87 @@ export const dashboardStyles = css`
     display: flex;
     flex-direction: column;
     padding: var(--wa-space-m) var(--wa-space-l) var(--wa-space-l);
-    gap: 2px;
+    gap: var(--wa-space-l);
   }
-  .yaml-hit {
+  .yaml-hit-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-xs);
+  }
+  .yaml-hit-group-header {
     display: flex;
     align-items: center;
     gap: var(--wa-space-s);
-    padding: var(--wa-space-xs) var(--wa-space-s);
+    padding-bottom: var(--wa-space-xs);
+    border-bottom: 1px solid var(--wa-color-surface-border);
+  }
+  .yaml-hit-group-name {
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
+  }
+  .yaml-hit-group-count {
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-quiet);
+    margin-left: auto;
+  }
+  /* The legacy .yaml-hit / .yaml-hit-label rows (palette-style
+     flat per-match listing) are gone from the dashboard; the
+     snippet-block styles below replace them with a grouped
+     code-search shape. */
+  .yaml-snippet {
+    display: block;
+    background: var(--wa-color-surface-lowered);
+    border: 1px solid var(--wa-color-surface-border);
     border-radius: 6px;
     color: var(--wa-color-text-normal);
     text-decoration: none;
+    font-family: var(--wa-font-family-code, ui-monospace, monospace);
     font-size: var(--wa-font-size-s);
-    transition: background-color 0.1s ease;
+    overflow: hidden;
+    transition: border-color 0.1s ease, background-color 0.1s ease;
   }
-  .yaml-hit:hover,
-  .yaml-hit:focus-visible {
-    background: var(--wa-color-surface-raised);
+  .yaml-snippet:hover,
+  .yaml-snippet:focus-visible {
+    border-color: var(--esphome-primary);
     outline: none;
   }
-  .yaml-hit-label {
-    /* Single line, ellipsis on overflow — long YAML lines
-       (lambdas, comments) can run wide. */
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .yaml-snippet-line {
+    display: flex;
+    align-items: baseline;
+    padding: 1px 0;
+  }
+  .yaml-snippet-line--match {
+    background: color-mix(
+      in srgb,
+      var(--esphome-primary),
+      transparent 92%
+    );
+  }
+  .yaml-snippet-gutter {
+    flex: 0 0 auto;
+    width: 3em;
+    padding: 0 var(--wa-space-s);
+    text-align: right;
+    color: var(--wa-color-text-quiet);
+    user-select: none;
+  }
+  .yaml-snippet-text {
     flex: 1;
-    font-family: var(--wa-font-family-code, ui-monospace, monospace);
+    /* Preserve YAML indentation but wrap long lines (lambdas /
+       deeply-nested config) instead of horizontally scrolling. */
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding-right: var(--wa-space-s);
+  }
+  .yaml-snippet-text mark {
+    background: color-mix(
+      in srgb,
+      var(--esphome-primary),
+      transparent 70%
+    );
+    color: inherit;
+    padding: 0 1px;
+    border-radius: 2px;
   }
   .device-count {
     font-size: var(--wa-font-size-xs);

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -20,6 +20,7 @@ import type {
   ArchivedDevice,
   ConfiguredDevice,
   FirmwareJob,
+  YamlSearchHit,
 } from "../api/types.js";
 import type { SortingState, VisibilityState } from "@tanstack/lit-table";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -36,10 +37,11 @@ import { espHomeStyles } from "../styles/shared.js";
 import { YamlSearchController } from "../components/yaml-search-controller.js";
 import { matchesDeviceName } from "../util/device-search.js";
 import {
-  forEachYamlMatch,
+  buildYamlSnippetBlocks,
   yamlEmptyMessageKey,
-  yamlHitHref,
-  yamlHitLabel,
+  yamlHitDeviceLabel,
+  yamlSnippetBlockHref,
+  type YamlSnippetBlock,
 } from "../util/yaml-search-helpers.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { navigate } from "../util/navigation.js";
@@ -472,10 +474,20 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   /**
-   * YAML-mode body — empty-state copy or a list of hit rows. Each
-   * row links to ``/device/<config>?line=<n>`` so click /
-   * cmd-click / middle-click all do the right thing without
-   * hand-rolling a click handler.
+   * YAML-mode body — empty-state copy or grouped device sections.
+   *
+   * Per device: a header (icon + friendly name + match count)
+   * followed by one or more code-snippet blocks. Each snippet
+   * block bundles a match together with its ±N context lines
+   * (from the backend's ``before`` / ``after`` fields), with the
+   * matched line(s) highlighted. Adjacent matches whose context
+   * windows overlap collapse into a single block — the visual
+   * shape GitHub code search and VS Code search both use.
+   *
+   * Each snippet block is its own clickable link to the editor
+   * pinned at the block's first match line, so click / cmd-click
+   * / middle-click all do the right thing without a custom
+   * click handler beyond the SPA-navigate guard.
    */
   private _renderYamlMode() {
     const hits = this._yamlSearch.hits;
@@ -494,31 +506,104 @@ export class ESPHomePageDashboard extends LitElement {
       // ``yaml_search.no_matches`` (fetched, no hits).
       return this._renderYamlEmptyState(emptyKey);
     }
-    // hits is non-empty here — render the rows.
+    // hits is non-empty here — render the device sections.
     return html`
       <div class="yaml-hits">
-        ${forEachYamlMatch(
-          hits,
-          (hit, match) => html`
-            <a
-              class="yaml-hit"
-              href=${yamlHitHref(hit, match)}
-              @click=${(e: MouseEvent) => {
-                // Plain left-click → SPA navigate; let middle /
-                // cmd / shift-click fall through to the browser
-                // for new-tab / new-window behaviour.
-                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
-                e.preventDefault();
-                navigate(yamlHitHref(hit, match));
-              }}
-            >
-              <wa-icon library="mdi" name="code-braces"></wa-icon>
-              <span class="yaml-hit-label">${yamlHitLabel(hit, match)}</span>
-            </a>
-          `
-        )}
+        ${(hits ?? []).map((hit) => {
+          const blocks = buildYamlSnippetBlocks(hit.matches);
+          const matchCount = hit.matches.length;
+          const countUnit =
+            matchCount === 1
+              ? this._localize("yaml_search.match_count_singular")
+              : this._localize("yaml_search.match_count_plural");
+          return html`
+            <section class="yaml-hit-group">
+              <header class="yaml-hit-group-header">
+                <wa-icon library="mdi" name="code-braces"></wa-icon>
+                <span class="yaml-hit-group-name"
+                  >${yamlHitDeviceLabel(hit)}</span
+                >
+                <span class="yaml-hit-group-count"
+                  >${matchCount} ${countUnit}</span
+                >
+              </header>
+              ${blocks.map((block) =>
+                this._renderYamlSnippetBlock(hit, block, query)
+              )}
+            </section>
+          `;
+        })}
       </div>
     `;
+  }
+
+  /** Render a single ``YamlSnippetBlock`` as a clickable code panel.
+   *
+   *  Lines render in monospace with a small line-number gutter.
+   *  Match lines get a class hook (``yaml-snippet-line--match``)
+   *  so styling can highlight the row; the matched substring
+   *  itself is wrapped in ``<mark>`` for inline highlighting.
+   */
+  private _renderYamlSnippetBlock(
+    hit: YamlSearchHit,
+    block: YamlSnippetBlock,
+    query: string,
+  ) {
+    const href = yamlSnippetBlockHref(hit, block);
+    return html`
+      <a
+        class="yaml-snippet"
+        href=${href}
+        @click=${(e: MouseEvent) => {
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+          e.preventDefault();
+          navigate(href);
+        }}
+      >
+        ${block.lines.map((text, i) => {
+          const lineNumber = block.startLine + i;
+          const isMatch = block.matchedLines.has(lineNumber);
+          return html`
+            <div
+              class="yaml-snippet-line ${isMatch
+                ? "yaml-snippet-line--match"
+                : ""}"
+            >
+              <span class="yaml-snippet-gutter">${lineNumber}</span>
+              <span class="yaml-snippet-text"
+                >${isMatch ? this._highlightMatch(text, query) : text}</span
+              >
+            </div>
+          `;
+        })}
+      </a>
+    `;
+  }
+
+  /** Wrap every case-insensitive occurrence of *needle* in *text*
+   *  with a ``<mark>`` element so the matched substring stands
+   *  out inside the snippet line. *needle* may be empty (the
+   *  caller already gates on ``query`` being non-empty before
+   *  calling, but defensively returns the unmodified text in
+   *  that case).
+   */
+  private _highlightMatch(text: string, needle: string) {
+    if (!needle) return text;
+    const lower = text.toLowerCase();
+    const lowerNeedle = needle.toLowerCase();
+    const out: Array<unknown> = [];
+    let i = 0;
+    while (i < text.length) {
+      const idx = lower.indexOf(lowerNeedle, i);
+      if (idx === -1) {
+        out.push(text.slice(i));
+        break;
+      }
+      if (idx > i) out.push(text.slice(i, idx));
+      out.push(html`<mark>${text.slice(idx, idx + needle.length)}</mark>`);
+      i = idx + needle.length;
+    }
+    return out;
   }
 
   private _renderYamlEmptyState(messageKey: string) {

--- a/src/util/yaml-search-helpers.ts
+++ b/src/util/yaml-search-helpers.ts
@@ -146,12 +146,19 @@ export function yamlEmptyMessage(
 /**
  * Walk every (hit, match) pair across a result list.
  *
- * Both consumers (palette → ``CommandAction`` rows, dashboard
- * → ``<a>`` link cards) iterate ``hits → matches`` to produce
- * one row per matching line. Centralising the traversal means
- * a future shape change (e.g. grouping rows by device) lands
- * in one place. Returns the mapped values flattened in
- * file → match order. ``null``/empty hits → empty array.
+ * Used by the command palette, which renders each match as its
+ * own one-line ``CommandAction`` (the keyboard-driven nav
+ * surface — flat list reads better there than a grouped tree
+ * because the user is keying down through results, not visually
+ * scanning). Centralising the traversal means a label-format /
+ * url-shape tweak lands in one place. Returns the mapped values
+ * flattened in file → match order. ``null``/empty hits → empty
+ * array.
+ *
+ * The dashboard view uses a grouped renderer instead — see
+ * ``_renderYamlMode`` in ``pages/dashboard.ts`` — so this helper
+ * is *only* the right shape for "I want every matching line as a
+ * standalone row" callers.
  */
 export function forEachYamlMatch<T>(
   hits: YamlSearchHit[] | null,
@@ -165,4 +172,139 @@ export function forEachYamlMatch<T>(
     }
   }
   return out;
+}
+
+/**
+ * One contiguous ``before / matched / after`` window for the
+ * dashboard's grouped snippet renderer.
+ *
+ * The wire shape carries each match independently with its own
+ * ±N context window. When two matches in the same file land
+ * close enough that their windows overlap (or are adjacent),
+ * rendering them as separate snippet blocks produces a visually
+ * noisy stack of duplicated context lines. This collapses any
+ * such run into one block:
+ *
+ * - ``startLine`` / ``endLine`` are the inclusive line numbers
+ *   the block covers (1-based, matching ``YamlSearchMatch.
+ *   line_number``).
+ * - ``lines`` is the line-by-line content for that range, in
+ *   file order; the caller renders each with the line number
+ *   from ``startLine + index``.
+ * - ``matchedLines`` is the set of 1-based line numbers within
+ *   the block that are *match* lines (highlight target). Lines
+ *   in ``startLine..endLine`` that aren't in this set are
+ *   pure context.
+ */
+export interface YamlSnippetBlock {
+  startLine: number;
+  endLine: number;
+  lines: string[];
+  matchedLines: Set<number>;
+}
+
+/**
+ * Collapse a hit's ``matches`` list into one ``YamlSnippetBlock``
+ * per non-overlapping run. Adjacent / overlapping windows merge.
+ *
+ * Lines are reconstructed from the (``before`` ⨁ ``line_text``
+ * ⨁ ``after``) tuples each match carries — we don't have the
+ * full file on the frontend, so the helper walks per-line
+ * coordinates and picks whichever match's tuple covers each
+ * line number. Where multiple matches cover the same line, the
+ * content is identical (the backend slices from one source list)
+ * so the order doesn't matter; this just defends against the
+ * case where one match's ``after`` ends mid-overlap with the
+ * next match's ``before``.
+ *
+ * Matches MUST already be sorted by ``line_number`` ascending —
+ * the backend guarantees that.
+ */
+export function buildYamlSnippetBlocks(
+  matches: readonly YamlSearchMatch[]
+): YamlSnippetBlock[] {
+  if (matches.length === 0) return [];
+  // Per-line content map keyed on absolute (1-based) line number.
+  // Each match contributes its before/line/after; later writes
+  // for a line that's already filled are a no-op since the
+  // content is identical.
+  const lineContent = new Map<number, string>();
+  // The 1-based line numbers that are *match* lines (vs context).
+  const matchLineNumbers = new Set<number>();
+  for (const m of matches) {
+    matchLineNumbers.add(m.line_number);
+    lineContent.set(m.line_number, maskSensitiveLine(m.line_text));
+    // ``before`` is in file order, so the line immediately
+    // preceding the match is at index ``length - 1`` and walks
+    // backwards from there.
+    const beforeStart = m.line_number - m.before.length;
+    m.before.forEach((text, i) => {
+      const ln = beforeStart + i;
+      if (!lineContent.has(ln)) lineContent.set(ln, maskSensitiveLine(text));
+    });
+    // ``after`` is in file order starting at line+1.
+    m.after.forEach((text, i) => {
+      const ln = m.line_number + 1 + i;
+      if (!lineContent.has(ln)) lineContent.set(ln, maskSensitiveLine(text));
+    });
+  }
+  // Walk the populated line numbers in order, splitting on gaps.
+  const ordered = [...lineContent.keys()].sort((a, b) => a - b);
+  const blocks: YamlSnippetBlock[] = [];
+  let blockStart = ordered[0];
+  let prev = ordered[0];
+  const flushBlock = (start: number, end: number) => {
+    const lines: string[] = [];
+    for (let ln = start; ln <= end; ln++) {
+      lines.push(lineContent.get(ln) ?? "");
+    }
+    const matchedLines = new Set<number>();
+    for (let ln = start; ln <= end; ln++) {
+      if (matchLineNumbers.has(ln)) matchedLines.add(ln);
+    }
+    blocks.push({ startLine: start, endLine: end, lines, matchedLines });
+  };
+  for (let i = 1; i < ordered.length; i++) {
+    const cur = ordered[i];
+    if (cur !== prev + 1) {
+      // Gap — close the current block and start a new one.
+      flushBlock(blockStart, prev);
+      blockStart = cur;
+    }
+    prev = cur;
+  }
+  flushBlock(blockStart, prev);
+  return blocks;
+}
+
+/**
+ * Display label for a device-section header in the grouped
+ * dashboard renderer. Falls back through the same precedence as
+ * ``yamlHitLabel`` — ``friendly_name`` → ``device_name`` →
+ * ``configuration``.
+ */
+export function yamlHitDeviceLabel(hit: YamlSearchHit): string {
+  return hit.friendly_name || hit.device_name || hit.configuration;
+}
+
+/**
+ * Click-target URL for a snippet block — routes to the device
+ * editor pinned at the block's *first match* line. The dashboard
+ * makes the whole block a clickable link, so picking the first
+ * match (rather than the block's start line, which is usually a
+ * context line) lands the cursor on actual matched content.
+ */
+export function yamlSnippetBlockHref(
+  hit: YamlSearchHit,
+  block: YamlSnippetBlock
+): string {
+  // matchedLines is unsorted (it's a Set); the smallest entry
+  // is what we want. Falls back to ``startLine`` for a block
+  // that somehow has no matched lines — defensive only;
+  // ``buildYamlSnippetBlocks`` always populates it.
+  const firstMatch =
+    block.matchedLines.size > 0
+      ? Math.min(...block.matchedLines)
+      : block.startLine;
+  return `/device/${encodeURIComponent(hit.configuration)}?line=${firstMatch}`;
 }

--- a/test/components/yaml-search-controller.test.ts
+++ b/test/components/yaml-search-controller.test.ts
@@ -33,7 +33,7 @@ const HIT: YamlSearchHit = {
   configuration: "kitchen.yaml",
   device_name: "kitchen",
   friendly_name: "Kitchen",
-  matches: [{ line_number: 1, line_text: "wifi:" }],
+  matches: [{ line_number: 1, line_text: "wifi:", before: [], after: [] }],
 };
 
 describe("YamlSearchController", () => {

--- a/test/util/yaml-search-helpers.test.ts
+++ b/test/util/yaml-search-helpers.test.ts
@@ -1,20 +1,49 @@
 import { describe, expect, it, vi } from "vitest";
 import type { YamlSearchHit, YamlSearchMatch } from "../../src/api/types.js";
 import {
+  buildYamlSnippetBlocks,
   forEachYamlMatch,
   yamlEmptyMessage,
   yamlEmptyMessageKey,
+  yamlHitDeviceLabel,
   yamlHitHref,
   yamlHitLabel,
+  yamlSnippetBlockHref,
 } from "../../src/util/yaml-search-helpers.js";
 
-const HIT: YamlSearchHit = {
-  configuration: "kitchen.yaml",
-  device_name: "kitchen",
-  friendly_name: "Kitchen Lamp",
-  matches: [{ line_number: 7, line_text: "  ssid: home" }],
-};
+/**
+ * Build a ``YamlSearchMatch`` with sensible defaults.
+ *
+ * Most label / mask tests don't care about the context windows;
+ * they only assert on ``line_text``. The factory keeps those
+ * cases readable (``mkMatch({ line_text: "wifi:" })``) without
+ * sprinkling ``before: [], after: []`` through every fixture,
+ * and centralises the wire-shape compatibility — when the
+ * backend adds another match-level field, only this helper
+ * changes.
+ */
+function mkMatch(overrides: Partial<YamlSearchMatch> = {}): YamlSearchMatch {
+  return {
+    line_number: 1,
+    line_text: "",
+    before: [],
+    after: [],
+    ...overrides,
+  };
+}
 
+/** Build a ``YamlSearchHit`` with a single match unless overridden. */
+function mkHit(overrides: Partial<YamlSearchHit> = {}): YamlSearchHit {
+  return {
+    configuration: "kitchen.yaml",
+    device_name: "kitchen",
+    friendly_name: "Kitchen Lamp",
+    matches: [mkMatch({ line_number: 7, line_text: "  ssid: home" })],
+    ...overrides,
+  };
+}
+
+const HIT: YamlSearchHit = mkHit();
 const MATCH: YamlSearchMatch = HIT.matches[0];
 
 describe("yamlHitLabel", () => {
@@ -23,23 +52,27 @@ describe("yamlHitLabel", () => {
   });
 
   it("falls back to device_name when friendly_name is empty", () => {
-    const hit = { ...HIT, friendly_name: "" };
-    expect(yamlHitLabel(hit, MATCH)).toBe("kitchen — ssid: home");
+    expect(yamlHitLabel(mkHit({ friendly_name: "" }), MATCH)).toBe(
+      "kitchen — ssid: home",
+    );
   });
 
   it("falls back to configuration when neither name is set", () => {
-    const hit = { ...HIT, friendly_name: "", device_name: "" };
-    expect(yamlHitLabel(hit, MATCH)).toBe("kitchen.yaml — ssid: home");
+    expect(
+      yamlHitLabel(mkHit({ friendly_name: "", device_name: "" }), MATCH),
+    ).toBe("kitchen.yaml — ssid: home");
   });
 
   it("uses 'line N' fallback when the matched line is whitespace-only", () => {
-    const match = { line_number: 12, line_text: "    " };
-    expect(yamlHitLabel(HIT, match)).toBe("Kitchen Lamp — line 12");
+    expect(
+      yamlHitLabel(HIT, mkMatch({ line_number: 12, line_text: "    " })),
+    ).toBe("Kitchen Lamp — line 12");
   });
 
   it("trims surrounding whitespace from the line text", () => {
-    const match = { line_number: 3, line_text: "    wifi:    " };
-    expect(yamlHitLabel(HIT, match)).toBe("Kitchen Lamp — wifi:");
+    expect(
+      yamlHitLabel(HIT, mkMatch({ line_number: 3, line_text: "    wifi:    " })),
+    ).toBe("Kitchen Lamp — wifi:");
   });
 
   it.each([
@@ -48,15 +81,18 @@ describe("yamlHitLabel", () => {
     ["  - ota_password: yellow1@@", "- ota_password: ••••••••"],
     ["psk: 0123456789abcdef", "psk: ••••••••"],
   ])("masks inline credential value in %s", (raw, expectedTrimmed) => {
-    const match = { line_number: 1, line_text: raw };
-    expect(yamlHitLabel(HIT, match)).toBe(`Kitchen Lamp — ${expectedTrimmed}`);
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
+      `Kitchen Lamp — ${expectedTrimmed}`,
+    );
   });
 
   it("does not mask !secret references — those are indirections, not credentials", () => {
-    const match = { line_number: 1, line_text: "  password: !secret wifi_password" };
-    expect(yamlHitLabel(HIT, match)).toBe(
-      "Kitchen Lamp — password: !secret wifi_password"
-    );
+    expect(
+      yamlHitLabel(
+        HIT,
+        mkMatch({ line_text: "  password: !secret wifi_password" }),
+      ),
+    ).toBe("Kitchen Lamp — password: !secret wifi_password");
   });
 
   it("does not mask ${substitution} references — same indirection rule", () => {
@@ -66,15 +102,15 @@ describe("yamlHitLabel", () => {
     // the name of an indirection, not the credential itself —
     // the credential lives in the substitutions block (which
     // *is* masked, see the ``*_password`` suffix tests below).
-    const match = { line_number: 1, line_text: "  password: ${wifi_password}" };
-    expect(yamlHitLabel(HIT, match)).toBe(
-      "Kitchen Lamp — password: ${wifi_password}"
-    );
+    expect(
+      yamlHitLabel(HIT, mkMatch({ line_text: "  password: ${wifi_password}" })),
+    ).toBe("Kitchen Lamp — password: ${wifi_password}");
   });
 
   it("does not mask non-sensitive keys", () => {
-    const match = { line_number: 1, line_text: "  ssid: home_network" };
-    expect(yamlHitLabel(HIT, match)).toBe("Kitchen Lamp — ssid: home_network");
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: "  ssid: home_network" }))).toBe(
+      "Kitchen Lamp — ssid: home_network",
+    );
   });
 
   it("does not mask key: under ESPHome contexts where it's a button code, not a credential", () => {
@@ -83,8 +119,9 @@ describe("yamlHitLabel", () => {
     // here. Pin the don't-mask behaviour so a future change that
     // over-masks button codes (remote_receiver / remote_transmitter
     // commonly use ``key: <number>``) surfaces as a test failure.
-    const match = { line_number: 1, line_text: "    key: 0xABCDEF12" };
-    expect(yamlHitLabel(HIT, match)).toBe("Kitchen Lamp — key: 0xABCDEF12");
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: "    key: 0xABCDEF12" }))).toBe(
+      "Kitchen Lamp — key: 0xABCDEF12",
+    );
   });
 
   it.each([
@@ -98,8 +135,9 @@ describe("yamlHitLabel", () => {
     ["## password: hunter2", "## password: ••••••••"],
     ["# - ap_password: 42dfadc0c2", "# - ap_password: ••••••••"],
   ])("masks credential value inside a YAML comment (%s)", (raw, expectedTrimmed) => {
-    const match = { line_number: 1, line_text: raw };
-    expect(yamlHitLabel(HIT, match)).toBe(`Kitchen Lamp — ${expectedTrimmed}`);
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
+      `Kitchen Lamp — ${expectedTrimmed}`,
+    );
   });
 
   it.each([
@@ -110,10 +148,14 @@ describe("yamlHitLabel", () => {
     ["wifi_password: yellow1@@", "wifi_password: ••••••••"],
     ["  guest_psk: HFrhVdN37Bb6mTFm", "guest_psk: ••••••••"],
     ['  WiFi_Password: "uppercase-key"', "WiFi_Password: ••••••••"],
-  ])("masks credential value for user-defined *_password / *_psk keys (%s)", (raw, expectedTrimmed) => {
-    const match = { line_number: 1, line_text: raw };
-    expect(yamlHitLabel(HIT, match)).toBe(`Kitchen Lamp — ${expectedTrimmed}`);
-  });
+  ])(
+    "masks credential value for user-defined *_password / *_psk keys (%s)",
+    (raw, expectedTrimmed) => {
+      expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
+        `Kitchen Lamp — ${expectedTrimmed}`,
+      );
+    },
+  );
 
   it.each([
     // Don't over-mask: keys that contain ``password`` mid-name
@@ -122,8 +164,7 @@ describe("yamlHitLabel", () => {
     "max_passwords: 5",
     "key_signed: 12345",
   ])("does not mask non-credential keys (%s)", (raw) => {
-    const match = { line_number: 1, line_text: raw };
-    expect(yamlHitLabel(HIT, match)).toContain(raw.trim());
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toContain(raw.trim());
   });
 
   it("only masks in search results — editor's sensitive-scan keeps its own scope", () => {
@@ -135,8 +176,9 @@ describe("yamlHitLabel", () => {
     // ``findSensitiveValueRanges`` — verify by checking that
     // the editor's scan-only path (``key`` under encryption) is
     // *not* masked here.
-    const match = { line_number: 1, line_text: "    key: random-noise-here" };
-    expect(yamlHitLabel(HIT, match)).toBe("Kitchen Lamp — key: random-noise-here");
+    expect(
+      yamlHitLabel(HIT, mkMatch({ line_text: "    key: random-noise-here" })),
+    ).toBe("Kitchen Lamp — key: random-noise-here");
   });
 });
 
@@ -146,8 +188,25 @@ describe("yamlHitHref", () => {
   });
 
   it("URL-encodes the configuration filename", () => {
-    const hit = { ...HIT, configuration: "guest room (1).yaml" };
-    expect(yamlHitHref(hit, MATCH)).toBe("/device/guest%20room%20(1).yaml?line=7");
+    expect(
+      yamlHitHref(mkHit({ configuration: "guest room (1).yaml" }), MATCH),
+    ).toBe("/device/guest%20room%20(1).yaml?line=7");
+  });
+});
+
+describe("yamlHitDeviceLabel", () => {
+  it("uses friendly_name when set", () => {
+    expect(yamlHitDeviceLabel(HIT)).toBe("Kitchen Lamp");
+  });
+
+  it("falls back to device_name when friendly_name is empty", () => {
+    expect(yamlHitDeviceLabel(mkHit({ friendly_name: "" }))).toBe("kitchen");
+  });
+
+  it("falls back to configuration when neither name is set", () => {
+    expect(
+      yamlHitDeviceLabel(mkHit({ friendly_name: "", device_name: "" })),
+    ).toBe("kitchen.yaml");
   });
 });
 
@@ -191,21 +250,21 @@ describe("forEachYamlMatch", () => {
 
   it("walks each (hit, match) pair in file → match order", () => {
     const hits: YamlSearchHit[] = [
-      {
+      mkHit({
         configuration: "a.yaml",
         device_name: "a",
         friendly_name: "A",
         matches: [
-          { line_number: 1, line_text: "wifi:" },
-          { line_number: 5, line_text: "  ssid: home" },
+          mkMatch({ line_number: 1, line_text: "wifi:" }),
+          mkMatch({ line_number: 5, line_text: "  ssid: home" }),
         ],
-      },
-      {
+      }),
+      mkHit({
         configuration: "b.yaml",
         device_name: "b",
         friendly_name: "B",
-        matches: [{ line_number: 3, line_text: "wifi:" }],
-      },
+        matches: [mkMatch({ line_number: 3, line_text: "wifi:" })],
+      }),
     ];
     const fn = vi.fn((hit, match) => `${hit.device_name}:${match.line_number}`);
     expect(forEachYamlMatch(hits, fn)).toEqual(["a:1", "a:5", "b:3"]);
@@ -214,16 +273,186 @@ describe("forEachYamlMatch", () => {
 
   it("preserves typing — caller's return type flows through", () => {
     const hits: YamlSearchHit[] = [
-      {
+      mkHit({
         configuration: "a.yaml",
         device_name: "a",
         friendly_name: "A",
-        matches: [{ line_number: 1, line_text: "x" }],
-      },
+        matches: [mkMatch({ line_text: "x" })],
+      }),
     ];
     const out = forEachYamlMatch<{ id: string }>(hits, (hit, match) => ({
       id: `${hit.configuration}:${match.line_number}`,
     }));
     expect(out).toEqual([{ id: "a.yaml:1" }]);
+  });
+});
+
+describe("buildYamlSnippetBlocks", () => {
+  it("returns [] for an empty matches list", () => {
+    expect(buildYamlSnippetBlocks([])).toEqual([]);
+  });
+
+  it("turns a single match into one block spanning context + match", () => {
+    const m = mkMatch({
+      line_number: 5,
+      line_text: "wifi:",
+      before: ["esphome:", "  name: kitchen"],
+      after: ["  ssid: home", "  api:"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.startLine).toBe(3);
+    expect(block.endLine).toBe(7);
+    expect(block.lines).toEqual([
+      "esphome:",
+      "  name: kitchen",
+      "wifi:",
+      "  ssid: home",
+      "  api:",
+    ]);
+    expect([...block.matchedLines]).toEqual([5]);
+  });
+
+  it("merges adjacent matches whose context windows overlap", () => {
+    // Two matches in the same file at lines 5 and 7 with a
+    // ±2-line context window each. The windows overlap (5's
+    // ``after`` ends at 7, 7's ``before`` starts at 5), so the
+    // result must be ONE block spanning 3..9 with two matched
+    // lines, not two blocks with duplicated context rows.
+    const matches = [
+      mkMatch({
+        line_number: 5,
+        line_text: "wifi:",
+        before: ["esphome:", "  name: kitchen"],
+        after: ["  ssid: home", "binary_sensor:"],
+      }),
+      mkMatch({
+        line_number: 7,
+        line_text: "binary_sensor:",
+        before: ["wifi:", "  ssid: home"],
+        after: ["  - platform: gpio", "    name: door"],
+      }),
+    ];
+
+    const blocks = buildYamlSnippetBlocks(matches);
+
+    expect(blocks).toHaveLength(1);
+    const [block] = blocks;
+    expect(block.startLine).toBe(3);
+    expect(block.endLine).toBe(9);
+    expect(block.lines).toEqual([
+      "esphome:",
+      "  name: kitchen",
+      "wifi:",
+      "  ssid: home",
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    name: door",
+    ]);
+    expect([...block.matchedLines].sort()).toEqual([5, 7]);
+  });
+
+  it("keeps non-overlapping matches as separate blocks", () => {
+    // Match at line 3 with ±2 context (lines 1..5) and match at
+    // line 50 with ±2 context (lines 48..52) — the windows are
+    // far apart, so each is its own block.
+    const matches = [
+      mkMatch({
+        line_number: 3,
+        line_text: "wifi:",
+        before: ["esphome:", "  name: kitchen"],
+        after: ["  ssid: home", "  password: x"],
+      }),
+      mkMatch({
+        line_number: 50,
+        line_text: "binary_sensor:",
+        before: ["", "switch:"],
+        after: ["  - platform: gpio", ""],
+      }),
+    ];
+
+    const blocks = buildYamlSnippetBlocks(matches);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].startLine).toBe(1);
+    expect(blocks[0].endLine).toBe(5);
+    expect([...blocks[0].matchedLines]).toEqual([3]);
+    expect(blocks[1].startLine).toBe(48);
+    expect(blocks[1].endLine).toBe(52);
+    expect([...blocks[1].matchedLines]).toEqual([50]);
+  });
+
+  it("handles a match at the file edge (before / after partly empty)", () => {
+    // Backend clamps the context window at file edges. Pin
+    // that we don't synthesise lines we don't have — the block
+    // shrinks to whatever ``before`` / ``after`` actually
+    // contain.
+    const m = mkMatch({
+      line_number: 1,
+      line_text: "esphome:",
+      before: [],
+      after: ["  name: kitchen", "  friendly_name: Kitchen"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.startLine).toBe(1);
+    expect(block.endLine).toBe(3);
+    expect(block.lines).toEqual([
+      "esphome:",
+      "  name: kitchen",
+      "  friendly_name: Kitchen",
+    ]);
+  });
+
+  it("masks credential values in context lines too", () => {
+    // The ``password:`` line happens to be a *context* line
+    // for a match on the surrounding ``wifi:`` block, not the
+    // matched line itself — so masking has to apply to
+    // ``before`` / ``after`` content, not just ``line_text``.
+    // Otherwise a search for ``ssid`` would leak the password
+    // value in the rendered snippet.
+    const m = mkMatch({
+      line_number: 3,
+      line_text: "  ssid: home",
+      before: ["wifi:"],
+      after: ["  password: hunter2"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "wifi:",
+      "  ssid: home",
+      "  password: ••••••••",
+    ]);
+  });
+});
+
+describe("yamlSnippetBlockHref", () => {
+  it("links to the block's first matched line, not its start line", () => {
+    // The block spans context lines 3..7 with a single match
+    // at line 5. Linking to ``startLine`` would land the
+    // editor cursor on a context line — pin that we use the
+    // first match in the block instead.
+    const m = mkMatch({
+      line_number: 5,
+      line_text: "wifi:",
+      before: ["esphome:", "  name: kitchen"],
+      after: ["  ssid: home", "  password: x"],
+    });
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(yamlSnippetBlockHref(HIT, block)).toBe("/device/kitchen.yaml?line=5");
+  });
+
+  it("URL-encodes the configuration filename", () => {
+    const m = mkMatch({ line_number: 5, line_text: "wifi:" });
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(
+      yamlSnippetBlockHref(mkHit({ configuration: "guest room (1).yaml" }), block),
+    ).toBe("/device/guest%20room%20(1).yaml?line=5");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Replaces the flat per-match row list (`{} <DeviceName> — <line>` repeated for every hit) with a code-search shape: section per device (header with `{}` icon, friendly name, match count) on top of one or more snippet blocks. Each block carries the matched line plus its `before` / `after` context window, with the matched substring highlighted inline via `<mark>`. Adjacent matches whose context windows overlap collapse into one block (GitHub code search / VS Code search behaviour).

Companion to esphome/device-builder#378 which adds `before` / `after` to the wire shape.

## Helpers

`util/yaml-search-helpers.ts` gains three:

- `buildYamlSnippetBlocks(matches)` reconstructs per-line content from the `(before + line_text + after)` tuples each match carries — there's no full file on the frontend, so the helper walks per-line coordinates and picks whichever match covers each line number. Overlap collapses naturally because the line-number set becomes contiguous; gaps split into separate blocks. Match lines are tracked in a `Set` so the renderer knows which rows to highlight.
- `yamlHitDeviceLabel(hit)` — same `friendly_name → device_name → configuration` fallback chain `yamlHitLabel` uses, but for the section header (label only, no line text).
- `yamlSnippetBlockHref(hit, block)` links to the block's first *match* line (not its start line) — landing the editor cursor on actual matched content rather than a context line.

The legacy `yamlHitLabel` / `yamlHitHref` / `forEachYamlMatch` stay — the command palette still renders one row per match (keyboard nav reads better as a flat list there). Only the dashboard's `_renderYamlMode` flips to the grouped shape.

## Safety

- **XSS** — every interpolation is a Lit child binding (text-bound via DOM text nodes, never `innerHTML`). `_highlightMatch` returns an array of plain strings and `html\`<mark>\${slice}</mark>\`` templates; both shapes go through the same escape path.
- **Credential leak** — `maskSensitiveLine` runs on every line that goes into a block, not just the matched line. A search for `ssid` would otherwise leak a `password: hunter2` line two rows below the match.
- **URL** — `encodeURIComponent` on the configuration filename, plain integer for the line number.

## Tests

- Extracted `mkMatch` / `mkHit` factories in the helper test file so existing fixtures don't sprinkle `before: [], after: []` through every case.
- Eight new `buildYamlSnippetBlocks` / `yamlSnippetBlockHref` tests covering single-match expansion, adjacent-match merging, non-overlapping splits, file-edge clamping, mask coverage on context lines, and the first-match-line link target.

Lint + 740/740 tests pass on the branch.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#378 (backend adds `before` / `after` to `YamlSearchMatch`)
- driven by user feedback that the search "shows only matched lines" with no context, and that the per-row icon + repeated device-name prefix made the list hard to scan

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes (740/740).
  - [x] Tests have been added to verify that the new code works (where applicable).
