### PR TITLE
Add first-run onboarding wizard with Wi-Fi credentials step

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -35,6 +35,7 @@ import type {
   ResultMessage,
   SerialPort,
   ServerInfoMessage,
+  OnboardingState,
   StreamCallbacks,
   UpdateDeviceResponse,
   UserPreferences,
@@ -1284,6 +1285,45 @@ export class ESPHomeAPI {
   /** Get secret key names. */
   async getSecretKeys(): Promise<string[]> {
     return this.sendCommand<string[]>("config/get_secrets");
+  }
+
+  /**
+   * Onboarding state — current version, what the user has
+   * acknowledged, and per-step ``pending`` / ``done`` status. The
+   * dashboard hits this on app load to decide whether to surface
+   * the setup wizard and whether to show the secrets-menu badge.
+   */
+  async getOnboardingState(): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>("onboarding/get_state");
+  }
+
+  /**
+   * Save Wi-Fi credentials into the user's ``secrets.yaml``. The
+   * backend validates against ESPHome's own length limits
+   * (32 char SSID, 64 char password) and surfaces violations as
+   * ``CommandError(INVALID_ARGS)`` for the UI to render.
+   */
+  async setOnboardingWifi(
+    ssid: string,
+    password: string,
+  ): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>(
+      "onboarding/set_wifi_credentials",
+      { ssid, password },
+    );
+  }
+
+  /**
+   * Mark the current onboarding flow as acknowledged. Called when
+   * the user explicitly closes the wizard (either after saving
+   * credentials or after declining — e.g. an Ethernet-only user
+   * who'll never set Wi-Fi). The badge in the secrets menu stays
+   * if the underlying data is still un-configured; this only
+   * stops the wizard dialog from re-popping until a future
+   * onboarding-version bump.
+   */
+  async markOnboardingAcknowledged(): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>("onboarding/mark_acknowledged");
   }
 
   /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -796,6 +796,50 @@ export interface UserPreferences {
   table_column_visibility: Record<string, boolean>;
   table_sort_column: string | null;
   table_sort_direction: SortDirection | null;
+  /** Highest onboarding-flow version the user has acknowledged.
+   *  ``0`` ⇒ never gone through onboarding. The dashboard surfaces
+   *  the wizard whenever this is below the server's
+   *  ``OnboardingState.current_version``. */
+  onboarding_completed_version: number;
+}
+
+/**
+ * Stable identifiers for onboarding steps. Keep in lockstep with
+ * the backend's ``OnboardingStepId`` enum — these strings flow
+ * through the wire as-is.
+ */
+export enum OnboardingStepId {
+  WIFI_CREDENTIALS = "wifi_credentials",
+}
+
+export enum OnboardingStepStatus {
+  PENDING = "pending",
+  DONE = "done",
+}
+
+export interface OnboardingStep {
+  id: OnboardingStepId;
+  status: OnboardingStepStatus;
+}
+
+/**
+ * Snapshot of the dashboard onboarding flow.
+ *
+ * ``current_version`` is the version of onboarding the server
+ * knows about; ``completed_version`` is what the user last
+ * acknowledged. The dashboard shows the wizard whenever the user
+ * is behind the current version OR a step is data-derived
+ * ``pending`` and the user hasn't dismissed for the session.
+ *
+ * Step status is computed from live on-disk state every call —
+ * never persisted — so the secrets-menu badge clears the moment
+ * the user configures the underlying data, even via a manual
+ * ``secrets.yaml`` edit.
+ */
+export interface OnboardingState {
+  current_version: number;
+  completed_version: number;
+  steps: OnboardingStep[];
 }
 
 /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -836,10 +836,12 @@ export interface OnboardingStep {
  * stops re-opening regardless of whether the data is now set.
  *
  * Step status drives a separate signal: the always-on badge in
- * the secrets kebab. It's computed from live on-disk state
- * every call — never persisted — so the badge clears the moment
- * the user configures the underlying data, even via a manual
- * ``secrets.yaml`` edit.
+ * the secrets kebab. It's computed from live on-disk state on
+ * every server-side ``get_state`` call — never persisted — and
+ * the dashboard re-fetches on (re)connect, so a manual
+ * ``secrets.yaml`` edit clears the badge no later than the next
+ * WS reconnect (or page reload). Within a single session the
+ * badge is a snapshot of the auth-time fetch.
  */
 export interface OnboardingState {
   current_version: number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -827,12 +827,17 @@ export interface OnboardingStep {
  *
  * ``current_version`` is the version of onboarding the server
  * knows about; ``completed_version`` is what the user last
- * acknowledged. The dashboard shows the wizard whenever the user
- * is behind the current version OR a step is data-derived
- * ``pending`` and the user hasn't dismissed for the session.
+ * acknowledged. The dashboard shows the wizard when
+ * ``completed_version < current_version`` AND the user hasn't
+ * frontend-side session-dismissed it. The data-derived
+ * ``steps[].status`` doesn't gate the dialog — saving real
+ * values OR declining ("I only use Ethernet") both call
+ * ``mark_acknowledged`` to advance the version, so the dialog
+ * stops re-opening regardless of whether the data is now set.
  *
- * Step status is computed from live on-disk state every call —
- * never persisted — so the secrets-menu badge clears the moment
+ * Step status drives a separate signal: the always-on badge in
+ * the secrets kebab. It's computed from live on-disk state
+ * every call — never persisted — so the badge clears the moment
  * the user configures the underlying data, even via a manual
  * ``secrets.yaml`` edit.
  */

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -548,6 +548,15 @@ export class ESPHomeApp extends LitElement {
     this._onboardingShouldShow = false;
   };
 
+  /** User picked the "Set up Wi-Fi" kebab item. Re-launches the
+   *  wizard regardless of acknowledged-version / session-dismiss
+   *  — the kebab entry is the explicit "I want to do this now"
+   *  signal, so we override both gates. */
+  private _onOpenOnboarding = () => {
+    this._onboardingSessionDismissed = false;
+    this._onboardingDialog?.open();
+  };
+
   // True while a ``setRemoteBuildSettings`` write is in flight. The
   // reload path on (re)connect skips when this is set so a write
   // racing with an auto-reconnect can't get clobbered by the
@@ -928,6 +937,7 @@ export class ESPHomeApp extends LitElement {
         @open-firmware-jobs=${this._onOpenFirmwareJobs}
         @open-reset-build-env=${this._onOpenResetBuildEnv}
         @open-feedback=${this._onOpenFeedback}
+        @open-onboarding-wifi=${this._onOpenOnboarding}
       >
         ${this._router.outlet()}
       </esphome-layout>

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -231,10 +231,11 @@ export class ESPHomeApp extends LitElement {
 
   /** True when onboarding has any data-derived ``pending`` step.
    *  Derived in ``_loadOnboardingState`` from
-   *  ``onboarding/get_state``. Surfaced to header-actions for the
-   *  Secrets-menu dot. Dialog visibility uses a separate signal
-   *  (acknowledged-version + session-dismissal) — this context is
-   *  the always-on data signal that should outlive any dismissal. */
+   *  ``onboarding/get_state``. Surfaced to header-actions to gate
+   *  the conditional ``Set up Wi-Fi…`` kebab entry. Dialog
+   *  visibility uses a separate signal (acknowledged-version +
+   *  session-dismissal) — this context is the always-on data
+   *  signal that should outlive any dismissal. */
   @provide({ context: onboardingPendingContext })
   @state()
   private _onboardingPending = false;
@@ -507,12 +508,13 @@ export class ESPHomeApp extends LitElement {
   }
 
   /** Load the onboarding snapshot and update both the
-   *  always-on data signal (``_onboardingPending`` — drives the
-   *  Secrets-menu dot) and the dialog-show signal
-   *  (``_onboardingShouldShow`` — gated by acknowledged-version
-   *  + session-dismissal). Re-runs on reconnect; the dialog
-   *  doesn't re-open mid-session because
-   *  ``_onboardingSessionDismissed`` survives the refresh. */
+   *  always-on data signal (``_onboardingPending`` — gates the
+   *  ``Set up Wi-Fi…`` kebab entry in header-actions) and the
+   *  dialog-show signal (``_onboardingShouldShow`` — gated by
+   *  acknowledged-version + session-dismissal). Re-runs on
+   *  reconnect and after every secrets save; the dialog doesn't
+   *  re-open mid-session because ``_onboardingSessionDismissed``
+   *  survives the refresh. */
   private async _loadOnboardingState() {
     try {
       const state = await this._api.getOnboardingState();

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -381,6 +381,12 @@ export class ESPHomeApp extends LitElement {
     if ("serial" in navigator) {
       navigator.serial.addEventListener("connect", this._onSerialConnect);
     }
+    // ``secrets-saved`` is dispatched on ``window`` by every code
+    // path that writes ``secrets.yaml`` (the secrets editor, the
+    // onboarding wizard). Refresh the onboarding snapshot so the
+    // kebab "Set up Wi-Fi" entry tracks the on-disk state in real
+    // time regardless of which surface initiated the write.
+    window.addEventListener("secrets-saved", this._onSecretsSaved);
   }
 
   disconnectedCallback() {
@@ -390,6 +396,7 @@ export class ESPHomeApp extends LitElement {
     if ("serial" in navigator) {
       navigator.serial.removeEventListener("connect", this._onSerialConnect);
     }
+    window.removeEventListener("secrets-saved", this._onSecretsSaved);
   }
 
   private _initDarkMode() {
@@ -946,7 +953,6 @@ export class ESPHomeApp extends LitElement {
         @open-reset-build-env=${this._onOpenResetBuildEnv}
         @open-feedback=${this._onOpenFeedback}
         @open-onboarding-wifi=${this._onOpenOnboarding}
-        @secrets-saved=${this._onSecretsSaved}
       >
         ${this._router.outlet()}
       </esphome-layout>

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -518,15 +518,17 @@ export class ESPHomeApp extends LitElement {
         userBehindCurrent && !this._onboardingSessionDismissed;
     } catch (err) {
       // Onboarding is non-critical — a transient WS failure here
-      // shouldn't block the rest of the dashboard. Logged for
-      // visibility; we explicitly clear both signals so a
-      // previously-true badge / dialog from an earlier successful
-      // load doesn't outlive the failure (the latest state is
-      // unknown — false reads as "no nudge", which is safer than
-      // a stale red indicator on data we can no longer verify).
+      // shouldn't block the rest of the dashboard. Clear the
+      // badge (the latest data is unknown, so reading as "no
+      // nudge" is safer than a stale red dot) but leave the
+      // dialog-show signal alone: a transient reload on a
+      // session-dismissed state must not cause a false→true
+      // transition that re-opens the wizard the user just
+      // closed. ``_onboardingSessionDismissed`` already prevents
+      // the *next* successful load from re-opening, but only if
+      // we don't toggle the show signal in between.
       console.warn("Failed to load onboarding state:", err);
       this._onboardingPending = false;
-      this._onboardingShouldShow = false;
     }
   }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -519,9 +519,14 @@ export class ESPHomeApp extends LitElement {
     } catch (err) {
       // Onboarding is non-critical — a transient WS failure here
       // shouldn't block the rest of the dashboard. Logged for
-      // visibility; the dialog stays closed (its absence is
-      // safer than a blank or broken-state render).
+      // visibility; we explicitly clear both signals so a
+      // previously-true badge / dialog from an earlier successful
+      // load doesn't outlive the failure (the latest state is
+      // unknown — false reads as "no nudge", which is safer than
+      // a stale red indicator on data we can no longer verify).
       console.warn("Failed to load onboarding state:", err);
+      this._onboardingPending = false;
+      this._onboardingShouldShow = false;
     }
   }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -19,6 +19,7 @@ import {
   ErrorCode,
   JobStatus,
   JobType,
+  OnboardingStepStatus,
   Theme,
 } from "../api/types.js";
 import type {
@@ -56,6 +57,7 @@ import {
   isHaIngressContext,
   labelsContext,
   localizeContext,
+  onboardingPendingContext,
   remoteBuildEnabledContext,
   serverVersionContext,
   versionContext,
@@ -108,6 +110,7 @@ import "./feedback-dialog.js";
 import type { ESPHomeFeedbackDialog } from "./feedback-dialog.js";
 import "./firmware-jobs-dialog.js";
 import type { ESPHomeFirmwareJobsDialog } from "./firmware-jobs-dialog.js";
+import "./onboarding-wifi-dialog.js";
 import "./settings-dialog.js";
 import type { ESPHomeSettingsDialog } from "./settings-dialog.js";
 
@@ -225,6 +228,31 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: labelsContext })
   @state()
   private _labels: Label[] = [];
+
+  /** True when onboarding has any data-derived ``pending`` step.
+   *  Derived in ``_loadOnboardingState`` from
+   *  ``onboarding/get_state``. Surfaced to header-actions for the
+   *  Secrets-menu dot. Dialog visibility uses a separate signal
+   *  (acknowledged-version + session-dismissal) — this context is
+   *  the always-on data signal that should outlive any dismissal. */
+  @provide({ context: onboardingPendingContext })
+  @state()
+  private _onboardingPending = false;
+
+  /** True when the onboarding wizard should be shown. Computed
+   *  from ``completed_version < current_version`` AND not
+   *  session-dismissed. Session-only ``"maybe later"`` flips
+   *  ``_onboardingSessionDismissed`` so the dialog stays closed
+   *  until the next dashboard load; explicit decline / save call
+   *  ``mark_acknowledged`` on the backend so the dialog stops
+   *  re-popping until a future onboarding-version bump. */
+  @state()
+  private _onboardingShouldShow = false;
+
+  /** Frontend-only "maybe later" — closes the dialog without
+   *  POSTing acknowledgement. Reset on next page load. */
+  @state()
+  private _onboardingSessionDismissed = false;
 
   // ─── Auth gate ───────────────────────────────────────────
   // Drives whether we render the connecting spinner, the login form,
@@ -468,7 +496,50 @@ export class ESPHomeApp extends LitElement {
     this._loadLabels();
     this._loadThemePreference();
     this._loadRemoteBuildSettings();
+    this._loadOnboardingState();
   }
+
+  /** Load the onboarding snapshot and update both the
+   *  always-on data signal (``_onboardingPending`` — drives the
+   *  Secrets-menu dot) and the dialog-show signal
+   *  (``_onboardingShouldShow`` — gated by acknowledged-version
+   *  + session-dismissal). Re-runs on reconnect; the dialog
+   *  doesn't re-open mid-session because
+   *  ``_onboardingSessionDismissed`` survives the refresh. */
+  private async _loadOnboardingState() {
+    try {
+      const state = await this._api.getOnboardingState();
+      this._onboardingPending = state.steps.some(
+        (s) => s.status === OnboardingStepStatus.PENDING,
+      );
+      const userBehindCurrent =
+        state.completed_version < state.current_version;
+      this._onboardingShouldShow =
+        userBehindCurrent && !this._onboardingSessionDismissed;
+    } catch (err) {
+      // Onboarding is non-critical — a transient WS failure here
+      // shouldn't block the rest of the dashboard. Logged for
+      // visibility; the dialog stays closed (its absence is
+      // safer than a blank or broken-state render).
+      console.warn("Failed to load onboarding state:", err);
+    }
+  }
+
+  private _onOnboardingAcknowledged = () => {
+    // Triggered by the dialog after a successful save or explicit
+    // decline — both of which call ``mark_acknowledged`` on the
+    // backend. Refresh the state so the badge reflects the new
+    // data (cleared after a save) and so the dialog signal stays
+    // accurate without another full round-trip on the user's
+    // next page load.
+    this._onboardingShouldShow = false;
+    this._loadOnboardingState();
+  };
+
+  private _onOnboardingDismissedSession = () => {
+    this._onboardingSessionDismissed = true;
+    this._onboardingShouldShow = false;
+  };
 
   // True while a ``setRemoteBuildSettings`` write is in flight. The
   // reload path on (re)connect skips when this is set so a write
@@ -868,8 +939,25 @@ export class ESPHomeApp extends LitElement {
         @firmware-history-cleared=${this._onFirmwareHistoryCleared}
       ></esphome-firmware-jobs-dialog>
       <esphome-feedback-dialog></esphome-feedback-dialog>
+      <esphome-onboarding-wifi-dialog
+        @onboarding-acknowledged=${this._onOnboardingAcknowledged}
+        @onboarding-dismissed-session=${this._onOnboardingDismissedSession}
+      ></esphome-onboarding-wifi-dialog>
     `;
   }
+
+  /** When ``_onboardingShouldShow`` flips true, programmatically
+   *  open the dialog. The dialog itself is mounted unconditionally
+   *  (so the ``@`` event listeners are wired) but starts closed. */
+  protected updated(changed: Map<string | number | symbol, unknown>) {
+    super.updated?.(changed);
+    if (changed.has("_onboardingShouldShow") && this._onboardingShouldShow) {
+      this._onboardingDialog?.open();
+    }
+  }
+
+  @query("esphome-onboarding-wifi-dialog")
+  private _onboardingDialog?: HTMLElement & { open(): void };
 
   private async _onLoginSubmit(
     e: CustomEvent<{ username: string; password: string }>,

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -557,6 +557,14 @@ export class ESPHomeApp extends LitElement {
     this._onboardingDialog?.open();
   };
 
+  /** Secrets editor finished a save. Refresh the onboarding
+   *  snapshot so the kebab entry appears / disappears in real
+   *  time when the user clears or fills in Wi-Fi credentials by
+   *  hand instead of going through the wizard. */
+  private _onSecretsSaved = () => {
+    this._loadOnboardingState();
+  };
+
   // True while a ``setRemoteBuildSettings`` write is in flight. The
   // reload path on (re)connect skips when this is set so a write
   // racing with an auto-reconnect can't get clobbered by the
@@ -938,6 +946,7 @@ export class ESPHomeApp extends LitElement {
         @open-reset-build-env=${this._onOpenResetBuildEnv}
         @open-feedback=${this._onOpenFeedback}
         @open-onboarding-wifi=${this._onOpenOnboarding}
+        @secrets-saved=${this._onSecretsSaved}
       >
         ${this._router.outlet()}
       </esphome-layout>

--- a/src/components/device/password-input.ts
+++ b/src/components/device/password-input.ts
@@ -11,7 +11,7 @@
 
 import { mdiEye, mdiEyeOff } from "@mdi/js";
 import { consume } from "@lit/context";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
@@ -57,6 +57,14 @@ export class ESPHomePasswordInput extends LitElement {
 
   @property({ type: Boolean })
   invalid = false;
+
+  /** Optional client-side cap on input length. Mirrors the ``maxlength``
+   *  attribute on a native ``<input>``; surfaces immediate feedback
+   *  instead of round-tripping through a backend rejection for known
+   *  caps (e.g. ESPHome's 64-char WPA password). Default 0 (no cap)
+   *  so existing call sites stay unchanged. */
+  @property({ type: Number })
+  maxlength = 0;
 
   @state()
   private _revealed = false;
@@ -134,6 +142,7 @@ export class ESPHomePasswordInput extends LitElement {
           ?disabled=${this.disabled}
           placeholder=${this.placeholder}
           autocomplete="off"
+          maxlength=${this.maxlength > 0 ? this.maxlength : nothing}
           @input=${this._onInput}
         />
         <button

--- a/src/components/device/password-input.ts
+++ b/src/components/device/password-input.ts
@@ -66,6 +66,16 @@ export class ESPHomePasswordInput extends LitElement {
   @property({ type: Number })
   maxlength = 0;
 
+  /** Optional accessible name forwarded to the inner ``<input>`` as
+   *  ``aria-label``. Custom elements aren't labelable form controls,
+   *  so an external ``<label for="...">`` won't reliably bind to
+   *  the inner input — pass the label text in here when the visible
+   *  label lives outside this component. Default empty (no
+   *  ``aria-label`` attribute) so existing call sites are
+   *  unchanged. */
+  @property()
+  label = "";
+
   @state()
   private _revealed = false;
 
@@ -143,6 +153,7 @@ export class ESPHomePasswordInput extends LitElement {
           placeholder=${this.placeholder}
           autocomplete="off"
           maxlength=${this.maxlength > 0 ? this.maxlength : nothing}
+          aria-label=${this.label || nothing}
           @input=${this._onInput}
         />
         <button

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -9,6 +9,7 @@ import {
   mdiEyeOutline,
   mdiKeyVariant,
   mdiPlaylistCheck,
+  mdiWifiCog,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
@@ -37,6 +38,7 @@ registerMdiIcons({
   "eye-outline": mdiEyeOutline,
   "key-variant": mdiKeyVariant,
   "playlist-check": mdiPlaylistCheck,
+  "wifi-cog": mdiWifiCog,
 });
 
 @customElement("esphome-header-actions")
@@ -240,18 +242,6 @@ export class ESPHomeHeaderActions extends LitElement {
         text-align: center;
       }
 
-      /* Dot variant — surfaced next to a menu item that needs the
-         user's attention but has no useful count to display
-         (onboarding-pending Secrets, future similar nudges). */
-      .menu-item-dot {
-        margin-left: auto;
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: var(--esphome-primary);
-        flex-shrink: 0;
-      }
-
       .menu-divider {
         height: 1px;
         background: var(--wa-color-surface-border);
@@ -353,22 +343,26 @@ export class ESPHomeHeaderActions extends LitElement {
                 class="menu-item"
                 role="menuitem"
                 tabindex="0"
-                aria-label=${this._onboardingPending
-                  ? `${this._localize("layout.secrets")} — ${this._localize("onboarding.secrets_dot_title")}`
-                  : this._localize("layout.secrets")}
                 @click=${this._openSecrets}
                 @keydown=${this._onMenuItemKeydown}
               >
                 <wa-icon library="mdi" name="key-variant"></wa-icon>
                 <span class="menu-item-label">${this._localize("layout.secrets")}</span>
-                ${this._onboardingPending
-                  ? html`<span
-                      class="menu-item-dot"
-                      title=${this._localize("onboarding.secrets_dot_title")}
-                      aria-hidden="true"
-                    ></span>`
-                  : nothing}
               </div>
+              ${this._onboardingPending
+                ? html`<div
+                    class="menu-item"
+                    role="menuitem"
+                    tabindex="0"
+                    @click=${this._openOnboarding}
+                    @keydown=${this._onMenuItemKeydown}
+                  >
+                    <wa-icon library="mdi" name="wifi-cog"></wa-icon>
+                    <span class="menu-item-label"
+                      >${this._localize("onboarding.menu_item_setup_wifi")}</span
+                    >
+                  </div>`
+                : nothing}
               <div
                 class="menu-item ${this._showIgnored ? "menu-item--active" : ""}"
                 role="menuitemcheckbox"
@@ -511,6 +505,21 @@ export class ESPHomeHeaderActions extends LitElement {
   private _openSecrets() {
     this._close();
     navigate("/secrets");
+  }
+
+  /** Re-launches the onboarding wizard on demand. The kebab item
+   *  is gated on ``_onboardingPending`` (data-derived from
+   *  ``secrets.yaml``), so it appears only when there's actually
+   *  something to onboard — a user who declined "I don't use Wi-Fi"
+   *  earlier sees the entry and can change their mind. */
+  private _openOnboarding() {
+    this._close();
+    this.dispatchEvent(
+      new CustomEvent("open-onboarding-wifi", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private _openFirmwareJobs() {

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -63,11 +63,14 @@ export class ESPHomeHeaderActions extends LitElement {
 
   /** True when onboarding still has work to do (currently:
    *  Wi-Fi step pending — data-derived from ``secrets.yaml``).
-   *  Renders a small dot next to the Secrets menu item so a user
-   *  who's declined the onboarding wizard still has a visible
-   *  reminder that their credentials aren't set — important for
-   *  users who later switch from Ethernet to Wi-Fi.
-   *  Owned by the app shell, threaded via context. */
+   *  Gates a dedicated ``Set up Wi-Fi…`` kebab entry so a user
+   *  who declined the wizard with "I don't use Wi-Fi" — or who
+   *  cleared the credentials by hand from the Secrets editor —
+   *  still has a one-click re-entry into the wizard. The entry
+   *  appears / disappears in real time as ``secrets.yaml``
+   *  changes (the app-shell re-fetches the snapshot on every
+   *  ``secrets-saved`` event). Owned by the app shell, threaded
+   *  via context. */
   @consume({ context: onboardingPendingContext, subscribe: true })
   @state()
   private _onboardingPending = false;

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -353,6 +353,9 @@ export class ESPHomeHeaderActions extends LitElement {
                 class="menu-item"
                 role="menuitem"
                 tabindex="0"
+                aria-label=${this._onboardingPending
+                  ? `${this._localize("layout.secrets")} — ${this._localize("onboarding.secrets_dot_title")}`
+                  : this._localize("layout.secrets")}
                 @click=${this._openSecrets}
                 @keydown=${this._onMenuItemKeydown}
               >
@@ -362,6 +365,7 @@ export class ESPHomeHeaderActions extends LitElement {
                   ? html`<span
                       class="menu-item-dot"
                       title=${this._localize("onboarding.secrets_dot_title")}
+                      aria-hidden="true"
                     ></span>`
                   : nothing}
               </div>

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -15,7 +15,11 @@ import { customElement, state } from "lit/decorators.js";
 import { JobStatus } from "../api/types.js";
 import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { firmwareJobsContext, localizeContext } from "../context/index.js";
+import {
+  firmwareJobsContext,
+  localizeContext,
+  onboardingPendingContext,
+} from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
@@ -54,6 +58,17 @@ export class ESPHomeHeaderActions extends LitElement {
    *  level settings. */
   @state()
   private _showIgnored = false;
+
+  /** True when onboarding still has work to do (currently:
+   *  Wi-Fi step pending — data-derived from ``secrets.yaml``).
+   *  Renders a small dot next to the Secrets menu item so a user
+   *  who's declined the onboarding wizard still has a visible
+   *  reminder that their credentials aren't set — important for
+   *  users who later switch from Ethernet to Wi-Fi.
+   *  Owned by the app shell, threaded via context. */
+  @consume({ context: onboardingPendingContext, subscribe: true })
+  @state()
+  private _onboardingPending = false;
 
   static styles = [
     espHomeStyles,
@@ -225,6 +240,18 @@ export class ESPHomeHeaderActions extends LitElement {
         text-align: center;
       }
 
+      /* Dot variant — surfaced next to a menu item that needs the
+         user's attention but has no useful count to display
+         (onboarding-pending Secrets, future similar nudges). */
+      .menu-item-dot {
+        margin-left: auto;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--esphome-primary);
+        flex-shrink: 0;
+      }
+
       .menu-divider {
         height: 1px;
         background: var(--wa-color-surface-border);
@@ -330,7 +357,13 @@ export class ESPHomeHeaderActions extends LitElement {
                 @keydown=${this._onMenuItemKeydown}
               >
                 <wa-icon library="mdi" name="key-variant"></wa-icon>
-                ${this._localize("layout.secrets")}
+                <span class="menu-item-label">${this._localize("layout.secrets")}</span>
+                ${this._onboardingPending
+                  ? html`<span
+                      class="menu-item-dot"
+                      title=${this._localize("onboarding.secrets_dot_title")}
+                    ></span>`
+                  : nothing}
               </div>
               <div
                 class="menu-item ${this._showIgnored ? "menu-item--active" : ""}"

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -223,12 +223,17 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   }
 
   private async _save() {
-    const ssid = this._ssid.trim();
-    if (!ssid) return;
+    // IEEE 802.11 SSIDs may legally contain leading/trailing
+    // whitespace, so don't ``trim()`` the value being sent —
+    // mutating it would silently change the network name and
+    // the device would fail to associate. The Save button is
+    // already disabled on all-whitespace input via the same
+    // check below.
+    if (!this._ssid.trim()) return;
     this._saving = true;
     this._error = null;
     try {
-      await this._api.setOnboardingWifi(ssid, this._password);
+      await this._api.setOnboardingWifi(this._ssid, this._password);
       // Acknowledge so the dialog doesn't re-pop on next load even
       // if the badge logic wants to keep the menu indicator.
       await this._api.markOnboardingAcknowledged();

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -64,11 +64,18 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
+  /** True after the user has explicitly saved or declined inside
+   *  the current open() — suppresses the close-via-X session-
+   *  dismiss path so we don't both ``mark_acknowledged`` AND fire
+   *  ``onboarding-dismissed-session`` for the same close. */
+  private _exitedExplicitly = false;
+
   open() {
     this._ssid = "";
     this._password = "";
     this._saving = false;
     this._error = null;
+    this._exitedExplicitly = false;
     this._dialog.open = true;
   }
 
@@ -138,7 +145,10 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog label=${this._localize("onboarding.wifi.title")}>
+      <wa-dialog
+        label=${this._localize("onboarding.wifi.title")}
+        @wa-after-hide=${this._onAfterHide}
+      >
         <div class="body">
           <p class="intro">
             <wa-icon library="mdi" name="wifi"></wa-icon>
@@ -172,7 +182,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
             ></esphome-password-input>
           </div>
           ${this._error
-            ? html`<p class="error">${this._error}</p>`
+            ? html`<p class="error" role="alert">${this._error}</p>`
             : nothing}
         </div>
         <div slot="footer" class="actions">
@@ -216,9 +226,8 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       // Acknowledge so the dialog doesn't re-pop on next load even
       // if the badge logic wants to keep the menu indicator.
       await this._api.markOnboardingAcknowledged();
-      toast.success(this._localize("onboarding.wifi.save_success"), {
-        richColors: true,
-      });
+      toast.success(this._localize("onboarding.wifi.save_success"));
+      this._exitedExplicitly = true;
       this._emitAcknowledged();
       this.close();
     } catch (err) {
@@ -232,12 +241,26 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._saving = true;
     try {
       await this._api.markOnboardingAcknowledged();
+      this._exitedExplicitly = true;
       this._emitAcknowledged();
       this.close();
     } catch (err) {
       this._error = this._formatError(err);
     } finally {
       this._saving = false;
+    }
+  }
+
+  /**
+   * Catch-all for any close that wasn't initiated via Save / Decline /
+   * the explicit "Maybe later" button — e.g. the dialog's built-in
+   * X, Escape, or a backdrop click. Treat it as a session dismiss
+   * so the badge stays accurate but the dialog doesn't re-open
+   * mid-session.
+   */
+  private _onAfterHide() {
+    if (!this._exitedExplicitly) {
+      this._dismissForSession();
     }
   }
 
@@ -259,7 +282,12 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     return this._localize("onboarding.wifi.save_failed");
   }
 
-  private _dismissForSession() {
+  private _dismissForSession = () => {
+    // Idempotent — wa-after-hide also routes here, and an explicit
+    // "Maybe later" tap fires this directly *and* synthesises an
+    // after-hide. Setting ``_exitedExplicitly`` first short-
+    // circuits the second pass through the after-hide handler.
+    this._exitedExplicitly = true;
     this.dispatchEvent(
       new CustomEvent("onboarding-dismissed-session", {
         bubbles: true,
@@ -267,7 +295,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       }),
     );
     this.close();
-  }
+  };
 
   private _emitAcknowledged() {
     this.dispatchEvent(

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -259,6 +259,16 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._error = null;
     try {
       await this._api.setOnboardingWifi(this._ssid, this._password);
+      // Notify any mounted secrets-editor instance (and app-shell's
+      // onboarding-state refresh) that secrets.yaml has changed on
+      // disk. Window-level so listeners can live anywhere in the
+      // tree; ``detail.source`` lets a future self-listener short-
+      // circuit. Fired before ``markOnboardingAcknowledged`` so a
+      // failure on the second call doesn't suppress the refresh
+      // — the wifi write is the user-visible state change.
+      window.dispatchEvent(
+        new CustomEvent("secrets-saved", { detail: { source: this } }),
+      );
       // Acknowledge so the dialog doesn't re-pop on next load even
       // if the badge logic wants to keep the menu indicator.
       await this._api.markOnboardingAcknowledged();

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -163,7 +163,12 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               placeholder=${this._localize("onboarding.wifi.ssid_placeholder")}
               ?disabled=${this._saving}
               @input=${(e: Event) => {
-                this._ssid = (e.target as HTMLInputElement).value;
+                // Read from currentTarget so we get the wa-input
+                // host element's value rather than risking the
+                // retargeted inner native ``<input>`` (mirrors the
+                // pattern in ``label-form.ts``).
+                this._ssid = (e.currentTarget as unknown as { value: string })
+                  .value;
               }}
             ></wa-input>
           </div>
@@ -173,6 +178,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               id="onboarding-password"
               .value=${this._password}
               .placeholder=${this._localize("onboarding.wifi.password_placeholder")}
+              .maxlength=${64}
               ?disabled=${this._saving}
               @password-input-change=${(
                 e: CustomEvent<PasswordInputValueChange>,
@@ -239,6 +245,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
 
   private async _declinePermanently() {
     this._saving = true;
+    this._error = null;
     try {
       await this._api.markOnboardingAcknowledged();
       this._exitedExplicitly = true;

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -171,6 +171,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     return html`
       <wa-dialog
         label=${this._localize("onboarding.wifi.title")}
+        @wa-request-close=${this._onRequestClose}
         @wa-after-hide=${this._onAfterHide}
       >
         <div class="body">
@@ -299,6 +300,21 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       this._dismissForSession();
     }
   }
+
+  /**
+   * Block close requests while a save / decline is in flight. The
+   * X / Escape / backdrop-click would otherwise hide the dialog
+   * before the network round-trip resolves; a failed save would
+   * then route through ``_onAfterHide`` → session-dismiss with
+   * the user never seeing the inline error. Same pattern as
+   * ``adopt-dialog`` (``_onRequestClose`` + ``e.preventDefault()``
+   * gate on its ``_busy`` flag).
+   */
+  private _onRequestClose = (e: Event) => {
+    if (this._saving) {
+      e.preventDefault();
+    }
+  };
 
   /**
    * Surface a backend error in user-facing prose. ``APIError``

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -3,6 +3,7 @@ import { mdiWifi } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
+import { APIError } from "../api/index.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
@@ -221,10 +222,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       this._emitAcknowledged();
       this.close();
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("onboarding.wifi.save_failed");
+      this._error = this._formatError(err);
     } finally {
       this._saving = false;
     }
@@ -237,13 +235,28 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       this._emitAcknowledged();
       this.close();
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("onboarding.wifi.save_failed");
+      this._error = this._formatError(err);
     } finally {
       this._saving = false;
     }
+  }
+
+  /**
+   * Surface a backend error in user-facing prose. ``APIError``
+   * carries a structured ``errorCode`` + ``details`` pair; its
+   * ``Error.message`` is the wire form ``"INVALID_ARGS: …"`` —
+   * fine for logs, leaks an internal code into the dialog's
+   * inline error if rendered raw. Show ``details`` directly when
+   * we have an ``APIError``, fall back to ``message`` for native
+   * errors, and fall back to the localized generic when we have
+   * neither.
+   */
+  private _formatError(err: unknown): string {
+    if (err instanceof APIError) {
+      return err.details || this._localize("onboarding.wifi.save_failed");
+    }
+    if (err instanceof Error) return err.message;
+    return this._localize("onboarding.wifi.save_failed");
   }
 
   private _dismissForSession() {

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -186,6 +186,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               .value=${this._ssid}
               maxlength="32"
               placeholder=${this._localize("onboarding.wifi.ssid_placeholder")}
+              aria-label=${this._localize("onboarding.wifi.ssid_label")}
               ?disabled=${this._saving}
               @input=${(e: Event) => {
                 // Read from currentTarget so we get the wa-input
@@ -204,6 +205,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               .value=${this._password}
               .placeholder=${this._localize("onboarding.wifi.password_placeholder")}
               .maxlength=${64}
+              .label=${this._localize("onboarding.wifi.password_label")}
               ?disabled=${this._saving}
               @password-input-change=${(
                 e: CustomEvent<PasswordInputValueChange>,

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -127,17 +127,41 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
         font-size: var(--wa-font-size-s);
       }
 
+      /* Decline-permanent is rendered as a low-emphasis text link
+         under the body fields rather than a third button in the
+         footer — a button on the same row as Save / Maybe later
+         drew the eye away from the primary action and looked
+         visually heavier than its real weight. The link styling
+         keeps it accessible and discoverable without competing
+         with the buttons. */
+      .opt-out {
+        font-size: var(--wa-font-size-2xs);
+        color: var(--wa-color-text-quiet);
+        text-align: center;
+        margin: 0;
+      }
+
+      .opt-out button {
+        background: none;
+        border: none;
+        padding: 0;
+        font-family: inherit;
+        font-size: inherit;
+        color: var(--esphome-primary);
+        cursor: pointer;
+        text-decoration: underline;
+      }
+
+      .opt-out button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
       .actions {
         display: flex;
         flex-direction: row;
-        justify-content: space-between;
+        justify-content: flex-end;
         align-items: center;
-        gap: var(--wa-space-s);
-        flex-wrap: wrap;
-      }
-
-      .actions-secondary {
-        display: flex;
         gap: var(--wa-space-s);
       }
     `,
@@ -190,33 +214,33 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
           ${this._error
             ? html`<p class="error" role="alert">${this._error}</p>`
             : nothing}
+          <p class="opt-out">
+            <button
+              type="button"
+              ?disabled=${this._saving}
+              @click=${this._declinePermanently}
+            >
+              ${this._localize("onboarding.wifi.decline_permanent")}
+            </button>
+          </p>
         </div>
         <div slot="footer" class="actions">
           <wa-button
             appearance="plain"
             ?disabled=${this._saving}
-            @click=${this._declinePermanently}
+            @click=${this._dismissForSession}
           >
-            ${this._localize("onboarding.wifi.decline_permanent")}
+            ${this._localize("onboarding.wifi.dismiss_session")}
           </wa-button>
-          <div class="actions-secondary">
-            <wa-button
-              appearance="plain"
-              ?disabled=${this._saving}
-              @click=${this._dismissForSession}
-            >
-              ${this._localize("onboarding.wifi.dismiss_session")}
-            </wa-button>
-            <wa-button
-              variant="brand"
-              ?disabled=${this._saving || !this._ssid.trim()}
-              @click=${this._save}
-            >
-              ${this._saving
-                ? this._localize("onboarding.wifi.saving")
-                : this._localize("onboarding.wifi.save")}
-            </wa-button>
-          </div>
+          <wa-button
+            variant="brand"
+            ?disabled=${this._saving || !this._ssid.trim()}
+            @click=${this._save}
+          >
+            ${this._saving
+              ? this._localize("onboarding.wifi.saving")
+              : this._localize("onboarding.wifi.save")}
+          </wa-button>
         </div>
       </wa-dialog>
     `;

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -261,28 +261,44 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._error = null;
     try {
       await this._api.setOnboardingWifi(this._ssid, this._password);
-      // Notify any mounted secrets-editor instance (and app-shell's
-      // onboarding-state refresh) that secrets.yaml has changed on
-      // disk. Window-level so listeners can live anywhere in the
-      // tree; ``detail.source`` lets a future self-listener short-
-      // circuit. Fired before ``markOnboardingAcknowledged`` so a
-      // failure on the second call doesn't suppress the refresh
-      // — the wifi write is the user-visible state change.
-      window.dispatchEvent(
-        new CustomEvent("secrets-saved", { detail: { source: this } }),
-      );
+    } catch (err) {
+      // The wifi write itself failed — the user's credentials
+      // never landed on disk. Surface the error inline so they
+      // can correct and retry.
+      this._error = this._formatError(err, "onboarding.wifi.save_failed");
+      this._saving = false;
+      return;
+    }
+    // Notify any mounted secrets-editor instance (and app-shell's
+    // onboarding-state refresh) that secrets.yaml has changed on
+    // disk. Window-level so listeners can live anywhere in the
+    // tree; ``detail.source`` lets a future self-listener short-
+    // circuit. Fired before ``markOnboardingAcknowledged`` so a
+    // failure on the second call doesn't suppress the refresh
+    // — the wifi write is the user-visible state change.
+    window.dispatchEvent(
+      new CustomEvent("secrets-saved", { detail: { source: this } }),
+    );
+    try {
       // Acknowledge so the dialog doesn't re-pop on next load even
       // if the badge logic wants to keep the menu indicator.
       await this._api.markOnboardingAcknowledged();
-      toast.success(this._localize("onboarding.wifi.save_success"));
-      this._exitedExplicitly = true;
-      this._emitAcknowledged();
-      this.close();
     } catch (err) {
-      this._error = this._formatError(err);
-    } finally {
-      this._saving = false;
+      // Wifi WAS saved — the only consequence of a failed ack is
+      // that the wizard will re-pop on next load. Don't gate the
+      // success path on it: log + show a non-blocking warning
+      // toast, then close as if everything succeeded. Inline
+      // errors at this point would be misleading ("Couldn't save
+      // Wi-Fi credentials" while the credentials are now safely
+      // on disk).
+      console.warn("Failed to mark onboarding acknowledged:", err);
+      toast.warning(this._localize("onboarding.wifi.ack_failed"));
     }
+    toast.success(this._localize("onboarding.wifi.save_success"));
+    this._exitedExplicitly = true;
+    this._emitAcknowledged();
+    this.close();
+    this._saving = false;
   }
 
   private async _declinePermanently() {
@@ -294,7 +310,11 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       this._emitAcknowledged();
       this.close();
     } catch (err) {
-      this._error = this._formatError(err);
+      // Decline never writes secrets — only the ack call
+      // happened. Use the decline-specific fallback so the user
+      // doesn't see "Couldn't save Wi-Fi credentials" when
+      // nothing of theirs was being saved in the first place.
+      this._error = this._formatError(err, "onboarding.wifi.decline_failed");
     } finally {
       this._saving = false;
     }
@@ -335,15 +355,18 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
    * fine for logs, leaks an internal code into the dialog's
    * inline error if rendered raw. Show ``details`` directly when
    * we have an ``APIError``, fall back to ``message`` for native
-   * errors, and fall back to the localized generic when we have
-   * neither.
+   * errors, and fall back to the *caller-supplied* localization
+   * key when we have neither — different code paths (save vs
+   * decline) want different fallback copy so the user isn't told
+   * "Couldn't save Wi-Fi credentials" when the failing call
+   * wasn't the wifi save.
    */
-  private _formatError(err: unknown): string {
+  private _formatError(err: unknown, fallbackKey: string): string {
     if (err instanceof APIError) {
-      return err.details || this._localize("onboarding.wifi.save_failed");
+      return err.details || this._localize(fallbackKey);
     }
     if (err instanceof Error) return err.message;
-    return this._localize("onboarding.wifi.save_failed");
+    return this._localize(fallbackKey);
   }
 
   private _dismissForSession = () => {

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -1,0 +1,320 @@
+import { consume } from "@lit/context";
+import { mdiEye, mdiEyeOff, mdiWifi } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, query, state } from "lit/decorators.js";
+import toast from "sonner-js";
+import type { ESPHomeAPI } from "../api/index.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import { apiContext, localizeContext } from "../context/index.js";
+import { espHomeStyles } from "../styles/shared.js";
+import { registerMdiIcons } from "../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/button/button.js";
+import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/input/input.js";
+
+registerMdiIcons({ eye: mdiEye, "eye-off": mdiEyeOff, wifi: mdiWifi });
+
+/**
+ * First-run Wi-Fi setup dialog.
+ *
+ * Surfaced by the app shell when ``OnboardingState.completed_version
+ * < current_version``. The dialog gives the user three exits:
+ *
+ * - **Save** — POSTs the new credentials to
+ *   ``onboarding/set_wifi_credentials`` and acknowledges the
+ *   current version. Closes.
+ * - **Maybe later** (close button) — frontend-only session
+ *   dismiss. The dialog reopens on the next dashboard load.
+ * - **I only use Ethernet** — explicit decline. POSTs
+ *   ``onboarding/mark_acknowledged`` so the dialog stops
+ *   re-opening for this user, but the secrets-menu badge stays
+ *   (the underlying data is still un-configured) so a user who
+ *   later switches to Wi-Fi has a visible reminder.
+ *
+ * The dialog is dispatched a ``onboarding-acknowledged`` event on
+ * a successful save / decline so the app shell can refresh its
+ * cached state without re-querying.
+ */
+@customElement("esphome-onboarding-wifi-dialog")
+export class ESPHomeOnboardingWifiDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  private _api!: ESPHomeAPI;
+
+  @state()
+  private _ssid = "";
+
+  @state()
+  private _password = "";
+
+  @state()
+  private _showPassword = false;
+
+  @state()
+  private _saving = false;
+
+  @state()
+  private _error: string | null = null;
+
+  @query("wa-dialog")
+  private _dialog!: HTMLElement & { open: boolean };
+
+  open() {
+    this._ssid = "";
+    this._password = "";
+    this._showPassword = false;
+    this._saving = false;
+    this._error = null;
+    this._dialog.open = true;
+  }
+
+  close() {
+    this._dialog.open = false;
+  }
+
+  static styles = [
+    espHomeStyles,
+    css`
+      wa-dialog {
+        --width: 480px;
+      }
+
+      .body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-m);
+      }
+
+      .intro {
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-quiet);
+        line-height: 1.5;
+        margin: 0;
+      }
+
+      .intro wa-icon {
+        font-size: 18px;
+        vertical-align: -3px;
+        margin-right: var(--wa-space-2xs);
+        color: var(--esphome-primary);
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--wa-space-2xs);
+      }
+
+      label {
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-bold);
+        color: var(--wa-color-text-normal);
+      }
+
+      .password-row {
+        display: flex;
+        align-items: stretch;
+        gap: var(--wa-space-2xs);
+      }
+
+      .password-row wa-input {
+        flex: 1;
+      }
+
+      .reveal-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        border-radius: var(--wa-border-radius-m);
+        padding: 0 12px;
+        color: var(--wa-color-text-quiet);
+        cursor: pointer;
+      }
+
+      .reveal-btn:hover {
+        color: var(--wa-color-text-normal);
+      }
+
+      .error {
+        color: var(--esphome-error);
+        font-size: var(--wa-font-size-s);
+      }
+
+      .actions {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--wa-space-s);
+        flex-wrap: wrap;
+      }
+
+      .actions-secondary {
+        display: flex;
+        gap: var(--wa-space-s);
+      }
+    `,
+  ];
+
+  protected render() {
+    return html`
+      <wa-dialog label=${this._localize("onboarding.wifi.title")}>
+        <div class="body">
+          <p class="intro">
+            <wa-icon library="mdi" name="wifi"></wa-icon>
+            ${this._localize("onboarding.wifi.intro")}
+          </p>
+          <div class="field">
+            <label for="onboarding-ssid">${this._localize("onboarding.wifi.ssid_label")}</label>
+            <wa-input
+              id="onboarding-ssid"
+              .value=${this._ssid}
+              maxlength="32"
+              placeholder=${this._localize("onboarding.wifi.ssid_placeholder")}
+              ?disabled=${this._saving}
+              @input=${(e: Event) => {
+                this._ssid = (e.target as HTMLInputElement).value;
+              }}
+            ></wa-input>
+          </div>
+          <div class="field">
+            <label for="onboarding-password">${this._localize("onboarding.wifi.password_label")}</label>
+            <div class="password-row">
+              <wa-input
+                id="onboarding-password"
+                type=${this._showPassword ? "text" : "password"}
+                .value=${this._password}
+                maxlength="64"
+                placeholder=${this._localize("onboarding.wifi.password_placeholder")}
+                ?disabled=${this._saving}
+                @input=${(e: Event) => {
+                  this._password = (e.target as HTMLInputElement).value;
+                }}
+              ></wa-input>
+              <button
+                type="button"
+                class="reveal-btn"
+                title=${this._localize(
+                  this._showPassword
+                    ? "dashboard.action_api_key_hide"
+                    : "dashboard.action_api_key_show",
+                )}
+                @click=${() => {
+                  this._showPassword = !this._showPassword;
+                }}
+              >
+                <wa-icon
+                  library="mdi"
+                  name=${this._showPassword ? "eye-off" : "eye"}
+                ></wa-icon>
+              </button>
+            </div>
+          </div>
+          ${this._error
+            ? html`<p class="error">${this._error}</p>`
+            : nothing}
+        </div>
+        <div slot="footer" class="actions">
+          <wa-button
+            appearance="plain"
+            ?disabled=${this._saving}
+            @click=${this._declinePermanently}
+          >
+            ${this._localize("onboarding.wifi.decline_permanent")}
+          </wa-button>
+          <div class="actions-secondary">
+            <wa-button
+              appearance="plain"
+              ?disabled=${this._saving}
+              @click=${this._dismissForSession}
+            >
+              ${this._localize("onboarding.wifi.dismiss_session")}
+            </wa-button>
+            <wa-button
+              variant="brand"
+              ?disabled=${this._saving || !this._ssid.trim()}
+              @click=${this._save}
+            >
+              ${this._saving
+                ? this._localize("onboarding.wifi.saving")
+                : this._localize("onboarding.wifi.save")}
+            </wa-button>
+          </div>
+        </div>
+      </wa-dialog>
+    `;
+  }
+
+  private async _save() {
+    const ssid = this._ssid.trim();
+    if (!ssid) return;
+    this._saving = true;
+    this._error = null;
+    try {
+      await this._api.setOnboardingWifi(ssid, this._password);
+      // Acknowledge so the dialog doesn't re-pop on next load even
+      // if the badge logic wants to keep the menu indicator.
+      await this._api.markOnboardingAcknowledged();
+      toast.success(this._localize("onboarding.wifi.save_success"), {
+        richColors: true,
+      });
+      this._emitAcknowledged();
+      this.close();
+    } catch (err) {
+      this._error =
+        err instanceof Error
+          ? err.message
+          : this._localize("onboarding.wifi.save_failed");
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  private async _declinePermanently() {
+    this._saving = true;
+    try {
+      await this._api.markOnboardingAcknowledged();
+      this._emitAcknowledged();
+      this.close();
+    } catch (err) {
+      this._error =
+        err instanceof Error
+          ? err.message
+          : this._localize("onboarding.wifi.save_failed");
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  private _dismissForSession() {
+    this.dispatchEvent(
+      new CustomEvent("onboarding-dismissed-session", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.close();
+  }
+
+  private _emitAcknowledged() {
+    this.dispatchEvent(
+      new CustomEvent("onboarding-acknowledged", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-onboarding-wifi-dialog": ESPHomeOnboardingWifiDialog;
+  }
+}

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiEye, mdiEyeOff, mdiWifi } from "@mdi/js";
+import { mdiWifi } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
@@ -8,13 +8,15 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { type PasswordInputValueChange } from "./device/password-input-event.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/input/input.js";
+import "./device/password-input.js";
 
-registerMdiIcons({ eye: mdiEye, "eye-off": mdiEyeOff, wifi: mdiWifi });
+registerMdiIcons({ wifi: mdiWifi });
 
 /**
  * First-run Wi-Fi setup dialog.
@@ -53,9 +55,6 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   private _password = "";
 
   @state()
-  private _showPassword = false;
-
-  @state()
   private _saving = false;
 
   @state()
@@ -67,7 +66,6 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   open() {
     this._ssid = "";
     this._password = "";
-    this._showPassword = false;
     this._saving = false;
     this._error = null;
     this._dialog.open = true;
@@ -116,32 +114,6 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
         color: var(--wa-color-text-normal);
       }
 
-      .password-row {
-        display: flex;
-        align-items: stretch;
-        gap: var(--wa-space-2xs);
-      }
-
-      .password-row wa-input {
-        flex: 1;
-      }
-
-      .reveal-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        background: transparent;
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        border-radius: var(--wa-border-radius-m);
-        padding: 0 12px;
-        color: var(--wa-color-text-quiet);
-        cursor: pointer;
-      }
-
-      .reveal-btn:hover {
-        color: var(--wa-color-text-normal);
-      }
-
       .error {
         color: var(--esphome-error);
         font-size: var(--wa-font-size-s);
@@ -186,36 +158,17 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
           </div>
           <div class="field">
             <label for="onboarding-password">${this._localize("onboarding.wifi.password_label")}</label>
-            <div class="password-row">
-              <wa-input
-                id="onboarding-password"
-                type=${this._showPassword ? "text" : "password"}
-                .value=${this._password}
-                maxlength="64"
-                placeholder=${this._localize("onboarding.wifi.password_placeholder")}
-                ?disabled=${this._saving}
-                @input=${(e: Event) => {
-                  this._password = (e.target as HTMLInputElement).value;
-                }}
-              ></wa-input>
-              <button
-                type="button"
-                class="reveal-btn"
-                title=${this._localize(
-                  this._showPassword
-                    ? "dashboard.action_api_key_hide"
-                    : "dashboard.action_api_key_show",
-                )}
-                @click=${() => {
-                  this._showPassword = !this._showPassword;
-                }}
-              >
-                <wa-icon
-                  library="mdi"
-                  name=${this._showPassword ? "eye-off" : "eye"}
-                ></wa-icon>
-              </button>
-            </div>
+            <esphome-password-input
+              id="onboarding-password"
+              .value=${this._password}
+              .placeholder=${this._localize("onboarding.wifi.password_placeholder")}
+              ?disabled=${this._saving}
+              @password-input-change=${(
+                e: CustomEvent<PasswordInputValueChange>,
+              ) => {
+                this._password = e.detail.value;
+              }}
+            ></esphome-password-input>
           </div>
           ${this._error
             ? html`<p class="error">${this._error}</p>`

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -118,11 +118,13 @@ export const labelsContext = createContext<Label[]>(
  * Context for whether onboarding still has work to do.
  *
  * App shell loads ``onboarding/get_state`` on (re)connect and
- * provides ``true`` when any step is data-derived ``pending``
- * (currently only the Wi-Fi step). Header-actions consumes it to
- * render a small dot next to the Secrets menu item — the only
- * persistent reminder for a user who declined the setup wizard
- * with "I only use Ethernet" but might later switch to Wi-Fi.
+ * after every ``secrets-saved`` event, providing ``true`` when
+ * any step is data-derived ``pending`` (currently only the
+ * Wi-Fi step). Header-actions consumes it to gate a dedicated
+ * ``Set up Wi-Fi…`` kebab entry — the persistent re-entry path
+ * for a user who declined the wizard with "I don't use Wi-Fi"
+ * but might later change their mind, or who hand-cleared
+ * ``wifi_ssid`` in the secrets editor.
  */
 export const onboardingPendingContext = createContext<boolean>(
   Symbol("esphome-onboarding-pending")

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -113,3 +113,17 @@ export const integrationDocsContext = createContext<Record<string, string>>(
 export const labelsContext = createContext<Label[]>(
   Symbol("esphome-labels")
 );
+
+/**
+ * Context for whether onboarding still has work to do.
+ *
+ * App shell loads ``onboarding/get_state`` on (re)connect and
+ * provides ``true`` when any step is data-derived ``pending``
+ * (currently only the Wi-Fi step). Header-actions consumes it to
+ * render a small dot next to the Secrets menu item — the only
+ * persistent reminder for a user who declined the setup wizard
+ * with "I only use Ethernet" but might later switch to Wi-Fi.
+ */
+export const onboardingPendingContext = createContext<boolean>(
+  Symbol("esphome-onboarding-pending")
+);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -15,4 +15,5 @@ export {
   remoteBuildEnabledContext,
   integrationDocsContext,
   labelsContext,
+  onboardingPendingContext,
 } from "./contexts.js";

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -53,6 +53,25 @@ export class ESPHomePageSecrets extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    window.addEventListener(
+      "secrets-saved",
+      this._onExternalSecretsSaved as EventListener,
+    );
+    await this._loadFromServer();
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener(
+      "secrets-saved",
+      this._onExternalSecretsSaved as EventListener,
+    );
+    super.disconnectedCallback();
+  }
+
+  /** Pull `secrets.yaml` from the server and reset both buffers.
+   *  On read error (file missing) seeds the editor with the
+   *  localized header so the user has a starting point. */
+  private async _loadFromServer() {
     try {
       const yaml = await this._api.getConfig(SECRETS_FILE);
       this._yaml = yaml;
@@ -64,6 +83,19 @@ export class ESPHomePageSecrets extends LitElement {
     }
     this._loaded = true;
   }
+
+  /** Another component (typically the onboarding wizard) just
+   *  wrote `secrets.yaml`. Reload from the server so the editor
+   *  doesn't show stale content. Skip when this page initiated
+   *  the save (no work to do — buffers already reflect the new
+   *  content) and when the user has unsaved edits in the editor
+   *  (silently overwriting their typing would lose work; they'll
+   *  see the disk's view next time they reload the page or save). */
+  private _onExternalSecretsSaved = (e: CustomEvent<{ source: EventTarget }>) => {
+    if (e.detail?.source === this) return;
+    if (this._yaml !== this._savedYaml) return;
+    void this._loadFromServer();
+  };
 
   static styles = [
     espHomeStyles,
@@ -273,11 +305,12 @@ export class ESPHomePageSecrets extends LitElement {
     this._api
       .updateConfig(SECRETS_FILE, this._yaml)
       .then(() => {
-        this.dispatchEvent(
-          new CustomEvent("secrets-saved", {
-            bubbles: true,
-            composed: true,
-          }),
+        // Window-level so other mounted components (app-shell's
+        // onboarding-state refresh, peer secrets-page instances)
+        // can react regardless of where they live in the tree.
+        // ``detail.source`` lets self-listeners short-circuit.
+        window.dispatchEvent(
+          new CustomEvent("secrets-saved", { detail: { source: this } }),
         );
       })
       .catch((e) => {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -300,6 +300,11 @@ export class ESPHomePageSecrets extends LitElement {
   }
 
   private _save() {
+    // Optimistic update: dirty-state UI flips back to "saved"
+    // immediately so the Save button disables. Snapshot the
+    // previous saved buffer first so a real (non-timeout)
+    // failure can revert and let the user retry.
+    const previousSaved = this._savedYaml;
     this._savedYaml = this._yaml;
     toast.success(this._localize("secrets.saved"), { richColors: true });
     this._api
@@ -315,7 +320,14 @@ export class ESPHomePageSecrets extends LitElement {
       })
       .catch((e) => {
         const msg = e instanceof Error ? e.message : "";
+        // WS commands may time out client-side while the server
+        // still completes the write — keep the optimistic buffer
+        // so the user isn't told their save failed when it
+        // probably succeeded. Any other error is a real failure:
+        // restore the previous saved buffer so the dirty state
+        // returns and the user can retry.
         if (!msg.includes("timed out")) {
+          this._savedYaml = previousSaved;
           toast.error(this._localize("secrets.save_error"), {
             richColors: true,
           });

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -270,12 +270,24 @@ export class ESPHomePageSecrets extends LitElement {
   private _save() {
     this._savedYaml = this._yaml;
     toast.success(this._localize("secrets.saved"), { richColors: true });
-    this._api.updateConfig(SECRETS_FILE, this._yaml).catch((e) => {
-      const msg = e instanceof Error ? e.message : "";
-      if (!msg.includes("timed out")) {
-        toast.error(this._localize("secrets.save_error"), { richColors: true });
-      }
-    });
+    this._api
+      .updateConfig(SECRETS_FILE, this._yaml)
+      .then(() => {
+        this.dispatchEvent(
+          new CustomEvent("secrets-saved", {
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      })
+      .catch((e) => {
+        const msg = e instanceof Error ? e.message : "";
+        if (!msg.includes("timed out")) {
+          toast.error(this._localize("secrets.save_error"), {
+            richColors: true,
+          });
+        }
+      });
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -643,7 +643,7 @@
     "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks"
   },
   "onboarding": {
-    "secrets_dot_title": "Wi-Fi credentials still need to be set in secrets.yaml",
+    "menu_item_setup_wifi": "Set up Wi-Fi…",
     "wifi": {
       "title": "Set up Wi-Fi credentials",
       "intro": "Your devices use these to join your network. They're stored once in secrets.yaml and shared across every config you create.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -642,6 +642,23 @@
     "device_name_underscore": "Underscores work but aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks",
     "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks"
   },
+  "onboarding": {
+    "secrets_dot_title": "Wi-Fi credentials still need to be set in secrets.yaml",
+    "wifi": {
+      "title": "Set up Wi-Fi credentials",
+      "intro": "Your devices use these to join your network. They're stored once in secrets.yaml and shared across every config you create.",
+      "ssid_label": "Wi-Fi network name (SSID)",
+      "ssid_placeholder": "MyHomeWifi",
+      "password_label": "Wi-Fi password",
+      "password_placeholder": "Leave blank for an open network",
+      "save": "Save credentials",
+      "saving": "Saving…",
+      "save_success": "Wi-Fi credentials saved",
+      "save_failed": "Failed to save Wi-Fi credentials",
+      "dismiss_session": "Maybe later",
+      "decline_permanent": "I only use Ethernet"
+    }
+  },
   "layout": {
     "secrets": "Secrets",
     "update_all_started": "{count} device update(s) started",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -655,6 +655,8 @@
       "saving": "Saving…",
       "save_success": "Wi-Fi credentials saved",
       "save_failed": "Failed to save Wi-Fi credentials",
+      "ack_failed": "Wi-Fi credentials saved, but the wizard couldn't be marked as completed — it may reappear next time.",
+      "decline_failed": "Couldn't update onboarding preferences",
       "dismiss_session": "Maybe later",
       "decline_permanent": "I don't use Wi-Fi — skip this step"
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -656,7 +656,7 @@
       "save_success": "Wi-Fi credentials saved",
       "save_failed": "Failed to save Wi-Fi credentials",
       "dismiss_session": "Maybe later",
-      "decline_permanent": "I only use Ethernet"
+      "decline_permanent": "I don't use Wi-Fi — skip this step"
     }
   },
   "layout": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -534,7 +534,7 @@
       "save_success": "Identifiants Wi-Fi enregistrés",
       "save_failed": "Échec de l'enregistrement des identifiants Wi-Fi",
       "dismiss_session": "Plus tard",
-      "decline_permanent": "J'utilise uniquement l'Ethernet"
+      "decline_permanent": "Je n'utilise pas le Wi-Fi — ignorer cette étape"
     }
   },
   "layout": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -533,6 +533,8 @@
       "saving": "Enregistrement…",
       "save_success": "Identifiants Wi-Fi enregistrés",
       "save_failed": "Échec de l'enregistrement des identifiants Wi-Fi",
+      "ack_failed": "Identifiants Wi-Fi enregistrés, mais l'assistant n'a pas pu être marqué comme terminé — il pourrait réapparaître la prochaine fois.",
+      "decline_failed": "Impossible de mettre à jour les préférences d'intégration",
       "dismiss_session": "Plus tard",
       "decline_permanent": "Je n'utilise pas le Wi-Fi — ignorer cette étape"
     }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -520,6 +520,23 @@
     "discard_changes": "Annuler",
     "save_and_leave": "Enregistrer"
   },
+  "onboarding": {
+    "secrets_dot_title": "Les identifiants Wi-Fi doivent encore être renseignés dans secrets.yaml",
+    "wifi": {
+      "title": "Configurer les identifiants Wi-Fi",
+      "intro": "Vos appareils s'en servent pour rejoindre le réseau. Ils sont enregistrés une seule fois dans secrets.yaml et partagés entre toutes vos configurations.",
+      "ssid_label": "Nom du réseau Wi-Fi (SSID)",
+      "ssid_placeholder": "MonWifiMaison",
+      "password_label": "Mot de passe Wi-Fi",
+      "password_placeholder": "Laisser vide pour un réseau ouvert",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "save_success": "Identifiants Wi-Fi enregistrés",
+      "save_failed": "Échec de l'enregistrement des identifiants Wi-Fi",
+      "dismiss_session": "Plus tard",
+      "decline_permanent": "J'utilise uniquement l'Ethernet"
+    }
+  },
   "layout": {
     "secrets": "Secrets",
     "update_all_started": "{count} mise(s) à jour démarrée(s)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -521,7 +521,7 @@
     "save_and_leave": "Enregistrer"
   },
   "onboarding": {
-    "secrets_dot_title": "Les identifiants Wi-Fi doivent encore être renseignés dans secrets.yaml",
+    "menu_item_setup_wifi": "Configurer le Wi-Fi…",
     "wifi": {
       "title": "Configurer les identifiants Wi-Fi",
       "intro": "Vos appareils s'en servent pour rejoindre le réseau. Ils sont enregistrés une seule fois dans secrets.yaml et partagés entre toutes vos configurations.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -521,7 +521,7 @@
     "save_and_leave": "Opslaan"
   },
   "onboarding": {
-    "secrets_dot_title": "Wi-Fi-inloggegevens moeten nog ingesteld worden in secrets.yaml",
+    "menu_item_setup_wifi": "Wi-Fi instellen…",
     "wifi": {
       "title": "Wi-Fi-inloggegevens instellen",
       "intro": "Uw apparaten gebruiken deze om verbinding te maken met uw netwerk. Ze worden één keer opgeslagen in secrets.yaml en gedeeld door elke configuratie die u maakt.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -533,6 +533,8 @@
       "saving": "Bezig met opslaan…",
       "save_success": "Wi-Fi-inloggegevens opgeslagen",
       "save_failed": "Wi-Fi-inloggegevens konden niet worden opgeslagen",
+      "ack_failed": "Wi-Fi-inloggegevens opgeslagen, maar de wizard kon niet als voltooid worden gemarkeerd — hij kan de volgende keer opnieuw verschijnen.",
+      "decline_failed": "Kan onboarding-voorkeuren niet bijwerken",
       "dismiss_session": "Later misschien",
       "decline_permanent": "Ik gebruik geen wifi — deze stap overslaan"
     }

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -520,6 +520,23 @@
     "discard_changes": "Negeren",
     "save_and_leave": "Opslaan"
   },
+  "onboarding": {
+    "secrets_dot_title": "Wi-Fi-inloggegevens moeten nog ingesteld worden in secrets.yaml",
+    "wifi": {
+      "title": "Wi-Fi-inloggegevens instellen",
+      "intro": "Uw apparaten gebruiken deze om verbinding te maken met uw netwerk. Ze worden één keer opgeslagen in secrets.yaml en gedeeld door elke configuratie die u maakt.",
+      "ssid_label": "Wi-Fi-netwerknaam (SSID)",
+      "ssid_placeholder": "MijnThuisWifi",
+      "password_label": "Wi-Fi-wachtwoord",
+      "password_placeholder": "Laat leeg voor een open netwerk",
+      "save": "Opslaan",
+      "saving": "Bezig met opslaan…",
+      "save_success": "Wi-Fi-inloggegevens opgeslagen",
+      "save_failed": "Wi-Fi-inloggegevens konden niet worden opgeslagen",
+      "dismiss_session": "Later misschien",
+      "decline_permanent": "Ik gebruik alleen Ethernet"
+    }
+  },
   "layout": {
     "secrets": "Geheimen",
     "update_all_started": "{count} apparaat-update(s) gestart",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -534,7 +534,7 @@
       "save_success": "Wi-Fi-inloggegevens opgeslagen",
       "save_failed": "Wi-Fi-inloggegevens konden niet worden opgeslagen",
       "dismiss_session": "Later misschien",
-      "decline_permanent": "Ik gebruik alleen Ethernet"
+      "decline_permanent": "Ik gebruik geen wifi — deze stap overslaan"
     }
   },
   "layout": {


### PR DESCRIPTION
# What does this implement/fix?

Frontend companion to esphome/device-builder#455 — drives the new `onboarding/*` WS commands to deliver the user-visible first-run flow.

**App-shell wiring:**
- Loads `onboarding/get_state` after auth.
- Provides a new `onboardingPendingContext` (true when any step is data-derived `pending`) so the header-actions kebab can surface a dedicated `Set up Wi-Fi…` entry — a one-click re-entry path for a user who declined the wizard with "I don't use Wi-Fi" but later changes their mind, or who hand-cleared `wifi_ssid` from the Secrets editor.
- Opens the onboarding dialog when `completed_version < current_version` AND the user hasn't session-dismissed.

**`esphome-onboarding-wifi-dialog`:**
Three exits, matching the user's stated UX:
- **Save credentials** → POSTs `set_wifi_credentials` → `mark_acknowledged` → close. Toast on success.
- **Maybe later** → frontend-only session dismiss; reopens on next dashboard load.
- **I don't use Wi-Fi — skip this step** → POSTs `mark_acknowledged` so the dialog stops re-popping. The `Set up Wi-Fi…` kebab entry stays visible because it reads the data signal, not the acknowledged flag — so a user who later changes their mind has a one-click way back into the wizard.

32-char SSID + 64-char password input caps mirror the backend validators so violations surface client-side without a round-trip. Empty password is allowed (open networks). Reveal-password toggle, busy state, inline error rendering.

**Header-actions:**
Consumes `onboardingPendingContext` and conditionally renders a dedicated `Set up Wi-Fi…` menu entry (with a `wifi-cog` icon) when true. Clicking it dispatches `open-onboarding-wifi`, which the app shell catches to re-open the wizard — overriding both `_onboardingSessionDismissed` and the acknowledged-version gate, since the kebab entry IS the explicit "I want to do this now" signal. The entry's presence/absence directly mirrors whether onboarding has work to do, so no badge interpretation is needed; it appears/disappears in real time as `secrets.yaml` changes (app-shell re-fetches the snapshot on every `secrets-saved` event).

**Translations:** en/fr/nl strings under `onboarding.*` (intro, labels, save/decline/dismiss copy, error fallbacks per failing call, plus the kebab entry's `menu_item_setup_wifi`).

933 tests pass (no new tests — the onboarding flow is mostly WebSocket I/O + Lit dialog rendering; will add integration coverage once the backend PR lands and we can wire this into a playwright run).

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#455

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

