### PR TITLE
Dismiss terminal remote-build jobs on dialog close

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1460,6 +1460,7 @@ export class ESPHomeApp extends LitElement {
         @set-language=${this._onSetLanguage}
         @pair-request-sent=${this._onPairRequestSent}
         @remote-build-job-submitted=${this._onRemoteBuildJobSubmitted}
+        @remote-build-job-dismissed=${this._onRemoteBuildJobDismissed}
       ></esphome-settings-dialog>
       <esphome-firmware-jobs-dialog
         @firmware-history-cleared=${this._onFirmwareHistoryCleared}
@@ -1622,6 +1623,19 @@ export class ESPHomeApp extends LitElement {
     }>,
   ): void {
     this.registerRemoteBuildJob(e.detail);
+  }
+
+  /** Drop a terminal remote-build job from the in-flight map
+   *  when the user closes its progress dialog. The dialog
+   *  only fires this for terminal status (completed / failed
+   *  / cancelled); non-terminal closes are "minimise" and
+   *  leave the entry in place. Without this, terminal jobs
+   *  would accumulate in buildOffloadJobsContext across
+   *  every submit cycle. */
+  private _onRemoteBuildJobDismissed(
+    e: CustomEvent<{ job_id: string }>,
+  ): void {
+    this.dismissRemoteBuildJob(e.detail.job_id);
   }
 
   private async _onSetLanguage(

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -111,11 +111,10 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     // cancelled) is the operator's "I've seen the result"
     // signal — drop the entry from buildOffloadJobsContext so
     // it doesn't accumulate forever. Closing on a still-
-    // running job is "minimise": the receiver keeps building
-    // and the entry stays in the map (the user may re-open
-    // the dialog to see live progress until terminal). The
-    // dispatch helper backfills display fields on submit
-    // success, so a re-opened dialog finds the row intact.
+    // running job only hides this dialog; the receiver keeps
+    // building and the job entry stays in the shared map
+    // until it reaches a terminal state and is explicitly
+    // dismissed.
     const job = this._job;
     if (job && isTerminalJobStatus(job.status)) {
       this.dispatchEvent(

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -107,6 +107,25 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
   }
 
   private _close = () => {
+    // Closing on a terminal job (completed / failed /
+    // cancelled) is the operator's "I've seen the result"
+    // signal — drop the entry from buildOffloadJobsContext so
+    // it doesn't accumulate forever. Closing on a still-
+    // running job is "minimise": the receiver keeps building
+    // and the entry stays in the map (the user may re-open
+    // the dialog to see live progress until terminal). The
+    // dispatch helper backfills display fields on submit
+    // success, so a re-opened dialog finds the row intact.
+    const job = this._job;
+    if (job && isTerminalJobStatus(job.status)) {
+      this.dispatchEvent(
+        new CustomEvent("remote-build-job-dismissed", {
+          bubbles: true,
+          composed: true,
+          detail: { job_id: job.job_id },
+        }),
+      );
+    }
     this._open = false;
     this._errorMessage = "";
   };

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -107,6 +107,14 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
   }
 
   private _close = () => {
+    // Idempotent: bound to the close-button @click AND the
+    // wa-dialog @wa-after-hide, which fires when ?open flips
+    // to false — so without this guard the second invocation
+    // would re-fire the dismiss event. dismissRemoteBuildJob
+    // is idempotent itself, but double-emitting an event the
+    // parent listens to is observable and risks future
+    // side-effects on subscribers.
+    if (!this._open) return;
     // Closing on a terminal job (completed / failed /
     // cancelled) is the operator's "I've seen the result"
     // signal — drop the entry from buildOffloadJobsContext so


### PR DESCRIPTION
# What does this implement/fix?

Closes esphome/device-builder-frontend#267 (a 5c-4 follow-up).

Closing the remote-build progress dialog on a **terminal**
status (completed / failed / cancelled) now drops the entry
from `buildOffloadJobsContext`. Closing on a still-running
status remains "minimise" — the receiver keeps building and
the entry stays in the map; the user may re-open the dialog
and see live progress until terminal.

Without this, every submit cycle leaves a terminal entry
behind permanently. Over time the in-flight map fills with
old completed jobs the user has no path back to (until the
in-flight job list-view from
esphome/device-builder-frontend#268 lands).

## Wire path

- `remote-build-job-dialog._close` dispatches
  `remote-build-job-dismissed { job_id }` iff the job's
  status is terminal at close time. The event bubbles +
  composes so the parent settings-dialog and app-shell both
  see it.

- `app-shell` adds an `@remote-build-job-dismissed` listener
  on the `<esphome-settings-dialog>` mount, calling the
  existing `dismissRemoteBuildJob` method (which was already
  on app-shell as the explicit drop surface and previously
  unwired).

The terminal-vs-non-terminal split mirrors the dialog's
existing close-button label split (Hide on running, Close on
terminal). The button label gates user expectation; this
change makes the action match the label.

## Tests

No new tests: the dispatch / listen wiring follows the
existing `remote-build-job-submitted` pattern (which is
similarly untested at the component level — app-shell event
handlers don't have unit-test precedent in this repo).
TypeScript catches the type-level wiring; 994 tests pass.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#267

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
