### PR TITLE
Invalidate cached identity / tokens on off-section cross-tab event

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -292,19 +292,16 @@ export class ESPHomeSettingsDialog extends LitElement {
    *   receiver, but the extra fetch is idempotent and the
    *   tokens list cap is small.
    *
-   * Both branches gate on ``_section === "build_server"`` rather
-   * than on the loaded-state of the field they refresh. A
-   * loaded-state guard ("only refetch if not null") would skip
-   * the event in two real cases:
+   * Each branch handles two cases:
    *
-   * 1. The initial ``_loadBuildServerIdentity`` is in flight when
-   *    the rotation event arrives — the field is still ``null``
-   *    so we'd skip, then the in-flight request lands with
-   *    pre-rotation data.
-   * 2. The user navigated away from the section since loading;
-   *    the field is non-null but stale.
-   *
-   * Section-active is the user-intent signal we actually want.
+   * - User is currently on the Build server section
+   *   (``_section === "build_server"``): refetch immediately
+   *   so the visible card / list shows fresh data.
+   * - User is on a different section: null the cached value
+   *   so the lazy-load in ``_selectSection`` fires a fresh
+   *   load when they navigate back. (A non-null value would
+   *   short-circuit the lazy-load and leave the user staring
+   *   at the pre-event snapshot.)
    *
    * For both: ``changed.get(...)`` returns the *previous*
    * value, which is ``undefined`` on the very first sync (Lit's
@@ -314,17 +311,26 @@ export class ESPHomeSettingsDialog extends LitElement {
    */
   protected updated(changed: Map<string, unknown>) {
     super.updated(changed);
-    if (this._section !== "build_server") return;
     if (changed.has("_buildServerIdentityRotationCounter")) {
       const prev = changed.get("_buildServerIdentityRotationCounter");
       if (prev !== undefined) {
-        void this._loadBuildServerIdentity();
+        if (this._section === "build_server") {
+          void this._loadBuildServerIdentity();
+        } else {
+          this._buildServerIdentity = null;
+          this._buildServerIdentityLoadFailed = false;
+        }
       }
     }
     if (changed.has("_buildServerBindingMismatches")) {
       const prev = changed.get("_buildServerBindingMismatches");
       if (prev !== undefined) {
-        void this._loadBuildServerTokens();
+        if (this._section === "build_server") {
+          void this._loadBuildServerTokens();
+        } else {
+          this._buildServerTokens = null;
+          this._buildServerTokensLoadFailed = false;
+        }
       }
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Follow-up on the post-merge review of esphome/device-builder-frontend#245.

The section-active gate I introduced there (`_section === "build_server"`) fixed the in-flight-load race Copilot flagged but regressed a different case the previous gate (`_buildServerIdentity !== null`) had handled correctly:

> user opens Settings → Build server (loads identity) → navigates to Appearance → another tab rotates the cert → user navigates back to Build server.

With the section gate, the rotation event fired while `_section === "appearance"`, so `updated()` returned early. The loaded identity stayed cached. `_selectSection`'s lazy-load short-circuits when the field is non-null, so on return the user stared at the pre-rotation fingerprint until they closed and reopened Settings.

## Fix

When an event arrives off-section, null out the cached field (and clear the load-failed flag) instead of returning. The lazy-load in `_selectSection` then fires fresh on the next visit. On-section path is unchanged: refetch immediately so the visible card refreshes live.

Symmetric shape for both branches (identity rotation, binding mismatch / tokens). No new state — the existing `_buildServer{Identity,Tokens}` fields cover both the "currently rendering" and "lazy-load on next visit" paths.

## Coverage matrix after this PR

| User location at event | Identity rotation | Binding mismatch (tokens) |
|---|---|---|
| On Build server section | refetch immediately ✅ | refetch immediately ✅ |
| On a different Settings section | null cache, lazy-load on return ✅ | null cache, lazy-load on return ✅ |
| Settings dialog closed | next `open()` already resets fields to null ✅ | next `open()` already resets fields to null ✅ |

## Related issue

- esphome/device-builder#106 (phase 3c2d follow-up)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (964 tests, 70 files).
- [x] Tests have been added to verify that the new code works (where applicable). The change is one symmetric branch in `updated()` per signal; no new pure helpers warranted extraction.
