### PR TITLE
Render esphome.devices and esphome.areas as repeatable lists (closes #434)

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -167,6 +167,38 @@ export const configEntryFormStyles = css`
     padding-top: var(--wa-space-xs);
   }
 
+  /* ─── nested list (repeatable nested mapping) ───────────── */
+  .nested-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-s);
+  }
+
+  .nested-list-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-xs);
+    padding: var(--wa-space-s) var(--wa-space-m);
+    background: var(--wa-color-surface-lowered);
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+  }
+
+  .nested-list-item-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+  }
+
+  .nested-list-item-title {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
+  }
+
   /* ─── multi-value rows ──────────────────────────────────── */
   .multi-row {
     display: flex;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -54,6 +54,7 @@ import {
   renderMapField,
   renderMultiValueField,
   renderNestedField,
+  renderNestedListField,
   renderNumberField,
   renderPinField,
   renderSelectField,
@@ -399,6 +400,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
       return html`<div class="alert-entry">${labelFor(entry, ctx)}</div>`;
     }
     if (entry.type === ConfigEntryType.NESTED) {
+      // Repeatable nested mapping (``esphome.devices``,
+      // ``esphome.areas``, …). The single-group renderer can't
+      // express the list shape, so route to the list renderer first.
+      if (entry.multi_value) {
+        return renderNestedListField(entry, path, ctx);
+      }
       return renderNestedField(entry, path, ctx);
     }
     if (entry.type === ConfigEntryType.MAP) {

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -130,22 +130,20 @@ export function filterRenderable(
     ) {
       continue;
     }
-    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
+    if (entry.type === ConfigEntryType.NESTED) {
       // List-form NESTED always renders — the renderer paints the
       // Add button even with zero items, and ``filterRenderable``
       // is called per-item at render time with the item's own
       // scope. Skipping based on the parent ``values`` shape would
       // hide the field exactly when the user needs it.
-      out.push(entry);
-      continue;
-    }
-    if (entry.type === ConfigEntryType.NESTED) {
-      const renderableChildren = filterRenderable(
-        entry.config_entries ?? [],
-        asRecord(values[entry.key]),
-        opts,
-      );
-      if (renderableChildren.length === 0) continue;
+      if (!entry.multi_value) {
+        const renderableChildren = filterRenderable(
+          entry.config_entries ?? [],
+          asRecord(values[entry.key]),
+          opts,
+        );
+        if (renderableChildren.length === 0) continue;
+      }
     } else if (
       opts.requiredOnly &&
       !entry.required &&
@@ -186,30 +184,31 @@ export function collectRenderablePaths(
   out: Set<string> = new Set(),
 ): Set<string> {
   for (const entry of filterRenderable(entries, values, opts)) {
-    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
-      // List-form NESTED: emit one path tree per item with the
-      // index segment (``devices.0.id``) so ``_anyErrorIsVisible``
-      // can reconcile validation errors keyed on per-item leaves.
-      asMappingList(values[entry.key]).forEach((itemValues, idx) => {
+    if (entry.type === ConfigEntryType.NESTED) {
+      const childSchema = entry.config_entries ?? [];
+      if (entry.multi_value) {
+        // List-form NESTED: emit one path tree per item with the
+        // index segment (``devices.0.id``) so
+        // ``_anyErrorIsVisible`` can reconcile validation errors
+        // keyed on per-item leaves.
+        asMappingList(values[entry.key]).forEach((itemValues, idx) => {
+          collectRenderablePaths(
+            childSchema,
+            itemValues,
+            opts,
+            [...pathPrefix, entry.key, String(idx)],
+            out,
+          );
+        });
+      } else {
         collectRenderablePaths(
-          entry.config_entries ?? [],
-          itemValues,
+          childSchema,
+          asRecord(values[entry.key]),
           opts,
-          [...pathPrefix, entry.key, String(idx)],
+          [...pathPrefix, entry.key],
           out,
         );
-      });
-      out.add([...pathPrefix, entry.key].join("."));
-      continue;
-    }
-    if (entry.type === ConfigEntryType.NESTED) {
-      collectRenderablePaths(
-        entry.config_entries ?? [],
-        asRecord(values[entry.key]),
-        opts,
-        [...pathPrefix, entry.key],
-        out,
-      );
+      }
       out.add([...pathPrefix, entry.key].join("."));
       continue;
     }

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -29,6 +29,7 @@ import {
   asRecord,
   isPlainObject,
 } from "../../util/nested-values.js";
+import { YamlRawValue } from "../../util/yaml-serialize.js";
 
 /**
  * Entry keys the form keeps visible even when ``requiredOnly`` is
@@ -95,7 +96,12 @@ function hasMaterialValue(
       // ``esphome.areas``): any non-empty array of items counts.
       // We don't recurse — items are user-added, and a freshly
       // added empty ``{}`` still represents user intent (the row
-      // exists because they clicked Add).
+      // exists because they clicked Add). A ``YamlRawValue`` at
+      // this key (the parser preserved the block byte-for-byte
+      // because the items didn't fit the flat-mapping contract)
+      // also counts — the user's YAML must keep showing without
+      // a trip through the Advanced toggle.
+      if (value instanceof YamlRawValue) return true;
       return Array.isArray(value) && value.length > 0;
     }
     if (!isPlainObject(value)) return false;

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -85,6 +85,14 @@ function hasMaterialValue(
 ): boolean {
   const value = values[entry.key];
   if (entry.type === ConfigEntryType.NESTED) {
+    if (entry.multi_value) {
+      // Repeatable nested mapping (``esphome.devices`` /
+      // ``esphome.areas``): any non-empty array of items counts.
+      // We don't recurse — items are user-added, and a freshly
+      // added empty ``{}`` still represents user intent (the row
+      // exists because they clicked Add).
+      return Array.isArray(value) && value.length > 0;
+    }
     if (value === null || typeof value !== "object" || Array.isArray(value)) {
       return false;
     }
@@ -118,6 +126,15 @@ export function filterRenderable(
       !opts.showAdvanced &&
       !hasMaterialValue(entry, values)
     ) {
+      continue;
+    }
+    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
+      // List-form NESTED always renders — the renderer paints the
+      // Add button even with zero items, and ``filterRenderable``
+      // is called per-item at render time with the item's own
+      // scope. Skipping based on the parent ``values`` shape would
+      // hide the field exactly when the user needs it.
+      out.push(entry);
       continue;
     }
     if (entry.type === ConfigEntryType.NESTED) {
@@ -172,6 +189,28 @@ export function collectRenderablePaths(
   out: Set<string> = new Set(),
 ): Set<string> {
   for (const entry of filterRenderable(entries, values, opts)) {
+    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
+      // List-form NESTED: emit one path tree per item with the
+      // index segment (``devices.0.id``) so ``_anyErrorIsVisible``
+      // can reconcile validation errors keyed on per-item leaves.
+      const child = values[entry.key];
+      const items = Array.isArray(child) ? child : [];
+      items.forEach((item, idx) => {
+        const itemValues =
+          item !== null && typeof item === "object" && !Array.isArray(item)
+            ? (item as Record<string, unknown>)
+            : {};
+        collectRenderablePaths(
+          entry.config_entries ?? [],
+          itemValues,
+          opts,
+          [...pathPrefix, entry.key, String(idx)],
+          out,
+        );
+      });
+      out.add([...pathPrefix, entry.key].join("."));
+      continue;
+    }
     if (entry.type === ConfigEntryType.NESTED) {
       const child = values[entry.key];
       const childValues =

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -24,6 +24,11 @@
 import type { ConfigEntry } from "../../api/types.js";
 import { ConfigEntryType } from "../../api/types.js";
 import { isEntryVisible } from "../../util/config-validation.js";
+import {
+  asMappingList,
+  asRecord,
+  isPlainObject,
+} from "../../util/nested-values.js";
 
 /**
  * Entry keys the form keeps visible even when ``requiredOnly`` is
@@ -93,12 +98,9 @@ function hasMaterialValue(
       // exists because they clicked Add).
       return Array.isArray(value) && value.length > 0;
     }
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
-      return false;
-    }
-    const childValues = value as Record<string, unknown>;
+    if (!isPlainObject(value)) return false;
     return (entry.config_entries ?? []).some((child) =>
-      hasMaterialValue(child, childValues),
+      hasMaterialValue(child, value),
     );
   }
   return value !== undefined;
@@ -138,14 +140,9 @@ export function filterRenderable(
       continue;
     }
     if (entry.type === ConfigEntryType.NESTED) {
-      const child = values[entry.key];
-      const childValues =
-        child !== null && typeof child === "object" && !Array.isArray(child)
-          ? (child as Record<string, unknown>)
-          : {};
       const renderableChildren = filterRenderable(
         entry.config_entries ?? [],
-        childValues,
+        asRecord(values[entry.key]),
         opts,
       );
       if (renderableChildren.length === 0) continue;
@@ -193,13 +190,7 @@ export function collectRenderablePaths(
       // List-form NESTED: emit one path tree per item with the
       // index segment (``devices.0.id``) so ``_anyErrorIsVisible``
       // can reconcile validation errors keyed on per-item leaves.
-      const child = values[entry.key];
-      const items = Array.isArray(child) ? child : [];
-      items.forEach((item, idx) => {
-        const itemValues =
-          item !== null && typeof item === "object" && !Array.isArray(item)
-            ? (item as Record<string, unknown>)
-            : {};
+      asMappingList(values[entry.key]).forEach((itemValues, idx) => {
         collectRenderablePaths(
           entry.config_entries ?? [],
           itemValues,
@@ -212,14 +203,9 @@ export function collectRenderablePaths(
       continue;
     }
     if (entry.type === ConfigEntryType.NESTED) {
-      const child = values[entry.key];
-      const childValues =
-        child !== null && typeof child === "object" && !Array.isArray(child)
-          ? (child as Record<string, unknown>)
-          : {};
       collectRenderablePaths(
         entry.config_entries ?? [],
-        childValues,
+        asRecord(values[entry.key]),
         opts,
         [...pathPrefix, entry.key],
         out,

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -494,44 +494,105 @@ export function renderIconField(
   `;
 }
 
+/**
+ * Read the array currently stored at *path* in form state. Returns
+ * an empty array (not ``undefined``) when nothing is there or the
+ * value isn't an array — every list-renderer mutation closure
+ * round-trips through this so the new array is always a clean copy
+ * of a known-array shape.
+ */
+function readArrayAt(ctx: RenderCtx, path: string[]): readonly unknown[] {
+  const cur = ctx.getAt(path);
+  return Array.isArray(cur) ? cur : [];
+}
+
+/**
+ * Build the add/remove closures shared by ``renderMultiValueField``
+ * (scalar items) and ``renderNestedListField`` (mapping items).
+ * The caller passes a factory for the new-item placeholder so each
+ * renderer chooses the empty shape that matches its children
+ * (``""`` for scalars, ``{}`` for nested mappings).
+ */
+function arrayItemHandlers(
+  ctx: RenderCtx,
+  path: string[],
+  makeNewItem: () => unknown,
+): { addItem: () => void; removeAt: (idx: number) => void } {
+  const removeAt = (idx: number) =>
+    ctx.emitChange(
+      path,
+      readArrayAt(ctx, path).filter((_, i) => i !== idx),
+    );
+  const addItem = () =>
+    ctx.emitChange(path, [...readArrayAt(ctx, path), makeNewItem()]);
+  return { addItem, removeAt };
+}
+
+/** Empty-state hint shared by both list renderers. */
+function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {
+  return items.length === 0
+    ? html`<p class="field-description">
+        ${ctx.localize("device.multi_value_empty")}
+      </p>`
+    : nothing;
+}
+
+/** Per-item remove button shared by both list renderers. */
+function renderListRemoveButton(
+  ctx: RenderCtx,
+  disabled: boolean,
+  onClick: () => void,
+) {
+  return html`
+    <button
+      type="button"
+      class="multi-btn"
+      ?disabled=${disabled}
+      aria-label=${ctx.localize("device.multi_value_remove")}
+      @click=${onClick}
+    >
+      <wa-icon library="mdi" name="close"></wa-icon>
+    </button>
+  `;
+}
+
+/** Trailing Add button shared by both list renderers. */
+function renderListAddButton(
+  ctx: RenderCtx,
+  disabled: boolean,
+  onClick: () => void,
+) {
+  return html`
+    <button
+      type="button"
+      class="multi-btn multi-add"
+      ?disabled=${disabled}
+      @click=${onClick}
+    >
+      <wa-icon library="mdi" name="plus"></wa-icon>
+      ${ctx.localize("device.multi_value_add")}
+    </button>
+  `;
+}
+
 export function renderMultiValueField(
   entry: ConfigEntry,
   path: string[],
   ctx: RenderCtx,
 ) {
-  const raw = ctx.getAt(path);
-  const items: string[] = Array.isArray(raw) ? raw.map((v) => String(v)) : [];
+  const items: string[] = readArrayAt(ctx, path).map((v) => String(v));
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
-
+  const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
   const updateAt = (idx: number, value: string) => {
-    const cur = ctx.getAt(path);
-    const current = Array.isArray(cur) ? [...cur] : [];
+    const current = [...readArrayAt(ctx, path)];
     current[idx] = value;
     ctx.emitChange(path, current);
-  };
-  const removeAt = (idx: number) => {
-    const cur = ctx.getAt(path);
-    const current = Array.isArray(cur) ? cur : [];
-    ctx.emitChange(
-      path,
-      current.filter((_, i) => i !== idx),
-    );
-  };
-  const addItem = () => {
-    const cur = ctx.getAt(path);
-    const current = Array.isArray(cur) ? cur : [];
-    ctx.emitChange(path, [...current, ""]);
   };
 
   return html`
     <div class="field" data-field-key=${path.join(".")}>
-      ${renderLabel(entry, ctx)}
-      ${items.length === 0
-        ? html`<p class="field-description">
-            ${ctx.localize("device.multi_value_empty")}
-          </p>`
-        : nothing}
+      ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map(
         (item, i) => html`
           <div class="multi-row">
@@ -543,27 +604,11 @@ export function renderMultiValueField(
               @input=${(e: Event) =>
                 updateAt(i, (e.target as HTMLInputElement).value)}
             />
-            <button
-              type="button"
-              class="multi-btn"
-              ?disabled=${disabled}
-              aria-label=${ctx.localize("device.multi_value_remove")}
-              @click=${() => removeAt(i)}
-            >
-              <wa-icon library="mdi" name="close"></wa-icon>
-            </button>
+            ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
           </div>
         `,
       )}
-      <button
-        type="button"
-        class="multi-btn multi-add"
-        ?disabled=${disabled}
-        @click=${addItem}
-      >
-        <wa-icon library="mdi" name="plus"></wa-icon>
-        ${ctx.localize("device.multi_value_add")}
-      </button>
+      ${renderListAddButton(ctx, disabled, addItem)}
       ${renderFieldError(path, ctx)}
     </div>
   `;
@@ -726,8 +771,13 @@ export function renderMapField(
  * Render a repeatable nested-mapping list — used for
  * ``esphome.devices`` / ``esphome.areas`` and any future
  * ``type=nested, multi_value=true`` catalog entry. Each item is its
- * own collapsible group with the same children as a single nested
- * entry; the user can add and remove items at will.
+ * own bordered group with the same children as a single nested
+ * entry, plus a per-item remove button; a single Add button at the
+ * bottom appends a new empty item. Items render expanded — there's
+ * no per-item collapse toggle, since the typical case is a handful
+ * of devices / areas the user wants to see at once. Long lists can
+ * still scroll, and a future revision could add a toggle on the
+ * per-item header without changing the storage shape.
  *
  * Storage shape: ``values[entry.key] = [ {child: value, ...}, ... ]``
  * — a list of plain objects matching ``entry.config_entries``.
@@ -740,60 +790,27 @@ export function renderNestedListField(
   path: string[],
   ctx: RenderCtx,
 ) {
-  const raw = ctx.getAt(path);
-  const items: Record<string, unknown>[] = Array.isArray(raw)
-    ? raw.map((v) => (isPlainObject(v) ? v : {}))
-    : [];
+  const items = readArrayAt(ctx, path).map((v) =>
+    isPlainObject(v) ? v : {},
+  );
   const disabled = effectiveDisabled(entry, ctx);
-
-  const removeAt = (idx: number) => {
-    const cur = ctx.getAt(path);
-    const current = Array.isArray(cur) ? cur : [];
-    ctx.emitChange(
-      path,
-      current.filter((_, i) => i !== idx),
-    );
-  };
-  const addItem = () => {
-    const cur = ctx.getAt(path);
-    const current = Array.isArray(cur) ? cur : [];
-    ctx.emitChange(path, [...current, {}]);
-  };
-
+  const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => ({}));
   const itemTitle = labelFor(entry, ctx);
+  const childrenSchema = entry.config_entries ?? [];
 
   return html`
     <div class="nested-list" data-field-key=${path.join(".")}>
-      ${renderLabel(entry, ctx)}
-      ${items.length === 0
-        ? html`<p class="field-description">
-            ${ctx.localize("device.multi_value_empty")}
-          </p>`
-        : nothing}
+      ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
         const itemPath = [...path, String(i)];
-        const renderableChildren = ctx.filterRenderable(
-          entry.config_entries ?? [],
-          item,
-        );
+        const renderableChildren = ctx.filterRenderable(childrenSchema, item);
         return html`
-          <div
-            class="nested-list-item"
-            data-field-key=${itemPath.join(".")}
-          >
+          <div class="nested-list-item" data-field-key=${itemPath.join(".")}>
             <div class="nested-list-item-header">
               <span class="nested-list-item-title">
                 ${itemTitle} ${i + 1}
               </span>
-              <button
-                type="button"
-                class="multi-btn"
-                ?disabled=${disabled}
-                aria-label=${ctx.localize("device.multi_value_remove")}
-                @click=${() => removeAt(i)}
-              >
-                <wa-icon library="mdi" name="close"></wa-icon>
-              </button>
+              ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
             </div>
             <div class="nested-fields">
               ${renderableChildren.map((child) =>
@@ -803,15 +820,7 @@ export function renderNestedListField(
           </div>
         `;
       })}
-      <button
-        type="button"
-        class="multi-btn multi-add"
-        ?disabled=${disabled}
-        @click=${addItem}
-      >
-        <wa-icon library="mdi" name="plus"></wa-icon>
-        ${ctx.localize("device.multi_value_add")}
-      </button>
+      ${renderListAddButton(ctx, disabled, addItem)}
       ${renderFieldError(path, ctx)}
     </div>
   `;

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -23,7 +23,11 @@ import {
 } from "../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../util/hex-int.js";
 import { renderMarkdown } from "../../util/markdown.js";
-import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
+import {
+  asMappingList,
+  isPlainObject,
+  isPrimitiveOrNullish,
+} from "../../util/nested-values.js";
 import { YamlRawValue } from "../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -790,9 +794,7 @@ export function renderNestedListField(
   path: string[],
   ctx: RenderCtx,
 ) {
-  const items = readArrayAt(ctx, path).map((v) =>
-    isPlainObject(v) ? v : {},
-  );
+  const items = asMappingList(ctx.getAt(path));
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => ({}));
   const itemTitle = labelFor(entry, ctx);

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -793,7 +793,28 @@ export function renderNestedListField(
   path: string[],
   ctx: RenderCtx,
 ) {
-  const items = asMappingList(ctx.getAt(path));
+  // Bail to a YAML-only notice when the parser preserved the
+  // value as ``YamlRawValue`` (the catalog's flat-mapping
+  // contract didn't fit and the block round-trips byte-for-byte
+  // as raw lines). Without this, ``asMappingList`` would coerce
+  // the raw block to ``[]``, the renderer would show "No items
+  // yet" + an Add button, and the next save would replace the
+  // user's preserved YAML with whatever the renderer emits —
+  // silent data loss.
+  const raw = ctx.getAt(path);
+  if (raw instanceof YamlRawValue) {
+    return html`
+      <div class="nested-list" data-field-key=${path.join(".")}>
+        ${renderLabel(entry, ctx)}
+        <p class="field-description">
+          ${ctx.localize("device.multi_value_yaml_only")}
+        </p>
+        ${renderFieldError(path, ctx)}
+      </div>
+    `;
+  }
+
+  const items = asMappingList(raw);
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => ({}));
   const itemTitle = labelFor(entry, ctx);

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -25,7 +25,6 @@ import { formatHexInt, parseHexInt } from "../../util/hex-int.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import {
   asMappingList,
-  isPlainObject,
   isPrimitiveOrNullish,
 } from "../../util/nested-values.js";
 import { YamlRawValue } from "../../util/yaml-serialize.js";

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -23,7 +23,7 @@ import {
 } from "../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../util/hex-int.js";
 import { renderMarkdown } from "../../util/markdown.js";
-import { isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { YamlRawValue } from "../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -716,6 +716,101 @@ export function renderMapField(
       >
         <wa-icon library="mdi" name="plus"></wa-icon>
         ${ctx.localize("device.map_add")}
+      </button>
+      ${renderFieldError(path, ctx)}
+    </div>
+  `;
+}
+
+/**
+ * Render a repeatable nested-mapping list — used for
+ * ``esphome.devices`` / ``esphome.areas`` and any future
+ * ``type=nested, multi_value=true`` catalog entry. Each item is its
+ * own collapsible group with the same children as a single nested
+ * entry; the user can add and remove items at will.
+ *
+ * Storage shape: ``values[entry.key] = [ {child: value, ...}, ... ]``
+ * — a list of plain objects matching ``entry.config_entries``.
+ * Children write through array-aware ``setIn`` paths
+ * (``[..., entry.key, "0", "name"]``), so the array slot survives
+ * round-trips through the form-state reducer.
+ */
+export function renderNestedListField(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+) {
+  const raw = ctx.getAt(path);
+  const items: Record<string, unknown>[] = Array.isArray(raw)
+    ? raw.map((v) => (isPlainObject(v) ? v : {}))
+    : [];
+  const disabled = effectiveDisabled(entry, ctx);
+
+  const removeAt = (idx: number) => {
+    const cur = ctx.getAt(path);
+    const current = Array.isArray(cur) ? cur : [];
+    ctx.emitChange(
+      path,
+      current.filter((_, i) => i !== idx),
+    );
+  };
+  const addItem = () => {
+    const cur = ctx.getAt(path);
+    const current = Array.isArray(cur) ? cur : [];
+    ctx.emitChange(path, [...current, {}]);
+  };
+
+  const itemTitle = labelFor(entry, ctx);
+
+  return html`
+    <div class="nested-list" data-field-key=${path.join(".")}>
+      ${renderLabel(entry, ctx)}
+      ${items.length === 0
+        ? html`<p class="field-description">
+            ${ctx.localize("device.multi_value_empty")}
+          </p>`
+        : nothing}
+      ${items.map((item, i) => {
+        const itemPath = [...path, String(i)];
+        const renderableChildren = ctx.filterRenderable(
+          entry.config_entries ?? [],
+          item,
+        );
+        return html`
+          <div
+            class="nested-list-item"
+            data-field-key=${itemPath.join(".")}
+          >
+            <div class="nested-list-item-header">
+              <span class="nested-list-item-title">
+                ${itemTitle} ${i + 1}
+              </span>
+              <button
+                type="button"
+                class="multi-btn"
+                ?disabled=${disabled}
+                aria-label=${ctx.localize("device.multi_value_remove")}
+                @click=${() => removeAt(i)}
+              >
+                <wa-icon library="mdi" name="close"></wa-icon>
+              </button>
+            </div>
+            <div class="nested-fields">
+              ${renderableChildren.map((child) =>
+                ctx.renderEntry(child, [...itemPath, child.key]),
+              )}
+            </div>
+          </div>
+        `;
+      })}
+      <button
+        type="button"
+        class="multi-btn multi-add"
+        ?disabled=${disabled}
+        @click=${addItem}
+      >
+        <wa-icon library="mdi" name="plus"></wa-icon>
+        ${ctx.localize("device.multi_value_add")}
       </button>
       ${renderFieldError(path, ctx)}
     </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -566,6 +566,7 @@
     "multi_value_empty": "No items yet — click + to add one.",
     "multi_value_add": "Add",
     "multi_value_remove": "Remove",
+    "multi_value_yaml_only": "This list contains YAML the visual editor can't model — edit it directly in the YAML pane on the right.",
     "map_empty": "No entries yet — click + to add one.",
     "map_add": "Add entry",
     "map_remove": "Remove entry",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -489,6 +489,7 @@
     "multi_value_empty": "Aucun élément — cliquez sur + pour en ajouter un.",
     "multi_value_add": "Ajouter",
     "multi_value_remove": "Supprimer",
+    "multi_value_yaml_only": "Cette liste contient du YAML que l'éditeur visuel ne peut pas modéliser — modifiez-la directement dans le volet YAML à droite.",
     "map_empty": "Aucune entrée — cliquez sur + pour en ajouter une.",
     "map_add": "Ajouter une entrée",
     "map_remove": "Supprimer l'entrée",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -489,6 +489,7 @@
     "multi_value_empty": "Nog geen items — klik op + om er een toe te voegen.",
     "multi_value_add": "Toevoegen",
     "multi_value_remove": "Verwijderen",
+    "multi_value_yaml_only": "Deze lijst bevat YAML die de visuele editor niet kan modelleren — bewerk hem rechtstreeks in het YAML-paneel rechts.",
     "map_empty": "Nog geen vermeldingen — klik op + om er een toe te voegen.",
     "map_add": "Vermelding toevoegen",
     "map_remove": "Vermelding verwijderen",

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -2,6 +2,7 @@ import type { ConfigEntry } from "../api/types.js";
 import { ConfigEntryType } from "../api/types.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { asMappingList, asRecord } from "./nested-values.js";
+import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
  * Determine if a config entry is currently visible.
@@ -232,7 +233,15 @@ function _validateEntriesRecursive(
         // empty list on an optional field is fine (the user opted
         // out by adding nothing); a required list with zero items
         // surfaces a single error on the field itself.
-        const items = asMappingList(values[entry.key]);
+        //
+        // ``YamlRawValue`` short-circuits — the parser preserved
+        // the block byte-for-byte because items don't fit the
+        // flat-mapping contract, so we can't introspect them. The
+        // user's YAML is present (treats a required field as
+        // satisfied) but unreachable for per-item validation.
+        const raw = values[entry.key];
+        if (raw instanceof YamlRawValue) continue;
+        const items = asMappingList(raw);
         if (items.length === 0) {
           if (entry.required) {
             const fullPath = [...pathPrefix, entry.key].join(".");

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -221,6 +221,43 @@ function _validateEntriesRecursive(
     // we don't want to require fields the user can't even see.
     if (!isEntryVisible(entry, values, presentComponents, targetPlatform)) continue;
 
+    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
+      // List-form NESTED (``esphome.devices`` / ``esphome.areas``):
+      // validate each item independently with an array-index path
+      // segment so errors land at ``devices.0.id`` etc. — matching
+      // how the form looks errors up via ``path.join(".")``. An
+      // empty list on an optional field is fine (the user opted
+      // out by adding nothing); a required list with zero items
+      // surfaces a single error on the field itself.
+      const child = values[entry.key];
+      const items = Array.isArray(child) ? child : [];
+      if (items.length === 0) {
+        if (entry.required) {
+          const fullPath = [...pathPrefix, entry.key].join(".");
+          errors.set(fullPath, {
+            key: fullPath,
+            code: "validation.required",
+          });
+        }
+        continue;
+      }
+      items.forEach((item, idx) => {
+        const itemValues =
+          item !== null && typeof item === "object" && !Array.isArray(item)
+            ? (item as Record<string, unknown>)
+            : {};
+        _validateEntriesRecursive(
+          entry.config_entries ?? [],
+          itemValues,
+          presentComponents,
+          targetPlatform,
+          [...pathPrefix, entry.key, String(idx)],
+          errors,
+        );
+      });
+      continue;
+    }
+
     if (entry.type === ConfigEntryType.NESTED) {
       const child = values[entry.key];
       const childValues =

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry } from "../api/types.js";
 import { ConfigEntryType } from "../api/types.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
+import { asMappingList, asRecord } from "./nested-values.js";
 
 /**
  * Determine if a config entry is currently visible.
@@ -229,8 +230,7 @@ function _validateEntriesRecursive(
       // empty list on an optional field is fine (the user opted
       // out by adding nothing); a required list with zero items
       // surfaces a single error on the field itself.
-      const child = values[entry.key];
-      const items = Array.isArray(child) ? child : [];
+      const items = asMappingList(values[entry.key]);
       if (items.length === 0) {
         if (entry.required) {
           const fullPath = [...pathPrefix, entry.key].join(".");
@@ -241,11 +241,7 @@ function _validateEntriesRecursive(
         }
         continue;
       }
-      items.forEach((item, idx) => {
-        const itemValues =
-          item !== null && typeof item === "object" && !Array.isArray(item)
-            ? (item as Record<string, unknown>)
-            : {};
+      items.forEach((itemValues, idx) => {
         _validateEntriesRecursive(
           entry.config_entries ?? [],
           itemValues,
@@ -259,11 +255,7 @@ function _validateEntriesRecursive(
     }
 
     if (entry.type === ConfigEntryType.NESTED) {
-      const child = values[entry.key];
-      const childValues =
-        child !== null && typeof child === "object" && !Array.isArray(child)
-          ? (child as Record<string, unknown>)
-          : {};
+      const childValues = asRecord(values[entry.key]);
       // Optional nested groups (e.g. `web_server.auth`) often have
       // required CHILDREN (`auth.username`, `auth.password`). Don't
       // flag those as missing when the user hasn't populated the
@@ -297,12 +289,8 @@ function _validateEntriesRecursive(
     // regex here would silently drift on any upstream change).
     if (entry.type === ConfigEntryType.MAP) {
       if (entry.required) {
-        const raw = values[entry.key];
-        const map =
-          raw !== null && typeof raw === "object" && !Array.isArray(raw)
-            ? (raw as Record<string, unknown>)
-            : null;
-        if (!map || Object.keys(map).length === 0) {
+        const map = asRecord(values[entry.key]);
+        if (Object.keys(map).length === 0) {
           const fullPath = [...pathPrefix, entry.key].join(".");
           errors.set(fullPath, {
             key: fullPath,

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -222,39 +222,39 @@ function _validateEntriesRecursive(
     // we don't want to require fields the user can't even see.
     if (!isEntryVisible(entry, values, presentComponents, targetPlatform)) continue;
 
-    if (entry.type === ConfigEntryType.NESTED && entry.multi_value) {
-      // List-form NESTED (``esphome.devices`` / ``esphome.areas``):
-      // validate each item independently with an array-index path
-      // segment so errors land at ``devices.0.id`` etc. — matching
-      // how the form looks errors up via ``path.join(".")``. An
-      // empty list on an optional field is fine (the user opted
-      // out by adding nothing); a required list with zero items
-      // surfaces a single error on the field itself.
-      const items = asMappingList(values[entry.key]);
-      if (items.length === 0) {
-        if (entry.required) {
-          const fullPath = [...pathPrefix, entry.key].join(".");
-          errors.set(fullPath, {
-            key: fullPath,
-            code: "validation.required",
-          });
+    if (entry.type === ConfigEntryType.NESTED) {
+      const childSchema = entry.config_entries ?? [];
+      if (entry.multi_value) {
+        // List-form NESTED (``esphome.devices`` / ``esphome.areas``):
+        // validate each item independently with an array-index path
+        // segment so errors land at ``devices.0.id`` etc. — matching
+        // how the form looks errors up via ``path.join(".")``. An
+        // empty list on an optional field is fine (the user opted
+        // out by adding nothing); a required list with zero items
+        // surfaces a single error on the field itself.
+        const items = asMappingList(values[entry.key]);
+        if (items.length === 0) {
+          if (entry.required) {
+            const fullPath = [...pathPrefix, entry.key].join(".");
+            errors.set(fullPath, {
+              key: fullPath,
+              code: "validation.required",
+            });
+          }
+          continue;
         }
+        items.forEach((itemValues, idx) => {
+          _validateEntriesRecursive(
+            childSchema,
+            itemValues,
+            presentComponents,
+            targetPlatform,
+            [...pathPrefix, entry.key, String(idx)],
+            errors,
+          );
+        });
         continue;
       }
-      items.forEach((itemValues, idx) => {
-        _validateEntriesRecursive(
-          entry.config_entries ?? [],
-          itemValues,
-          presentComponents,
-          targetPlatform,
-          [...pathPrefix, entry.key, String(idx)],
-          errors,
-        );
-      });
-      continue;
-    }
-
-    if (entry.type === ConfigEntryType.NESTED) {
       const childValues = asRecord(values[entry.key]);
       // Optional nested groups (e.g. `web_server.auth`) often have
       // required CHILDREN (`auth.username`, `auth.password`). Don't
@@ -268,7 +268,7 @@ function _validateEntriesRecursive(
         continue;
       }
       _validateEntriesRecursive(
-        entry.config_entries ?? [],
+        childSchema,
         childValues,
         presentComponents,
         targetPlatform,

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -41,19 +41,25 @@ export function setIn(
 }
 
 /**
- * Recurse into an array child of ``setIn``. ``path[0]`` is parsed
- * as a numeric index; out-of-range indices grow the array (so the
- * nested-list renderer can write to a freshly-added item before its
- * placeholder object is materialised). The returned array is a
- * fresh copy — callers stay structural-sharing-safe.
+ * Recurse into an array child of ``setIn``. ``path[0]`` must parse
+ * as a non-negative integer; non-numeric, negative, or fractional
+ * segments are dropped on the floor (the array is returned
+ * unchanged) — writing to ``arr["name"]`` or ``arr[-1]`` would
+ * silently set a string property on the array object, leaving
+ * ``.length`` stale and surprising every downstream consumer.
+ * Indices past the end grow the array (so the nested-list renderer
+ * can write to a freshly-added item before its placeholder object
+ * is materialised). The returned array is a fresh copy on every
+ * write — callers stay structural-sharing-safe.
  */
 function _setInArray(
   arr: readonly unknown[],
   path: string[],
   value: unknown,
-): unknown[] {
+): readonly unknown[] {
   const [head, ...rest] = path;
   const idx = Number(head);
+  if (!Number.isInteger(idx) || idx < 0) return arr;
   const copy = [...arr];
   if (rest.length === 0) {
     copy[idx] = value;

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -52,14 +52,28 @@ export function setIn(
  * is materialised). The returned array is a fresh copy on every
  * write — callers stay structural-sharing-safe.
  */
+/**
+ * Parse a path segment as a non-negative integer index into an
+ * array. Returns ``null`` for non-numeric, negative, or fractional
+ * segments — callers translate that to "skip this access" (read
+ * paths return ``undefined``, write paths leave the array
+ * unchanged). Centralised so the read and write sides agree on
+ * what counts as a valid array index — an inconsistency between
+ * them would let writes land at indices reads can't reach.
+ */
+function _parseArrayIndex(segment: string): number | null {
+  const idx = Number(segment);
+  return Number.isInteger(idx) && idx >= 0 ? idx : null;
+}
+
 function _setInArray(
   arr: readonly unknown[],
   path: string[],
   value: unknown,
 ): readonly unknown[] {
   const [head, ...rest] = path;
-  const idx = Number(head);
-  if (!Number.isInteger(idx) || idx < 0) return arr;
+  const idx = _parseArrayIndex(head);
+  if (idx === null) return arr;
   const copy = [...arr];
   if (rest.length === 0) {
     copy[idx] = value;
@@ -91,10 +105,8 @@ export function getIn(
       return undefined;
     }
     if (Array.isArray(cur)) {
-      const idx = Number(k);
-      if (!Number.isInteger(idx) || idx < 0 || idx >= cur.length) {
-        return undefined;
-      }
+      const idx = _parseArrayIndex(k);
+      if (idx === null || idx >= cur.length) return undefined;
       cur = cur[idx];
       continue;
     }

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -27,31 +27,11 @@ export function setIn(
   // empty object when value isn't object-shaped so the caller's
   // contract that this returns a Record<string, unknown> stays
   // intact.
-  if (path.length === 0) {
-    return isPlainObject(value) ? value : {};
-  }
+  if (path.length === 0) return isPlainObject(value) ? value : {};
   const [head, ...rest] = path;
-  if (rest.length === 0) return { ...obj, [head]: value };
-  const child = obj[head];
-  if (Array.isArray(child)) {
-    return { ...obj, [head]: _setInArray(child, rest, value) };
-  }
-  const childObj = isPlainObject(child) ? child : {};
-  return { ...obj, [head]: setIn(childObj, rest, value) };
+  return { ...obj, [head]: _newChild(obj[head], rest, value) };
 }
 
-/**
- * Recurse into an array child of ``setIn``. ``path[0]`` must parse
- * as a non-negative integer; non-numeric, negative, or fractional
- * segments are dropped on the floor (the array is returned
- * unchanged) — writing to ``arr["name"]`` or ``arr[-1]`` would
- * silently set a string property on the array object, leaving
- * ``.length`` stale and surprising every downstream consumer.
- * Indices past the end grow the array (so the nested-list renderer
- * can write to a freshly-added item before its placeholder object
- * is materialised). The returned array is a fresh copy on every
- * write — callers stay structural-sharing-safe.
- */
 /**
  * Parse a path segment as a non-negative integer index into an
  * array. Returns ``null`` for non-numeric, negative, or fractional
@@ -66,6 +46,39 @@ function _parseArrayIndex(segment: string): number | null {
   return Number.isInteger(idx) && idx >= 0 ? idx : null;
 }
 
+/**
+ * Compute the new child to install at the head of a path, given
+ * the existing child at that slot. Shared by ``setIn`` (Record
+ * containers) and ``_setInArray`` (Array containers); each caller
+ * handles its own container-shape spread/copy and just plugs the
+ * result of ``_newChild`` in. Empty ``rest`` ⇒ value goes in
+ * directly; otherwise descend via the appropriate sibling for the
+ * existing child's shape (Array → ``_setInArray``; anything else
+ * is coerced to ``{}`` and handed to ``setIn``).
+ */
+function _newChild(
+  currentChild: unknown,
+  rest: string[],
+  value: unknown,
+): unknown {
+  if (rest.length === 0) return value;
+  if (Array.isArray(currentChild)) {
+    return _setInArray(currentChild, rest, value);
+  }
+  return setIn(isPlainObject(currentChild) ? currentChild : {}, rest, value);
+}
+
+/**
+ * Recurse into an array child of ``setIn``. ``path[0]`` must parse
+ * as a non-negative integer (non-numeric, negative, or fractional
+ * segments leave the array unchanged — writing to ``arr["name"]``
+ * or ``arr[-1]`` would silently set a string property on the
+ * array, leaving ``.length`` stale). Indices past the end grow
+ * the array so the nested-list renderer can write to a
+ * freshly-added item before its placeholder object materialises.
+ * The returned array is a fresh copy on every write — callers
+ * stay structural-sharing-safe.
+ */
 function _setInArray(
   arr: readonly unknown[],
   path: string[],
@@ -75,17 +88,7 @@ function _setInArray(
   const idx = _parseArrayIndex(head);
   if (idx === null) return arr;
   const copy = [...arr];
-  if (rest.length === 0) {
-    copy[idx] = value;
-    return copy;
-  }
-  const child = copy[idx];
-  if (Array.isArray(child)) {
-    copy[idx] = _setInArray(child, rest, value);
-  } else {
-    const childObj = isPlainObject(child) ? child : {};
-    copy[idx] = setIn(childObj, rest, value);
-  }
+  copy[idx] = _newChild(arr[idx], rest, value);
   return copy;
 }
 

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -10,7 +10,11 @@
  * Immutably set `value` at `path` inside an object, returning a new
  * object with structural sharing of untouched branches. Intermediate
  * objects are created when the path crosses missing or non-object
- * nodes (so a fresh form can write to nested fields).
+ * nodes (so a fresh form can write to nested fields). Array children
+ * are descended via numeric path segments (``["devices", "0",
+ * "name"]``), preserving the array shape — required by the
+ * nested-list renderer for ``esphome.devices`` / ``esphome.areas``
+ * and any future repeatable-mapping field.
  */
 export function setIn(
   obj: Record<string, unknown>,
@@ -24,21 +28,52 @@ export function setIn(
   // contract that this returns a Record<string, unknown> stays
   // intact.
   if (path.length === 0) {
-    return value !== null && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
+    return isPlainObject(value) ? value : {};
   }
   const [head, ...rest] = path;
   if (rest.length === 0) return { ...obj, [head]: value };
   const child = obj[head];
+  if (Array.isArray(child)) {
+    return { ...obj, [head]: _setInArray(child, rest, value) };
+  }
   const childObj = isPlainObject(child) ? child : {};
   return { ...obj, [head]: setIn(childObj, rest, value) };
 }
 
 /**
+ * Recurse into an array child of ``setIn``. ``path[0]`` is parsed
+ * as a numeric index; out-of-range indices grow the array (so the
+ * nested-list renderer can write to a freshly-added item before its
+ * placeholder object is materialised). The returned array is a
+ * fresh copy — callers stay structural-sharing-safe.
+ */
+function _setInArray(
+  arr: readonly unknown[],
+  path: string[],
+  value: unknown,
+): unknown[] {
+  const [head, ...rest] = path;
+  const idx = Number(head);
+  const copy = [...arr];
+  if (rest.length === 0) {
+    copy[idx] = value;
+    return copy;
+  }
+  const child = copy[idx];
+  if (Array.isArray(child)) {
+    copy[idx] = _setInArray(child, rest, value);
+  } else {
+    const childObj = isPlainObject(child) ? child : {};
+    copy[idx] = setIn(childObj, rest, value);
+  }
+  return copy;
+}
+
+/**
  * Read the value at `path` inside `obj`. Returns `undefined` for
- * missing paths or when the path crosses a non-object (e.g. trying to
- * descend into a string or array).
+ * missing paths or when the path crosses a non-object/non-array
+ * intermediate. Numeric path segments index into arrays (mirrors
+ * the array-aware writes in :func:`setIn`).
  */
 export function getIn(
   obj: Record<string, unknown>,
@@ -46,8 +81,16 @@ export function getIn(
 ): unknown {
   let cur: unknown = obj;
   for (const k of path) {
-    if (cur === null || typeof cur !== "object" || Array.isArray(cur)) {
+    if (cur === null || cur === undefined || typeof cur !== "object") {
       return undefined;
+    }
+    if (Array.isArray(cur)) {
+      const idx = Number(k);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= cur.length) {
+        return undefined;
+      }
+      cur = cur[idx];
+      continue;
     }
     cur = (cur as Record<string, unknown>)[k];
   }

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -151,3 +151,31 @@ export function isPlainObject(
 ): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+
+/**
+ * Coerce *value* to a ``Record<string, unknown>``, falling back to
+ * ``{}`` for ``null`` / undefined / primitives / arrays. Used by
+ * the filter and validator's NESTED branches when descending into
+ * a sub-mapping that the user might have left unset (or filled
+ * with mid-edit YAML stragglers like ``key: null``); the recursion
+ * keeps a stable shape instead of crashing on
+ * ``Object.keys(null)``.
+ */
+export function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {};
+}
+
+/**
+ * Coerce *value* to a list of mapping items, each item coerced to
+ * a ``Record`` via :func:`asRecord`. Returns ``[]`` when ``value``
+ * isn't an array. Used by every NESTED + ``multi_value=true`` site
+ * (filter, validator, path collector, renderer) to iterate
+ * ``esphome.devices`` / ``esphome.areas`` rows as a stable
+ * ``Record<string, unknown>[]`` regardless of mid-edit YAML
+ * weirdness.
+ */
+export function asMappingList(
+  value: unknown,
+): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.map(asRecord) : [];
+}

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -495,37 +495,43 @@ const collectBlockListMappings = (
   );
   const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
   const bareDash = `${dashIndent}-`;
-  const items: Record<string, unknown>[] = [];
-  let j = startIdx;
 
-  while (j < lines.length) {
-    const line = lines[j];
-    if (line.trim() === "") {
-      j++;
-      continue;
-    }
-    if (!isListItemLine(line, dashIndent)) break;
-
+  /**
+   * Parse one list item starting at *at* (the dash line). Returns
+   * the new line index on success, ``null`` to bail. Bare-dash
+   * items (``${dashIndent}-`` with no inline key) are the
+   * serializer's placeholder for a freshly-added Add row the user
+   * saved before filling fields — we skip the header parse and let
+   * the sub-key walk find zero follow-ups, so the item stays
+   * ``{}`` and the row survives the round-trip.
+   */
+  const parseItem = (
+    at: number,
+  ): { item: Record<string, unknown>; endIdx: number } | null => {
     // Same null-prototype defence as the surrounding parser — see
     // the comment in ``parseYamlSectionValues``.
     const item: Record<string, unknown> = Object.create(null);
-
-    // Bare ``${dashIndent}-`` is the serializer's placeholder for
-    // an empty mapping item (a freshly-added Add row saved before
-    // any fields were filled in). The header parse runs only for
-    // the with-content shape; bare-dash items skip it and the
-    // sub-key walk finds no follow-ups, so the item stays ``{}``
-    // and the row survives the round-trip.
-    if (line !== bareDash) {
-      const header = _matchFlatMappingField(line, headerRe);
+    if (lines[at] !== bareDash) {
+      const header = _matchFlatMappingField(lines[at], headerRe);
       if (!header) return null;
       item[header.key] = header.value;
     }
+    const after = _parseItemSubKeys(lines, at + 1, childIndent, childRe, item);
+    return after === null ? null : { item, endIdx: after };
+  };
 
-    const after = _parseItemSubKeys(lines, j + 1, childIndent, childRe, item);
-    if (after === null) return null;
-    items.push(item);
-    j = after;
+  const items: Record<string, unknown>[] = [];
+  let j = startIdx;
+  while (j < lines.length) {
+    if (lines[j].trim() === "") {
+      j++;
+      continue;
+    }
+    if (!isListItemLine(lines[j], dashIndent)) break;
+    const parsed = parseItem(j);
+    if (!parsed) return null;
+    items.push(parsed.item);
+    j = parsed.endIdx;
   }
   return { items, endIdx: j };
 };

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -148,6 +148,39 @@ const listItemRegexFor = (dashIndent: string) =>
   new RegExp(`^${dashIndent}-\\s+(.*)$`);
 
 /**
+ * True when *line* is structurally invisible to the key/value
+ * parser — blank, or a comment-only line whose first non-whitespace
+ * character is ``#``. Centralised so every "skip blank line"
+ * loop in this module also skips comments; otherwise a comment
+ * between ``key:`` and a child list/mapping (or interleaved with
+ * list items) makes the parser bail or terminate early, dropping
+ * the field from values and deleting it on the next save.
+ *
+ * This minimal parser doesn't preserve comments on round-trip
+ * either way — they're already silently dropped by the
+ * line-by-line serializer. Skipping them here just keeps comments
+ * from corrupting the structural read.
+ */
+const isBlankOrCommentLine = (line: string): boolean => {
+  const trimmed = line.trim();
+  return trimmed === "" || trimmed.startsWith("#");
+};
+
+/**
+ * Walk forward from *startIdx* skipping blank and comment-only
+ * lines. Returns the first index that holds real content, or
+ * ``lines.length`` if none.
+ */
+const _skipBlankAndCommentLines = (
+  lines: string[],
+  startIdx: number,
+): number => {
+  let j = startIdx;
+  while (j < lines.length && isBlankOrCommentLine(lines[j])) j++;
+  return j;
+};
+
+/**
  * Measure the leading whitespace on *line* — used to detect the
  * actual indent the user's YAML uses for the first child of a
  * section. The parser is tied to ESPHome's emit format (2 spaces
@@ -187,7 +220,7 @@ const _detectSectionChildIndent = (
     : ESPHOME_YAML_INDENT;
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i];
-    if (line.trim() === "") continue;
+    if (isBlankOrCommentLine(line)) continue;
     // Column-0 identifier ⇒ sibling section, this section has no
     // children of its own.
     if (TOP_LEVEL_KEY_START_RE.test(line)) return fallback;
@@ -214,7 +247,7 @@ const _detectListItemChildIndent = (
 ): string | null => {
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
-    if (line.trim() === "") continue;
+    if (isBlankOrCommentLine(line)) continue;
     const lead = _leadingIndent(line);
     // A sibling dash (or shallower) terminates this item.
     if (lead.length <= dashIndent.length) return null;
@@ -293,7 +326,7 @@ const collectBlockListItems = (
   const items: string[] = [];
   let j = startIdx;
   for (; j < lines.length; j++) {
-    if (lines[j].trim() === "") continue;
+    if (isBlankOrCommentLine(lines[j])) continue;
     if (!lines[j].startsWith(prefix)) break;
     const m = lines[j].match(itemRegex);
     if (!m) break;
@@ -317,7 +350,7 @@ const _detectFirstDashIndent = (
   let firstDashIdx = startIdx;
   while (
     firstDashIdx < lines.length &&
-    lines[firstDashIdx].trim() === ""
+    isBlankOrCommentLine(lines[firstDashIdx])
   ) {
     firstDashIdx++;
   }
@@ -474,7 +507,7 @@ const _parseItemSubKeys = (
   let j = startIdx;
   while (j < lines.length) {
     const sub = lines[j];
-    if (sub.trim() === "") {
+    if (isBlankOrCommentLine(sub)) {
       j++;
       continue;
     }
@@ -515,16 +548,20 @@ const collectBlockListMappings = (
     `^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`,
   );
   const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
-  const bareDash = `${dashIndent}-`;
 
   /**
    * Parse one list item starting at *at* (the dash line). Returns
    * the new line index on success, ``null`` to bail. Bare-dash
-   * items (``${dashIndent}-`` with no inline key) are the
-   * serializer's placeholder for a freshly-added Add row the user
-   * saved before filling fields — we skip the header parse and let
-   * the sub-key walk find zero follow-ups, so the item stays
-   * ``{}`` and the row survives the round-trip.
+   * items (``${dashIndent}-`` followed by EOL or only whitespace)
+   * are the serializer's placeholder for a freshly-added Add row
+   * the user saved before filling fields — we skip the header
+   * parse and let the sub-key walk find zero follow-ups, so the
+   * item stays ``{}`` and the row survives the round-trip. The
+   * trailing-whitespace shape (``    -  ``) is what some editors
+   * emit when the user's cursor lands on a fresh dash line, and
+   * also what ``LIST_ITEM_BARE_DASH_RE`` already accepts as a
+   * complexity signal — using the same regex here keeps the two
+   * predicates in lockstep.
    */
   const parseItem = (
     at: number,
@@ -532,7 +569,7 @@ const collectBlockListMappings = (
     // Same null-prototype defence as the surrounding parser — see
     // the comment in ``parseYamlSectionValues``.
     const item: Record<string, unknown> = Object.create(null);
-    if (lines[at] !== bareDash) {
+    if (!LIST_ITEM_BARE_DASH_RE.test(lines[at])) {
       const header = _matchFlatMappingField(lines[at], headerRe);
       if (!header) return null;
       item[header.key] = header.value;
@@ -544,7 +581,7 @@ const collectBlockListMappings = (
   const items: Record<string, unknown>[] = [];
   let j = startIdx;
   while (j < lines.length) {
-    if (lines[j].trim() === "") {
+    if (isBlankOrCommentLine(lines[j])) {
       j++;
       continue;
     }
@@ -598,7 +635,7 @@ const _scanValueBlock = (
   let isComplex = false;
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
-    if (line.trim() === "") continue;
+    if (isBlankOrCommentLine(line)) continue;
     const lead = line.match(/^ */)![0];
     if (lead.length <= keyIndent.length) return { endIdx: i, isComplex };
     if (!isComplex) {
@@ -697,7 +734,7 @@ export function parseYamlSectionValues(
 
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i];
-    if (line.trim() === "") continue;
+    if (isBlankOrCommentLine(line)) continue;
     if (isListItem) {
       const dashMatch = line.match(/^(\s*)-(\s|$)/);
       if (dashMatch && dashMatch[1].length === siblingDashIndent) break;
@@ -727,8 +764,7 @@ export function parseYamlSectionValues(
     }
 
     if (raw === "") {
-      let peek = i + 1;
-      while (peek < lines.length && lines[peek].trim() === "") peek++;
+      const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (peek >= lines.length) continue;
       const peekLine = lines[peek];
 
@@ -782,7 +818,7 @@ function parseNestedBlock(
   let i = startIdx;
   while (i < lines.length) {
     const line = lines[i];
-    if (line.trim() === "") {
+    if (isBlankOrCommentLine(line)) {
       i++;
       continue;
     }
@@ -808,8 +844,7 @@ function parseNestedBlock(
     }
 
     if (raw === "") {
-      let peek = i + 1;
-      while (peek < lines.length && lines[peek].trim() === "") peek++;
+      const peek = _skipBlankAndCommentLines(lines, i + 1);
       if (
         peek < lines.length &&
         isDeeperListItemLine(lines[peek], indent)

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -303,26 +303,6 @@ const collectBlockListItems = (
 };
 
 /**
- * Dispatch a YAML list block (``key:\n  - …``) into the right
- * value shape: structured array of mappings for editor-friendly
- * lists (``esphome.devices`` / ``esphome.areas``), ``YamlRawValue``
- * for complex automation triggers, or ``string[]`` for scalar
- * lists. Shared between the top-level and nested-block parsers
- * so both surfaces agree on the dispatch.
- *
- * ``parentIndent`` is the indent of the parent KEY (the one whose
- * value is the list). The dash and child indents are detected
- * from the first list-item line so 4-space (or other consistent)
- * user YAML round-trips correctly — the editor's canonical
- * 2-space emit applies on save, but reads accept any indent the
- * user chose.
- *
- * Returns ``endIdx`` — the line after the block ends — so callers
- * can fast-forward their loop index. ``isEmptyScalarList`` lets
- * the top-level caller preserve its existing "skip the assignment
- * for an empty scalar list" semantic.
- */
-/**
  * Find the leading whitespace of the first list-item dash at or
  * after *startIdx*. Returns *fallback* when no dash is reachable
  * (the block is blank or terminates before any item) and the
@@ -349,6 +329,26 @@ const _detectFirstDashIndent = (
   return { dashIndent, firstDashIdx };
 };
 
+/**
+ * Dispatch a YAML list block (``key:\n  - …``) into the right
+ * value shape: structured array of mappings for editor-friendly
+ * lists (``esphome.devices`` / ``esphome.areas``), ``YamlRawValue``
+ * for complex automation triggers, or ``string[]`` for scalar
+ * lists. Shared between the top-level and nested-block parsers
+ * so both surfaces agree on the dispatch.
+ *
+ * ``parentIndent`` is the indent of the parent KEY (the one whose
+ * value is the list). The dash and child indents are detected
+ * from the first list-item line so 4-space (or other consistent)
+ * user YAML round-trips correctly — the editor's canonical
+ * 2-space emit applies on save, but reads accept any indent the
+ * user chose.
+ *
+ * Returns ``endIdx`` — the line after the block ends — so callers
+ * can fast-forward their loop index. ``isEmptyScalarList`` lets
+ * the top-level caller preserve its existing "skip the assignment
+ * for an empty scalar list" semantic.
+ */
 const parseListBlock = (
   lines: string[],
   startIdx: number,

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -7,6 +7,7 @@
  * read and write — not as a general YAML parser.
  */
 
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import {
   YamlRawValue,
   formatYamlScalar,
@@ -116,7 +117,7 @@ const childRegexFor = (indent: string) =>
 // would over-match `KEY_PATTERN`'s purpose; that constraint
 // applies only to dict keys.
 const listItemRegexFor = (indent: string) =>
-  new RegExp(`^${indent}  -\\s+(.*)$`);
+  new RegExp(`^${indent}${ESPHOME_YAML_INDENT}-\\s+(.*)$`);
 
 const stripQuotes = (s: string): string => {
   if (
@@ -155,6 +156,164 @@ const collectBlockListItems = (
     const m = lines[j].match(itemRegex);
     if (!m) break;
     items.push(stripQuotes(m[1].trim()));
+  }
+  return { items, endIdx: j };
+};
+
+/**
+ * Dispatch a YAML list block (``key:\n  - …``) into the right
+ * value shape: structured array of mappings for editor-friendly
+ * lists (``esphome.devices`` / ``esphome.areas``), ``YamlRawValue``
+ * for complex automation triggers, or ``string[]`` for scalar
+ * lists. Shared between the top-level and nested-block parsers
+ * so both surfaces agree on the dispatch.
+ *
+ * ``parentIndent`` is the indent of the parent KEY (the one whose
+ * value is the list). The dash is one ``ESPHOME_YAML_INDENT`` step
+ * deeper, and child keys inside an item are two steps deeper.
+ *
+ * Returns ``endIdx`` — the line after the block ends — so callers
+ * can fast-forward their loop index. ``isEmptyScalarList`` lets
+ * the top-level caller preserve its existing "skip the assignment
+ * for an empty scalar list" semantic.
+ */
+const parseListBlock = (
+  lines: string[],
+  startIdx: number,
+  parentIndent: string,
+): {
+  value: YamlRawValue | Record<string, unknown>[] | string[];
+  endIdx: number;
+  isEmptyScalarList: boolean;
+} => {
+  const dashIndent = `${parentIndent}${ESPHOME_YAML_INDENT}`;
+  const childIndent = `${dashIndent}${ESPHOME_YAML_INDENT}`;
+  const { endIdx, isComplex } = _scanValueBlock(lines, startIdx, parentIndent);
+  if (isComplex) {
+    // Try parsing as a list of flat key:value mappings first
+    // (``esphome.devices`` / ``esphome.areas`` shape). Falls
+    // through to ``YamlRawValue`` when the block carries
+    // anything the editor can't round-trip cleanly — see
+    // ``collectBlockListMappings``.
+    const mapping = collectBlockListMappings(
+      lines,
+      startIdx,
+      dashIndent,
+      childIndent,
+    );
+    if (mapping) {
+      return {
+        value: mapping.items,
+        endIdx: mapping.endIdx,
+        isEmptyScalarList: false,
+      };
+    }
+    return {
+      value: new YamlRawValue(lines.slice(startIdx, endIdx)),
+      endIdx,
+      isEmptyScalarList: false,
+    };
+  }
+  const { items, endIdx: scalarEndIdx } = collectBlockListItems(
+    lines,
+    startIdx,
+    `${dashIndent}- `,
+    listItemRegexFor(parentIndent),
+  );
+  return {
+    value: items,
+    endIdx: scalarEndIdx,
+    isEmptyScalarList: items.length === 0,
+  };
+};
+
+/**
+ * Parse a single ``key: value`` field of a flat-mapping list item
+ * — used by ``collectBlockListMappings`` for both the inline header
+ * (``- key: value``) and the follow-up child lines. Returns
+ * ``null`` whenever the field carries anything outside the
+ * mapping-list contract (dotted automation-trigger keys, empty
+ * raw values that would open a nested mapping/list, block-scalar
+ * headers). Callers translate ``null`` into "bail out, fall back
+ * to YamlRawValue".
+ */
+const parseFlatMappingField = (
+  key: string,
+  raw: string,
+): { key: string; value: unknown } | null => {
+  // Dotted keys (``logger.log:``, ``switch.turn_on:``) are
+  // automation-action shorthand — not flat-mapping fields. Bail
+  // so the surrounding parser keeps the block as YamlRawValue
+  // and the serializer doesn't quote the dotted key on save.
+  if (key.includes(".")) return null;
+  if (raw === "" || BLOCK_SCALAR_INLINE_RE.test(raw)) return null;
+  return { key, value: parseScalar(raw) };
+};
+
+/**
+ * Collect a YAML list whose items are flat key:value mappings —
+ * ``esphome.devices`` / ``esphome.areas`` and similar
+ * ``multi_value=true`` schema entries — as ``Record<string, unknown>[]``.
+ * Each item starts with ``<dashIndent>-`` and continues at
+ * ``<childIndent>`` (one level deeper than the dash). Returns
+ * ``null`` when the block can't be parsed cleanly into a structured
+ * array — caller should fall back to ``YamlRawValue`` so complex
+ * shapes (block scalars, automation triggers, nested mappings)
+ * still round-trip.
+ *
+ * The helper is deliberately conservative: false negatives drop
+ * back to the existing raw path (no behaviour change), false
+ * positives would silently lose user content on save.
+ */
+const collectBlockListMappings = (
+  lines: string[],
+  startIdx: number,
+  dashIndent: string,
+  childIndent: string,
+): { items: Record<string, unknown>[]; endIdx: number } | null => {
+  const itemHeaderRe = new RegExp(
+    `^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`,
+  );
+  const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
+  const items: Record<string, unknown>[] = [];
+  let j = startIdx;
+  while (j < lines.length) {
+    const line = lines[j];
+    if (line.trim() === "") {
+      j++;
+      continue;
+    }
+    if (!line.startsWith(`${dashIndent}-`)) break;
+    const headerMatch = line.match(itemHeaderRe);
+    if (!headerMatch) return null;
+    const headerField = parseFlatMappingField(
+      headerMatch[1],
+      headerMatch[2].trim(),
+    );
+    if (!headerField) return null;
+    // Same null-prototype defence as the surrounding parser — see
+    // the comment in ``parseYamlSectionValues``.
+    const item: Record<string, unknown> = Object.create(null);
+    item[headerField.key] = headerField.value;
+    j++;
+    while (j < lines.length) {
+      const sub = lines[j];
+      if (sub.trim() === "") {
+        j++;
+        continue;
+      }
+      if (!sub.startsWith(childIndent)) break;
+      // A line strictly deeper than ``childIndent`` is a nested
+      // mapping / list under a sub-key — bail.
+      if (sub.startsWith(`${childIndent} `)) return null;
+      const m = sub.match(childRe);
+      if (!m) return null;
+      const subField = parseFlatMappingField(m[1], m[2].trim());
+      if (!subField) return null;
+      item[subField.key] = subField.value;
+      j++;
+    }
+    items.push(item);
   }
   return { items, endIdx: j };
 };
@@ -264,7 +423,9 @@ export function parseYamlSectionValues(
   if (startIdx < 0) return values;
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
-  const childIndent = isListItem ? "    " : "  ";
+  const childIndent = isListItem
+    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
+    : ESPHOME_YAML_INDENT;
   const childRegex = childRegexFor(childIndent);
 
   // List-item form: the first child key may sit on the same line as
@@ -277,8 +438,7 @@ export function parseYamlSectionValues(
     }
   }
 
-  const listItemPrefix = `${childIndent}  - `;
-  const listItemRegex = listItemRegexFor(childIndent);
+  const listItemPrefix = `${childIndent}${ESPHOME_YAML_INDENT}- `;
   // For list-item-rooted sections: only sibling dashes at the
   // SAME indentation as the leading dash terminate the section.
   // A nested list inside a value (`on_press:` → `      - lambda:`)
@@ -328,39 +488,19 @@ export function parseYamlSectionValues(
       const peekLine = lines[peek];
 
       if (peekLine.startsWith(listItemPrefix)) {
-        // Find the full extent of this key's value-block AND its
-        // complexity in a single forward scan. Complexity can
-        // hide on a follow-up body line — `      - lambda: |-`
-        // looks parseable on its own; the next-line
-        // `          some_code();` body is what triggers raw-mode.
-        const { endIdx, isComplex } = _scanValueBlock(
+        const { value, endIdx, isEmptyScalarList } = parseListBlock(
           lines,
           i + 1,
           childIndent,
         );
-        if (isComplex) {
-          // Slice with `lines.slice(i + 1, endIdx)` to capture
-          // the lines verbatim (with trailing blank lines
-          // trimmed by `_scanValueBlock`'s "next non-blank line
-          // at keyIndent or shallower" terminator).
-          values[key] = new YamlRawValue(lines.slice(i + 1, endIdx));
+        if (!isEmptyScalarList) {
+          values[key] = value;
           i = endIdx - 1;
-          continue;
-        }
-        const { items, endIdx: listEndIdx } = collectBlockListItems(
-          lines,
-          i + 1,
-          listItemPrefix,
-          listItemRegex,
-        );
-        if (items.length > 0) {
-          values[key] = items;
-          i = listEndIdx - 1;
         }
         continue;
       }
 
-      const nestedIndent = `${childIndent}  `;
+      const nestedIndent = `${childIndent}${ESPHOME_YAML_INDENT}`;
       if (peekLine.startsWith(nestedIndent)) {
         const result = parseNestedBlock(lines, i + 1, nestedIndent);
         if (Object.keys(result.values).length > 0) {
@@ -388,8 +528,7 @@ function parseNestedBlock(
   indent: string,
 ): { values: Record<string, unknown>; endIdx: number } {
   const childRegex = childRegexFor(indent);
-  const listItemPrefix = `${indent}  - `;
-  const listItemRegex = listItemRegexFor(indent);
+  const listItemPrefix = `${indent}${ESPHOME_YAML_INDENT}- `;
   // Null-prototype — same prototype-pollution defense as the
   // top-level `parseYamlSectionValues` map; nested blocks recurse
   // into here so they need the same safety.
@@ -426,26 +565,12 @@ function parseNestedBlock(
       let peek = i + 1;
       while (peek < lines.length && lines[peek].trim() === "") peek++;
       if (peek < lines.length && lines[peek].startsWith(listItemPrefix)) {
-        // Same complex-block detection as the top-level parser:
-        // block scalars or sub-dict list items under a key get
-        // captured raw rather than mangled into `string[]`.
-        const { endIdx, isComplex } = _scanValueBlock(lines, i + 1, indent);
-        if (isComplex) {
-          values[key] = new YamlRawValue(lines.slice(i + 1, endIdx));
-          i = endIdx;
-          continue;
-        }
-        const { items, endIdx: listEndIdx } = collectBlockListItems(
-          lines,
-          i + 1,
-          listItemPrefix,
-          listItemRegex,
-        );
-        values[key] = items;
-        i = listEndIdx;
+        const { value, endIdx } = parseListBlock(lines, i + 1, indent);
+        values[key] = value;
+        i = endIdx;
         continue;
       }
-      const deeper = `${indent}  `;
+      const deeper = `${indent}${ESPHOME_YAML_INDENT}`;
       if (peek < lines.length && lines[peek].startsWith(deeper)) {
         const sub = parseNestedBlock(lines, i + 1, deeper);
         if (Object.keys(sub.values).length > 0) values[key] = sub.values;
@@ -535,7 +660,9 @@ export function updateSectionInYaml(
   if (start < 0) return yaml;
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
-  const childIndent = isListItem ? "    " : "  ";
+  const childIndent = isListItem
+    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
+    : ESPHOME_YAML_INDENT;
   let toSerialize = values;
   let dashLine = lines[start];
   if (isListItem) {

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -99,6 +99,20 @@ const BLOCK_SCALAR_RE = /^[^"']*:\s*[|>][-+]?\s*(?:#.*)?$/;
 const BLOCK_SCALAR_INLINE_RE = /^[|>][-+]?$/;
 
 /**
+ * Match a bare-dash list item (``    -`` followed by EOL or only
+ * whitespace). The serializer emits this shape as a placeholder
+ * for an empty mapping item — a freshly-added Add row the user
+ * saved before filling fields. Without flagging it as a
+ * complexity signal the scalar-list branch in ``parseListBlock``
+ * runs (``- `` regex misses the bare dash, items=0), the key is
+ * dropped from the values dict, and the user's empty row vanishes
+ * on save. Marking it complex routes the block through
+ * ``collectBlockListMappings`` which already treats bare dashes
+ * as ``{}`` placeholders.
+ */
+const LIST_ITEM_BARE_DASH_RE = /^\s+-\s*$/;
+
+/**
  * Match a list item whose value is a key-style sub-dict header
  * (`- then:`, `- lambda:`, `- logger.log: pressed`,
  * `- switch.turn_on: relay`). The dash + key + colon shape is the
@@ -588,7 +602,11 @@ const _scanValueBlock = (
     const lead = line.match(/^ */)![0];
     if (lead.length <= keyIndent.length) return { endIdx: i, isComplex };
     if (!isComplex) {
-      if (BLOCK_SCALAR_RE.test(line) || LIST_ITEM_DICT_KEY_RE.test(line)) {
+      if (
+        BLOCK_SCALAR_RE.test(line) ||
+        LIST_ITEM_DICT_KEY_RE.test(line) ||
+        LIST_ITEM_BARE_DASH_RE.test(line)
+      ) {
         isComplex = true;
       }
     }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -145,16 +145,15 @@ const _detectSectionChildIndent = (
   startIdx: number,
   isListItem: boolean,
 ): string => {
-  // For list-item sections the dash sits at the section's leading
-  // whitespace, and child keys live one level deeper than the
-  // dash itself. Use the dash's column as the floor so a
-  // ``  - id: …`` section doesn't pick up the dash line as its
-  // own child indent.
+  // The "floor" is the column a child line must beat to count as a
+  // child of this section. For non-list sections that's the
+  // section header's leading whitespace; for list-item sections
+  // it's one column past the dash itself, so a child key (which
+  // sits at ``dash + 2 columns``) clears the floor while a
+  // sibling dash (same column as ours) doesn't.
   const headLine = lines[startIdx];
   const sectionLead = isListItem
-    ? _leadingIndent(headLine).length +
-      (headLine.indexOf("-") - _leadingIndent(headLine).length) +
-      1 // dash + space
+    ? headLine.indexOf("-") + 1
     : _leadingIndent(headLine).length;
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i];
@@ -393,6 +392,24 @@ const parseFlatMappingField = (
 };
 
 /**
+ * Match *line* against *re* (one of the two ``key: value`` regexes
+ * built by :func:`collectBlockListMappings`) and run the captured
+ * key + raw value through :func:`parseFlatMappingField`. Returns
+ * ``null`` for any failure — regex miss, dotted key, block scalar,
+ * empty raw — which all share the same "bail out, fall back to
+ * YamlRawValue" semantic at the caller. Centralised so the inline
+ * header (``- key: value``) and child-line (``  key: value``)
+ * paths share one match-and-validate step.
+ */
+const _matchFlatMappingField = (
+  line: string,
+  re: RegExp,
+): { key: string; value: unknown } | null => {
+  const m = line.match(re);
+  return m ? parseFlatMappingField(m[1], m[2].trim()) : null;
+};
+
+/**
  * Collect a YAML list whose items are flat key:value mappings —
  * ``esphome.devices`` / ``esphome.areas`` and similar
  * ``multi_value=true`` schema entries — as ``Record<string, unknown>[]``.
@@ -413,12 +430,14 @@ const collectBlockListMappings = (
   dashIndent: string,
   childIndent: string,
 ): { items: Record<string, unknown>[]; endIdx: number } | null => {
-  const itemHeaderRe = new RegExp(
+  const headerRe = new RegExp(
     `^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`,
   );
   const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
+  const bareDash = `${dashIndent}-`;
   const items: Record<string, unknown>[] = [];
   let j = startIdx;
+
   while (j < lines.length) {
     const line = lines[j];
     if (line.trim() === "") {
@@ -426,29 +445,24 @@ const collectBlockListMappings = (
       continue;
     }
     if (!isListItemLine(line, dashIndent)) break;
+
     // Same null-prototype defence as the surrounding parser — see
     // the comment in ``parseYamlSectionValues``.
     const item: Record<string, unknown> = Object.create(null);
-    // Bare ``${dashIndent}-`` (no inline key) is the serializer's
-    // placeholder for an empty mapping item — a freshly-added Add
-    // row the user saved before filling in any fields. Treat it
-    // as ``{}`` so the row survives the round-trip; the renderer
-    // re-paints it on reload and the user's "in-progress" item
-    // doesn't silently vanish.
-    if (line === `${dashIndent}-`) {
-      items.push(item);
-      j++;
-      continue;
+
+    // Bare ``${dashIndent}-`` is the serializer's placeholder for
+    // an empty mapping item (a freshly-added Add row the user saved
+    // before filling fields). Skip the header parse and let the
+    // child loop run — for a bare dash there are no sibling sub
+    // keys, so the item stays ``{}`` and the row survives the
+    // round-trip.
+    if (line !== bareDash) {
+      const header = _matchFlatMappingField(line, headerRe);
+      if (!header) return null;
+      item[header.key] = header.value;
     }
-    const headerMatch = line.match(itemHeaderRe);
-    if (!headerMatch) return null;
-    const headerField = parseFlatMappingField(
-      headerMatch[1],
-      headerMatch[2].trim(),
-    );
-    if (!headerField) return null;
-    item[headerField.key] = headerField.value;
     j++;
+
     while (j < lines.length) {
       const sub = lines[j];
       if (sub.trim() === "") {
@@ -459,11 +473,9 @@ const collectBlockListMappings = (
       // A line strictly deeper than ``childIndent`` is a nested
       // mapping / list under a sub-key — bail.
       if (sub.startsWith(`${childIndent} `)) return null;
-      const m = sub.match(childRe);
-      if (!m) return null;
-      const subField = parseFlatMappingField(m[1], m[2].trim());
-      if (!subField) return null;
-      item[subField.key] = subField.value;
+      const child = _matchFlatMappingField(sub, childRe);
+      if (!child) return null;
+      item[child.key] = child.value;
       j++;
     }
     items.push(item);
@@ -904,12 +916,19 @@ export function updateSectionInYaml(
       }
     }
   }
-  // Derive the user's indent step from the detected childIndent so
-  // saves preserve their chosen step end-to-end (top-level fields
-  // AND nested mapping recursion AND list-item shapes).
-  const detectedStep = isListItem
-    ? " ".repeat(Math.max(2, childIndent.length / 2))
-    : childIndent || ESPHOME_YAML_INDENT;
+  // For non-list-item sections the user's indent step IS the
+  // section's child indent (top-level keys at column 0, children
+  // at one step deeper). Pass that through so nested-mapping
+  // recursion preserves the user's chosen step end-to-end.
+  //
+  // For list-item sections the picture is messier — child keys
+  // align with the inline first key after the dash, not at a
+  // step-multiple — and there's no clean "user step" to read off.
+  // Default to canonical 2-space; the round-trip stays
+  // valid-and-readable even when the surrounding file uses a
+  // different step elsewhere.
+  const detectedStep =
+    !isListItem && childIndent ? childIndent : ESPHOME_YAML_INDENT;
   const newLines = [
     dashLine,
     ...serializeYamlValues(toSerialize, childIndent, {

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -36,6 +36,17 @@ import {
 const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
 
 /**
+ * Matches a line that begins a top-level YAML section (column-0
+ * identifier). Mirrors ``KEY_PATTERN``'s leading-character set —
+ * accepts ``_internal:`` and similar underscore-leading keys, not
+ * just ASCII letters. Used by every "stop at the next sibling
+ * section" terminator in this module so the predicate stays
+ * consistent — drift between sites would let one walk past a
+ * section header another walk treats as a hard stop.
+ */
+const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_]/;
+
+/**
  * Match the inline-key form on a YAML list-item line
  * (`  - platform: esphome`). Capture group 1 is the key.
  *
@@ -145,35 +156,30 @@ const _detectSectionChildIndent = (
   startIdx: number,
   isListItem: boolean,
 ): string => {
-  // The "floor" is the column a child line must beat to count as a
-  // child of this section. For non-list sections that's the
-  // section header's leading whitespace; for list-item sections
-  // it's one column past the dash itself, so a child key (which
-  // sits at ``dash + 2 columns``) clears the floor while a
-  // sibling dash (same column as ours) doesn't.
+  // The "floor" is the column a child line must strictly beat. For
+  // map sections that's the section header's leading whitespace;
+  // for list-item sections it's one column past the dash, so a
+  // child key (at ``dash + 2``) clears it while a sibling dash
+  // (same column as ours) doesn't.
   const headLine = lines[startIdx];
-  const sectionLead = isListItem
+  const floor = isListItem
     ? headLine.indexOf("-") + 1
     : _leadingIndent(headLine).length;
+  const fallback = isListItem
+    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
+    : ESPHOME_YAML_INDENT;
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
-    if (/^[a-zA-Z]/.test(line)) break; // sibling section
+    // Column-0 identifier ⇒ sibling section, this section has no
+    // children of its own.
+    if (TOP_LEVEL_KEY_START_RE.test(line)) return fallback;
     const lead = _leadingIndent(line);
-    if (lead.length <= sectionLead) {
-      // For list-item sections, a sibling dash at the same
-      // column as ours terminates the section.
-      if (isListItem) break;
-      // For map sections, a back-out terminates without contributing.
-      break;
-    }
-    return lead;
+    if (lead.length > floor) return lead;
+    // Sibling dash (list-item) or back-out (map) — done scanning.
+    return fallback;
   }
-  // Fallback to canonical 2-space — keeps existing behaviour for
-  // empty sections / EOF.
-  return isListItem
-    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
-    : ESPHOME_YAML_INDENT;
+  return fallback;
 };
 
 /**
@@ -299,6 +305,33 @@ const collectBlockListItems = (
  * the top-level caller preserve its existing "skip the assignment
  * for an empty scalar list" semantic.
  */
+/**
+ * Find the leading whitespace of the first list-item dash at or
+ * after *startIdx*. Returns *fallback* when no dash is reachable
+ * (the block is blank or terminates before any item) and the
+ * 0-indexed line of the first dash so the caller can hand it to
+ * :func:`_detectListItemChildIndent`.
+ */
+const _detectFirstDashIndent = (
+  lines: string[],
+  startIdx: number,
+  fallback: string,
+): { dashIndent: string; firstDashIdx: number } => {
+  let firstDashIdx = startIdx;
+  while (
+    firstDashIdx < lines.length &&
+    lines[firstDashIdx].trim() === ""
+  ) {
+    firstDashIdx++;
+  }
+  if (firstDashIdx >= lines.length) {
+    return { dashIndent: fallback, firstDashIdx };
+  }
+  const dashIndent =
+    lines[firstDashIdx].match(/^( *)-/)?.[1] ?? fallback;
+  return { dashIndent, firstDashIdx };
+};
+
 const parseListBlock = (
   lines: string[],
   startIdx: number,
@@ -308,34 +341,23 @@ const parseListBlock = (
   endIdx: number;
   isEmptyScalarList: boolean;
 } => {
-  // Find the first non-blank line to read the dash indent from.
-  let firstDashIdx = startIdx;
-  while (
-    firstDashIdx < lines.length &&
-    lines[firstDashIdx].trim() === ""
-  ) {
-    firstDashIdx++;
-  }
-  const dashIndent =
-    firstDashIdx < lines.length
-      ? lines[firstDashIdx].match(/^( *)-/)?.[1] ??
-        `${parentIndent}${ESPHOME_YAML_INDENT}`
-      : `${parentIndent}${ESPHOME_YAML_INDENT}`;
-  // Child keys inside an item live one indent step deeper than
-  // the dash. Detect from a follow-up sub-line when one's
-  // available; fall back to "dash + 2 spaces" (matches ESPHome's
-  // canonical emit) when the first item is bare or the only
-  // line.
+  const canonicalDashIndent = `${parentIndent}${ESPHOME_YAML_INDENT}`;
+  const { dashIndent, firstDashIdx } = _detectFirstDashIndent(
+    lines,
+    startIdx,
+    canonicalDashIndent,
+  );
   const childIndent =
     _detectListItemChildIndent(lines, firstDashIdx + 1, dashIndent) ??
     `${dashIndent}${ESPHOME_YAML_INDENT}`;
   const { endIdx, isComplex } = _scanValueBlock(lines, startIdx, parentIndent);
+
+  // Complex blocks are anything beyond a flat scalar list (block
+  // scalars, automation triggers, mapping items). Try the
+  // structured-mapping parse first (``esphome.devices`` /
+  // ``esphome.areas``); fall through to ``YamlRawValue`` for
+  // shapes the editor can't round-trip.
   if (isComplex) {
-    // Try parsing as a list of flat key:value mappings first
-    // (``esphome.devices`` / ``esphome.areas`` shape). Falls
-    // through to ``YamlRawValue`` when the block carries
-    // anything the editor can't round-trip cleanly — see
-    // ``collectBlockListMappings``.
     const mapping = collectBlockListMappings(
       lines,
       startIdx,
@@ -355,6 +377,8 @@ const parseListBlock = (
       isEmptyScalarList: false,
     };
   }
+
+  // Flat scalar list (``packages: [- a, - b]``).
   const { items, endIdx: scalarEndIdx } = collectBlockListItems(
     lines,
     startIdx,
@@ -410,6 +434,42 @@ const _matchFlatMappingField = (
 };
 
 /**
+ * Walk follow-up sub-key lines under a list-item dash and merge
+ * them into *item*. Stops at the next sibling dash, blank-then-EOF,
+ * or a back-out. Returns the line index after the last sub-key,
+ * or ``null`` if anything outside the flat-mapping contract turned
+ * up (line strictly deeper than ``childIndent`` ⇒ nested mapping;
+ * unmatched key shape; dotted key; block scalar; empty raw).
+ * Mutates *item* in place — keeps the caller's outer loop from
+ * having to thread two return values.
+ */
+const _parseItemSubKeys = (
+  lines: string[],
+  startIdx: number,
+  childIndent: string,
+  childRe: RegExp,
+  item: Record<string, unknown>,
+): number | null => {
+  let j = startIdx;
+  while (j < lines.length) {
+    const sub = lines[j];
+    if (sub.trim() === "") {
+      j++;
+      continue;
+    }
+    if (!sub.startsWith(childIndent)) break;
+    // Strictly deeper than ``childIndent`` ⇒ nested mapping/list
+    // under a sub-key — bail.
+    if (sub.startsWith(`${childIndent} `)) return null;
+    const field = _matchFlatMappingField(sub, childRe);
+    if (!field) return null;
+    item[field.key] = field.value;
+    j++;
+  }
+  return j;
+};
+
+/**
  * Collect a YAML list whose items are flat key:value mappings —
  * ``esphome.devices`` / ``esphome.areas`` and similar
  * ``multi_value=true`` schema entries — as ``Record<string, unknown>[]``.
@@ -451,34 +511,21 @@ const collectBlockListMappings = (
     const item: Record<string, unknown> = Object.create(null);
 
     // Bare ``${dashIndent}-`` is the serializer's placeholder for
-    // an empty mapping item (a freshly-added Add row the user saved
-    // before filling fields). Skip the header parse and let the
-    // child loop run — for a bare dash there are no sibling sub
-    // keys, so the item stays ``{}`` and the row survives the
-    // round-trip.
+    // an empty mapping item (a freshly-added Add row saved before
+    // any fields were filled in). The header parse runs only for
+    // the with-content shape; bare-dash items skip it and the
+    // sub-key walk finds no follow-ups, so the item stays ``{}``
+    // and the row survives the round-trip.
     if (line !== bareDash) {
       const header = _matchFlatMappingField(line, headerRe);
       if (!header) return null;
       item[header.key] = header.value;
     }
-    j++;
 
-    while (j < lines.length) {
-      const sub = lines[j];
-      if (sub.trim() === "") {
-        j++;
-        continue;
-      }
-      if (!sub.startsWith(childIndent)) break;
-      // A line strictly deeper than ``childIndent`` is a nested
-      // mapping / list under a sub-key — bail.
-      if (sub.startsWith(`${childIndent} `)) return null;
-      const child = _matchFlatMappingField(sub, childRe);
-      if (!child) return null;
-      item[child.key] = child.value;
-      j++;
-    }
+    const after = _parseItemSubKeys(lines, j + 1, childIndent, childRe, item);
+    if (after === null) return null;
     items.push(item);
+    j = after;
   }
   return { items, endIdx: j };
 };
@@ -623,8 +670,8 @@ export function parseYamlSectionValues(
     if (isListItem) {
       const dashMatch = line.match(/^(\s*)-(\s|$)/);
       if (dashMatch && dashMatch[1].length === siblingDashIndent) break;
-      if (/^[a-zA-Z]/.test(line)) break;
-    } else if (/^[a-zA-Z]/.test(line)) {
+      if (TOP_LEVEL_KEY_START_RE.test(line)) break;
+    } else if (TOP_LEVEL_KEY_START_RE.test(line)) {
       break;
     }
 
@@ -799,11 +846,11 @@ export function findSectionRange(
         end = i;
         break;
       }
-      if (/^[a-zA-Z]/.test(lines[i])) {
+      if (TOP_LEVEL_KEY_START_RE.test(lines[i])) {
         end = i;
         break;
       }
-    } else if (/^[a-zA-Z]/.test(lines[i])) {
+    } else if (TOP_LEVEL_KEY_START_RE.test(lines[i])) {
       end = i;
       break;
     }
@@ -974,14 +1021,14 @@ export function removeSectionFromYaml(
     // Walk backwards to the parent top-level key; if nothing but
     // blanks remain between it and the next sibling, drop it too.
     let parentIdx = start - 1;
-    while (parentIdx >= 0 && !/^[a-zA-Z]/.test(lines[parentIdx])) {
+    while (parentIdx >= 0 && !TOP_LEVEL_KEY_START_RE.test(lines[parentIdx])) {
       parentIdx--;
     }
     if (parentIdx >= 0) {
       let hasContent = false;
       let parentEnd = lines.length;
       for (let i = parentIdx + 1; i < lines.length; i++) {
-        if (/^[a-zA-Z]/.test(lines[i])) {
+        if (TOP_LEVEL_KEY_START_RE.test(lines[i])) {
           parentEnd = i;
           break;
         }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -126,9 +126,12 @@ const childRegexFor = (indent: string) =>
 // scalar (string with spaces, number, !secret reference) and we
 // just round-trip it. Validating the leading-token shape here
 // would over-match `KEY_PATTERN`'s purpose; that constraint
-// applies only to dict keys.
-const listItemRegexFor = (indent: string) =>
-  new RegExp(`^${indent}${ESPHOME_YAML_INDENT}-\\s+(.*)$`);
+// applies only to dict keys. The argument is the indent BEFORE
+// the dash (detected from the actual list content by the caller),
+// not the parent key's indent — a 4-space user file puts the
+// dash at ``parent + 4``, not the canonical ``parent + 2``.
+const listItemRegexFor = (dashIndent: string) =>
+  new RegExp(`^${dashIndent}-\\s+(.*)$`);
 
 /**
  * Measure the leading whitespace on *line* — used to detect the
@@ -378,12 +381,16 @@ const parseListBlock = (
     };
   }
 
-  // Flat scalar list (``packages: [- a, - b]``).
+  // Flat scalar list (``packages: [- a, - b]``). Both the
+  // startsWith prefix and the line regex use the detected
+  // ``dashIndent`` so 4-space user YAMLs round-trip — the older
+  // ``listItemRegexFor(parentIndent)`` hardcoded the canonical
+  // 2-space step and silently dropped scalar lists otherwise.
   const { items, endIdx: scalarEndIdx } = collectBlockListItems(
     lines,
     startIdx,
     `${dashIndent}- `,
-    listItemRegexFor(parentIndent),
+    listItemRegexFor(dashIndent),
   );
   return {
     value: items,

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -119,6 +119,126 @@ const childRegexFor = (indent: string) =>
 const listItemRegexFor = (indent: string) =>
   new RegExp(`^${indent}${ESPHOME_YAML_INDENT}-\\s+(.*)$`);
 
+/**
+ * Measure the leading whitespace on *line* — used to detect the
+ * actual indent the user's YAML uses for the first child of a
+ * section. The parser is tied to ESPHome's emit format (2 spaces
+ * per level) at write time, but reads must accept any consistent
+ * indent: a user-typed 4-space file is just as valid as the
+ * 2-space canonical form, and pasting one into the editor
+ * shouldn't silently come back empty.
+ */
+const _leadingIndent = (line: string): string =>
+  line.match(/^ */)![0];
+
+/**
+ * Walk forward from *startIdx* and return the indent of the first
+ * line that's a child of the section that starts at *startIdx*.
+ * "Child" means deeper-indented than the section's leading
+ * whitespace and not a sibling section header (a column-0
+ * identifier line). Returns the canonical 2-space indent when
+ * the section has no readable children — the empty case where
+ * the parser has nothing to learn from.
+ */
+const _detectSectionChildIndent = (
+  lines: string[],
+  startIdx: number,
+  isListItem: boolean,
+): string => {
+  // For list-item sections the dash sits at the section's leading
+  // whitespace, and child keys live one level deeper than the
+  // dash itself. Use the dash's column as the floor so a
+  // ``  - id: …`` section doesn't pick up the dash line as its
+  // own child indent.
+  const headLine = lines[startIdx];
+  const sectionLead = isListItem
+    ? _leadingIndent(headLine).length +
+      (headLine.indexOf("-") - _leadingIndent(headLine).length) +
+      1 // dash + space
+    : _leadingIndent(headLine).length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (/^[a-zA-Z]/.test(line)) break; // sibling section
+    const lead = _leadingIndent(line);
+    if (lead.length <= sectionLead) {
+      // For list-item sections, a sibling dash at the same
+      // column as ours terminates the section.
+      if (isListItem) break;
+      // For map sections, a back-out terminates without contributing.
+      break;
+    }
+    return lead;
+  }
+  // Fallback to canonical 2-space — keeps existing behaviour for
+  // empty sections / EOF.
+  return isListItem
+    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
+    : ESPHOME_YAML_INDENT;
+};
+
+/**
+ * Find the indent of the first sub-key inside a list item — the
+ * line just under ``${dashIndent}- key: …`` that starts at a
+ * deeper column. Returns ``null`` when the item has no
+ * follow-up sub-keys before the next sibling dash (a single-key
+ * item or a freshly-added bare-dash placeholder); the caller
+ * falls back to a canonical 2-space step in that case.
+ */
+const _detectListItemChildIndent = (
+  lines: string[],
+  startIdx: number,
+  dashIndent: string,
+): string | null => {
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    const lead = _leadingIndent(line);
+    // A sibling dash (or shallower) terminates this item.
+    if (lead.length <= dashIndent.length) return null;
+    // Skip nested list items (``      - ``) under this item —
+    // those are not the item's own child keys.
+    if (line[lead.length] === "-") continue;
+    return lead;
+  }
+  return null;
+};
+
+/**
+ * True when *line* is a list-item dash at *dashIndent*. Accepts
+ * both ``${dashIndent}- ``  (item with content) and the bare
+ * ``${dashIndent}-`` followed by EOL (the placeholder shape the
+ * serializer emits for an empty mapping item — a freshly-added
+ * Add-button row the user hasn't filled in yet). Without the
+ * bare-dash branch the parser would skip the empty row on
+ * reload and the user's freshly-added item would silently
+ * vanish.
+ */
+const isListItemLine = (line: string, dashIndent: string): boolean => {
+  const prefix = `${dashIndent}-`;
+  if (!line.startsWith(prefix)) return false;
+  const trailing = line.slice(prefix.length);
+  return trailing === "" || trailing.startsWith(" ");
+};
+
+/**
+ * True when *line* is a list-item dash deeper than *parentIndent*.
+ * The exact dash column doesn't matter at peek time — that's
+ * detected later by ``parseListBlock`` from the actual line —
+ * so the peek check only needs to confirm "this is a child
+ * list of the current key, regardless of which indent step the
+ * user picked". 4-space YAML pastes work as a result.
+ */
+const isDeeperListItemLine = (
+  line: string,
+  parentIndent: string,
+): boolean => {
+  const lead = _leadingIndent(line);
+  if (lead.length <= parentIndent.length) return false;
+  const tail = line.slice(lead.length);
+  return tail === "-" || tail.startsWith("- ");
+};
+
 const stripQuotes = (s: string): string => {
   if (
     (s.startsWith('"') && s.endsWith('"')) ||
@@ -169,8 +289,11 @@ const collectBlockListItems = (
  * so both surfaces agree on the dispatch.
  *
  * ``parentIndent`` is the indent of the parent KEY (the one whose
- * value is the list). The dash is one ``ESPHOME_YAML_INDENT`` step
- * deeper, and child keys inside an item are two steps deeper.
+ * value is the list). The dash and child indents are detected
+ * from the first list-item line so 4-space (or other consistent)
+ * user YAML round-trips correctly — the editor's canonical
+ * 2-space emit applies on save, but reads accept any indent the
+ * user chose.
  *
  * Returns ``endIdx`` — the line after the block ends — so callers
  * can fast-forward their loop index. ``isEmptyScalarList`` lets
@@ -186,8 +309,27 @@ const parseListBlock = (
   endIdx: number;
   isEmptyScalarList: boolean;
 } => {
-  const dashIndent = `${parentIndent}${ESPHOME_YAML_INDENT}`;
-  const childIndent = `${dashIndent}${ESPHOME_YAML_INDENT}`;
+  // Find the first non-blank line to read the dash indent from.
+  let firstDashIdx = startIdx;
+  while (
+    firstDashIdx < lines.length &&
+    lines[firstDashIdx].trim() === ""
+  ) {
+    firstDashIdx++;
+  }
+  const dashIndent =
+    firstDashIdx < lines.length
+      ? lines[firstDashIdx].match(/^( *)-/)?.[1] ??
+        `${parentIndent}${ESPHOME_YAML_INDENT}`
+      : `${parentIndent}${ESPHOME_YAML_INDENT}`;
+  // Child keys inside an item live one indent step deeper than
+  // the dash. Detect from a follow-up sub-line when one's
+  // available; fall back to "dash + 2 spaces" (matches ESPHome's
+  // canonical emit) when the first item is bare or the only
+  // line.
+  const childIndent =
+    _detectListItemChildIndent(lines, firstDashIdx + 1, dashIndent) ??
+    `${dashIndent}${ESPHOME_YAML_INDENT}`;
   const { endIdx, isComplex } = _scanValueBlock(lines, startIdx, parentIndent);
   if (isComplex) {
     // Try parsing as a list of flat key:value mappings first
@@ -283,7 +425,21 @@ const collectBlockListMappings = (
       j++;
       continue;
     }
-    if (!line.startsWith(`${dashIndent}-`)) break;
+    if (!isListItemLine(line, dashIndent)) break;
+    // Same null-prototype defence as the surrounding parser — see
+    // the comment in ``parseYamlSectionValues``.
+    const item: Record<string, unknown> = Object.create(null);
+    // Bare ``${dashIndent}-`` (no inline key) is the serializer's
+    // placeholder for an empty mapping item — a freshly-added Add
+    // row the user saved before filling in any fields. Treat it
+    // as ``{}`` so the row survives the round-trip; the renderer
+    // re-paints it on reload and the user's "in-progress" item
+    // doesn't silently vanish.
+    if (line === `${dashIndent}-`) {
+      items.push(item);
+      j++;
+      continue;
+    }
     const headerMatch = line.match(itemHeaderRe);
     if (!headerMatch) return null;
     const headerField = parseFlatMappingField(
@@ -291,9 +447,6 @@ const collectBlockListMappings = (
       headerMatch[2].trim(),
     );
     if (!headerField) return null;
-    // Same null-prototype defence as the surrounding parser — see
-    // the comment in ``parseYamlSectionValues``.
-    const item: Record<string, unknown> = Object.create(null);
     item[headerField.key] = headerField.value;
     j++;
     while (j < lines.length) {
@@ -423,9 +576,12 @@ export function parseYamlSectionValues(
   if (startIdx < 0) return values;
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
-  const childIndent = isListItem
-    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
-    : ESPHOME_YAML_INDENT;
+  // Detect the indent the user actually picked for this
+  // section's children so 4-space (or other consistent) YAMLs
+  // round-trip through the editor without coming back empty.
+  // Falls back to ESPHome's canonical 2-space step on empty
+  // sections.
+  const childIndent = _detectSectionChildIndent(lines, startIdx, isListItem);
   const childRegex = childRegexFor(childIndent);
 
   // List-item form: the first child key may sit on the same line as
@@ -438,7 +594,6 @@ export function parseYamlSectionValues(
     }
   }
 
-  const listItemPrefix = `${childIndent}${ESPHOME_YAML_INDENT}- `;
   // For list-item-rooted sections: only sibling dashes at the
   // SAME indentation as the leading dash terminate the section.
   // A nested list inside a value (`on_press:` → `      - lambda:`)
@@ -487,7 +642,7 @@ export function parseYamlSectionValues(
       if (peek >= lines.length) continue;
       const peekLine = lines[peek];
 
-      if (peekLine.startsWith(listItemPrefix)) {
+      if (isDeeperListItemLine(peekLine, childIndent)) {
         const { value, endIdx, isEmptyScalarList } = parseListBlock(
           lines,
           i + 1,
@@ -500,9 +655,11 @@ export function parseYamlSectionValues(
         continue;
       }
 
-      const nestedIndent = `${childIndent}${ESPHOME_YAML_INDENT}`;
-      if (peekLine.startsWith(nestedIndent)) {
-        const result = parseNestedBlock(lines, i + 1, nestedIndent);
+      // Read the deeper indent from the peek line itself so a
+      // user-typed 4-space file recurses correctly.
+      const peekLead = _leadingIndent(peekLine);
+      if (peekLead.length > childIndent.length) {
+        const result = parseNestedBlock(lines, i + 1, peekLead);
         if (Object.keys(result.values).length > 0) {
           values[key] = result.values;
         }
@@ -528,7 +685,6 @@ function parseNestedBlock(
   indent: string,
 ): { values: Record<string, unknown>; endIdx: number } {
   const childRegex = childRegexFor(indent);
-  const listItemPrefix = `${indent}${ESPHOME_YAML_INDENT}- `;
   // Null-prototype — same prototype-pollution defense as the
   // top-level `parseYamlSectionValues` map; nested blocks recurse
   // into here so they need the same safety.
@@ -564,18 +720,23 @@ function parseNestedBlock(
     if (raw === "") {
       let peek = i + 1;
       while (peek < lines.length && lines[peek].trim() === "") peek++;
-      if (peek < lines.length && lines[peek].startsWith(listItemPrefix)) {
+      if (
+        peek < lines.length &&
+        isDeeperListItemLine(lines[peek], indent)
+      ) {
         const { value, endIdx } = parseListBlock(lines, i + 1, indent);
         values[key] = value;
         i = endIdx;
         continue;
       }
-      const deeper = `${indent}${ESPHOME_YAML_INDENT}`;
-      if (peek < lines.length && lines[peek].startsWith(deeper)) {
-        const sub = parseNestedBlock(lines, i + 1, deeper);
-        if (Object.keys(sub.values).length > 0) values[key] = sub.values;
-        i = sub.endIdx;
-        continue;
+      if (peek < lines.length) {
+        const peekLead = _leadingIndent(lines[peek]);
+        if (peekLead.length > indent.length) {
+          const sub = parseNestedBlock(lines, i + 1, peekLead);
+          if (Object.keys(sub.values).length > 0) values[key] = sub.values;
+          i = sub.endIdx;
+          continue;
+        }
       }
       i++;
       continue;
@@ -660,9 +821,11 @@ export function updateSectionInYaml(
   if (start < 0) return yaml;
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
-  const childIndent = isListItem
-    ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
-    : ESPHOME_YAML_INDENT;
+  // Match the user's existing indent step on save so 4-space (or
+  // other consistent) YAML doesn't get re-emitted with a mixed
+  // 2-space slice. Falls back to the canonical 2-space step when
+  // the section is otherwise empty.
+  const childIndent = _detectSectionChildIndent(lines, start, isListItem);
   let toSerialize = values;
   let dashLine = lines[start];
   if (isListItem) {
@@ -741,9 +904,18 @@ export function updateSectionInYaml(
       }
     }
   }
+  // Derive the user's indent step from the detected childIndent so
+  // saves preserve their chosen step end-to-end (top-level fields
+  // AND nested mapping recursion AND list-item shapes).
+  const detectedStep = isListItem
+    ? " ".repeat(Math.max(2, childIndent.length / 2))
+    : childIndent || ESPHOME_YAML_INDENT;
   const newLines = [
     dashLine,
-    ...serializeYamlValues(toSerialize, childIndent, options),
+    ...serializeYamlValues(toSerialize, childIndent, {
+      ...options,
+      indentStep: options.indentStep ?? detectedStep,
+    }),
   ];
   lines.splice(start, end - start, ...newLines);
   return lines.join("\n");

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -13,6 +13,8 @@
  * dependency checks against the user's current configuration.
  */
 
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+
 /**
  * Opaque wrapper for a section-value block the parser couldn't fully
  * model — block scalars (`lambda: |-`), automation handlers with
@@ -142,6 +144,15 @@ export interface SerializeYamlOptions {
    * existing empty-string substitution.)
    */
   keepEmptyStrings?: boolean;
+  /**
+   * Indent step for one level deeper. Defaults to
+   * ``ESPHOME_YAML_INDENT`` (two spaces, the canonical emit
+   * format). Pass the user's detected step (e.g. ``"    "`` for
+   * a 4-space file) so saves preserve the surrounding YAML's
+   * indentation instead of splicing canonical 2-space content
+   * into a 4-space file.
+   */
+  indentStep?: string;
 }
 
 /**
@@ -157,12 +168,18 @@ export interface SerializeYamlOptions {
  * ``${indent}    other_key: value`` for each remaining field;
  * scalar items keep the legacy ``${indent}  - value`` shape.
  *
- * Mapping items are filtered through the same skip rules as the
- * top-level serializer (``undefined`` / ``null`` / empty-string
- * unless ``keepEmptyStrings``) so a freshly-added empty item
- * doesn't emit a bare dash. ``YamlRawValue`` values inside an
- * item are emitted with the same inline-header / body shape as
- * the top-level branch.
+ * Per-field skip rules match the top-level serializer
+ * (``undefined`` / ``null`` / empty-string unless
+ * ``keepEmptyStrings``). When all fields are filtered out — or
+ * the item is literally ``{}`` (a freshly-added Add row the user
+ * hasn't filled yet) — emit a bare ``${indent}  -`` placeholder
+ * so the row survives the round-trip. The parser's
+ * ``collectBlockListMappings`` recognises bare dashes and
+ * rebuilds the empty mapping on reload; without the placeholder
+ * the user's in-progress row would silently vanish.
+ *
+ * ``YamlRawValue`` values inside an item are emitted with the
+ * same inline-header / body shape as the top-level branch.
  */
 function serializeListItem(
   item: unknown,
@@ -170,14 +187,15 @@ function serializeListItem(
   options: SerializeYamlOptions,
 ): string[] {
   const keepEmpty = options.keepEmptyStrings === true;
+  const step = options.indentStep ?? ESPHOME_YAML_INDENT;
+  const dashIndent = `${indent}${step}`;
   if (item !== null && typeof item === "object" && !Array.isArray(item)) {
     const entries = Object.entries(item as Record<string, unknown>).filter(
       ([, v]) => v !== undefined && v !== null && (v !== "" || keepEmpty),
     );
-    if (entries.length === 0) return [`${indent}  -`];
+    if (entries.length === 0) return [`${dashIndent}-`];
     const lines: string[] = [];
-    const dashIndent = `${indent}  `;
-    const childIndent = `${dashIndent}  `;
+    const childIndent = `${dashIndent}${step}`;
     entries.forEach(([k, v], idx) => {
       const prefix = idx === 0 ? `${dashIndent}- ` : childIndent;
       if (v instanceof YamlRawValue) {
@@ -190,7 +208,7 @@ function serializeListItem(
     });
     return lines;
   }
-  return [`${indent}  - ${formatYamlScalar(item)}`];
+  return [`${dashIndent}- ${formatYamlScalar(item)}`];
 }
 
 export function serializeYamlValues(
@@ -200,6 +218,7 @@ export function serializeYamlValues(
 ): string[] {
   const lines: string[] = [];
   const keepEmpty = options.keepEmptyStrings === true;
+  const step = options.indentStep ?? ESPHOME_YAML_INDENT;
   for (const [key, val] of Object.entries(values)) {
     if (val === undefined || val === null) continue;
     if (val === "" && !keepEmpty) continue;
@@ -233,7 +252,7 @@ export function serializeYamlValues(
       // is surprising and loses data on round-trip. (Copilot.)
       const sub = serializeYamlValues(
         val as Record<string, unknown>,
-        `${indent}  `,
+        `${indent}${step}`,
         options,
       );
       if (sub.length === 0) continue;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -14,6 +14,7 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { isPlainObject } from "./nested-values.js";
 
 /**
  * Opaque wrapper for a section-value block the parser couldn't fully
@@ -189,8 +190,8 @@ function serializeListItem(
   const keepEmpty = options.keepEmptyStrings === true;
   const step = options.indentStep ?? ESPHOME_YAML_INDENT;
   const dashIndent = `${indent}${step}`;
-  if (item !== null && typeof item === "object" && !Array.isArray(item)) {
-    const entries = Object.entries(item as Record<string, unknown>).filter(
+  if (isPlainObject(item)) {
+    const entries = Object.entries(item).filter(
       ([, v]) => v !== undefined && v !== null && (v !== "" || keepEmpty),
     );
     if (entries.length === 0) return [`${dashIndent}-`];

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -149,6 +149,50 @@ export interface SerializeYamlOptions {
  * Returns an array of lines (not a joined string) so callers can
  * splice them into existing YAML when needed.
  */
+/**
+ * Serialize a single list item. Mapping items
+ * (``esphome.devices`` / ``esphome.areas`` shape — the new
+ * ``multi_value=true`` schema entries) emit as
+ * ``${indent}  - first_key: value`` followed by
+ * ``${indent}    other_key: value`` for each remaining field;
+ * scalar items keep the legacy ``${indent}  - value`` shape.
+ *
+ * Mapping items are filtered through the same skip rules as the
+ * top-level serializer (``undefined`` / ``null`` / empty-string
+ * unless ``keepEmptyStrings``) so a freshly-added empty item
+ * doesn't emit a bare dash. ``YamlRawValue`` values inside an
+ * item are emitted with the same inline-header / body shape as
+ * the top-level branch.
+ */
+function serializeListItem(
+  item: unknown,
+  indent: string,
+  options: SerializeYamlOptions,
+): string[] {
+  const keepEmpty = options.keepEmptyStrings === true;
+  if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+    const entries = Object.entries(item as Record<string, unknown>).filter(
+      ([, v]) => v !== undefined && v !== null && (v !== "" || keepEmpty),
+    );
+    if (entries.length === 0) return [`${indent}  -`];
+    const lines: string[] = [];
+    const dashIndent = `${indent}  `;
+    const childIndent = `${dashIndent}  `;
+    entries.forEach(([k, v], idx) => {
+      const prefix = idx === 0 ? `${dashIndent}- ` : childIndent;
+      if (v instanceof YamlRawValue) {
+        const header = v.inlineHeader ? ` ${v.inlineHeader}` : "";
+        lines.push(`${prefix}${k}:${header}`);
+        lines.push(...v.lines);
+        return;
+      }
+      lines.push(`${prefix}${k}: ${formatYamlScalar(v)}`);
+    });
+    return lines;
+  }
+  return [`${indent}  - ${formatYamlScalar(item)}`];
+}
+
 export function serializeYamlValues(
   values: Record<string, unknown>,
   indent: string,
@@ -176,7 +220,8 @@ export function serializeYamlValues(
       if (val.length === 0) continue;
       lines.push(`${indent}${key}:`);
       for (const item of val) {
-        lines.push(`${indent}  - ${formatYamlScalar(item)}`);
+        const itemLines = serializeListItem(item, indent, options);
+        lines.push(...itemLines);
       }
       continue;
     }

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -196,7 +196,15 @@ function serializeListItem(
     );
     if (entries.length === 0) return [`${dashIndent}-`];
     const lines: string[] = [];
-    const childIndent = `${dashIndent}${step}`;
+    // Follow-up sub-keys align with the inline first key (which
+    // sits at ``${dashIndent}- ``, a fixed two-character offset
+    // past the dash) — NOT at ``${dashIndent}${step}``. With a
+    // canonical 2-space step those happen to coincide, but on a
+    // 4-space user file ``${dashIndent}${step}`` lands sub-keys
+    // four columns deeper than the inline key, producing
+    // valid-but-misaligned YAML. ``ESPHOME_YAML_INDENT`` is the
+    // canonical 2-character "- " gap and stays fixed.
+    const childIndent = `${dashIndent}${ESPHOME_YAML_INDENT}`;
     entries.forEach(([k, v], idx) => {
       const prefix = idx === 0 ? `${dashIndent}- ` : childIndent;
       if (v instanceof YamlRawValue) {

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -157,11 +157,6 @@ export interface SerializeYamlOptions {
 }
 
 /**
- * Serialize a values dict as YAML lines at the given indent.
- * Returns an array of lines (not a joined string) so callers can
- * splice them into existing YAML when needed.
- */
-/**
  * Serialize a single list item. Mapping items
  * (``esphome.devices`` / ``esphome.areas`` shape — the new
  * ``multi_value=true`` schema entries) emit as
@@ -220,6 +215,11 @@ function serializeListItem(
   return [`${dashIndent}- ${formatYamlScalar(item)}`];
 }
 
+/**
+ * Serialize a values dict as YAML lines at the given indent.
+ * Returns an array of lines (not a joined string) so callers can
+ * splice them into existing YAML when needed.
+ */
 export function serializeYamlValues(
   values: Record<string, unknown>,
   indent: string,

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -204,6 +204,66 @@ describe("filterRenderable", () => {
     expect(out.map((e) => e.key)).toEqual(["auth"]);
   });
 
+  it("keeps multi_value NESTED entries with zero items (Add button is the UI)", () => {
+    // Single-nested groups are dropped when no child would render,
+    // because the body would be empty. List-form is different:
+    // ``renderNestedListField`` paints an Add button so the user
+    // can declare the first device — dropping the field would
+    // make ``esphome.devices: []`` un-fillable from the editor.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        config_entries: [
+          // Required, but no items yet — the single-nested branch
+          // would drop the group. The list branch must NOT.
+          makeEntry({ key: "id", required: true }),
+        ],
+      }),
+    ];
+    const empty = filterRenderable(
+      entries,
+      {},
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(empty.map((e) => e.key)).toEqual(["devices"]);
+    const populated = filterRenderable(
+      entries,
+      { devices: [{ id: "front" }] },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(populated.map((e) => e.key)).toEqual(["devices"]);
+  });
+
+  it("keeps an advanced multi_value NESTED entry with items, even when showAdvanced is off", () => {
+    // ``hasMaterialValue`` for list-form should treat any non-empty
+    // array as material so an advanced device list set in YAML
+    // stays visible without the user toggling the advanced switch.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        advanced: true,
+        config_entries: [makeEntry({ key: "id" })],
+      }),
+    ];
+    const filled = filterRenderable(
+      entries,
+      { devices: [{ id: "front" }] },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(filled.map((e) => e.key)).toEqual(["devices"]);
+    const empty = filterRenderable(
+      entries,
+      { devices: [] },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    // Empty array → not material → advanced gate hides it.
+    expect(empty.map((e) => e.key)).toEqual([]);
+  });
+
   it("respects depends_on visibility", () => {
     const entries = [
       makeEntry({ key: "mode", required: true }),
@@ -455,5 +515,52 @@ describe("collectRenderablePaths", () => {
       showAdvanced: false,
     });
     expect([...paths]).toEqual(["vis"]);
+  });
+
+  it("emits per-item indexed paths for multi_value NESTED entries", () => {
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        config_entries: [
+          makeEntry({ key: "id", required: true }),
+          makeEntry({ key: "name" }),
+        ],
+      }),
+    ];
+    const paths = collectRenderablePaths(
+      entries,
+      { devices: [{ id: "front" }, { id: "kitchen", name: "Kitchen" }] },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect([...paths].sort()).toEqual(
+      [
+        "devices",
+        "devices.0.id",
+        "devices.0.name",
+        "devices.1.id",
+        "devices.1.name",
+      ].sort(),
+    );
+  });
+
+  it("emits the bare field path for an empty multi_value NESTED entry", () => {
+    // No items → no per-item paths, but the field itself is still
+    // onscreen (Add button), so its path should land in the set so
+    // an error keyed on the bare field surfaces as visible.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        config_entries: [makeEntry({ key: "id", required: true })],
+      }),
+    ];
+    const paths = collectRenderablePaths(entries, {}, {
+      requiredOnly: false,
+      showAdvanced: false,
+    });
+    expect([...paths]).toEqual(["devices"]);
   });
 });

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -6,6 +6,7 @@ import {
   filterRenderable,
 } from "../../../src/components/device/config-entry-render-filter.js";
 import { makeConfigEntry as makeEntry } from "../../util/_make-config-entry.js";
+import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
 
 describe("ALWAYS_SHOWN_KEYS", () => {
   it("contains 'name' (the friendly-name leaf)", () => {
@@ -234,6 +235,31 @@ describe("filterRenderable", () => {
       { requiredOnly: false, showAdvanced: false },
     );
     expect(populated.map((e) => e.key)).toEqual(["devices"]);
+  });
+
+  it("treats a YamlRawValue at a multi_value NESTED key as material", () => {
+    // The parser falls back to ``YamlRawValue`` when the items
+    // can't fit the flat-mapping contract (dotted keys, block
+    // scalars, nested mappings). The user clearly has YAML
+    // there, so an advanced multi_value field with raw content
+    // must stay visible without a trip through the Advanced
+    // toggle — otherwise the visual editor would silently hide
+    // the user's data.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        advanced: true,
+        config_entries: [makeEntry({ key: "id" })],
+      }),
+    ];
+    const out = filterRenderable(
+      entries,
+      { devices: new YamlRawValue(["    - id: kitchen", "      filters:", "        delta: 0.5"]) },
+      { requiredOnly: false, showAdvanced: false },
+    );
+    expect(out.map((e) => e.key)).toEqual(["devices"]);
   });
 
   it("keeps an advanced multi_value NESTED entry with items, even when showAdvanced is off", () => {

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -24,6 +24,7 @@ import { renderNestedListField } from "../../../src/components/device/config-ent
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { getIn } from "../../../src/util/nested-values.js";
+import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
 
 function makeListEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -205,5 +206,30 @@ describe("renderNestedListField", () => {
     expect(renderEntry).toHaveBeenCalledTimes(2);
     const keys = renderEntry.mock.calls.map((c) => (c[0] as ConfigEntry).key);
     expect(keys).not.toContain("area_id");
+  });
+
+  it("renders a YAML-only notice and disables Add/Remove for YamlRawValue", () => {
+    // The parser preserves a list block byte-for-byte as
+    // ``YamlRawValue`` when the items don't fit the flat-mapping
+    // contract (dotted keys, block scalars, nested mappings).
+    // The renderer must NOT coerce that to ``[]`` and offer Add /
+    // Remove — the next save would clobber the user's preserved
+    // YAML. Surface a notice instead, no Add/Remove, no children.
+    const entry = makeListEntry();
+    const { ctx, renderEntry } = makeCtx({
+      devices: new YamlRawValue([
+        "    - logger.log: hello",
+        "      switch.turn_on: relay_id",
+      ]),
+    });
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    // No per-item children rendered.
+    expect(renderEntry).not.toHaveBeenCalled();
+    // The YAML-only translation key is in the template.
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("device.multi_value_yaml_only");
+    // No Add / Remove translation keys — those buttons aren't rendered.
+    expect(json).not.toContain("device.multi_value_add");
+    expect(json).not.toContain("device.multi_value_remove");
   });
 });

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Targeted tests for ``renderNestedListField`` — the renderer for
+ * repeatable nested mappings (``esphome.devices``,
+ * ``esphome.areas``, …; the catalog flag is
+ * ``type=nested, multi_value=true``).
+ *
+ * Two behaviours that matter for #434:
+ *
+ * - Each item is rendered as its own group with the same children
+ *   as a single nested entry; child paths land at
+ *   ``[..., "0", child.key]`` so the array slot survives writes.
+ * - Add / remove handlers emit the whole new array at the field's
+ *   path. Existing items keep identity so structural sharing in
+ *   the form-state reducer holds.
+ *
+ * Tests run in vitest's default ``node`` environment — no DOM —
+ * so we don't render the Lit template to a real shadow root, just
+ * inspect ``ctx.renderEntry`` call patterns + the returned
+ * ``TemplateResult``'s interpolated values.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
+import { renderNestedListField } from "../../../src/components/device/config-entry-renderers.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { getIn } from "../../../src/util/nested-values.js";
+
+function makeListEntry(): ConfigEntry {
+  return makeConfigEntry({
+    key: "devices",
+    type: ConfigEntryType.NESTED,
+    multi_value: true,
+    config_entries: [
+      makeConfigEntry({ key: "id", type: ConfigEntryType.ID, required: true }),
+      makeConfigEntry({ key: "name", type: ConfigEntryType.STRING }),
+      makeConfigEntry({ key: "area_id", type: ConfigEntryType.ID }),
+    ],
+  });
+}
+
+interface CtxStub {
+  ctx: RenderCtx;
+  renderEntry: ReturnType<typeof vi.fn>;
+  emitChange: ReturnType<typeof vi.fn>;
+  filterRenderable: ReturnType<typeof vi.fn>;
+}
+
+function collectHandlers(
+  values: unknown[],
+): Array<(...args: unknown[]) => unknown> {
+  const out: Array<(...args: unknown[]) => unknown> = [];
+  const walk = (v: unknown): void => {
+    if (typeof v === "function") {
+      out.push(v as (...args: unknown[]) => unknown);
+    } else if (Array.isArray(v)) {
+      v.forEach(walk);
+    } else if (v && typeof v === "object" && "values" in v) {
+      walk((v as { values: unknown[] }).values);
+    }
+  };
+  walk(values);
+  return out;
+}
+
+function makeCtx(values: Record<string, unknown>): CtxStub {
+  const renderEntry = vi.fn(() => "<rendered>");
+  const emitChange = vi.fn();
+  const filterRenderable = vi.fn((entries: ConfigEntry[]) => entries);
+  const ctx: RenderCtx = {
+    localize: (key) => key,
+    disabled: false,
+    yaml: "",
+    fromLine: undefined,
+    board: null,
+    requiredOnly: false,
+    nestedOpenSections: new Set(),
+    getAt: (path: string[]) => getIn(values, path),
+    errorAt: () => null,
+    emitChange,
+    toggleNested: () => {},
+    requestAddComponent: () => {},
+    scopeValues: () => ({}),
+    filterRenderable,
+    renderEntry,
+    getPendingUnit: () => undefined,
+    setPendingUnit: () => {},
+    getEditingMagnitude: () => undefined,
+    setEditingMagnitude: () => {},
+    clearEditingMagnitude: () => {},
+  };
+  return { ctx, renderEntry, emitChange, filterRenderable };
+}
+
+describe("renderNestedListField", () => {
+  it("renders one child set per item at array-indexed paths", () => {
+    const entry = makeListEntry();
+    const { ctx, renderEntry } = makeCtx({
+      devices: [
+        { id: "front_door", name: "Front Door" },
+        { id: "kitchen", name: "Kitchen" },
+      ],
+    });
+
+    renderNestedListField(entry, ["devices"], ctx);
+
+    // Each of the 3 child entries gets rendered for each of the 2 items.
+    expect(renderEntry).toHaveBeenCalledTimes(6);
+    const paths = renderEntry.mock.calls.map((c) => c[1]);
+    expect(paths).toContainEqual(["devices", "0", "id"]);
+    expect(paths).toContainEqual(["devices", "0", "name"]);
+    expect(paths).toContainEqual(["devices", "0", "area_id"]);
+    expect(paths).toContainEqual(["devices", "1", "id"]);
+    expect(paths).toContainEqual(["devices", "1", "name"]);
+    expect(paths).toContainEqual(["devices", "1", "area_id"]);
+  });
+
+  it("renders no items and the empty hint when the array is missing", () => {
+    const entry = makeListEntry();
+    const { ctx, renderEntry } = makeCtx({});
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    expect(renderEntry).not.toHaveBeenCalled();
+    // The empty-state translation key is rendered as a literal in
+    // the template values. Walk values to find it.
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("device.multi_value_empty");
+  });
+
+  it("addItem appends a fresh empty object at the field's path", () => {
+    const entry = makeListEntry();
+    const { ctx, emitChange } = makeCtx({
+      devices: [{ id: "kitchen" }],
+    });
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    const handlers = collectHandlers(tpl.values);
+    // Last handler in render order is the add button (rendered after
+    // the items + their per-item remove buttons).
+    handlers[handlers.length - 1]();
+    expect(emitChange).toHaveBeenCalledWith(
+      ["devices"],
+      [{ id: "kitchen" }, {}],
+    );
+  });
+
+  it("removeAt drops the item at idx and emits the new array", () => {
+    const entry = makeListEntry();
+    const before = { devices: [{ id: "a" }, { id: "b" }, { id: "c" }] };
+    const { ctx, emitChange } = makeCtx(before);
+    const tpl = renderNestedListField(entry, ["devices"], ctx);
+    // Handlers are emitted in render order: per-item remove (3 of
+    // them, one per item), then the add button. Pick the second
+    // remove handler (idx 1) and invoke it.
+    const handlers = collectHandlers(tpl.values);
+    expect(handlers).toHaveLength(4);
+    handlers[1]();
+    expect(emitChange).toHaveBeenCalledWith(
+      ["devices"],
+      [{ id: "a" }, { id: "c" }],
+    );
+    // Untouched siblings preserve identity.
+    const next = emitChange.mock.calls[0][1] as Array<Record<string, unknown>>;
+    expect(next[0]).toBe(before.devices[0]);
+    expect(next[1]).toBe(before.devices[2]);
+  });
+
+  it("filterRenderable receives the per-item values for depends_on resolution", () => {
+    const entry = makeListEntry();
+    const { ctx, filterRenderable } = makeCtx({
+      devices: [{ id: "front" }, { id: "kitchen", area_id: "main" }],
+    });
+    renderNestedListField(entry, ["devices"], ctx);
+    // One call per item, with the *item* (not the parent dict) as
+    // the scoping values.
+    expect(filterRenderable).toHaveBeenCalledTimes(2);
+    expect(filterRenderable.mock.calls[0][1]).toEqual({ id: "front" });
+    expect(filterRenderable.mock.calls[1][1]).toEqual({
+      id: "kitchen",
+      area_id: "main",
+    });
+  });
+
+  it("coerces non-object items to {} so the renderer never crashes", () => {
+    // js-yaml can briefly emit ``null`` items mid-edit (a stray ``-``
+    // line). The renderer should still render something instead of
+    // throwing on ``Object.keys(null)``-style descents.
+    const entry = makeListEntry();
+    const { ctx, renderEntry, filterRenderable } = makeCtx({
+      devices: [null, "weird", { id: "real" }],
+    });
+    renderNestedListField(entry, ["devices"], ctx);
+    expect(filterRenderable).toHaveBeenCalledTimes(3);
+    // Each of the 3 items still gets all 3 children rendered.
+    expect(renderEntry).toHaveBeenCalledTimes(9);
+  });
+
+  it("respects filterRenderable filtering — children dropped per item", () => {
+    const entry = makeListEntry();
+    const { ctx, renderEntry, filterRenderable } = makeCtx({
+      devices: [{ id: "a" }],
+    });
+    // Pretend the filter drops ``area_id`` for this item.
+    filterRenderable.mockImplementation((entries) =>
+      entries.filter((e) => e.key !== "area_id"),
+    );
+    renderNestedListField(entry, ["devices"], ctx);
+    expect(renderEntry).toHaveBeenCalledTimes(2);
+    const keys = renderEntry.mock.calls.map((c) => (c[0] as ConfigEntry).key);
+    expect(keys).not.toContain("area_id");
+  });
+});

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -7,6 +7,7 @@ import {
   validateEntry,
 } from "../../src/util/config-validation.js";
 import { makeConfigEntry as makeEntry } from "./_make-config-entry.js";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 
 describe("validateDeviceName", () => {
   it("accepts valid slug", () => {
@@ -223,6 +224,29 @@ describe("validateEntries", () => {
     // Other items should be clean.
     expect(errors.has("devices.0.id")).toBe(false);
     expect(errors.has("devices.2.id")).toBe(false);
+  });
+
+  it("treats a YamlRawValue at a multi_value NESTED key as satisfied", () => {
+    // The parser preserves un-modellable list shapes as
+    // ``YamlRawValue`` (dotted keys, block scalars, etc.). The
+    // validator can't introspect items, so:
+    //   1. A required field whose value is a YamlRawValue is
+    //      satisfied by the YAML's existence — no
+    //      ``validation.required`` on the bare field.
+    //   2. Per-item rules can't run, so we skip recursion.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        required: true,
+        config_entries: [makeEntry({ key: "id", required: true })],
+      }),
+    ];
+    const errors = validateEntries(entries, {
+      devices: new YamlRawValue(["    - logger.log: hello"]),
+    });
+    expect(errors.size).toBe(0);
   });
 
   it("does not validate inside an empty optional multi_value NESTED entry", () => {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -194,6 +194,91 @@ describe("validateEntries", () => {
     expect(errors.size).toBe(0);
   });
 
+  it("validates each item of a multi_value NESTED entry with index path segments", () => {
+    // ``esphome.devices`` / ``esphome.areas`` shape: the catalog
+    // marks the field optional but each item's ``id`` is required.
+    // Validation must visit every item and key errors at
+    // ``devices.<idx>.<child>`` so the form can look them up via
+    // ``path.join(".")`` against the renderer's per-item paths.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        required: false,
+        config_entries: [
+          makeEntry({ key: "id", required: true }),
+          makeEntry({ key: "name" }),
+        ],
+      }),
+    ];
+    const errors = validateEntries(entries, {
+      devices: [
+        { id: "front" },
+        {}, // missing required id
+        { id: "kitchen", name: "Kitchen" },
+      ],
+    });
+    expect(errors.get("devices.1.id")?.code).toBe("validation.required");
+    // Other items should be clean.
+    expect(errors.has("devices.0.id")).toBe(false);
+    expect(errors.has("devices.2.id")).toBe(false);
+  });
+
+  it("does not validate inside an empty optional multi_value NESTED entry", () => {
+    // Adding zero devices is fine for an optional field — forcing
+    // an item just to opt out would mirror the bug
+    // ``does not require nested children of an untouched optional
+    // group`` already pins for single-nested.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        config_entries: [makeEntry({ key: "id", required: true })],
+      }),
+    ];
+    expect(validateEntries(entries, {}).size).toBe(0);
+    expect(validateEntries(entries, { devices: [] }).size).toBe(0);
+  });
+
+  it("flags an empty required multi_value NESTED entry on the field itself", () => {
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        required: true,
+        config_entries: [makeEntry({ key: "id", required: true })],
+      }),
+    ];
+    const errors = validateEntries(entries, { devices: [] });
+    expect(errors.get("devices")?.code).toBe("validation.required");
+    // Items aren't there to validate, so no per-item errors.
+    expect(errors.size).toBe(1);
+  });
+
+  it("coerces non-object items to {} so each item is still validated cleanly", () => {
+    // js-yaml round-trips can briefly emit ``null`` items mid-edit
+    // (a stray ``-`` line). Validation should treat those as empty
+    // mappings — the recursion shouldn't blow up on
+    // ``Object.keys(null)``-style descents.
+    const entries = [
+      makeEntry({
+        key: "devices",
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        config_entries: [makeEntry({ key: "id", required: true })],
+      }),
+    ];
+    const errors = validateEntries(entries, {
+      devices: [null, "weird", { id: "real" }],
+    });
+    expect(errors.get("devices.0.id")?.code).toBe("validation.required");
+    expect(errors.get("devices.1.id")?.code).toBe("validation.required");
+    expect(errors.has("devices.2.id")).toBe(false);
+  });
+
   it("does not require nested children of an untouched optional group", () => {
     // web_server.auth in real life: the auth block is optional but
     // its username/password children are required. The user must be

--- a/test/util/nested-values.test.ts
+++ b/test/util/nested-values.test.ts
@@ -44,6 +44,37 @@ describe("setIn", () => {
     expect(setIn({ a: 1 }, [], "wat")).toEqual({});
     expect(setIn({ a: 1 }, [], [1, 2])).toEqual({});
   });
+
+  it("descends into arrays via numeric path segments", () => {
+    // Editing ``esphome.devices[0].name`` from the nested-list
+    // renderer; the array slot must survive the write.
+    const before = { devices: [{ name: "old" }, { name: "kitchen" }] };
+    const after = setIn(before, ["devices", "0", "name"], "front");
+    expect(after).toEqual({
+      devices: [{ name: "front" }, { name: "kitchen" }],
+    });
+    // Untouched siblings keep identity (structural sharing).
+    expect((after.devices as unknown[])[1]).toBe(before.devices[1]);
+  });
+
+  it("creates intermediate objects inside an array slot", () => {
+    expect(setIn({ devices: [{}] }, ["devices", "0", "id", "x"], 1)).toEqual({
+      devices: [{ id: { x: 1 } }],
+    });
+  });
+
+  it("grows the array when writing past the end", () => {
+    // Newly-added nested-list items can write to their own slot
+    // before the placeholder object is materialised in form state.
+    const after = setIn({ devices: [] }, ["devices", "0", "name"], "front");
+    expect(after).toEqual({ devices: [{ name: "front" }] });
+  });
+
+  it("preserves array shape when replacing a slot", () => {
+    expect(
+      setIn({ devices: [{ name: "old" }] }, ["devices", "0"], { name: "new" }),
+    ).toEqual({ devices: [{ name: "new" }] });
+  });
 });
 
 describe("getIn", () => {
@@ -58,7 +89,21 @@ describe("getIn", () => {
 
   it("returns undefined when the path crosses a non-object", () => {
     expect(getIn({ a: "hello" }, ["a", "b"])).toBeUndefined();
-    expect(getIn({ a: [1, 2] }, ["a", "0"])).toBeUndefined();
+    expect(getIn({ a: 5 }, ["a", "b"])).toBeUndefined();
+  });
+
+  it("descends into arrays via numeric path segments", () => {
+    // Arrays are valid containers — the nested-list renderer needs
+    // to read child fields out of items at ``devices[0]``.
+    expect(getIn({ devices: [{ name: "front" }] }, ["devices", "0", "name"]))
+      .toBe("front");
+    expect(getIn({ a: [1, 2, 3] }, ["a", "2"])).toBe(3);
+  });
+
+  it("returns undefined for out-of-range / non-numeric array paths", () => {
+    expect(getIn({ a: [1, 2] }, ["a", "5"])).toBeUndefined();
+    expect(getIn({ a: [1, 2] }, ["a", "-1"])).toBeUndefined();
+    expect(getIn({ a: [1, 2] }, ["a", "name"])).toBeUndefined();
   });
 });
 

--- a/test/util/nested-values.test.ts
+++ b/test/util/nested-values.test.ts
@@ -75,6 +75,17 @@ describe("setIn", () => {
       setIn({ devices: [{ name: "old" }] }, ["devices", "0"], { name: "new" }),
     ).toEqual({ devices: [{ name: "new" }] });
   });
+
+  it("ignores invalid array-index segments instead of writing string keys", () => {
+    // ``arr["name"] = ...`` would silently set a string property on
+    // the array object, leaving ``.length`` stale — every consumer
+    // downstream sees the array as untouched but ``Object.keys``
+    // surfaces the rogue key. The helper drops the write instead.
+    const before = { devices: [{ id: "kitchen" }] };
+    expect(setIn(before, ["devices", "name", "x"], 1)).toEqual(before);
+    expect(setIn(before, ["devices", "-1", "x"], 1)).toEqual(before);
+    expect(setIn(before, ["devices", "1.5", "x"], 1)).toEqual(before);
+  });
 });
 
 describe("getIn", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1044,6 +1044,69 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(after).not.toContain("    - area_id:");
   });
 
+  it("treats a bare dash with trailing whitespace as an empty placeholder", () => {
+    // Some editors emit ``    -  `` (dash + trailing spaces)
+    // when the user lands on a fresh dash line and pauses. The
+    // exact-match check (``lines[at] === bareDash``) used to
+    // miss this and bail to YamlRawValue, breaking the visual
+    // editor. ``LIST_ITEM_BARE_DASH_RE`` already accepts any
+    // trailing whitespace as a complexity signal — the parser
+    // now uses the same predicate inside ``parseItem`` so the
+    // two stay in lockstep.
+    const yaml = `esphome:
+  devices:
+    -
+    - id: kitchen
+      name: Kitchen
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.devices).toEqual([
+      {},
+      { id: "kitchen", name: "Kitchen" },
+    ]);
+  });
+
+  it("parses a list-of-mappings with a comment line between key and items", () => {
+    // Regression for Copilot's catch: a comment between
+    // ``devices:`` and the first ``- id:`` line used to make
+    // ``peekLine`` land on the comment, fail
+    // ``isDeeperListItemLine``, and route through
+    // ``parseNestedBlock`` — which then skipped the list items
+    // entirely, returning an empty mapping. The field got
+    // dropped from values and deleted on save.
+    const yaml = `esphome:
+  devices:
+    # the kitchen sensor and the front door
+    - id: kitchen
+      name: Kitchen
+    - id: front_door
+      name: "Front Door"
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.devices).toEqual([
+      { id: "kitchen", name: "Kitchen" },
+      { id: "front_door", name: "Front Door" },
+    ]);
+  });
+
+  it("parses a nested mapping with a comment line between key and content", () => {
+    // Same comment-skip semantic in ``parseNestedBlock`` — the
+    // recursion path that handles deeper map blocks. A comment
+    // between ``manual_ip:`` and ``static_ip:`` would silently
+    // drop the manual_ip field from values.
+    const yaml = `wifi:
+  manual_ip:
+    # static IP for the office sensor
+    static_ip: 10.0.0.5
+    gateway: 10.0.0.1
+`;
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values.manual_ip).toEqual({
+      static_ip: "10.0.0.5",
+      gateway: "10.0.0.1",
+    });
+  });
+
   it("preserves a list of only bare-dash placeholder items", () => {
     // Regression for the bug Copilot caught: a list whose only
     // items are bare-dash placeholders (the user clicked Add but

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1142,14 +1142,18 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     const values = parseYamlSectionValues(yaml, "esphome");
     (values.devices as Record<string, unknown>[])[0].name = "Renamed";
     const after = updateSectionInYaml(yaml, "esphome", values);
-    // Top-level fields stay at 4-space.
-    expect(after).toContain("    name: test");
-    // Devices list keeps its 8-space dash indent (4 + 4) and
-    // 10-space sub-key indent.
-    expect(after).toContain("        - id: kitchen");
-    expect(after).toContain("          name: Renamed");
+    // Top-level fields stay at 4-space — column 4, exactly.
+    expect(after).toMatch(/^ {4}name: test/m);
+    // Devices list keeps its 8-space dash indent (4 + 4 step) and
+    // sub-keys align with the inline first key — column 10
+    // (= dash col 8 + the literal 2-char ``- `` gap), NOT
+    // dash + step (which would be 12 on a 4-space file). Pin the
+    // exact column so a regression to ``${dashIndent}${step}``
+    // surfaces in CI instead of hiding behind a substring match.
+    expect(after).toMatch(/^ {8}- id: kitchen/m);
+    expect(after).toMatch(/^ {10}name: Renamed/m);
     // No 2-space children sneaking in mid-section.
-    expect(after).not.toMatch(/^  [a-zA-Z]/m);
+    expect(after).not.toMatch(/^ {2}[a-zA-Z]/m);
   });
 
   it("reads list-of-mappings with non-default user indent (4-space YAML)", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1044,6 +1044,27 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(after).not.toContain("    - area_id:");
   });
 
+  it("preserves a list of only bare-dash placeholder items", () => {
+    // Regression for the bug Copilot caught: a list whose only
+    // items are bare-dash placeholders (the user clicked Add but
+    // hadn't filled any fields yet, then saved) used to drop the
+    // whole field. ``_scanValueBlock`` saw no ``- key:`` lines and
+    // returned ``isComplex=false``, so the scalar-list branch
+    // ran, the ``- `` regex missed the bare dash, items=0, and
+    // the key got omitted from the values dict — which then
+    // *deleted* the user's in-progress rows on the next save.
+    // The bare-dash regex is now part of the complexity signal,
+    // so the block routes through ``collectBlockListMappings``
+    // and rebuilds each placeholder as ``{}``.
+    const yaml = `esphome:
+  devices:
+    -
+    -
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.devices).toEqual([{}, {}]);
+  });
+
   it("re-parses a bare-dash list item as an empty mapping (round-trip stable)", () => {
     // The serializer emits ``    -`` (no trailing key) for an
     // empty mapping item — the placeholder shape for a

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -873,3 +873,200 @@ describe("updateSectionInYaml — keepEmptyStrings option", () => {
     expect(after).toMatch(/inner_empty:\s*""/);
   });
 });
+
+describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () => {
+  // Regression pin for issue #434: catalog entries marked
+  // ``type=nested, multi_value=true`` (``esphome.devices`` /
+  // ``esphome.areas``) must reach the renderer as structured
+  // arrays of objects, not as ``YamlRawValue``. The parser used to
+  // capture the whole block raw (because ``LIST_ITEM_DICT_KEY_RE``
+  // flagged any ``- key:`` line as "complex"), and the editor's
+  // nested-list renderer would then show "No items yet" even when
+  // the YAML had items.
+
+  it("parses esphome.devices into an array of plain objects", () => {
+    const yaml = `esphome:
+  name: test
+  devices:
+    - id: front_door_device
+      name: "Front Door Sensor"
+      area_id: entrance_area
+    - id: kitchen_motion_device
+      name: "Kitchen Motion"
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.name).toBe("test");
+    expect(values.devices).toEqual([
+      {
+        id: "front_door_device",
+        name: "Front Door Sensor",
+        area_id: "entrance_area",
+      },
+      { id: "kitchen_motion_device", name: "Kitchen Motion" },
+    ]);
+    // Not a YamlRawValue — the editor must be able to recurse
+    // into per-item children, which it can't with raw text.
+    expect(values.devices).not.toBeInstanceOf(YamlRawValue);
+  });
+
+  it("parses esphome.areas alongside esphome.devices in the same section", () => {
+    const yaml = `esphome:
+  devices:
+    - id: front_door
+      name: "Front Door"
+  areas:
+    - id: entrance
+      name: "Entrance"
+    - id: kitchen
+      name: "Kitchen"
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.devices).toEqual([
+      { id: "front_door", name: "Front Door" },
+    ]);
+    expect(values.areas).toEqual([
+      { id: "entrance", name: "Entrance" },
+      { id: "kitchen", name: "Kitchen" },
+    ]);
+  });
+
+  it("falls back to YamlRawValue when items contain dotted-key automation actions", () => {
+    // ``- logger.log: pressed`` is automation-action shorthand,
+    // not a flat-mapping field. Capturing it as a structured
+    // ``{ "logger.log": "pressed" }`` would round-trip on save as
+    // ``- "logger.log": pressed``, corrupting the trigger.
+    const yaml = `binary_sensor:
+  - platform: gpio
+    pin: D1
+    on_press:
+      - logger.log: pressed
+      - switch.turn_on: relay_id
+`;
+    const values = parseYamlSectionValues(yaml, "binary_sensor.gpio", 2);
+    expect(values.on_press).toBeInstanceOf(YamlRawValue);
+  });
+
+  it("falls back to YamlRawValue when items contain block scalars", () => {
+    const yaml = `script:
+  - id: my_script
+    actions:
+      - lambda: |-
+          some_function();
+          another_line;
+`;
+    const values = parseYamlSectionValues(yaml, "script", 2);
+    expect(values.actions).toBeInstanceOf(YamlRawValue);
+  });
+
+  it("falls back to YamlRawValue when items have nested mappings under a sub-key", () => {
+    // ``- key:\n      sub_key:`` (sub_key with empty raw, opening
+    // a deeper mapping) carries shape the flat-mapping helper
+    // can't model. The conservative bail-out keeps the block raw
+    // so the deeper content survives a round-trip.
+    const yaml = `sensor:
+  - platform: template
+    name: outside_temp
+    triggers:
+      - id: my_trigger
+        filters:
+          delta: 0.5
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.triggers).toBeInstanceOf(YamlRawValue);
+  });
+
+  it("round-trips esphome.devices through update with edits to one item", () => {
+    const yaml = `esphome:
+  devices:
+    - id: front_door
+      name: "Front Door"
+    - id: kitchen
+      name: "Kitchen"
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    const devices = values.devices as Record<string, unknown>[];
+    devices[0].name = "Front Entry";
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    // Both items survive; only the first item's name changed.
+    expect(after).toContain("- id: front_door");
+    expect(after).toContain("name: Front Entry");
+    expect(after).toContain("- id: kitchen");
+    expect(after).toContain("name: Kitchen");
+    // No double-quoted dotted-key corruption.
+    expect(after).not.toMatch(/"id":/);
+  });
+
+  it("round-trips a freshly-added empty item via the renderer's Add button", () => {
+    // ``renderNestedListField`` emits ``[..., {}]`` when the user
+    // clicks Add. The serializer should emit a bare dash
+    // placeholder so the YAML stays valid even before the user
+    // fills in a key.
+    const yaml = `esphome:
+  devices:
+    - id: existing
+      name: Existing
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    const devices = values.devices as Record<string, unknown>[];
+    devices.push({});
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    // The existing item still emits with its keys.
+    expect(after).toContain("- id: existing");
+    // The new empty item emits as a bare dash; the next compile
+    // will surface a real schema error if any required field is
+    // missing.
+    const lines = after.split("\n");
+    const dashLines = lines.filter((l) => /^\s+-/.test(l));
+    expect(dashLines).toHaveLength(2);
+    expect(dashLines[1].trim()).toBe("-");
+  });
+
+  it("emits new mapping items with the dash on the first key only", () => {
+    // The serializer's contract for list-of-mappings: the dash
+    // sits on the first sub-key's line; remaining keys live one
+    // indent step deeper, no leading dash. Matches what
+    // ``parseYamlSectionValues`` reads back so the round-trip is
+    // stable.
+    const yaml = `esphome:
+  name: test
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    (values as Record<string, unknown>).devices = [
+      { id: "front", name: "Front Door", area_id: "entrance" },
+    ];
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    expect(after).toContain("    - id: front");
+    expect(after).toContain("      name: Front Door");
+    expect(after).toContain("      area_id: entrance");
+    // The dash must NOT appear on the second / third sub-key's
+    // line — the parser would re-read those as new list items.
+    expect(after).not.toContain("    - name:");
+    expect(after).not.toContain("    - area_id:");
+  });
+
+  it("skips null / undefined / empty-string fields inside a mapping item", () => {
+    // Same skip semantics the top-level serializer applies, so a
+    // partially-filled item written by ``renderNestedListField``
+    // doesn't emit half-blank rows that re-parse as different
+    // values on the next round-trip.
+    const yaml = `esphome:
+  name: test
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    (values as Record<string, unknown>).devices = [
+      {
+        id: "front",
+        name: "Front Door",
+        area_id: null,
+        comment: undefined,
+        empty_field: "",
+      },
+    ];
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    expect(after).toContain("- id: front");
+    expect(after).toContain("name: Front Door");
+    expect(after).not.toContain("area_id:");
+    expect(after).not.toContain("comment:");
+    expect(after).not.toContain("empty_field:");
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1156,6 +1156,25 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(after).not.toMatch(/^ {2}[a-zA-Z]/m);
   });
 
+  it("treats an underscore-leading sibling section as a section terminator", () => {
+    // The terminator predicate has to mirror ``KEY_PATTERN``'s
+    // leading-character set (``[a-zA-Z_]``). A section header
+    // like ``_internal:`` wasn't matched by the older
+    // ``/^[a-zA-Z]/`` shape and could leak into the parent
+    // section's child walk, picking up its keys as siblings of
+    // the parent.
+    const yaml = `esphome:
+  name: test
+_internal:
+  hidden: true
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.name).toBe("test");
+    // The ``_internal`` section's children must not bleed into
+    // ``esphome``'s.
+    expect(values.hidden).toBeUndefined();
+  });
+
   it("reads list-of-mappings with non-default user indent (4-space YAML)", () => {
     // YAML allows any consistent indent step — a user-typed
     // 4-space file is just as valid as ESPHome's canonical

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1044,7 +1044,138 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(after).not.toContain("    - area_id:");
   });
 
-  it("skips null / undefined / empty-string fields inside a mapping item", () => {
+  it("re-parses a bare-dash list item as an empty mapping (round-trip stable)", () => {
+    // The serializer emits ``    -`` (no trailing key) for an
+    // empty mapping item — the placeholder shape for a
+    // freshly-added Add row the user saved before filling in any
+    // fields. The parser must accept the bare dash and rebuild
+    // ``{}`` so the row survives the round-trip; otherwise the
+    // user's in-progress item vanishes on reload.
+    const yaml = `esphome:
+  devices:
+    - id: kitchen
+      name: Kitchen
+    -
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.devices).toEqual([
+      { id: "kitchen", name: "Kitchen" },
+      {},
+    ]);
+  });
+
+  it("re-parses a bare-dash item inside a parseNestedBlock recursion", () => {
+    // Same bare-dash handling at deeper indents — exercises the
+    // ``parseNestedBlock`` branch that ``parseYamlSectionValues``
+    // delegates to for nested mappings.
+    const yaml = `outer:
+  meta:
+    rows:
+      - id: first
+      -
+`;
+    const values = parseYamlSectionValues(yaml, "outer");
+    expect(values.meta).toEqual({ rows: [{ id: "first" }, {}] });
+  });
+
+  it("survives a full Add → save → reload cycle", () => {
+    // Drives the exact flow the user hits in the visual editor:
+    // start with one item, click Add, save (serializer emits
+    // bare dash for the new empty row), reload (parser rebuilds
+    // the array). Without the round-trip fix the second item
+    // disappears on reload.
+    const yaml = `esphome:
+  devices:
+    - id: kitchen
+      name: Kitchen
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    (values.devices as Record<string, unknown>[]).push({});
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    const reloaded = parseYamlSectionValues(after, "esphome");
+    expect(reloaded.devices).toEqual([{ id: "kitchen", name: "Kitchen" }, {}]);
+  });
+
+  it("reads a flat section with 4-space user indent", () => {
+    // The non-list path through ``parseYamlSectionValues`` —
+    // every leaf is a bare ``key: value`` and the section has
+    // no list-of-mappings child — must also detect indent.
+    const yaml = `wifi:
+    ssid: home
+    password: secret
+`;
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values.ssid).toBe("home");
+    expect(values.password).toBe("secret");
+  });
+
+  it("reads nested mappings with 4-space user indent", () => {
+    // ``parseNestedBlock`` recursion must propagate the
+    // detected indent so a ``manual_ip:`` block with
+    // ``static_ip:`` underneath comes back as a structured
+    // sub-object, not undefined.
+    const yaml = `wifi:
+    ssid: home
+    manual_ip:
+        static_ip: 10.0.0.5
+        gateway: 10.0.0.1
+`;
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values.manual_ip).toEqual({
+      static_ip: "10.0.0.5",
+      gateway: "10.0.0.1",
+    });
+  });
+
+  it("round-trips 4-space user YAML through update without mixing indents", () => {
+    // The save path detects the user's indent step and threads it
+    // through the serializer so the rewritten section keeps the
+    // user's 4-space style instead of splicing canonical 2-space
+    // content into a 4-space file (mixed indent inside one
+    // mapping is valid YAML but visually inconsistent).
+    const yaml = `esphome:
+    name: test
+    devices:
+        - id: kitchen
+          name: Kitchen
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    (values.devices as Record<string, unknown>[])[0].name = "Renamed";
+    const after = updateSectionInYaml(yaml, "esphome", values);
+    // Top-level fields stay at 4-space.
+    expect(after).toContain("    name: test");
+    // Devices list keeps its 8-space dash indent (4 + 4) and
+    // 10-space sub-key indent.
+    expect(after).toContain("        - id: kitchen");
+    expect(after).toContain("          name: Renamed");
+    // No 2-space children sneaking in mid-section.
+    expect(after).not.toMatch(/^  [a-zA-Z]/m);
+  });
+
+  it("reads list-of-mappings with non-default user indent (4-space YAML)", () => {
+    // YAML allows any consistent indent step — a user-typed
+    // 4-space file is just as valid as ESPHome's canonical
+    // 2-space emit. The parser detects the actual indent from
+    // the first child line and propagates it down so the same
+    // ``esphome.devices`` list works regardless of the step
+    // the user chose.
+    const yaml = `esphome:
+    name: test
+    devices:
+        - id: kitchen
+          name: Kitchen
+        - id: front_door
+          name: "Front Door"
+`;
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(values.name).toBe("test");
+    expect(values.devices).toEqual([
+      { id: "kitchen", name: "Kitchen" },
+      { id: "front_door", name: "Front Door" },
+    ]);
+  });
+
+  it("skips null / undefined / empty-string fields inside a mapping item — round-trip", () => {
     // Same skip semantics the top-level serializer applies, so a
     // partially-filled item written by ``renderNestedListField``
     // doesn't emit half-blank rows that re-parse as different

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1156,6 +1156,43 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(after).not.toMatch(/^ {2}[a-zA-Z]/m);
   });
 
+  it("reads a flat scalar list with 4-space user indent", () => {
+    // Regression pin for the bug Copilot caught:
+    // ``listItemRegexFor`` was building its regex from
+    // ``parentIndent + ESPHOME_YAML_INDENT``, hardcoding the dash
+    // at ``parent + 2`` even when the actual dash sat at
+    // ``parent + 4`` for a 4-space user file. The startsWith
+    // prefix check passed (it was already detected from the
+    // content) but the regex match failed, so
+    // ``collectBlockListItems`` returned ``[]`` and the list was
+    // silently dropped — and would have been deleted on save.
+    const yaml = `wifi:
+    networks:
+        - one
+        - two
+        - three
+`;
+    const values = parseYamlSectionValues(yaml, "wifi");
+    expect(values.networks).toEqual(["one", "two", "three"]);
+  });
+
+  it("round-trips a 4-space scalar list through update without dropping items", () => {
+    // The save path would have spliced the empty parsed list back
+    // into the YAML, deleting the user's networks. Pin both the
+    // parse and the round-trip so a regression is caught at CI.
+    const yaml = `wifi:
+    networks:
+        - one
+        - two
+`;
+    const values = parseYamlSectionValues(yaml, "wifi");
+    (values.networks as string[]).push("three");
+    const after = updateSectionInYaml(yaml, "wifi", values);
+    expect(after).toContain("- one");
+    expect(after).toContain("- two");
+    expect(after).toContain("- three");
+  });
+
   it("treats an underscore-leading sibling section as a section terminator", () => {
     // The terminator predicate has to mirror ``KEY_PATTERN``'s
     // leading-character set (``[a-zA-Z_]``). A section header


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's `esphome:` block accepts a list of devices and a list of areas:

```yaml
esphome:
  devices:
    - id: front_door_device
      name: "Front Door Sensor"
      area_id: entrance_area
    - id: kitchen_motion_device
      name: "Kitchen Motion"
  areas:
    - id: entrance_area
      name: "Entrance"
    - id: kitchen_area
      name: "Kitchen"
```

The catalog already marks both fields `type=nested, multi_value=true`, but the form's `_renderEntryUnsafe` short-circuits any `NESTED` entry to `renderNestedField` *before* checking `multi_value` — so the editor showed a single device / area group with no way to add more. The second screenshot in esphome/device-builder-frontend#232 illustrates the bug exactly: one `id` / `name` / `area_id` row and nowhere to declare the next.

**Renderer changes:**

- New `renderNestedListField` next to `renderNestedField`. One collapsible group per array item, with a per-item remove button and a single Add button at the bottom. Re-uses `nested-fields` styles so each item visually matches a single nested group.
- Dispatch in `config-entry-form.ts` routes `type=nested && multi_value=true` to the new helper before the single-group fallback.
- `filterRenderable` is called per-item with the item's own values, so `depends_on` and presence-derived filtering resolve correctly inside each row.

**`setIn` / `getIn` array support:**

The renderer threads child paths like `["esphome", "devices", "0", "name"]` through the existing form-state plumbing. `setIn` previously hit `isPlainObject(child)` on the array, treated it as "non-object — replace with `{}`", and clobbered the whole list on the first child edit. Both helpers now descend into arrays via numeric path segments and copy-on-write the array slot, so siblings keep identity (structural sharing in the form-state reducer holds). Writing past the end grows the array — needed when a freshly-added item writes to a child field before its placeholder object is materialised.

**Tests** (12 new, all 886 in the suite passing):

- 5 new `nested-values` tests cover array-path read / write, growing the array, and the structural-sharing identity guarantee. The one existing test that asserted "crosses an array → undefined" was updated to reflect the new contract — that branch was the bug.
- New `render-nested-list-field.test.ts` (7 tests) covers:
  - Per-item child rendering at array-indexed paths.
  - Empty-state hint when the field is missing.
  - Add appends `{}` at the field's path.
  - Remove drops the right index and preserves sibling identity.
  - `filterRenderable` is scoped per-item.
  - Non-object items (`null`, stray strings from a mid-edit YAML) are coerced to `{}` — the renderer never crashes.
  - Filter respect — children dropped by `filterRenderable` aren't rendered.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#232

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
