### PR TITLE
wizard: add nRF52 chip to the platform filter row

### DIFF
--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -38,4 +38,5 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
   { platform: "bk72xx", variant: "", label: "BK72xx" },
   { platform: "rtl87xx", variant: "", label: "RTL87xx" },
   { platform: "ln882x", variant: "", label: "LN882x" },
+  { platform: "nrf52", variant: "", label: "nRF52" },
 ];

--- a/test/components/wizard/wizard-step-board-platforms.test.ts
+++ b/test/components/wizard/wizard-step-board-platforms.test.ts
@@ -13,6 +13,20 @@ describe("wizard step-board platform chips", () => {
     expect(ln882x?.variant).toBe("");
   });
 
+  it("includes an nRF52 chip backed by the nrf52 platform", () => {
+    // Backend `_PLATFORM_KEYS` advertises `nrf52` as a
+    // first-class platform alongside the libretiny chips.
+    // Even when the curated catalog has zero `nrf52`
+    // manifests today, the chip's presence tells users with
+    // nRF52 hardware that their platform is supported and
+    // saves them scrolling OTHER BOARDS for nothing — entries
+    // land here as the catalog grows.
+    const nrf52 = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "nRF52");
+    expect(nrf52).toBeDefined();
+    expect(nrf52?.platform).toBe("nrf52");
+    expect(nrf52?.variant).toBe("");
+  });
+
   it("labels the rp2040 platform 'RP2040 / RP2350' so users searching for either chip name see it", () => {
     // ESPHome's `rp2040` platform key covers both the original
     // RP2040 and the newer RP2350 (Raspberry Pi Pico 2). A plain


### PR DESCRIPTION
# What does this implement/fix?

Same shape as the LN882x chip from #221. Backend `_PLATFORM_KEYS` already accepts `nrf52` as a first-class platform alongside the libretiny chips (BK72xx / RTL87xx / LN882x), but the wizard's filter row had no chip for it — users with nRF52 hardware had to scroll the "OTHER BOARDS" list to find their board.

The curated catalog has zero `nrf52` manifests today, so the chip resolves to an empty result against the current catalogue. Shipping the chip anyway is still a UX win: it tells the user with nRF52 hardware that the platform is supported by the dashboard at all, instead of leaving them to guess. Curated nRF52 entries can land in the catalog incrementally; until they do, ESPHome's pre-built schema still accepts arbitrary nRF52 boards via the YAML editor.

A new `includes_an_nRF52_chip` test mirrors the LN882x one — pins the chip's `platform: "nrf52"` resolution and the `variant: ""` shape so a regression that drops it surfaces loudly.

**Related issue or feature (if applicable):**

- follow-up to #221

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
