### PR TITLE
Mirror offloader pin-keying refactor (4a-o part 6)

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1509,7 +1509,7 @@ export class ESPHomeAPI {
   }
 
   /**
-   * Drop the local pairing row for ``(hostname, port)``.
+   * Drop the local pairing row identified by *pin_sha256*.
    *
    * Idempotent — returns ``{removed: false}`` when no row
    * matches. Cancels the row's pair-status listener task if
@@ -1519,6 +1519,14 @@ export class ESPHomeAPI {
    * so other tabs / clients on the global ``subscribe_events``
    * stream see the removal.
    *
+   * 4a-o part 6 changed the WS arg from ``hostname / port`` to
+   * ``pin_sha256``: the offloader's controller now keys
+   * pairings on the receiver's stable cryptographic identity,
+   * so the lookup arg follows. Every ``PairingSummary`` row the
+   * frontend renders carries ``pin_sha256``, so the UI
+   * passes that value directly without needing a host/port
+   * round-trip.
+   *
    * Receiver-side state is NOT notified — the receiver's
    * ``StoredPeer`` row stays until the receiver admin clicks
    * Remove on their own inbox; that's the receiver's ownership
@@ -1527,8 +1535,7 @@ export class ESPHomeAPI {
    * affordance for the receiver-side admin.
    */
   async unpairRemoteBuild(args: {
-    hostname: string;
-    port: number;
+    pin_sha256: string;
   }): Promise<{ removed: boolean }> {
     return this.sendCommand<{ removed: boolean }>("remote_build/unpair", args);
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1462,6 +1462,15 @@ export type RemoteBuildPairingWindowChangedEventData = PairingWindowState;
 export interface OffloaderPairStatusChangedEventData {
   receiver_hostname: string;
   receiver_port: number;
+  /**
+   * Stable cryptographic identifier the offloader-side
+   * controller keys ``_pairings`` on (4a-o part 6 — re-keyed
+   * offloader state from ``(host, port)`` to ``pin_sha256``);
+   * frontend handlers should look up the matching
+   * ``PairingSummary`` row by pin rather than by host/port to
+   * stay correct across receiver hostname changes.
+   */
+  pin_sha256: string;
   status: "approved" | "removed";
 }
 
@@ -1505,6 +1514,13 @@ export interface OffloaderPairPinMismatchEventData {
   receiver_hostname: string;
   receiver_port: number;
   receiver_label: string;
+  /**
+   * The **stored** pin the row was keyed on (same value as
+   * ``expected_pin``); duplicated as a separate field so a
+   * pin-keyed lookup doesn't have to parse ``expected_pin``.
+   * 4a-o part 6.
+   */
+  pin_sha256: string;
   expected_pin: string;
   observed_pin: string;
 }
@@ -1529,6 +1545,11 @@ export interface OffloaderPairPeerRevokedEventData {
   receiver_hostname: string;
   receiver_port: number;
   receiver_label: string;
+  /**
+   * Stable cryptographic identifier the alert row keys on
+   * (4a-o part 6).
+   */
+  pin_sha256: string;
 }
 
 /**
@@ -1549,6 +1570,11 @@ export interface OffloaderPairPeerRevokedEventData {
 export interface OffloaderPairAlertDismissedEventData {
   receiver_hostname: string;
   receiver_port: number;
+  /**
+   * Stable cryptographic identifier the dismissed alert row
+   * keyed on (4a-o part 6 — alerts dict re-keyed on pin).
+   */
+  pin_sha256: string;
 }
 
 /**
@@ -1569,6 +1595,8 @@ export interface OffloaderPinMismatchAlert {
   kind: "pin_mismatch";
   receiver_hostname: string;
   receiver_port: number;
+  /** Stable cryptographic identifier (4a-o part 6). */
+  pin_sha256: string;
   receiver_label: string;
   expected_pin: string;
   observed_pin: string;
@@ -1582,6 +1610,8 @@ export interface OffloaderPeerRevokedAlert {
   kind: "peer_revoked";
   receiver_hostname: string;
   receiver_port: number;
+  /** Stable cryptographic identifier (4a-o part 6). */
+  pin_sha256: string;
   receiver_label: string;
   fired_at: number;
 }

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -952,21 +952,11 @@ export class ESPHomeApp extends LitElement {
         this._buildOffloadPairings =
           pairings === undefined
             ? null
-            : new Map(
-                pairings.map((p) => [
-                  this._pairingKey(p.receiver_hostname, p.receiver_port),
-                  p,
-                ]),
-              );
+            : new Map(pairings.map((p) => [p.pin_sha256, p]));
         this._buildOffloadAlerts =
           offloader_alerts === undefined
             ? null
-            : new Map(
-                offloader_alerts.map((a) => [
-                  this._pairingKey(a.receiver_hostname, a.receiver_port),
-                  a,
-                ]),
-              );
+            : new Map(offloader_alerts.map((a) => [a.pin_sha256, a]));
         break;
       }
       case DeviceEventType.DEVICE_ADDED: {
@@ -1199,19 +1189,15 @@ export class ESPHomeApp extends LitElement {
         if (this._buildOffloadPairings === null) {
           break;
         }
-        const key = this._pairingKey(
-          evt.receiver_hostname,
-          evt.receiver_port,
-        );
         const next = new Map(this._buildOffloadPairings);
         if (evt.status === "removed") {
-          next.delete(key);
+          next.delete(evt.pin_sha256);
         } else {
-          const existing = next.get(key);
+          const existing = next.get(evt.pin_sha256);
           if (existing === undefined) {
             break;
           }
-          next.set(key, { ...existing, status: "approved" });
+          next.set(evt.pin_sha256, { ...existing, status: "approved" });
         }
         this._buildOffloadPairings = next;
         break;
@@ -1220,21 +1206,16 @@ export class ESPHomeApp extends LitElement {
         // Backend's pair-status listener detected the receiver's
         // static X25519 pubkey hash drifted from what the
         // offloader had on disk. Upsert the alert keyed on
-        // ``${hostname}:${port}`` (overwrites any prior alert
-        // for the same row — only one alert per receiver, the
-        // most recent detection wins). Same key shape as the
-        // backend's ``_offloader_alerts`` dict so the snapshot
-        // and the live event both target the same map slot.
+        // ``pin_sha256`` (4a-o part 6 — the alerts dict is
+        // pin-keyed; same key shape as the snapshot's
+        // ``initial_state.offloader_alerts`` push).
         const evt = data as OffloaderPairPinMismatchEventData;
-        const key = this._pairingKey(
-          evt.receiver_hostname,
-          evt.receiver_port,
-        );
         const next = new Map(this._buildOffloadAlerts ?? []);
-        next.set(key, {
+        next.set(evt.pin_sha256, {
           kind: "pin_mismatch",
           receiver_hostname: evt.receiver_hostname,
           receiver_port: evt.receiver_port,
+          pin_sha256: evt.pin_sha256,
           receiver_label: evt.receiver_label,
           expected_pin: evt.expected_pin,
           observed_pin: evt.observed_pin,
@@ -1248,15 +1229,12 @@ export class ESPHomeApp extends LitElement {
         // long-poll. Same upsert pattern as pin_mismatch, just
         // a different ``kind`` discriminator.
         const evt = data as OffloaderPairPeerRevokedEventData;
-        const key = this._pairingKey(
-          evt.receiver_hostname,
-          evt.receiver_port,
-        );
         const next = new Map(this._buildOffloadAlerts ?? []);
-        next.set(key, {
+        next.set(evt.pin_sha256, {
           kind: "peer_revoked",
           receiver_hostname: evt.receiver_hostname,
           receiver_port: evt.receiver_port,
+          pin_sha256: evt.pin_sha256,
           receiver_label: evt.receiver_label,
           fired_at: Date.now() / 1000,
         });
@@ -1265,34 +1243,21 @@ export class ESPHomeApp extends LitElement {
       }
       case DeviceEventType.OFFLOADER_PAIR_ALERT_DISMISSED: {
         // Backend dropped the alert via one of the resolution
-        // paths (``request_pair`` succeeded for matching
-        // ``(host, port)``, or ``unpair`` removed the row).
-        // Drop the local row to match.
+        // paths (``request_pair`` succeeded for matching pin,
+        // or ``unpair`` removed the row). Drop the local row
+        // to match. Pin-keyed since 4a-o part 6.
         const evt = data as OffloaderPairAlertDismissedEventData;
         if (this._buildOffloadAlerts === null) {
           break;
         }
-        const key = this._pairingKey(
-          evt.receiver_hostname,
-          evt.receiver_port,
-        );
         const next = new Map(this._buildOffloadAlerts);
-        next.delete(key);
+        next.delete(evt.pin_sha256);
         this._buildOffloadAlerts = next;
         break;
       }
     }
   }
 
-  /** Compose the pairings-map key from receiver coordinates.
-   *
-   *  ``${hostname}:${port}`` matches the backend's
-   *  ``StoredPairing`` key shape. Hostname is lowercase already
-   *  (backend normalises to RFC 1035 §2.3.3 on persist), so a
-   *  case-flip on either side wouldn't desync the lookup. */
-  private _pairingKey(hostname: string, port: number): string {
-    return `${hostname}:${port}`;
-  }
 
   // ─── Render ──────────────────────────────────────────────
 
@@ -1493,12 +1458,8 @@ export class ESPHomeApp extends LitElement {
     e: CustomEvent<{ summary: PairingSummary }>,
   ): void {
     const summary = e.detail.summary;
-    const key = this._pairingKey(
-      summary.receiver_hostname,
-      summary.receiver_port,
-    );
     const next = new Map(this._buildOffloadPairings ?? []);
-    next.set(key, summary);
+    next.set(summary.pin_sha256, summary);
     this._buildOffloadPairings = next;
   }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1174,14 +1174,17 @@ export class ESPHomeApp extends LitElement {
         break;
       }
       case DeviceEventType.OFFLOADER_PAIR_STATUS_CHANGED: {
-        // Two cases keyed on ``status``:
+        // Two cases keyed on ``status``. The map (and event) is
+        // keyed by ``pin_sha256`` (the receiver's static
+        // X25519 pubkey hash), the wire-canonical stable row
+        // identity — receiver hostname/port are display-only
+        // and can change without remapping (4a-o part 6).
         // - ``approved``: flip the matching pairing row's status
         //   to "approved". Other fields stay valid (the receiver-
-        //   side approval doesn't mutate label / pin / paired_at;
-        //   the row's identity is the receiver coordinates the
-        //   user typed). If the row isn't in the map yet (event
-        //   raced ahead of the snapshot), skip the flip — the
-        //   next initial-state push reseeds.
+        //   side approval doesn't mutate label / pin / paired_at).
+        //   If the row isn't in the map yet (event raced ahead
+        //   of the snapshot), skip the flip — the next
+        //   initial-state push reseeds.
         // - ``removed``: drop the row by key. ``unpair`` /
         //   receiver-side reject / receiver-rotated-out-from-
         //   under-us all funnel through this event.

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -391,11 +391,19 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     }
     const row = this._buildOffloadPairings?.get(this._sentKey);
     if (row !== undefined && row.status === "approved") {
+      // Read display fields off the row (still present in the
+      // map at this point — the ``approved`` flip is a value
+      // mutation, not a pop). Avoids hard-coding the
+      // ``${hostname}:${port}`` parse pattern that worked when
+      // the map was hostname-keyed pre-4a-o-part-6.
       this.dispatchEvent(
         new CustomEvent<{ hostname: string; port: number }>(
           "pair-approved",
           {
-            detail: this._parseSentKey(this._sentKey),
+            detail: {
+              hostname: row.receiver_hostname,
+              port: row.receiver_port,
+            },
             bubbles: true,
             composed: true,
           },
@@ -413,12 +421,18 @@ export class ESPHomePairBuildServerDialog extends LitElement {
       // ``removed`` event. The dialog can't tell which, but
       // the user-visible outcome is the same ("the request
       // didn't land"); fire a generic ``pair-rejected``
-      // event for the parent toast.
+      // event for the parent toast. Source hostname/port from
+      // the dialog's own form state — the row is gone, and
+      // the form fields are still what the user typed when
+      // they submitted.
       this.dispatchEvent(
         new CustomEvent<{ hostname: string; port: number }>(
           "pair-rejected",
           {
-            detail: this._parseSentKey(this._sentKey),
+            detail: {
+              hostname: this._hostname.trim(),
+              port: Number.parseInt(this._port, 10),
+            },
             bubbles: true,
             composed: true,
           },
@@ -427,14 +441,6 @@ export class ESPHomePairBuildServerDialog extends LitElement {
       this._sentKey = null;
       this.close();
     }
-  }
-
-  private _parseSentKey(key: string): { hostname: string; port: number } {
-    const idx = key.lastIndexOf(":");
-    return {
-      hostname: key.slice(0, idx),
-      port: Number.parseInt(key.slice(idx + 1), 10),
-    };
   }
 
   protected render() {
@@ -737,19 +743,17 @@ export class ESPHomePairBuildServerDialog extends LitElement {
       });
       this._step = "sent";
       // Pin the key the auto-close watcher in ``willUpdate``
-      // checks against the offloader pairings map. Built from
-      // the response, NOT the form fields, because the backend
-      // normalises hostname (lowercase via
-      // ``_validate_hostname``) and that's the form
-      // ``summary.receiver_hostname`` carries — which is what
-      // app-shell's ``_onPairRequestSent`` keys the map on. A
-      // user who types ``MacBook-Pro.local.`` would otherwise
-      // build ``_sentKey`` mixed-case while the map landed
-      // lowercase, the watcher's ``map.get(_sentKey)`` would
-      // return undefined, and the dialog would mistake "row
-      // arrived under the canonical key" for "row never landed
-      // → rejected".
-      this._sentKey = `${summary.receiver_hostname}:${summary.receiver_port}`;
+      // checks against the offloader pairings map. The key is
+      // ``summary.pin_sha256`` — the stable cryptographic
+      // identity of the receiver, which the backend's
+      // ``_pairings`` dict and app-shell's
+      // ``_buildOffloadPairings`` map both key on (4a-o part
+      // 6 — pin-keyed offloader state). Mirrors what
+      // app-shell's ``_onPairRequestSent`` upserts; the
+      // watcher's ``map.get(_sentKey)`` resolves to the same
+      // row regardless of receiver hostname case or
+      // subsequent rename.
+      this._sentKey = summary.pin_sha256;
       // Backend persists the new ``StoredPairing`` row but
       // doesn't fire ``OFFLOADER_PAIR_STATUS_CHANGED`` for the
       // create — only on subsequent status flips. Seed the row

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -204,10 +204,11 @@ export class ESPHomeSettingsDialog extends LitElement {
   private _buildOffloadAlerts: Map<string, OffloaderAlertSnapshotEntry> | null =
     null;
 
-  // Pending Unpair confirmation: receiver coordinates of the
-  // row whose Unpair button was clicked. Captured here so the
-  // shared destructive-confirm dialog's @confirm handler knows
-  // which row to drop. ``null`` when no Unpair is pending.
+  // Pending Unpair confirmation. Identified by ``pin_sha256``
+  // (the wire-canonical row id sent to ``unpairRemoteBuild``);
+  // ``hostname`` / ``port`` / ``label`` are retained for display
+  // in the destructive-confirm dialog only. ``null`` when no
+  // Unpair is pending.
   @state()
   private _pendingUnpair: {
     pin_sha256: string;

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -210,6 +210,7 @@ export class ESPHomeSettingsDialog extends LitElement {
   // which row to drop. ``null`` when no Unpair is pending.
   @state()
   private _pendingUnpair: {
+    pin_sha256: string;
     hostname: string;
     port: number;
     label: string;
@@ -1967,6 +1968,7 @@ export class ESPHomeSettingsDialog extends LitElement {
     // backend-side auto-clears the alert (same
     // ``OFFLOADER_PAIR_ALERT_DISMISSED`` event path).
     this._pendingUnpair = {
+      pin_sha256: alert.pin_sha256,
       hostname: alert.receiver_hostname,
       port: alert.receiver_port,
       label: alert.receiver_label,
@@ -2040,6 +2042,7 @@ export class ESPHomeSettingsDialog extends LitElement {
 
   private _onUnpairRequest = (pairing: PairingSummary): void => {
     this._pendingUnpair = {
+      pin_sha256: pairing.pin_sha256,
       hostname: pairing.receiver_hostname,
       port: pairing.receiver_port,
       label: pairing.label,
@@ -2054,9 +2057,11 @@ export class ESPHomeSettingsDialog extends LitElement {
       return;
     }
     try {
+      // 4a-o part 6 changed the WS arg from ``hostname / port``
+      // to ``pin_sha256``; offloader-side state is keyed on the
+      // receiver's stable cryptographic identity now.
       await this._api.unpairRemoteBuild({
-        hostname: pending.hostname,
-        port: pending.port,
+        pin_sha256: pending.pin_sha256,
       });
     } catch (err) {
       // Log to the dashboard console for diagnostics; the

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -741,12 +741,11 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     await expect(pending).resolves.toEqual(result);
   });
 
-  it("unpairRemoteBuild sends remote_build/unpair with hostname + port", async () => {
+  it("unpairRemoteBuild sends remote_build/unpair with pin_sha256", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     const pending = api.unpairRemoteBuild({
-      hostname: "build.local",
-      port: 6055,
+      pin_sha256: "a".repeat(64),
     });
     const sent = ws.sentAs<{
       command: string;
@@ -754,7 +753,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       args: Record<string, unknown>;
     }>(0);
     expect(sent.command).toBe("remote_build/unpair");
-    expect(sent.args).toEqual({ hostname: "build.local", port: 6055 });
+    expect(sent.args).toEqual({ pin_sha256: "a".repeat(64) });
     const result = { removed: true };
     ws.receive({ message_id: sent.message_id, result });
     await expect(pending).resolves.toEqual(result);


### PR DESCRIPTION
# What does this implement/fix?

Mirrors the offloader-side pin-keying refactor from
esphome/device-builder#532 in the frontend. The backend
re-keyed `_pairings` / `_pair_status_listeners` /
`_offloader_alerts` from `(hostname, port)` to
`pin_sha256`, added `pin_sha256` to every
`Offloader*EventData` payload, and changed the
`remote_build/unpair` WS arg shape to take a `pin_sha256`
instead of `hostname` + `port`. Without this companion
PR the frontend would hit type drift on the new payload
field and 400 against the new `unpair` arg shape.

Changes in this PR:

* `src/api/types.ts` adds `pin_sha256: string` to
  `OffloaderPairStatusChangedEventData`,
  `OffloaderPairPinMismatchEventData`,
  `OffloaderPairPeerRevokedEventData`,
  `OffloaderPairAlertDismissedEventData`, and to the
  alert snapshot rows
  (`OffloaderPinMismatchAlert`,
  `OffloaderPeerRevokedAlert`).

* `src/api/esphome-api.ts` changes
  `unpairRemoteBuild` to take
  `{ pin_sha256: string }`. Frontend already has
  `PairingSummary.pin_sha256`, so the call sites thread
  that value directly.

* `src/components/app-shell.ts` re-keys the
  offloader-pairings and offloader-alerts maps from
  `${hostname}:${port}` to `pin_sha256` for both
  initial-state seeding and per-event upserts/drops.
  Removes the `_pairingKey` helper (no remaining
  callers).

* `src/components/pair-build-server-dialog.ts` updates
  the auto-close watcher to key off `summary.pin_sha256`.
  Removes `_parseSentKey`. Side benefit: closes the
  case-sensitivity gap (#256) at its source by keying
  off the wire-canonical pin.

* `src/components/settings-dialog.ts` plumbs
  `pin_sha256` through `_pendingUnpair` and the
  destructive-confirm flow so `unpairRemoteBuild` always
  sees the canonical identifier.

* `test/api/esphome-api.test.ts::unpairRemoteBuild`
  asserts the new arg shape on the wire.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#106 (frontend mirror for
  offloader-side pin-keying)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
