### PR TITLE
Surface offloader peer-link session state on PairingSummary

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1002,6 +1002,15 @@ export enum DeviceEventType {
   // ``_buildServerPeers``.
   RECEIVER_PEER_LINK_SESSION_OPENED = "receiver_peer_link_session_opened",
   RECEIVER_PEER_LINK_SESSION_CLOSED = "receiver_peer_link_session_closed",
+  // Offloader-side peer-link session lifecycle. Fired by the
+  // offloader's long-lived PeerLinkClient when its Noise WS
+  // to the receiver enters / leaves the post-handshake parked
+  // state. Drives the PairingSummary.connected indicator on
+  // the offloader-side Paired-build-servers list. Both events
+  // share the same OffloaderPeerLinkSessionEventData shape;
+  // the discriminator is the event type itself.
+  OFFLOADER_PEER_LINK_OPENED = "offloader_peer_link_opened",
+  OFFLOADER_PEER_LINK_CLOSED = "offloader_peer_link_closed",
   // mDNS-discovered peer dashboards. Replaces the deleted
   // ``remote_build/list_hosts`` WS command — the controller fires
   // these events as its mDNS browser callback resolves /
@@ -1333,6 +1342,22 @@ export interface PairingSummary {
   label: string;
   paired_at: number;
   status: PeerStatus;
+  /**
+   * Whether the offloader currently has an open 5a-2 peer-link
+   * session to the receiver (pin_sha256 membership in the
+   * controller's _open_peer_links set). Live updates flow
+   * through OFFLOADER_PEER_LINK_OPENED /
+   * OFFLOADER_PEER_LINK_CLOSED bus events on the
+   * subscribe_events stream; the snapshot
+   * (initial_state.pairings) carries the current value at
+   * subscribe time so a reconnecting tab paints the right state
+   * without waiting for the next event.
+   *
+   * Always false for PENDING rows: the offloader doesn't spawn
+   * a peer-link client until the receiver flips the row to
+   * APPROVED.
+   */
+  connected: boolean;
 }
 
 /**
@@ -1488,6 +1513,27 @@ export interface OffloaderPairStatusChangedEventData {
  */
 export interface ReceiverPeerLinkSessionEventData {
   dashboard_id: string;
+}
+
+/**
+ * Data payload for offloader_peer_link_opened and
+ * offloader_peer_link_closed.
+ *
+ * Fires on the offloader-side bus whenever the long-lived
+ * PeerLinkClient enters / leaves its post-handshake parked
+ * state. Drives the PairingSummary.connected indicator:
+ * app-shell flips the matching row's connected flag in the
+ * local _buildOffloadPairings map keyed by pin_sha256. Both
+ * events share the same shape; the discriminator is the event
+ * type itself. Receiver coords are carried as display fields
+ * the renderer can use without a follow-up lookup, but they're
+ * ignored when keying the map (4a-o part 6; pin_sha256 is the
+ * canonical row identity).
+ */
+export interface OffloaderPeerLinkSessionEventData {
+  receiver_hostname: string;
+  receiver_port: number;
+  pin_sha256: string;
 }
 
 /**

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -42,6 +42,7 @@ import type {
   OffloaderPairPeerRevokedEventData,
   OffloaderPairPinMismatchEventData,
   OffloaderPairStatusChangedEventData,
+  OffloaderPeerLinkSessionEventData,
   PairingSummary,
   PairingWindowState,
   PeerSummary,
@@ -1202,6 +1203,32 @@ export class ESPHomeApp extends LitElement {
           }
           next.set(evt.pin_sha256, { ...existing, status: "approved" });
         }
+        this._buildOffloadPairings = next;
+        break;
+      }
+      case DeviceEventType.OFFLOADER_PEER_LINK_OPENED:
+      case DeviceEventType.OFFLOADER_PEER_LINK_CLOSED: {
+        // Flip 'connected' on the matching APPROVED row. Keyed
+        // on pin_sha256 (the same wire-canonical identity
+        // OFFLOADER_PAIR_STATUS_CHANGED uses). Both events share
+        // the same payload shape; the discriminator is the event
+        // type itself. _buildOffloadPairings may be null
+        // (snapshot not yet seeded) or missing the row (event
+        // raced ahead of the snapshot, or fired against a
+        // pairing the backend just dropped). In both cases the
+        // next initial_state reseed carries the right state, so
+        // skip rather than synthesise a partial row.
+        if (this._buildOffloadPairings === null) {
+          break;
+        }
+        const evt = data as OffloaderPeerLinkSessionEventData;
+        const existing = this._buildOffloadPairings.get(evt.pin_sha256);
+        if (existing === undefined) {
+          break;
+        }
+        const connected = event === DeviceEventType.OFFLOADER_PEER_LINK_OPENED;
+        const next = new Map(this._buildOffloadPairings);
+        next.set(evt.pin_sha256, { ...existing, connected });
         this._buildOffloadPairings = next;
         break;
       }

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -2008,6 +2008,23 @@ export class ESPHomeSettingsDialog extends LitElement {
       pairing.status === "approved"
         ? "pairing-status-approved"
         : "pairing-status-pending";
+    // Connection-state pill renders next to the status pill on
+    // APPROVED rows so the operator sees at a glance whether the
+    // offloader's long-lived PeerLinkClient currently has an
+    // open Noise WS to the receiver. Fed by
+    // OFFLOADER_PEER_LINK_OPENED / _CLOSED events on app-shell,
+    // with the snapshot (initial_state.pairings) seeding the
+    // initial paint. PENDING rows hide the pill: the offloader
+    // doesn't spawn a peer-link client until the receiver flips
+    // APPROVED, so a "Disconnected" pill on PENDING would just
+    // be noise next to "Pending".
+    const showConnection = pairing.status === "approved";
+    const connectedClass = pairing.connected
+      ? "peer-connection-connected"
+      : "peer-connection-disconnected";
+    const connectedLabel = pairing.connected
+      ? this._localize("settings.build_offload_pairing_connected")
+      : this._localize("settings.build_offload_pairing_disconnected");
     return html`
       <div class="row peer-row pairing-row">
         <div class="row-label">
@@ -2016,6 +2033,13 @@ export class ESPHomeSettingsDialog extends LitElement {
             <span class=${`pairing-status-pill ${statusClass}`}>
               ${this._localize(statusKey)}
             </span>
+            ${showConnection
+              ? html`
+                  <span class=${`peer-connection-pill ${connectedClass}`}>
+                    ${connectedLabel}
+                  </span>
+                `
+              : null}
           </span>
           <span class="row-desc">
             ${pairing.receiver_hostname}:${pairing.receiver_port}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -799,6 +799,8 @@
     "paired_build_servers_empty": "No build servers paired yet.",
     "pairing_status_pending": "Pending",
     "pairing_status_approved": "Approved",
+    "build_offload_pairing_connected": "Connected",
+    "build_offload_pairing_disconnected": "Disconnected",
     "unpair_action": "Unpair",
     "unpair_aria": "Unpair {label}",
     "unpair_confirm_title": "Unpair this build server?",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -736,6 +736,8 @@
     "paired_build_servers_empty": "Aucun serveur de compilation appairé pour le moment.",
     "pairing_status_pending": "En attente",
     "pairing_status_approved": "Approuvé",
+    "build_offload_pairing_connected": "Connecté",
+    "build_offload_pairing_disconnected": "Déconnecté",
     "unpair_action": "Désappairer",
     "unpair_aria": "Désappairer {label}",
     "unpair_confirm_title": "Désappairer ce serveur de compilation ?",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -736,6 +736,8 @@
     "paired_build_servers_empty": "Nog geen build-servers gekoppeld.",
     "pairing_status_pending": "In afwachting",
     "pairing_status_approved": "Goedgekeurd",
+    "build_offload_pairing_connected": "Verbonden",
+    "build_offload_pairing_disconnected": "Niet verbonden",
     "unpair_action": "Ontkoppelen",
     "unpair_aria": "{label} ontkoppelen",
     "unpair_confirm_title": "Deze build-server ontkoppelen?",


### PR DESCRIPTION
# What does this implement/fix?

Mirror frontend for esphome/device-builder#529. Adds the
`connected` field on the offloader-side `PairingSummary` and
renders a Connected / Disconnected pill next to APPROVED rows
in the Send-builds Settings section, so the operator sees at
a glance whether the offloader's long-lived `PeerLinkClient`
has an open Noise WS to each paired receiver. Mirrors the
receiver-side connected indicator (#257) for the other
direction.

Wire path:

* `src/api/types.ts` adds `connected: boolean` to
  `PairingSummary`, plus `OFFLOADER_PEER_LINK_OPENED` /
  `OFFLOADER_PEER_LINK_CLOSED` to `DeviceEventType` and the
  matching `OffloaderPeerLinkSessionEventData` payload
  interface.

* `src/components/app-shell.ts` handles the two events. Both
  share one case branch (the discriminator is the event type
  itself, mirroring the receiver-side
  RECEIVER_PEER_LINK_SESSION_OPENED / _CLOSED handler); flips
  `connected` on the matching `_buildOffloadPairings` row
  keyed by `pin_sha256`. Skips when the snapshot hasn't
  seeded or the row's missing (event raced ahead of
  snapshot, or fired against a pairing the backend just
  dropped); the next `initial_state` reseed carries the right
  state.

* `src/components/settings-dialog.ts` renders a Connected /
  Disconnected pill next to APPROVED rows in the offloader
  pairings list. PENDING rows hide the pill (offloader
  doesn't spawn a peer-link client until approval, so the
  pill would just be noise next to Pending). Reuses the
  existing `.peer-connection-pill` /
  `.peer-connection-connected` /
  `.peer-connection-disconnected` styles from the
  receiver-side renderer; no new CSS rules.

* Translations: new `settings.build_offload_pairing_connected`
  / `..._disconnected` keys in en / fr / nl.

No new tests: the event handler shape is identical to the
receiver-side handler whose contract is already locked in by
the existing 958-test suite. TypeScript + the backend's
runtime payload-contract assertions cover the wire-shape
correctness.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#106 (frontend mirror for
  offloader-side connected indicator)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
