### PR TITLE
wizard: add LN882x chip + relabel RP2040 as 'RP2040 / RP2350'

### DIFF
--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -1,0 +1,41 @@
+/**
+ * Platform-filter chip definitions for the wizard's "Select your
+ * board" step. Lives in its own module (not on the component
+ * class) so the data shape can be unit-tested without spinning up
+ * a DOM env to import the Lit component, mirroring the
+ * ``password-input-event.ts`` split pattern elsewhere in the repo.
+ *
+ * - ``platform`` is the canonical ESPHome platform key the backend
+ *   exposes via ``_PLATFORM_KEYS`` in
+ *   ``helpers/device_yaml.py``. Backend catalogue lookups expect
+ *   this value verbatim.
+ * - ``variant`` narrows ESP32 chips into their families (S2 / S3 /
+ *   C3 / C6 / H2). Empty for non-ESP32 platforms.
+ * - ``label`` is the user-facing chip text. The RP2040 chip's
+ *   label is ``RP2040 / RP2350`` because ESPHome's ``rp2040``
+ *   platform covers both chip generations; users searching for
+ *   either chip name need to recognise the filter as theirs.
+ */
+export interface WizardBoardPlatform {
+  readonly platform: string;
+  readonly variant: string;
+  readonly label: string;
+}
+
+export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
+  { platform: "esp32", variant: "esp32", label: "ESP32" },
+  { platform: "esp32", variant: "esp32s2", label: "ESP32-S2" },
+  { platform: "esp32", variant: "esp32s3", label: "ESP32-S3" },
+  { platform: "esp32", variant: "esp32c3", label: "ESP32-C3" },
+  { platform: "esp32", variant: "esp32c6", label: "ESP32-C6" },
+  { platform: "esp32", variant: "esp32h2", label: "ESP32-H2" },
+  { platform: "esp8266", variant: "", label: "ESP8266" },
+  // ESPHome's ``rp2040`` platform covers both the original
+  // RP2040 and the newer RP2350; the label calls out both
+  // chip names so a user searching for either one sees the
+  // filter chip that owns them.
+  { platform: "rp2040", variant: "", label: "RP2040 / RP2350" },
+  { platform: "bk72xx", variant: "", label: "BK72xx" },
+  { platform: "rtl87xx", variant: "", label: "RTL87xx" },
+  { platform: "ln882x", variant: "", label: "LN882x" },
+];

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -71,9 +71,14 @@ export class ESPHomeWizardStepBoard extends LitElement {
     { platform: "esp32", variant: "esp32c6", label: "ESP32-C6" },
     { platform: "esp32", variant: "esp32h2", label: "ESP32-H2" },
     { platform: "esp8266", variant: "", label: "ESP8266" },
-    { platform: "rp2040", variant: "", label: "RP2040" },
+    // ESPHome's ``rp2040`` platform covers both the original
+    // RP2040 and the newer RP2350; the label calls out both
+    // chip names so a user searching for either one sees the
+    // filter chip that owns them.
+    { platform: "rp2040", variant: "", label: "RP2040 / RP2350" },
     { platform: "bk72xx", variant: "", label: "BK72xx" },
     { platform: "rtl87xx", variant: "", label: "RTL87xx" },
+    { platform: "ln882x", variant: "", label: "LN882x" },
   ];
 
   connectedCallback() {

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -14,6 +14,7 @@ import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { WIZARD_BOARD_PLATFORMS } from "./wizard-step-board-platforms.js";
 import { withBase } from "../../util/base-path.js";
 import { debounce } from "../../util/debounce.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -63,23 +64,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
 
   private _debouncedSearch = debounce(() => this._fetchBoards(), 300);
 
-  private static readonly PLATFORMS = [
-    { platform: "esp32", variant: "esp32", label: "ESP32" },
-    { platform: "esp32", variant: "esp32s2", label: "ESP32-S2" },
-    { platform: "esp32", variant: "esp32s3", label: "ESP32-S3" },
-    { platform: "esp32", variant: "esp32c3", label: "ESP32-C3" },
-    { platform: "esp32", variant: "esp32c6", label: "ESP32-C6" },
-    { platform: "esp32", variant: "esp32h2", label: "ESP32-H2" },
-    { platform: "esp8266", variant: "", label: "ESP8266" },
-    // ESPHome's ``rp2040`` platform covers both the original
-    // RP2040 and the newer RP2350; the label calls out both
-    // chip names so a user searching for either one sees the
-    // filter chip that owns them.
-    { platform: "rp2040", variant: "", label: "RP2040 / RP2350" },
-    { platform: "bk72xx", variant: "", label: "BK72xx" },
-    { platform: "rtl87xx", variant: "", label: "RTL87xx" },
-    { platform: "ln882x", variant: "", label: "LN882x" },
-  ];
+  private static readonly PLATFORMS = WIZARD_BOARD_PLATFORMS;
 
   connectedCallback() {
     super.connectedCallback();

--- a/test/components/wizard/wizard-step-board-platforms.test.ts
+++ b/test/components/wizard/wizard-step-board-platforms.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { WIZARD_BOARD_PLATFORMS } from "../../../src/components/wizard/wizard-step-board-platforms.js";
+
+describe("wizard step-board platform chips", () => {
+  it("includes an LN882x chip backed by the ln882x platform", () => {
+    // Without this chip, users with LightLink LN882x hardware
+    // had to scroll the OTHER BOARDS list to find their board.
+    // The backend's `_PLATFORM_KEYS` already advertises
+    // `ln882x`, so the FE chip just resolves to a real query.
+    const ln882x = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "LN882x");
+    expect(ln882x).toBeDefined();
+    expect(ln882x?.platform).toBe("ln882x");
+    expect(ln882x?.variant).toBe("");
+  });
+
+  it("labels the rp2040 platform 'RP2040 / RP2350' so users searching for either chip name see it", () => {
+    // ESPHome's `rp2040` platform key covers both the original
+    // RP2040 and the newer RP2350 (Raspberry Pi Pico 2). A plain
+    // "RP2040" label hides the filter from anyone searching for
+    // their RP2350 board. The platform key stays `rp2040` —
+    // this is a label-only contract.
+    const labels = WIZARD_BOARD_PLATFORMS.map((p) => p.label);
+    expect(labels).toContain("RP2040 / RP2350");
+    expect(labels).not.toContain("RP2040");
+    const rp = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "RP2040 / RP2350");
+    expect(rp?.platform).toBe("rp2040");
+  });
+
+  it("groups the libretiny-family chips (BK72xx / RTL87xx / LN882x) adjacent", () => {
+    // The three libretiny-based platforms sit next to each
+    // other so the user scanning the chip row sees them as a
+    // family. A regression that re-orders them into different
+    // positions wouldn't break functionality but would hurt
+    // discoverability — pin the ordering.
+    const labels = WIZARD_BOARD_PLATFORMS.map((p) => p.label);
+    const bk = labels.indexOf("BK72xx");
+    const rtl = labels.indexOf("RTL87xx");
+    const ln = labels.indexOf("LN882x");
+    expect(bk).toBeGreaterThanOrEqual(0);
+    expect(rtl).toBe(bk + 1);
+    expect(ln).toBe(rtl + 1);
+  });
+
+  it("every chip's platform is in the backend's accepted set", () => {
+    // The backend's `_PLATFORM_KEYS` (helpers/device_yaml.py)
+    // restricts `platform:` to a fixed set. A chip whose
+    // `platform` field falls outside that set would query the
+    // catalog with a string the backend has no boards for and
+    // the chip would always come up empty.
+    const accepted = new Set([
+      "esp32",
+      "esp8266",
+      "rp2040",
+      "bk72xx",
+      "rtl87xx",
+      "ln882x",
+      "nrf52",
+    ]);
+    for (const p of WIZARD_BOARD_PLATFORMS) {
+      expect(accepted.has(p.platform)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Two issues with the "Select your board" step's quick-filter chips, spotted from a running dashboard:

- **LN882x was missing entirely.** The backend's `_PLATFORM_KEYS` set advertises `ln882x` alongside `esp32` / `esp8266` / `rp2040` / `bk72xx` / `rtl87xx` / `nrf52`, but the wizard's `PLATFORMS` list didn't have a chip for it — users with LightLink LN882x hardware had to fall back to the "OTHER BOARDS" scroll list to find their board. Adds a chip after RTL87xx so the libretiny-family filters (BK72xx / RTL87xx / LN882x) sit next to each other.
- **The "RP2040" label is too narrow.** ESPHome's `rp2040` platform covers the original RP2040 *and* the newer RP2350 (Raspberry Pi Pico 2); a user searching for "RP2350" wouldn't recognise the "RP2040" chip as the right filter for their hardware. Relabels to **"RP2040 / RP2350"** so both chip names land on the filter that owns them. The platform key stays `rp2040` because that's still the canonical ESPHome platform string; this is a label-only change.

Catalog-coverage note: today the LN882x chip surfaces only the `generic-ln882hki` manifest from `definitions/boards/` (the only entry with platform `ln882x`). The chip is still worth shipping -- a single-entry filter is more discoverable than making LN882x users scroll the OTHER BOARDS list -- and curated manifests for specific LN882x products will land naturally as the catalog grows.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

