### PR TITLE
Split drawer's Loaded Integrations into direct + auto-loaded

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -111,12 +111,14 @@ export interface ConfiguredDevice {
    * ``mdns`` from ``api``, ``web_server_base`` from ``web_server``,
    * ``voltage_sampler`` from ADC sensors).
    *
-   * Empty array is the graceful-degrade signal — backend couldn't
-   * resolve the YAML (mid-edit drafts, missing secrets) so it
-   * doesn't know what's direct. The drawer falls back to
-   * rendering ``loaded_integrations`` as a flat list.
+   * Optional on the wire: older backends (pre-#425) don't emit
+   * the field at all, and a backend whose resolved-YAML parse
+   * failed mid-edit emits an empty array. Both are the
+   * graceful-degrade signal — the drawer falls back to rendering
+   * ``loaded_integrations`` as a flat list. ``splitIntegrations``
+   * accepts ``null`` / ``undefined`` / ``[]`` interchangeably.
    */
-  directly_referenced_integrations: string[];
+  directly_referenced_integrations?: string[];
   state: DeviceState;
   /**
    * 8-char hex hash of the YAML as last successfully compiled,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -100,6 +100,23 @@ export interface ConfiguredDevice {
   current_version: string;
   deployed_version: string;
   loaded_integrations: string[];
+  /**
+   * Subset of ``loaded_integrations`` the user directly wrote in
+   * YAML — top-level keys (``api:``, ``wifi:``, ``sensor:``) plus
+   * the platform stems from ``- platform: <name>`` references
+   * (``gpio`` under ``binary_sensor``, ``homeassistant`` /
+   * ``sntp`` under ``time``, ``esphome`` under ``ota``). The
+   * complement against ``loaded_integrations`` is the auto-loaded
+   * dependency chain (``md5`` from WPA2 password hashing,
+   * ``mdns`` from ``api``, ``web_server_base`` from ``web_server``,
+   * ``voltage_sampler`` from ADC sensors).
+   *
+   * Empty array is the graceful-degrade signal — backend couldn't
+   * resolve the YAML (mid-edit drafts, missing secrets) so it
+   * doesn't know what's direct. The drawer falls back to
+   * rendering ``loaded_integrations`` as a flat list.
+   */
+  directly_referenced_integrations: string[];
   state: DeviceState;
   /**
    * 8-char hex hash of the YAML as last successfully compiled,

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -47,6 +47,7 @@ import {
 import { espHomeStyles } from "../../styles/shared.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
+import { splitIntegrations } from "../../util/integration-split.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import { renderIpValue } from "./device-drawer-render.js";
@@ -472,6 +473,34 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         outline-offset: 2px;
       }
 
+      /* Auto-loaded-integrations collapsible. The drawer's primary
+         "Loaded Integrations" row shows the user-meaningful chips
+         inline; auto-loaded dependencies (the upstream AUTO_LOAD
+         chain — md5, mdns, web_server_base, etc.) tuck in here
+         so a 30-component config doesn't drown the panel in
+         framework noise. The summary row gets the muted text
+         colour so it reads as secondary metadata, not as another
+         tag-row header. */
+      .auto-loaded-details {
+        margin-top: var(--wa-space-s);
+      }
+
+      .auto-loaded-details > summary {
+        cursor: pointer;
+        font-size: var(--wa-font-size-2xs);
+        color: var(--wa-color-text-quiet);
+        padding: 2px 0;
+        user-select: none;
+      }
+
+      .auto-loaded-details > summary:hover {
+        color: var(--wa-color-text-normal);
+      }
+
+      .tags-wrap--auto-loaded {
+        margin-top: var(--wa-space-2xs);
+      }
+
       .status-badges {
         display: flex;
         flex-wrap: wrap;
@@ -642,28 +671,77 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
 
       ${this._renderConfigHashSection(d)}
 
-      ${d.loaded_integrations && d.loaded_integrations.length > 0
-        ? html`
-            <div class="section">
-              <h4 class="section-title">${this._localize("dashboard.drawer_loaded_integrations")}</h4>
-              <div class="tags-wrap">
-                ${d.loaded_integrations.map((i) => {
-                  const url = this._integrationDocs[i];
-                  return url && _isSafeDocsUrl(url)
-                    ? html`<a
-                        class="tag tag--link"
-                        href=${url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        >${i}</a
-                      >`
-                    : html`<span class="tag">${i}</span>`;
-                })}
-              </div>
-            </div>
-          `
-        : nothing}
+      ${this._renderLoadedIntegrationsSection(d)}
     `;
+  }
+
+  /**
+   * Render the "Loaded Integrations" section with a direct /
+   * auto-loaded split.
+   *
+   * `loaded_integrations` from the backend lumps every integration
+   * upstream ESPHome resolved at compile time — the user's
+   * top-level blocks, their `- platform: ...` references, AND the
+   * AUTO_LOAD chain those things drag in (`md5` from WPA2 password
+   * hashing, `mdns` from `api`, `web_server_base` from
+   * `web_server`, `voltage_sampler` from ADC sensors). For
+   * non-trivial configs the auto-loaded chain dominates, burying
+   * the user-meaningful entries.
+   *
+   * Backend's `directly_referenced_integrations` is the subset
+   * the user actually wrote (issue #422 fix); the complement is
+   * the auto-loaded chain. We render direct chips inline, and
+   * tuck auto-loaded ones inside a `<details>` collapsible the
+   * user can expand on demand.
+   *
+   * Falls back to rendering the flat `loaded_integrations` list
+   * when the backend couldn't compute the split — empty
+   * `directly_referenced_integrations` is the graceful-degrade
+   * signal (resolved-config parse failed mid-edit).
+   */
+  private _renderLoadedIntegrationsSection(d: ConfiguredDevice) {
+    if (!d.loaded_integrations || d.loaded_integrations.length === 0) {
+      return nothing;
+    }
+    const { direct, indirect } = splitIntegrations(
+      d.loaded_integrations,
+      d.directly_referenced_integrations,
+    );
+    return html`
+      <div class="section">
+        <h4 class="section-title">
+          ${this._localize("dashboard.drawer_loaded_integrations")}
+        </h4>
+        <div class="tags-wrap">${direct.map((i) => this._renderIntegrationTag(i))}</div>
+        ${indirect.length > 0
+          ? html`
+              <details class="auto-loaded-details">
+                <summary>
+                  ${this._localize("dashboard.drawer_auto_loaded_integrations", {
+                    count: String(indirect.length),
+                  })}
+                </summary>
+                <div class="tags-wrap tags-wrap--auto-loaded">
+                  ${indirect.map((i) => this._renderIntegrationTag(i))}
+                </div>
+              </details>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderIntegrationTag(name: string) {
+    const url = this._integrationDocs[name];
+    return url && _isSafeDocsUrl(url)
+      ? html`<a
+          class="tag tag--link"
+          href=${url}
+          target="_blank"
+          rel="noopener noreferrer"
+          >${name}</a
+        >`
+      : html`<span class="tag">${name}</span>`;
   }
 
   /**

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -278,6 +278,7 @@
     "filter_labels": "Labels",
     "filter_clear": "Clear filter",
     "drawer_loaded_integrations": "Loaded Integrations",
+    "drawer_auto_loaded_integrations": "Show {count} auto-loaded dependencies",
     "drawer_config_hash_title": "Config Hash",
     "drawer_config_hash_local": "Local",
     "drawer_config_hash_deployed": "Deployed",

--- a/src/util/integration-split.ts
+++ b/src/util/integration-split.ts
@@ -1,0 +1,76 @@
+/**
+ * Split a device's `loaded_integrations` into two buckets:
+ * directly-written and auto-loaded.
+ *
+ * The backend exposes `loaded_integrations` (every integration
+ * the upstream `esphome` resolver pulled in at compile time) and
+ * `directly_referenced_integrations` (the subset the user
+ * literally wrote in YAML — top-level keys plus
+ * `- platform: <name>` stems). The complement of the second
+ * against the first is the AUTO_LOAD dependency chain (e.g.
+ * `md5` from WPA2 password hashing, `mdns` from `api`,
+ * `web_server_base` from `web_server`, `voltage_sampler` from
+ * ADC sensors).
+ *
+ * Issue #422: the device-drawer's "Loaded Integrations" panel
+ * was rendering the flat `loaded_integrations` list, drowning
+ * the user-meaningful entries in framework noise for any
+ * non-trivial config. This helper produces the per-bucket
+ * lists the drawer renders inline (direct) vs collapsed
+ * (indirect / auto-loaded).
+ *
+ * Order is stable: each bucket preserves the relative order
+ * of its entries in the input `loaded_integrations` (which the
+ * backend already sorts alphabetically).
+ *
+ * Graceful-degrade signal: when the backend couldn't resolve
+ * the YAML — mid-edit drafts, missing secrets — it emits an
+ * empty `directly_referenced_integrations` array. We treat
+ * that as "split is unknown" (`splitable: false`) and put
+ * everything into `direct` so the drawer renders the original
+ * flat list under its existing header. Per-call branch in the
+ * drawer's render template stays a one-liner.
+ */
+export interface IntegrationSplit {
+  /** Integrations the user directly wrote — render inline. */
+  direct: string[];
+  /** Auto-loaded dependencies — render in a collapsible. */
+  indirect: string[];
+  /**
+   * `true` when the backend supplied a non-empty
+   * `directly_referenced_integrations` (so we have authority to
+   * split). `false` means we fell back to "everything in
+   * `direct`" as a graceful degrade — the caller should hide
+   * the indirect collapsible entirely in that case.
+   */
+  splitable: boolean;
+}
+
+export function splitIntegrations(
+  loaded: readonly string[] | null | undefined,
+  directlyReferenced: readonly string[] | null | undefined,
+): IntegrationSplit {
+  const loadedList = loaded ?? [];
+  const direct = directlyReferenced ?? [];
+  if (direct.length === 0) {
+    // Graceful degrade — backend doesn't know what's direct, so
+    // we render everything as direct (matches the pre-#422
+    // flat-list behaviour exactly).
+    return { direct: [...loadedList], indirect: [], splitable: false };
+  }
+  const directSet = new Set(direct);
+  const directBucket: string[] = [];
+  const indirectBucket: string[] = [];
+  for (const name of loadedList) {
+    if (directSet.has(name)) {
+      directBucket.push(name);
+    } else {
+      indirectBucket.push(name);
+    }
+  }
+  return {
+    direct: directBucket,
+    indirect: indirectBucket,
+    splitable: true,
+  };
+}

--- a/src/util/integration-split.ts
+++ b/src/util/integration-split.ts
@@ -26,7 +26,7 @@
  * Graceful-degrade signal: when the backend couldn't resolve
  * the YAML — mid-edit drafts, missing secrets — it emits an
  * empty `directly_referenced_integrations` array. We treat
- * that as "split is unknown" (`splitable: false`) and put
+ * that as "split is unknown" (`splittable: false`) and put
  * everything into `direct` so the drawer renders the original
  * flat list under its existing header. Per-call branch in the
  * drawer's render template stays a one-liner.
@@ -43,7 +43,7 @@ export interface IntegrationSplit {
    * `direct`" as a graceful degrade — the caller should hide
    * the indirect collapsible entirely in that case.
    */
-  splitable: boolean;
+  splittable: boolean;
 }
 
 export function splitIntegrations(
@@ -56,7 +56,7 @@ export function splitIntegrations(
     // Graceful degrade — backend doesn't know what's direct, so
     // we render everything as direct (matches the pre-#422
     // flat-list behaviour exactly).
-    return { direct: [...loadedList], indirect: [], splitable: false };
+    return { direct: [...loadedList], indirect: [], splittable: false };
   }
   const directSet = new Set(direct);
   const directBucket: string[] = [];
@@ -71,6 +71,6 @@ export function splitIntegrations(
   return {
     direct: directBucket,
     indirect: indirectBucket,
-    splitable: true,
+    splittable: true,
   };
 }

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -37,7 +37,6 @@ const _BASE = {
   current_version: "",
   deployed_version: "",
   loaded_integrations: [],
-  directly_referenced_integrations: [],
   state: DeviceState.UNKNOWN,
   expected_config_hash: "",
   deployed_config_hash: "",

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -37,6 +37,7 @@ const _BASE = {
   current_version: "",
   deployed_version: "",
   loaded_integrations: [],
+  directly_referenced_integrations: [],
   state: DeviceState.UNKNOWN,
   expected_config_hash: "",
   deployed_config_hash: "",

--- a/test/util/integration-split.test.ts
+++ b/test/util/integration-split.test.ts
@@ -12,7 +12,7 @@
  *     normal path, validates ordering + bucket assignment.
  *  2. Empty ``directly_referenced_integrations`` (graceful
  *     degrade — backend couldn't resolve the YAML) — everything
- *     lands in ``direct`` with ``splitable: false`` so the
+ *     lands in ``direct`` with ``splittable: false`` so the
  *     drawer falls back to the pre-#422 flat-list rendering.
  *  3. Empty ``loaded_integrations`` — empty buckets either way.
  *  4. ``null`` / ``undefined`` inputs — defensive against the
@@ -72,7 +72,7 @@ describe("splitIntegrations", () => {
       "socket",
       "watchdog",
     ]);
-    expect(result.splitable).toBe(true);
+    expect(result.splittable).toBe(true);
   });
 
   it("preserves the input ordering within each bucket", () => {
@@ -103,7 +103,7 @@ describe("splitIntegrations", () => {
     const result = splitIntegrations(loaded, []);
     expect(result.direct).toEqual(["api", "wifi", "logger"]);
     expect(result.indirect).toEqual([]);
-    expect(result.splitable).toBe(false);
+    expect(result.splittable).toBe(false);
   });
 
   it("returns empty buckets for empty loaded_integrations", () => {
@@ -115,9 +115,9 @@ describe("splitIntegrations", () => {
     expect(result.indirect).toEqual([]);
     // ``directly_referenced_integrations`` was non-empty so the
     // backend DID compute a split — there just wasn't anything
-    // loaded to bucket. ``splitable: true`` is harmless either
+    // loaded to bucket. ``splittable: true`` is harmless either
     // way (the drawer hides the section anyway).
-    expect(result.splitable).toBe(true);
+    expect(result.splittable).toBe(true);
   });
 
   it("treats null / undefined as empty", () => {
@@ -127,17 +127,17 @@ describe("splitIntegrations", () => {
     expect(splitIntegrations(null, null)).toEqual({
       direct: [],
       indirect: [],
-      splitable: false,
+      splittable: false,
     });
     expect(splitIntegrations(undefined, undefined)).toEqual({
       direct: [],
       indirect: [],
-      splitable: false,
+      splittable: false,
     });
     expect(splitIntegrations(["api"], null)).toEqual({
       direct: ["api"],
       indirect: [],
-      splitable: false,
+      splittable: false,
     });
   });
 
@@ -153,6 +153,6 @@ describe("splitIntegrations", () => {
     const result = splitIntegrations(loaded, direct);
     expect(result.direct).toEqual(["api", "wifi"]);
     expect(result.indirect).toEqual([]);
-    expect(result.splitable).toBe(true);
+    expect(result.splittable).toBe(true);
   });
 });

--- a/test/util/integration-split.test.ts
+++ b/test/util/integration-split.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for ``splitIntegrations`` — the helper that powers the
+ * device-drawer's "Loaded Integrations" direct/auto-loaded split
+ * (issue #422).
+ *
+ * The function is the entire correctness boundary for the
+ * drawer's primary vs collapsed sections; bug here means the
+ * wrong chips land in the wrong bucket. Pin the four scenarios
+ * the drawer's render path actually hits:
+ *
+ *  1. Real device with both direct + auto-loaded entries — the
+ *     normal path, validates ordering + bucket assignment.
+ *  2. Empty ``directly_referenced_integrations`` (graceful
+ *     degrade — backend couldn't resolve the YAML) — everything
+ *     lands in ``direct`` with ``splitable: false`` so the
+ *     drawer falls back to the pre-#422 flat-list rendering.
+ *  3. Empty ``loaded_integrations`` — empty buckets either way.
+ *  4. ``null`` / ``undefined`` inputs — defensive against the
+ *     wire shape changing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { splitIntegrations } from "../../src/util/integration-split.js";
+
+describe("splitIntegrations", () => {
+  it("buckets direct + auto-loaded entries from a real device", () => {
+    // Mirrors the issue #422 reporter's ``acfloatmonitor32`` case:
+    // a config with ``api``, ``ethernet``, ``binary_sensor`` /
+    // ``- platform: gpio``, etc. The auto-loaded chain pulls in
+    // ``md5``, ``mdns``, ``network``, ``preferences``, ``socket``,
+    // ``watchdog`` (and more) which the drawer's collapsible
+    // tucks away.
+    const loaded = [
+      "api",
+      "binary_sensor",
+      "esp32",
+      "esphome",
+      "ethernet",
+      "gpio",
+      "md5",
+      "mdns",
+      "network",
+      "ota",
+      "preferences",
+      "socket",
+      "watchdog",
+    ];
+    const direct = [
+      "api",
+      "binary_sensor",
+      "esp32",
+      "esphome",
+      "ethernet",
+      "gpio",
+      "ota",
+    ];
+    const result = splitIntegrations(loaded, direct);
+    expect(result.direct).toEqual([
+      "api",
+      "binary_sensor",
+      "esp32",
+      "esphome",
+      "ethernet",
+      "gpio",
+      "ota",
+    ]);
+    expect(result.indirect).toEqual([
+      "md5",
+      "mdns",
+      "network",
+      "preferences",
+      "socket",
+      "watchdog",
+    ]);
+    expect(result.splitable).toBe(true);
+  });
+
+  it("preserves the input ordering within each bucket", () => {
+    // Backend already sorts ``loaded_integrations`` alphabetically;
+    // both buckets need to inherit that ordering (the drawer
+    // renders them as flat chip rows, not re-sorted). A naive
+    // ``filter()`` over a Set could shuffle the auto-loaded
+    // bucket, which is what this case pins.
+    const loaded = ["zlast", "alpha", "mid", "beta", "auto1", "auto2"];
+    const direct = ["alpha", "beta"];
+    const { direct: out, indirect } = splitIntegrations(loaded, direct);
+    expect(out).toEqual(["alpha", "beta"]);
+    // ``zlast`` and ``mid`` weren't in ``direct`` — they land in
+    // indirect alongside ``auto1`` / ``auto2``, in the same
+    // order they appeared in ``loaded``.
+    expect(indirect).toEqual(["zlast", "mid", "auto1", "auto2"]);
+  });
+
+  it("falls back to direct=loaded when the backend didn't compute the split", () => {
+    // Empty ``directly_referenced_integrations`` is the
+    // graceful-degrade signal — backend's resolved-YAML parse
+    // failed (mid-edit drafts, missing secrets) so it doesn't
+    // know which entries are direct. The drawer must render the
+    // flat ``loaded_integrations`` list under its existing
+    // header, NOT bucket everything as auto-loaded — that would
+    // hide every chip behind the collapsible.
+    const loaded = ["api", "wifi", "logger"];
+    const result = splitIntegrations(loaded, []);
+    expect(result.direct).toEqual(["api", "wifi", "logger"]);
+    expect(result.indirect).toEqual([]);
+    expect(result.splitable).toBe(false);
+  });
+
+  it("returns empty buckets for empty loaded_integrations", () => {
+    // Brand-new device that hasn't compiled — the drawer's
+    // section guard hides the whole row in that case, but the
+    // helper still has to return a valid split.
+    const result = splitIntegrations([], ["api"]);
+    expect(result.direct).toEqual([]);
+    expect(result.indirect).toEqual([]);
+    // ``directly_referenced_integrations`` was non-empty so the
+    // backend DID compute a split — there just wasn't anything
+    // loaded to bucket. ``splitable: true`` is harmless either
+    // way (the drawer hides the section anyway).
+    expect(result.splitable).toBe(true);
+  });
+
+  it("treats null / undefined as empty", () => {
+    // Defensive — older device records on the wire (or a stale
+    // serialiser path) might omit either field. Coerce to ``[]``
+    // so the helper never throws on access.
+    expect(splitIntegrations(null, null)).toEqual({
+      direct: [],
+      indirect: [],
+      splitable: false,
+    });
+    expect(splitIntegrations(undefined, undefined)).toEqual({
+      direct: [],
+      indirect: [],
+      splitable: false,
+    });
+    expect(splitIntegrations(["api"], null)).toEqual({
+      direct: ["api"],
+      indirect: [],
+      splitable: false,
+    });
+  });
+
+  it("ignores entries in directly_referenced that aren't in loaded", () => {
+    // The two lists come from different backend sources
+    // (StorageJSON for ``loaded``, resolved YAML for ``direct``)
+    // — they normally agree, but a stale StorageJSON could
+    // theoretically report ``direct`` entries the firmware
+    // doesn't actually have loaded. The split should silently
+    // ignore those rather than hallucinate them as chips.
+    const loaded = ["api", "wifi"];
+    const direct = ["api", "wifi", "fictional_component"];
+    const result = splitIntegrations(loaded, direct);
+    expect(result.direct).toEqual(["api", "wifi"]);
+    expect(result.indirect).toEqual([]);
+    expect(result.splitable).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of issue #422. The device drawer's "Loaded
Integrations" section renders `loaded_integrations` as one flat
block of tags — every component upstream ESPHome resolved
during the compile, mixing user-typed top-level blocks (`api`,
`wifi`, `sensor`) with auto-loaded transitive dependencies
(`md5` from WPA2 password hashing, `mdns` from `api`,
`web_server_base` from `web_server`, `voltage_sampler` from
ADC sensors). For non-trivial configs the auto-loaded chain
dominates, and the user-meaningful entries get visually buried.

Backend companion PR esphome/device-builder#425 adds a
`directly_referenced_integrations` field on `ConfiguredDevice`
— the subset of `loaded_integrations` the user wrote (top-level
keys plus `- platform: <name>` stems). This PR consumes that
field to split the drawer rendering:

- **Direct chips** render inline under the existing header —
  same chip styling, same docs-link behaviour, just filtered to
  the user-written subset.
- **Auto-loaded chips** tuck into a `<details>` collapsible
  underneath, labelled "Show N auto-loaded dependencies". The
  summary uses the muted text colour so it reads as secondary
  metadata, not as another tag-row header.

`splitIntegrations` lives in `src/util/integration-split.ts` as
a pure helper so the drawer's render path stays a one-liner;
exported separately to keep the bucketing logic unit-testable
without spinning up Lit / happy-dom. Order is stable per
bucket (both inherit the backend's alphabetical sort).

**Graceful degrade**: empty `directly_referenced_integrations`
on the wire (older backend pre-#425, or a backend whose
resolved-YAML parse failed mid-edit) means the helper falls
back to "direct = loaded, indirect = []" with `splitable:
false`. The drawer then renders the original flat list under
the unchanged header — pre-#422 behaviour exactly. Older
frontends that didn't know about the field would also just
ignore it, so the wire is forward+backward compatible during
the rollout.

Six unit tests in `test/util/integration-split.test.ts` pin
every shape: real-device split (issue reporter's
`acfloatmonitor32`), per-bucket order preservation, the
graceful-degrade fallback, empty `loaded_integrations`,
`null` / `undefined` defensive coverage, and the stale-
StorageJSON case where `directly_referenced` lists an entry
that isn't in `loaded` (silently ignored).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#422 (frontend half)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
