### PR TITLE
Add <esphome-base-dialog> wrapper + migrate edit-pairing-endpoint-dialog (DRY #3)

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -2,7 +2,7 @@ import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
 import { consume } from "@lit/context";
 import { LitElement, css, html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
@@ -29,22 +29,47 @@ import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
  * **Busy gate**. When ``?busy=true``:
  *
  * - ``<wa-dialog>``'s ``?light-dismiss`` is disabled, so
- *   outside-click / Esc can't dismiss while a WS round-trip
- *   is in flight.
+ *   outside-click can't dismiss while a WS round-trip is
+ *   in flight.
  * - The close-button is ``disabled``.
- * - Hosts that want to *also* veto programmatic close
- *   (``dialog.close()`` from a parent) can still listen for
- *   ``@request-close`` and call ``e.preventDefault()`` on
- *   their own logic.
+ * - The wrapper proactively ``preventDefault()``s
+ *   ``wa-request-close`` so Escape / programmatic close
+ *   are blocked too, even when the consumer doesn't wire
+ *   their own ``@request-close`` veto handler. The busy
+ *   gate is comprehensive — consumers don't have to
+ *   double-cover it.
  *
  * **Events re-emitted**:
  *
  * - ``@request-close`` mirrors ``wa-dialog``'s
  *   ``wa-request-close`` (cancellable; ``preventDefault()``
- *   to veto).
+ *   to veto for host-side reasons like unsaved changes).
+ *   Not fired when the wrapper vetoes for ``busy`` — the
+ *   host can't override the busy gate.
  * - ``@after-hide`` mirrors ``wa-dialog``'s
  *   ``wa-after-hide`` (fires once the dialog has fully
- *   hidden; consumers reset local state here).
+ *   hidden; consumers reset local state and flip their
+ *   own ``_open = false`` here so the next render's
+ *   ``?open`` binding matches the wrapper's state).
+ *
+ * **Close paths**:
+ *
+ * All close paths flow through ``wa-request-close`` so
+ * busy gate + host veto are evaluated uniformly:
+ *
+ * - Escape key / outside-click → ``wa-dialog`` fires
+ *   ``wa-request-close`` directly.
+ * - Custom X button click → wrapper calls
+ *   ``waDialog.hide()`` which fires ``wa-request-close``.
+ * - Reactive ``?open`` flip → ``wa-dialog`` fires
+ *   ``wa-request-close`` as part of its hide sequence.
+ *
+ * The wrapper never mutates its own ``open`` property in
+ * response to user actions; closing is the host's
+ * responsibility via ``?open=${false}`` (typically wired
+ * inside the ``@after-hide`` listener). This keeps a
+ * single source of truth on the host so a re-render
+ * mid-close can't reopen the dialog.
  *
  * **Slots**:
  *
@@ -75,11 +100,22 @@ export class ESPHomeBaseDialog extends LitElement {
    *  flight; don't let the user orphan it". */
   @property({ type: Boolean }) busy = false;
 
+  @query("wa-dialog")
+  private _waDialog?: HTMLElement & { hide?: () => void };
+
   private _onWaRequestClose = (e: Event): void => {
-    // Re-emit as ``request-close``; preserve cancellation
-    // semantics so a host that calls preventDefault() on
-    // the re-emitted event vetoes the close on the
-    // underlying wa-dialog too.
+    // Busy gate first: refuse close regardless of source
+    // (Esc / outside-click / X / programmatic) while a WS
+    // round-trip is in flight. Consumers don't have to
+    // wire their own veto — the wrapper handles it.
+    if (this.busy) {
+      e.preventDefault();
+      return;
+    }
+    // Re-emit as ``request-close`` so host can veto for
+    // its own reasons (unsaved changes, mid-step flow,
+    // …). preventDefault() on the re-emitted event
+    // vetoes the close on the underlying wa-dialog too.
     const passthrough = new CustomEvent("request-close", {
       cancelable: true,
       bubbles: false,
@@ -96,12 +132,15 @@ export class ESPHomeBaseDialog extends LitElement {
   };
 
   private _onCloseClick = (): void => {
-    // Mirrors the explicit ``_close()`` handler every
-    // consumer used to wire. wa-dialog's after-hide fires
-    // afterwards so the host's state cleanup still runs
-    // via the @after-hide listener.
-    if (this.busy) return;
-    this.open = false;
+    // Drive close through wa-dialog's hide() so the entire
+    // close flow (busy gate via wa-request-close + host
+    // veto + after-hide cleanup) runs uniformly. Mutating
+    // ``this.open`` directly would (a) bypass the host's
+    // veto opportunity and (b) desync with a state-driven
+    // host whose own ``_open`` is still true — a host
+    // re-render mid-close would flip ``?open`` back to
+    // true and re-open the dialog.
+    this._waDialog?.hide?.();
   };
 
   protected render() {

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -1,0 +1,144 @@
+import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
+
+import { consume } from "@lit/context";
+import { LitElement, css, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { LocalizeFunc } from "../common/localize.js";
+import { localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
+
+/**
+ * Thin shared wrapper around ``<wa-dialog>``.
+ *
+ * Every dialog in the app spent ~20 lines on identical
+ * scaffolding — the ``?open`` binding, the
+ * ``?light-dismiss`` busy-gate, the ``@wa-request-close``
+ * / ``@wa-after-hide`` wiring, and a custom dialog-close X
+ * button in ``slot="header-actions"`` with a disabled-when-
+ * busy contract. This element bundles all of that into one
+ * place so consumers carry just the dialog title and body.
+ *
+ * Reactive open/close: consumers pass ``?open=${this._open}``
+ * and listen for ``@after-hide`` to clear local state. The
+ * imperative ``dialog.open = true`` pattern some legacy
+ * dialogs still use is incompatible with this wrapper —
+ * those consumers should switch to a state-driven open flag
+ * during migration.
+ *
+ * **Busy gate**. When ``?busy=true``:
+ *
+ * - ``<wa-dialog>``'s ``?light-dismiss`` is disabled, so
+ *   outside-click / Esc can't dismiss while a WS round-trip
+ *   is in flight.
+ * - The close-button is ``disabled``.
+ * - Hosts that want to *also* veto programmatic close
+ *   (``dialog.close()`` from a parent) can still listen for
+ *   ``@request-close`` and call ``e.preventDefault()`` on
+ *   their own logic.
+ *
+ * **Events re-emitted**:
+ *
+ * - ``@request-close`` mirrors ``wa-dialog``'s
+ *   ``wa-request-close`` (cancellable; ``preventDefault()``
+ *   to veto).
+ * - ``@after-hide`` mirrors ``wa-dialog``'s
+ *   ``wa-after-hide`` (fires once the dialog has fully
+ *   hidden; consumers reset local state here).
+ *
+ * **Slots**:
+ *
+ * - Default slot: dialog body. Consumers put their form
+ *   fields, error banner, and actions row inline here.
+ *   The wrapper doesn't impose a ``slot="footer"`` because
+ *   most existing dialogs render the actions row as a
+ *   plain ``<div class="actions">`` at the end of the
+ *   body, and forcing them to migrate to a slotted footer
+ *   would balloon the diff for no behaviour change.
+ */
+@customElement("esphome-base-dialog")
+export class ESPHomeBaseDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  /** Dialog title rendered in the header. Consumers pass
+   *  the already-localised string. */
+  @property() label = "";
+
+  /** Reactive open flag. Bind to your component's open
+   *  state and the dialog opens / closes accordingly. */
+  @property({ type: Boolean }) open = false;
+
+  /** When ``true``: light-dismiss is disabled and the
+   *  close-button is greyed out. Use for "WS round-trip in
+   *  flight; don't let the user orphan it". */
+  @property({ type: Boolean }) busy = false;
+
+  private _onWaRequestClose = (e: Event): void => {
+    // Re-emit as ``request-close``; preserve cancellation
+    // semantics so a host that calls preventDefault() on
+    // the re-emitted event vetoes the close on the
+    // underlying wa-dialog too.
+    const passthrough = new CustomEvent("request-close", {
+      cancelable: true,
+      bubbles: false,
+      composed: false,
+    });
+    this.dispatchEvent(passthrough);
+    if (passthrough.defaultPrevented) e.preventDefault();
+  };
+
+  private _onWaAfterHide = (): void => {
+    this.dispatchEvent(
+      new CustomEvent("after-hide", { bubbles: false, composed: false }),
+    );
+  };
+
+  private _onCloseClick = (): void => {
+    // Mirrors the explicit ``_close()`` handler every
+    // consumer used to wire. wa-dialog's after-hide fires
+    // afterwards so the host's state cleanup still runs
+    // via the @after-hide listener.
+    if (this.busy) return;
+    this.open = false;
+  };
+
+  protected render() {
+    return html`
+      <wa-dialog
+        ?open=${this.open}
+        ?light-dismiss=${!this.busy}
+        @wa-request-close=${this._onWaRequestClose}
+        @wa-after-hide=${this._onWaAfterHide}
+      >
+        <header slot="label">${this.label}</header>
+        <button
+          class="dialog-close"
+          slot="header-actions"
+          aria-label=${this._localize("layout.close")}
+          ?disabled=${this.busy}
+          @click=${this._onCloseClick}
+        >
+          ✕
+        </button>
+        <slot></slot>
+      </wa-dialog>
+    `;
+  }
+
+  static styles = [
+    dialogCloseButtonStyles,
+    css`
+      :host {
+        display: contents;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-base-dialog": ESPHomeBaseDialog;
+  }
+}

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -1,5 +1,3 @@
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
-
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
@@ -9,7 +7,6 @@ import { APIError } from "../api/api-error.js";
 import { ErrorCode, type PairingSummary } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import {
@@ -18,6 +15,8 @@ import {
   trimTrailingDot,
 } from "../util/hostname.js";
 import { renderErrorBanner } from "../util/render-error.js";
+
+import "./base-dialog.js";
 
 /**
  * Edit a paired build server's hostname / port without re-pairing.
@@ -248,26 +247,15 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
   protected render() {
     if (!this._open) return nothing;
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         ?open=${this._open}
-        ?light-dismiss=${!this._submitting}
-        @wa-request-close=${this._onRequestClose}
-        @wa-after-hide=${this._close}
+        ?busy=${this._submitting}
+        .label=${this._localize("settings.edit_pairing_endpoint_title", {
+          label: this._label,
+        })}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._close}
       >
-        <header slot="label">
-          ${this._localize("settings.edit_pairing_endpoint_title", {
-            label: this._label,
-          })}
-        </header>
-        <button
-          class="dialog-close"
-          slot="header-actions"
-          aria-label=${this._localize("layout.close")}
-          ?disabled=${this._submitting}
-          @click=${this._close}
-        >
-          ✕
-        </button>
         <p class="desc">
           ${this._localize("settings.edit_pairing_endpoint_desc")}
         </p>
@@ -324,14 +312,13 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             )}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
   static styles = [
     espHomeStyles,
     inputStyles,
-    dialogCloseButtonStyles,
     css`
       .desc {
         margin: 0 0 var(--wa-space-m);


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 from `dry_followup_plan.md`. Ten frontend
dialogs duplicate the same `<wa-dialog>` scaffolding — the
`?open` binding, the `?light-dismiss` busy-gate, the
`@wa-request-close` / `@wa-after-hide` wiring, and a custom
dialog-close X button in `slot="header-actions"` with a
disabled-when-busy contract.

This PR lands the shared wrapper + migrates one consumer
(`edit-pairing-endpoint-dialog`) to pin the contract before
the rest fan out in batched follow-ups.

## What ships

- New `<esphome-base-dialog>` in `src/components/base-dialog.ts`.

  ```html
  <esphome-base-dialog
    ?open=${this._open}
    ?busy=${this._submitting}
    .label=${title}
    @request-close=${this._onRequestClose}
    @after-hide=${this._close}
  >
    body…
  </esphome-base-dialog>
  ```

  The wrapper:

  - Forwards `?open` to `<wa-dialog>`.
  - `?busy` gates `light-dismiss` off **and** disables the
    close button so a WS round-trip in flight can't be
    orphaned by outside-click / Esc / X.
  - Re-emits `@wa-request-close` as `@request-close`
    (cancellable; `preventDefault()` vetoes the underlying
    `wa-dialog` close).
  - Re-emits `@wa-after-hide` as `@after-hide` for
    post-close cleanup.
  - Bundles `dialogCloseButtonStyles` + the custom
    `<button class="dialog-close" slot="header-actions">`
    shape every consumer was repeating.

- Migrated `edit-pairing-endpoint-dialog` as the
  contract-pin:
  - 23 lines deleted, 10 added (net −13).
  - Dropped the local `dialogCloseButtonStyles` import (now
    bundled in the base).
  - Dropped the local `<wa-dialog>` + custom close-button
    shape.
  - Renamed listener attribute names from `@wa-*` to the
    re-emitted shorter `@request-close` / `@after-hide`.
  - No behaviour change — same submitting-gate, same
    request-close veto, same after-hide cleanup.

## Why no forced footer slot?

Most existing consumers render the actions row inline as
`<div class="actions">` at the end of the body. Forcing
them to migrate to a slotted footer would balloon each
follow-up PR for no behaviour change. Default slot is the
body; consumers keep their actions row inline.

## What's NOT in this PR

- **The other nine dialogs** (`adopt-`,
  `firmware-install-`, `logs-`, `settings-`, `api-key-`,
  `install-method-`, `friendly-name-`,
  `pair-build-server-`, `archived-devices-`). Each carries
  its own variant — light-dismiss always-on vs busy-gated,
  imperative `dialog.open = true` vs reactive `?open`
  binding — so migrating them in batches of 2-3 per PR
  keeps any subtle drift visible per-batch instead of
  buried in a 10-dialog diff. Phasing per
  `dry_followup_plan.md`.
- **A unit test for `<esphome-base-dialog>` itself.**
  Component-internals aren't unit-tested in this codebase
  (the vitest config runs in `node` env without a DOM).
  The migration is verified by the type checker + the
  existing 1012 tests that exercise dialogs through their
  public surface.

## Tests

- 1012 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 from internal `dry_followup_plan.md`.
- Continues the dedupe pass that landed
  `renderInlineError` / `renderErrorBanner` in
  esphome/device-builder-frontend#279 and `seededMap` in
  esphome/device-builder-frontend#280.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migration target is exercised
through its public surface by the existing test suite.
