### PR TITLE
Extract downloadBase64Binary helper for save-firmware-to-disk paths

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -19,6 +19,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { chipNameToVariant } from "../util/chip-variant.js";
+import { downloadBase64Binary } from "../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -999,14 +1000,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         device.configuration,
         flashable.file
       );
-      const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
-      const blob = new Blob([bytes], { type: "application/octet-stream" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = result.filename;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBase64Binary(result.data, result.filename);
       this._downloadedFilename = result.filename;
     } catch {
       this._fail(this._localize("firmware.download_failed"));

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -37,6 +37,7 @@ import {
 import { espHomeStyles } from "../styles/shared.js";
 import { YamlSearchController } from "../components/yaml-search-controller.js";
 import { matchesDeviceName } from "../util/device-search.js";
+import { downloadBase64Binary } from "../util/download-text.js";
 import { computeLabelUsage, deleteConfirmKey } from "../util/label-usage.js";
 import {
   buildYamlSnippetBlocks,
@@ -2056,14 +2057,7 @@ export class ESPHomePageDashboard extends LitElement {
       }
       const binary = binaries[0];
       const result = await this._api.firmwareDownload(device.configuration, binary.file);
-      const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
-      const blob = new Blob([bytes], { type: "application/octet-stream" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = result.filename;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBase64Binary(result.data, result.filename);
     } catch {
       toast.error(this._localize("dashboard.download_firmware_failed", { name }), {
         richColors: true,

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -1,6 +1,69 @@
 import { stripAnsi } from "./strip-ansi.js";
 
 /**
+ * Trigger a browser save of *bytes* as *filename* via an
+ * anchor-click + revoked object URL.
+ *
+ * Centralises the "create a Blob, mint an object URL, click a
+ * synthetic anchor, revoke" dance that every save-to-disk
+ * path in the dashboard needs. Behaviour:
+ *
+ * - ``bytes`` rides through a single ``Blob`` with the given
+ *   MIME type. Binary firmware images pass
+ *   ``application/octet-stream`` so the browser doesn't try to
+ *   sniff the type; text-shaped output (logs, manifests) passes
+ *   ``text/plain``.
+ * - ``filename`` is offered to the browser's save dialog as-is —
+ *   callers own slug / extension shaping.
+ * - The object URL is revoked synchronously after the click.
+ *   Chromium / Firefox both keep the in-flight download alive
+ *   after revocation; the URL just stops resolving for *new*
+ *   reads. Holding the URL around would leak the underlying
+ *   ``Blob`` for the page's lifetime.
+ *
+ * Private helper — call sites use the typed wrappers below
+ * (:func:`downloadAnsiText`, :func:`downloadBase64Binary`)
+ * rather than touching this directly.
+ */
+function _downloadBlob(
+  bytes: BlobPart,
+  filename: string,
+  mimeType: string,
+): void {
+  const blob = new Blob([bytes], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Save a base64-encoded binary payload to the user's disk.
+ *
+ * Used by every install-related save path that hands the user
+ * a firmware binary to flash with their own tooling:
+ *
+ * - :class:`ESPHomeFirmwareInstallDialog`'s manual-download
+ *   install flow (post-compile save of the local-build output);
+ * - :class:`ESPHomeDashboard`'s per-device "Download firmware"
+ *   button on configured-device rows.
+ *
+ * ``b64`` is standard (not URL-safe) base64 — decoded via
+ * ``atob`` + ``Uint8Array.from`` in one pass. Saves as
+ * ``application/octet-stream`` so browsers don't sniff the
+ * bytes as an executable / text / image. ``filename`` is
+ * offered to the save dialog as-is; callers own extension
+ * shaping (``.bin`` for firmware images, ``.uf2`` for
+ * mass-storage flashes, etc.).
+ */
+export function downloadBase64Binary(b64: string, filename: string): void {
+  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  _downloadBlob(bytes, filename, "application/octet-stream");
+}
+
+/**
  * Save terminal-style output to a plain text file.
  *
  * Used by the logs and command dialogs' download buttons. ANSI
@@ -29,12 +92,6 @@ export function downloadAnsiText(lines: string[], filename: string): string {
   const text = lines
     .map((line) => stripAnsi(line).replace(/[\r\n]+$/, ""))
     .join("\n");
-  const blob = new Blob([text], { type: "text/plain" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
+  _downloadBlob(text, filename, "text/plain");
   return text;
 }

--- a/test/util/download-text.test.ts
+++ b/test/util/download-text.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { downloadAnsiText } from "../../src/util/download-text.js";
+import {
+  downloadAnsiText,
+  downloadBase64Binary,
+} from "../../src/util/download-text.js";
 
 /* The runtime test environment is Node, so we stub the bits of the
    browser API the helper touches. The download mechanics (anchor +
@@ -111,5 +114,61 @@ describe("downloadAnsiText", () => {
     const blob = FakeBlob.instances[0];
     expect(blob.options?.type).toBe("text/plain");
     expect(blob.parts).toEqual(["hello\nworld"]);
+  });
+});
+
+describe("downloadBase64Binary", () => {
+  it("decodes the base64 payload and saves as application/octet-stream", () => {
+    /* ``AAECAw==`` decodes to the four-byte sequence 0x00 0x01 0x02 0x03. */
+    const { anchor } = withBrowserStubs(() =>
+      downloadBase64Binary("AAECAw==", "firmware.bin"),
+    );
+    expect(anchor.download).toBe("firmware.bin");
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+    expect(FakeBlob.instances).toHaveLength(1);
+    const blob = FakeBlob.instances[0];
+    expect(blob.options?.type).toBe("application/octet-stream");
+    expect(blob.parts).toHaveLength(1);
+    const part = blob.parts[0];
+    expect(part).toBeInstanceOf(Uint8Array);
+    expect(Array.from(part as Uint8Array)).toEqual([0x00, 0x01, 0x02, 0x03]);
+  });
+
+  it("creates and revokes an object URL for the Blob", () => {
+    const createSpy = vi.fn(() => "blob:fake");
+    const revokeSpy = vi.fn();
+    const stubs = {
+      Blob: FakeBlob,
+      URL: { createObjectURL: createSpy, revokeObjectURL: revokeSpy },
+      document: { createElement: vi.fn(() => new FakeAnchor()) },
+    };
+    const g = globalThis as Record<string, unknown>;
+    const prev: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(stubs)) {
+      prev[key] = g[key];
+      g[key] = value;
+    }
+    try {
+      downloadBase64Binary("aGVsbG8=", "hello.bin");
+    } finally {
+      for (const [key, value] of Object.entries(prev)) g[key] = value;
+    }
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+    expect(revokeSpy).toHaveBeenCalledWith("blob:fake");
+  });
+
+  it("accepts an empty payload (zero-byte download)", () => {
+    /* An empty base64 string decodes to zero bytes. Helpful for
+       defensive call sites that pass through whatever the backend
+       returned without their own length gate. */
+    const { anchor } = withBrowserStubs(() =>
+      downloadBase64Binary("", "empty.bin"),
+    );
+    expect(anchor.download).toBe("empty.bin");
+    const blob = FakeBlob.instances[0];
+    const part = blob.parts[0];
+    expect(part).toBeInstanceOf(Uint8Array);
+    expect((part as Uint8Array).length).toBe(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Pure refactor — no behaviour change. The base64 → Uint8Array →
Blob → object URL → anchor click → revoke dance was duplicated
verbatim in two save-firmware-to-disk paths:

- `ESPHomeFirmwareInstallDialog._startDownload` (manual-download
  install flow's post-compile save);
- `ESPHomeDashboard._downloadFirmware` (per-device "Download
  firmware" button on configured-device rows).

Extracted into `src/util/download-text.ts` alongside the existing
`downloadAnsiText` helper:

- `downloadBase64Binary(b64, filename)` — decodes via `atob` +
  `Uint8Array.from`, saves as `application/octet-stream`.
- `_downloadBlob(bytes, filename, mimeType)` — private helper
  that both `downloadAnsiText` and `downloadBase64Binary` route
  through, so the anchor + object-URL + revoke dance lives in
  exactly one place.

Three new tests on `downloadBase64Binary` pin the decode shape,
the URL-revoke contract, and the zero-byte edge case. **1005 tests
pass** (was 999 base + 3 new + same coverage for the converged
callers).

## Why now

Came up while scoping phase 6b frontend (Install paths consuming
the new `remote_build/download_artifacts` WS command from
esphome/device-builder#547). The new path is a third caller of
exactly the same byte-save pattern; rather than adding a third
copy, this PR converges the existing two so 6b proper can target
the helper directly.

Also sets up the transparent-install flow described in
[`transparent_remote_install_design.md`](https://github.com/esphome/device-builder/blob/main/transparent_remote_install_design.md):
when phase 7a's backend scheduler routes the per-device
"Download firmware" button transparently to either local or
remote-fetched bytes, the install paths keep calling the same
helper regardless of where the bytes came from.

**Related issue or feature:**

- Refactor preparing the ground for esphome/device-builder#106
  phase 6b / 7a frontend work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1005 tests).
- [x] Tests have been added to verify that the new code works (where applicable).
