### PR TITLE
Fix labels filter popover overflow and surface create affordance

### DIFF
--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -28,7 +28,6 @@ import {
   mdiCheck,
   mdiClose,
   mdiPencil,
-  mdiPlus,
   mdiTagMultiple,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
@@ -39,12 +38,14 @@ import type { ConfiguredDevice, Label } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { LABEL_COLOR_SWATCHES, labelChipStyleString } from "../../util/label-style.js";
+import { labelChipStyleString } from "../../util/label-style.js";
 import {
   labelChipStyles,
   resolveLabelIds,
 } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import "./label-create-form.js";
+import type { ESPHomeLabelCreateForm } from "./label-create-form.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -54,7 +55,6 @@ registerMdiIcons({
   check: mdiCheck,
   close: mdiClose,
   pencil: mdiPencil,
-  plus: mdiPlus,
   "tag-multiple": mdiTagMultiple,
 });
 
@@ -80,22 +80,9 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   @state()
   private _filter = "";
 
-  /** Whether the "Create new label" inline form is expanded inside
-   *  the dialog. Collapsed by default to keep the dialog compact. */
-  @state()
-  private _createOpen = false;
-
-  /** Pending values for the in-progress label creation. */
-  @state()
-  private _newName = "";
-
-  @state()
-  private _newColor: string | null = null;
-
-  /** True while a ``set_labels`` round trip is in flight. Disables
-   *  the create submit button to prevent double-fires; toggle
-   *  clicks are still accepted and queued so fast multi-toggle
-   *  feels responsive. */
+  /** True while a ``set_labels`` round trip is in flight. Used to
+   *  gate optimistic-state cleanup; toggle clicks are still
+   *  accepted and queued so fast multi-toggle feels responsive. */
   @state()
   private _saving = false;
 
@@ -118,6 +105,9 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
   @query("wa-dialog")
   private _dialog?: HTMLElement & { open: boolean };
+
+  @query("esphome-label-create-form")
+  private _createForm?: ESPHomeLabelCreateForm;
 
   static styles = [
     espHomeStyles,
@@ -303,95 +293,6 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         margin: var(--wa-space-s) 0;
       }
 
-      .create-toggle {
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-        padding: 6px 8px;
-        background: transparent;
-        border: none;
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--esphome-primary);
-        cursor: pointer;
-        align-self: flex-start;
-        font-family: inherit;
-      }
-
-      .create-toggle wa-icon {
-        font-size: 14px;
-      }
-
-      .create-form {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-s) 0;
-      }
-
-      .create-form-label {
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .swatch-row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
-      }
-
-      .swatch {
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        cursor: pointer;
-        padding: 0;
-      }
-
-      .swatch--selected {
-        outline: 2px solid var(--esphome-primary);
-        outline-offset: 2px;
-      }
-
-      .swatch--clear {
-        background: transparent;
-        color: var(--wa-color-text-quiet);
-        font-size: 12px;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .create-actions {
-        display: flex;
-        gap: var(--wa-space-xs);
-        justify-content: flex-end;
-      }
-
-      .btn {
-        padding: 6px 14px;
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        border-radius: var(--wa-border-radius-s);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        background: var(--wa-color-surface-default);
-        color: var(--wa-color-text-normal);
-        cursor: pointer;
-        font-family: inherit;
-      }
-
-      .btn--primary {
-        background: var(--esphome-primary);
-        color: var(--esphome-on-primary);
-        border-color: var(--esphome-primary);
-      }
-
-      .btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
     `,
   ];
 
@@ -404,9 +305,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       // ``_saving`` indicator until that promise settled.
       if (this._dialog) this._dialog.open = false;
       this._filter = "";
-      this._createOpen = false;
-      this._newName = "";
-      this._newColor = null;
+      this._createForm?.collapse();
       this._optimisticLabels = null;
       this._saving = false;
       this._saveChain = Promise.resolve();
@@ -509,157 +408,26 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
                 })}
         </div>
         <div class="divider"></div>
-        ${this._createOpen ? this._renderCreateForm() : html`<button
-          class="create-toggle"
-          type="button"
-          @click=${() => {
-            this._createOpen = true;
-            // Pre-fill the name from the current filter when the
-            // user typed something that didn't match — saves the
-            // re-type when "filter to find" turns into "didn't
-            // exist, create it".
-            this._newName = this._filter;
+        <esphome-label-create-form
+          .existingNames=${this._catalog.map((l) => l.name)}
+          .nameSeed=${this._filter}
+          @label-created=${(e: CustomEvent<Label>) => {
+            void this._assignNewLabel(e.detail);
           }}
-        >
-          <wa-icon library="mdi" name="plus"></wa-icon>
-          ${this._localize("dashboard.labels_create")}
-        </button>`}
+        ></esphome-label-create-form>
       </wa-dialog>
     `;
   }
 
-  private _renderCreateForm() {
-    const trimmed = this._newName.trim();
-    const duplicate = this._catalog.some(
-      (l) => l.name.toLowerCase() === trimmed.toLowerCase(),
-    );
-    const canCreate = trimmed.length > 0 && trimmed.length <= 50 && !duplicate;
-    const values: (string | null)[] = [null, ...LABEL_COLOR_SWATCHES];
-    return html`
-      <form
-        class="create-form"
-        @submit=${(e: Event) => {
-          e.preventDefault();
-          if (canCreate) void this._createAndAssign();
-        }}
-      >
-        <span class="create-form-label">${this._localize("dashboard.labels_create")}</span>
-        <wa-input
-          placeholder=${this._localize("dashboard.labels_create_placeholder")}
-          maxlength="50"
-          .value=${this._newName}
-          @input=${(e: Event) => {
-            this._newName = (e.currentTarget as unknown as { value: string }).value;
-          }}
-        ></wa-input>
-        <div
-          class="swatch-row"
-          role="radiogroup"
-          aria-label=${this._localize("dashboard.labels_color")}
-          @keydown=${(e: KeyboardEvent) => this._onSwatchKeyDown(e, values)}
-        >
-          ${values.map((c) => {
-            const selected = this._newColor === c;
-            if (c === null) {
-              return html`<button
-                type="button"
-                role="radio"
-                aria-checked=${selected ? "true" : "false"}
-                tabindex=${selected ? "0" : "-1"}
-                class="swatch swatch--clear ${selected ? "swatch--selected" : ""}"
-                aria-label=${this._localize("dashboard.labels_color_none")}
-                title=${this._localize("dashboard.labels_color_none")}
-                @click=${() => {
-                  this._newColor = null;
-                }}
-              >
-                ${selected ? html`<wa-icon library="mdi" name="check"></wa-icon>` : nothing}
-              </button>`;
-            }
-            return html`<button
-              type="button"
-              role="radio"
-              aria-checked=${selected ? "true" : "false"}
-              tabindex=${selected ? "0" : "-1"}
-              class="swatch ${selected ? "swatch--selected" : ""}"
-              style="background:${c}"
-              aria-label=${c}
-              title=${c}
-              @click=${() => {
-                this._newColor = c;
-              }}
-            ></button>`;
-          })}
-        </div>
-        <div class="create-actions">
-          <button
-            type="button"
-            class="btn"
-            @click=${() => {
-              this._createOpen = false;
-              this._newName = "";
-              this._newColor = null;
-            }}
-          >
-            ${this._localize("dashboard.labels_create_cancel")}
-          </button>
-          <button
-            type="submit"
-            class="btn btn--primary"
-            ?disabled=${!canCreate || this._saving}
-          >
-            ${this._localize("dashboard.labels_create_submit")}
-          </button>
-        </div>
-      </form>
-    `;
-  }
-
-  private _onSwatchKeyDown(e: KeyboardEvent, values: (string | null)[]) {
-    let idx = values.indexOf(this._newColor);
-    if (idx < 0) idx = 0;
-    let next = idx;
-    switch (e.key) {
-      case "ArrowRight":
-      case "ArrowDown":
-        next = (idx + 1) % values.length;
-        break;
-      case "ArrowLeft":
-      case "ArrowUp":
-        next = (idx - 1 + values.length) % values.length;
-        break;
-      case "Home":
-        next = 0;
-        break;
-      case "End":
-        next = values.length - 1;
-        break;
-      default:
-        return;
-    }
-    e.preventDefault();
-    this._newColor = values[next];
-    requestAnimationFrame(() => {
-      const swatch = this.renderRoot.querySelectorAll<HTMLButtonElement>(
-        ".swatch",
-      )[next];
-      swatch?.focus();
-    });
-  }
-
   private _openDialog = () => {
     this._filter = "";
-    this._createOpen = false;
-    this._newName = "";
-    this._newColor = null;
+    this._createForm?.collapse();
     if (this._dialog) this._dialog.open = true;
   };
 
   private _onDialogClose = () => {
     this._filter = "";
-    this._createOpen = false;
-    this._newName = "";
-    this._newColor = null;
+    this._createForm?.collapse();
   };
 
   /** Re-emit a ``label_ids`` change as a serialized
@@ -704,31 +472,16 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     await this._toggleAssignment(labelId, false);
   }
 
-  private async _createAndAssign() {
-    if (!this._api) return;
-    const name = this._newName.trim();
-    if (!name) return;
-    this._saving = true;
-    try {
-      const created = await this._api.createLabel({
-        name,
-        color: this._newColor,
-      });
-      const next = [...this._currentLabelIds, created.id];
-      this._optimisticLabels = next;
-      await this._persist(next);
-      this._createOpen = false;
-      this._newName = "";
-      this._newColor = null;
-      this._filter = "";
-    } catch (err) {
-      console.warn("label create failed", err);
-      toast.error(this._localize("dashboard.labels_create_failed"), {
-        richColors: true,
-      });
-    } finally {
-      this._saving = false;
-    }
+  /** Handle a freshly-created Label emitted by the inline form by
+   *  assigning it to the current device. The form already round-
+   *  tripped to ``labels/create`` and surfaced its own toast on
+   *  failure — this method is only on the success path, so the
+   *  only thing left is the ``set_labels`` follow-up. */
+  private async _assignNewLabel(label: Label) {
+    const next = [...this._currentLabelIds, label.id];
+    this._optimisticLabels = next;
+    this._filter = "";
+    await this._persist(next);
   }
 }
 

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -86,6 +86,16 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   @state()
   private _saving = false;
 
+  /** Snapshot of ``device.configuration`` taken when the user
+   *  initiated a ``labels/create`` round trip. ``null`` means "no
+   *  create in flight". A device swap mid-flight clears it (in
+   *  ``willUpdate``) and the late ``label-created`` event is
+   *  ignored — without this, the freshly-minted label would get
+   *  assigned to whatever device the drawer happens to be showing
+   *  by the time the create resolves, which may not be the device
+   *  the user clicked Create from. */
+  private _pendingCreateConfig: string | null = null;
+
   /** Optimistic label assignment that overrides ``device.labels``
    *  while a save is in flight or queued. Lets the user toggle
    *  multiple chips quickly without each click computing ``next``
@@ -309,6 +319,10 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       this._optimisticLabels = null;
       this._saving = false;
       this._saveChain = Promise.resolve();
+      // Drop any in-flight create snapshot so a late
+      // ``label-created`` arriving after the swap is ignored rather
+      // than misapplied to the new device.
+      this._pendingCreateConfig = null;
     }
   }
 
@@ -411,13 +425,27 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         <esphome-label-create-form
           .existingNames=${this._catalog.map((l) => l.name)}
           .nameSeed=${this._filter}
-          @label-created=${(e: CustomEvent<Label>) => {
-            void this._assignNewLabel(e.detail);
-          }}
+          @submitting=${this._onCreateSubmitting}
+          @label-created=${this._onCreateResolved}
         ></esphome-label-create-form>
       </wa-dialog>
     `;
   }
+
+  /** Snapshot the device the user clicked Create from — checked
+   *  in ``_onCreateResolved`` against the current device so a
+   *  mid-flight swap can't misroute the assignment. */
+  private _onCreateSubmitting = () => {
+    this._pendingCreateConfig = this.device.configuration;
+  };
+
+  private _onCreateResolved = (e: CustomEvent<Label>) => {
+    const targetConfig = this._pendingCreateConfig;
+    this._pendingCreateConfig = null;
+    if (targetConfig === null) return;
+    if (targetConfig !== this.device.configuration) return;
+    void this._assignNewLabel(e.detail);
+  };
 
   private _openDialog = () => {
     this._filter = "";

--- a/src/components/labels/label-create-form.ts
+++ b/src/components/labels/label-create-form.ts
@@ -89,14 +89,18 @@ export class ESPHomeLabelCreateForm extends LitElement {
    *  the initial render (Lit fires ``willUpdate`` before the first
    *  paint with every reactive property in *changed*) and a later
    *  flip (e.g. the labels-filter rebinding ``default-open`` when
-   *  the catalog drains back to zero). We deliberately *don't*
-   *  auto-collapse on becomes-false: a host that flips it (e.g.
-   *  catalog growing past zero after a create) shouldn't yank a
-   *  half-typed form out from under the user — the user can
-   *  Cancel themselves. */
+   *  the catalog drains back to zero). Routes through ``expand()``
+   *  so ``nameSeed`` is honoured the same way it would be from a
+   *  manual click on the toggle button — both expansion paths must
+   *  agree, otherwise a host that uses ``default-open`` to start
+   *  expanded would silently lose the seed. We deliberately
+   *  *don't* auto-collapse on becomes-false: a host that flips it
+   *  (e.g. catalog growing past zero after a create) shouldn't
+   *  yank a half-typed form out from under the user — the user
+   *  can Cancel themselves. */
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("defaultOpen") && this.defaultOpen) {
-      this._open = true;
+    if (changed.has("defaultOpen") && this.defaultOpen && !this._open) {
+      this.expand();
     }
   }
 
@@ -338,6 +342,15 @@ export class ESPHomeLabelCreateForm extends LitElement {
   }
 
   private async _submit() {
+    // Re-entry guard. ``canCreate`` already gates the submit
+    // button on ``!this._saving``, but the ``@submit`` handler's
+    // closure captures whichever ``canCreate`` was active in the
+    // last render — a fast double-click / Enter before Lit has
+    // re-rendered the disabled state can route two submits
+    // through here and mint duplicate labels. The check on
+    // ``_saving`` makes that race harmless regardless of UI
+    // timing.
+    if (this._saving) return;
     if (!this._api) return;
     const name = this._name.trim();
     if (!name) return;

--- a/src/components/labels/label-create-form.ts
+++ b/src/components/labels/label-create-form.ts
@@ -221,9 +221,18 @@ export class ESPHomeLabelCreateForm extends LitElement {
 
   protected render() {
     if (!this._open) {
+      // ``aria-expanded`` + ``aria-controls`` advertise the
+      // disclosure relationship to assistive tech: the toggle
+      // reveals the form below it (which carries id ``create-form``
+      // when expanded), and a screen reader user gets to hear that
+      // the button reveals further controls instead of just
+      // landing on a bare "Create new label" button with no hint
+      // about what happens on click.
       return html`<button
         class="create-toggle"
         type="button"
+        aria-expanded="false"
+        aria-controls="create-form"
         @click=${() => this.expand()}
       >
         <wa-icon library="mdi" name="plus"></wa-icon>
@@ -247,6 +256,7 @@ export class ESPHomeLabelCreateForm extends LitElement {
     const values: (string | null)[] = [null, ...LABEL_COLOR_SWATCHES];
     return html`
       <form
+        id="create-form"
         class="create-form"
         @submit=${(e: Event) => {
           e.preventDefault();
@@ -262,6 +272,7 @@ export class ESPHomeLabelCreateForm extends LitElement {
           placeholder=${this._localize("dashboard.labels_create_placeholder")}
           maxlength="50"
           .value=${this._name}
+          aria-label=${this._localize("dashboard.labels_create")}
           @input=${(e: Event) => {
             this._name = (e.currentTarget as unknown as { value: string }).value;
           }}

--- a/src/components/labels/label-create-form.ts
+++ b/src/components/labels/label-create-form.ts
@@ -85,9 +85,19 @@ export class ESPHomeLabelCreateForm extends LitElement {
   @state()
   private _saving = false;
 
-  override connectedCallback() {
-    super.connectedCallback();
-    if (this.defaultOpen) this._open = true;
+  /** Open the form when ``defaultOpen`` flips true — handles both
+   *  the initial render (Lit fires ``willUpdate`` before the first
+   *  paint with every reactive property in *changed*) and a later
+   *  flip (e.g. the labels-filter rebinding ``default-open`` when
+   *  the catalog drains back to zero). We deliberately *don't*
+   *  auto-collapse on becomes-false: a host that flips it (e.g.
+   *  catalog growing past zero after a create) shouldn't yank a
+   *  half-typed form out from under the user — the user can
+   *  Cancel themselves. */
+  protected willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("defaultOpen") && this.defaultOpen) {
+      this._open = true;
+    }
   }
 
   static styles = [
@@ -219,8 +229,17 @@ export class ESPHomeLabelCreateForm extends LitElement {
     const trimmed = this._name.trim();
     const lowerExisting = this.existingNames.map((n) => n.toLowerCase());
     const duplicate = lowerExisting.includes(trimmed.toLowerCase());
+    // ``_api`` is consumed from context; it's typically present once
+    // the dashboard has finished its connect dance, but during the
+    // initial WS handshake the context may still be undefined. Gate
+    // the submit button on it so we don't enable a control whose
+    // click would silently no-op.
     const canCreate =
-      trimmed.length > 0 && trimmed.length <= 50 && !duplicate && !this._saving;
+      trimmed.length > 0 &&
+      trimmed.length <= 50 &&
+      !duplicate &&
+      !this._saving &&
+      !!this._api;
     const values: (string | null)[] = [null, ...LABEL_COLOR_SWATCHES];
     return html`
       <form
@@ -322,6 +341,14 @@ export class ESPHomeLabelCreateForm extends LitElement {
     if (!this._api) return;
     const name = this._name.trim();
     if (!name) return;
+    // Fire ``submitting`` *before* the round trip so a host that
+    // owns per-context state (the device-labels editor's "is the
+    // user still on the same device?" check) can snapshot before
+    // the await. The event has no detail; the host already knows
+    // its own context.
+    this.dispatchEvent(
+      new CustomEvent("submitting", { bubbles: true, composed: true }),
+    );
     this._saving = true;
     try {
       const created = await this._api.createLabel({

--- a/src/components/labels/label-create-form.ts
+++ b/src/components/labels/label-create-form.ts
@@ -1,0 +1,392 @@
+/**
+ * Inline "Create new label" affordance — shared by the device-drawer
+ * label editor and the dashboard's labels filter.
+ *
+ * Renders as a collapsed toggle button by default; clicking expands
+ * an in-place form (name input + color-swatch radiogroup + submit /
+ * cancel buttons) that round-trips to ``labels/create`` and emits a
+ * ``label-created`` ``CustomEvent<Label>`` once the backend
+ * acknowledges. The host owns whatever happens next (assigning the
+ * label to a device, selecting it in a filter, etc.) — this
+ * component only knows how to mint a new ``Label``.
+ *
+ * Extracted so the dashboard's labels filter can offer creation in
+ * its empty state (and after, via a popover footer) without
+ * duplicating the form layout, validation, swatch keyboard nav, or
+ * the toast-on-failure plumbing the editor already had.
+ */
+import { consume } from "@lit/context";
+import { mdiCheck, mdiPlus } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import toast from "sonner-js";
+import type { ESPHomeAPI } from "../../api/index.js";
+import type { Label } from "../../api/types.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+import { apiContext, localizeContext } from "../../context/index.js";
+import { espHomeStyles } from "../../styles/shared.js";
+import { LABEL_COLOR_SWATCHES } from "../../util/label-style.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/input/input.js";
+
+registerMdiIcons({
+  check: mdiCheck,
+  plus: mdiPlus,
+});
+
+@customElement("esphome-label-create-form")
+export class ESPHomeLabelCreateForm extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  @state()
+  private _api?: ESPHomeAPI;
+
+  /** Existing label names to dedup against (case-insensitive). The
+   *  caller passes the ``Label[]`` catalog so the form can refuse a
+   *  duplicate before the backend rejects it — the backend dedup is
+   *  authoritative, this is just a UX guard. */
+  @property({ attribute: false })
+  existingNames: string[] = [];
+
+  /** Pre-fill the name input when expanding. Useful when "filter to
+   *  find" turned into "didn't exist, create it" and we already
+   *  have the user's typed-but-unmatched search string. */
+  @property({ attribute: false })
+  nameSeed = "";
+
+  /** Render expanded by default. The labels filter's empty popover
+   *  passes ``true`` so a freshly-installed dashboard doesn't show
+   *  the "click to expand" indirection — there's nothing else in
+   *  the popover anyway. */
+  @property({ type: Boolean, attribute: "default-open", reflect: true })
+  defaultOpen = false;
+
+  /** Hide the form's surrounding "Create new label" header label
+   *  inside the form body. The standalone toggle-button text is
+   *  enough context in the labels-filter empty state, where the
+   *  popover already says "Labels". */
+  @property({ type: Boolean, attribute: "compact" })
+  compact = false;
+
+  @state()
+  private _open = false;
+
+  @state()
+  private _name = "";
+
+  @state()
+  private _color: string | null = null;
+
+  @state()
+  private _saving = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    if (this.defaultOpen) this._open = true;
+  }
+
+  static styles = [
+    espHomeStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .create-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 6px 8px;
+        background: transparent;
+        border: none;
+        font-size: var(--wa-font-size-xs);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--esphome-primary);
+        cursor: pointer;
+        align-self: flex-start;
+        font-family: inherit;
+      }
+
+      .create-toggle wa-icon {
+        font-size: 14px;
+      }
+
+      .create-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-s);
+        padding: var(--wa-space-s) 0;
+      }
+
+      .create-form-label {
+        font-size: var(--wa-font-size-xs);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-quiet);
+      }
+
+      .swatch-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .swatch {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        cursor: pointer;
+        padding: 0;
+      }
+
+      .swatch--selected {
+        outline: 2px solid var(--esphome-primary);
+        outline-offset: 2px;
+      }
+
+      .swatch--clear {
+        background: transparent;
+        color: var(--wa-color-text-quiet);
+        font-size: 12px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .create-actions {
+        display: flex;
+        gap: var(--wa-space-xs);
+        justify-content: flex-end;
+      }
+
+      .btn {
+        padding: 6px 14px;
+        font-size: var(--wa-font-size-xs);
+        font-weight: var(--wa-font-weight-bold);
+        border-radius: var(--wa-border-radius-s);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        background: var(--wa-color-surface-default);
+        color: var(--wa-color-text-normal);
+        cursor: pointer;
+        font-family: inherit;
+      }
+
+      .btn--primary {
+        background: var(--esphome-primary);
+        color: var(--esphome-on-primary);
+        border-color: var(--esphome-primary);
+      }
+
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    `,
+  ];
+
+  /** Open the form programmatically. Hosts that drive the open
+   *  state externally (e.g. seeding from a filter input) can call
+   *  this rather than poking ``_open`` via DOM. */
+  expand(seed = "") {
+    this._name = seed || this.nameSeed;
+    this._open = true;
+  }
+
+  /** Collapse the form and reset transient state. Called after a
+   *  successful create and from the in-form Cancel button. */
+  collapse() {
+    this._open = false;
+    this._name = "";
+    this._color = null;
+  }
+
+  protected render() {
+    if (!this._open) {
+      return html`<button
+        class="create-toggle"
+        type="button"
+        @click=${() => this.expand()}
+      >
+        <wa-icon library="mdi" name="plus"></wa-icon>
+        ${this._localize("dashboard.labels_create")}
+      </button>`;
+    }
+    const trimmed = this._name.trim();
+    const lowerExisting = this.existingNames.map((n) => n.toLowerCase());
+    const duplicate = lowerExisting.includes(trimmed.toLowerCase());
+    const canCreate =
+      trimmed.length > 0 && trimmed.length <= 50 && !duplicate && !this._saving;
+    const values: (string | null)[] = [null, ...LABEL_COLOR_SWATCHES];
+    return html`
+      <form
+        class="create-form"
+        @submit=${(e: Event) => {
+          e.preventDefault();
+          if (canCreate) void this._submit();
+        }}
+      >
+        ${this.compact
+          ? nothing
+          : html`<span class="create-form-label"
+              >${this._localize("dashboard.labels_create")}</span
+            >`}
+        <wa-input
+          placeholder=${this._localize("dashboard.labels_create_placeholder")}
+          maxlength="50"
+          .value=${this._name}
+          @input=${(e: Event) => {
+            this._name = (e.currentTarget as unknown as { value: string }).value;
+          }}
+        ></wa-input>
+        <div
+          class="swatch-row"
+          role="radiogroup"
+          aria-label=${this._localize("dashboard.labels_color")}
+          @keydown=${(e: KeyboardEvent) => this._onSwatchKeyDown(e, values)}
+        >
+          ${values.map((c) => {
+            const selected = this._color === c;
+            if (c === null) {
+              return html`<button
+                type="button"
+                role="radio"
+                aria-checked=${selected ? "true" : "false"}
+                tabindex=${selected ? "0" : "-1"}
+                class="swatch swatch--clear ${selected ? "swatch--selected" : ""}"
+                aria-label=${this._localize("dashboard.labels_color_none")}
+                title=${this._localize("dashboard.labels_color_none")}
+                @click=${() => {
+                  this._color = null;
+                }}
+              >
+                ${selected
+                  ? html`<wa-icon library="mdi" name="check"></wa-icon>`
+                  : nothing}
+              </button>`;
+            }
+            return html`<button
+              type="button"
+              role="radio"
+              aria-checked=${selected ? "true" : "false"}
+              tabindex=${selected ? "0" : "-1"}
+              class="swatch ${selected ? "swatch--selected" : ""}"
+              style="background:${c}"
+              aria-label=${c}
+              title=${c}
+              @click=${() => {
+                this._color = c;
+              }}
+            ></button>`;
+          })}
+        </div>
+        <div class="create-actions">
+          <button
+            type="button"
+            class="btn"
+            @click=${() => this._cancel()}
+          >
+            ${this._localize("dashboard.labels_create_cancel")}
+          </button>
+          <button
+            type="submit"
+            class="btn btn--primary"
+            ?disabled=${!canCreate}
+          >
+            ${this._localize("dashboard.labels_create_submit")}
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  private _cancel() {
+    // The labels filter's empty popover relies on the form staying
+    // visible, so when ``defaultOpen`` is set we never collapse —
+    // we just blank the inputs. Hosts that want a real "close"
+    // behaviour leave ``defaultOpen`` false (the editor's dialog
+    // does this).
+    if (this.defaultOpen) {
+      this._name = "";
+      this._color = null;
+      return;
+    }
+    this.collapse();
+  }
+
+  private async _submit() {
+    if (!this._api) return;
+    const name = this._name.trim();
+    if (!name) return;
+    this._saving = true;
+    try {
+      const created = await this._api.createLabel({
+        name,
+        color: this._color,
+      });
+      this.dispatchEvent(
+        new CustomEvent<Label>("label-created", {
+          detail: created,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      this._name = "";
+      this._color = null;
+      if (!this.defaultOpen) this._open = false;
+    } catch (err) {
+      console.warn("label create failed", err);
+      toast.error(this._localize("dashboard.labels_create_failed"), {
+        richColors: true,
+      });
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  /** Roving-tabindex keyboard nav across the colour swatches —
+   *  matches the WAI-ARIA radiogroup pattern (only the selected
+   *  swatch is in the tab order; arrow keys move focus + selection
+   *  through the row). Arrow / Home / End wrap inside the row. */
+  private _onSwatchKeyDown(e: KeyboardEvent, values: (string | null)[]) {
+    let idx = values.indexOf(this._color);
+    if (idx < 0) idx = 0;
+    let next = idx;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = (idx + 1) % values.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = (idx - 1 + values.length) % values.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = values.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    this._color = values[next];
+    requestAnimationFrame(() => {
+      const swatch = this.renderRoot.querySelectorAll<HTMLButtonElement>(
+        ".swatch",
+      )[next];
+      swatch?.focus();
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-label-create-form": ESPHomeLabelCreateForm;
+  }
+}

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -2,14 +2,17 @@
  * Filter affordance that narrows the device list to entries
  * carrying every selected label (logical AND).
  *
- * Sits next to the search input in the dashboard toolbar. Hidden
- * when the catalog is empty so an un-tagged fleet doesn't see a
- * dead button. The component owns no filter state itself —
- * selections live on the parent dashboard so the device-filter
- * logic, the URL query string, and the empty-state copy can all
- * read from a single source. Selection changes are emitted as a
- * ``labels-filter-change`` ``CustomEvent<string[]>`` carrying the
- * new full set of selected ids.
+ * Sits next to the search input in the dashboard toolbar. The
+ * trigger renders unconditionally — even on a fleet that hasn't
+ * defined any labels yet — because the popover is the discovery
+ * path for creating the first label; hiding the button on an
+ * empty catalog (the original behaviour) made that affordance
+ * unreachable from the dashboard. The component owns no filter
+ * state itself — selections live on the parent dashboard so the
+ * device-filter logic, the URL query string, and the empty-state
+ * copy can all read from a single source. Selection changes are
+ * emitted as a ``labels-filter-change`` ``CustomEvent<string[]>``
+ * carrying the new full set of selected ids.
  */
 import { consume } from "@lit/context";
 import {

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -28,6 +28,7 @@ import {
 } from "../../util/label-chip-template.js";
 import { labelChipStyleString } from "../../util/label-style.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import "./label-create-form.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
@@ -140,13 +141,18 @@ export class ESPHomeLabelsFilter extends LitElement {
         border-color: var(--esphome-primary);
       }
 
+      /* The trigger sits in the right-hand cluster of the dashboard
+         toolbar, so anchoring the popover to the trigger's right
+         edge keeps it inside the viewport — anchoring to the left
+         edge made the popover extend off the right side of the
+         screen. */
       .popover {
         position: absolute;
         z-index: 10;
         top: calc(100% + 4px);
-        left: 0;
-        min-width: 220px;
-        max-width: 320px;
+        right: 0;
+        min-width: 240px;
+        max-width: min(320px, calc(100vw - 32px));
         background: var(--wa-color-surface-default);
         border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         border-radius: var(--wa-border-radius-m);
@@ -216,23 +222,20 @@ export class ESPHomeLabelsFilter extends LitElement {
         color: var(--wa-color-text-quiet);
         padding: var(--wa-space-s);
       }
+
+      /* Divider between the catalog list / empty hint and the
+         "Create new label" affordance. Matches the .clear button's
+         border-top treatment so the popover reads as a vertical
+         stack of distinct sections. */
+      .divider {
+        height: 1px;
+        background: var(--wa-color-surface-border);
+        margin: 4px 0;
+      }
     `,
   ];
 
   protected willUpdate(changed: Map<string, unknown>) {
-    // If the catalog drains while the popover is open (last label
-    // deleted via a push event), force-close so we don't leave the
-    // EscapeController bound and the component in an
-    // open-but-unrenderable state — ``render()`` returns ``nothing``
-    // on an empty catalog, so without this the popover is invisible
-    // but keystrokes still pretend to dismiss it.
-    if (
-      changed.has("_catalog") &&
-      this._catalog.length === 0 &&
-      this._open
-    ) {
-      this._open = false;
-    }
     if (changed.has("_open")) this._escape.set(this._open);
   }
 
@@ -253,7 +256,10 @@ export class ESPHomeLabelsFilter extends LitElement {
   };
 
   protected render() {
-    if (this._catalog.length === 0) return nothing;
+    // Render the trigger unconditionally — even with an empty
+    // catalog, the popover is the path to creating the first
+    // label, so hiding the button entirely would leave that
+    // affordance undiscoverable.
     const selectedSet = new Set(this.selected);
     const count = this.selected.length;
     const label = this._localize("dashboard.filter_labels");
@@ -277,15 +283,16 @@ export class ESPHomeLabelsFilter extends LitElement {
   }
 
   private _renderPopover(selectedSet: Set<string>) {
+    const isEmpty = this._catalog.length === 0;
     return html`
       <div
         class="popover"
         role="group"
         aria-label=${this._localize("dashboard.filter_labels")}
       >
-        ${this._catalog.length === 0
+        ${isEmpty
           ? html`<div class="empty">
-              ${this._localize("dashboard.labels_no_matches")}
+              ${this._localize("dashboard.labels_dialog_empty")}
             </div>`
           : this._catalog.map((label) => {
               const checked = selectedSet.has(label.id);
@@ -311,9 +318,25 @@ export class ESPHomeLabelsFilter extends LitElement {
               ${this._localize("dashboard.filter_clear")}
             </button>`
           : nothing}
+        <div class="divider"></div>
+        <esphome-label-create-form
+          .existingNames=${this._catalog.map((l) => l.name)}
+          ?default-open=${isEmpty}
+          compact
+          @label-created=${this._onLabelCreated}
+        ></esphome-label-create-form>
       </div>
     `;
   }
+
+  private _onLabelCreated = (e: CustomEvent<Label>) => {
+    // Auto-select the freshly-minted label so the filter is
+    // immediately useful — a user who just typed a name and hit
+    // Create clearly intends to filter by it.
+    const id = e.detail.id;
+    if (this.selected.includes(id)) return;
+    this._emit([...this.selected, id]);
+  };
 
   private _toggle = () => {
     this._open = !this._open;

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -151,7 +151,12 @@ export class ESPHomeLabelsFilter extends LitElement {
         z-index: 10;
         top: calc(100% + 4px);
         right: 0;
-        min-width: 240px;
+        /* Both bounds clamp to the viewport: on a phone-narrow
+           layout calc(100vw - 32px) can drop below the desired
+           240px floor, so a fixed min-width would force overflow.
+           Using min() lets the floor relax when the viewport is
+           tight, while the max-width keeps the upper bound. */
+        min-width: min(240px, calc(100vw - 32px));
         max-width: min(320px, calc(100vw - 32px));
         background: var(--wa-color-surface-default);
         border: var(--wa-border-width-s) solid var(--wa-color-surface-border);


### PR DESCRIPTION
# What does this implement/fix?

Two things in the dashboard's labels filter, on top of a small
refactor that DRYs the new "create" path against the existing
in-drawer editor.

## 1. Popover went off-screen (bug)

The `.popover` was anchored with `position: absolute; left: 0`,
relative to the trigger. The trigger lives in the right-hand
toolbar cluster, so the popover extended off the right edge of the
viewport (clipping the only label chip and the "Clear filter"
button — see the screenshot in the issue).

Anchored to `right: 0` instead so the popover grows leftward from
the trigger, and capped `max-width` to `min(320px, calc(100vw - 32px))`
so even the popover's leftward extent is bounded by the viewport.

## 2. Filter affordance hidden when no labels exist (discoverability)

`labels-filter.ts`'s `render()` returned `nothing` when the
catalog was empty, and `willUpdate` force-closed an open popover
on a drain-to-zero. So a freshly-installed dashboard never showed
the trigger at all — the path to creating the first label was
"open any device's drawer → Edit labels → ...", which is a couple
of clicks deeper than it ought to be for the central feature of
"organise your fleet".

Now:

- The trigger always renders. The popover opens on click whether
  the catalog is empty or not.
- Empty popover shows the existing "No labels yet — create one
  below." copy and an inline create form.
- After a successful create, the new label is auto-selected so the
  filter is immediately useful — a user who just typed a name and
  hit Create clearly intends to filter by it.

## 3. Refactor — `<esphome-label-create-form>`

Pulled the "Create new label" form (name input + colour-swatch
radiogroup + roving-tabindex keyboard nav + submit/cancel) out of
`device-labels-editor.ts` into a new
`src/components/labels/label-create-form.ts`. Both the editor's
dialog and the filter's popover now mount that subcomponent and
listen for `label-created` (`CustomEvent<Label>`) — the editor's
handler chains a `set_labels` round trip; the filter's handler
auto-selects.

This deletes ~200 lines of duplicated form / styles / swatch nav
from the editor; the shared component owns the `labels/create`
round trip and the failure toast in one place.

`device-labels-editor.ts`: -303 / +81
`labels-filter.ts`: net +27
`label-create-form.ts`: new (+392)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
