### PR TITLE
Render long-form pin fields under an Advanced disclosure (closes #420)

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -403,6 +403,41 @@ export const configEntryFormStyles = css`
     font-style: normal;
   }
 
+  /* ─── Pin "Advanced" disclosure (long-form fields) ──────── */
+  /* Compact toggle that opens the long-form pin fields (mode
+     flags, inverted) attached by the catalog's
+     _pin_long_form_extras helper. Visually subordinate to the
+     primary GPIO picker — the user has to opt in to the
+     advanced fields per pin. */
+  .pin-advanced {
+    margin-top: var(--wa-space-2xs);
+  }
+
+  .pin-advanced-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    padding: 2px 0;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-2xs);
+    cursor: pointer;
+  }
+
+  .pin-advanced-toggle:hover {
+    color: var(--wa-color-text-normal);
+  }
+
+  .pin-advanced-fields {
+    margin-top: var(--wa-space-xs);
+    padding-left: var(--wa-space-s);
+    border-left: 2px solid var(--wa-color-surface-border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-s);
+  }
+
   /* ─── ID reference picker option layout ──────────────────── */
   .id-option-stack {
     display: inline-flex;

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -12,7 +12,7 @@ import {
   findUsedPins,
   sectionEndLine,
 } from "../../util/config-entry-yaml-scan.js";
-import { isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   effectiveDisabled,
   renderFieldError,
@@ -173,10 +173,7 @@ export function renderPinField(
     sectionEndLine(ctx.yaml, ctx.fromLine),
   );
   const fieldDisabled = effectiveDisabled(entry, ctx);
-  const isLongForm =
-    rawValue !== null &&
-    typeof rawValue === "object" &&
-    !Array.isArray(rawValue);
+  const isLongForm = isPlainObject(rawValue);
 
   // Pin-select onChange routes to ``path.number`` when the field is
   // already in long form (the user expanded Advanced and set a flag,
@@ -232,7 +229,7 @@ export function renderPinField(
         })}
       </wa-select>
       ${renderFieldError(path, ctx)}
-      ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm)}
+      ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm, fieldDisabled)}
     </div>
   `;
 }
@@ -264,8 +261,18 @@ function renderPinAdvanced(
   ctx: RenderCtx,
   rawValue: unknown,
   isLongForm: boolean,
+  fieldDisabled: boolean,
 ): TemplateResult | typeof nothing {
-  const longFormFields = entry.config_entries ?? [];
+  // Apply the same visibility filter every other nested renderer
+  // uses so requiredOnly / showAdvanced / platform-gating rules
+  // hide long-form sub-fields the user shouldn't see (e.g. an
+  // analog-mode flag on a platform that lacks it). Skipping
+  // ``filterRenderable`` would let the long-form disclosure leak
+  // sub-fields the rest of the form has hidden.
+  const longFormFields = ctx.filterRenderable(
+    entry.config_entries ?? [],
+    ctx.scopeValues(path),
+  );
   if (longFormFields.length === 0) return nothing;
 
   const advancedKey = `${path.join(".")}:pin-advanced`;
@@ -277,6 +284,14 @@ function renderPinAdvanced(
   const isOpen = ctx.nestedOpenSections.has(advancedKey);
 
   const onAdvancedToggle = () => {
+    // Locked / disabled fields (board-preset pins, parent-disabled
+    // groups) must not mutate via Advanced — without this guard,
+    // opening the disclosure on a short-form locked pin would fire
+    // the promotion ``emitChange`` and rewrite the locked value to
+    // the long form. The toggle is also rendered ``disabled`` below,
+    // but defending in both places means a synthetic click event
+    // (test code, accessibility tooling) can't bypass the guard.
+    if (fieldDisabled) return;
     ctx.toggleNested(advancedKey);
     // When opening for the first time on a short-form pin value,
     // promote ``pin: GPIO5`` → ``pin: { number: GPIO5 }`` so a
@@ -299,6 +314,7 @@ function renderPinAdvanced(
         type="button"
         class="pin-advanced-toggle"
         aria-expanded=${isOpen}
+        ?disabled=${fieldDisabled}
         @click=${onAdvancedToggle}
       >
         <wa-icon

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -173,6 +173,26 @@ export function renderPinField(
     sectionEndLine(ctx.yaml, ctx.fromLine),
   );
   const fieldDisabled = effectiveDisabled(entry, ctx);
+  const isLongForm =
+    rawValue !== null &&
+    typeof rawValue === "object" &&
+    !Array.isArray(rawValue);
+
+  // Pin-select onChange routes to ``path.number`` when the field is
+  // already in long form (the user expanded Advanced and set a flag,
+  // promoting ``pin: GPIO5`` to ``pin: { number: GPIO5, mode: ... }``)
+  // and to bare ``path`` otherwise. Without this branch, picking a
+  // different GPIO on a long-form pin would overwrite the whole
+  // mapping (mode flags + inverted) with the GPIO string — silently
+  // discarding every Advanced setting the user just configured.
+  const onPinChange = (e: Event) => {
+    const newGpio = (e.target as HTMLSelectElement).value;
+    if (isLongForm) {
+      ctx.emitChange([...path, "number"], newGpio);
+    } else {
+      ctx.emitChange(path, newGpio);
+    }
+  };
 
   return html`
     <div class="field" data-field-key=${path.join(".")}>
@@ -181,8 +201,7 @@ export function renderPinField(
         data-no-value-sync
         class=${invalid ? "invalid" : ""}
         ?disabled=${fieldDisabled}
-        @change=${(e: Event) =>
-          ctx.emitChange(path, (e.target as HTMLSelectElement).value)}
+        @change=${onPinChange}
       >
         ${visible.map((pin) => {
           const v = buildPinOption(pin, entry, usedPins, ctx);
@@ -213,6 +232,88 @@ export function renderPinField(
         })}
       </wa-select>
       ${renderFieldError(path, ctx)}
+      ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm)}
+    </div>
+  `;
+}
+
+/**
+ * Render the "Advanced" disclosure carrying the long-form pin
+ * fields (``mode`` flag group + ``inverted``) attached by
+ * ``script/sync_components.py``'s ``_pin_long_form_extras``
+ * (esphome/device-builder#430). ESPHome accepts both forms:
+ *
+ *     pin: GPIO5          # short form — what the picker writes
+ *     pin:                # long form — what flipping any flag promotes to
+ *       number: GPIO5
+ *       mode:
+ *         pullup: true
+ *       inverted: false
+ *
+ * Without this disclosure the visual editor only ever writes the
+ * short form, and configurations that need a pull-up (issue #420)
+ * have no path through the editor.
+ *
+ * Returns ``nothing`` when the entry has no nested config_entries —
+ * pre-#430 catalogs (or future entries that opt out by clearing
+ * ``config_entries``) keep the simple short-form picker.
+ */
+function renderPinAdvanced(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+  rawValue: unknown,
+  isLongForm: boolean,
+): TemplateResult | typeof nothing {
+  const longFormFields = entry.config_entries ?? [];
+  if (longFormFields.length === 0) return nothing;
+
+  const advancedKey = `${path.join(".")}:pin-advanced`;
+  // Reuse the form's ``nestedOpenSections`` machinery so the
+  // open/closed state survives a re-render and follows the same
+  // semantics as a regular ``nested`` group's expand toggle.
+  // Default closed — the long-form fields are an opt-in
+  // disclosure, never on the main form.
+  const isOpen = ctx.nestedOpenSections.has(advancedKey);
+
+  const onAdvancedToggle = () => {
+    ctx.toggleNested(advancedKey);
+    // When opening for the first time on a short-form pin value,
+    // promote ``pin: GPIO5`` → ``pin: { number: GPIO5 }`` so a
+    // subsequent flag flip can write to ``pin.mode.pullup``
+    // without ``setIn`` clobbering the GPIO. The form's
+    // value-change handler picks this up before the children
+    // render, so the nested fields read off the freshly-promoted
+    // mapping. Skip when already long-form (preserves the
+    // user's existing flags) or when the pin has no value yet
+    // (no GPIO to preserve; the picker will write to bare path
+    // on first selection).
+    if (!isOpen && !isLongForm && rawValue != null && rawValue !== "") {
+      ctx.emitChange(path, { number: rawValue });
+    }
+  };
+
+  return html`
+    <div class="pin-advanced" data-field-key="${advancedKey}">
+      <button
+        type="button"
+        class="pin-advanced-toggle"
+        aria-expanded=${isOpen}
+        @click=${onAdvancedToggle}
+      >
+        <wa-icon
+          library="mdi"
+          name=${isOpen ? "chevron-up" : "chevron-down"}
+        ></wa-icon>
+        <span>${ctx.localize("device.pin_advanced")}</span>
+      </button>
+      ${isOpen
+        ? html`<div class="pin-advanced-fields">
+            ${longFormFields.map((child) =>
+              ctx.renderEntry(child, [...path, child.key]),
+            )}
+          </div>`
+        : nothing}
     </div>
   `;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -575,6 +575,7 @@
     "pin_occupied_by": "Reserved for {name}",
     "pin_used_by": "Already used by {name}",
     "pin_input_only": "Input only — can't be used as output",
+    "pin_advanced": "Advanced",
     "save": "Save",
     "save_yaml": "Save YAML",
     "validate": "Validate",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -499,6 +499,7 @@
     "pin_occupied_by": "Réservé pour {name}",
     "pin_used_by": "Déjà utilisé par {name}",
     "pin_input_only": "Entrée uniquement — ne peut pas être utilisé comme sortie",
+    "pin_advanced": "Avancé",
     "loading_components": "Chargement des composants…",
     "missing_dependencies_title": "{name} nécessite d'autres composants",
     "missing_dependencies_body": "Configurez d'abord ceux-ci, puis revenez ajouter celui-ci :",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -499,6 +499,7 @@
     "pin_occupied_by": "Gereserveerd voor {name}",
     "pin_used_by": "Al in gebruik door {name}",
     "pin_input_only": "Alleen invoer — kan niet als uitvoer worden gebruikt",
+    "pin_advanced": "Geavanceerd",
     "loading_components": "Componenten laden…",
     "missing_dependencies_title": "{name} vereist andere componenten",
     "missing_dependencies_body": "Configureer deze eerst, kom dan terug om deze toe te voegen:",

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -31,10 +31,7 @@ export function setIn(
   const [head, ...rest] = path;
   if (rest.length === 0) return { ...obj, [head]: value };
   const child = obj[head];
-  const childObj =
-    child !== null && typeof child === "object" && !Array.isArray(child)
-      ? (child as Record<string, unknown>)
-      : {};
+  const childObj = isPlainObject(child) ? child : {};
   return { ...obj, [head]: setIn(childObj, rest, value) };
 }
 
@@ -87,4 +84,21 @@ export function isPrimitiveOrNullish(
   if (value === null || value === undefined) return true;
   const t = typeof value;
   return t === "string" || t === "number" || t === "boolean";
+}
+
+/**
+ * Narrowing predicate: is *value* a plain object (a YAML mapping
+ * candidate)? Excludes ``null``, primitives, and arrays. The
+ * pin renderer uses this to detect long-form pin values
+ * (``{ number: GPIO5, mode: { ... } }``) so it can route
+ * GPIO-picker edits to ``path.number`` instead of clobbering the
+ * mapping. ``setIn`` uses the same check to decide whether to
+ * descend into an existing child object or replace it with a
+ * fresh ``{}``. Centralised so both call sites can share one
+ * definition of "object I can deep-merge into".
+ */
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -3,7 +3,7 @@ import {
   parsePinGpio,
   renderPinField,
 } from "../../../src/components/device/config-entry-pin-renderer.js";
-import { ConfigEntryType } from "../../../src/api/types.js";
+import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
@@ -102,5 +102,210 @@ describe("renderPinField wa-select binding", () => {
       ".value" in bindings,
       "wa-select must not have a property binding to .value alongside data-no-value-sync",
     ).toBe(false);
+  });
+});
+
+describe("renderPinField long-form Advanced disclosure", () => {
+  // The catalog's _pin_long_form_extras (esphome/device-builder#430)
+  // attaches mode-flag + inverted children to every type=pin entry.
+  // Without rendering them under an Advanced section the visual
+  // editor stays short-form-only and issue #420 (binary_sensor.gpio
+  // pullup not configurable) persists.
+
+  const makeLongFormChildren = (): ConfigEntry[] =>
+    [
+      {
+        key: "mode",
+        type: ConfigEntryType.NESTED,
+        label: "Mode",
+        config_entries: [
+          {
+            key: "input",
+            type: ConfigEntryType.BOOLEAN,
+            label: "Input",
+          } as ConfigEntry,
+          {
+            key: "pullup",
+            type: ConfigEntryType.BOOLEAN,
+            label: "Pullup",
+          } as ConfigEntry,
+        ],
+      } as ConfigEntry,
+      {
+        key: "inverted",
+        type: ConfigEntryType.BOOLEAN,
+        label: "Inverted",
+      } as ConfigEntry,
+    ] as never;
+
+  it("omits the Advanced toggle when the entry has no nested children", () => {
+    // Pre-#430 catalogs (or future entries that opt out by clearing
+    // config_entries) keep the simple short-form picker — no
+    // disclosure rendered, no surprise UI shift after a catalog
+    // regen.
+    const ctx = makeRenderCtx({ pin: 0 });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: null,
+      }),
+      ["pin"],
+      ctx,
+    );
+    expect(findTemplatesByAnchor(result, "<button").length).toBe(0);
+  });
+
+  it("renders an Advanced toggle when the entry carries long-form children", () => {
+    const ctx = makeRenderCtx({ pin: 0 });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const toggles = findTemplatesByAnchor(result, "<button");
+    expect(toggles.length, "Advanced toggle button must render").toBe(1);
+    // No call to renderEntry yet — children only render when the
+    // user opens the disclosure.
+    expect(ctx.renderEntry).not.toHaveBeenCalled();
+  });
+
+  it("renders the long-form children when the disclosure is open", () => {
+    // Toggle is keyed on `${path}:pin-advanced`; populating the
+    // open-set simulates the user having clicked open.
+    const openSet = new Set<string>(["pin:pin-advanced"]);
+    const ctx = makeRenderCtx(
+      { pin: { number: "GPIO5" } },
+      { overrides: { nestedOpenSections: openSet } },
+    );
+    const children = makeLongFormChildren();
+    renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: children,
+      }),
+      ["pin"],
+      ctx,
+    );
+    // ``mode`` and ``inverted`` both rendered, each at its nested
+    // path under the pin field. Order-sensitive — ``mode`` first
+    // matches the catalog's emission order, which the form's
+    // tab-order convention follows.
+    expect(ctx.renderEntry).toHaveBeenNthCalledWith(1, children[0], [
+      "pin",
+      "mode",
+    ]);
+    expect(ctx.renderEntry).toHaveBeenNthCalledWith(2, children[1], [
+      "pin",
+      "inverted",
+    ]);
+  });
+
+  it("promotes the pin value to long form when the user opens Advanced", () => {
+    // Short-form value: opening Advanced needs to rewrite ``pin: 5``
+    // to ``pin: { number: 5 }`` so the subsequent ``setIn`` on a
+    // nested flag (``pin.mode.pullup``) doesn't clobber the GPIO.
+    // Without this promotion, flipping the first flag would silently
+    // drop the user's pin selection.
+    const ctx = makeRenderCtx({ pin: "GPIO5" });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const toggle = findTemplatesByAnchor(result, "<button")[0];
+    const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
+    onClick();
+    // Two effects in order: open the disclosure, then promote the
+    // value. The promotion's emitChange writes to the same path
+    // with the long-form mapping, preserving the existing GPIO.
+    expect(ctx.toggleNested).toHaveBeenCalledWith("pin:pin-advanced");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], { number: "GPIO5" });
+  });
+
+  it("skips the promotion when the value is already long-form", () => {
+    // Reopening Advanced on an already-long-form pin must not
+    // overwrite the user's existing flags with ``{ number: ... }``
+    // — that would silently undo every Advanced setting they made.
+    const ctx = makeRenderCtx({
+      pin: { number: "GPIO5", mode: { pullup: true }, inverted: true },
+    });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const toggle = findTemplatesByAnchor(result, "<button")[0];
+    const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
+    onClick();
+    // Toggle still fires (the user wants the disclosure to open),
+    // but no promotion event — the value already has the right
+    // shape.
+    expect(ctx.toggleNested).toHaveBeenCalledWith("pin:pin-advanced");
+    expect(ctx.emitChange).not.toHaveBeenCalled();
+  });
+
+  it("routes pin-select changes to ``path.number`` on a long-form value", () => {
+    // After the user has expanded Advanced and set a flag, the
+    // pin value is in long-form. A subsequent GPIO change from
+    // the picker has to write to ``pin.number`` — writing to bare
+    // ``pin`` would replace the whole mapping with the new GPIO
+    // string and drop every flag the user set.
+    const ctx = makeRenderCtx({
+      pin: { number: "GPIO5", mode: { pullup: true } },
+    });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (
+      e: Event,
+    ) => void;
+    // Synthesise the pick event the way wa-select dispatches it.
+    onChange({ target: { value: "GPIO12" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "number"], "GPIO12");
+  });
+
+  it("routes pin-select changes to bare ``path`` on a short-form value", () => {
+    // Default short-form value: the picker writes to bare ``pin``
+    // (today's behaviour, preserved for every config that hasn't
+    // touched Advanced). A regression that always wrote to
+    // ``pin.number`` would silently break every existing pin field
+    // that doesn't have an open disclosure.
+    const ctx = makeRenderCtx({ pin: 0 });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (
+      e: Event,
+    ) => void;
+    onChange({ target: { value: "GPIO12" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "GPIO12");
   });
 });

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   parsePinGpio,
   renderPinField,
@@ -307,5 +307,122 @@ describe("renderPinField long-form Advanced disclosure", () => {
     ) => void;
     onChange({ target: { value: "GPIO12" } } as never);
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "GPIO12");
+  });
+
+  it("disables the Advanced toggle when the field is disabled", () => {
+    // Locked board presets (Sonoff Basic's front-panel button etc.)
+    // mark the pin field disabled. The Advanced toggle has to
+    // mirror that — without the disabled binding the user can
+    // open the disclosure on a locked field, and the click handler
+    // would fire the promotion ``emitChange`` and rewrite the
+    // locked value.
+    const ctx = makeRenderCtx(
+      { pin: 5 },
+      { overrides: { disabled: true } },
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const toggle = findTemplatesByAnchor(result, "<button")[0];
+    const bindings = extractAttributeBindings(toggle);
+    expect(
+      "?disabled" in bindings,
+      "Advanced toggle must carry a ?disabled binding",
+    ).toBe(true);
+    expect(bindings["?disabled"], "binding must reflect the field-disabled state").toBe(
+      true,
+    );
+  });
+
+  it("does not promote or toggle when the disabled handler is invoked", () => {
+    // Defence-in-depth: even when ``?disabled`` is set the click
+    // handler is still wired (the framework / accessibility tooling
+    // / a synthetic event from a test could fire it). Confirm the
+    // handler short-circuits before mutating state.
+    const ctx = makeRenderCtx(
+      { pin: "GPIO5" },
+      { overrides: { disabled: true } },
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    const toggle = findTemplatesByAnchor(result, "<button")[0];
+    const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
+    onClick();
+    expect(ctx.toggleNested).not.toHaveBeenCalled();
+    expect(ctx.emitChange).not.toHaveBeenCalled();
+  });
+
+  it("filters long-form children through ctx.filterRenderable", () => {
+    // Every other nested renderer applies ``filterRenderable`` so
+    // requiredOnly / showAdvanced / platform-visibility rules hide
+    // sub-fields the rest of the form has hidden. Skipping the
+    // filter here would let the long-form disclosure leak fields
+    // the catalog has marked advanced or gated by platform.
+    const openSet = new Set<string>(["pin:pin-advanced"]);
+    const filterMock = vi.fn(
+      (entries: ConfigEntry[]) => entries.slice(0, 1),
+    );
+    const ctx = makeRenderCtx(
+      { pin: { number: "GPIO5" } },
+      {
+        overrides: {
+          nestedOpenSections: openSet,
+          filterRenderable: filterMock as never,
+        },
+      },
+    );
+    const children = makeLongFormChildren();
+    renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: children,
+      }),
+      ["pin"],
+      ctx,
+    );
+    // Filter received the full children list; only the survivor
+    // (the first child) gets handed to renderEntry. A regression
+    // that bypassed ``filterRenderable`` would render both
+    // children and the assertion below would catch the second
+    // one.
+    expect(filterMock).toHaveBeenCalledWith(children, expect.anything());
+    expect(ctx.renderEntry).toHaveBeenCalledTimes(1);
+    expect(ctx.renderEntry).toHaveBeenCalledWith(children[0], ["pin", "mode"]);
+  });
+
+  it("omits the Advanced disclosure when filterRenderable hides every child", () => {
+    // requiredOnly mode (the add-component dialog) hides everything
+    // marked advanced. The pin extras are all advanced, so the
+    // whole disclosure should disappear — rendering an empty
+    // toggle would invite the user to expand into nothing.
+    const filterMock = vi.fn(() => [] as ConfigEntry[]);
+    const ctx = makeRenderCtx(
+      { pin: 0 },
+      { overrides: { filterRenderable: filterMock as never } },
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx,
+    );
+    expect(findTemplatesByAnchor(result, "<button").length).toBe(0);
   });
 });

--- a/test/util/nested-values.test.ts
+++ b/test/util/nested-values.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getIn,
+  isPlainObject,
   isPrimitiveOrNullish,
   setIn,
 } from "../../src/util/nested-values.js";
@@ -103,6 +104,47 @@ describe("isPrimitiveOrNullish", () => {
       // — TypeScript accepts ``String(value)`` without a cast.
       const s: string = String(value ?? "");
       expect(s).toBe("hello");
+    }
+  });
+});
+
+describe("isPlainObject", () => {
+  it("accepts plain objects (the deep-merge target shape)", () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+    expect(isPlainObject(Object.create(null))).toBe(true);
+  });
+
+  it("rejects null and undefined", () => {
+    // ``setIn`` and the pin renderer both treat null/undefined as
+    // "no existing object — start fresh". The check has to be
+    // explicit because ``typeof null === 'object'``.
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject(undefined)).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isPlainObject("hello")).toBe(false);
+    expect(isPlainObject("")).toBe(false);
+    expect(isPlainObject(0)).toBe(false);
+    expect(isPlainObject(true)).toBe(false);
+  });
+
+  it("rejects arrays", () => {
+    // The pin renderer's long-form detection has to exclude arrays
+    // — ``pin: [GPIO5]`` is invalid YAML for an ESPHome pin field
+    // (and ``setIn`` treats arrays as "non-object child, replace
+    // with {}"), so descending into one would be wrong either way.
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject([1, 2, 3])).toBe(false);
+  });
+
+  it("narrows the type for the caller", () => {
+    const value: unknown = { a: 1 };
+    if (isPlainObject(value)) {
+      // ``value`` is now ``Record<string, unknown>`` — TypeScript
+      // accepts ``value.a`` without a cast.
+      expect(value.a).toBe(1);
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's pin schema accepts both shapes:

```yaml
# Short form — what the visual editor writes today
pin: GPIO5

# Long form — what the user in #420 needs (pullup), and what
# every gpio config that needs debounce / pull / inversion needs
pin:
  number: GPIO5
  mode:
    pullup: true
  inverted: true
```

The visual editor's PIN renderer is a single GPIO `<wa-select>` — short-form only. Configurations that need a pull-up resistor, an inverted level, or any other long-form field were impossible to drive from the wizard; users had to drop into raw YAML mode for every gpio sensor / output / switch / light.

Companion to esphome/device-builder#430 (merged) which attached the long-form fields (`mode` group + `inverted`) as nested `config_entries` on every `type=pin` catalog entry. This PR makes the editor actually render them.

**Renderer changes:**

- A compact **"Advanced"** toggle below the GPIO picker. Default closed, only renders when `entry.config_entries` is non-empty (so pre-#430 catalogs keep the simple short-form picker — no UI shift after the catalog regen).
- When the user opens Advanced on a short-form pin value, the renderer **promotes** `pin: GPIO5` → `pin: { number: GPIO5 }` so subsequent flag flips don't get clobbered by `setIn` deep-merging into a string node. Without this, flipping the first flag would silently drop the user's GPIO selection.
- The pin-select onChange routes to `path.number` on long-form values and bare `path` on short-form values, so changing the GPIO on a configured-with-flags pin doesn't replace the whole mapping.

**Tests** (6 new, all passing):

- Omit-when-no-children — pre-#430 entries render unchanged.
- Render-when-children — toggle appears.
- Render-children-when-open — `mode` and `inverted` nested fields rendered at their nested paths.
- Promotion-on-first-open — short-form value gets promoted.
- No-double-promote on already-long-form — preserves existing flags when re-opening.
- Pin-select onChange routes correctly for both value shapes.

**Translations:** `pin_advanced` added in en / fr / nl.

**Related issue or feature (if applicable):**

- fixes #420
- companion to esphome/device-builder#430

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
