### PR TITLE
Show peer_ip in pairing-requests inbox

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1201,7 +1201,13 @@ export type PeerStatus = "pending" | "approved";
  * by the controller because the receiver-side ``StoredPeer``
  * itself doesn't carry one (PENDING peers live in the
  * controller's in-memory dict; persisted peers are implicitly
- * APPROVED).
+ * APPROVED). ``peer_ip`` is the source IP observed at
+ * pair_request time and persisted on ``StoredPeer``; the
+ * receiver Settings inbox renders it next to the pin so the
+ * operator can clone-risk-sanity-check the source against
+ * expectations. Empty string for legacy on-disk rows from
+ * receivers that pre-date the persisted ``peer_ip`` field —
+ * the renderer hides the row line in that case.
  */
 export interface PeerSummary {
   dashboard_id: string;
@@ -1209,6 +1215,7 @@ export interface PeerSummary {
   label: string;
   paired_at: number;
   status: PeerStatus;
+  peer_ip: string;
 }
 
 /**

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -969,12 +969,14 @@ export class ESPHomeApp extends LitElement {
       case DeviceEventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED: {
         // Upsert a PENDING row keyed on ``dashboard_id``. Carries
         // every field needed for a complete ``PeerSummary``-shape
-        // (the receiver fires this event with ``paired_at`` so
-        // the frontend doesn't need a follow-up read). A re-pair
-        // by the same offloader before admin clicked Accept lands
-        // a fresh event with the new pin / pubkey / paired_at;
-        // upsert overwrites in place. ``peer_ip`` is for inbox
-        // display only, not stored on the row.
+        // (the receiver fires this event with ``paired_at`` and
+        // ``peer_ip`` so the frontend doesn't need a follow-up
+        // read). A re-pair by the same offloader before admin
+        // clicked Accept lands a fresh event with the new pin /
+        // pubkey / paired_at / peer_ip; upsert overwrites in
+        // place. ``peer_ip`` is display-only — the inbox renders
+        // it as a clone-risk sanity-check, no decision logic
+        // keys on it.
         const evt = data as RemoteBuildPairRequestReceivedEventData;
         const incoming: PeerSummary = {
           dashboard_id: evt.dashboard_id,

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -982,6 +982,7 @@ export class ESPHomeApp extends LitElement {
           label: evt.label,
           paired_at: evt.paired_at,
           status: "pending",
+          peer_ip: evt.peer_ip,
         };
         const current = this._buildServerPeers ?? [];
         const idx = current.findIndex(

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -1541,6 +1541,14 @@ export class ESPHomeSettingsDialog extends LitElement {
           <span class="row-desc">
             <code class="peer-pin">${formattedPin}</code>
           </span>
+          ${peer.peer_ip
+            ? html`
+                <span class="row-desc">
+                  ${this._localize("settings.build_server_peer_ip_label")}
+                  <code class="peer-ip">${peer.peer_ip}</code>
+                </span>
+              `
+            : nothing}
         </div>
         <div class="peer-actions">
           <button

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -797,6 +797,7 @@
     "build_server_paired_senders_desc": "Other dashboards approved to send compile jobs to this one.",
     "build_server_paired_senders_loading": "Loading pairings…",
     "build_server_paired_senders_empty": "No paired senders yet.",
+    "build_server_peer_ip_label": "From IP",
     "build_server_peer_approve": "Accept",
     "build_server_peer_approve_aria": "Accept pairing request from {label}",
     "build_server_peer_approve_success": "Sender approved.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -734,6 +734,7 @@
     "build_server_paired_senders_desc": "Autres tableaux de bord autorisés à envoyer des compilations à celui-ci.",
     "build_server_paired_senders_loading": "Chargement des appairages…",
     "build_server_paired_senders_empty": "Aucun expéditeur appairé pour le moment.",
+    "build_server_peer_ip_label": "Depuis l'IP",
     "build_server_peer_approve": "Accepter",
     "build_server_peer_approve_aria": "Accepter la demande d'appairage de {label}",
     "build_server_peer_approve_success": "Expéditeur approuvé.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -734,6 +734,7 @@
     "build_server_paired_senders_desc": "Andere dashboards die compilatieopdrachten naar dit dashboard mogen sturen.",
     "build_server_paired_senders_loading": "Koppelingen laden…",
     "build_server_paired_senders_empty": "Nog geen gekoppelde afzenders.",
+    "build_server_peer_ip_label": "Vanaf IP",
     "build_server_peer_approve": "Accepteren",
     "build_server_peer_approve_aria": "Koppelingsverzoek van {label} accepteren",
     "build_server_peer_approve_success": "Afzender goedgekeurd.",


### PR DESCRIPTION
# What does this implement/fix?

Adds the source IP that the receiver observed at pair_request time as a third row-desc line on each PENDING entry in the Build server pairing-requests inbox, so the operator can clone-risk-sanity-check the request against expectations ("legit dashboard runs on .50; this request shows .99 — refuse").

The IP was already on the live `RemoteBuildPairRequestReceivedEventData` payload from 4b-1, but it was never threaded onto the in-context `_buildServerPeers` row, and the snapshot path (`subscribe_events`'s `initial_state.peers`) didn't carry it at all — meaning a snapshot-loaded PENDING row (admin opened the dashboard *after* the request landed) had no IP to show.

## Backend coordination

Companion backend PR: esphome/device-builder#516 — persists `peer_ip` on `StoredPeer` and projects it onto `PeerSummary` so the snapshot path closes the no-IP-after-reload gap. Land both together (or backend first); the wheel ships the prebuilt frontend so the bundle in the next release expects `peer_ip` on every `PeerSummary` it renders.

## What's added

- `PeerSummary.peer_ip: string` (matches backend's `StoredPeer.peer_ip` projection — empty string for legacy on-disk rows from receivers that pre-date the field).
- App-shell stamps `peer_ip` onto the upserted `PeerSummary` on `REMOTE_BUILD_PAIR_REQUEST_RECEIVED`.
- `_renderPendingPeerRow` renders `${label}: ${peer_ip}` as a third `row-desc` line when `peer_ip` is non-empty; hidden for empty-string rows so the renderer degrades cleanly until a re-pair refreshes the row.
- New `build_server_peer_ip_label` translation key in en/fr/nl ("From IP" / "Depuis l'IP" / "Vanaf IP").

## Verification

- `npm run lint` (tsc --noEmit): clean
- `npm run test`: 961/961 passing
- `npm run build`: succeeds (rspack bundle-size warnings pre-existing)

**Related issue or feature (if applicable):**

- esphome/device-builder#106 — receiver-side phase 4b inbox enrichment (clone-risk sanity-check).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
