### PR TITLE
Pre-fill peer-link port from mDNS TXT in the Pair wizard

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1418,6 +1418,27 @@ export interface RemoteBuildPeer {
   addresses: string[];
   server_version: string;
   esphome_version: string;
+  /**
+   * SHA-256 of the receiver's static X25519 peer-link pubkey,
+   * lowercase hex, parsed off the mDNS TXT record. Empty string
+   * for receivers that haven't bound the peer-link listener at
+   * announce time (default-off mode). The offloader's mDNS
+   * auto-rebind path matches this against persisted pairings;
+   * the discovered-row Pair button doesn't read it (the wizard
+   * runs `preview_pair` against the chosen endpoint and OOBs
+   * the live fingerprint).
+   */
+  pin_sha256: string;
+  /**
+   * Receiver's peer-link Noise WS port from the TXT
+   * `remote_build_port` key, NOT the SRV-advertised dashboard
+   * HTTP port (`port` above). The discovered-row Pair button
+   * pre-fills this into the wizard so operators on a non-default
+   * `--remote-build-port` don't have to retype it on every pair.
+   * `0` for receivers that haven't bound the peer-link listener
+   * yet; the wizard falls back to its 6055 default in that case.
+   */
+  remote_build_port: number;
 }
 
 /**

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -2726,18 +2726,19 @@ export class ESPHomeSettingsDialog extends LitElement {
           esphome: peer.esphome_version,
         })
       : nothing;
-    // The Pair button pre-fills only the hostname. The row's
-    // ``peer.port`` is the dashboard's HTTP port from the SRV
-    // record (default 6052), not the peer-link Noise WS port
-    // (default 6055); pre-filling SRV port would land a
-    // ``UNAVAILABLE`` on the very first preview round-trip.
-    // Until the backend surfaces the receiver's peer-link
-    // ``remote_build_port`` from TXT, the dialog falls back to
-    // its 6055 default and the user can edit if the receiver
-    // overrode ``--remote-build-port``. Already-paired hosts
-    // never reach this renderer; ``_renderRemoteBuildPeers``
-    // filters them out one level up so the list is just
-    // unpaired discovered hosts.
+    // The Pair button pre-fills the hostname AND the peer-link
+    // port. The row's ``peer.port`` is the dashboard's HTTP port
+    // from the SRV record (default 6052), NOT the peer-link
+    // Noise WS port (default 6055); the wizard wants the latter.
+    // ``peer.remote_build_port`` carries that value off the mDNS
+    // TXT ``remote_build_port`` key — non-zero whenever the
+    // receiver's peer-link listener is bound, ``0`` for receivers
+    // that haven't published it (default-off mode);
+    // ``_onPairDiscoveredHost`` falls back to the wizard's 6055
+    // default in the latter case. Already-paired hosts never
+    // reach this renderer; ``_renderRemoteBuildPeers`` filters
+    // them out one level up so the list is just unpaired
+    // discovered hosts.
     return html`
       <div class="row peer-row">
         <div class="row-label">
@@ -2782,7 +2783,18 @@ export class ESPHomeSettingsDialog extends LitElement {
   }
 
   private _onPairDiscoveredHost = (peer: RemoteBuildPeer): void => {
-    this._pairBuildServerDialog?.open({ hostname: peer.hostname });
+    // Pre-fill the wizard's port from the receiver's TXT
+    // ``remote_build_port`` (the actual peer-link Noise WS port)
+    // when present; ``0`` means the receiver hasn't published it
+    // (peer-link listener unbound at announce time), so let the
+    // wizard fall back to its 6055 default. Pre-filling the
+    // SRV-advertised ``peer.port`` would land an ``UNAVAILABLE``
+    // on the very first ``preview_pair`` round-trip — that's the
+    // dashboard HTTP port, not the peer-link WS port.
+    this._pairBuildServerDialog?.open({
+      hostname: peer.hostname,
+      port: peer.remote_build_port > 0 ? peer.remote_build_port : undefined,
+    });
   };
 
   private _onThemeChange(e: Event) {


### PR DESCRIPTION
# What does this implement/fix?

Closes the deferred follow-up tracked on issue esphome/device-builder#106 row 4b-3:

> Open follow-up still tracked: surface the receiver's actual peer-link port from the TXT `remote_build_port` key on `RemoteBuildPeer` so the discovered-row Pair pre-fill can use it instead of falling back to the 6055 default.

The backend has been broadcasting `remote_build_port` on the mDNS TXT record since the receiver's advertise was wired up, and `controllers/remote_build/controller._peer_from_service_info` already parses both the TXT `remote_build_port` and `pin_sha256` keys onto `RemoteBuildPeer.remote_build_port` / `.pin_sha256`. The TypeScript `RemoteBuildPeer` interface was missing both fields; type drift was silent (TS widens to `any`).

This PR is small and frontend-only:

* **`src/api/types.ts`** — adds `pin_sha256: string` and `remote_build_port: number` to the `RemoteBuildPeer` interface so the TS shape mirrors the backend model. JSDoc on each spells out where the value comes from on the wire and what `0` / empty means.
* **`src/components/settings-dialog.ts`**:
    * `_onPairDiscoveredHost` now passes `port: peer.remote_build_port` to `<esphome-pair-build-server-dialog>.open()` when the value is non-zero. `0` (receiver hasn't bound the peer-link listener at announce time) falls through to `undefined` so the wizard's existing 6055 default takes over — same shape as before this PR for those rows.
    * Updates the inline comment that previously said "Until the backend surfaces the receiver's peer-link `remote_build_port` from TXT, the dialog falls back to its 6055 default" to describe the new behaviour.

The wizard's `open()` already accepts `{hostname?, port?}` (added when the discovered-row Pair button first landed), so no dialog-side changes were needed.

## Why this matters

Operators running their receivers on a non-default `--remote-build-port` had to manually retype the port in the wizard every pair, even when the row in the discovered-hosts list already knew the right value. The wizard's hostname pre-fill was a partial improvement; this finishes the pair off so the wizard's input step is "Continue" for the common-case happy path.

## Testing

`npm run lint` passes. `npm run test` passes (996 tests; same surface as pre-PR — there are no existing test fixtures for `RemoteBuildPeer` that would need defaulting for the new required fields, and the repo doesn't carry DOM-level tests for `<esphome-settings-dialog>`).

The wire path is exercised by the existing backend unit + e2e tests (`tests/test_remote_build.py` + `tests/e2e/test_pair_and_session.py` cover `_peer_from_service_info`'s TXT parsing).

**Related issue or feature (if applicable):**

- esphome/device-builder#106 row 4b-3 deferred follow-up.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
