### PR TITLE
Render connected indicator on receiver-side Paired senders

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1293,10 +1293,10 @@ export interface PeerSummary {
   /**
    * Whether the receiver currently has an active 5a-2 peer-link
    * session for this peer (``dashboard_id`` membership in the
-   * receiver's ``_peer_link_sessions`` registry). Defaults
-   * ``false`` for legacy backends that pre-date the field —
-   * a missing field deserialises as ``false`` so the renderer
-   * just shows "offline" rather than crashing.
+   * receiver's ``_peer_link_sessions`` registry). Legacy
+   * backends that pre-date the field may omit it; in that case,
+   * the renderer treats the missing value as falsy and shows
+   * "Disconnected" rather than crashing.
    *
    * Live updates flow through
    * ``RECEIVER_PEER_LINK_SESSION_OPENED`` /

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -992,6 +992,16 @@ export enum DeviceEventType {
   // fires from the offloader's pair-status listener task and from
   // ``remote_build/unpair``.
   OFFLOADER_PAIR_STATUS_CHANGED = "offloader_pair_status_changed",
+  // Receiver-side peer-link session lifecycle. Fired by the
+  // receiver's ``register_peer_link_session`` /
+  // ``unregister_peer_link_session`` hooks when a 5a-2 offloader
+  // client connects / disconnects. Drives the
+  // ``PeerSummary.connected`` indicator on the receiver-side
+  // Paired senders list. Payload is just the ``dashboard_id``;
+  // the matching row is found by lookup against
+  // ``_buildServerPeers``.
+  RECEIVER_PEER_LINK_SESSION_OPENED = "receiver_peer_link_session_opened",
+  RECEIVER_PEER_LINK_SESSION_CLOSED = "receiver_peer_link_session_closed",
   // mDNS-discovered peer dashboards. Replaces the deleted
   // ``remote_build/list_hosts`` WS command — the controller fires
   // these events as its mDNS browser callback resolves /
@@ -1280,6 +1290,28 @@ export interface PeerSummary {
   paired_at: number;
   status: PeerStatus;
   peer_ip: string;
+  /**
+   * Whether the receiver currently has an active 5a-2 peer-link
+   * session for this peer (``dashboard_id`` membership in the
+   * receiver's ``_peer_link_sessions`` registry). Defaults
+   * ``false`` for legacy backends that pre-date the field —
+   * a missing field deserialises as ``false`` so the renderer
+   * just shows "offline" rather than crashing.
+   *
+   * Live updates flow through
+   * ``RECEIVER_PEER_LINK_SESSION_OPENED`` /
+   * ``RECEIVER_PEER_LINK_SESSION_CLOSED`` bus events on the
+   * ``subscribe_events`` stream; the snapshot
+   * (``initial_state.peers``) carries the current value at
+   * subscribe time so a reconnecting tab paints the right
+   * state without waiting for the next event.
+   *
+   * Always ``false`` for PENDING rows: peer-link is gated on
+   * APPROVED status server-side via ``lookup_peer_for_session``,
+   * so a PENDING peer can never legitimately have a registered
+   * session.
+   */
+  connected: boolean;
 }
 
 /**
@@ -1431,6 +1463,22 @@ export interface OffloaderPairStatusChangedEventData {
   receiver_hostname: string;
   receiver_port: number;
   status: "approved" | "removed";
+}
+
+/**
+ * Data payload for ``receiver_peer_link_session_opened`` and
+ * ``receiver_peer_link_session_closed``.
+ *
+ * Fires on the receiver-side bus whenever an APPROVED peer's
+ * 5a-2 ``PeerLinkClient`` connects or disconnects. Drives the
+ * ``PeerSummary.connected`` indicator: app-shell flips the
+ * matching row's ``connected`` flag in the local
+ * ``_buildServerPeers`` list. Both events share the same shape
+ * (just the ``dashboard_id``); the discriminator is the event
+ * type itself.
+ */
+export interface ReceiverPeerLinkSessionEventData {
+  dashboard_id: string;
 }
 
 /**

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -45,6 +45,7 @@ import type {
   PairingSummary,
   PairingWindowState,
   PeerSummary,
+  ReceiverPeerLinkSessionEventData,
   RemoteBuildHostAddedEventData,
   RemoteBuildHostRemovedEventData,
   RemoteBuildPairingWindowChangedEventData,
@@ -1081,6 +1082,11 @@ export class ESPHomeApp extends LitElement {
           paired_at: evt.paired_at,
           status: "pending",
           peer_ip: evt.peer_ip,
+          // PENDING peers are always offline; peer-link is gated
+          // on APPROVED status server-side via
+          // ``lookup_peer_for_session``, so the receiver won't
+          // register a session for this row until admin accepts.
+          connected: false,
         };
         const current = this._buildServerPeers ?? [];
         const idx = current.findIndex(
@@ -1115,6 +1121,28 @@ export class ESPHomeApp extends LitElement {
               : p
           );
         }
+        break;
+      }
+      case DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED:
+      case DeviceEventType.RECEIVER_PEER_LINK_SESSION_CLOSED: {
+        // Flip ``connected`` on the matching APPROVED row.
+        // Both events share the same payload shape; the
+        // discriminator is the event type itself.
+        // ``_buildServerPeers`` may be ``null`` (snapshot not
+        // yet seeded) or missing the row entirely (event raced
+        // ahead of the snapshot, or fired against a peer the
+        // backend just dropped). In both cases the next
+        // ``initial_state`` reseed carries the right state, so
+        // skip rather than synthesise a partial row.
+        if (this._buildServerPeers === null) {
+          break;
+        }
+        const evt = data as ReceiverPeerLinkSessionEventData;
+        const connected =
+          event === DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED;
+        this._buildServerPeers = this._buildServerPeers.map((p) =>
+          p.dashboard_id === evt.dashboard_id ? { ...p, connected } : p
+        );
         break;
       }
       case DeviceEventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED: {

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -1070,6 +1070,40 @@ export class ESPHomeSettingsDialog extends LitElement {
         letter-spacing: 0.05em;
       }
 
+      /* Same shape as .pairing-status-pill, separate class so
+         the receiver-side Paired-senders connection pill can
+         track the offloader-side pairing-status pill stylistic
+         changes without one accidentally inheriting the
+         other's colour palette. */
+      .peer-connection-pill {
+        display: inline-block;
+        padding: 1px 6px;
+        margin-left: var(--wa-space-xs);
+        border-radius: 4px;
+        font-size: var(--wa-font-size-xs);
+        font-weight: var(--wa-font-weight-semibold);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .peer-connection-connected {
+        background: color-mix(
+          in srgb,
+          var(--esphome-success, #16a34a),
+          transparent 80%
+        );
+        color: var(--esphome-success, #16a34a);
+      }
+
+      .peer-connection-disconnected {
+        background: color-mix(
+          in srgb,
+          var(--wa-color-neutral-500, #6b7280),
+          transparent 80%
+        );
+        color: var(--wa-color-neutral-500, #6b7280);
+      }
+
       .pairing-status-pending {
         background: color-mix(
           in srgb,
@@ -1662,10 +1696,27 @@ export class ESPHomeSettingsDialog extends LitElement {
   }
 
   private _renderApprovedPeerRow(peer: PeerSummary) {
+    // Connection-state pill renders next to the label so the
+    // operator sees at a glance whether the paired sender
+    // currently has an active 5a-2 peer-link session. The
+    // value is fed by ``RECEIVER_PEER_LINK_SESSION_OPENED`` /
+    // ``_CLOSED`` events on app-shell, with the snapshot
+    // (``initial_state.peers``) seeding the initial paint.
+    const connectedClass = peer.connected
+      ? "peer-connection-connected"
+      : "peer-connection-disconnected";
+    const connectedLabel = peer.connected
+      ? this._localize("settings.build_server_peer_connected")
+      : this._localize("settings.build_server_peer_disconnected");
     return html`
       <div class="row peer-row peer-row-approved">
         <div class="row-label">
-          <span class="row-title">${peer.label}</span>
+          <span class="row-title">
+            ${peer.label}
+            <span class=${`peer-connection-pill ${connectedClass}`}>
+              ${connectedLabel}
+            </span>
+          </span>
           <span class="row-desc">
             <code class="peer-dashboard-id">${peer.dashboard_id}</code>
           </span>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -861,6 +861,8 @@
     "build_server_peer_reject_success": "Pairing request rejected.",
     "build_server_peer_reject_already_gone": "That pairing request is no longer pending.",
     "build_server_peer_reject_failed": "Couldn't reject the pairing request.",
+    "build_server_peer_connected": "Connected",
+    "build_server_peer_disconnected": "Disconnected",
     "build_server_peer_remove": "Remove",
     "build_server_peer_remove_aria": "Remove paired sender {label}",
     "build_server_peer_remove_confirm_title": "Remove this sender?",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -798,6 +798,8 @@
     "build_server_peer_reject_success": "Demande d'appairage refusée.",
     "build_server_peer_reject_already_gone": "Cette demande d'appairage n'est plus en attente.",
     "build_server_peer_reject_failed": "Impossible de refuser la demande d'appairage.",
+    "build_server_peer_connected": "Connecté",
+    "build_server_peer_disconnected": "Déconnecté",
     "build_server_peer_remove": "Supprimer",
     "build_server_peer_remove_aria": "Supprimer l'expéditeur appairé {label}",
     "build_server_peer_remove_confirm_title": "Supprimer cet expéditeur ?",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -798,6 +798,8 @@
     "build_server_peer_reject_success": "Koppelingsverzoek geweigerd.",
     "build_server_peer_reject_already_gone": "Dat koppelingsverzoek staat niet meer in de wacht.",
     "build_server_peer_reject_failed": "Kan het koppelingsverzoek niet weigeren.",
+    "build_server_peer_connected": "Verbonden",
+    "build_server_peer_disconnected": "Niet verbonden",
     "build_server_peer_remove": "Verwijderen",
     "build_server_peer_remove_aria": "Gekoppelde afzender {label} verwijderen",
     "build_server_peer_remove_confirm_title": "Deze afzender verwijderen?",


### PR DESCRIPTION
# What does this implement/fix?

Frontend follow-up to backend PR
[esphome/device-builder#527](https://github.com/esphome/device-builder/pull/527).
Renders a connection indicator next to each row in the
receiver-side Settings UI's "Paired senders" list so the user
can see at a glance whether each paired sender currently has
an active 5a-2 peer-link session.

**Wire shape:**

- `PeerSummary.connected: boolean` added to `src/api/types.ts`.
  Defaults `false` for legacy backends that pre-date the
  field; a missing value deserialises as `false`, so the
  renderer just shows "Disconnected" rather than crashing.
- New event types `RECEIVER_PEER_LINK_SESSION_OPENED` and
  `RECEIVER_PEER_LINK_SESSION_CLOSED` on `DeviceEventType`,
  with a shared `ReceiverPeerLinkSessionEventData` payload
  (just `dashboard_id`; the discriminator is the event type).

**App-shell handler:**

- Flips `connected` on the matching peer in
  `_buildServerPeers` for both events; skips when the snapshot
  hasn't been seeded yet or the row is missing (event raced
  ahead of the snapshot, or fired against a peer the backend
  just dropped). The next `initial_state` reseed catches up.
- The existing `REMOTE_BUILD_PAIR_REQUEST_RECEIVED` upsert
  path now sets `connected: false` explicitly on the
  synthesised PENDING row to satisfy the new field's shape
  mandate (peer-link is APPROVED-gated server-side via
  `lookup_peer_for_session`, so a PENDING row can never
  legitimately be connected).

**Renderer:**

The approved peer row now shows a small status pill next to
the label, green "Connected" or grey "Disconnected", same
shape and CSS pattern as the existing pairing-status pill on
the offloader-side pairings list.

**Localization:**

Three new keys per locale: `build_server_peer_connected`,
`build_server_peer_disconnected`. en / fr / nl parity.

**Late-subscriber semantics:**

Refreshing the dashboard pulls the current state from
`subscribe_events.initial_state.peers` (the backend computes
`connected` at snapshot-build time from
`_peer_link_sessions` membership), so a fresh tab paints the
right state without waiting for the next event.

**Related issue or feature (if applicable):**

- part of #106 (receiver-side Settings UI polish).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
