### PR TITLE
Address late Copilot review on #199 (IPv6 wrap + dedupe URL)

### DIFF
--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -49,6 +49,7 @@ import { getEncryptionState } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
+import { renderIpValue } from "./device-drawer-render.js";
 import {
   ageOf,
   formatSecondsAgo,
@@ -955,43 +956,8 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     `;
   }
 
-  /**
-   * Render the primary IP cell, optionally suffixed with a "Visit web UI"
-   * icon-link.
-   *
-   * *url* is the precomputed ``buildWebUiUrl`` result for the device —
-   * passed in (rather than recomputed) so the empty-IP guard in the
-   * caller and this render share a single URL parse. An empty *url*
-   * suppresses the link, mirroring the original "no link" branch.
-   * Pass an empty *ip* to render the ``—`` placeholder alongside the
-   * link; used in the "no resolved IPs yet but ``device.address`` is
-   * known" branch so the visit affordance isn't gated on the first
-   * mDNS A-record.
-   */
   private _renderIpValue(ip: string, url: string) {
-    const isPlaceholder = !ip;
-    const display = ip || "—";
-    if (!url) {
-      return html`<div
-        class="value mono ${isPlaceholder ? "muted" : ""}"
-      >${display}</div>`;
-    }
-    const visitLabel = this._localize("dashboard.action_visit_web_ui");
-    return html`
-      <div class="value mono ip-value ${isPlaceholder ? "muted" : ""}">
-        <span class="ip-value-text">${display}</span>
-        <a
-          class="ip-visit-link"
-          href=${url}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label=${visitLabel}
-          title=${visitLabel}
-        >
-          <wa-icon library="mdi" name="open-in-new"></wa-icon>
-        </a>
-      </div>
-    `;
+    return renderIpValue(ip, url, this._localize);
   }
 
   /**

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -334,15 +334,31 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-xs);
+        /* Cap to the row's text column so a long IPv6 literal wraps
+           in-place instead of pushing the visit-link icon out of the
+           drawer. The flex children below carry the actual wrapping
+           (min-width: 0) and shrink-protection (flex-shrink: 0). */
+        max-width: 100%;
+      }
+      /* Flex items default to min-width: auto, which prevents the IP
+         text from shrinking below its intrinsic width — long IPv6
+         literals would then overflow. Force min-width: 0 and let
+         overflow-wrap break inside the address. */
+      .ip-value-text {
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
       /* Match the table's .cell-action-btn icon-only target geometry
          so the drawer link is reachable by keyboard and touch —
          square hit area, :focus-visible ring, and the same hover
-         affordance the table-cell visit-web button uses. */
+         affordance the table-cell visit-web button uses.
+         flex-shrink: 0 keeps the icon a stable 24x24 even when the
+         IPv6 text is wrapping next to it. */
       .ip-visit-link {
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        flex-shrink: 0;
         width: 24px;
         height: 24px;
         border-radius: var(--wa-border-radius-m);
@@ -864,6 +880,10 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
   private _renderIpAddressRow(d: ConfiguredDevice) {
     const list = d.ip_addresses;
     const label = this._localize("dashboard.drawer_ip_address");
+    // Resolve once per render — ``buildWebUiUrl`` parses a URL and
+    // both the empty-IP guard and ``_renderIpValue`` need the same
+    // answer.
+    const webUrl = buildWebUiUrl(d);
     if (list.length === 0) {
       // ``device.address`` (the YAML-declared mDNS hostname) plus a
       // configured ``web_port`` is enough to build a usable visit-web
@@ -871,7 +891,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
       // route through ``_renderIpValue`` to surface the link in that
       // window. Falls back to ``_row``'s muted em-dash when neither
       // is available.
-      if (!buildWebUiUrl(d)) {
+      if (!webUrl) {
         return this._row("ip-network-outline", label, "", true);
       }
       return html`
@@ -881,7 +901,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           </div>
           <div class="content">
             <div class="label">${label}</div>
-            ${this._renderIpValue(d, "")}
+            ${this._renderIpValue("", webUrl)}
           </div>
         </div>
       `;
@@ -894,7 +914,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
           </div>
           <div class="content">
             <div class="label">${label}</div>
-            ${this._renderIpValue(d, list[0])}
+            ${this._renderIpValue(list[0], webUrl)}
           </div>
         </div>
       `;
@@ -908,7 +928,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         </div>
         <div class="content">
           <div class="label">${label}</div>
-          ${this._renderIpValue(d, list[0])}
+          ${this._renderIpValue(list[0], webUrl)}
           ${expanded
             ? list
                 .slice(1)
@@ -939,19 +959,16 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
    * Render the primary IP cell, optionally suffixed with a "Visit web UI"
    * icon-link.
    *
-   * The link only renders when ``buildWebUiUrl`` returns a non-empty
-   * URL — i.e. the YAML enabled ``web_server`` and we have a host to
-   * point at. ``buildWebUiUrl`` is the single source of truth for the
-   * host/port/protocol logic shared with the table column and the
-   * row-menu, so the drawer can't drift out of sync with them.
-   *
+   * *url* is the precomputed ``buildWebUiUrl`` result for the device —
+   * passed in (rather than recomputed) so the empty-IP guard in the
+   * caller and this render share a single URL parse. An empty *url*
+   * suppresses the link, mirroring the original "no link" branch.
    * Pass an empty *ip* to render the ``—`` placeholder alongside the
    * link; used in the "no resolved IPs yet but ``device.address`` is
    * known" branch so the visit affordance isn't gated on the first
    * mDNS A-record.
    */
-  private _renderIpValue(d: ConfiguredDevice, ip: string) {
-    const url = buildWebUiUrl(d);
+  private _renderIpValue(ip: string, url: string) {
     const isPlaceholder = !ip;
     const display = ip || "—";
     if (!url) {
@@ -962,7 +979,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const visitLabel = this._localize("dashboard.action_visit_web_ui");
     return html`
       <div class="value mono ip-value ${isPlaceholder ? "muted" : ""}">
-        <span>${display}</span>
+        <span class="ip-value-text">${display}</span>
         <a
           class="ip-visit-link"
           href=${url}

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -1,0 +1,55 @@
+/**
+ * Stateless renderers for the device drawer.
+ *
+ * Lives in a sibling file (rather than inside ``device-drawer-content.ts``)
+ * so the unit tests can import the renderer without dragging in
+ * ``webawesome``'s side-effect modules — those reach for DOM globals
+ * (``CSSStyleSheet``, ``customElements``) that the vitest ``node``
+ * environment doesn't define. The renderer itself only needs ``lit``
+ * and the localize signature.
+ */
+import { html } from "lit";
+import type { LocalizeFunc } from "../../common/localize.js";
+
+/**
+ * Render the primary IP cell, optionally suffixed with a "Visit web UI"
+ * icon-link.
+ *
+ * *url* is the precomputed ``buildWebUiUrl`` result for the device —
+ * passed in (rather than recomputed) so the empty-IP guard in the
+ * caller and this render share a single URL parse. An empty *url*
+ * suppresses the link, mirroring the original "no link" branch.
+ * Pass an empty *ip* to render the ``—`` placeholder alongside the
+ * link; used in the "no resolved IPs yet but ``device.address`` is
+ * known" branch so the visit affordance isn't gated on the first
+ * mDNS A-record.
+ */
+export function renderIpValue(
+  ip: string,
+  url: string,
+  localize: LocalizeFunc,
+) {
+  const isPlaceholder = !ip;
+  const display = ip || "—";
+  if (!url) {
+    return html`<div
+      class="value mono ${isPlaceholder ? "muted" : ""}"
+    >${display}</div>`;
+  }
+  const visitLabel = localize("dashboard.action_visit_web_ui");
+  return html`
+    <div class="value mono ip-value ${isPlaceholder ? "muted" : ""}">
+      <span class="ip-value-text">${display}</span>
+      <a
+        class="ip-visit-link"
+        href=${url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label=${visitLabel}
+        title=${visitLabel}
+      >
+        <wa-icon library="mdi" name="open-in-new"></wa-icon>
+      </a>
+    </div>
+  `;
+}

--- a/test/components/dashboard/render-ip-value.test.ts
+++ b/test/components/dashboard/render-ip-value.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the drawer's IP-value renderer.
+ *
+ * The renderer is the helper behind the IP Address row in the
+ * device drawer's "Network" section: it stamps the IP text and,
+ * when ``buildWebUiUrl`` produced a URL for the device, an
+ * ``open-in-new`` icon-link to the device's web UI. The empty-IP
+ * branch is the interesting one — the affordance has to render
+ * even before the first resolved A-record arrives so a freshly-
+ * adopted device with only a YAML mDNS hostname (``device.address``)
+ * still gets a visit link.
+ *
+ * Vitest runs in the ``node`` environment so we don't mount Lit;
+ * the existing template-walker (``test/_lit-template-walker.ts``)
+ * gives us a way to assert on the produced ``TemplateResult`` —
+ * presence of the anchor element, attribute bindings, and the
+ * placeholder text — without a DOM.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+} from "../../_lit-template-walker.js";
+import { renderIpValue } from "../../../src/components/dashboard/device-drawer-render.js";
+
+const _identityLocalize: (key: string) => string = (key) => key;
+
+describe("renderIpValue", () => {
+  it("omits the visit link when url is empty", () => {
+    const result = renderIpValue("192.168.1.42", "", _identityLocalize);
+    expect(findTemplatesByAnchor(result, "<a").length).toBe(0);
+    expect(findTemplatesByAnchor(result, "ip-visit-link").length).toBe(0);
+    // Still emits the IP value cell.
+    const valueCells = findTemplatesByAnchor(result, "value mono");
+    expect(valueCells.length).toBeGreaterThan(0);
+  });
+
+  it("renders the visit-web link when url is set", () => {
+    const url = "http://kitchen.local";
+    const result = renderIpValue("192.168.1.42", url, _identityLocalize);
+    const anchors = findTemplatesByAnchor(result, "<a");
+    expect(anchors.length).toBe(1);
+    const bindings = extractAttributeBindings(anchors[0]);
+    expect(bindings.href).toBe(url);
+    // ``rel="noopener noreferrer"`` and ``target="_blank"`` are
+    // static (no Lit binding), so they don't appear in the binding
+    // map — assert via the joined static template strings instead.
+    const staticText = anchors[0].strings.join("§");
+    expect(staticText).toContain('target="_blank"');
+    expect(staticText).toContain('rel="noopener noreferrer"');
+  });
+
+  it("uses the localised visit-web label for aria-label and title", () => {
+    const localize = (key: string): string =>
+      key === "dashboard.action_visit_web_ui" ? "Visit web UI" : key;
+    const result = renderIpValue(
+      "192.168.1.42",
+      "http://kitchen.local",
+      localize,
+    );
+    const [anchor] = findTemplatesByAnchor(result, "<a");
+    const bindings = extractAttributeBindings(anchor);
+    expect(bindings["aria-label"]).toBe("Visit web UI");
+    expect(bindings.title).toBe("Visit web UI");
+  });
+
+  it("renders the em-dash placeholder when ip is empty", () => {
+    // No URL: render the bare placeholder cell with the muted class.
+    const noUrl = renderIpValue("", "", _identityLocalize);
+    const noUrlValues = noUrl.values.flat(Infinity);
+    expect(noUrlValues).toContain("—");
+
+    // With URL: still render the placeholder, plus the visit link
+    // alongside it so the affordance isn't blocked on the first
+    // mDNS A-record.
+    const withUrl = renderIpValue("", "http://kitchen.local", _identityLocalize);
+    const withUrlValues = withUrl.values.flat(Infinity);
+    expect(withUrlValues).toContain("—");
+    expect(findTemplatesByAnchor(withUrl, "<a").length).toBe(1);
+  });
+
+  it("applies the muted class only in the empty-IP placeholder", () => {
+    // The class string is built via ``class="value mono ${expr}"``,
+    // so ``muted`` lives in ``values`` (an empty string when
+    // populated; ``"muted"`` when the placeholder is rendering).
+    const placeholder = renderIpValue("", "", _identityLocalize);
+    expect(placeholder.values).toContain("muted");
+
+    const populated = renderIpValue("192.168.1.42", "", _identityLocalize);
+    expect(populated.values).not.toContain("muted");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Followup on #199 addressing the two late Copilot review comments
([review #4240848891](https://github.com/esphome/device-builder-frontend/pull/199#pullrequestreview-4240848891)):

- **IPv6 overflow.** The visit-link's `<span>` lived inside an
  `inline-flex` container; flex children default to `min-width: auto`
  so a long IPv6 literal wouldn't shrink and could push the icon
  out of the drawer row. Added a class on the text span with
  `min-width: 0` + `overflow-wrap: anywhere`, plus
  `flex-shrink: 0` on the link so the 24×24 hit-area stays stable
  while the text wraps next to it. The container also gets
  `max-width: 100%` so wrapping is bounded by the row's text column.

- **Duplicate `buildWebUiUrl` work.** The empty-IP branch evaluated
  `buildWebUiUrl(d)` for the existence guard and then
  `_renderIpValue` recomputed it. `buildWebUiUrl` parses a URL via
  `safeWebUiUrl`, so this was wasted on every render. Hoisted
  the call to `_renderIpAddressRow` and pass the result into
  `_renderIpValue(ip, url)` — single parse per row render, and
  `_renderIpValue` no longer needs the device argument.

- **Tests + extraction.** Pulled the IP-value renderer out into a
  sibling `device-drawer-render.ts` module (importing only `lit` +
  the localize signature). The drawer's class re-exports it via a
  thin wrapper, and `test/components/dashboard/render-ip-value.test.ts`
  now exercises the renderer with the existing template-walker
  helper (5 tests: link suppression when URL is empty, anchor
  attributes when URL is set, localised aria-label/title, em-dash
  placeholder rendering with and without URL, and the muted-class
  toggle). The split also keeps the tests vitest-compatible — the
  drawer component imports webawesome side-effect modules that
  reach for `CSSStyleSheet`, which the `node` test environment
  doesn't define.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- followup to #199

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [x] Tests have been added to verify that the new code works (where applicable).
