### PR TITLE
Surface paired senders above the build-server identity card

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -1536,6 +1536,9 @@ export class ESPHomeSettingsDialog extends LitElement {
         ></button>
       </div>
 
+      ${this._renderApprovedPeers()}
+      ${this._renderPeerRemoveConfirmDialog()}
+
       <div class="section-heading">
         ${this._localize("settings.build_server_card_heading")}
       </div>
@@ -1544,8 +1547,6 @@ export class ESPHomeSettingsDialog extends LitElement {
       </div>
       ${this._renderBuildServerCard()}
       ${this._renderPairingRequests()}
-      ${this._renderApprovedPeers()}
-      ${this._renderPeerRemoveConfirmDialog()}
       <esphome-accept-peer-dialog
         @confirm=${this._onAcceptPeerConfirm}
         @reject=${this._onRejectPeerFromDialog}


### PR DESCRIPTION
# What does this implement/fix?

Reverses the rendering order on the Build server section so the operator's first read is "who is currently paired with this dashboard," and the cert-fingerprint identity card sits below it. The previous order put the identity card first, which is the right thing to read off when an operator is *about* to pair a new sender, but the day-to-day question for an admin opening Build server is "who already has access right now"; surfacing the paired-senders list at the top matches that intent and makes the Remove buttons reachable without scrolling past the rotate / dashboard ID / version block.

The master enable toggle stays at the top of the section since it's the global "is this dashboard accepting build requests at all" gate. The pairing-requests inbox stays below the identity card; that block is moving to its own top-level Settings section in #263 anyway.

The reorder is intentionally just a swap of two render calls (and the heading + intro that goes with the identity card); no copy / behavioural / wire changes.

## What changed

* `src/components/settings-dialog.ts` `_renderBuildServer`: paired-senders block (`_renderApprovedPeers` plus the shared remove-confirm dialog) renders before the build-server-card heading + intro + card. The pairing-requests inbox and accept-peer dialog stay where they were since #263 is the right place to relocate those.

## Testing

`npm run lint`, `npm run test` (969 tests) pass.

**Related issue or feature (if applicable):**

- User feedback: the paired senders list should be the first thing visible on Build server.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
