### PR TITLE
Extract inline + banner field-error helpers to shared util

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -10,6 +10,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
+import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
@@ -320,11 +321,11 @@ export class ESPHomeAdoptDialog extends LitElement {
                     if (e.key === "Enter" && canSubmit) this._submit();
                   }}
                 />
-                ${nameErr
-                  ? html`<span class="field-error"
-                      >${this._localize(nameErr.code, nameErr.params)}</span
-                    >`
-                  : nothing}
+                ${renderInlineError(
+                  nameErr
+                    ? this._localize(nameErr.code, nameErr.params)
+                    : undefined,
+                )}
               </div>
 
               <div class="field">

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
@@ -203,9 +204,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
             }}
           />
           ${err
-            ? html`<span class="field-error"
-                >${this._localize(err.code, err.params)}</span
-              >`
+            ? renderInlineError(this._localize(err.code, err.params))
             : warning
               ? html`<span class="field-warning"
                   >${this._localize(warning.code, warning.params)}</span

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -13,6 +13,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import type { PasswordInputValueChange } from "./password-input.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
+import { renderInlineError } from "../../util/render-error.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
 registerMdiIcons({
@@ -174,8 +175,9 @@ export function renderLabel(
 
 export function renderFieldError(path: string[], ctx: RenderCtx) {
   const err = ctx.errorAt(path);
-  if (!err) return nothing;
-  return html`<span class="field-error">${ctx.localize(err.code, err.params)}</span>`;
+  return renderInlineError(
+    err ? ctx.localize(err.code, err.params) : undefined,
+  );
 }
 
 /**

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -17,6 +17,7 @@ import {
   parsePortInput,
   trimTrailingDot,
 } from "../util/hostname.js";
+import { renderErrorBanner } from "../util/render-error.js";
 
 /**
  * Edit a paired build server's hostname / port without re-pairing.
@@ -300,11 +301,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             @input=${this._onPortInput}
           />
         </div>
-        ${this._errorMessage
-          ? html`<div class="field-error" role="alert">
-              ${this._errorMessage}
-            </div>`
-          : nothing}
+        ${renderErrorBanner(this._errorMessage)}
         <div class="actions">
           <button
             class="btn-secondary"

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -5,6 +5,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
@@ -213,9 +214,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
             }}
           />
           ${err
-            ? html`<span class="field-error"
-                >${this._localize(err.code)}</span
-              >`
+            ? renderInlineError(this._localize(err.code))
             : html`<span class="helper"
                 >${this._localize(
                   "dashboard.action_friendly_name_helper",

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -27,6 +27,7 @@ import { inputStyles } from "../styles/inputs.js";
 import { jobStatusPillStyles } from "../styles/job-status-pill.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { isTerminalJobStatus } from "../util/firmware-job-status.js";
+import { renderErrorBanner } from "../util/render-error.js";
 
 import "./ansi-log.js";
 
@@ -323,16 +324,6 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     if (this._expandedJobId === job_id) this._expandedJobId = "";
   };
 
-  /** Render an error banner row, or ``nothing`` when *message*
-   *  is empty. Centralises the field-error markup so the input
-   *  step's submit-error, each row's per-job ``error_message``
-   *  (terminal failures from the receiver), and per-row
-   *  cancel-errors all share one visual shape. */
-  private _renderErrorBanner(message: string | undefined) {
-    if (!message) return nothing;
-    return html`<div class="field-error" role="alert">${message}</div>`;
-  }
-
   private _formatCancelError(err: unknown): string {
     if (err instanceof APIError) {
       switch (err.errorCode) {
@@ -416,7 +407,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
           </option>
         </select>
       </div>
-      ${this._renderErrorBanner(this._submitErrorMessage)}
+      ${renderErrorBanner(this._submitErrorMessage)}
       <div class="actions">
         <button class="btn-secondary" type="button" @click=${this._close}>
           ${this._localize("layout.close")}
@@ -516,8 +507,8 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         ${expanded
           ? html`
               <div class="job-body">
-                ${this._renderErrorBanner(job.error_message)}
-                ${this._renderErrorBanner(row.errorMessage)}
+                ${renderErrorBanner(job.error_message)}
+                ${renderErrorBanner(row.errorMessage)}
                 <div class="logs-container">
                   <esphome-ansi-log
                     .lines=${job.output}

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
@@ -162,7 +163,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
             @keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" && canSubmit) this._confirm(); }}
           />
           ${err
-            ? html`<span class="field-error">${this._localize(err.code, err.params)}</span>`
+            ? renderInlineError(this._localize(err.code, err.params))
             : warning
               ? html`<span class="field-warning">${this._localize(warning.code, warning.params)}</span>`
               : nothing}

--- a/src/util/render-error.ts
+++ b/src/util/render-error.ts
@@ -1,0 +1,56 @@
+import { html, nothing } from "lit";
+
+/**
+ * Shared helpers for rendering an error in dialog / form
+ * markup.
+ *
+ * Two shapes survive in the codebase because they're
+ * semantically distinct:
+ *
+ * - **Inline-validation error** — a ``<span class="field-error">``
+ *   placed next to the input that failed. Read by sighted users
+ *   as "this field is wrong"; no ``role="alert"`` because the
+ *   message follows the visual flow and screen readers
+ *   announce it via the label association. The dialogs that
+ *   surface per-field validation errors (adopt-dialog,
+ *   friendly-name-dialog, clone-device-dialog,
+ *   rename-device-dialog, the config-entry renderers) use this
+ *   shape.
+ *
+ * - **Status-region banner error** — a ``<div class="field-error"
+ *   role="alert">`` placed below the form, used for
+ *   submit-time / wire failures that don't bind to any single
+ *   field. ``role="alert"`` so screen readers announce it
+ *   even when focus is elsewhere. The dialogs that wrap a WS
+ *   command (edit-pairing-endpoint-dialog,
+ *   remote-build-job-dialog) use this shape.
+ *
+ * Both return ``nothing`` for falsy / empty messages so call
+ * sites can write ``${renderInlineError(maybeMessage)}`` without
+ * a guarding ternary.
+ *
+ * The ``.field-error`` CSS rule stays per-component for now —
+ * moving the colour / typography tokens into ``shared.ts`` is a
+ * separate decision; this helper unifies the markup but not
+ * the styles.
+ */
+
+/**
+ * Render an inline ``<span class="field-error">`` next to a
+ * form input, or :external:lit:`nothing` when *message* is
+ * falsy / empty.
+ */
+export function renderInlineError(message: string | undefined) {
+  if (!message) return nothing;
+  return html`<span class="field-error">${message}</span>`;
+}
+
+/**
+ * Render a status-region ``<div class="field-error" role="alert">``
+ * below a form, or :external:lit:`nothing` when *message* is
+ * falsy / empty.
+ */
+export function renderErrorBanner(message: string | undefined) {
+  if (!message) return nothing;
+  return html`<div class="field-error" role="alert">${message}</div>`;
+}

--- a/test/util/render-error.test.ts
+++ b/test/util/render-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { nothing } from "lit";
+
+import {
+  renderErrorBanner,
+  renderInlineError,
+} from "../../src/util/render-error.js";
+
+/**
+ * Lit's TemplateResult exposes a ``strings`` array (the static
+ * template literal segments) and a ``values`` array (the
+ * interpolated parts). Inspecting those is enough to pin the
+ * markup shape without spinning up a DOM (vitest config runs
+ * in the ``node`` environment).
+ */
+interface TemplateResult {
+  strings: readonly string[];
+  values: readonly unknown[];
+}
+
+function asTemplate(value: unknown): TemplateResult {
+  return value as TemplateResult;
+}
+
+describe("renderInlineError", () => {
+  it("returns nothing for undefined", () => {
+    expect(renderInlineError(undefined)).toBe(nothing);
+  });
+
+  it("returns nothing for empty string", () => {
+    expect(renderInlineError("")).toBe(nothing);
+  });
+
+  it("renders a span.field-error wrapping the message", () => {
+    const t = asTemplate(renderInlineError("name is required"));
+    expect(t.strings.join("")).toMatch(/^<span class="field-error">.*<\/span>$/);
+    expect(t.values).toEqual(["name is required"]);
+  });
+
+  it("does NOT add role=alert (inline-validation, not status region)", () => {
+    const t = asTemplate(renderInlineError("bad"));
+    expect(t.strings.join("")).not.toContain('role="alert"');
+  });
+});
+
+describe("renderErrorBanner", () => {
+  it("returns nothing for undefined", () => {
+    expect(renderErrorBanner(undefined)).toBe(nothing);
+  });
+
+  it("returns nothing for empty string", () => {
+    expect(renderErrorBanner("")).toBe(nothing);
+  });
+
+  it("renders a div.field-error[role=alert] wrapping the message", () => {
+    const t = asTemplate(renderErrorBanner("connect refused"));
+    expect(t.strings.join("")).toMatch(
+      /^<div class="field-error" role="alert">.*<\/div>$/,
+    );
+    expect(t.values).toEqual(["connect refused"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #1 from `dry_followup_plan.md` — seven call
sites across the codebase duplicated the same field-error
markup. Two distinct shapes survived in the wild:

- **Inline-validation**: `<span class="field-error">{msg}</span>`
  next to an input, ARIA flows via the input's label
  association.
- **Status-region banner**: `<div class="field-error" role="alert">{msg}</div>`
  below a form, needs `role="alert"` for screen-reader
  announcement when focus is elsewhere.

`remote-build-job-dialog` already had a private
`_renderErrorBanner(message)` helper from PR #272's review
pass; promoting it to a shared util folds the rest of the
codebase onto the same shape.

## What ships

- New `src/util/render-error.ts` exporting two helpers:
  - `renderInlineError(message: string | undefined)` returns
    `nothing` for falsy / empty, else
    `<span class="field-error">{msg}</span>`.
  - `renderErrorBanner(message: string | undefined)` returns
    `nothing` for falsy / empty, else
    `<div class="field-error" role="alert">{msg}</div>`.
- Both shapes intentionally survive — they're semantically
  distinct (inline vs status-region) and conflating them
  would lose either screen-reader semantics or visual
  alignment.

## Migrations

| File | Before | After |
|---|---|---|
| `adopt-dialog.ts` | inline ternary | `renderInlineError` |
| `clone-device-dialog.ts` | inline ternary (preserves the `field-warning` branch) | `renderInlineError` |
| `friendly-name-dialog.ts` | inline ternary (preserves the `helper` branch) | `renderInlineError` |
| `rename-device-dialog.ts` | inline ternary (preserves the `field-warning` branch) | `renderInlineError` |
| `device/config-entry-renderers-shared.ts` | local body in `renderFieldError(path, ctx)` | delegates to `renderInlineError`; outer signature unchanged so the nine `config-entry-renderers*` call sites don't need touching |
| `edit-pairing-endpoint-dialog.ts` | inline ternary | `renderErrorBanner` |
| `remote-build-job-dialog.ts` | private `_renderErrorBanner` helper from #272 | shared `renderErrorBanner`; three call sites swap |

## What's NOT in this PR

- **`.field-error` CSS rule consolidation.** Nine
  per-component copies of the same colour / typography rule
  remain. Promoting it to `src/styles/shared.ts` is a
  separate token-decision flagged in
  `dry_followup_plan.md`; the markup unification here
  doesn't depend on it.
- **The existing `renderFieldError(path, ctx)`'s outer
  signature.** That's the path-based variant heavily used
  by the config-entry renderers (9 call sites). Renaming
  it to make room for a top-level `renderFieldError(msg)`
  would have been a churn-y rename for a stylistic
  preference. Kept the existing name; new helpers got
  `renderInlineError` / `renderErrorBanner` for clarity.

## Tests

- Seven new unit tests in `test/util/render-error.test.ts`
  pin the markup shape via the `TemplateResult`'s
  `strings` / `values` arrays (the vitest config runs in
  `node` env without a DOM, so direct render-to-DOM
  assertions don't work).
- All 1009 frontend tests pass (was 1002, +7 new). Lint
  clean.

**Related issue or feature (if applicable):**

- DRY follow-up #1 from internal `dry_followup_plan.md`.
- Continues the dedupe started in
  esphome/device-builder-frontend#272 (which extracted
  the helper privately on `remote-build-job-dialog`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
