### PR TITLE
Reserve space for the multi-select bar so table pagination stays visible

### DIFF
--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -11,9 +11,9 @@ export const tableLayoutStyles = css`
 
   /* When the dashboard's floating multi-select bar is visible, reserve
      space at the bottom of the table host so the pagination row sits
-     above it rather than behind it. The variable is defined on the
-     dashboard host alongside the bar's own min-height to keep the two
-     in lockstep. */
+     above it rather than behind it. The bar pins itself to exactly
+     --select-bar-height (with nowrap labels) so this reservation
+     can't drift out of sync. */
   :host([select-mode]) {
     padding-bottom: var(--select-bar-height, 64px);
     box-sizing: border-box;

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -9,6 +9,16 @@ export const tableLayoutStyles = css`
     min-height: 0;
   }
 
+  /* When the dashboard's floating multi-select bar is visible, reserve
+     space at the bottom of the table host so the pagination row sits
+     above it rather than behind it. The variable is defined on the
+     dashboard host alongside the bar's own min-height to keep the two
+     in lockstep. */
+  :host([select-mode]) {
+    padding-bottom: var(--select-bar-height, 64px);
+    box-sizing: border-box;
+  }
+
   .controls {
     display: flex;
     align-items: center;

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -53,13 +53,23 @@ export class ESPHomeSelectBar extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: var(--wa-space-m) var(--wa-space-xl);
-        min-height: var(--select-bar-height, 64px);
+        height: var(--select-bar-height, 64px);
         box-sizing: border-box;
+        /* Locked at exactly --select-bar-height so the table host's
+           padding-bottom reservation can never be undershot by a
+           shorter bar or overshot by a wrapping label — the labels
+           below all carry white-space:nowrap to back this guarantee. */
         background: var(--wa-color-surface-raised);
         border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
         z-index: 20;
         animation: slide-in 0.2s ease-out;
+      }
+
+      .select-bar .count,
+      .select-bar .toggle,
+      .select-bar .btn {
+        white-space: nowrap;
       }
 
       .left {

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -53,6 +53,8 @@ export class ESPHomeSelectBar extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: var(--wa-space-m) var(--wa-space-xl);
+        min-height: var(--select-bar-height, 64px);
+        box-sizing: border-box;
         background: var(--wa-color-surface-raised);
         border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);

--- a/src/pages/dashboard-styles.ts
+++ b/src/pages/dashboard-styles.ts
@@ -17,6 +17,11 @@ export const dashboardStyles = css`
     --fab-bottom: var(--wa-space-l);
     --fab-height: 48px;
     --fab-clearance: calc(var(--fab-bottom) + var(--fab-height) + var(--wa-space-xs));
+    /* Height of the floating multi-select action bar (rendered by
+       esphome-select-bar at position:fixed; bottom:0). Used both to
+       enforce the bar's own height and to reserve clearance inside
+       the device table so its pagination row doesn't sit beneath it. */
+    --select-bar-height: 64px;
   }
 
   :host([view="cards"]) {


### PR DESCRIPTION
# What does this implement/fix?

The floating multi-select action bar is `position: fixed; bottom: 0` with `z-index: 20`, so in table view (where the dashboard host has `overflow: hidden`) it sat directly on top of the table's pagination row — there was no way to change pages while in select mode.

This PR adds a `--select-bar-height` token next to the existing `--fab-*` tokens on the dashboard host, applies it as `min-height` on the bar itself (so the visual bar and the reserved clearance can't drift), and uses it as `padding-bottom` on `<esphome-device-table>` whenever the `select-mode` attribute is present. The pagination now sits cleanly above the bar and is fully clickable.

Verified visually at the issue's reproducer viewport (2194×900, dark mode): page-2 advance works, FAB / card view unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/385

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] `npm run lint` passes.
  - [x] `npm run test` passes.
  - [ ] Tests have been added to verify that the new code works (where applicable).
