### PR TITLE
Show core configs in dep-detour catalog search (fixes #383)

### DIFF
--- a/src/components/device/add-component-dialog-categories.ts
+++ b/src/components/device/add-component-dialog-categories.ts
@@ -1,0 +1,36 @@
+import { CORE_CATEGORIES, type ComponentCategory } from "../../api/types.js";
+
+/**
+ * Decide which categories to *exclude* from the catalog query
+ * for the given dialog mode. Lives in its own module so the
+ * three-mode contract can be unit-tested without spinning up a
+ * DOM env to render the dialog.
+ *
+ * Three states the caller passes:
+ *
+ * - **Core-config dialog** (``isCoreLocked = true``). The
+ *   "Add core configuration" entry point already locks the
+ *   query *to* ``CORE_CATEGORIES``; excluding them too would
+ *   produce an empty catalog. Returns ``[]``.
+ * - **Dep-detour mode** (``isInDepDetour = true``). The form
+ *   just told the user "you need a top-level <domain> first"
+ *   and forwarded them back to the catalog filtered to that
+ *   domain. The missing dep is sometimes itself a core block
+ *   (e.g. a ``sensor.debug`` needs the bare ``debug:`` block
+ *   whose catalog entry is ``core.debug``); hiding it from
+ *   the very search the form drove the user to was the bug
+ *   behind device-builder#383. Returns ``[]`` so core entries
+ *   surface in the dep search.
+ * - **Regular browse** (everything else). Hide ``core`` /
+ *   ``ota`` / ``update`` so the user goes through the
+ *   dedicated "Add core configuration" entry point for those
+ *   instead of seeing them mixed into a sensor / output / etc.
+ *   browse. Returns ``CORE_CATEGORIES``.
+ */
+export function chooseExcludeCategories(opts: {
+  isCoreLocked: boolean;
+  isInDepDetour: boolean;
+}): readonly ComponentCategory[] {
+  if (opts.isCoreLocked || opts.isInDepDetour) return [];
+  return CORE_CATEGORIES;
+}

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -3,7 +3,6 @@ import { mdiArrowLeft, mdiClose, mdiPackageVariantClosed } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import {
-  CORE_CATEGORIES,
   type BoardCatalogEntry,
   type ComponentCatalogEntry,
   type FeaturedBundle,
@@ -14,6 +13,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, apiContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { chooseExcludeCategories } from "./add-component-dialog-categories.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -357,7 +357,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
           .board=${this.board}
           .yaml=${this.yaml}
           .lockedCategories=${this.lockedCategories}
-          .excludeCategories=${isCore ? [] : CORE_CATEGORIES}
+          .excludeCategories=${chooseExcludeCategories({
+            isCoreLocked: isCore,
+            isInDepDetour: this._returnTo !== null,
+          })}
         ></esphome-component-catalog>
         ${isForm
           ? html`<esphome-add-component-form

--- a/test/components/device/add-component-dialog-categories.test.ts
+++ b/test/components/device/add-component-dialog-categories.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { CORE_CATEGORIES } from "../../../src/api/types.js";
+import { chooseExcludeCategories } from "../../../src/components/device/add-component-dialog-categories.js";
+
+describe("chooseExcludeCategories", () => {
+  it("hides core / ota / update from a regular browse", () => {
+    // Default state of the "Add component" dialog: the user is
+    // looking for a sensor / output / etc. The dedicated
+    // "Add core configuration" entry point handles core / ota /
+    // update separately, so those are filtered out of this
+    // browse to keep the catalog focused.
+    const result = chooseExcludeCategories({
+      isCoreLocked: false,
+      isInDepDetour: false,
+    });
+    expect(result).toEqual(CORE_CATEGORIES);
+  });
+
+  it("excludes nothing when the dialog is locked to core categories", () => {
+    // The "Add core configuration" dialog locks IN core / ota /
+    // update via ``lockedCategories``. Excluding the same set
+    // would leave the catalog with zero results.
+    const result = chooseExcludeCategories({
+      isCoreLocked: true,
+      isInDepDetour: false,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("excludes nothing in dep-detour mode (regression for #383)", () => {
+    // The form's missing-deps banner forwards the user to the
+    // catalog filtered to the missing dep's domain. That dep is
+    // sometimes a core block — e.g. ``sensor.debug`` needs the
+    // bare ``debug:`` block whose catalog entry is
+    // ``core.debug``. Hiding it from the very search the form
+    // drove the user to is the foot-gun this exception fixes.
+    // A regression that re-narrows the condition (e.g. drops
+    // the ``isInDepDetour`` term) would put the user back in
+    // "the dep can't be added from here" and fail this test.
+    const result = chooseExcludeCategories({
+      isCoreLocked: false,
+      isInDepDetour: true,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("treats core-locked + dep-detour as a single 'show everything' state", () => {
+    // Defensive case: if both flags somehow flip true at once,
+    // the result is still ``[]``. Pinned to lock in the
+    // monotonic shape — adding either flag is a one-way
+    // transition from CORE_CATEGORIES to ``[]``, never the
+    // reverse.
+    const result = chooseExcludeCategories({
+      isCoreLocked: true,
+      isInDepDetour: true,
+    });
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes esphome/device-builder#383.

The reproduction from the issue:

1. Open a device, click "Add Component", search "debug" → catalog returns the two platform sensors (`sensor.debug` / `text_sensor.debug`).
2. Pick `sensor.debug.free`. The form opens, its missing-deps banner detects that `debug` (the bare top-level `debug:` block) isn't in the YAML and prompts "Add debug".
3. Clicking the prompt forwards the user back to the catalog filtered to `debug` — but the **Debug Core Configuration** entry (`core.debug` in the catalog) doesn't appear, so the user can't actually add the dep the form just told them they needed.

Cause: the regular "Add component" dialog passes `excludeCategories=CORE_CATEGORIES` to the catalog query so users go through the dedicated "Add core configuration" entry point for `core` / `ota` / `update` instead of seeing those mixed into a sensor browse. That exclusion is correct in the regular flow but wrong in the dep-detour case — the form has already narrowed the user's intent to "I need a top-level `<domain>` block", so a core-categorized entry matching that domain is exactly what they want.

Flip the exclusion off when `_returnTo !== null` (the dialog's existing dep-detour signal). Now the catalog filtered to `debug` surfaces `core.debug` (alongside the platform sensors), and the user can add the bare `debug:` block from the same dialog the form forwarded them to.

The exclusion logic moves to a tiny pure helper (`chooseExcludeCategories`) so the three-state contract — *regular browse* / *core-locked* / *dep-detour* — can be unit-tested without spinning up a DOM env to render the dialog. Four tests cover the matrix and pin the regression so a refactor that drops the `isInDepDetour` term fails loudly.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#383

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
