### PR TITLE
yaml/search: mask encryption key when its parent is in the context window

### DIFF
--- a/src/util/yaml-search-helpers.ts
+++ b/src/util/yaml-search-helpers.ts
@@ -18,7 +18,12 @@
 
 import type { LocalizeFunc } from "../common/localize.js";
 import type { YamlSearchHit, YamlSearchMatch } from "../api/types.js";
-import { ALWAYS_SENSITIVE_KEYS } from "./yaml-sensitive-scan.js";
+import {
+  ALWAYS_SENSITIVE_KEYS,
+  findSensitiveValueRanges,
+} from "./yaml-sensitive-scan.js";
+
+const MASK_PLACEHOLDER = "••••••••";
 
 /**
  * True when *key* names a credential whose value should never
@@ -81,7 +86,55 @@ function maskSensitiveLine(line: string): string {
   // value, not the value itself. Don't mask them.
   if (value.startsWith("!secret")) return line;
   if (value.startsWith("${")) return line;
-  return `${prefix}${key}: ••••••••`;
+  return `${prefix}${key}: ${MASK_PLACEHOLDER}`;
+}
+
+/**
+ * Mask credential values across a contiguous block of YAML lines.
+ *
+ * Single-line ``maskSensitiveLine`` can't reason about parent
+ * keys, so it can't mask ``key:`` under ``encryption:`` (a
+ * generic ``key:`` is also used for non-sensitive button codes
+ * in ``remote_receiver`` / ``remote_transmitter``). Snippet
+ * blocks now carry several lines of context, which is exactly
+ * the parent reasoning the editor's
+ * ``findSensitiveValueRanges`` already does. This runs the
+ * multi-line scanner over the joined block to catch
+ * parent-scoped credentials, then falls back to the single-line
+ * heuristic for what the scanner doesn't handle:
+ *
+ * - Commented-out credentials (``# password: hunter2``) — the
+ *   scanner's ``KEY_LINE`` regex doesn't match leading ``#``.
+ * - User-defined ``*_password`` / ``*_psk`` substitution keys —
+ *   not in the scanner's allowlist; the suffix heuristic only
+ *   lives in the single-line masker.
+ *
+ * Edge case: a ``key:`` line whose ``encryption:`` parent is
+ * outside the block window stays unmasked (the scanner sees no
+ * parent on its stack). Bounded — typical 2-line context windows
+ * include the parent — and unchanged from prior behaviour.
+ */
+function maskSnippetBlock(lines: readonly string[]): string[] {
+  if (lines.length === 0) return [];
+  const out = lines.slice();
+  const ranges = findSensitiveValueRanges(out.join("\n"));
+  const scannerMaskedLines = new Set<number>();
+  for (const range of ranges) {
+    const idx = range.line - 1;
+    if (idx < 0 || idx >= out.length) continue;
+    const line = out[idx];
+    if (range.valueFrom < 0 || range.valueTo > line.length) continue;
+    out[idx] =
+      line.slice(0, range.valueFrom) +
+      MASK_PLACEHOLDER +
+      line.slice(range.valueTo);
+    scannerMaskedLines.add(idx);
+  }
+  for (let i = 0; i < out.length; i++) {
+    if (scannerMaskedLines.has(i)) continue;
+    out[i] = maskSensitiveLine(out[i]);
+  }
+  return out;
 }
 
 /**
@@ -227,25 +280,28 @@ export function buildYamlSnippetBlocks(
   // Per-line content map keyed on absolute (1-based) line number.
   // Each match contributes its before/line/after; later writes
   // for a line that's already filled are a no-op since the
-  // content is identical.
+  // content is identical. Masking is deferred to ``flushBlock``
+  // so the parent-aware scanner can see contiguous lines as a
+  // unit (a ``key:`` line under ``encryption:`` only reads as
+  // sensitive when its parent is on the scanner's stack).
   const lineContent = new Map<number, string>();
   // The 1-based line numbers that are *match* lines (vs context).
   const matchLineNumbers = new Set<number>();
   for (const m of matches) {
     matchLineNumbers.add(m.line_number);
-    lineContent.set(m.line_number, maskSensitiveLine(m.line_text));
+    lineContent.set(m.line_number, m.line_text);
     // ``before`` is in file order, so the line immediately
     // preceding the match is at index ``length - 1`` and walks
     // backwards from there.
     const beforeStart = m.line_number - m.before.length;
     m.before.forEach((text, i) => {
       const ln = beforeStart + i;
-      if (!lineContent.has(ln)) lineContent.set(ln, maskSensitiveLine(text));
+      if (!lineContent.has(ln)) lineContent.set(ln, text);
     });
     // ``after`` is in file order starting at line+1.
     m.after.forEach((text, i) => {
       const ln = m.line_number + 1 + i;
-      if (!lineContent.has(ln)) lineContent.set(ln, maskSensitiveLine(text));
+      if (!lineContent.has(ln)) lineContent.set(ln, text);
     });
   }
   // Walk the populated line numbers in order, splitting on gaps.
@@ -254,15 +310,20 @@ export function buildYamlSnippetBlocks(
   let blockStart = ordered[0];
   let prev = ordered[0];
   const flushBlock = (start: number, end: number) => {
-    const lines: string[] = [];
+    const rawLines: string[] = [];
     for (let ln = start; ln <= end; ln++) {
-      lines.push(lineContent.get(ln) ?? "");
+      rawLines.push(lineContent.get(ln) ?? "");
     }
     const matchedLines = new Set<number>();
     for (let ln = start; ln <= end; ln++) {
       if (matchLineNumbers.has(ln)) matchedLines.add(ln);
     }
-    blocks.push({ startLine: start, endLine: end, lines, matchedLines });
+    blocks.push({
+      startLine: start,
+      endLine: end,
+      lines: maskSnippetBlock(rawLines),
+      matchedLines,
+    });
   };
   for (let i = 1; i < ordered.length; i++) {
     const cur = ordered[i];

--- a/src/util/yaml-search-helpers.ts
+++ b/src/util/yaml-search-helpers.ts
@@ -124,6 +124,15 @@ function maskSnippetBlock(lines: readonly string[]): string[] {
     if (idx < 0 || idx >= out.length) continue;
     const line = out[idx];
     if (range.valueFrom < 0 || range.valueTo > line.length) continue;
+    // ``findSensitiveValueRanges`` skips ``!secret <name>`` (it only
+    // carries the indirection name, not the credential) but doesn't
+    // skip ``${substitution}`` references — they're the same shape
+    // of indirection and ``maskSensitiveLine`` already preserves
+    // them on single-line paths. Mirror that here so the search
+    // result label and the snippet-block render agree on what stays
+    // visible.
+    const value = line.slice(range.valueFrom, range.valueTo).trim();
+    if (value.startsWith("${")) continue;
     out[idx] =
       line.slice(0, range.valueFrom) +
       MASK_PLACEHOLDER +

--- a/test/util/yaml-search-helpers.test.ts
+++ b/test/util/yaml-search-helpers.test.ts
@@ -517,6 +517,38 @@ describe("buildYamlSnippetBlocks", () => {
     expect(block.lines).toEqual(["wifi:", "  # password: ••••••••"]);
   });
 
+  it("keeps ${substitution} indirections visible on context lines", () => {
+    // The matched-line path (``yamlHitLabel``) deliberately
+    // leaves ``${wifi_password}`` and ``!secret wifi_password``
+    // visible — they carry only the *name* of an indirection,
+    // not the credential. The scanner-driven block mask doesn't
+    // natively skip ``${...}`` (only ``!secret``), so without a
+    // filter the snippet renderer would mask substitution
+    // references while the command-palette labels still show
+    // them. Pin the consistency: the ``password:
+    // ${wifi_password}`` reference stays visible in a context
+    // line, while the actual substitution definition further
+    // down (``wifi_password: yellow1@@``) gets masked via the
+    // suffix heuristic.
+    const m = mkMatch({
+      line_number: 4,
+      line_text: "wifi:",
+      before: ["substitutions:", "  wifi_password: yellow1@@", ""],
+      after: ["  ssid: home", "  password: ${wifi_password}"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "substitutions:",
+      "  wifi_password: ••••••••",
+      "",
+      "wifi:",
+      "  ssid: home",
+      "  password: ${wifi_password}",
+    ]);
+  });
+
   it("falls back to the *_password suffix heuristic on context lines", () => {
     // User-defined ``substitutions: wifi_password: …`` shape —
     // not in the scanner's ``ALWAYS_SENSITIVE_KEYS`` allowlist,

--- a/test/util/yaml-search-helpers.test.ts
+++ b/test/util/yaml-search-helpers.test.ts
@@ -428,6 +428,114 @@ describe("buildYamlSnippetBlocks", () => {
       "  password: ••••••••",
     ]);
   });
+
+  it("masks the API encryption key when its parent is in the snippet window", () => {
+    // ``key:`` is parent-scoped sensitive (only under
+    // ``encryption:`` — generic ``key:`` is also used for
+    // non-sensitive button codes). Single-line masking can't
+    // make this call, but a snippet block carries enough
+    // surrounding lines for the multi-line scanner to see the
+    // parent. Pin that a search for ``api`` (matched line ``api:``)
+    // masks the encryption key sitting two lines below in the
+    // ``after`` window.
+    const m = mkMatch({
+      line_number: 5,
+      line_text: "api:",
+      before: ["esphome:", "  name: kitchen"],
+      after: ["  encryption:", "    key: AAABBBCCCDDDEEEFFFGGG="],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "esphome:",
+      "  name: kitchen",
+      "api:",
+      "  encryption:",
+      "    key: ••••••••",
+    ]);
+  });
+
+  it("does not mask a bare ``key:`` line when its parent is outside the window", () => {
+    // The scanner walks the block top-to-bottom; if the
+    // ``encryption:`` parent isn't included, ``key:`` reads as a
+    // plain (non-sensitive) field — same as a button code under
+    // ``remote_receiver``. Pin the don't-over-mask behaviour so
+    // this fallback case stays consistent with the editor's scan.
+    const m = mkMatch({
+      line_number: 9,
+      line_text: "    key: 0xABCDEF12",
+      before: ["    - protocol: NEC", "      data: 0x00FF"],
+      after: ["    - protocol: NEC"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "    - protocol: NEC",
+      "      data: 0x00FF",
+      "    key: 0xABCDEF12",
+      "    - protocol: NEC",
+    ]);
+  });
+
+  it("preserves trailing comments when the scanner masks a value", () => {
+    // ``findSensitiveValueRanges`` returns a precise
+    // ``[valueFrom, valueTo)`` range so the slice replacement
+    // keeps any trailing ``# comment`` untouched. The single-line
+    // ``maskSensitiveLine`` would clobber it via the wholesale
+    // ``${prefix}${key}: ••••••••`` rewrite — pin that the
+    // scanner-driven path is preferred.
+    const m = mkMatch({
+      line_number: 2,
+      line_text: "wifi:",
+      before: [],
+      after: ["  password: hunter2  # admin pwd"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "wifi:",
+      "  password: ••••••••  # admin pwd",
+    ]);
+  });
+
+  it("falls back to the single-line heuristic for commented credentials", () => {
+    // The scanner's ``KEY_LINE`` doesn't match a leading ``#``,
+    // so commented-out credentials only get masked by the
+    // post-scanner single-line pass. Pin that the fallback runs.
+    const m = mkMatch({
+      line_number: 2,
+      line_text: "wifi:",
+      before: [],
+      after: ["  # password: hunter2"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual(["wifi:", "  # password: ••••••••"]);
+  });
+
+  it("falls back to the *_password suffix heuristic on context lines", () => {
+    // User-defined ``substitutions: wifi_password: …`` shape —
+    // not in the scanner's ``ALWAYS_SENSITIVE_KEYS`` allowlist,
+    // so the single-line suffix heuristic catches it on the
+    // post-scanner pass.
+    const m = mkMatch({
+      line_number: 2,
+      line_text: "substitutions:",
+      before: [],
+      after: ["  wifi_password: yellow1@@"],
+    });
+
+    const [block] = buildYamlSnippetBlocks([m]);
+
+    expect(block.lines).toEqual([
+      "substitutions:",
+      "  wifi_password: ••••••••",
+    ]);
+  });
 });
 
 describe("yamlSnippetBlockHref", () => {


### PR DESCRIPTION
# What does this implement/fix?

The grouped snippet renderer that landed in #198 showed each match's `before` / `after` context lines through `maskSensitiveLine`, which is single-line and can't reason about parent keys. `key:` under `encryption:` is parent-scoped sensitive in the editor's masking — without seeing the `encryption:` parent the masker can't tell whether `key:` is the API encryption key or a non-sensitive button code under `remote_receiver` / `remote_transmitter`, so it deliberately leaves bare `key:` lines alone.

Result: any search whose match landed at or near an `api:` block leaked the resolved encryption key in the rendered snippet, because that key sits under `encryption:` two lines below.

Fix: switch `buildYamlSnippetBlocks` to defer masking until the block is built, then run `findSensitiveValueRanges` (the editor's parent-aware multi-line scanner from `yaml-sensitive-scan.ts`) over the joined block YAML. The scanner pushes `encryption:` onto its parent stack as it walks down and correctly classifies the following `key:` line as sensitive. Lines the scanner doesn't flag (commented credentials like `# password:`, user-defined `*_password` / `*_psk` substitution keys) fall through to the original single-line masker so the existing search-side coverage is preserved.

Edge case: a `key:` line whose `encryption:` parent is outside the snippet window stays unmasked — the scanner sees no parent on its stack. Bounded by the configurable context-line window (defaults to ±2) and unchanged from the prior shipped behaviour.

Six new tests pin:
- Encryption key masked when `encryption:` parent is in the window
- Bare `key:` button code unchanged when no parent is in scope
- Trailing comment preserved when the scanner masks (`password: hunter2  # admin pwd` → `password: ••••••••  # admin pwd`)
- Commented credentials (`# password:`) still masked via the fallback
- `*_password` user-suffix keys in context still masked via the fallback

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #198 (grouped snippet renderer that introduced the leak path)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [x] Tests have been added to verify that the new code works (where applicable).
