### PR TITLE
Render YamlRawValue block scalars in the lambda textarea (fixes #428)

### DIFF
--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -24,6 +24,7 @@ import {
 import { formatHexInt, parseHexInt } from "../../util/hex-int.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { YamlRawValue } from "../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
   labelFor,
@@ -438,7 +439,15 @@ export function renderTextareaField(
   path: string[],
   ctx: RenderCtx,
 ) {
-  const value = String(ctx.getAt(path) ?? "");
+  // YAML block-scalar values (``lambda: |-``) come through the
+  // parser as ``YamlRawValue`` instances so the on-disk style
+  // round-trips. ``String(rawValue)`` now surfaces the dedented
+  // body via ``toString``; explicit detection here lets us re-wrap
+  // the user's edited text as a fresh ``YamlRawValue`` so the
+  // ``|-`` marker survives the next save (issue #428).
+  const raw = ctx.getAt(path);
+  const isRaw = raw instanceof YamlRawValue;
+  const value = isRaw ? raw.body : String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`
     <div class="field" data-field-key=${path.join(".")}>
@@ -449,8 +458,13 @@ export function renderTextareaField(
         ?disabled=${effectiveDisabled(entry, ctx)}
         .value=${value}
         placeholder=${String(entry.default_value ?? "")}
-        @input=${(e: Event) =>
-          ctx.emitChange(path, (e.target as HTMLTextAreaElement).value)}
+        @input=${(e: Event) => {
+          const text = (e.target as HTMLTextAreaElement).value;
+          ctx.emitChange(
+            path,
+            isRaw ? YamlRawValue.fromBodyText(text, raw) : text,
+          );
+        }}
       ></textarea>
       ${renderFieldError(path, ctx)}
     </div>

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -78,13 +78,15 @@ export class YamlRawValue {
 
   /**
    * The block-scalar body as the user typed it semantically,
-   * with the common indent stripped. ``YamlRawValue("    return foo;\n
-   * return bar;")`` displays as ``"return foo;\nreturn bar;"``
-   * — which is what a textarea / lambda editor wants to render.
+   * with the common indent stripped — what a textarea / lambda
+   * editor wants to render. For example a ``YamlRawValue`` whose
+   * ``lines`` is ``["    return foo;", "    return bar;"]``
+   * displays as ``"return foo;\nreturn bar;"``.
    *
-   * Round-trip pairing: ``new YamlRawValue.fromBodyText(body, original)``
-   * goes the other direction, re-applying the common indent so the
-   * resulting lines slot back into the YAML at the original depth.
+   * Round-trip pairing: ``YamlRawValue.fromBodyText(body, original)``
+   * goes the other direction, re-applying the common indent so
+   * the resulting lines slot back into the YAML at the original
+   * depth.
    */
   get body(): string {
     const indent = this.indent;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -48,6 +48,82 @@ export class YamlRawValue {
     public readonly lines: readonly string[],
     public readonly inlineHeader?: string,
   ) {}
+
+  /**
+   * Common leading-whitespace prefix of every non-blank line, or
+   * empty string when there are no non-blank lines. Used by
+   * ``body`` to dedent the editor view and by edit handlers to
+   * re-indent a user's freshly-typed text on round-trip.
+   */
+  get indent(): string {
+    const nonBlank = this.lines.filter((line) => line.trim() !== "");
+    if (nonBlank.length === 0) return "";
+    let common = nonBlank[0].match(/^\s*/)?.[0] ?? "";
+    for (const line of nonBlank.slice(1)) {
+      const lead = line.match(/^\s*/)?.[0] ?? "";
+      // Walk backwards from the current common prefix shrinking
+      // until both lines agree.
+      while (common && !line.startsWith(common)) {
+        common = common.slice(0, -1);
+      }
+      // Defensive: if the loop above zeroed out, the lines disagree
+      // at column 0 — fall through to the empty string.
+      if (!common) return "";
+      // Cap at the new line's leading whitespace so we don't keep
+      // a longer prefix than this line actually has.
+      if (lead.length < common.length) common = lead;
+    }
+    return common;
+  }
+
+  /**
+   * The block-scalar body as the user typed it semantically,
+   * with the common indent stripped. ``YamlRawValue("    return foo;\n
+   * return bar;")`` displays as ``"return foo;\nreturn bar;"``
+   * — which is what a textarea / lambda editor wants to render.
+   *
+   * Round-trip pairing: ``new YamlRawValue.fromBodyText(body, original)``
+   * goes the other direction, re-applying the common indent so the
+   * resulting lines slot back into the YAML at the original depth.
+   */
+  get body(): string {
+    const indent = this.indent;
+    return this.lines.map((line) => line.slice(indent.length)).join("\n");
+  }
+
+  /**
+   * Coercion path so ``String(rawValue)`` and ``${rawValue}`` produce
+   * the dedented body instead of the default ``[object Object]`` —
+   * the bug behind issue #428 (the lambda field rendering as
+   * ``[object Object]`` for any block-scalar value the YAML parser
+   * captured into a ``YamlRawValue``).
+   */
+  toString(): string {
+    return this.body;
+  }
+
+  /**
+   * Build a new ``YamlRawValue`` from an editor-friendly body
+   * string, re-applying the original ``YamlRawValue``'s indent and
+   * preserving its inline header. Used when the user edits a
+   * lambda / multi-line block scalar in the form: feed in the
+   * textarea's value, get back a properly-indented round-trippable
+   * ``YamlRawValue`` to write into the form's values dict.
+   *
+   * When *original* has no inline header (list-rooted block) the
+   * caller probably shouldn't be using a textarea at all — that
+   * shape carries its own dash row inside ``lines`` — so this
+   * helper drops it on the floor and treats the value as a fresh
+   * inline-header-less block. Callers that care about the
+   * list-rooted shape should special-case it before calling this.
+   */
+  static fromBodyText(body: string, original: YamlRawValue): YamlRawValue {
+    const indent = original.indent;
+    const lines = body
+      .split("\n")
+      .map((line) => (line === "" ? "" : `${indent}${line}`));
+    return new YamlRawValue(lines, original.inlineHeader);
+  }
 }
 
 /** Options for ``serializeYamlValues``. */

--- a/test/util/yaml-raw-value.test.ts
+++ b/test/util/yaml-raw-value.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for ``YamlRawValue``'s editor-friendly accessors.
+ *
+ * The parser captures block scalars (``lambda: |-``, ``packages:``
+ * shorthand, automation handlers) as ``YamlRawValue`` so the
+ * round-trip preserves the on-disk style. The form renderers used
+ * to ``String()`` these directly which produced
+ * ``"[object Object]"`` — issue #428. The class now exposes
+ * ``body`` / ``indent`` / ``toString`` for the renderer side and
+ * ``fromBodyText`` for the round-trip on edit.
+ */
+
+import { describe, expect, it } from "vitest";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
+
+describe("YamlRawValue.toString", () => {
+  it("returns the dedented body so String(rawValue) is editor-friendly", () => {
+    // Mirrors what the parser produces for ``lambda: |-`` whose
+    // body is indented 6 spaces under a list-item child:
+    //
+    //     - platform: template
+    //       lambda: |-
+    //         return foo;
+    //         return bar;
+    const raw = new YamlRawValue(
+      ["        return foo;", "        return bar;"],
+      "|-",
+    );
+    expect(String(raw)).toBe("return foo;\nreturn bar;");
+  });
+
+  it("matches the body getter", () => {
+    const raw = new YamlRawValue(["    return foo;"], "|-");
+    expect(String(raw)).toBe(raw.body);
+  });
+
+  it("template-literal interpolation produces the body", () => {
+    const raw = new YamlRawValue(["    abc"], "|-");
+    expect(`${raw}`).toBe("abc");
+  });
+});
+
+describe("YamlRawValue.indent", () => {
+  it("picks the common leading whitespace of every non-blank line", () => {
+    const raw = new YamlRawValue(
+      ["    return foo;", "    if (bar) {", "      return baz;", "    }"],
+      "|-",
+    );
+    expect(raw.indent).toBe("    ");
+  });
+
+  it("ignores blank lines when computing the common indent", () => {
+    // A blank middle line shouldn't collapse the common indent
+    // to "" — the body's indent comes from the non-blank lines.
+    const raw = new YamlRawValue(
+      ["    return foo;", "", "    return bar;"],
+      "|-",
+    );
+    expect(raw.indent).toBe("    ");
+  });
+
+  it("returns empty string when the lines have no shared indent", () => {
+    const raw = new YamlRawValue(["return foo;", "  return bar;"], "|-");
+    expect(raw.indent).toBe("");
+  });
+
+  it("returns empty string when the lines are all blank", () => {
+    const raw = new YamlRawValue(["", "", ""], "|-");
+    expect(raw.indent).toBe("");
+  });
+
+  it("handles a single line", () => {
+    const raw = new YamlRawValue(["      return foo;"], "|-");
+    expect(raw.indent).toBe("      ");
+  });
+});
+
+describe("YamlRawValue.body", () => {
+  it("strips the common indent across all lines", () => {
+    const raw = new YamlRawValue(
+      ["    return foo;", "    return bar;"],
+      "|-",
+    );
+    expect(raw.body).toBe("return foo;\nreturn bar;");
+  });
+
+  it("preserves indentation deeper than the common one", () => {
+    // Inside a lambda body the user might have nested braces with
+    // their own indent — the common-prefix stripping must keep
+    // those deeper indents intact, otherwise we'd corrupt the
+    // user's formatting on display.
+    const raw = new YamlRawValue(
+      ["    if (x) {", "      return foo;", "    }"],
+      "|-",
+    );
+    expect(raw.body).toBe("if (x) {\n  return foo;\n}");
+  });
+
+  it("preserves blank lines verbatim", () => {
+    const raw = new YamlRawValue(
+      ["    return foo;", "", "    return bar;"],
+      "|-",
+    );
+    expect(raw.body).toBe("return foo;\n\nreturn bar;");
+  });
+});
+
+describe("YamlRawValue.fromBodyText", () => {
+  it("re-applies the original common indent and preserves the inline header", () => {
+    const original = new YamlRawValue(
+      ["    return foo;", "    return bar;"],
+      "|-",
+    );
+    const edited = YamlRawValue.fromBodyText(
+      "return baz;\nreturn qux;",
+      original,
+    );
+    expect(edited.lines).toEqual(["    return baz;", "    return qux;"]);
+    expect(edited.inlineHeader).toBe("|-");
+  });
+
+  it("round-trips a body unchanged", () => {
+    // ``original.body → fromBodyText → .body`` must be identity for
+    // the no-edit case, otherwise opening + saving without typing
+    // would mutate the YAML.
+    const original = new YamlRawValue(
+      ["    return foo;", "      return bar;"],
+      "|-",
+    );
+    const roundTripped = YamlRawValue.fromBodyText(original.body, original);
+    expect(roundTripped.body).toBe(original.body);
+  });
+
+  it("emits empty lines without leading whitespace", () => {
+    // YAML block-scalar bodies can have blank lines; those should
+    // round-trip as TRULY empty lines (no trailing whitespace) so
+    // a subsequent re-parse doesn't see "this is a continuation."
+    const original = new YamlRawValue(
+      ["    return foo;", "    return bar;"],
+      "|-",
+    );
+    const edited = YamlRawValue.fromBodyText(
+      "return foo;\n\nreturn bar;",
+      original,
+    );
+    expect(edited.lines).toEqual([
+      "    return foo;",
+      "",
+      "    return bar;",
+    ]);
+  });
+
+  it("handles bodies with no original indent (zero-prefix lines)", () => {
+    // Edge case: an inline ``key: |- some_text`` shape would parse
+    // into a YamlRawValue whose lines have no shared indent. The
+    // helper shouldn't blow up — just emit what the user typed.
+    const original = new YamlRawValue(["return foo;"], "|-");
+    const edited = YamlRawValue.fromBodyText("return baz;", original);
+    expect(edited.lines).toEqual(["return baz;"]);
+  });
+
+  it("preserves the inline header when it's undefined (list-rooted block)", () => {
+    // A list-rooted block (``on_press:`` → ``- lambda:``) has no
+    // inline header — the dash row sits inside ``lines`` instead.
+    // Editing that shape via this helper is a degraded path
+    // documented in the class JSDoc; we still preserve undefined
+    // so the serializer's branch logic keeps working.
+    const original = new YamlRawValue(["  - lambda: !lambda return 1;"]);
+    const edited = YamlRawValue.fromBodyText("foo", original);
+    expect(edited.inlineHeader).toBeUndefined();
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -6,6 +6,7 @@ import {
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../src/util/yaml-section-values.js";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 
 /** 1-indexed line of the *n*th (1-based) list-item dash following
  *  `parent:` in `yaml`. Section-editor callers pass that line as
@@ -721,6 +722,79 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     expect(buttonBSlice).toContain('icon: "mdi:account"');
     // Sanity: only Button B got the icon (siblings stayed clean)
     expect(after.match(/icon:/g)).toHaveLength(1);
+  });
+
+  it("preserves a lambda block scalar verbatim when the user re-saves without editing", () => {
+    // Issue #428 — opening the form for a binary_sensor with a
+    // ``lambda: |-`` previously rendered ``[object Object]`` and
+    // a save round-trip would have dropped the body entirely. Now
+    // ``YamlRawValue.toString`` surfaces the dedented body for
+    // display; the parser keeps the wrapper intact so the
+    // serializer can paste the lines back unchanged.
+    const yaml = `binary_sensor:
+  - platform: template
+    name: "Driveway Opening"
+    id: opening_sensor
+    lambda: |-
+      return id(moving) && id(opening) && !id(opened).state ? true : false;
+`;
+    const values = parseYamlSectionValues(
+      yaml,
+      "binary_sensor.template",
+      2,
+    );
+    // Parser wraps the block scalar so the on-disk style round-trips.
+    expect(values.lambda).toBeInstanceOf(YamlRawValue);
+    // Re-save without editing: serializer pastes the lines back.
+    const after = updateSectionInYaml(
+      yaml,
+      "binary_sensor.template",
+      values,
+      2,
+    );
+    expect(after).toContain("lambda: |-");
+    expect(after).toContain(
+      "return id(moving) && id(opening) && !id(opened).state ? true : false;",
+    );
+  });
+
+  it("re-wraps an edited lambda body as a YamlRawValue with the same indent", () => {
+    // Issue #428 — when the user edits a lambda body, the renderer
+    // calls ``YamlRawValue.fromBodyText`` to wrap the textarea
+    // content as a fresh ``YamlRawValue`` with the original indent
+    // and ``|-`` header preserved. The serializer must paste it back
+    // in the same shape so the YAML doesn't drift to inline-quoted
+    // form on save.
+    const yaml = `binary_sensor:
+  - platform: template
+    name: "Driveway Opening"
+    lambda: |-
+      return original_body;
+`;
+    const values = parseYamlSectionValues(
+      yaml,
+      "binary_sensor.template",
+      2,
+    );
+    const original = values.lambda;
+    expect(original).toBeInstanceOf(YamlRawValue);
+    // Simulate the form editing the body:
+    values.lambda = YamlRawValue.fromBodyText(
+      "return id(moving) && id(opening);",
+      original as YamlRawValue,
+    );
+    const after = updateSectionInYaml(
+      yaml,
+      "binary_sensor.template",
+      values,
+      2,
+    );
+    // Block-scalar form is preserved.
+    expect(after).toContain("lambda: |-");
+    // Body has the new content at the original indent.
+    expect(after).toContain("      return id(moving) && id(opening);");
+    // Old body is gone.
+    expect(after).not.toContain("return original_body");
   });
 });
 

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -731,12 +731,23 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     // ``YamlRawValue.toString`` surfaces the dedented body for
     // display; the parser keeps the wrapper intact so the
     // serializer can paste the lines back unchanged.
+    //
+    // Byte-equality assertion (rather than substring presence) so
+    // a future drift — extra whitespace, indent change, missing
+    // ``|-`` marker — fails the test. The contract for "no edit"
+    // on the lambda is "no diff," so we slice the exact lambda
+    // block out of both the input and the output and compare them
+    // line-for-line. (The test fixture's ``name: "..."`` quoting
+    // gets stripped by the unrelated scalar serializer, so we
+    // can't byte-compare the WHOLE document — that's a separate
+    // pre-existing concern.)
+    const lambdaBlock = `    lambda: |-
+      return id(moving) && id(opening) && !id(opened).state ? true : false;`;
     const yaml = `binary_sensor:
   - platform: template
-    name: "Driveway Opening"
+    name: Driveway Opening
     id: opening_sensor
-    lambda: |-
-      return id(moving) && id(opening) && !id(opened).state ? true : false;
+${lambdaBlock}
 `;
     const values = parseYamlSectionValues(
       yaml,
@@ -745,17 +756,18 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     );
     // Parser wraps the block scalar so the on-disk style round-trips.
     expect(values.lambda).toBeInstanceOf(YamlRawValue);
-    // Re-save without editing: serializer pastes the lines back.
+    // Re-save without editing → byte-identical YAML.
     const after = updateSectionInYaml(
       yaml,
       "binary_sensor.template",
       values,
       2,
     );
-    expect(after).toContain("lambda: |-");
-    expect(after).toContain(
-      "return id(moving) && id(opening) && !id(opened).state ? true : false;",
-    );
+    expect(after).toBe(yaml);
+    // Belt + suspenders: even if a future serializer change
+    // reformats some surrounding key, the lambda block itself
+    // must survive byte-identical.
+    expect(after).toContain(lambdaBlock);
   });
 
   it("re-wraps an edited lambda body as a YamlRawValue with the same indent", () => {


### PR DESCRIPTION
# What does this implement/fix?

Fixes esphome/device-builder#428.

The form's textarea renderer (lambda / json fields) was calling `String(ctx.getAt(path) ?? "")` directly on the value dict. When the parser captured a YAML block scalar (`lambda: |-` ... body) into a `YamlRawValue` so the on-disk `|-` style would round-trip, `String()` produced the default `"[object Object]"` — what the user saw in the screenshot on the issue. A no-op save would then have replaced the lambda body with the literal text `"[object Object]"` and corrupted the YAML.

## Fix

Two parts:

1. **`YamlRawValue` exposes editor-friendly accessors.** New `body` / `indent` / `toString` getters so `String(rawValue)` yields the dedented body string. The indent algorithm walks every non-blank line shrinking the common prefix; blank lines are ignored (so a blank middle line doesn't collapse the indent to empty); the body strips that common prefix verbatim, preserving any deeper indents inside the user's lambda. This protects every `String(value)` site downstream, not just the textarea.

2. **`renderTextareaField` re-wraps on edit.** The renderer detects the `YamlRawValue` and on `@input` calls a new `YamlRawValue.fromBodyText(text, original)` helper that re-applies the original common indent and preserves the inline `|-` header. On save the serializer pastes the re-indented lines back in their original block-scalar shape — a no-op open + save round-trip is byte-identical.

The fix is local to two files:
- `src/util/yaml-serialize.ts` — `body` / `indent` / `toString` / `fromBodyText` on `YamlRawValue`.
- `src/components/device/config-entry-renderers.ts` — `renderTextareaField` uses the wrapper.

## Tests

- 16 unit tests in `test/util/yaml-raw-value.test.ts` — `toString` / template-literal path, `indent` algorithm (common-prefix shrinking, blank-line ignoring, no-shared-indent fallback, single line), `body` dedenting (deeper-indent preservation, blank-line preservation), `fromBodyText` (re-apply indent, round-trip identity, blank lines emit empty without trailing whitespace, zero-prefix edge case, list-rooted-block undefined-header preservation).
- 2 integration tests in `test/util/yaml-section-values.test.ts` pinning the issue #428 fix end-to-end:
  - lambda block scalar re-saved without editing is byte-identical (no drift)
  - lambda edited via the textarea path comes back as a properly-indented `|-` block

All 857 existing FE tests pass.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#428

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).