### PR TITLE
Match FLOAT_WITH_UNIT suffixes case-insensitively (#213)

### DIFF
--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -28,8 +28,19 @@ export interface FloatWithUnit {
  * is the canonical unit and is used as the default when the input has
  * no unit suffix. When `unitOptions` is empty we fall back to `""`.
  *
- * The unit match prefers the longest matching option so `"mHz"` doesn't
- * lose its `m` prefix to a shorter `"Hz"` option earlier in the list.
+ * Matching mirrors ESPHome's ``cv.float_with_unit`` regex
+ * (``config_validation.py``): the base unit is matched
+ * case-insensitively (``cv.frequency`` accepts ``Hz|HZ|hz``) but the
+ * SI prefix is significant (``m`` = milli, ``M`` = mega — different
+ * entries in ``METRIC_SUFFIXES``). For an ambiguous case-insensitive
+ * match — e.g. ``"433.92Mhz"`` against options ``mHz`` and ``MHz`` —
+ * each option is scored by the longest leading run of characters
+ * whose case matches the input verbatim, and the highest-scoring
+ * option wins. So ``"Mhz"`` → ``MHz`` (M matches → score 1 beats
+ * ``mHz``'s 0) and ``"mhz"`` → ``mHz`` (m matches → score 1 beats
+ * ``MHz``'s 0). The returned ``unit`` is always the canonical-cased
+ * option from ``unitOptions``, so a save round-trip normalises the
+ * user's casing to the ESPHome-canonical form. Issue #213.
  */
 export function parseFloatWithUnit(
   raw: unknown,
@@ -43,14 +54,39 @@ export function parseFloatWithUnit(
   const text =
     raw === null || raw === undefined ? "" : String(raw).trim();
   if (text === "") return { value: null, unit: fallbackUnit };
-  // Try the longest option first so `"50mHz"` matches `"mHz"` rather
-  // than the shorter `"Hz"` option earlier in the canonical-prefix
-  // list. `endsWith` is case-sensitive — esphome catalog units are
-  // canonical-cased.
-  const sortedOptions = [...unitOptions].sort((a, b) => b.length - a.length);
-  const match = sortedOptions.find(
-    (option) => option !== "" && text.endsWith(option),
-  );
+
+  const lowerText = text.toLowerCase();
+  let match: string | undefined;
+  let bestScore = -1;
+  let bestLength = -1;
+  for (const option of unitOptions) {
+    if (option === "") continue;
+    if (!lowerText.endsWith(option.toLowerCase())) continue;
+    // Score: count of leading characters whose case matches the
+    // input's corresponding suffix character. Higher score → the
+    // option's prefix-case lines up with what the user typed, which
+    // is the disambiguator for ``mHz`` (milli) vs ``MHz`` (mega)
+    // when the user's input is case-folded (``Mhz`` / ``mhz``).
+    const suffix = text.slice(-option.length);
+    let score = 0;
+    for (let i = 0; i < option.length; i++) {
+      if (suffix[i] !== option[i]) break;
+      score++;
+    }
+    // Prefer higher score; tie-break on length (longer match
+    // captures more of the user's input — ``"50mHz"`` should match
+    // ``mHz`` over ``Hz`` so the ``m`` prefix isn't stranded as
+    // part of the numeric portion).
+    if (
+      score > bestScore ||
+      (score === bestScore && option.length > bestLength)
+    ) {
+      match = option;
+      bestScore = score;
+      bestLength = option.length;
+    }
+  }
+
   const [numericText, unit] = match
     ? [text.slice(0, -match.length).trim(), match]
     : [text, fallbackUnit];

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -177,9 +177,13 @@ describe("parseFloatWithUnit", () => {
 
     it("normalises lowercase 'ghz' to canonical 'GHz'", () => {
       // Lowercase 'g' is NOT in ESPHome's METRIC_SUFFIXES (only G
-      // for giga); the case-insensitive match still picks GHz
-      // because that's the only option whose lowercase form ends
-      // the input. Round-trips through save as canonical GHz.
+      // for giga). Both ``GHz`` and ``Hz`` match ``"2ghz"`` case-
+      // insensitively (both lowercase forms end the input), and
+      // both score 0 case-sensitive leading-match characters
+      // (``2`` ≠ ``G``, ``h`` ≠ ``H``). The length tie-break picks
+      // ``GHz`` (3 chars > 2) so the user's ``g`` prefix isn't
+      // stranded as part of the numeric portion. Round-trips
+      // through save as canonical ``GHz``.
       expect(parseFloatWithUnit("2ghz", FREQUENCY_UNITS)).toEqual({
         value: 2,
         unit: "GHz",
@@ -204,11 +208,25 @@ describe("parseFloatWithUnit", () => {
       // not specific to ``cv.frequency``. Pin that resistance
       // (which takes ``Ω|ohm|Ohm|OHM`` and various SI prefixes in
       // its ESPHome regex) gets the same case-insensitive
-      // treatment.
-      const resistanceUnits = ["Ω", "kΩ", "MΩ"] as const;
-      expect(parseFloatWithUnit("4.7kΩ", resistanceUnits)).toEqual({
+      // treatment for the BASE unit. The user can type the base
+      // in any case (``ohm``, ``Ohm``, ``OHM``) and the parser
+      // picks the right SI-prefixed option, normalising to the
+      // canonical-cased option on round-trip.
+      const resistanceUnits = ["Ohm", "kOhm", "MOhm"] as const;
+      // All-lowercase: ``k`` matches case (score 1) > ``Ohm``'s
+      // ``o`` ≠ ``O`` (score 0). Length tie-break would also pick
+      // ``kOhm`` over the bare ``Ohm`` if scores tied.
+      expect(parseFloatWithUnit("4.7kohm", resistanceUnits)).toEqual({
         value: 4.7,
-        unit: "kΩ",
+        unit: "kOhm",
+      });
+      // Lowercase prefix + uppercase base: ``kOhm`` scores 2
+      // (k=k, O=O) vs ``Ohm``'s 1 (O=O, h≠H), so the SI prefix
+      // is preserved correctly even though the user uppercased
+      // the base.
+      expect(parseFloatWithUnit("4.7kOHM", resistanceUnits)).toEqual({
+        value: 4.7,
+        unit: "kOhm",
       });
     });
 

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -115,6 +115,112 @@ describe("parseFloatWithUnit", () => {
         .toBe(raw);
     }
   });
+
+  // ESPHome's ``cv.frequency`` accepts the base ``Hz`` suffix
+  // case-insensitively (``Hz|HZ|hz``); the SI prefix (``m`` /
+  // ``M`` / ``k`` / ``G`` / …) IS case-significant per
+  // ``METRIC_SUFFIXES`` — ``m`` is milli, ``M`` is mega. The parser
+  // mirrors that: case-fold the base, preserve prefix case
+  // disambiguation when the input is case-mixed. Issue #213.
+  describe("case-variant base units", () => {
+    it("normalises lowercase 'hz' to canonical 'Hz'", () => {
+      expect(parseFloatWithUnit("60hz", FREQUENCY_UNITS)).toEqual({
+        value: 60,
+        unit: "Hz",
+      });
+    });
+
+    it("normalises uppercase 'HZ' to canonical 'Hz'", () => {
+      expect(parseFloatWithUnit("60HZ", FREQUENCY_UNITS)).toEqual({
+        value: 60,
+        unit: "Hz",
+      });
+    });
+
+    it("'Mhz' (capital prefix, lowercase base) → 'MHz' (mega)", () => {
+      // The trigger from #213: user typed `433.92Mhz` and saw the
+      // form snap to canonical `Hz` (zero) instead of recognising
+      // the mega-Hz value. Capital prefix M wins the score over
+      // lowercase prefix m.
+      expect(parseFloatWithUnit("433.92Mhz", FREQUENCY_UNITS)).toEqual({
+        value: 433.92,
+        unit: "MHz",
+      });
+    });
+
+    it("'MHZ' (capital prefix + uppercase base) → 'MHz' (mega)", () => {
+      expect(parseFloatWithUnit("433.92MHZ", FREQUENCY_UNITS)).toEqual({
+        value: 433.92,
+        unit: "MHz",
+      });
+    });
+
+    it("'mhz' (lowercase prefix + lowercase base) → 'mHz' (milli)", () => {
+      // ESPHome's METRIC_SUFFIXES distinguishes ``m`` (milli) from
+      // ``M`` (mega), so a lowercase prefix means milli regardless
+      // of the base unit's case. The score-based tiebreak picks
+      // ``mHz`` (m matches case → 1) over ``MHz`` (m≠M → 0). A
+      // user who meant mega should have typed ``Mhz`` / ``MHz``;
+      // we faithfully report what ESPHome would parse.
+      expect(parseFloatWithUnit("433.92mhz", FREQUENCY_UNITS)).toEqual({
+        value: 433.92,
+        unit: "mHz",
+      });
+    });
+
+    it("normalises lowercase 'khz' to canonical 'kHz'", () => {
+      expect(parseFloatWithUnit("50khz", FREQUENCY_UNITS)).toEqual({
+        value: 50,
+        unit: "kHz",
+      });
+    });
+
+    it("normalises lowercase 'ghz' to canonical 'GHz'", () => {
+      // Lowercase 'g' is NOT in ESPHome's METRIC_SUFFIXES (only G
+      // for giga); the case-insensitive match still picks GHz
+      // because that's the only option whose lowercase form ends
+      // the input. Round-trips through save as canonical GHz.
+      expect(parseFloatWithUnit("2ghz", FREQUENCY_UNITS)).toEqual({
+        value: 2,
+        unit: "GHz",
+      });
+    });
+
+    it("preserves the user's case when it already matches an option", () => {
+      // Sanity check: case-sensitive matches still win when no
+      // case-variant ambiguity exists.
+      expect(parseFloatWithUnit("0.5mHz", FREQUENCY_UNITS)).toEqual({
+        value: 0.5,
+        unit: "mHz",
+      });
+      expect(parseFloatWithUnit("50MHz", FREQUENCY_UNITS)).toEqual({
+        value: 50,
+        unit: "MHz",
+      });
+    });
+
+    it("handles case-variant resistance suffixes", () => {
+      // Scope check: the bug is in ``cv.float_with_unit`` itself,
+      // not specific to ``cv.frequency``. Pin that resistance
+      // (which takes ``Ω|ohm|Ohm|OHM`` and various SI prefixes in
+      // its ESPHome regex) gets the same case-insensitive
+      // treatment.
+      const resistanceUnits = ["Ω", "kΩ", "MΩ"] as const;
+      expect(parseFloatWithUnit("4.7kΩ", resistanceUnits)).toEqual({
+        value: 4.7,
+        unit: "kΩ",
+      });
+    });
+
+    it("save round-trip normalises case-variant input to canonical", () => {
+      // Round-trip via parse → serialize. The user's lowercase
+      // ``Mhz`` becomes the canonical ``MHz`` on save — same shape
+      // ESPHome's emitter produces, so a YAML diff after save is
+      // limited to the casing fix.
+      const parsed = parseFloatWithUnit("433.92Mhz", FREQUENCY_UNITS);
+      expect(serializeFloatWithUnit(parsed)).toBe("433.92MHz");
+    });
+  });
 });
 
 describe("placeholderForFloatWithUnit", () => {


### PR DESCRIPTION
# What does this implement/fix?

`parseFloatWithUnit` (`src/util/float-with-unit.ts`) used a case-sensitive
`endsWith` to match unit suffixes. ESPHome's `cv.float_with_unit` regex
matches the *base* unit case-insensitively (e.g. `cv.frequency` accepts
`Hz|HZ|hz`), so a YAML value the upstream validator happily accepts —
e.g. `frequency: 433.92Mhz` (lowercase `h`) — would fail to match any
catalog option, fall through to the bare-number path, return
`{value: NaN, unit: "Hz"}` and surface "not a number" in the visual
editor. Issue #213.

## How

Match each option's lowercased form against the input's lowercased form
(`endsWith` after `toLowerCase()`), then disambiguate ambiguous matches
by scoring how many leading characters of the option match the input
**case-sensitively**. The highest score wins; ties break on length.

The score-based disambiguation matters because ESPHome's
`METRIC_SUFFIXES` table is case-sensitive: `m` is milli (1e-3), `M` is
mega (1e6) — different prefixes, different multipliers. So:

- `"433.92Mhz"` → option `MHz` wins (M=M score 1) over `mHz` (m≠M
  score 0). Result: `{value: 433.92, unit: "MHz"}` — what the user
  intended.
- `"433.92mhz"` → option `mHz` wins (m=m score 1) over `MHz` (M≠m
  score 0). Result: `{value: 433.92, unit: "mHz"}` — milli-Hz, which
  is what ESPHome would *also* parse it as. We faithfully report
  what the upstream validator sees instead of silently converting
  the user's lowercase prefix to mega.
- `"433.92MHZ"` → option `MHz` wins (M=M, H=H → score 2; mHz scores
  0). Result: canonical `MHz`.

The returned `unit` is always the canonical-cased option from
`unitOptions`, so a save round-trip normalises the user's casing to
the ESPHome-canonical form. The `433.92Mhz` example becomes
`433.92MHz` in the YAML on save.

## Tests

12 new cases under a new `describe("case-variant base units")` block
covering:

- The three forms the issue called out: `433.92Mhz`, `433.92MHZ`,
  `433.92mhz` (with the milli-Hz interpretation explained inline).
- Lowercase / uppercase base-only variants (`60hz`, `60HZ`, `50khz`,
  `2ghz`).
- A non-frequency case (`4.7kΩ`) to pin that the fix scopes to
  `cv.float_with_unit` generally, not just frequency.
- Save round-trip: `parse("433.92Mhz") → serialize → "433.92MHz"`.
- Sanity checks that previously-working canonical inputs (`0.5mHz`,
  `50MHz`) still resolve to the right option.

All 778 tests pass; lint clean.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#213

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
