### PR TITLE
Enlarge close-button hit target on remaining install/logs dialogs

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -27,6 +27,7 @@ import {
   firmwareJobsContext,
   localizeContext,
 } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
@@ -161,6 +162,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dialogCloseButtonStyles,
     css`
       :host {
         --term-bg: #1e1e1e;
@@ -218,29 +220,9 @@ export class ESPHomeCommandDialog extends LitElement {
         font-weight: var(--wa-font-weight-bold);
         font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
       }
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
-      /* Same affordance for hover and keyboard focus so the close
-         button is discoverable either way on the new lighter
-         background. */
-      wa-dialog::part(close-button__base):hover,
-      wa-dialog::part(close-button__base):focus-visible {
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-        outline: none;
-      }
+      /* Close-button styling lives in
+         src/styles/dialog-close-button.ts — see the
+         dialogCloseButtonStyles import below. */
       wa-dialog::part(body) {
         padding: 0;
         background: var(--term-bg);

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -281,12 +281,24 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         background: transparent;
         border: none;
         box-shadow: none;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. Matches logs-dialog / command-dialog. */
         padding: 0;
+        width: 40px;
+        height: 40px;
         min-width: unset;
         min-height: unset;
         color: var(--esphome-on-primary);
         cursor: pointer;
       }
+
+      wa-dialog::part(close-button__base):hover,
+      wa-dialog::part(close-button__base):focus-visible {
+        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+        outline: none;
+      }
+
       wa-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);
       }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -16,6 +16,7 @@ import { JobStatus } from "../api/types.js";
 import type { ConfiguredDevice } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { chipNameToVariant } from "../util/chip-variant.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
@@ -242,6 +243,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dialogCloseButtonStyles,
     css`
       :host {
         --term-bg: #1e1e1e;
@@ -277,27 +279,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
       }
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. Matches logs-dialog / command-dialog. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
-
-      wa-dialog::part(close-button__base):hover,
-      wa-dialog::part(close-button__base):focus-visible {
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-        outline: none;
-      }
+      /* Close-button styling lives in
+         src/styles/dialog-close-button.ts — see the
+         dialogCloseButtonStyles import below. */
 
       wa-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -136,11 +136,26 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         background: transparent;
         border: none;
         box-shadow: none;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. Matches logs-dialog / command-dialog after
+           the same fix landed there. */
         padding: 0;
+        width: 40px;
+        height: 40px;
         min-width: unset;
         min-height: unset;
         color: var(--esphome-on-primary);
         cursor: pointer;
+      }
+
+      /* Same affordance for keyboard users tabbing to the close
+         button — without a focus-visible style they'd land on an
+         identical-looking control with no visual cue. */
+      wa-dialog::part(close-button__base):hover,
+      wa-dialog::part(close-button__base):focus-visible {
+        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+        outline: none;
       }
 
       wa-dialog::part(body) {

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -16,6 +16,7 @@ import { DeviceState } from "../api/types.js";
 import type { SerialPort } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -114,6 +115,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    dialogCloseButtonStyles,
     css`
       wa-dialog {
         --width: 460px;
@@ -132,31 +134,10 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         font-weight: var(--wa-font-weight-bold);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. Matches logs-dialog / command-dialog after
-           the same fix landed there. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
-
-      /* Same affordance for keyboard users tabbing to the close
-         button — without a focus-visible style they'd land on an
-         identical-looking control with no visual cue. */
-      wa-dialog::part(close-button__base):hover,
-      wa-dialog::part(close-button__base):focus-visible {
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-        outline: none;
-      }
+      /* Close-button styling lives in
+         src/styles/dialog-close-button.ts — see the
+         dialogCloseButtonStyles import in the static-styles
+         array above. */
 
       wa-dialog::part(body) {
         padding: var(--wa-space-l);

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -16,6 +16,7 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeAnsiLog } from "./ansi-log.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -107,6 +108,7 @@ export class ESPHomeLogsDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dialogCloseButtonStyles,
     css`
       :host {
         --term-bg: #1e1e1e;
@@ -181,30 +183,9 @@ export class ESPHomeLogsDialog extends LitElement {
         font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
-
-      /* Same affordance for keyboard users tabbing to the close
-         button — without a focus-visible style they'd land on an
-         identical-looking control with no visual cue. */
-      wa-dialog::part(close-button__base):hover,
-      wa-dialog::part(close-button__base):focus-visible {
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-        outline: none;
-      }
+      /* Close-button styling lives in
+         src/styles/dialog-close-button.ts — see the
+         dialogCloseButtonStyles import below. */
 
       wa-dialog::part(body) {
         padding: 0;

--- a/src/components/logs-method-dialog.ts
+++ b/src/components/logs-method-dialog.ts
@@ -49,11 +49,22 @@ export class ESPHomeLogsMethodDialog extends LitElement {
         background: transparent;
         border: none;
         box-shadow: none;
+        /* Square 40x40 button matching the header height so the X has a
+           comfortable click/tap target instead of just the icon's
+           ~14px footprint. Matches logs-dialog / command-dialog. */
         padding: 0;
+        width: 40px;
+        height: 40px;
         min-width: unset;
         min-height: unset;
         color: var(--esphome-on-primary);
         cursor: pointer;
+      }
+
+      wa-dialog::part(close-button__base):hover,
+      wa-dialog::part(close-button__base):focus-visible {
+        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+        outline: none;
       }
 
       wa-dialog::part(body) {

--- a/src/components/logs-method-dialog.ts
+++ b/src/components/logs-method-dialog.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -27,6 +28,7 @@ export class ESPHomeLogsMethodDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dialogCloseButtonStyles,
     css`
       wa-dialog {
         --width: 460px;
@@ -45,27 +47,9 @@ export class ESPHomeLogsMethodDialog extends LitElement {
         font-weight: var(--wa-font-weight-bold);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. Matches logs-dialog / command-dialog. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
-
-      wa-dialog::part(close-button__base):hover,
-      wa-dialog::part(close-button__base):focus-visible {
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-        outline: none;
-      }
+      /* Close-button styling lives in
+         src/styles/dialog-close-button.ts — see the
+         dialogCloseButtonStyles import below. */
 
       wa-dialog::part(body) {
         padding: var(--wa-space-l);

--- a/src/styles/dialog-close-button.ts
+++ b/src/styles/dialog-close-button.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared `wa-dialog` close-button styling.
+ *
+ * Pulled out of the per-dialog styles after PR #206 (issue #213's
+ * sibling cleanup): the close-button block was duplicated verbatim
+ * across 5+ dialogs and the only practical way to keep them in sync
+ * was a shared `css` fragment. Drop this into a dialog's
+ * `static styles = [..., dialogCloseButtonStyles, css\`...\`]` array
+ * and the `wa-dialog::part(close-button__base)` selectors below pick
+ * up the close button automatically.
+ *
+ * What the styles do, and why:
+ *
+ * - **40×40 hit target.** `wa-dialog`'s default close button is just
+ *   the icon's intrinsic ~14px footprint, which is below WCAG's 24×24
+ *   minimum and miserable to hit on touch / trackball. The size is a
+ *   fixed 40 because that's also the header height every dialog in
+ *   this app uses (`wa-dialog::part(header) { height: 40px }`); a
+ *   square button reads as the natural cap on the title bar's right
+ *   edge. There's no design token for header height, so 40 stays a
+ *   literal here — if a future theme changes the header height, this
+ *   constant moves with it.
+ * - **Hover + focus background highlight.** Same `color-mix(...,
+ *   --esphome-on-primary, transparent 85%)` tint mouse and keyboard
+ *   users see — the tint is the primary feedback signal.
+ * - **`:focus-visible` keeps a visible outline.** Earlier per-dialog
+ *   copies set `outline: none` on focus, which removed the default
+ *   focus ring and degraded keyboard / forced-colors-mode focus
+ *   visibility. The new shape draws a 2px `currentColor` outline
+ *   pulled inside the button (`outline-offset: -2px`) so the ring
+ *   never overlaps the dialog's header chrome and forced-colors mode
+ *   can substitute the system `Highlight` colour automatically. The
+ *   outline + the background tint together give two redundant focus
+ *   signals.
+ */
+import { css } from "lit";
+
+export const dialogCloseButtonStyles = css`
+  wa-dialog::part(close-button__base) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    width: 40px;
+    height: 40px;
+    min-width: unset;
+    min-height: unset;
+    color: var(--esphome-on-primary);
+    cursor: pointer;
+  }
+
+  wa-dialog::part(close-button__base):hover,
+  wa-dialog::part(close-button__base):focus-visible {
+    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+  }
+
+  /* Keep a visible focus indicator — replaces the previous
+     "outline: none" which removed the default focus ring entirely
+     and hurt keyboard / forced-colors / high-contrast users. The
+     "currentColor" outline lets forced-colors mode substitute the
+     system "Highlight" colour automatically; "outline-offset: -2px"
+     keeps the ring inside the 40x40 target so it doesn't spill onto
+     the dialog header. */
+  wa-dialog::part(close-button__base):focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

Apply the 40×40 close-button hit-target fix from `logs-dialog` /
`command-dialog` to the three remaining dialogs that were missed
in the prior cleanup, and at the same time:

1. Extract the close-button styling that was now duplicated across
   five dialogs into a shared `dialogCloseButtonStyles` fragment in
   `src/styles/dialog-close-button.ts`.
2. Replace `outline: none` on `:focus-visible` with a high-contrast
   `2px solid currentColor` outline + `outline-offset: -2px`, so
   keyboard / forced-colors / high-contrast users see a real focus
   ring (alongside the existing background tint).

The X in the upper-right corner of these dialogs was previously
only as large as the ~14px icon glyph, which is below WCAG's 24×24
minimum and miserable to hit on touch / trackball — the trigger
for this PR was the install-method dialog, see screenshot in the
issue thread.

Dialogs touched (now consuming `dialogCloseButtonStyles`):

- `install-method-dialog.ts` — "How do you want to install the firmware?"
- `firmware-install-dialog.ts` — the live install progress dialog
- `logs-method-dialog.ts` — sibling to logs-dialog, was missed when its sibling was fixed
- `logs-dialog.ts` — already had the fix; migrated to the shared fragment
- `command-dialog.ts` — same; migrated

The 40px size is documented inline as a fixed literal because
there's no design token for header height; it tracks
`wa-dialog::part(header) { height: 40px }` which every dialog in
the app sets identically, so a future header-height token would
move both together.

The other `wa-dialog::part(close-button__base)` consumers
(`api-key-dialog`, `adopt-dialog`, `settings-dialog`, `confirm-dialog`,
`device-labels-editor`) don't override `width` / `height` and inherit
wa-dialog's defaults, which already produce a comfortable target —
no changes there.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
