### PR TITLE
Refresh build-server identity after enable toggle

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1426,6 +1426,17 @@ export class ESPHomeApp extends LitElement {
     this._remoteBuildSetInFlight = true;
     try {
       await this._api.setRemoteBuildSettings({ enabled });
+      // Toggling ``enabled`` runs ``apply_remote_build_enabled``
+      // on the backend, which tears down or re-binds the peer-
+      // link runner; ``IdentityView.listener_bound`` flips
+      // alongside. The cached identity in settings-dialog goes
+      // stale immediately, so bump the counter to force a
+      // re-fetch and pick up the fresh ``listener_bound`` (plus
+      // any version fields that depend on the bound state).
+      // Without this the "Listener active / down" indicator
+      // would render whatever ``listener_bound`` was at the
+      // last fetch, ignoring the toggle the user just clicked.
+      this._buildServerIdentityRotationCounter += 1;
     } catch {
       this._remoteBuildEnabled = previous;
       toast.error(

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -136,17 +136,26 @@ export const onboardingPendingContext = createContext<boolean>(
 );
 
 /**
- * Counter that increments every time the receiver fires a
- * ``remote_build_identity_rotated`` event. Phase 3c2d (#106).
+ * Counter that increments whenever the cached ``IdentityView``
+ * may have gone stale; the Build server settings card watches
+ * the counter and re-fetches identity when it changes. Phase
+ * 3c2d (#106).
  *
- * The Build server settings card consumes this and re-fetches
- * its identity (``getRemoteBuildIdentity``) when the value
- * changes, so a rotation triggered in another tab (or via the
- * server's REST surface, eventually) refreshes the visible cert
- * fingerprint here without a manual reload. A counter rather
- * than the event payload because the IdentityView model carries
- * fields the event payload doesn't (``listener_bound``,
- * versions); a re-fetch is the simplest way to pick those up.
+ * Bump sites:
+ * * ``remote_build_identity_rotated`` event lands a new cert /
+ *   pin fingerprint; another tab triggered a rotation we want
+ *   to mirror.
+ * * The user toggles the "Enable remote build" switch
+ *   (``setRemoteBuildSettings``); ``IdentityView.listener_bound``
+ *   flips alongside the runner teardown / re-bind so the cached
+ *   view goes stale immediately.
+ *
+ * A counter rather than the event payload because the
+ * IdentityView model carries fields the events don't
+ * (``listener_bound``, versions); a re-fetch is the simplest
+ * way to pick those up regardless of which path invalidated
+ * it. Settings dialog reacts to the value going up; the
+ * specific number doesn't matter.
  */
 export const buildServerIdentityRotationCounterContext = createContext<number>(
   Symbol("esphome-build-server-identity-rotation-counter")


### PR DESCRIPTION
# What does this implement/fix?

Fixes a stale "Listener active" / "Listener down" indicator on
the Build server settings card after the user flips the
**"Enable remote build"** switch.

**Symptom**: toggle off, indicator still says "Listener active";
toggle back on, indicator still says "Listener down". The state
only refreshed on a full dashboard reload.

**Cause**: settings-dialog caches its `IdentityView` from the
initial `getRemoteBuildIdentity()` and only re-fetches when
`_buildServerIdentityRotationCounter` bumps. Until now that
counter only bumped on the `remote_build_identity_rotated`
event (cert rotation). The enable-toggle path
(`_onSetRemoteBuildEnabled` in `app-shell`) called
`setRemoteBuildSettings` and updated `_remoteBuildEnabled`
optimistically, but never invalidated the cached identity, so
`identity.listener_bound` rendered against pre-toggle state
indefinitely.

**Fix**: bump the rotation counter after a successful
`setRemoteBuildSettings`. Settings-dialog already watches the
counter and calls `_loadBuildServerIdentity()` on change, so
the indicator picks up the post-teardown / post-rebind
`listener_bound` immediately. Bump only on success — the catch
path reverts the optimistic value, so backend listener state is
unchanged on failure.

Updated the context's JSDoc to spell out the broader contract:
the counter is a "refetch IdentityView" signal, bumped by
either the rotated event or the enable toggle.

**Related issue or feature (if applicable):**

- (none — caught while exercising the toggle interactively)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
