### PR TITLE
Update project.urls to correct repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/esphome/device-builder-dashboard-frontend"
-Issues = "https://github.com/esphome/device-builder-dashboard-backend/issues"
-Repository = "https://github.com/esphome/device-builder-dashboard-frontend"
+Documentation = "https://esphome.io"
+Homepage = "https://esphome.io"
+Issues = "https://github.com/esphome/device-builder/issues"
+Repository = "https://github.com/esphome/device-builder-frontend"
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `[project.urls]` block in `pyproject.toml`, which pointed at non-existent repos (`device-builder-dashboard-frontend`, `device-builder-dashboard-backend`). Aligns the entries with the backend's set: `Documentation` and `Homepage` now point to esphome.io, `Issues` to the backend tracker (where UI bugs are filed), and `Repository` to this frontend repo.

**Related issue or feature (if applicable):**

-

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).