### PR TITLE
Drop the `v` prefix from the ESPHome version in the footer

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -267,7 +267,7 @@ export class ESPHomeLayout extends LitElement {
       <slot></slot>
       <div class="app-footer">
         ${this._serverVersion ? html`<span>ESPHome Device Builder v${this._serverVersion}</span>` : nothing}
-        ${this._esphomeVersion ? html`<span>ESPHome v${this._esphomeVersion}</span>` : nothing}
+        ${this._esphomeVersion ? html`<span>ESPHome ${this._esphomeVersion}</span>` : nothing}
       </div>
     `;
   }


### PR DESCRIPTION
# What does this implement/fix?

The footer was rendering the ESPHome version as `ESPHome v2026.x.x`, but the upstream ESPHome version string is already used directly elsewhere (and supports `dev` suffixes, etc.) without a `v`. Drop the prefix so the label matches the canonical version string.

The neighbouring "ESPHome Device Builder v…" line is kept as-is — that one is our own internal version and isn't sourced from the same field.

**Related issue or feature (if applicable):**

-

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).