### PR TITLE
Don't auto-pop the onboarding wizard when no step is pending

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -827,21 +827,33 @@ export interface OnboardingStep {
  *
  * ``current_version`` is the version of onboarding the server
  * knows about; ``completed_version`` is what the user last
- * acknowledged. The dashboard shows the wizard when
- * ``completed_version < current_version`` AND the user hasn't
- * frontend-side session-dismissed it. The data-derived
- * ``steps[].status`` doesn't gate the dialog — saving real
- * values OR declining ("I only use Ethernet") both call
- * ``mark_acknowledged`` to advance the version, so the dialog
- * stops re-opening regardless of whether the data is now set.
+ * acknowledged. The wizard auto-pops when ALL of the following
+ * are true: ``completed_version < current_version`` (user is
+ * behind a newer onboarding version), at least one
+ * ``steps[].status`` is ``pending`` (there's actually
+ * something to do), and the user hasn't frontend-side
+ * session-dismissed it. A version bump alone isn't enough —
+ * pre-wizard installs all started at ``completed_version = 0``
+ * and asking a user with already-configured secrets to re-enter
+ * them is friction with no payoff. The exact gate lives in
+ * ``src/util/onboarding-gate.ts`` (``shouldAutoShowOnboarding``)
+ * with unit-test coverage of every branch.
  *
- * Step status drives a separate signal: the always-on badge in
- * the secrets kebab. It's computed from live on-disk state on
- * every server-side ``get_state`` call — never persisted — and
- * the dashboard re-fetches on (re)connect, so a manual
- * ``secrets.yaml`` edit clears the badge no later than the next
- * WS reconnect (or page reload). Within a single session the
- * badge is a snapshot of the auth-time fetch.
+ * Manual entry via the ``Set up Wi-Fi…`` kebab item bypasses
+ * both the version-bump gate and the session-dismiss flag —
+ * the click IS the explicit "I want to do this now" signal —
+ * but is itself only visible when ``isOnboardingPending`` is
+ * true (so the user never sees the entry when there's nothing
+ * to do).
+ *
+ * Step status also drives the kebab entry's visibility
+ * directly. It's computed from live on-disk state on every
+ * server-side ``get_state`` call — never persisted — and the
+ * dashboard re-fetches on (re)connect AND on every
+ * ``secrets-saved`` event, so an in-app save (wizard or
+ * Secrets editor) updates the entry in real time and an
+ * out-of-band ``secrets.yaml`` edit clears it no later than
+ * the next WS reconnect.
  */
 export interface OnboardingState {
   current_version: number;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -513,11 +513,14 @@ export class ESPHomeApp extends LitElement {
   /** Load the onboarding snapshot and update both the
    *  always-on data signal (``_onboardingPending`` — gates the
    *  ``Set up Wi-Fi…`` kebab entry in header-actions) and the
-   *  dialog-show signal (``_onboardingShouldShow`` — gated by
-   *  acknowledged-version + session-dismissal). Re-runs on
-   *  reconnect and after every secrets save; the dialog doesn't
-   *  re-open mid-session because ``_onboardingSessionDismissed``
-   *  survives the refresh. */
+   *  dialog-show signal (``_onboardingShouldShow`` — auto-pop
+   *  requires acknowledged-version-behind AND a pending step
+   *  AND no session-dismissal; see ``shouldAutoShowOnboarding``
+   *  for the full predicate). Re-runs on reconnect and after
+   *  every secrets save; the dialog doesn't re-open mid-session
+   *  because ``_onboardingSessionDismissed`` survives the
+   *  refresh. The kebab entry is the manual override for users
+   *  who want the wizard outside of the auto-pop conditions. */
   private async _loadOnboardingState() {
     try {
       const state = await this._api.getOnboardingState();

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -19,9 +19,12 @@ import {
   ErrorCode,
   JobStatus,
   JobType,
-  OnboardingStepStatus,
   Theme,
 } from "../api/types.js";
+import {
+  isOnboardingPending,
+  shouldAutoShowOnboarding,
+} from "../util/onboarding-gate.js";
 import type {
   AdoptableDevice,
   ConfiguredDevice,
@@ -518,13 +521,11 @@ export class ESPHomeApp extends LitElement {
   private async _loadOnboardingState() {
     try {
       const state = await this._api.getOnboardingState();
-      this._onboardingPending = state.steps.some(
-        (s) => s.status === OnboardingStepStatus.PENDING,
+      this._onboardingPending = isOnboardingPending(state);
+      this._onboardingShouldShow = shouldAutoShowOnboarding(
+        state,
+        this._onboardingSessionDismissed,
       );
-      const userBehindCurrent =
-        state.completed_version < state.current_version;
-      this._onboardingShouldShow =
-        userBehindCurrent && !this._onboardingSessionDismissed;
     } catch (err) {
       // Onboarding is non-critical — a transient WS failure here
       // shouldn't block the rest of the dashboard. Clear the

--- a/src/util/onboarding-gate.ts
+++ b/src/util/onboarding-gate.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure gating logic shared between the app shell and the kebab
+ * header-actions, broken out so it can be unit-tested without
+ * dragging in the WebSocket client + Lit lifecycle.
+ */
+import {
+  type OnboardingState,
+  OnboardingStepStatus,
+} from "../api/types.js";
+
+/** True when any onboarding step is data-derived ``pending``.
+ *  Drives the ``Set up Wi-Fi…`` kebab entry's visibility. */
+export function isOnboardingPending(state: OnboardingState): boolean {
+  return state.steps.some((s) => s.status === OnboardingStepStatus.PENDING);
+}
+
+/**
+ * True when the wizard should auto-pop on load.
+ *
+ * Three conditions must hold simultaneously:
+ *
+ * 1. The user is behind the current onboarding version (a future
+ *    bump re-prompts users who completed an earlier flow).
+ * 2. *Something is actually pending.* A version bump alone isn't
+ *    a reason to interrupt a user whose secrets are already
+ *    configured — most notably, installs that pre-date the
+ *    wizard have ``completed_version = 0`` but already-valid
+ *    Wi-Fi credentials, and asking them to re-enter values they
+ *    already set is friction with no payoff. The kebab
+ *    ``Set up Wi-Fi…`` entry uses the same pending gate, so the
+ *    user never loses access — they just don't get an
+ *    unsolicited prompt.
+ * 3. The user hasn't already session-dismissed the dialog (the
+ *    "Maybe later" / X / Escape paths set this so a refresh
+ *    doesn't re-pop the dialog they just closed).
+ */
+export function shouldAutoShowOnboarding(
+  state: OnboardingState,
+  sessionDismissed: boolean,
+): boolean {
+  return (
+    state.completed_version < state.current_version &&
+    isOnboardingPending(state) &&
+    !sessionDismissed
+  );
+}

--- a/test/util/onboarding-gate.test.ts
+++ b/test/util/onboarding-gate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the onboarding-gate helpers.
+ *
+ * The two helpers decide whether the wizard auto-pops on load
+ * and whether the ``Set up Wi-Fi…`` kebab entry is visible. The
+ * subtle case is the existing-install upgrade path: a user with
+ * ``completed_version = 0`` (never ran the wizard) but already
+ * valid wifi credentials must NOT be interrupted on next page
+ * load. A version bump alone shouldn't trigger the wizard.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type OnboardingState,
+  OnboardingStepId,
+  OnboardingStepStatus,
+} from "../../src/api/types.js";
+import {
+  isOnboardingPending,
+  shouldAutoShowOnboarding,
+} from "../../src/util/onboarding-gate.js";
+
+const wifi = (status: OnboardingStepStatus) => ({
+  id: OnboardingStepId.WIFI_CREDENTIALS,
+  status,
+});
+
+const stateWith = (
+  steps: ReturnType<typeof wifi>[],
+  current_version = 1,
+  completed_version = 0,
+): OnboardingState => ({
+  current_version,
+  completed_version,
+  steps,
+});
+
+describe("isOnboardingPending", () => {
+  it("returns true when any step is pending", () => {
+    expect(
+      isOnboardingPending(stateWith([wifi(OnboardingStepStatus.PENDING)])),
+    ).toBe(true);
+  });
+
+  it("returns false when every step is done", () => {
+    expect(
+      isOnboardingPending(stateWith([wifi(OnboardingStepStatus.DONE)])),
+    ).toBe(false);
+  });
+
+  it("returns false on an empty step list", () => {
+    expect(isOnboardingPending(stateWith([]))).toBe(false);
+  });
+});
+
+describe("shouldAutoShowOnboarding", () => {
+  it("pops for a fresh-install user behind current with pending step", () => {
+    expect(
+      shouldAutoShowOnboarding(
+        stateWith([wifi(OnboardingStepStatus.PENDING)]),
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it(
+    "does NOT pop for a pre-wizard install with secrets already configured " +
+      "(this is the bug fix — completed_version=0 + step DONE must not interrupt)",
+    () => {
+      expect(
+        shouldAutoShowOnboarding(
+          stateWith([wifi(OnboardingStepStatus.DONE)]),
+          false,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("does NOT pop when user is up to date even with pending step", () => {
+    expect(
+      shouldAutoShowOnboarding(
+        stateWith([wifi(OnboardingStepStatus.PENDING)], 1, 1),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT pop when user is ahead of current (rolled back from a future build)", () => {
+    expect(
+      shouldAutoShowOnboarding(
+        stateWith([wifi(OnboardingStepStatus.PENDING)], 1, 2),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("respects session-dismissal even with pending work", () => {
+    expect(
+      shouldAutoShowOnboarding(
+        stateWith([wifi(OnboardingStepStatus.PENDING)]),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT pop when behind current but step list is empty", () => {
+    expect(shouldAutoShowOnboarding(stateWith([], 2, 0), false)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression that landed with the onboarding wizard (#239): on every page load, users whose `secrets.yaml` already has valid Wi-Fi credentials still saw the wizard pop with an empty SSID/password form asking them to "set up Wi-Fi credentials" — values they had already configured.

The root cause is the auto-pop gate in `_loadOnboardingState`. It only checked whether the user was behind the current onboarding version (`completed_version < current_version`), without also requiring an actual pending step. Pre-wizard installs all start at `completed_version = 0`; if `current_version = 1` and Wi-Fi is already set, `userBehindCurrent` is true and `_onboardingPending` is false, but the wizard auto-popped anyway.

**The fix** gates `_onboardingShouldShow` on `_onboardingPending` too — only auto-pop when there's actually something for the user to do. The kebab `Set up Wi-Fi…` entry is gated the same way, so users never lose access to the wizard; they just don't get an unsolicited prompt for work that's already done.

Refactored the gate logic into a small pure-function module (`src/util/onboarding-gate.ts`) so it's directly unit-testable without dragging in the WS client + Lit lifecycle. `app-shell.ts` now calls `isOnboardingPending(state)` and `shouldAutoShowOnboarding(state, sessionDismissed)`.

**Related issue or feature (if applicable):**

- follow-up to #239 (regression report came in directly from the user after the merge)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

**Tests:** 9 new in `test/util/onboarding-gate.test.ts` covering the bug-fix case (pre-wizard install with Wi-Fi already configured must not pop), the fresh-install case (auto-pops as before), version-equal / rolled-back-from-future cases, session-dismissal precedence, and the empty-step-list edge. Total now 942 (was 933).
