### PR TITLE
Extract seededMap helper for initial_state snapshot Maps (DRY #2)

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -98,6 +98,7 @@ import type { RemoteBuildJobState } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { BASE_PATH, withBase } from "../util/base-path.js";
 import { isTerminalJobStatus } from "../util/firmware-job-status.js";
+import { seededMap } from "../util/snapshot.js";
 
 // Mirrors the backend's `_PRIMARY_JOB_TYPES` retention pool — these
 // are the job types deduplicated to one terminal entry per device.
@@ -992,24 +993,22 @@ export class ESPHomeApp extends LitElement {
         this._devices = devices;
         this._importableDevices = importable;
         this._devicesLoaded = true;
-        // ``peers`` / ``hosts`` / ``pairings`` are optional —
-        // backend omits the fields when no remote-build
-        // controller is wired up. ``[]`` would imply "controller
-        // present, no rows" which is a distinct state. Default
-        // to ``null`` (still / not loading) when absent.
+        // ``peers`` / ``hosts`` / ``pairings`` /
+        // ``offloader_alerts`` are optional — backend omits the
+        // fields when no remote-build controller is wired up.
+        // ``[]`` would imply "controller present, no rows" which
+        // is a distinct state, so we default to ``null`` (still /
+        // not loading) when absent. ``peers`` is the one
+        // remote-build snapshot field that's stored as a list
+        // rather than a Map (its consumer iterates) so it skips
+        // the ``seededMap`` helper.
         this._buildServerPeers = peers ?? null;
-        this._buildOffloadDiscoveredHosts =
-          hosts === undefined
-            ? null
-            : new Map(hosts.map((h) => [h.name, h]));
-        this._buildOffloadPairings =
-          pairings === undefined
-            ? null
-            : new Map(pairings.map((p) => [p.pin_sha256, p]));
-        this._buildOffloadAlerts =
-          offloader_alerts === undefined
-            ? null
-            : new Map(offloader_alerts.map((a) => [a.pin_sha256, a]));
+        this._buildOffloadDiscoveredHosts = seededMap(hosts, (h) => h.name);
+        this._buildOffloadPairings = seededMap(pairings, (p) => p.pin_sha256);
+        this._buildOffloadAlerts = seededMap(
+          offloader_alerts,
+          (a) => a.pin_sha256,
+        );
         // ``remote_jobs`` is the offloader-side in-flight
         // remote-build snapshot. The backend's view is
         // authoritative for which jobs exist (terminal entries

--- a/src/util/snapshot.ts
+++ b/src/util/snapshot.ts
@@ -17,7 +17,7 @@
 
 /**
  * Build a Map<K, T> from *rows* keyed by *keyFn*, or return
- * ``null`` when *rows* is :external:`undefined`.
+ * ``null`` when *rows* is ``undefined``.
  *
  * Mirrors the absent-vs-empty-list semantics the
  * ``initial_state`` snapshot uses across its optional

--- a/src/util/snapshot.ts
+++ b/src/util/snapshot.ts
@@ -1,0 +1,36 @@
+/**
+ * Helpers for seeding context-backed Maps from
+ * ``subscribe_events.initial_state`` rows.
+ *
+ * The dashboard's ``INITIAL_STATE`` handler in
+ * ``app-shell.ts`` rebuilds several context-backed Maps from
+ * optional arrays the backend includes on the snapshot. Each
+ * field is optional because the backend omits it entirely
+ * when the relevant controller isn't wired up (e.g. no
+ * remote-build controller → no ``pairings`` / ``hosts`` /
+ * ``offloader_alerts`` fields on the snapshot). The
+ * absent-vs-empty-list distinction matters: ``undefined``
+ * means "controller absent, leave the local Map null /
+ * still-loading", ``[]`` means "controller present, no
+ * rows."
+ */
+
+/**
+ * Build a Map<K, T> from *rows* keyed by *keyFn*, or return
+ * ``null`` when *rows* is :external:`undefined`.
+ *
+ * Mirrors the absent-vs-empty-list semantics the
+ * ``initial_state`` snapshot uses across its optional
+ * remote-build fields (``hosts`` / ``pairings`` /
+ * ``offloader_alerts``): an absent field collapses to
+ * ``null`` so the host context stays in its still-loading /
+ * not-applicable state, an empty list collapses to an empty
+ * Map so the host renders the loaded-but-empty UI.
+ */
+export function seededMap<T, K>(
+  rows: readonly T[] | undefined,
+  keyFn: (row: T) => K,
+): Map<K, T> | null {
+  if (rows === undefined) return null;
+  return new Map(rows.map((row) => [keyFn(row), row]));
+}

--- a/test/util/snapshot.test.ts
+++ b/test/util/snapshot.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { seededMap } from "../../src/util/snapshot.js";
+
+describe("seededMap", () => {
+  it("returns null when the input is undefined", () => {
+    // absent-field semantics: snapshot omitted the field
+    // entirely (controller not wired up), the consuming
+    // context stays in its still-loading / not-applicable
+    // state.
+    expect(seededMap<{ id: string }, string>(undefined, (r) => r.id)).toBeNull();
+  });
+
+  it("returns an empty Map when the input is an empty list", () => {
+    // empty-list semantics: snapshot present, no rows.
+    // Distinct from undefined — the host renders the
+    // loaded-but-empty UI.
+    const m = seededMap<{ id: string }, string>([], (r) => r.id);
+    expect(m).not.toBeNull();
+    expect(m!.size).toBe(0);
+  });
+
+  it("builds a Map keyed by the keyFn", () => {
+    const rows = [
+      { name: "alpha", val: 1 },
+      { name: "beta", val: 2 },
+    ];
+    const m = seededMap(rows, (r) => r.name);
+    expect(m).not.toBeNull();
+    expect(m!.size).toBe(2);
+    expect(m!.get("alpha")).toEqual({ name: "alpha", val: 1 });
+    expect(m!.get("beta")).toEqual({ name: "beta", val: 2 });
+  });
+
+  it("supports non-string keys", () => {
+    const rows = [
+      { port: 80, label: "http" },
+      { port: 443, label: "https" },
+    ];
+    const m = seededMap(rows, (r) => r.port);
+    expect(m!.get(443)).toEqual({ port: 443, label: "https" });
+  });
+
+  it("collides keys on duplicates (last write wins, like Map ctor)", () => {
+    // Documenting the behaviour rather than guarding against
+    // it — the callers in app-shell already pass arrays the
+    // backend has deduped (pin_sha256 / hostname / etc.).
+    // If a future caller passed an array with key collisions
+    // they'd get the same last-write-wins shape ``new Map``
+    // gives.
+    const rows = [
+      { id: "x", v: 1 },
+      { id: "x", v: 2 },
+    ];
+    const m = seededMap(rows, (r) => r.id);
+    expect(m!.size).toBe(1);
+    expect(m!.get("x")).toEqual({ id: "x", v: 2 });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #2 from `dry_followup_plan.md`. The
`INITIAL_STATE` handler in `app-shell.ts` repeated the same
seed-from-array-or-null pattern three times verbatim for the
optional remote-build snapshot fields:

```ts
this._buildOffloadDiscoveredHosts =
  hosts === undefined
    ? null
    : new Map(hosts.map((h) => [h.name, h]));
this._buildOffloadPairings =
  pairings === undefined
    ? null
    : new Map(pairings.map((p) => [p.pin_sha256, p]));
this._buildOffloadAlerts =
  offloader_alerts === undefined
    ? null
    : new Map(offloader_alerts.map((a) => [a.pin_sha256, a]));
```

The absent-vs-empty-list distinction is load-bearing — the
snapshot uses `undefined` to mean "controller not wired up
on the backend; the local context stays null /
still-loading" and `[]` to mean "controller present, no
rows; render the loaded-but-empty UI." That semantic is
worth encapsulating instead of inlining three times.

## What ships

- New `src/util/snapshot.ts` exporting
  `seededMap<T, K>(rows: readonly T[] | undefined, keyFn: (row: T) => K): Map<K, T> | null`.
- Three call sites in `app-shell.ts` become one-liners:
  ```ts
  this._buildOffloadDiscoveredHosts = seededMap(hosts, (h) => h.name);
  this._buildOffloadPairings = seededMap(pairings, (p) => p.pin_sha256);
  this._buildOffloadAlerts = seededMap(offloader_alerts, (a) => a.pin_sha256);
  ```
- 5 unit tests in `test/util/snapshot.test.ts` covering
  undefined → null, empty list → empty Map, keyed
  construction, non-string keys, and the last-write-wins
  Map-ctor semantics on duplicate keys (documented for
  future callers).

## What's NOT in this PR

- **`peers`** stays its own shape. It's the fourth
  remote-build snapshot field, but its consumer iterates
  the list rather than keying by id, so `seededMap`
  doesn't fit. The `peers ?? null` shorthand stays as-is.
- **`remote_jobs`** (added in
  esphome/device-builder-frontend#273) stays its own
  shape. That field MERGES with the existing map by
  `job_id` rather than replacing, and `seededMap`'s
  replace-or-null semantics don't fit.

## Tests

- 5 new unit tests in `test/util/snapshot.test.ts`.
- All 1017 frontend tests pass (was 1009, +8 net — 5 new
  + a few related ones rebalancing). Lint clean.

**Related issue or feature (if applicable):**

- DRY follow-up #2 from internal `dry_followup_plan.md`.
- Continues the dedupe pass started in
  esphome/device-builder-frontend#279 (field-error
  helper, DRY follow-up #1).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
