### PR TITLE
Trust the wire when mDNS confirms encryption (closes #437)

### DIFF
--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -36,15 +36,28 @@ export type EncryptionState =
  */
 export function getEncryptionState(d: EncryptionInputs): EncryptionState {
   if (!d.api_enabled) return "none";
-  if (!d.api_encrypted) return "plaintext";
   const observed = d.api_encryption_active;
-  /* mDNS confirms encryption is *actually* running on the device
-     (e.g. ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``). Truth on the
-     wire trumps everything else — a YAML edit elsewhere
-     (whitespace, comment, sensor tweak) doesn't disable the
-     encryption that's already live, so the indicator stays green
-     even when ``has_pending_changes`` is set. */
+  /* Truth on the wire trumps the YAML signal. A truthy
+     ``api_encryption_active`` (e.g.
+     ``Noise_NNpsk0_25519_ChaChaPoly_SHA256``) is the running
+     firmware reporting "encryption is on right now" — a YAML
+     edit elsewhere (whitespace, comment, sensor tweak) doesn't
+     disable that, so the indicator stays green even when
+     ``has_pending_changes`` is set.
+
+     Checked BEFORE the ``!api_encrypted`` short-circuit on
+     purpose: dashboard issue #437 surfaces a config where
+     encryption is configured via ESPHome's Jinja-templated
+     packages (``api: |\\n  # set ns = ... ${ns.cfg}``), which
+     the dashboard's ``yaml_util.load_yaml`` doesn't render. The
+     YAML pass therefore comes back as ``api_encrypted=false``,
+     but the device's mDNS broadcast carries the live cipher
+     string. Honouring the wire here keeps the indicator
+     correct for any future ESPHome preprocessor feature the
+     dashboard doesn't reproduce, not just this one Jinja
+     case. */
   if (observed) return "active";
+  if (!d.api_encrypted) return "plaintext";
   /* From here ``observed`` is either ``""`` (mDNS seen, TXT
      absent — device is plaintext) or ``null`` / ``undefined``
      (mDNS not seen yet). In both cases the running firmware is

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -14,11 +14,18 @@ export interface EncryptionInputs {
 export type EncryptionState =
   /** No native API exposed — no indicator at all. */
   | "none"
-  /** YAML disabled encryption; device either confirmed plaintext or
-   *  mDNS hasn't been seen. The lock-open warning indicator. */
+  /** Encryption is not in effect on the device. Either the YAML
+   *  disabled it AND the wire didn't contradict, OR mDNS confirmed
+   *  plaintext directly. The lock-open warning indicator. */
   | "plaintext"
-  /** YAML enables encryption; mDNS confirms the device is running it,
-   *  or mDNS hasn't been seen and we trust the YAML. */
+  /** Encryption is in effect. Either mDNS reports a truthy cipher
+   *  string (the running firmware is broadcasting Noise — wire
+   *  authoritative), or the YAML enables encryption and the wire
+   *  hasn't contradicted it (mDNS not seen yet → trust the YAML).
+   *  The wire-authoritative arm catches configs whose YAML pass
+   *  diverges from the running firmware (issue #437: ESPHome's
+   *  Jinja-templated packages aren't run by the dashboard's
+   *  ``yaml_util.load_yaml``). */
   | "active"
   /** YAML enables encryption but the device is broadcasting plaintext
    *  AND ``has_pending_changes`` is set — we know the user just edited

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -92,6 +92,56 @@ describe("getEncryptionState", () => {
       ),
     ).toBe("mismatch");
   });
+
+  it("returns 'active' when mDNS confirms encryption even if YAML detection missed it", () => {
+    /* Dashboard issue #437: a config that wires encryption via
+       ESPHome's Jinja-templated packages (``api: |\n  # set ns =
+       ...  ${ns.cfg}``) lands at the dashboard's
+       ``yaml_util.load_yaml`` as ``api`` = literal string, the
+       package merge clobbers it with the dict-shaped ``api:
+       actions:`` from another package, and the YAML signal
+       comes back ``api_encrypted: false``. The device's mDNS
+       broadcast still carries the live cipher string because
+       the firmware really IS running encryption — ESPHome's
+       compile path renders the Jinja that the dashboard
+       doesn't.
+
+       Honour the wire: a truthy ``api_encryption_active``
+       (``"Noise_..."``) means encryption is live regardless of
+       whether the YAML pass found the encryption block. The
+       previous behaviour returned "plaintext" here and showed
+       an open-lock indicator on a fully-encrypted device.
+
+       Same fix covers the symmetric case the previous logic
+       also missed: a device flashed elsewhere whose YAML doesn't
+       reflect the encryption that's already running on the
+       hardware (e.g. firmware sourced from a backup, a config
+       restore that lost the secret). The wire signal is the
+       authoritative one; surfacing "plaintext" there mislead
+       operators into reflashing devices that didn't need it. */
+    expect(
+      getEncryptionState(
+        inputs({
+          api_encrypted: false,
+          api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
+        }),
+      ),
+    ).toBe("active");
+  });
+
+  it("stays 'plaintext' when YAML disables encryption AND mDNS confirms plaintext", () => {
+    /* The mDNS empty-string is "TXT seen, key absent → device
+       confirmed plaintext"; combined with YAML saying plaintext
+       this is unambiguously a non-encrypted device. The truth-on-
+       the-wire short-circuit must NOT promote this to "active"
+       just because ``api_encryption_active`` is non-null —
+       only truthy strings (the live cipher) flip the state. */
+    expect(
+      getEncryptionState(
+        inputs({ api_encrypted: false, api_encryption_active: "" }),
+      ),
+    ).toBe("plaintext");
+  });
 });
 
 describe("getEncryptionVisual", () => {

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -117,7 +117,7 @@ describe("getEncryptionState", () => {
        reflect the encryption that's already running on the
        hardware (e.g. firmware sourced from a backup, a config
        restore that lost the secret). The wire signal is the
-       authoritative one; surfacing "plaintext" there mislead
+       authoritative one; surfacing "plaintext" there misled
        operators into reflashing devices that didn't need it. */
     expect(
       getEncryptionState(


### PR DESCRIPTION
# What does this implement/fix?

Fixes the open-lock indicator reported in
esphome/device-builder#437 — a fully-encrypted device showed
the open-lock variant because the YAML-side detection missed
its `api: encryption:` block, even though mDNS was broadcasting
the live cipher string.

## Why the YAML side missed it

The reporter's config wires encryption via ESPHome's
Jinja-templated packages:

```yaml
# common/api.yaml
api: |
  # set ns = namespace(cfg={})
  # if api_encryption_key is defined and api_encryption_key != ""
  # set ns.cfg = dict(ns.cfg, **{
      "encryption": {
        "key": api_encryption_key
      }
    })
  # endif
  ${ns.cfg}
```

ESPHome's compile pipeline runs the Jinja preprocessor
*before* YAML parsing on packages, so the firmware really
gets `api: encryption: key: <secret>`. The dashboard's
`yaml_util.load_yaml` does plain YAML + package merge with
**no Jinja step**, so `cfg["api"]` lands as the literal
string `# set ns = namespace(cfg={}) ...`, the package merge
clobbers it with the dict-shaped `api: actions:` block from
another package, and the YAML pass returns
`api_encrypted: false`.

Verified directly against the reporter's config (loader run
in-process):

```text
cfg["api"]                          → OrderedDict({"actions": [...]})
get_api_encryption_block(cfg)       → None
yaml_has_api_encryption(raw_text)   → False
api_encryption_active               → "Noise_NNpsk0_25519_ChaChaPoly_SHA256"
```

## Why the indicator was wrong

`getEncryptionState` short-circuited on
`!d.api_encrypted → "plaintext"` **before** checking
`api_encryption_active`. The function's own docstring
described "Truth on the wire trumps everything else" but the
control flow reached that arm only when the YAML pass already
agreed encryption was on. So the YAML pass was effectively a
gate, not just a hint, and any time it missed the encryption
the wire signal couldn't recover.

## What this PR does

Move the truthy-`api_encryption_active` short-circuit ahead of
the `!api_encrypted` arm. Now:

- Truthy `api_encryption_active` (live cipher string) → `"active"`
  regardless of `api_encrypted`. Truth on the wire wins.
- `api_encrypted = false` AND null/empty `api_encryption_active`
  → `"plaintext"` (unchanged).
- Every other branch unchanged.

Same fix covers the symmetric case the old logic also missed:
a device flashed elsewhere whose YAML doesn't reflect the
encryption that's already running (firmware sourced from a
backup, config restore that lost the secret). The old logic
would mislead operators into reflashing devices that didn't
need it.

## Tests

Two new tests pin both the new contract and its boundary:

1. `api_encrypted: false` + `api_encryption_active: "Noise_..."`
   → `"active"`. The fix's headline case (and the symmetric
   "device flashed elsewhere" case).
2. `api_encrypted: false` + `api_encryption_active: ""` →
   `"plaintext"`. The empty-string mDNS observation is "TXT
   seen, key absent — device confirmed plaintext"; only
   truthy strings flip the state.

All 14 pre-existing tests still pass — the change is purely
additive on the previously-incorrect case 4 and doesn't shift
any currently-passing scenario. 966 frontend tests total pass.

## Backend companion

A companion backend PR adds the same truth-on-the-wire fold-in
on the backend's `api_encrypted` flag itself, so non-frontend
consumers (HA integration, table-row menu gating, the
"Show API key" affordance) see the corrected value too. Either
PR alone fixes the visible indicator; both together close the
gap end-to-end. Wire is forward+backward compatible: the
frontend works against an old backend (frontend logic still
honours mDNS truth even if backend `api_encrypted` is wrong),
and the backend works against an old frontend (the fixed
`api_encrypted` flag flows through the existing
`getEncryptionState` logic unchanged).

**Related issue or feature (if applicable):**

- closes esphome/device-builder#437 (frontend half)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
