### PR TITLE
Surface backend CommandError on the create-config dialog

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -160,25 +160,40 @@ export class ESPHomeCreateConfigDialog extends LitElement {
 
   public open(startStep?: WizardStep) {
     this._step = startStep ?? "method";
-    this._creationMethod = "basic";
     this._selectedBoard = null;
-    this._importFile = null;
-    this._submitting = false;
-    this._importError = "";
-    this._createError = "";
-    this._dialog.open = true;
+    this._resetTransientState();
   }
 
   /** Open directly at the setup step with a pre-selected board. */
   public openWithBoard(board: BoardCatalogEntry) {
     this._step = "setup";
-    this._creationMethod = "basic";
     this._selectedBoard = board;
+    this._resetTransientState();
+  }
+
+  /** Clear submission / file / error state shared by the two
+   * ``open`` entry points so a re-open after a prior dismissal
+   * doesn't carry stale state across. ``_step`` /
+   * ``_selectedBoard`` are intentionally excluded — each entry
+   * point sets those to its own starting value before calling
+   * here. */
+  private _resetTransientState(): void {
+    this._creationMethod = "basic";
     this._importFile = null;
     this._submitting = false;
+    this._resetCreateErrors();
+    this._dialog.open = true;
+  }
+
+  /** Clear both error slots so a stale message from a prior
+   * attempt (e.g. a failed import the user backed out of)
+   * doesn't sit alongside whatever this attempt produces. Both
+   * slots clear together because the two flows share the same
+   * dialog body — leaving ``_importError`` set while showing
+   * ``_createError`` would render two red bars stacked. */
+  private _resetCreateErrors(): void {
     this._importError = "";
     this._createError = "";
-    this._dialog.open = true;
   }
 
   public close() {
@@ -316,43 +331,22 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   }
 
   private async _onCreateEmptyConfig(e: CustomEvent<{ name: string }>) {
-    if (this._submitting) return;
     const { name } = e.detail;
-    const slug = friendlyNameSlugify(name);
-    // Clear both error slots so a stale message from a prior attempt
-    // (e.g. a failed import the user backed out of) doesn't sit
-    // alongside whatever this attempt produces.
-    this._createError = "";
-    this._importError = "";
-    this._submitting = true;
-    try {
-      const { configuration } = await this._api.createDevice({
-        name: slug,
+    await this._runCreate(
+      {
+        name: friendlyNameSlugify(name),
         board_id: this._selectedBoard?.id ?? "",
         config_type: "empty",
-      });
-      this._navigateToCreated(configuration);
-    } catch (err) {
-      // Surface the backend's CommandError on the dialog rather
-      // than dropping it silently to the browser console — backend
-      // validation rejections (e.g. INVALID_ARGS for a YAML that
-      // doesn't validate) carry actionable messages the user needs
-      // to see.
-      console.error("Failed to create empty config:", err);
-      this._createError = this._extractCreateErrorMessage(err);
-    } finally {
-      this._submitting = false;
-    }
+      },
+      { board: this._selectedBoard ?? null },
+    );
   }
 
   private async _createImportedDevice() {
     if (this._submitting) return;
     if (!this._importFile) return;
 
-    // Same dual-clear as the other create handlers — see
-    // ``_onCreateEmptyConfig`` for the rationale.
-    this._importError = "";
-    this._createError = "";
+    this._resetCreateErrors();
 
     let fileContent: string;
     try {
@@ -410,26 +404,56 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       wifiPassword: string;
     }>
   ) {
-    if (this._submitting) return;
     const { board, name, wifiSsid, wifiPassword } = e.detail;
     if (!board) return;
-    const slug = friendlyNameSlugify(name);
-    // Same dual-clear as ``_onCreateEmptyConfig``.
-    this._createError = "";
-    this._importError = "";
-    this._submitting = true;
-    try {
-      const { configuration } = await this._api.createDevice({
-        name: slug,
+    await this._runCreate(
+      {
+        name: friendlyNameSlugify(name),
         board_id: board.id,
         config_type: "basic",
         ssid: wifiSsid,
         psk: wifiPassword,
-      });
+      },
+      { board },
+    );
+  }
+
+  /** Run a ``createDevice`` call with shared error-handling glue.
+   *
+   * Centralises the submitting flag, the dual error reset, the
+   * success navigation, and the catch-side error extraction so
+   * the empty- and basic-setup flows can't drift on which
+   * failure modes get surfaced to the user. The ``board``
+   * option, when provided, is woven into the error message so a
+   * template-generation failure tells the user *which* board
+   * they were on (the bug behind the "AquaPing for d1_mini"
+   * report — once the backend rejects a bad template, the
+   * dashboard should at least name the board the wizard tried
+   * to use).
+   */
+  private async _runCreate(
+    args: {
+      name: string;
+      board_id?: string;
+      config_type?: string;
+      ssid?: string;
+      psk?: string;
+      file_content?: string;
+    },
+    options: { board?: BoardCatalogEntry | null } = {},
+  ): Promise<void> {
+    if (this._submitting) return;
+    this._resetCreateErrors();
+    this._submitting = true;
+    try {
+      const { configuration } = await this._api.createDevice(args);
       this._navigateToCreated(configuration);
     } catch (err) {
       console.error("Failed to create device:", err);
-      this._createError = this._extractCreateErrorMessage(err);
+      this._createError = this._extractCreateErrorMessage(
+        err,
+        options.board ?? null,
+      );
     } finally {
       this._submitting = false;
     }
@@ -446,13 +470,30 @@ export class ESPHomeCreateConfigDialog extends LitElement {
    * with no body — empty after trimming would otherwise render as
    * a blank red bar on the dialog, which is worse than a generic
    * "create failed").
+   *
+   * When ``board`` is provided, the result is wrapped with
+   * ``wizard.create_with_board_error`` so the displayed message
+   * names the board the wizard was trying to use. The basic-setup
+   * flow always passes a board; the empty-config flow only does
+   * when the user picked one (it's optional there).
    */
-  private _extractCreateErrorMessage(err: unknown): string {
-    if (err instanceof APIError) {
-      const details = err.details.trim();
-      if (details) return details;
+  private _extractCreateErrorMessage(
+    err: unknown,
+    board: BoardCatalogEntry | null,
+  ): string {
+    let message: string;
+    if (err instanceof APIError && err.details.trim()) {
+      message = err.details.trim();
+    } else {
+      message = this._localize("wizard.create_general_error");
     }
-    return this._localize("wizard.create_general_error");
+    if (board) {
+      return this._localize("wizard.create_with_board_error", {
+        board: board.name,
+        message,
+      });
+    }
+    return message;
   }
 }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -56,6 +56,18 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   @state()
   private _importError = "";
 
+  /** Catch-all error for the empty / basic create flows.
+   *
+   * Mirrors ``_importError`` but for the two paths that don't have
+   * their own bespoke "duplicate"/"invalid filename" messages. A
+   * backend ``CommandError`` (validation reject, name collision,
+   * unknown board, ...) lands here so the user sees something
+   * actionable on the dialog instead of the failure dropping
+   * silently to the browser console.
+   */
+  @state()
+  private _createError = "";
+
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
@@ -152,6 +164,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     this._importFile = null;
     this._submitting = false;
     this._importError = "";
+    this._createError = "";
     this._dialog.open = true;
   }
 
@@ -163,6 +176,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     this._importFile = null;
     this._submitting = false;
     this._importError = "";
+    this._createError = "";
     this._dialog.open = true;
   }
 
@@ -204,6 +218,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         ${this._renderStep()}
         ${this._importError
           ? html`<p class="error">${this._importError}</p>`
+          : nothing}
+        ${this._createError
+          ? html`<p class="error">${this._createError}</p>`
           : nothing}
       </wa-dialog>
     `;
@@ -301,6 +318,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     if (this._submitting) return;
     const { name } = e.detail;
     const slug = friendlyNameSlugify(name);
+    this._createError = "";
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -310,7 +328,13 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       });
       this._navigateToCreated(configuration);
     } catch (err) {
+      // Surface the backend's CommandError on the dialog rather
+      // than dropping it silently to the browser console — backend
+      // validation rejections (e.g. INVALID_ARGS for a YAML that
+      // doesn't validate) carry actionable messages the user needs
+      // to see.
       console.error("Failed to create empty config:", err);
+      this._createError = this._extractCreateErrorMessage(err);
     } finally {
       this._submitting = false;
     }
@@ -382,6 +406,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     const { board, name, wifiSsid, wifiPassword } = e.detail;
     if (!board) return;
     const slug = friendlyNameSlugify(name);
+    this._createError = "";
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -394,9 +419,31 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       this._navigateToCreated(configuration);
     } catch (err) {
       console.error("Failed to create device:", err);
+      this._createError = this._extractCreateErrorMessage(err);
     } finally {
       this._submitting = false;
     }
+  }
+
+  /** Pull the user-facing message out of an APIError-shaped failure.
+   *
+   * Backend ``CommandError`` messages carry the actual validation
+   * detail (e.g. "Provide either board_id or file_content; ...");
+   * the WS client wraps them as ``APIError: <code>: <message>``.
+   * Strip the wrapper prefix(es) so the dialog renders just the
+   * message, not the protocol noise. Falls back to a localised
+   * generic when the error doesn't expose a message at all.
+   */
+  private _extractCreateErrorMessage(err: unknown): string {
+    const raw = err instanceof Error ? err.message : String(err);
+    if (!raw) return this._localize("wizard.create_general_error");
+    // Strip "APIError: " and the lowercase ErrorCode token
+    // (e.g. ``invalid_args:``, ``internal_error:``) so the
+    // surfaced text starts at the actual diagnostic.
+    return raw
+      .replace(/^APIError:\s*/, "")
+      .replace(/^[a-z_]+:\s*/, "")
+      .trim();
   }
 }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
+import { APIError } from "../../api/api-error.js";
 import type { BoardCatalogEntry } from "../../api/types.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -318,7 +319,11 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     if (this._submitting) return;
     const { name } = e.detail;
     const slug = friendlyNameSlugify(name);
+    // Clear both error slots so a stale message from a prior attempt
+    // (e.g. a failed import the user backed out of) doesn't sit
+    // alongside whatever this attempt produces.
     this._createError = "";
+    this._importError = "";
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -344,7 +349,10 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     if (this._submitting) return;
     if (!this._importFile) return;
 
+    // Same dual-clear as the other create handlers — see
+    // ``_onCreateEmptyConfig`` for the rationale.
     this._importError = "";
+    this._createError = "";
 
     let fileContent: string;
     try {
@@ -406,7 +414,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     const { board, name, wifiSsid, wifiPassword } = e.detail;
     if (!board) return;
     const slug = friendlyNameSlugify(name);
+    // Same dual-clear as ``_onCreateEmptyConfig``.
     this._createError = "";
+    this._importError = "";
     this._submitting = true;
     try {
       const { configuration } = await this._api.createDevice({
@@ -427,23 +437,22 @@ export class ESPHomeCreateConfigDialog extends LitElement {
 
   /** Pull the user-facing message out of an APIError-shaped failure.
    *
-   * Backend ``CommandError`` messages carry the actual validation
-   * detail (e.g. "Provide either board_id or file_content; ...");
-   * the WS client wraps them as ``APIError: <code>: <message>``.
-   * Strip the wrapper prefix(es) so the dialog renders just the
-   * message, not the protocol noise. Falls back to a localised
-   * generic when the error doesn't expose a message at all.
+   * Reads the structured ``details`` field directly when the WS
+   * client throws an :class:`APIError`, so we don't have to parse
+   * the formatted ``"<code>: <details>"`` message string back
+   * apart. Falls back to a localised generic for any non-APIError
+   * shape (transport failures, unexpected non-Error throws) and
+   * for the case where ``details`` is empty (e.g. ``invalid_args:``
+   * with no body — empty after trimming would otherwise render as
+   * a blank red bar on the dialog, which is worse than a generic
+   * "create failed").
    */
   private _extractCreateErrorMessage(err: unknown): string {
-    const raw = err instanceof Error ? err.message : String(err);
-    if (!raw) return this._localize("wizard.create_general_error");
-    // Strip "APIError: " and the lowercase ErrorCode token
-    // (e.g. ``invalid_args:``, ``internal_error:``) so the
-    // surfaced text starts at the actual diagnostic.
-    return raw
-      .replace(/^APIError:\s*/, "")
-      .replace(/^[a-z_]+:\s*/, "")
-      .trim();
+    if (err instanceof APIError) {
+      const details = err.details.trim();
+      if (details) return details;
+    }
+    return this._localize("wizard.create_general_error");
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -486,7 +486,8 @@
       "tuya": "Tuya",
       "shelly": "Shelly"
     },
-    "create_general_error": "Failed to create the device. Please try again."
+    "create_general_error": "Failed to create the device. Please try again.",
+    "create_with_board_error": "Failed to create device for {board}: {message}"
   },
   "device": {
     "navigator_title": "Device navigator",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -485,7 +485,8 @@
       "sonoff": "Sonoff",
       "tuya": "Tuya",
       "shelly": "Shelly"
-    }
+    },
+    "create_general_error": "Failed to create the device. Please try again."
   },
   "device": {
     "navigator_title": "Device navigator",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -389,7 +389,8 @@
       "tuya": "Tuya",
       "shelly": "Shelly"
     },
-    "starter_kit": "À la une"
+    "starter_kit": "À la une",
+    "create_general_error": "La création du dispositif a échoué. Veuillez réessayer."
   },
   "device": {
     "navigator_title": "Navigateur d'appareil",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -390,7 +390,8 @@
       "shelly": "Shelly"
     },
     "starter_kit": "À la une",
-    "create_general_error": "La création du dispositif a échoué. Veuillez réessayer."
+    "create_general_error": "La création du dispositif a échoué. Veuillez réessayer.",
+    "create_with_board_error": "Échec de la création du dispositif pour {board} : {message}"
   },
   "device": {
     "navigator_title": "Navigateur d'appareil",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -390,7 +390,8 @@
       "shelly": "Shelly"
     },
     "starter_kit": "Aanbevolen",
-    "create_general_error": "Het aanmaken van het apparaat is mislukt. Probeer het opnieuw."
+    "create_general_error": "Het aanmaken van het apparaat is mislukt. Probeer het opnieuw.",
+    "create_with_board_error": "Aanmaken van apparaat voor {board} is mislukt: {message}"
   },
   "device": {
     "navigator_title": "Apparaatnavigator",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -389,7 +389,8 @@
       "tuya": "Tuya",
       "shelly": "Shelly"
     },
-    "starter_kit": "Aanbevolen"
+    "starter_kit": "Aanbevolen",
+    "create_general_error": "Het aanmaken van het apparaat is mislukt. Probeer het opnieuw."
   },
   "device": {
     "navigator_title": "Apparaatnavigator",


### PR DESCRIPTION
# What does this implement/fix?

The "Empty Configuration — for manually writing or pasting" button and the basic-setup finish step both wrapped their `createDevice` call in `catch (err) { console.error(...); }`, so any backend rejection (validation reject, name collision, unknown board) dropped silently to the browser console with no indication on the dialog. Users would click "Create" and see nothing happen.

Adds a `_createError` state that mirrors `_importError`'s pattern, wires it from both `_onCreateEmptyConfig` and `_onFinishSetup`, and renders it in the dialog's existing `.error` styled paragraph. Errors are extracted via `_extractCreateErrorMessage`, which strips the WS layer's `APIError: <code>:` wrapper so the displayed text starts at the actual diagnostic. New `wizard.create_general_error` localisation key (en/fr/nl) covers the case where the backend doesn't expose a message at all.

Companion to esphome/device-builder#405 — backend now refuses invalid `file_content` with `INVALID_ARGS` instead of writing it to disk; without this PR the dashboard would have shown the same silent-fail behaviour even though the backend is now telling the frontend why.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#405

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
