### PR TITLE
Align Settings dialog close button with shared 40x40 styling

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -39,6 +39,7 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { warningBannerStyles } from "../styles/banners.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { formatPinSha256 } from "../util/cert-pin-format.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
@@ -666,6 +667,7 @@ export class ESPHomeSettingsDialog extends LitElement {
   static styles = [
     espHomeStyles,
     warningBannerStyles,
+    dialogCloseButtonStyles,
     css`
       wa-dialog {
         --width: min(800px, 95vw);
@@ -673,7 +675,10 @@ export class ESPHomeSettingsDialog extends LitElement {
 
       wa-dialog::part(header) {
         background: var(--esphome-primary);
-        padding: 0 var(--wa-space-m);
+        /* Right padding is 0 so the 40x40 close button (sized via
+           dialogCloseButtonStyles) sits flush with the dialog's
+           corner. */
+        padding: 0 0 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
@@ -682,17 +687,6 @@ export class ESPHomeSettingsDialog extends LitElement {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
-      }
-
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        padding: 0;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
       }
 
       wa-dialog::part(footer) {


### PR DESCRIPTION
# What does this implement/fix?

The Settings dialog's close button was missing the shared 40×40 sizing every other dialog in this app uses, so the X glyph rendered at its intrinsic ~14px footprint and sat slightly inset from the dialog's top-right corner instead of flush. Switch the dialog over to the shared `dialogCloseButtonStyles` (which provides the 40×40 hit target + hover/focus tint) and zero out the header's right padding so the now-square button caps the title bar's right edge — same shape `logs-dialog`, `firmware-install-dialog`, etc. already use.

**Related issue or feature (if applicable):**

- fixes — visual misalignment of the close button in `<esphome-settings-dialog>`

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
