### PR TITLE
Re-attach to a running remote-build job after closing the dialog

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1378,7 +1378,15 @@ export class ESPHomeApp extends LitElement {
       status: existing?.status ?? JobStatus.QUEUED,
       error_message: existing?.error_message ?? "",
       output: existing?.output ?? [],
-      started_at: existing?.started_at ?? Date.now(),
+      // ``||`` not ``??``: stubRemoteBuildJobState seeds 0 as
+      // the "unset" sentinel, and ``??`` would preserve it
+      // here (?? only falls through on null / undefined). Any
+      // existing>0 wins (the entry was stamped on a previous
+      // submit's bubble); a 0 from an events-only stub gets
+      // replaced with the current dispatch time so consumers
+      // sorting by started_at (settings-dialog's
+      // _latestRemoteBuildJobForPin) reliably pick the newest.
+      started_at: existing?.started_at || Date.now(),
     });
     this._buildOffloadJobs = next;
   }

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -106,6 +106,35 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     this._open = true;
   }
 
+  /** Open the dialog re-attached to an existing remote-build
+   *  job, skipping the input form and landing directly on the
+   *  running view. Used by settings-dialog's per-row "View
+   *  build" affordance to let the user check on a running
+   *  build (or last result) after closing the dialog without
+   *  losing access to the live output buffer.
+   *
+   *  Display fields (configuration / target / receiver_label)
+   *  come from the job entry itself; the entry was stamped
+   *  on the original submit's success bubble through
+   *  registerRemoteBuildJob, so a job that originated in this
+   *  tab carries full display fields. A job whose state was
+   *  observed only via wire events (events arrived before the
+   *  ack landed, or a different tab dispatched it) carries
+   *  empty display strings — the running view tolerates them
+   *  and shows the live status / output regardless. */
+  openForJob(job_id: string): void {
+    const job = this._jobs?.get(job_id);
+    if (!job) return;
+    this._jobId = job_id;
+    this._pinSha256 = job.pin_sha256;
+    this._receiverLabel = job.receiver_label;
+    this._configuration = job.configuration;
+    this._target = job.target;
+    this._errorMessage = "";
+    this._step = "running";
+    this._open = true;
+  }
+
   private _close = () => {
     this._open = false;
     this._errorMessage = "";

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -31,6 +31,7 @@ import {
   apiContext,
   buildOffloadDiscoveredHostsContext,
   buildOffloadAlertsContext,
+  buildOffloadJobsContext,
   buildOffloadPairingsContext,
   buildServerIdentityRotationCounterContext,
   buildServerPairingWindowStateContext,
@@ -39,6 +40,7 @@ import {
   remoteBuildEnabledContext,
   yamlDiffButtonContext,
 } from "../context/index.js";
+import type { RemoteBuildJobState } from "../context/index.js";
 import { warningBannerStyles } from "../styles/banners.js";
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
@@ -233,6 +235,19 @@ export class ESPHomeSettingsDialog extends LitElement {
   @state()
   private _buildOffloadAlerts: Map<string, OffloaderAlertSnapshotEntry> | null =
     null;
+
+  // In-flight + recently-terminal remote-build jobs the user
+  // dispatched, keyed on job_id. Used by the per-pairing-row
+  // "View build" affordance to re-open the dispatch dialog
+  // on a previously-submitted job's progress view (the row
+  // surfaces the most-recent entry for its pin). Driven by
+  // OFFLOADER_JOB_STATE_CHANGED / OFFLOADER_JOB_OUTPUT events
+  // through app-shell. null until app-shell mounts (always
+  // immediate today; the null-vs-empty distinction follows
+  // the same shape sibling contexts use).
+  @consume({ context: buildOffloadJobsContext, subscribe: true })
+  @state()
+  private _buildOffloadJobs: Map<string, RemoteBuildJobState> | null = null;
 
   // Pending Unpair confirmation. Identified by ``pin_sha256``
   // (the wire-canonical row id sent to ``unpairRemoteBuild``);
@@ -2413,6 +2428,7 @@ export class ESPHomeSettingsDialog extends LitElement {
               </button>
             `
           : nothing}
+        ${this._renderViewRemoteBuildButton(pairing)}
         <button
           type="button"
           class="peer-remove btn-unpair"
@@ -2426,6 +2442,60 @@ export class ESPHomeSettingsDialog extends LitElement {
       </div>
     `;
   }
+
+  /** Render the "View build" affordance for a pairing row when
+   *  the in-flight remote-build jobs map carries an entry for
+   *  the row's pin. The dispatch dialog's openForJob() lands
+   *  directly on the running view so the user can re-attach
+   *  to a build they previously closed the dialog on (or see
+   *  the last terminal result before the user dismisses it).
+   *
+   *  Pairing-disconnected rows still get this button: the
+   *  job state lives client-side regardless of whether the
+   *  peer-link is currently up; surfacing the last output of
+   *  a build that finished before disconnect is the whole
+   *  point of the deferred-dismiss behaviour. */
+  private _renderViewRemoteBuildButton(pairing: PairingSummary) {
+    const job = this._latestRemoteBuildJobForPin(pairing.pin_sha256);
+    if (job === undefined) return nothing;
+    return html`
+      <button
+        type="button"
+        class="btn-view-remote-build"
+        aria-label=${this._localize("settings.remote_build_view_aria", {
+          label: pairing.label,
+        })}
+        @click=${() => this._onViewRemoteBuildClick(job.job_id)}
+      >
+        ${this._localize("settings.remote_build_view_action")}
+      </button>
+    `;
+  }
+
+  /** Pick the most-recently-started remote-build job for *pin*
+   *  out of the in-flight jobs map, or undefined if there are
+   *  no entries for the pin. ``started_at`` is stamped by the
+   *  dispatch dialog's success bubble; events-only entries
+   *  (events arrived before the ack landed) carry 0 and sort
+   *  to the bottom — that's fine because they're rare and the
+   *  re-attach path tolerates either ordering. */
+  private _latestRemoteBuildJobForPin(
+    pin_sha256: string,
+  ): RemoteBuildJobState | undefined {
+    if (this._buildOffloadJobs === null) return undefined;
+    let best: RemoteBuildJobState | undefined;
+    for (const job of this._buildOffloadJobs.values()) {
+      if (job.pin_sha256 !== pin_sha256) continue;
+      if (best === undefined || job.started_at > best.started_at) {
+        best = job;
+      }
+    }
+    return best;
+  }
+
+  private _onViewRemoteBuildClick = (job_id: string): void => {
+    this._remoteBuildDialog?.openForJob(job_id);
+  };
 
   private _onBuildRemoteClick = (pairing: PairingSummary): void => {
     this._remoteBuildDialog?.open({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -804,6 +804,8 @@
     "build_offload_pairing_disconnected": "Disconnected",
     "remote_build_submit_action": "Build remotely",
     "remote_build_submit_aria": "Build remotely on {label}",
+    "remote_build_view_action": "View build",
+    "remote_build_view_aria": "View remote build on {label}",
     "remote_build_submit_title": "Build remotely on {label}",
     "remote_build_running_title": "Remote build on {label}",
     "remote_build_submit_configuration_label": "Configuration",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -741,6 +741,8 @@
     "build_offload_pairing_disconnected": "Déconnecté",
     "remote_build_submit_action": "Compiler à distance",
     "remote_build_submit_aria": "Compiler à distance sur {label}",
+    "remote_build_view_action": "Voir la compilation",
+    "remote_build_view_aria": "Voir la compilation distante sur {label}",
     "remote_build_submit_title": "Compiler à distance sur {label}",
     "remote_build_running_title": "Compilation distante sur {label}",
     "remote_build_submit_configuration_label": "Configuration",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -741,6 +741,8 @@
     "build_offload_pairing_disconnected": "Niet verbonden",
     "remote_build_submit_action": "Bouw op afstand",
     "remote_build_submit_aria": "Bouw op afstand op {label}",
+    "remote_build_view_action": "Bouw bekijken",
+    "remote_build_view_aria": "Externe bouw op {label} bekijken",
     "remote_build_submit_title": "Bouw op afstand op {label}",
     "remote_build_running_title": "Externe bouw op {label}",
     "remote_build_submit_configuration_label": "Configuratie",


### PR DESCRIPTION
# What does this implement/fix?

Closes esphome/device-builder-frontend#268.

After closing the remote-build dispatch dialog mid-build the
operator had no path back to the running job's progress: a
re-click of "Build remotely" opens the dialog at the input
form for a NEW submit, not re-attached. The
`buildOffloadJobsContext` entry kept accumulating live
output and lifecycle but the UI never surfaced it.

Adds a per-pairing-row **View build** button that's only
rendered when the in-flight jobs map carries an entry for
the row's pin. Click opens the dispatch dialog directly on
the running view via a new `openForJob(job_id)` entry point
that skips the input step and reads display fields off the
existing job entry.

## Wire path

- `remote-build-job-dialog` gains `openForJob(job_id)`. Looks
  up the entry on `buildOffloadJobsContext`, populates
  display fields off it, sets `_step="running"`, opens.
  No-op on unknown `job_id` (defensive against a stale row
  dropped by the dismiss path between the button render and
  the click).

- `settings-dialog` renders the View-build button next to
  the existing Build-remotely / Unpair buttons via
  `_renderViewRemoteBuildButton(pairing)`.
  `_latestRemoteBuildJobForPin` walks the map once per row
  at render time; cheap (the map is bounded by the user's
  submit count and trim is wired via #269).

- `settings-dialog` now `@consume`s
  `buildOffloadJobsContext`.

## Multiple jobs per pin

Surface the most-recent (highest `started_at`). `started_at`
is stamped by the dispatch dialog's success bubble through
`registerRemoteBuildJob`; events-only entries (events
arrived before the ack landed, or cross-tab dispatch) carry
0 and sort to the bottom but still surface if there's
nothing more recent.

## Pairing-disconnected rows

Still get the button. The job state lives client-side
regardless of whether the peer-link is currently up;
surfacing the last output of a build that finished before
disconnect is the whole point of the deferred-dismiss
behaviour from #269.

## Translations

en / fr / nl parity, 2 new keys per locale (`view_action` /
`view_aria`).

## Tests

No new tests: the `openForJob` entry point follows the
existing `open()` shape and the per-row button follows the
existing Build-remotely shape; both pre-existing surfaces
lack component-level tests in this repo. TypeScript catches
the type-level wiring; 994 tests pass.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#268
- builds on esphome/device-builder-frontend#269 (terminal-
  job dismiss; this PR's "View build" surface presumes the
  map gets cleaned up on terminal close so old rows don't
  shadow newer ones)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
