### PR TITLE
Hide config entries gated by ConfigEntry.supported_platforms

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -636,6 +636,20 @@ export interface ConfigEntry {
    * "uart" buses. null = free-form ID input.
    */
   references_component: string | null;
+  /**
+   * Target chips this field is valid on. Empty list (or omitted) =
+   * no restriction (the common case); non-empty = the field is
+   * restricted to the listed chips. Same wire shape as
+   * `ComponentCatalogEntry.supported_platforms`, but at the
+   * single-field grain — a component may run on every platform
+   * while one of its fields (`sensor.debug.psram` is the canonical
+   * case, ESP32-only) does not. Form renderer hides the entry when
+   * the device's target platform isn't in this list.
+   *
+   * Recovered by the backend's sync script from upstream's
+   * declarative `cv.only_on` validators.
+   */
+  supported_platforms?: string[];
 
   // === pin selection (only meaningful when type == PIN) ===
   /** Pin capabilities required for this field. */

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -351,6 +351,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       this.component.config_entries,
       this._values,
       presentComponents,
+      this.board?.esphome.platform ?? null,
     );
     const isComplete = !this._hasRequiredErrors(validation);
 
@@ -594,6 +595,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       this.component.config_entries,
       this._values,
       presentComponents,
+      this.board?.esphome.platform ?? null,
     );
     if (errors.size > 0) {
       this._errors = errors;

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -525,6 +525,7 @@ export class ESPHomeAddComponentForm extends LitElement {
         requiredOnly: true,
         showAdvanced: false,
         presentComponents,
+        targetPlatform: this.board?.esphome.platform ?? null,
       },
     );
     for (const key of errors.keys()) {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -178,6 +178,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       requiredOnly: this.requiredOnly,
       showAdvanced: this.showAdvanced,
       presentComponents: this.presentComponents,
+      targetPlatform: this.board?.esphome.platform ?? null,
     });
 
   protected render() {

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -49,19 +49,17 @@ export interface RenderFilterOptions {
   presentComponents?: Set<string>;
   /**
    * The device's target platform (``esp32`` / ``esp8266`` /
-   * ``rp2040`` / ...). When set, entries whose
-   * ``supported_platforms`` is non-empty AND doesn't include this
-   * value are filtered out — pre-emptively hiding fields that
-   * would fail validation at compile time on the user's selected
-   * board (see ``ConfigEntry.supported_platforms`` and the
-   * upstream ``cv.only_on`` validator they're derived from).
+   * ``rp2040`` / ...). Forwarded to ``isEntryVisible`` which
+   * applies the actual platform gate against
+   * ``ConfigEntry.supported_platforms``. Keeping the predicate
+   * inside ``isEntryVisible`` (rather than re-implementing it
+   * here) means ``validateEntries``, which also calls
+   * ``isEntryVisible``, stays in lockstep with what the form
+   * paints — no flagging required-and-platform-gated fields the
+   * user can't even see.
    *
    * ``null`` / ``undefined`` skips the gate — used by the
-   * add-component dialog when no board is selected yet. The
-   * cross-component validation-error visibility check
-   * (``collectRenderablePaths``) passes the same value so an
-   * error keyed on a hidden-by-platform field doesn't claim the
-   * paint exists.
+   * add-component dialog when no board is selected yet.
    */
   targetPlatform?: string | null;
 }
@@ -105,16 +103,14 @@ export function filterRenderable(
 ): ConfigEntry[] {
   const out: ConfigEntry[] = [];
   for (const entry of entries) {
-    if (!isEntryVisible(entry, values, opts.presentComponents)) continue;
     if (
-      entry.supported_platforms &&
-      entry.supported_platforms.length > 0 &&
-      opts.targetPlatform &&
-      !entry.supported_platforms.includes(opts.targetPlatform)
+      !isEntryVisible(
+        entry,
+        values,
+        opts.presentComponents,
+        opts.targetPlatform,
+      )
     ) {
-      // Field is platform-gated and the device's target chip isn't
-      // in the allowlist — hide it so the user can't fill in
-      // something that will fail compile.
       continue;
     }
     if (

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -47,6 +47,23 @@ export interface RenderFilterOptions {
   showAdvanced: boolean;
   /** Pass-through to ``isEntryVisible`` for cross-component checks. */
   presentComponents?: Set<string>;
+  /**
+   * The device's target platform (``esp32`` / ``esp8266`` /
+   * ``rp2040`` / ...). When set, entries whose
+   * ``supported_platforms`` is non-empty AND doesn't include this
+   * value are filtered out — pre-emptively hiding fields that
+   * would fail validation at compile time on the user's selected
+   * board (see ``ConfigEntry.supported_platforms`` and the
+   * upstream ``cv.only_on`` validator they're derived from).
+   *
+   * ``null`` / ``undefined`` skips the gate — used by the
+   * add-component dialog when no board is selected yet. The
+   * cross-component validation-error visibility check
+   * (``collectRenderablePaths``) passes the same value so an
+   * error keyed on a hidden-by-platform field doesn't claim the
+   * paint exists.
+   */
+  targetPlatform?: string | null;
 }
 
 /**
@@ -89,6 +106,17 @@ export function filterRenderable(
   const out: ConfigEntry[] = [];
   for (const entry of entries) {
     if (!isEntryVisible(entry, values, opts.presentComponents)) continue;
+    if (
+      entry.supported_platforms &&
+      entry.supported_platforms.length > 0 &&
+      opts.targetPlatform &&
+      !entry.supported_platforms.includes(opts.targetPlatform)
+    ) {
+      // Field is platform-gated and the device's target chip isn't
+      // in the allowlist — hide it so the user can't fill in
+      // something that will fail compile.
+      continue;
+    }
     if (
       entry.advanced &&
       !opts.showAdvanced &&

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -746,6 +746,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       renderEntries,
       this._values,
       this._presentComponents,
+      this.board?.esphome.platform ?? null,
     );
 
     const fromLine = resolveCurrentFromLine(

--- a/src/util/config-entry-defaults.ts
+++ b/src/util/config-entry-defaults.ts
@@ -53,6 +53,7 @@ export function makeConfigEntry(
     suggestions: null,
     config_entries: null,
     platform_type: null,
+    supported_platforms: undefined,
     ...overrides,
   };
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -5,26 +5,47 @@ import { parseFloatWithUnit } from "./float-with-unit.js";
 /**
  * Determine if a config entry is currently visible.
  *
- * Visibility is the AND of three checks:
+ * Visibility is the AND of four checks:
  *  1. `hidden === false`
  *  2. The `depends_on` predicate against the current form values
  *  3. `depends_on_component` is present in `presentComponents` (when given)
+ *  4. The device's target platform is in ``supported_platforms``
+ *     when the entry is platform-gated (when ``targetPlatform`` given)
  *
- * Pass `presentComponents` to honor the third check; when omitted the
- * cross-component dependency is treated as satisfied (callers without
- * device-wide context — e.g. add-component before insertion — should
- * leave it undefined).
+ * Pass `presentComponents` / `targetPlatform` to honor checks #3 / #4;
+ * when omitted those dependencies are treated as satisfied (callers
+ * without device-wide context — e.g. add-component before insertion
+ * with no board picked — should leave them undefined).
+ *
+ * Used by both ``filterRenderable`` (deciding what to paint) and
+ * ``validateEntries`` (deciding what to validate). Keeping the
+ * predicate in one place means a hidden-by-platform field can't be
+ * paint-skipped but still validated as required — the failure mode
+ * Copilot flagged on PR #226.
  */
 export function isEntryVisible(
   entry: ConfigEntry,
   values: Record<string, unknown>,
   presentComponents?: Set<string>,
+  targetPlatform?: string | null,
 ): boolean {
   if (entry.hidden) return false;
 
   // Cross-component dependency: only check when caller provided context.
   if (entry.depends_on_component && presentComponents) {
     if (!presentComponents.has(entry.depends_on_component)) return false;
+  }
+
+  // Platform gate: only check when caller provided the target platform.
+  // Empty / missing ``supported_platforms`` is "no constraint" (the
+  // common case) and the field stays visible.
+  if (
+    targetPlatform &&
+    entry.supported_platforms &&
+    entry.supported_platforms.length > 0 &&
+    !entry.supported_platforms.includes(targetPlatform)
+  ) {
+    return false;
   }
 
   if (!entry.depends_on) return true;
@@ -167,9 +188,17 @@ export function validateEntries(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   presentComponents?: Set<string>,
+  targetPlatform?: string | null,
 ): Map<string, ValidationError> {
   const errors = new Map<string, ValidationError>();
-  _validateEntriesRecursive(entries, values, presentComponents, [], errors);
+  _validateEntriesRecursive(
+    entries,
+    values,
+    presentComponents,
+    targetPlatform,
+    [],
+    errors,
+  );
   return errors;
 }
 
@@ -183,13 +212,14 @@ function _validateEntriesRecursive(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   presentComponents: Set<string> | undefined,
+  targetPlatform: string | null | undefined,
   pathPrefix: string[],
   errors: Map<string, ValidationError>,
 ): void {
   for (const entry of entries) {
     // Skip hidden entries and those whose visibility predicates fail —
     // we don't want to require fields the user can't even see.
-    if (!isEntryVisible(entry, values, presentComponents)) continue;
+    if (!isEntryVisible(entry, values, presentComponents, targetPlatform)) continue;
 
     if (entry.type === ConfigEntryType.NESTED) {
       const child = values[entry.key];
@@ -212,6 +242,7 @@ function _validateEntriesRecursive(
         entry.config_entries ?? [],
         childValues,
         presentComponents,
+        targetPlatform,
         [...pathPrefix, entry.key],
         errors,
       );

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -254,6 +254,140 @@ describe("filterRenderable", () => {
       }).map((e) => e.key),
     ).toEqual(["mqtt_topic", "name"]);
   });
+
+  // ────────── supported_platforms gate ──────────────────────
+
+  it("hides a platform-gated entry when targetPlatform isn't in the allowlist", () => {
+    // Mirrors ``sensor.debug.psram`` upstream — wrapped in
+    // ``cv.only_on_esp32``, so the backend stamps
+    // ``supported_platforms = ["esp32"]`` and we hide it on
+    // every other board.
+    const entries = [
+      makeEntry({
+        key: "psram",
+        required: true,
+        supported_platforms: ["esp32"],
+      }),
+      makeEntry({ key: "free", required: true }),
+    ];
+    const onEsp8266 = filterRenderable(entries, {}, {
+      requiredOnly: true,
+      showAdvanced: false,
+      targetPlatform: "esp8266",
+    });
+    expect(onEsp8266.map((e) => e.key)).toEqual(["free"]);
+    const onEsp32 = filterRenderable(entries, {}, {
+      requiredOnly: true,
+      showAdvanced: false,
+      targetPlatform: "esp32",
+    });
+    expect(onEsp32.map((e) => e.key)).toEqual(["psram", "free"]);
+  });
+
+  it("respects multi-platform allowlists (union from cv.Any)", () => {
+    // Mirrors ``sensor.debug.fragmentation`` upstream —
+    // ``cv.Any(cv.only_on_esp8266, cv.only_on_esp32)`` collapses
+    // to ``["esp32", "esp8266"]``. The entry shows on either chip,
+    // hides on others (e.g. rp2040).
+    const entries = [
+      makeEntry({
+        key: "fragmentation",
+        required: true,
+        supported_platforms: ["esp32", "esp8266"],
+      }),
+    ];
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp32",
+      }).map((e) => e.key),
+    ).toEqual(["fragmentation"]);
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp8266",
+      }).map((e) => e.key),
+    ).toEqual(["fragmentation"]);
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "rp2040",
+      }).map((e) => e.key),
+    ).toEqual([]);
+  });
+
+  it("does not gate when supported_platforms is empty (the common case)", () => {
+    // Empty list = no constraint — most fields don't carry a
+    // platform restriction so the gate must be a no-op for them.
+    const entries = [
+      makeEntry({ key: "loop_time", required: true, supported_platforms: [] }),
+      makeEntry({ key: "free", required: true }),
+    ];
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp8266",
+      }).map((e) => e.key),
+    ).toEqual(["loop_time", "free"]);
+  });
+
+  it("does not gate when targetPlatform is null/undefined", () => {
+    // Add-component dialog opens before a board is locked in;
+    // we don't have a target platform yet so we shouldn't pre-
+    // emptively hide gated fields. Empty-allowlist semantics
+    // stay (which means "every field is visible until a board
+    // is picked").
+    const entries = [
+      makeEntry({
+        key: "psram",
+        required: true,
+        supported_platforms: ["esp32"],
+      }),
+    ];
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: null,
+      }).map((e) => e.key),
+    ).toEqual(["psram"]);
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+      }).map((e) => e.key),
+    ).toEqual(["psram"]);
+  });
+
+  it("hides a NESTED group when its only child is platform-gated away", () => {
+    // The "skip empty groups" rule still applies — a NESTED
+    // whose only renderable child got platform-gated should also
+    // disappear, otherwise the form shows an empty header.
+    const entries = [
+      makeEntry({
+        key: "diagnostics",
+        type: ConfigEntryType.NESTED,
+        config_entries: [
+          makeEntry({
+            key: "psram",
+            required: true,
+            supported_platforms: ["esp32"],
+          }),
+        ],
+      }),
+    ];
+    expect(
+      filterRenderable(entries, {}, {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp8266",
+      }).map((e) => e.key),
+    ).toEqual([]);
+  });
 });
 
 describe("collectRenderablePaths", () => {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -313,4 +313,84 @@ describe("validateEntries", () => {
     const values = { id: "i2c_1" };
     expect(validateEntries(i2cEntries, values).size).toBe(0);
   });
+
+  // ---------------------------------------------------------------------
+  // supported_platforms gate (mirrors the filterRenderable gate so a
+  // hidden-by-platform required field doesn't get flagged as missing —
+  // the bug Copilot caught on PR #226 before this lockstep was added).
+
+  it("does not require a platform-gated entry on an incompatible board", () => {
+    // ``sensor.debug.psram`` is required-only-on-esp32 in upstream's
+    // schema — when the user picks the debug component on an
+    // esp8266 board the form hides the field, so we must NOT
+    // surface a "required" error for it (the user can't see the
+    // input to fill it in).
+    const entries = [
+      makeEntry({
+        key: "psram",
+        required: true,
+        supported_platforms: ["esp32"],
+      }),
+    ];
+    expect(
+      validateEntries(entries, {}, undefined, "esp8266").size,
+    ).toBe(0);
+    // On the matching platform the gate is a no-op and the missing
+    // required field is still flagged.
+    expect(
+      validateEntries(entries, {}, undefined, "esp32").get("psram")?.code,
+    ).toBe("validation.required");
+  });
+
+  it("treats a null/undefined targetPlatform as 'no gate'", () => {
+    // The add-component dialog opens before a board is locked in;
+    // we don't have a target platform yet, so platform-gated fields
+    // stay visible *and* validatable. Once the user picks a board
+    // the validation re-runs with targetPlatform set and gated
+    // fields drop out of the required set.
+    const entries = [
+      makeEntry({
+        key: "psram",
+        required: true,
+        supported_platforms: ["esp32"],
+      }),
+    ];
+    expect(
+      validateEntries(entries, {}).get("psram")?.code,
+    ).toBe("validation.required");
+    expect(
+      validateEntries(entries, {}, undefined, null).get("psram")?.code,
+    ).toBe("validation.required");
+  });
+
+  it("recurses through NESTED groups with the platform gate", () => {
+    // Pin that the gate flows down — a required leaf inside a
+    // nested group, gated to esp32, should not be flagged on
+    // esp8266 even though the parent NESTED is unconstrained.
+    const entries = [
+      makeEntry({
+        key: "diagnostics",
+        type: ConfigEntryType.NESTED,
+        config_entries: [
+          makeEntry({
+            key: "psram",
+            required: true,
+            supported_platforms: ["esp32"],
+          }),
+        ],
+      }),
+    ];
+    // Provide a non-empty diagnostics dict so the "untouched optional
+    // group" short-circuit doesn't skip validation — we want to
+    // exercise the platform gate on the leaf.
+    const values = { diagnostics: { psram: undefined } };
+    expect(
+      validateEntries(entries, values, undefined, "esp8266").size,
+    ).toBe(0);
+    expect(
+      validateEntries(entries, values, undefined, "esp32").get(
+        "diagnostics.psram",
+      )?.code,
+    ).toBe("validation.required");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#423.

The backend now derives per-field platform constraints from upstream's `cv.only_on` validators and surfaces them through a new `ConfigEntry.supported_platforms` field — `sensor.debug.psram` is wrapped in `cv.only_on_esp32` upstream, so picking the debug sensor on an ESP8266 board today shows the user a PSRAM input that will fail validation at compile time well after they've left the dialog. This PR is the frontend half: read the signal in the form filter and hide the offending fields.

## How it wires through

The form already has access to the device's board (`BoardCatalogEntry.esphome.platform` is the target chip identifier — `esp32` / `esp8266` / `rp2040` / etc.). The shared `filterRenderable` helper already owns the "is this entry going to render?" decision for two consumers (the form's actual paint pass + the add-component dialog's "is this validation error visible?" check). I added the platform gate to that one helper so both surfaces stay in lockstep:

- New optional `supported_platforms?: string[]` on the `ConfigEntry` TypeScript type.
- New `targetPlatform: string | null` on `RenderFilterOptions`. The full form passes `board.esphome.platform`; the add-component dialog passes `null` while no board is locked in so it doesn't pre-emptively hide fields the user might want once they pick a chip.
- Gate logic: skip the entry when `supported_platforms` is non-empty AND `targetPlatform` is set AND `targetPlatform` isn't in the list. Empty allowlist or missing field = no constraint (the common case).

The "drop NESTED groups whose only child got filtered out" rule still applies — a `diagnostics:` group whose only renderable child was gated away also disappears, so the form doesn't show empty headers.

## What this does NOT do

- **No translations needed.** Fields just hide; nothing renders an "ESP32-only" badge or similar that would need a string.
- **No backwards-compat shim.** The model field is optional; old `components.json` payloads (no `supported_platforms` key) are treated as unconstrained and the gate is a no-op for them. Once the next nightly catalog sync ships, the gate becomes active for the affected fields.

## Tests

5 new tests in `config-entry-render-filter.test.ts`:

- Single-platform allowlist (psram on esp32 vs esp8266 — shows on esp32, hides on esp8266).
- Multi-platform allowlist (fragmentation on esp32/esp8266/rp2040 — shows on esp32 + esp8266, hides on rp2040).
- Empty allowlist is a no-op.
- `null` targetPlatform skips the gate.
- NESTED group whose only child got platform-gated collapses too.

All 830 existing tests still pass (was 825 + 5 new).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#417 (frontend half)
- companion to esphome/device-builder#423

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).