### PR TITLE
Make footer versions selectable and stop content overlap

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -200,15 +200,16 @@ export class ESPHomeLayout extends LitElement {
         bottom: 0;
         left: 0;
         right: 0;
-        height: 20px;
+        height: var(--esphome-footer-height);
         display: flex;
         align-items: center;
         justify-content: center;
         gap: var(--wa-space-m);
         font-size: 10px;
         color: var(--wa-color-text-quiet);
-        opacity: 0.5;
-        pointer-events: none;
+        background: var(--wa-color-surface-default);
+        opacity: 0.7;
+        user-select: text;
       }
     `,
   ];

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -206,9 +206,11 @@ export class ESPHomeLayout extends LitElement {
         justify-content: center;
         gap: var(--wa-space-m);
         font-size: 10px;
-        color: var(--wa-color-text-quiet);
+        /* Opaque background so scrolled content can't bleed through;
+           text is dimmed via color-mix instead of an opacity on the
+           host (which would make the background translucent too). */
         background: var(--wa-color-surface-default);
-        opacity: 0.7;
+        color: color-mix(in srgb, var(--wa-color-text-quiet), transparent 30%);
         user-select: text;
       }
     `,

--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -4,7 +4,7 @@ export const dashboardStyles = css`
   :host {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - var(--esphome-header-height));
+    height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
     overflow: hidden;
     /* Single source of truth for the floating Create-device button's
        footprint. --fab-bottom is the gap between the FAB and the
@@ -13,8 +13,9 @@ export const dashboardStyles = css`
        text). The card grid pads its bottom by their sum so the
        trailing card's action row never sits under the FAB. Defining
        these once stops the grid clearance and the FAB position from
-       drifting if either gets tweaked later. */
-    --fab-bottom: var(--wa-space-l);
+       drifting if either gets tweaked later. The fab-bottom also
+       includes the footer height so the FAB clears the version line. */
+    --fab-bottom: calc(var(--wa-space-l) + var(--esphome-footer-height));
     --fab-height: 48px;
     --fab-clearance: calc(var(--fab-bottom) + var(--fab-height) + var(--wa-space-xs));
   }

--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -23,6 +23,12 @@ export const dashboardStyles = css`
   :host([view="cards"]) {
     height: auto;
     overflow: visible;
+    /* Body scrolls in cards view (incl. YAML mode), and the layout
+       footer is fixed and opaque — without this padding the trailing
+       row of yaml-hits / banner content can sit behind the version
+       line. The configured device grid has its own --fab-clearance,
+       so this only matters for the YAML / discovered content paths. */
+    padding-bottom: var(--esphome-footer-height);
   }
 
   /* ─── Discovered Banner ─── */

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -8,14 +8,16 @@ export const devicePageStyles = css`
   .page {
     box-sizing: border-box;
     padding: var(--wa-space-l);
-    min-height: calc(100vh - var(--esphome-header-height));
+    min-height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
   }
 
   .layout-grid {
     display: grid;
     grid-template-columns: minmax(230px, 1fr) minmax(0, 5fr);
     gap: var(--wa-space-l);
-    height: calc(100vh - var(--esphome-header-height) - 2 * var(--wa-space-l));
+    height: calc(
+      100vh - var(--esphome-header-height) - var(--esphome-footer-height) - 2 * var(--wa-space-l)
+    );
     transition: grid-template-columns 0.25s ease;
   }
 
@@ -65,15 +67,15 @@ export const devicePageStyles = css`
        2 * var(--wa-space-l) subtracted and would leave a gap). */
     .page {
       padding: 0;
-      min-height: calc(100vh - var(--esphome-header-height));
-      min-height: calc(100dvh - var(--esphome-header-height));
+      min-height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
+      min-height: calc(100dvh - var(--esphome-header-height) - var(--esphome-footer-height));
     }
 
     .layout-grid {
       grid-template-columns: 1fr;
       gap: 0;
-      height: calc(100vh - var(--esphome-header-height));
-      height: calc(100dvh - var(--esphome-header-height));
+      height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
+      height: calc(100dvh - var(--esphome-header-height) - var(--esphome-footer-height));
     }
 
     .desktop-nav {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -71,7 +71,7 @@ export class ESPHomePageSecrets extends LitElement {
       :host {
         display: flex;
         flex-direction: column;
-        height: calc(100vh - var(--esphome-header-height));
+        height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
         box-sizing: border-box;
       }
 

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -25,6 +25,7 @@ export const espHomeStyles = css`
 
     /* ─── Layout ─── */
     --esphome-header-height: 56px;
+    --esphome-footer-height: 20px;
 
     font-family: var(--wa-font-family-body);
   }


### PR DESCRIPTION
# What does this implement/fix?

The version line at the bottom of every page (`ESPHome Device Builder vX` / `ESPHome vY`) had two small problems: the text could not be selected (it had `pointer-events: none`), and because the footer is fixed at the bottom while the dashboard / device / secrets pages sized themselves to the full viewport minus the header, page content could slide behind the footer. The floating "Create device" button also sat directly on top of the footer text.

Changes:

- Make footer text selectable: drop `pointer-events: none`, set `user-select: text`, give it a solid background so content can't show through.
- Add a shared `--esphome-footer-height: 20px` token alongside `--esphome-header-height`.
- Subtract the new token from the page height calcs in `dashboard-styles`, `device-styles`, and `secrets` so content stops at the footer.
- Bump `--fab-bottom` by the footer height so the floating Create-device button clears the version line.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/386

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
