### PR TITLE
Add 3c1 WS wrappers + client-side bearer mint helper (esphome/device-builder#106 phase 3c2a)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tanstack/lit-table": "^8.21.3",
         "codemirror": "^6.0.2",
         "esptool-js": "^0.6.0",
+        "js-sha256": "^0.11.1",
         "lit": "3.3.2",
         "lit-html": "3.3.2",
         "sonner-js": "^1.1.3",
@@ -1281,6 +1282,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/lit-table": "^8.21.3",
     "codemirror": "^6.0.2",
     "esptool-js": "^0.6.0",
+    "js-sha256": "^0.11.1",
     "lit": "3.3.2",
     "lit-html": "3.3.2",
     "sonner-js": "^1.1.3",

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -588,7 +588,7 @@ export class ESPHomeAPI {
    */
   async subscribeDeviceReachability(
     deviceName: string,
-    callback: (state: ReachabilityStateEvent) => void
+    callback: (state: ReachabilityStateEvent) => void,
   ): Promise<ReachabilitySubscription> {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
       throw new Error("WebSocket not connected");
@@ -636,7 +636,9 @@ export class ESPHomeAPI {
         const timer = setTimeout(() => {
           this._pendingRequests.delete(messageId);
           reject(
-            new Error(`subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`)
+            new Error(
+              `subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`,
+            ),
           );
         }, SUBSCRIBE_TIMEOUT_MS);
         this._pendingRequests.set(messageId, {
@@ -777,7 +779,9 @@ export class ESPHomeAPI {
     return this.sendCommand<{ configuration: string }>("devices/clone", {
       configuration,
       new_name: newName,
-      ...(newFriendlyName !== undefined ? { new_friendly_name: newFriendlyName } : {}),
+      ...(newFriendlyName !== undefined
+        ? { new_friendly_name: newFriendlyName }
+        : {}),
     });
   }
 
@@ -946,7 +950,7 @@ export class ESPHomeAPI {
    *  state without waiting for the ``device_updated`` event. */
   async setDeviceLabels(
     configuration: string,
-    labelIds: string[]
+    labelIds: string[],
   ): Promise<ConfiguredDevice> {
     return this.sendCommand<ConfiguredDevice>("devices/set_labels", {
       configuration,
@@ -964,7 +968,10 @@ export class ESPHomeAPI {
   /** Create a new label. ``name`` 1-50 chars, unique
    *  case-insensitively. ``color`` is ``#rrggbb`` (lowercased on
    *  save) or ``null`` / omitted for "no explicit color". */
-  async createLabel(args: { name: string; color?: string | null }): Promise<Label> {
+  async createLabel(args: {
+    name: string;
+    color?: string | null;
+  }): Promise<Label> {
     return this.sendCommand<Label>("labels/create", args);
   }
 
@@ -1299,11 +1306,14 @@ export class ESPHomeAPI {
    * (32 char SSID, 64 char password) and surfaces violations as
    * ``CommandError(INVALID_ARGS)`` for the UI to render.
    */
-  async setOnboardingWifi(ssid: string, password: string): Promise<OnboardingState> {
-    return this.sendCommand<OnboardingState>("onboarding/set_wifi_credentials", {
-      ssid,
-      password,
-    });
+  async setOnboardingWifi(
+    ssid: string,
+    password: string,
+  ): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>(
+      "onboarding/set_wifi_credentials",
+      { ssid, password },
+    );
   }
 
   /**
@@ -1331,8 +1341,13 @@ export class ESPHomeAPI {
   }
 
   /** Persist the receiver-side remote-build settings. */
-  async setRemoteBuildSettings(args: { enabled: boolean }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>("remote_build/set_settings", args);
+  async setRemoteBuildSettings(args: {
+    enabled: boolean;
+  }): Promise<RemoteBuildSettings> {
+    return this.sendCommand<RemoteBuildSettings>(
+      "remote_build/set_settings",
+      args
+    );
   }
 
   /**
@@ -1365,7 +1380,10 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>("remote_build/add_manual_host", args);
+    return this.sendCommand<RemoteBuildSettings>(
+      "remote_build/add_manual_host",
+      args
+    );
   }
 
   /**
@@ -1379,7 +1397,10 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>("remote_build/remove_manual_host", args);
+    return this.sendCommand<RemoteBuildSettings>(
+      "remote_build/remove_manual_host",
+      args
+    );
   }
 
   // ─── Remote build: receiver-issued tokens (phase 3b1 / 3b3) ──
@@ -1387,7 +1408,7 @@ export class ESPHomeAPI {
   /**
    * List the receiver-issued bearer tokens this dashboard recognises.
    *
-   * Each row is a ``TokenSummary`` (label + token_id +
+   * Each row is a {@link TokenSummary} (label + token_id +
    * created_at + bound_dashboard_id). The on-disk
    * ``secret_sha256`` is intentionally projected out; the
    * cleartext bearer was generated client-side at
@@ -1404,16 +1425,16 @@ export class ESPHomeAPI {
    * Register a client-generated bearer token under *label*.
    *
    * Caller MUST mint the bearer client-side via
-   * :func:`mintRemoteBuildBearer` and POST only the SHA-256
+   * {@link mintRemoteBuildBearer} and POST only the SHA-256
    * hash; the cleartext bearer never crosses the wire to the
-   * backend. The returned ``TokenSummary`` carries no secret
-   * material (the cleartext lives only in the caller's local
-   * state until they paste it into the offloader, then it's
-   * discarded). Duplicate ``token_id`` rejected with
+   * backend. The returned {@link TokenSummary} carries no
+   * secret material (the cleartext lives only in the caller's
+   * local state until they paste it into the offloader, then
+   * it's discarded). Duplicate ``token_id`` rejected with
    * ``ErrorCode.ALREADY_EXISTS``.
    */
   async addRemoteBuildToken(args: AddRemoteBuildTokenArgs): Promise<TokenSummary> {
-    return this.sendCommand<TokenSummary>("remote_build/add_token", { ...args });
+    return this.sendCommand<TokenSummary>("remote_build/add_token", args);
   }
 
   /**
@@ -1425,8 +1446,13 @@ export class ESPHomeAPI {
    * recognises and gets a 401. Unknown ``token_id`` raises
    * ``ErrorCode.NOT_FOUND``.
    */
-  async removeRemoteBuildToken(args: { token_id: string }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>("remote_build/remove_token", args);
+  async removeRemoteBuildToken(args: {
+    token_id: string;
+  }): Promise<RemoteBuildSettings> {
+    return this.sendCommand<RemoteBuildSettings>(
+      "remote_build/remove_token",
+      args
+    );
   }
 
   // ─── Remote build: receiver identity (phase 3c1) ──────────

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -28,11 +28,14 @@ import type {
   ReachabilitySubscription,
   FirmwareDownload,
   FirmwareJob,
+  AddRemoteBuildTokenArgs,
+  IdentityView,
   PagedBoardsResponse,
   PagedComponentsResponse,
   RemoteBuildPeer,
   RemoteBuildSettings,
   ResultMessage,
+  TokenSummary,
   SerialPort,
   ServerInfoMessage,
   OnboardingState,
@@ -585,7 +588,7 @@ export class ESPHomeAPI {
    */
   async subscribeDeviceReachability(
     deviceName: string,
-    callback: (state: ReachabilityStateEvent) => void,
+    callback: (state: ReachabilityStateEvent) => void
   ): Promise<ReachabilitySubscription> {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
       throw new Error("WebSocket not connected");
@@ -633,9 +636,7 @@ export class ESPHomeAPI {
         const timer = setTimeout(() => {
           this._pendingRequests.delete(messageId);
           reject(
-            new Error(
-              `subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`,
-            ),
+            new Error(`subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`)
           );
         }, SUBSCRIBE_TIMEOUT_MS);
         this._pendingRequests.set(messageId, {
@@ -776,9 +777,7 @@ export class ESPHomeAPI {
     return this.sendCommand<{ configuration: string }>("devices/clone", {
       configuration,
       new_name: newName,
-      ...(newFriendlyName !== undefined
-        ? { new_friendly_name: newFriendlyName }
-        : {}),
+      ...(newFriendlyName !== undefined ? { new_friendly_name: newFriendlyName } : {}),
     });
   }
 
@@ -947,7 +946,7 @@ export class ESPHomeAPI {
    *  state without waiting for the ``device_updated`` event. */
   async setDeviceLabels(
     configuration: string,
-    labelIds: string[],
+    labelIds: string[]
   ): Promise<ConfiguredDevice> {
     return this.sendCommand<ConfiguredDevice>("devices/set_labels", {
       configuration,
@@ -965,10 +964,7 @@ export class ESPHomeAPI {
   /** Create a new label. ``name`` 1-50 chars, unique
    *  case-insensitively. ``color`` is ``#rrggbb`` (lowercased on
    *  save) or ``null`` / omitted for "no explicit color". */
-  async createLabel(args: {
-    name: string;
-    color?: string | null;
-  }): Promise<Label> {
+  async createLabel(args: { name: string; color?: string | null }): Promise<Label> {
     return this.sendCommand<Label>("labels/create", args);
   }
 
@@ -1303,14 +1299,11 @@ export class ESPHomeAPI {
    * (32 char SSID, 64 char password) and surfaces violations as
    * ``CommandError(INVALID_ARGS)`` for the UI to render.
    */
-  async setOnboardingWifi(
-    ssid: string,
-    password: string,
-  ): Promise<OnboardingState> {
-    return this.sendCommand<OnboardingState>(
-      "onboarding/set_wifi_credentials",
-      { ssid, password },
-    );
+  async setOnboardingWifi(ssid: string, password: string): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>("onboarding/set_wifi_credentials", {
+      ssid,
+      password,
+    });
   }
 
   /**
@@ -1338,13 +1331,8 @@ export class ESPHomeAPI {
   }
 
   /** Persist the receiver-side remote-build settings. */
-  async setRemoteBuildSettings(args: {
-    enabled: boolean;
-  }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/set_settings",
-      args
-    );
+  async setRemoteBuildSettings(args: { enabled: boolean }): Promise<RemoteBuildSettings> {
+    return this.sendCommand<RemoteBuildSettings>("remote_build/set_settings", args);
   }
 
   /**
@@ -1377,10 +1365,7 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/add_manual_host",
-      args
-    );
+    return this.sendCommand<RemoteBuildSettings>("remote_build/add_manual_host", args);
   }
 
   /**
@@ -1394,10 +1379,94 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/remove_manual_host",
-      args
-    );
+    return this.sendCommand<RemoteBuildSettings>("remote_build/remove_manual_host", args);
+  }
+
+  // ─── Remote build: receiver-issued tokens (phase 3b1 / 3b3) ──
+
+  /**
+   * List the receiver-issued bearer tokens this dashboard recognises.
+   *
+   * Each row is a ``TokenSummary`` (label + token_id +
+   * created_at + bound_dashboard_id). The on-disk
+   * ``secret_sha256`` is intentionally projected out; the
+   * cleartext bearer was generated client-side at
+   * ``addRemoteBuildToken`` time and never crossed the wire to
+   * the backend, so the cleartext can't be recovered from this
+   * list (or anywhere server-side). The Settings UI renders one
+   * row per token with revoke + bound-dashboard-id badges.
+   */
+  async listRemoteBuildTokens(): Promise<TokenSummary[]> {
+    return this.sendCommand<TokenSummary[]>("remote_build/list_tokens");
+  }
+
+  /**
+   * Register a client-generated bearer token under *label*.
+   *
+   * Caller MUST mint the bearer client-side via
+   * :func:`mintRemoteBuildBearer` and POST only the SHA-256
+   * hash; the cleartext bearer never crosses the wire to the
+   * backend. The returned ``TokenSummary`` carries no secret
+   * material (the cleartext lives only in the caller's local
+   * state until they paste it into the offloader, then it's
+   * discarded). Duplicate ``token_id`` rejected with
+   * ``ErrorCode.ALREADY_EXISTS``.
+   */
+  async addRemoteBuildToken(args: AddRemoteBuildTokenArgs): Promise<TokenSummary> {
+    return this.sendCommand<TokenSummary>("remote_build/add_token", { ...args });
+  }
+
+  /**
+   * Revoke a previously-issued token.
+   *
+   * Removing a bound token immediately disconnects the
+   * offloader it's paired to: the next request the offloader
+   * sends presents a ``token_id`` the receiver no longer
+   * recognises and gets a 401. Unknown ``token_id`` raises
+   * ``ErrorCode.NOT_FOUND``.
+   */
+  async removeRemoteBuildToken(args: { token_id: string }): Promise<RemoteBuildSettings> {
+    return this.sendCommand<RemoteBuildSettings>("remote_build/remove_token", args);
+  }
+
+  // ─── Remote build: receiver identity (phase 3c1) ──────────
+
+  /**
+   * Read this dashboard's stable identity for the Settings card.
+   *
+   * Returns ``{dashboard_id, pin_sha256, server_version,
+   * esphome_version, listener_bound}``. The cert + key PEMs are
+   * intentionally NOT included; only the SPKI fingerprint
+   * (``pin_sha256``, lowercase hex) is safe to ship to a
+   * frontend, and the fingerprint is what an offloader pins
+   * against anyway. Idempotent (no rotation triggered by reads).
+   * Lazy-creates the cert + key on first call if missing.
+   */
+  async getRemoteBuildIdentity(): Promise<IdentityView> {
+    return this.sendCommand<IdentityView>("remote_build/get_identity");
+  }
+
+  /**
+   * Mint a fresh cert + keypair, replacing whatever's on disk.
+   *
+   * Forces every paired offloader to re-pair (the new SPKI
+   * produces a new ``pin_sha256``); ``dashboard_id`` is
+   * preserved across rotations. If the receiver listener is
+   * currently bound, it gets torn down and rebuilt against the
+   * new cert; the returned ``IdentityView.listener_bound``
+   * reflects the rebuild outcome (``false`` means the rebuild
+   * fail-softed; the operator should check the dashboard logs
+   * before assuming the rotation took effect end-to-end).
+   *
+   * Concurrent calls are rejected with
+   * ``ErrorCode.ALREADY_EXISTS``; the caller is expected to
+   * confirm before each click. Fires a
+   * ``remote_build_identity_rotated`` event on the bus carrying
+   * ``{dashboard_id, pin_sha256}`` so other tabs / subscribers
+   * refresh without polling.
+   */
+  async rotateRemoteBuildIdentity(): Promise<IdentityView> {
+    return this.sendCommand<IdentityView>("remote_build/rotate_identity");
   }
 
   /** Get compiled device metadata. */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -967,6 +967,9 @@ export enum DeviceEventType {
   JOB_OUTPUT = "job_output",
   JOB_COMPLETED = "job_completed",
   JOB_FAILED = "job_failed",
+  // Remote-build receiver-side events.
+  REMOTE_BUILD_BINDING_MISMATCH = "remote_build_binding_mismatch",
+  REMOTE_BUILD_IDENTITY_ROTATED = "remote_build_identity_rotated",
 }
 
 /** Data payload for job lifecycle events (queued, started, completed, failed). */
@@ -1142,7 +1145,8 @@ export interface EditorValidateResponse {
 // Remote-build feature (issue #106).
 // Phase 2: peer dashboard discovery + receiver-side master switch.
 // Phase 2b: user-supplied manual hosts for cross-subnet / non-mDNS LANs.
-// Phase 3+ extends ``RemoteBuildSettings`` with token / cert / TTL knobs.
+// Phase 3b1+: receiver-issued bearer tokens.
+// Phase 3c1: receiver dashboard identity + cert rotation.
 
 export type RemoteBuildPeerSource = "mdns" | "manual";
 
@@ -1151,9 +1155,35 @@ export interface ManualHost {
   port: number;
 }
 
+/**
+ * Public-facing token row from ``remote_build/list_tokens``.
+ *
+ * Mirrors the backend's ``TokenSummary`` (drops the on-disk
+ * ``secret_sha256`` so a leaked frontend snapshot can't be
+ * matched against candidate cleartext bearers). The cleartext
+ * bearer is generated client-side at ``add_token`` time and
+ * never crosses the wire to the backend; this list is the
+ * receiver's view of "which paired offloaders does this
+ * dashboard recognise" — there's no path to recover the
+ * cleartext from anywhere server-side.
+ *
+ * ``bound_dashboard_id`` starts ``null`` and is filled in by
+ * phase 3b3's first-use binding the first time an authenticated
+ * request lands carrying the offloader's ``X-Dashboard-ID``.
+ * The Settings UI renders a "not yet bound" badge while ``null``
+ * and a "bound to <id>" badge once set.
+ */
+export interface TokenSummary {
+  token_id: string;
+  label: string;
+  created_at: number;
+  bound_dashboard_id: string | null;
+}
+
 export interface RemoteBuildSettings {
   enabled: boolean;
   manual_hosts: ManualHost[];
+  tokens: TokenSummary[];
 }
 
 export interface RemoteBuildPeer {
@@ -1164,4 +1194,81 @@ export interface RemoteBuildPeer {
   addresses: string[];
   server_version: string;
   esphome_version: string;
+}
+
+/**
+ * Receiver's stable identity, returned from
+ * ``remote_build/get_identity`` and ``remote_build/rotate_identity``.
+ *
+ * The cert + key PEMs are intentionally NOT included — only the
+ * SPKI fingerprint (``pin_sha256``, lowercase hex SHA-256 of the
+ * SubjectPublicKeyInfo) is safe to ship, and it's what an
+ * offloader pins against anyway. ``listener_bound`` reports
+ * whether the ``/remote-build/v1/*`` HTTPS site is currently
+ * serving traffic; lets the Settings UI distinguish "rotation
+ * succeeded AND the listener is back up" from "rotation
+ * succeeded but the rebuild fail-softed; check logs".
+ */
+export interface IdentityView {
+  dashboard_id: string;
+  pin_sha256: string;
+  server_version: string;
+  esphome_version: string;
+  listener_bound: boolean;
+}
+
+/**
+ * Args for ``remote_build/add_token``.
+ *
+ * **The cleartext bearer is generated client-side** (see
+ * ``mintRemoteBuildBearer``). The frontend POSTs only the
+ * SHA-256 hash of the secret half; the cleartext never crosses
+ * the wire to the backend. This closes the leak that would
+ * otherwise occur on plain-HTTP standalone deployments where
+ * the main port carries the WS API in cleartext.
+ */
+export interface AddRemoteBuildTokenArgs {
+  /** Display label, 1-128 chars. Duplicates allowed; ``token_id`` is the unique key. */
+  label: string;
+  /** Client-generated, exactly 11 base64url chars (8 random bytes encoded). */
+  token_id: string;
+  /** Lowercase hex SHA-256 of the cleartext secret half (64 chars). */
+  secret_sha256: string;
+}
+
+/**
+ * Data payload for the ``remote_build_binding_mismatch`` event.
+ *
+ * Fires when an authenticated ``/remote-build/v1/*`` request's
+ * ``X-Dashboard-ID`` doesn't match the token's bound value.
+ * ``race_loss`` distinguishes a concurrent first-use bind that
+ * lost the race (likely an operator pasted the cleartext into
+ * two offloaders by mistake; soften the wording) from a hit on
+ * an already-bound token (more suspicious — stolen bearer or
+ * paste-into-wrong-machine; loud wording with an inline revoke
+ * CTA).
+ */
+export interface RemoteBuildBindingMismatchEventData {
+  token_id: string;
+  presented_dashboard_id: string;
+  bound_dashboard_id: string;
+  peer_ip: string;
+  race_loss: boolean;
+}
+
+/**
+ * Data payload for the ``remote_build_identity_rotated`` event.
+ *
+ * Fires when the operator triggers ``rotate_identity``. Lets the
+ * Settings UI refresh its cached pin without polling
+ * ``get_identity`` (the dashboard might've been rotated from
+ * another tab, or via the WS API directly). Only the rotated
+ * fields are carried; ``server_version`` and
+ * ``esphome_version`` don't change on rotation, and the
+ * ``listener_bound`` state is best read via a fresh
+ * ``get_identity`` call on the receiving tab.
+ */
+export interface RemoteBuildIdentityRotatedEventData {
+  dashboard_id: string;
+  pin_sha256: string;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1226,15 +1226,22 @@ export interface IdentityView {
  * the wire to the backend. This closes the leak that would
  * otherwise occur on plain-HTTP standalone deployments where
  * the main port carries the WS API in cleartext.
+ *
+ * Type alias rather than ``interface`` so it satisfies
+ * ``Record<string, unknown>`` at the ``sendCommand`` call site;
+ * named interfaces lose the index-signature compatibility a
+ * structurally-typed object literal has, which would otherwise
+ * force a defensive ``{ ...args }`` spread that no other
+ * remote-build wrapper uses.
  */
-export interface AddRemoteBuildTokenArgs {
+export type AddRemoteBuildTokenArgs = {
   /** Display label, 1-128 chars. Duplicates allowed; ``token_id`` is the unique key. */
   label: string;
   /** Client-generated, exactly 11 base64url chars (8 random bytes encoded). */
   token_id: string;
   /** Lowercase hex SHA-256 of the cleartext secret half (64 chars). */
   secret_sha256: string;
-}
+};
 
 /**
  * Data payload for the ``remote_build_binding_mismatch`` event.

--- a/src/util/remote-build-bearer.ts
+++ b/src/util/remote-build-bearer.ts
@@ -1,0 +1,123 @@
+/**
+ * Client-side bearer mint for remote-build receiver tokens.
+ *
+ * Phase 3b3 of issue #106 moved bearer generation from the
+ * backend to the frontend so the cleartext never crosses the wire
+ * to the dashboard. This closes the leak that would otherwise
+ * occur on plain-HTTP standalone deployments where the main port
+ * (default 6052) carries the WS API in cleartext.
+ *
+ * Wire format the receiver expects:
+ *
+ *   Authorization: Bearer {token_id}.{secret}
+ *
+ * where ``token_id`` is the textual form of 8 random bytes after
+ * base64url encoding (exactly 11 chars; the receiver pins the
+ * length so the 64-bit collision math at the 100-token cap stays
+ * load-bearing) and ``secret`` is 32 random bytes after base64url
+ * encoding (43 chars, 256 bits of entropy — infeasible to
+ * brute-force).
+ *
+ * The frontend POSTs only ``{label, token_id, secret_sha256}`` to
+ * ``remote_build/add_token``; the cleartext stays in local state
+ * long enough for the user to copy it into the offloader and is
+ * then discarded.
+ *
+ * RNG: ``crypto.getRandomValues`` is the ONLY acceptable source.
+ * A fallback to ``Math.random`` (or any other non-CSPRNG) is a
+ * security regression: the backend can verify only the hash's
+ * shape, not its entropy, so a weak source would produce
+ * predictable bearers that the backend silently accepts. The
+ * function throws if ``crypto.getRandomValues`` is missing rather
+ * than substituting a weaker source.
+ *
+ * Hash: ``js-sha256`` rather than ``crypto.subtle.digest``
+ * because ``crypto.subtle`` requires a "secure context" per the
+ * spec, which the dashboard often isn't (HA-addon direct port,
+ * container deployments on plain HTTP at non-localhost LAN IPs).
+ * ``crypto.getRandomValues`` has no such restriction and works
+ * everywhere.
+ */
+
+import { sha256 } from "js-sha256";
+
+/** Wire-format constraints from the backend's ``_validate_token_id``. */
+export const REMOTE_BUILD_TOKEN_ID_BYTES = 8;
+export const REMOTE_BUILD_TOKEN_ID_CHARS = 11;
+export const REMOTE_BUILD_SECRET_BYTES = 32;
+export const REMOTE_BUILD_SECRET_CHARS = 43;
+export const REMOTE_BUILD_SECRET_SHA256_CHARS = 64;
+
+/**
+ * Result of :func:`mintRemoteBuildBearer`.
+ *
+ * ``token_id`` and ``secret_sha256`` are what we POST to the
+ * backend via ``add_token``. ``secret`` is the cleartext half;
+ * the caller composes the wire bearer as
+ * ``${token_id}.${secret}`` and shows it to the user once for
+ * copy-into-offloader, then discards it.
+ *
+ * ``bearer`` is the convenience pre-composed wire form; the
+ * caller can use either ``bearer`` directly or compose from the
+ * halves, whichever is clearer.
+ */
+export interface MintedBearer {
+  token_id: string;
+  secret: string;
+  secret_sha256: string;
+  bearer: string;
+}
+
+/**
+ * Mint a fresh ``(token_id, secret, secret_sha256, bearer)`` tuple.
+ *
+ * Throws if ``crypto.getRandomValues`` is unavailable. The
+ * backend has no path to verify entropy, so falling back to a
+ * weaker source would silently produce predictable bearers
+ * that the backend would accept — refusing here surfaces the
+ * environment problem instead. In practice
+ * ``crypto.getRandomValues`` is available in every browser the
+ * dashboard supports (it predates ``crypto.subtle`` and works
+ * outside secure contexts), so the throw is a guard-rail
+ * against a misconfigured test runner / Node polyfill, not a
+ * realistic production failure mode.
+ */
+export function mintRemoteBuildBearer(): MintedBearer {
+  const idBytes = new Uint8Array(REMOTE_BUILD_TOKEN_ID_BYTES);
+  const secretBytes = new Uint8Array(REMOTE_BUILD_SECRET_BYTES);
+  const rng = globalThis.crypto;
+  if (!rng?.getRandomValues) {
+    throw new Error(
+      "remote_build: crypto.getRandomValues is unavailable; refusing to mint a bearer with a weaker RNG"
+    );
+  }
+  rng.getRandomValues(idBytes);
+  rng.getRandomValues(secretBytes);
+  const token_id = base64UrlEncode(idBytes);
+  const secret = base64UrlEncode(secretBytes);
+  const secret_sha256 = sha256(secret);
+  return {
+    token_id,
+    secret,
+    secret_sha256,
+    bearer: `${token_id}.${secret}`,
+  };
+}
+
+/**
+ * Encode bytes as base64url (RFC 4648 §5) without padding.
+ *
+ * Mirrors Python's ``secrets.token_urlsafe`` / Node's
+ * ``Buffer.from(b).toString("base64url")``: ``+`` → ``-``,
+ * ``/`` → ``_``, no trailing ``=``. Native ``btoa`` handles
+ * standard base64 only; we patch the URL-safe alphabet and
+ * trim padding ourselves so the output matches what the
+ * backend's ``_validate_token_id`` expects.
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/src/util/remote-build-bearer.ts
+++ b/src/util/remote-build-bearer.ts
@@ -49,27 +49,25 @@ export const REMOTE_BUILD_SECRET_CHARS = 43;
 export const REMOTE_BUILD_SECRET_SHA256_CHARS = 64;
 
 /**
- * Result of :func:`mintRemoteBuildBearer`.
+ * Result of {@link mintRemoteBuildBearer}.
  *
  * ``token_id`` and ``secret_sha256`` are what we POST to the
- * backend via ``add_token``. ``secret`` is the cleartext half;
- * the caller composes the wire bearer as
- * ``${token_id}.${secret}`` and shows it to the user once for
- * copy-into-offloader, then discards it.
- *
- * ``bearer`` is the convenience pre-composed wire form; the
- * caller can use either ``bearer`` directly or compose from the
- * halves, whichever is clearer.
+ * backend via ``add_token``; ``secret`` is the cleartext half
+ * the caller shows to the user once for copy-into-offloader.
+ * The caller composes the wire bearer as
+ * ``${token_id}.${secret}`` themselves at display time —
+ * carrying a pre-composed ``bearer`` field here would put the
+ * cleartext in two places and offers no compose-time safety
+ * (JS has no zeroize), so we keep it on the caller.
  */
 export interface MintedBearer {
   token_id: string;
   secret: string;
   secret_sha256: string;
-  bearer: string;
 }
 
 /**
- * Mint a fresh ``(token_id, secret, secret_sha256, bearer)`` tuple.
+ * Mint a fresh ``(token_id, secret, secret_sha256)`` tuple.
  *
  * Throws if ``crypto.getRandomValues`` is unavailable. The
  * backend has no path to verify entropy, so falling back to a
@@ -83,25 +81,19 @@ export interface MintedBearer {
  * realistic production failure mode.
  */
 export function mintRemoteBuildBearer(): MintedBearer {
-  const idBytes = new Uint8Array(REMOTE_BUILD_TOKEN_ID_BYTES);
-  const secretBytes = new Uint8Array(REMOTE_BUILD_SECRET_BYTES);
   const rng = globalThis.crypto;
   if (!rng?.getRandomValues) {
     throw new Error(
       "remote_build: crypto.getRandomValues is unavailable; refusing to mint a bearer with a weaker RNG"
     );
   }
+  const idBytes = new Uint8Array(REMOTE_BUILD_TOKEN_ID_BYTES);
+  const secretBytes = new Uint8Array(REMOTE_BUILD_SECRET_BYTES);
   rng.getRandomValues(idBytes);
   rng.getRandomValues(secretBytes);
   const token_id = base64UrlEncode(idBytes);
   const secret = base64UrlEncode(secretBytes);
-  const secret_sha256 = sha256(secret);
-  return {
-    token_id,
-    secret,
-    secret_sha256,
-    bearer: `${token_id}.${secret}`,
-  };
+  return { token_id, secret, secret_sha256: sha256(secret) };
 }
 
 /**
@@ -113,11 +105,19 @@ export function mintRemoteBuildBearer(): MintedBearer {
  * standard base64 only; we patch the URL-safe alphabet and
  * trim padding ourselves so the output matches what the
  * backend's ``_validate_token_id`` expects.
+ *
+ * TODO: switch to
+ * ``Uint8Array.prototype.toBase64({alphabet: "base64url", omitPadding: true})``
+ * once the TC39 Uint8Array-base64 proposal ships in every
+ * browser the dashboard supports. As of now (early 2026) it's
+ * available in current Chrome / Safari / Firefox but not
+ * broadly enough to drop the ``btoa`` fallback.
  */
 function base64UrlEncode(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
+  // ``String.fromCharCode(...bytes)`` is fine for the small
+  // inputs this helper handles (8 or 32 bytes); the call-stack
+  // limit on argument count would only matter at much larger
+  // sizes.
+  const binary = String.fromCharCode(...bytes);
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { APIError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { mintRemoteBuildBearer } from "../../src/util/remote-build-bearer.js";
@@ -60,11 +67,8 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("upgrades to wss:// when the page is https", async () => {
-    (
-      globalThis as unknown as {
-        window: { location: { protocol: string; host: string } };
-      }
-    ).window = { location: { protocol: "https:", host: "example.test" } };
+    (globalThis as unknown as { window: { location: { protocol: string; host: string } } }).window =
+      { location: { protocol: "https:", host: "example.test" } };
     const api = new ESPHomeAPI();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
@@ -193,7 +197,9 @@ describe("ESPHomeAPI — sendCommand", () => {
 
   it("throws when the socket is not open", async () => {
     const api = new ESPHomeAPI();
-    await expect(api.sendCommand("ping")).rejects.toThrow(/not connected/);
+    await expect(api.sendCommand("ping")).rejects.toThrow(
+      /not connected/,
+    );
   });
 
   it("assigns sequential message_ids", async () => {
@@ -230,7 +236,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
     const pending = api.cloneDevice(
       "kitchen.yaml",
       "bedroom-bulb",
-      "Bedroom Reading Lamp"
+      "Bedroom Reading Lamp",
     );
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
 
@@ -357,7 +363,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult }
+      { onOutput, onResult },
     );
     ws.receive({ message_id: messageId, event: "output", data: "line 1" });
     ws.receive({ message_id: messageId, event: "output", data: "line 2" });
@@ -374,7 +380,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult }
+      { onOutput, onResult },
     );
     ws.receive({
       message_id: messageId,
@@ -394,7 +400,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onError }
+      { onError },
     );
     ws.receive({
       message_id: messageId,
@@ -421,7 +427,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput: vi.fn(), onResult: vi.fn() }
+      { onOutput: vi.fn(), onResult: vi.fn() },
     );
 
     const pending = api.stopStream(streamId);
@@ -446,7 +452,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput, onResult }
+      { onOutput, onResult },
     );
 
     // Pre-stop: events flow normally.
@@ -490,7 +496,7 @@ describe("ESPHomeAPI — event subscriptions", () => {
     const ws = await connect(api);
     const received: Array<{ event: string; data: unknown }> = [];
     const subscribed = api.subscribeEvents((event, data) =>
-      received.push({ event, data })
+      received.push({ event, data }),
     );
     const msgId = ws.sentAs<{ message_id: string }>(0).message_id;
     ws.receive({ message_id: msgId, result: { subscribed: true } });
@@ -534,11 +540,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       component_id: "dht",
       fields: { pin: "GPIO4" },
     });
-    const sent = ws.sentAs<{
-      command: string;
-      message_id: string;
-      args: Record<string, unknown>;
-    }>(0);
+    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
     expect(sent.command).toBe("devices/add_component");
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -626,11 +628,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     const pending = api.setRemoteBuildSettings({ enabled: true });
-    const sent = ws.sentAs<{
-      command: string;
-      message_id: string;
-      args: Record<string, unknown>;
-    }>(0);
+    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
     expect(sent.command).toBe("remote_build/set_settings");
     expect(sent.args).toEqual({ enabled: true });
     // Same wire-shape rationale as ``getRemoteBuildSettings`` —
@@ -791,31 +789,13 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     await expect(pending).resolves.toEqual(result);
   });
 
-  it("getRemoteBuildIdentity sends remote_build/get_identity and unwraps the result", async () => {
-    const api = new ESPHomeAPI();
-    const ws = await connect(api);
-    const payload = {
-      dashboard_id: "abc123",
-      pin_sha256: "a".repeat(64),
-      server_version: "1.2.3",
-      esphome_version: "2026.5.0",
-      listener_bound: true,
-    };
-    const pending = api.getRemoteBuildIdentity();
-    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
-    expect(sent.command).toBe("remote_build/get_identity");
-    expect(sent.args).toBeUndefined();
-    ws.receive({ message_id: sent.message_id, result: payload });
-    await expect(pending).resolves.toEqual(payload);
-  });
-
   it("addRemoteBuildToken accepts mintRemoteBuildBearer output as-is (chain contract)", async () => {
     // Pin the integration the UI does end-to-end: the mint
-    // helper returns a shape that the wrapper accepts without
-    // any reformatting. A drift in either side's field naming
-    // (e.g. mint returns ``tokenId`` while the wrapper reads
-    // ``token_id``) would only surface in production today;
-    // this test catches it at unit-test time.
+    // helper returns a shape the wrapper accepts without any
+    // reformatting. A drift in either side's field naming
+    // (e.g. mint returns ``tokenId`` while the wrapper expects
+    // ``token_id``) would only surface in production today; this
+    // test catches it at unit-test time.
     const minted = mintRemoteBuildBearer();
     const api = new ESPHomeAPI();
     const ws = await connect(api);
@@ -835,7 +815,6 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       token_id: minted.token_id,
       secret_sha256: minted.secret_sha256,
     });
-    // Belt and braces: explicitly assert no cleartext leaked.
     expect(sent.args).not.toHaveProperty("secret");
     expect(sent.args).not.toHaveProperty("bearer");
     ws.receive({
@@ -848,6 +827,24 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       },
     });
     await pending;
+  });
+
+  it("getRemoteBuildIdentity sends remote_build/get_identity and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const payload = {
+      dashboard_id: "abc123",
+      pin_sha256: "a".repeat(64),
+      server_version: "1.2.3",
+      esphome_version: "2026.5.0",
+      listener_bound: true,
+    };
+    const pending = api.getRemoteBuildIdentity();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("remote_build/get_identity");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: payload });
+    await expect(pending).resolves.toEqual(payload);
   });
 
   it("rotateRemoteBuildIdentity sends remote_build/rotate_identity and unwraps the result", async () => {
@@ -938,7 +935,7 @@ describe("ESPHomeAPI — auth", () => {
 
     // Fresh token persisted for the next reconnect.
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 })
+      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 }),
     );
   });
 
@@ -1001,7 +998,7 @@ describe("ESPHomeAPI — auth", () => {
     });
     await expect(api.ready).resolves.toBeUndefined();
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 })
+      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 }),
     );
   });
 

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import { mintRemoteBuildBearer } from "../../src/util/remote-build-bearer.js";
 import {
   MockWebSocket,
   installMockWebSocket,
@@ -806,6 +807,47 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     expect(sent.args).toBeUndefined();
     ws.receive({ message_id: sent.message_id, result: payload });
     await expect(pending).resolves.toEqual(payload);
+  });
+
+  it("addRemoteBuildToken accepts mintRemoteBuildBearer output as-is (chain contract)", async () => {
+    // Pin the integration the UI does end-to-end: the mint
+    // helper returns a shape that the wrapper accepts without
+    // any reformatting. A drift in either side's field naming
+    // (e.g. mint returns ``tokenId`` while the wrapper reads
+    // ``token_id``) would only surface in production today;
+    // this test catches it at unit-test time.
+    const minted = mintRemoteBuildBearer();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const pending = api.addRemoteBuildToken({
+      label: "green",
+      token_id: minted.token_id,
+      secret_sha256: minted.secret_sha256,
+    });
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.command).toBe("remote_build/add_token");
+    expect(sent.args).toEqual({
+      label: "green",
+      token_id: minted.token_id,
+      secret_sha256: minted.secret_sha256,
+    });
+    // Belt and braces: explicitly assert no cleartext leaked.
+    expect(sent.args).not.toHaveProperty("secret");
+    expect(sent.args).not.toHaveProperty("bearer");
+    ws.receive({
+      message_id: sent.message_id,
+      result: {
+        token_id: minted.token_id,
+        label: "green",
+        created_at: 1715212800,
+        bound_dashboard_id: null,
+      },
+    });
+    await pending;
   });
 
   it("rotateRemoteBuildIdentity sends remote_build/rotate_identity and unwraps the result", async () => {

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -615,7 +615,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     // both ``enabled`` and ``manual_hosts``; mocking only
     // ``{ enabled }`` here would let an accidental field-rename
     // regression slip past this test.
-    const payload = { enabled: true, manual_hosts: [] };
+    const payload = { enabled: true, manual_hosts: [], tokens: [] };
     const pending = api.getRemoteBuildSettings();
     const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
     expect(sent.command).toBe("remote_build/get_settings");
@@ -632,8 +632,8 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     expect(sent.command).toBe("remote_build/set_settings");
     expect(sent.args).toEqual({ enabled: true });
     // Same wire-shape rationale as ``getRemoteBuildSettings`` —
-    // the result includes ``manual_hosts``.
-    const result = { enabled: true, manual_hosts: [] };
+    // the result includes ``manual_hosts`` and ``tokens``.
+    const result = { enabled: true, manual_hosts: [], tokens: [] };
     ws.receive({ message_id: sent.message_id, result });
     await expect(pending).resolves.toEqual(result);
   });
@@ -657,11 +657,13 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       result: {
         enabled: false,
         manual_hosts: [{ hostname: "10.0.0.5", port: 6052 }],
+        tokens: [],
       },
     });
     await expect(pending).resolves.toEqual({
       enabled: false,
       manual_hosts: [{ hostname: "10.0.0.5", port: 6052 }],
+      tokens: [],
     });
   });
 
@@ -681,9 +683,13 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     expect(sent.args).toEqual({ hostname: "10.0.0.5", port: 6052 });
     ws.receive({
       message_id: sent.message_id,
-      result: { enabled: false, manual_hosts: [] },
+      result: { enabled: false, manual_hosts: [], tokens: [] },
     });
-    await expect(pending).resolves.toEqual({ enabled: false, manual_hosts: [] });
+    await expect(pending).resolves.toEqual({
+      enabled: false,
+      manual_hosts: [],
+      tokens: [],
+    });
   });
 
   it("listRemoteBuildHosts sends remote_build/list_hosts and unwraps the result", async () => {

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import {
@@ -66,8 +59,11 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("upgrades to wss:// when the page is https", async () => {
-    (globalThis as unknown as { window: { location: { protocol: string; host: string } } }).window =
-      { location: { protocol: "https:", host: "example.test" } };
+    (
+      globalThis as unknown as {
+        window: { location: { protocol: string; host: string } };
+      }
+    ).window = { location: { protocol: "https:", host: "example.test" } };
     const api = new ESPHomeAPI();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
@@ -196,9 +192,7 @@ describe("ESPHomeAPI — sendCommand", () => {
 
   it("throws when the socket is not open", async () => {
     const api = new ESPHomeAPI();
-    await expect(api.sendCommand("ping")).rejects.toThrow(
-      /not connected/,
-    );
+    await expect(api.sendCommand("ping")).rejects.toThrow(/not connected/);
   });
 
   it("assigns sequential message_ids", async () => {
@@ -235,7 +229,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
     const pending = api.cloneDevice(
       "kitchen.yaml",
       "bedroom-bulb",
-      "Bedroom Reading Lamp",
+      "Bedroom Reading Lamp"
     );
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
 
@@ -362,7 +356,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
     ws.receive({ message_id: messageId, event: "output", data: "line 1" });
     ws.receive({ message_id: messageId, event: "output", data: "line 2" });
@@ -379,7 +373,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
     ws.receive({
       message_id: messageId,
@@ -399,7 +393,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onError },
+      { onError }
     );
     ws.receive({
       message_id: messageId,
@@ -426,7 +420,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput: vi.fn(), onResult: vi.fn() },
+      { onOutput: vi.fn(), onResult: vi.fn() }
     );
 
     const pending = api.stopStream(streamId);
@@ -451,7 +445,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
 
     // Pre-stop: events flow normally.
@@ -495,7 +489,7 @@ describe("ESPHomeAPI — event subscriptions", () => {
     const ws = await connect(api);
     const received: Array<{ event: string; data: unknown }> = [];
     const subscribed = api.subscribeEvents((event, data) =>
-      received.push({ event, data }),
+      received.push({ event, data })
     );
     const msgId = ws.sentAs<{ message_id: string }>(0).message_id;
     ws.receive({ message_id: msgId, result: { subscribed: true } });
@@ -539,7 +533,11 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       component_id: "dht",
       fields: { pin: "GPIO4" },
     });
-    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
     expect(sent.command).toBe("devices/add_component");
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -627,7 +625,11 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     const pending = api.setRemoteBuildSettings({ enabled: true });
-    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
     expect(sent.command).toBe("remote_build/set_settings");
     expect(sent.args).toEqual({ enabled: true });
     // Same wire-shape rationale as ``getRemoteBuildSettings`` —
@@ -715,6 +717,114 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     ws.receive({ message_id: sent.message_id, result: payload });
     await expect(pending).resolves.toEqual(payload);
   });
+
+  it("listRemoteBuildTokens sends remote_build/list_tokens and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const payload = [
+      {
+        token_id: "abcdefghijk",
+        label: "green",
+        created_at: 1715212800,
+        bound_dashboard_id: null,
+      },
+      {
+        token_id: "lmnopqrstuv",
+        label: "laptop",
+        created_at: 1715212900,
+        bound_dashboard_id: "laptop-dashboard-id",
+      },
+    ];
+    const pending = api.listRemoteBuildTokens();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("remote_build/list_tokens");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: payload });
+    await expect(pending).resolves.toEqual(payload);
+  });
+
+  it("addRemoteBuildToken sends label + token_id + secret_sha256 (no cleartext)", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const args = {
+      label: "green",
+      token_id: "abcdefghijk",
+      secret_sha256: "f".repeat(64),
+    };
+    const pending = api.addRemoteBuildToken(args);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.command).toBe("remote_build/add_token");
+    // Pin the wire shape: only label + token_id + secret_sha256.
+    // No "secret" or "bearer" key — the cleartext stays
+    // client-side and never lands in this payload.
+    expect(sent.args).toEqual(args);
+    expect(sent.args).not.toHaveProperty("secret");
+    expect(sent.args).not.toHaveProperty("bearer");
+    const result = {
+      token_id: args.token_id,
+      label: args.label,
+      created_at: 1715212800,
+      bound_dashboard_id: null,
+    };
+    ws.receive({ message_id: sent.message_id, result });
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  it("removeRemoteBuildToken sends remote_build/remove_token with token_id", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const pending = api.removeRemoteBuildToken({ token_id: "abcdefghijk" });
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.command).toBe("remote_build/remove_token");
+    expect(sent.args).toEqual({ token_id: "abcdefghijk" });
+    const result = { enabled: true, manual_hosts: [], tokens: [] };
+    ws.receive({ message_id: sent.message_id, result });
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  it("getRemoteBuildIdentity sends remote_build/get_identity and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const payload = {
+      dashboard_id: "abc123",
+      pin_sha256: "a".repeat(64),
+      server_version: "1.2.3",
+      esphome_version: "2026.5.0",
+      listener_bound: true,
+    };
+    const pending = api.getRemoteBuildIdentity();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("remote_build/get_identity");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: payload });
+    await expect(pending).resolves.toEqual(payload);
+  });
+
+  it("rotateRemoteBuildIdentity sends remote_build/rotate_identity and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const payload = {
+      dashboard_id: "abc123",
+      pin_sha256: "b".repeat(64),
+      server_version: "1.2.3",
+      esphome_version: "2026.5.0",
+      listener_bound: true,
+    };
+    const pending = api.rotateRemoteBuildIdentity();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("remote_build/rotate_identity");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: payload });
+    await expect(pending).resolves.toEqual(payload);
+  });
 });
 
 describe("ESPHomeAPI — auth", () => {
@@ -786,7 +896,7 @@ describe("ESPHomeAPI — auth", () => {
 
     // Fresh token persisted for the next reconnect.
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 }),
+      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 })
     );
   });
 
@@ -849,7 +959,7 @@ describe("ESPHomeAPI — auth", () => {
     });
     await expect(api.ready).resolves.toBeUndefined();
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 }),
+      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 })
     );
   });
 

--- a/test/util/remote-build-bearer.test.ts
+++ b/test/util/remote-build-bearer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { sha256 } from "js-sha256";
+import {
+  REMOTE_BUILD_SECRET_CHARS,
+  REMOTE_BUILD_SECRET_SHA256_CHARS,
+  REMOTE_BUILD_TOKEN_ID_CHARS,
+  mintRemoteBuildBearer,
+} from "../../src/util/remote-build-bearer.js";
+
+describe("mintRemoteBuildBearer", () => {
+  it("returns a token_id of exactly 11 base64url chars", () => {
+    const minted = mintRemoteBuildBearer();
+    expect(minted.token_id.length).toBe(REMOTE_BUILD_TOKEN_ID_CHARS);
+    // Backend's _validate_token_id pins this length so the
+    // 64-bit collision math at the 100-token cap stays
+    // load-bearing. A drift here would silently widen the
+    // namespace.
+    expect(minted.token_id).toMatch(/^[A-Za-z0-9_-]{11}$/);
+  });
+
+  it("returns a secret of exactly 43 base64url chars", () => {
+    const minted = mintRemoteBuildBearer();
+    expect(minted.secret.length).toBe(REMOTE_BUILD_SECRET_CHARS);
+    expect(minted.secret).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("returns secret_sha256 = sha256(secret) as 64 lowercase hex chars", () => {
+    const minted = mintRemoteBuildBearer();
+    expect(minted.secret_sha256.length).toBe(REMOTE_BUILD_SECRET_SHA256_CHARS);
+    expect(minted.secret_sha256).toMatch(/^[0-9a-f]{64}$/);
+    // Pin the relationship: backend stores secret_sha256 and
+    // verifies via hmac.compare_digest(stored, sha256(presented))
+    // — if the frontend's hash diverges from this formula, every
+    // ``add_token`` produces an unverifiable token.
+    expect(minted.secret_sha256).toBe(sha256(minted.secret));
+  });
+
+  it("returns bearer in the canonical {token_id}.{secret} wire form", () => {
+    const minted = mintRemoteBuildBearer();
+    expect(minted.bearer).toBe(`${minted.token_id}.${minted.secret}`);
+  });
+
+  it("produces distinct outputs across calls", () => {
+    // Birthday-bound assertion: with 64+256 bits of entropy the
+    // odds of two consecutive calls colliding are astronomical.
+    // Run a small batch to catch a refactor that accidentally
+    // reuses the random buffer.
+    const seen = new Set<string>();
+    for (let i = 0; i < 64; i++) {
+      seen.add(mintRemoteBuildBearer().bearer);
+    }
+    expect(seen.size).toBe(64);
+  });
+
+  it("base64url alphabet only — no '+' / '/' / padding", () => {
+    // Run a few iterations to exercise different random bytes.
+    for (let i = 0; i < 16; i++) {
+      const minted = mintRemoteBuildBearer();
+      expect(minted.token_id).not.toMatch(/[+/=]/);
+      expect(minted.secret).not.toMatch(/[+/=]/);
+    }
+  });
+
+  it("throws if crypto.getRandomValues is unavailable", () => {
+    // The backend can verify only the hash's shape, not its
+    // entropy, so falling back to ``Math.random`` would silently
+    // produce predictable bearers the backend would accept.
+    // Refusing here surfaces the environment problem instead.
+    const original = globalThis.crypto;
+    try {
+      vi.stubGlobal("crypto", undefined);
+      expect(() => mintRemoteBuildBearer()).toThrow(
+        /crypto\.getRandomValues is unavailable/
+      );
+    } finally {
+      vi.stubGlobal("crypto", original);
+    }
+  });
+});

--- a/test/util/remote-build-bearer.test.ts
+++ b/test/util/remote-build-bearer.test.ts
@@ -35,19 +35,17 @@ describe("mintRemoteBuildBearer", () => {
     expect(minted.secret_sha256).toBe(sha256(minted.secret));
   });
 
-  it("returns bearer in the canonical {token_id}.{secret} wire form", () => {
-    const minted = mintRemoteBuildBearer();
-    expect(minted.bearer).toBe(`${minted.token_id}.${minted.secret}`);
-  });
-
   it("produces distinct outputs across calls", () => {
     // Birthday-bound assertion: with 64+256 bits of entropy the
     // odds of two consecutive calls colliding are astronomical.
     // Run a small batch to catch a refactor that accidentally
-    // reuses the random buffer.
+    // reuses the random buffer. Hashing the (id, secret) pair
+    // — rather than just one half — catches a bug where one
+    // buffer is randomised and the other is reused stale.
     const seen = new Set<string>();
     for (let i = 0; i < 64; i++) {
-      seen.add(mintRemoteBuildBearer().bearer);
+      const m = mintRemoteBuildBearer();
+      seen.add(`${m.token_id}.${m.secret}`);
     }
     expect(seen.size).toBe(64);
   });
@@ -100,7 +98,6 @@ describe("mintRemoteBuildBearer", () => {
       expect(minted.token_id).toMatch(/^[A-Za-z0-9_-]{11}$/);
       // No '+', '/', or '=' in either half.
       expect(minted.secret).not.toMatch(/[+/=]/);
-      expect(minted.bearer).toBe(`${minted.token_id}.${minted.secret}`);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/test/util/remote-build-bearer.test.ts
+++ b/test/util/remote-build-bearer.test.ts
@@ -61,6 +61,51 @@ describe("mintRemoteBuildBearer", () => {
     }
   });
 
+  it("encodes known bytes to the canonical base64url form", () => {
+    // Pin the encoder against a deterministic input so a bug in
+    // the alphabet replacement (e.g. only patching ``+`` and
+    // forgetting ``/``) or in the padding strip can't pass by
+    // luck on random bytes that happened not to trigger the
+    // buggy path. The 8-byte id and 32-byte secret here are
+    // chosen so the standard base64 output contains BOTH ``+``
+    // and ``/`` and a trailing ``=``; the base64url form
+    // transforms all three.
+    //
+    // Standard base64(0xfb,0xff,0xbf,0xfe,0xff,0xbf,0xfe,0xff)
+    //                        = "+/+//v+//v8="
+    // base64url (RFC 4648 §5) of the same:
+    //                        = "-_-__v-__v8"  (12 → 11 chars, padding stripped)
+    const idBytes = new Uint8Array([0xfb, 0xff, 0xbf, 0xfe, 0xff, 0xbf, 0xfe, 0xff]);
+    // For the secret, just repeat a non-trivial pattern long
+    // enough to fill 32 bytes; the goal is to exercise the
+    // encoder over the longer length, not to pin the exact
+    // string.
+    const secretBytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) secretBytes[i] = (i * 37) & 0xff;
+
+    let call = 0;
+    const fakeCrypto = {
+      getRandomValues: <T extends ArrayBufferView>(view: T): T => {
+        const target = view as unknown as Uint8Array;
+        const src = call === 0 ? idBytes : secretBytes;
+        target.set(src);
+        call += 1;
+        return view;
+      },
+    };
+    vi.stubGlobal("crypto", fakeCrypto);
+    try {
+      const minted = mintRemoteBuildBearer();
+      expect(minted.token_id).toBe("-_-__v-__v8");
+      expect(minted.token_id).toMatch(/^[A-Za-z0-9_-]{11}$/);
+      // No '+', '/', or '=' in either half.
+      expect(minted.secret).not.toMatch(/[+/=]/);
+      expect(minted.bearer).toBe(`${minted.token_id}.${minted.secret}`);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("throws if crypto.getRandomValues is unavailable", () => {
     // The backend can verify only the hash's shape, not its
     // entropy, so falling back to ``Math.random`` would silently

--- a/test/util/remote-build-bearer.test.ts
+++ b/test/util/remote-build-bearer.test.ts
@@ -108,14 +108,21 @@ describe("mintRemoteBuildBearer", () => {
     // entropy, so falling back to ``Math.random`` would silently
     // produce predictable bearers the backend would accept.
     // Refusing here surfaces the environment problem instead.
-    const original = globalThis.crypto;
+    //
+    // Cleanup uses ``vi.unstubAllGlobals()`` rather than
+    // re-stubbing with the original — Vitest tracks stubs in an
+    // internal stack, and a second ``stubGlobal`` push leaves
+    // stack state dirty and can fail to restore the original
+    // property descriptor on globals that were defined as
+    // non-configurable. Same pattern as the
+    // ``encodes known bytes`` test above.
     try {
       vi.stubGlobal("crypto", undefined);
       expect(() => mintRemoteBuildBearer()).toThrow(
         /crypto\.getRandomValues is unavailable/
       );
     } finally {
-      vi.stubGlobal("crypto", original);
+      vi.unstubAllGlobals();
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Phase 3c2a of the remote-build receiver Settings work
(esphome/device-builder issue #106). Frontend-side API
client wrappers + types + a pure-function client-side
bearer-mint helper. **No UI in this PR** — locks the typed
surface that 3c2b (Build host card) and 3c2c (tokens list +
binding-mismatch alerts) will commit to.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 (remote-build offload, phase 3c2a)
- builds on phase 3b1 (esphome/device-builder#453), 3b3 (#458) and 3c1 (#461) on the backend

## What's in here

### New types in `src/api/types.ts`

- `IdentityView` mirrors the backend's wire shape from #461 (dashboard_id, pin_sha256, server/esphome versions, listener_bound). Cert + key PEMs intentionally NOT included — only the SPKI fingerprint (`pin_sha256`, lowercase hex) is safe to ship to a frontend.
- `TokenSummary` mirrors the backend projection (drops `secret_sha256` from the wire so a leaked frontend snapshot can't be matched against candidate cleartext bearers).
- `RemoteBuildSettings.tokens` finally typed (was missing since 3b1 landed).
- `AddRemoteBuildTokenArgs` for the `add_token` payload — only the three fields the cleartext doesn't appear in.
- `RemoteBuildBindingMismatchEventData` + `RemoteBuildIdentityRotatedEventData` for the two new event payloads, plus matching `DeviceEventType` enum entries so 3c2b/3c2c can subscribe.

### Five new typed wrappers in `src/api/esphome-api.ts`

- `listRemoteBuildTokens` / `addRemoteBuildToken` / `removeRemoteBuildToken` (3b1+3b3 surface)
- `getRemoteBuildIdentity` / `rotateRemoteBuildIdentity` (3c1 surface)

`addRemoteBuildToken` takes only `{label, token_id, secret_sha256}` — the cleartext bearer is never an arg, never a return value. The API test pins this with explicit `expect(sent.args).not.toHaveProperty("secret")` / `not.toHaveProperty("bearer")` so a refactor can't accidentally leak the cleartext through this wrapper.

### New `src/util/remote-build-bearer.ts`: `mintRemoteBuildBearer()`

Pure function returning `{token_id, secret, secret_sha256, bearer}`. Two load-bearing constraints baked in:

- **RNG: `crypto.getRandomValues` only.** Throws if unavailable rather than falling back to `Math.random` or anything else. The backend can verify only the hash's *shape*, not its *entropy*, so a weaker source would silently produce predictable bearers the backend would accept — refusing here surfaces the environment problem instead. Test pins this.

- **Hash: `js-sha256`, not `crypto.subtle.digest`.** `crypto.subtle` requires a "secure context" per the Web Crypto spec, which the dashboard often isn't (HA-addon direct port and container deployments on plain HTTP at non-localhost LAN IPs both fail the secure-context check). `crypto.getRandomValues` has no such restriction and works everywhere. `js-sha256` is a small audited pure-JS implementation; new dependency added.

## Test coverage

`test/util/remote-build-bearer.test.ts` (new file) pins:
- 11 + 43 + 64 char counts (length drift would silently break the backend's `_validate_token_id`)
- `secret_sha256 = sha256(secret)` relationship (a refactor that swaps in a different hash function blows up here, not in production)
- base64url alphabet only — no `+` / `/` / padding
- Output distinctness across 64 calls (catches a refactor that reuses the random buffer)
- Throw-when-no-CSPRNG guard
- **Deterministic encoding contract** — stubs `crypto.getRandomValues` with bytes whose standard-base64 output contains BOTH `+` and `/` AND trailing `=`, asserts the base64url output transforms all three. Catches encoder bugs that random-input tests would miss by luck.

`test/api/esphome-api.test.ts` adds:
- Five new wrapper tests following the existing typed-wrapper pattern (command + args + result unwrap)
- `addRemoteBuildToken` wire-shape pin (explicit no-cleartext assertions)
- **Mint → wrapper chain test** — calls `mintRemoteBuildBearer()` then `addRemoteBuildToken()` and pins that the helper's output is wire-compatible with the wrapper without any reformatting; a drift in field naming on either side would surface here at unit-test time rather than in production.

956/956 vitest passing; tsc clean; prettier clean.

## Types of changes

- [ ] Bugfix
- [x] New feature — `new-feature`
- [ ] Enhancement
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump (`js-sha256` is a runtime dep added for this feature; the change of substance is the new feature, not the dep bump)

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added or updated.
- [x] TypeScript strict + prettier pass.
- [x] Backend companion: esphome/device-builder#461 (3c1 — already merged).
