### PR TITLE
Collapse Update/Install and Logs to icon-only on device cards

### DIFF
--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -598,53 +598,45 @@ export class ESPHomeDeviceCard extends LitElement {
                   <wa-icon library="mdi" name="pencil"></wa-icon>
                   ${this._localize("dashboard.edit")}
                 </button>
-                ${this.hasUpdateAvailable
-                  ? html`
-                      <button
-                        class="action-btn action-btn--accent"
+                ${
+                  // Collapse the accent action (Update / Install) and
+                  // Logs to icon-only so only Edit keeps a label. In
+                  // long-language locales (French "Mettre à jour",
+                  // Dutch "Bijwerken"/"Bewerken") full-text Edit +
+                  // accent + Logs overflows the 300px-min card.
+                  // Edit stays labelled because it's the primary
+                  // action and the pencil alone is ambiguous; the
+                  // upload and console icons read clearly without one.
+                  this.hasUpdateAvailable
+                    ? html`<button
+                        class="action-btn action-btn--accent action-btn--tile"
                         ?disabled=${this.busy}
                         @click=${() => this._emit("update-device")}
+                        aria-label=${this._localize("dashboard.update")}
+                        title=${this._localize("dashboard.update")}
                       >
                         <wa-icon library="mdi" name="upload"></wa-icon>
-                        ${this._localize("dashboard.update")}
-                      </button>
-                    `
-                  : this.hasPendingChanges
-                    ? html`
-                        <button
-                          class="action-btn action-btn--accent"
+                      </button>`
+                    : this.hasPendingChanges
+                      ? html`<button
+                          class="action-btn action-btn--accent action-btn--tile"
                           ?disabled=${this.busy}
                           @click=${() => this._emit("install-device")}
+                          aria-label=${this._localize("dashboard.install")}
+                          title=${this._localize("dashboard.install")}
                         >
                           <wa-icon library="mdi" name="upload"></wa-icon>
-                          ${this._localize("dashboard.install")}
-                        </button>
-                      `
-                    : nothing}
-                ${
-                  // Collapse Logs to icon-only when an accent action
-                  // (Install/Update) is present — Edit + accent + Logs
-                  // + kebab overflows the 300px-min card in long-language
-                  // locales like Dutch ("Bewerken"/"Installeren"/"Logboek").
-                  // Logs collapses first since the console icon reads
-                  // clearly without a label.
-                  this.hasPendingChanges || this.hasUpdateAvailable
-                    ? html`<button
-                        class="action-btn action-btn--ghost action-btn--tile"
-                        @click=${() => this._emit("open-logs")}
-                        aria-label=${this._localize("dashboard.drawer_logs")}
-                        title=${this._localize("dashboard.drawer_logs")}
-                      >
-                        <wa-icon library="mdi" name="console"></wa-icon>
-                      </button>`
-                    : html`<button
-                        class="action-btn action-btn--ghost"
-                        @click=${() => this._emit("open-logs")}
-                      >
-                        <wa-icon library="mdi" name="console"></wa-icon>
-                        ${this._localize("dashboard.drawer_logs")}
-                      </button>`
+                        </button>`
+                      : nothing
                 }
+                <button
+                  class="action-btn action-btn--ghost action-btn--tile"
+                  @click=${() => this._emit("open-logs")}
+                  aria-label=${this._localize("dashboard.drawer_logs")}
+                  title=${this._localize("dashboard.drawer_logs")}
+                >
+                  <wa-icon library="mdi" name="console"></wa-icon>
+                </button>
                 ${this.webUrl
                   ? html`<a
                       class="action-btn action-btn--ghost action-btn--tile"

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -502,8 +502,9 @@ export class ESPHomeDeviceCard extends LitElement {
       /* Compact icon-only button that sits inline with the labelled
          buttons — same visual size as the kebab but without the auto
          left-margin that pushes the kebab to the right edge. Used by
-         the Visit Web UI control (icon-only since the open-in-new
-         icon is self-explanatory). */
+         the Update / Install accent action, Logs, and the Visit Web
+         UI link — Edit is the only labelled action so the row still
+         fits in long-language locales (French / Dutch). */
       .action-btn--tile {
         padding: 5px;
         flex-shrink: 0;


### PR DESCRIPTION
## Problem

In French and Dutch, the device card action row overflows its
300px-minimum container — both **Edit** ("Éditer" / "Bewerken") and
**Update** ("Mettre à jour" / "Bijwerken") are wider than English, so
side-by-side text labels for Edit + Update + Logs no longer fit at
standard FHD column widths.

Reported in esphome/device-builder#396.

## Changes

- Collapse the accent action (**Update** / **Install**) to icon-only
  whenever it is shown, with `aria-label` + `title` for screen readers
  and tooltips.
- Collapse **Logs** to icon-only unconditionally (was previously
  conditional on the accent button being present — now consistent
  across all card states).
- Keep **Edit** as the only labelled button. The pencil icon alone is
  ambiguous, so it stays text + icon; upload and console icons read
  clearly without a label.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
