### PR TITLE
Seed in-flight remote-build jobs from initial_state.remote_jobs

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1119,6 +1119,44 @@ export interface InitialStateEventData {
    *  for the same reason as ``pairings`` / ``peers`` —
    *  absent controller, omitted field. */
   offloader_alerts?: OffloaderAlertSnapshotEntry[];
+  /** Offloader-side in-flight remote-build jobs snapshot.
+   *  RAM-only on the backend; populated as
+   *  ``OFFLOADER_JOB_STATE_CHANGED`` events upsert rows by
+   *  ``job_id`` and dropped when a terminal event (completed /
+   *  failed / cancelled) fires. Lets a tab subscribing AFTER
+   *  a ``running`` transition (page reload mid-build, second
+   *  tab opened after dispatch) repaint the live build
+   *  without waiting for the next event. Output buffer isn't
+   *  in the snapshot — the receiver doesn't replay; the next
+   *  ``OFFLOADER_JOB_OUTPUT`` line repopulates from the
+   *  point-of-subscribe forward. Display fields
+   *  (configuration / target / receiver_label) aren't carried
+   *  either — the receiver doesn't echo them, so reload-time
+   *  rows show empty strings until terminal (the dialog's
+   *  re-attach view tolerates them). Optional for the same
+   *  reason as ``pairings`` / ``peers`` — absent controller,
+   *  omitted field. */
+  remote_jobs?: OffloaderRemoteJobSnapshotEntry[];
+}
+
+/**
+ * Snapshot row in the offloader-side in-flight remote-build
+ * jobs cache. Mirror of the backend's
+ * :class:`OffloaderRemoteJobSnapshotEntry` TypedDict (see
+ * ``models/remote_build.py``). Carries enough to render the
+ * lifecycle pill on a late-subscribing tab; display fields
+ * (configuration / target / receiver_label) and the output
+ * buffer are deliberately absent — the receiver doesn't echo
+ * the display fields back through the wire, and the output
+ * buffer would balloon the snapshot for any in-flight build.
+ */
+export interface OffloaderRemoteJobSnapshotEntry {
+  receiver_hostname: string;
+  receiver_port: number;
+  pin_sha256: string;
+  job_id: string;
+  status: JobStatus;
+  error_message: string;
 }
 
 /** Data payload for device_added / device_updated / device_removed events. */

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -987,6 +987,7 @@ export class ESPHomeApp extends LitElement {
           hosts,
           pairings,
           offloader_alerts,
+          remote_jobs,
         } = data as InitialStateEventData;
         this._devices = devices;
         this._importableDevices = importable;
@@ -1009,6 +1010,37 @@ export class ESPHomeApp extends LitElement {
           offloader_alerts === undefined
             ? null
             : new Map(offloader_alerts.map((a) => [a.pin_sha256, a]));
+        // ``remote_jobs`` is the offloader-side in-flight
+        // remote-build snapshot. Replaces (not merges) the
+        // current map so a reconnect-driven re-subscribe
+        // resyncs against the backend's view rather than
+        // accumulating stale local entries that the receiver
+        // already considers terminal. Display fields and
+        // output buffer are absent from the wire shape — the
+        // re-attach view tolerates empty defaults; the next
+        // OFFLOADER_JOB_OUTPUT line repopulates from the
+        // subscribe point forward. Skips the rebuild when
+        // the field is absent (controller not wired up) so
+        // a previously-seeded map from a different connection
+        // isn't lost on a reconnect against a backend that
+        // dropped the remote-build controller.
+        if (remote_jobs !== undefined) {
+          const seeded = new Map<string, RemoteBuildJobState>();
+          for (const entry of remote_jobs) {
+            seeded.set(entry.job_id, {
+              job_id: entry.job_id,
+              pin_sha256: entry.pin_sha256,
+              receiver_label: "",
+              configuration: "",
+              target: JobType.COMPILE as RemoteBuildSubmitTarget,
+              status: entry.status,
+              error_message: entry.error_message,
+              output: [],
+              started_at: 0,
+            });
+          }
+          this._buildOffloadJobs = seeded;
+        }
         break;
       }
       case DeviceEventType.DEVICE_ADDED: {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1027,16 +1027,14 @@ export class ESPHomeApp extends LitElement {
         if (remote_jobs !== undefined) {
           const seeded = new Map<string, RemoteBuildJobState>();
           for (const entry of remote_jobs) {
+            // ``stubRemoteBuildJobState`` already returns the
+            // empty-defaults shape (display fields + output
+            // buffer + started_at=0); the snapshot only overrides
+            // the two fields it actually carries on the wire.
             seeded.set(entry.job_id, {
-              job_id: entry.job_id,
-              pin_sha256: entry.pin_sha256,
-              receiver_label: "",
-              configuration: "",
-              target: JobType.COMPILE as RemoteBuildSubmitTarget,
+              ...stubRemoteBuildJobState(entry.job_id, entry.pin_sha256),
               status: entry.status,
               error_message: entry.error_message,
-              output: [],
-              started_at: 0,
             });
           }
           this._buildOffloadJobs = seeded;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -1011,28 +1011,39 @@ export class ESPHomeApp extends LitElement {
             ? null
             : new Map(offloader_alerts.map((a) => [a.pin_sha256, a]));
         // ``remote_jobs`` is the offloader-side in-flight
-        // remote-build snapshot. Replaces (not merges) the
-        // current map so a reconnect-driven re-subscribe
-        // resyncs against the backend's view rather than
-        // accumulating stale local entries that the receiver
-        // already considers terminal. Display fields and
-        // output buffer are absent from the wire shape — the
-        // re-attach view tolerates empty defaults; the next
-        // OFFLOADER_JOB_OUTPUT line repopulates from the
-        // subscribe point forward. Skips the rebuild when
-        // the field is absent (controller not wired up) so
-        // a previously-seeded map from a different connection
-        // isn't lost on a reconnect against a backend that
-        // dropped the remote-build controller.
+        // remote-build snapshot. The backend's view is
+        // authoritative for which jobs exist (terminal entries
+        // are already dropped on the receiver) and for the
+        // status / error_message fields the wire carries; for
+        // each snapshot entry we MERGE onto whatever the local
+        // map had so a WS reconnect doesn't wipe the
+        // dispatch-side display fields (configuration / target /
+        // receiver_label) the submit dialog stamped, the
+        // accumulated output buffer, or the started_at the
+        // dispatch helper recorded. Local entries the backend
+        // doesn't include in the snapshot get dropped — they're
+        // either terminal-and-cleaned-up (correct: receiver no
+        // longer has them) or never existed on the receiver
+        // (correct: they shouldn't survive a reconnect into
+        // the new connection's reality). Display fields stay
+        // empty on a fresh page load mid-build (no prior
+        // dispatch in this session); the re-attach view
+        // tolerates the empty defaults and the next
+        // OFFLOADER_JOB_OUTPUT line repopulates the buffer
+        // from the subscribe point forward. Skips the rebuild
+        // when the field is absent (controller not wired up)
+        // so a previously-seeded map isn't lost on a reconnect
+        // against a backend that dropped the controller.
         if (remote_jobs !== undefined) {
           const seeded = new Map<string, RemoteBuildJobState>();
           for (const entry of remote_jobs) {
-            // ``stubRemoteBuildJobState`` already returns the
-            // empty-defaults shape (display fields + output
-            // buffer + started_at=0); the snapshot only overrides
-            // the two fields it actually carries on the wire.
+            const existing = this._buildOffloadJobs.get(entry.job_id);
+            const base =
+              existing ??
+              stubRemoteBuildJobState(entry.job_id, entry.pin_sha256);
             seeded.set(entry.job_id, {
-              ...stubRemoteBuildJobState(entry.job_id, entry.pin_sha256),
+              ...base,
+              pin_sha256: entry.pin_sha256,
               status: entry.status,
               error_message: entry.error_message,
             });

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -315,12 +315,20 @@ export const buildOffloadAlertsContext = createContext<
  * gets them by listening to the submit dialog's success event
  * (or by retaining what submit_job's caller passed in).
  *
- * No snapshot seeding from initial_state today: the offloader
- * controller doesn't keep an in-flight remote-jobs cache (the
- * receiver owns queue state). A page reload mid-build means
- * the user has to wait for the next OFFLOADER_JOB_OUTPUT line
- * to repopulate; the lifecycle pill picks up on the next
- * STATE_CHANGED. Backend snapshot is a follow-up.
+ * Snapshot-seeded from
+ * ``subscribe_events.initial_state.remote_jobs`` so a page
+ * reload mid-build paints the lifecycle pill immediately
+ * instead of waiting for the next event. The snapshot doesn't
+ * carry the output buffer (would balloon for any in-flight
+ * compile) or the display fields (configuration / target /
+ * receiver_label — the receiver doesn't echo them through the
+ * wire), so reload-time rows start with an empty output buffer
+ * and empty display strings; the dialog's re-attach view
+ * tolerates the empty fields and live OFFLOADER_JOB_OUTPUT
+ * events repopulate from the subscribe point forward. The
+ * cache is offloader-side: receiver owns the underlying
+ * FirmwareJob row, the offloader keeps a thin projection of
+ * what's needed to render its in-flight UI.
  */
 export interface RemoteBuildJobState {
   job_id: string;


### PR DESCRIPTION
# What does this implement/fix?

Wires the offloader-side in-flight remote-build snapshot from
`subscribe_events.initial_state.remote_jobs` into
`buildOffloadJobsContext`. Backend has been seeding the field
since 5c-3 (see `RemoteBuildController._offloader_remote_jobs`)
but the frontend ignored it — a page reload mid-build painted
no in-flight rows until the next `OFFLOADER_JOB_OUTPUT` line
landed. This closes that gap.

Closes the second of three deferred 5c-4 frontend follow-ups
from esphome/device-builder#106. The Cancel affordance landed
in #272; the remaining follow-up is the multi-job in-flight
list (today's UI is one-job-per-dialog).

## What ships

- New `OffloaderRemoteJobSnapshotEntry` interface mirroring the
  backend's TypedDict (`receiver_hostname` / `receiver_port` /
  `pin_sha256` / `job_id` / `status` / `error_message`). The
  output buffer and display fields (configuration / target /
  receiver_label) deliberately don't ride the snapshot — output
  would balloon for any in-flight compile, and the receiver
  doesn't echo the display fields back through the wire.
- `InitialStateEventData` gains an optional `remote_jobs` field
  with the same absent-vs-empty-list distinction the sibling
  remote-build snapshots (`peers` / `hosts` / `pairings` /
  `offloader_alerts`) use.
- App-shell's `INITIAL_STATE` handler rebuilds
  `_buildOffloadJobs` from the snapshot when present, reusing
  the existing `stubRemoteBuildJobState` helper for the
  empty-defaults shape and overriding only the two fields the
  wire carries (`status` / `error_message`). Replaces (not
  merges) so a reconnect-driven re-subscribe resyncs against
  the backend's view rather than accumulating stale local
  entries the receiver already considers terminal.
- `RemoteBuildJobState`'s docstring on `buildOffloadJobsContext`
  was out of date — now reflects the new contract and documents
  the empty-defaults caveat.

## Caveats

- A reload-time row's display fields (configuration / target /
  receiver_label) are empty until terminal. The dialog's
  re-attach view already tolerates this — it shows the live
  status / output regardless. Live `OFFLOADER_JOB_OUTPUT` events
  repopulate the buffer from the subscribe point forward.
- The output buffer doesn't replay; what was streamed before
  the reload is gone. Acceptable: the receiver-side log is
  authoritative if the user wants the full transcript.
- `started_at` seeds at 0 (the helper's "unset" sentinel). The
  dispatch helper's `||` fallback in `registerRemoteBuildJob`
  swaps it out if a fresh dispatch races a reload-seeded entry.

**Related issue or feature (if applicable):**

- esphome/device-builder#106 phase 5c-4 deferred follow-up
  (snapshot seeding for mid-build reload).
- Backend seeding has been in place since
  esphome/device-builder#540 (5c-3); this PR is the frontend
  consumer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

App-shell's `INITIAL_STATE` handler isn't currently unit-tested
(no `test/components/app-shell.test.ts`). Adding the first one
in this PR would balloon the diff for a small typed-shape
change; the wire shape is pinned by TypeScript and the seeding
logic mirrors four sibling fields (`peers` / `hosts` /
`pairings` / `offloader_alerts`) that have shipped without
component-level coverage.
