### PR TITLE
base-dialog: forward wa-dialog parts; migrate api-key-dialog (DRY #3 batch 2)

### DIFF
--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { mdiContentCopy, mdiEye, mdiEyeOff } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { LitElement, css, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
@@ -9,8 +9,8 @@ import { espHomeStyles } from "../styles/shared.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "content-copy": mdiContentCopy,
@@ -30,37 +30,31 @@ export class ESPHomeApiKeyDialog extends LitElement {
   @state()
   private _visible = false;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   static styles = [
     espHomeStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 480px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -123,20 +117,32 @@ export class ESPHomeApiKeyDialog extends LitElement {
   open(key: string) {
     this.apiKey = key;
     this._visible = false;
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  private _onAfterHide = (): void => {
+    // ``base-dialog`` drives close via wa-dialog's hide()
+    // path which fires wa-after-hide; flip our local open
+    // state to match so the next render's ``?open`` binding
+    // doesn't reopen the dialog.
+    this._open = false;
+  };
 
   protected render() {
     return html`
-      <wa-dialog label=${this._localize("dashboard.action_api_key_title")} light-dismiss>
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("dashboard.action_api_key_title")}
+        @after-hide=${this._onAfterHide}
+      >
         <div class="content">
           ${this.apiKey ? this._renderKey() : this._renderNoKey()}
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -6,7 +6,6 @@ import { customElement, property, query, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 
 /**
  * Thin shared wrapper around ``<wa-dialog>``.
@@ -181,10 +180,62 @@ export class ESPHomeBaseDialog extends LitElement {
   }
 
   static styles = [
-    dialogCloseButtonStyles,
     css`
       :host {
         display: contents;
+      }
+
+      /* Hide wa-dialog's built-in close button — we render
+         our own in slot="header-actions" so we can bind
+         ?disabled to busy and gate the click through the
+         same close flow as Esc / outside-click. Without
+         this rule, both buttons render side-by-side
+         (header-actions content is additive next to the
+         built-in, not a replacement). The custom button
+         picks up its own styling from the .dialog-close
+         block below; dialogCloseButtonStyles is
+         intentionally NOT bundled here because it targets
+         wa-dialog::part(close-button__base) which we just
+         hid. */
+      wa-dialog::part(close-button) {
+        display: none;
+      }
+
+      /* Custom close button styling. Mirrors the shape
+         dialogCloseButtonStyles applies to wa-dialog's
+         built-in close (40x40 hit target, tinted hover /
+         focus background, currentColor focus outline) so
+         the visual is unchanged from the pre-base-dialog
+         shape every consumer used. */
+      .dialog-close {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        width: 40px;
+        height: 40px;
+        color: var(--esphome-on-primary);
+        cursor: pointer;
+        font-size: 18px;
+      }
+
+      .dialog-close:hover:not(:disabled),
+      .dialog-close:focus-visible {
+        background: color-mix(
+          in srgb,
+          var(--esphome-on-primary),
+          transparent 85%
+        );
+      }
+
+      .dialog-close:focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: -2px;
+      }
+
+      .dialog-close:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
       }
     `,
   ];

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -80,6 +80,19 @@ import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
  *   plain ``<div class="actions">`` at the end of the
  *   body, and forcing them to migrate to a slotted footer
  *   would balloon the diff for no behaviour change.
+ *
+ * **Part forwarding**. The inner ``<wa-dialog>`` is wrapped
+ * in this element's shadow DOM, so consumer styles that
+ * targeted ``wa-dialog::part(...)`` directly won't reach
+ * through. ``exportparts="..."`` on the inner element
+ * re-exposes the parts under the same names, addressable
+ * from a migrating consumer as
+ * ``esphome-base-dialog::part(header)`` etc. The
+ * forwarded parts are the ones currently overridden across
+ * the codebase: ``dialog``, ``header``, ``title``, ``body``,
+ * ``footer``, ``close-button``, ``close-button__base``.
+ * Consumers swap ``wa-dialog::part(X)`` →
+ * ``esphome-base-dialog::part(X)`` at migration time.
  */
 @customElement("esphome-base-dialog")
 export class ESPHomeBaseDialog extends LitElement {
@@ -146,6 +159,7 @@ export class ESPHomeBaseDialog extends LitElement {
   protected render() {
     return html`
       <wa-dialog
+        exportparts="dialog,header,title,body,footer,close-button,close-button__base"
         ?open=${this.open}
         ?light-dismiss=${!this.busy}
         @wa-request-close=${this._onWaRequestClose}

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -107,8 +107,19 @@ export class ESPHomeBaseDialog extends LitElement {
 
   /** When ``true``: light-dismiss is disabled and the
    *  close-button is greyed out. Use for "WS round-trip in
-   *  flight; don't let the user orphan it". */
-  @property({ type: Boolean }) busy = false;
+   *  flight; don't let the user orphan it".
+   *
+   *  Reflected to the ``busy`` attribute so the
+   *  ``:host([busy])`` CSS selector matches regardless of
+   *  whether the host binds via boolean-attribute syntax
+   *  (``?busy=${...}``), property syntax (``.busy=${...}``),
+   *  or imperative assignment (``dialog.busy = true``).
+   *  Without ``reflect: true``, only the boolean-attribute
+   *  form would update the attribute, so property /
+   *  imperative writers would get the functional gate
+   *  (wa-request-close veto) but not the visual dim on the
+   *  close button. */
+  @property({ type: Boolean, reflect: true }) busy = false;
 
   private _onWaRequestClose = (e: Event): void => {
     // Busy gate first: refuse close regardless of source

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -1,11 +1,9 @@
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
-import { consume } from "@lit/context";
 import { LitElement, css, html } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 
-import type { LocalizeFunc } from "../common/localize.js";
-import { localizeContext } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 
 /**
  * Thin shared wrapper around ``<wa-dialog>``.
@@ -13,10 +11,10 @@ import { localizeContext } from "../context/index.js";
  * Every dialog in the app spent ~20 lines on identical
  * scaffolding — the ``?open`` binding, the
  * ``?light-dismiss`` busy-gate, the ``@wa-request-close``
- * / ``@wa-after-hide`` wiring, and a custom dialog-close X
- * button in ``slot="header-actions"`` with a disabled-when-
- * busy contract. This element bundles all of that into one
- * place so consumers carry just the dialog title and body.
+ * / ``@wa-after-hide`` wiring, and ``dialogCloseButtonStyles``
+ * to dress the built-in close button. This element bundles
+ * all of that into one place so consumers carry just the
+ * dialog title and body.
  *
  * Reactive open/close: consumers pass ``?open=${this._open}``
  * and listen for ``@after-hide`` to clear local state. The
@@ -30,13 +28,17 @@ import { localizeContext } from "../context/index.js";
  * - ``<wa-dialog>``'s ``?light-dismiss`` is disabled, so
  *   outside-click can't dismiss while a WS round-trip is
  *   in flight.
- * - The close-button is ``disabled``.
  * - The wrapper proactively ``preventDefault()``s
- *   ``wa-request-close`` so Escape / programmatic close
- *   are blocked too, even when the consumer doesn't wire
- *   their own ``@request-close`` veto handler. The busy
- *   gate is comprehensive — consumers don't have to
- *   double-cover it.
+ *   ``wa-request-close`` so Escape / X-button click /
+ *   programmatic close are all silently absorbed, even
+ *   when the consumer doesn't wire their own
+ *   ``@request-close`` veto handler. The busy gate is
+ *   comprehensive — consumers don't have to double-cover
+ *   it.
+ * - The built-in close button is visually dimmed via
+ *   ``:host([busy]) wa-dialog::part(close-button__base)``
+ *   so the silent absorption doesn't read as a broken
+ *   button.
  *
  * **Events re-emitted**:
  *
@@ -56,19 +58,19 @@ import { localizeContext } from "../context/index.js";
  * All close paths flow through ``wa-request-close`` so
  * busy gate + host veto are evaluated uniformly:
  *
- * - Escape key / outside-click → ``wa-dialog`` fires
- *   ``wa-request-close`` directly.
- * - Custom X button click → wrapper calls
- *   ``waDialog.hide()`` which fires ``wa-request-close``.
- * - Reactive ``?open`` flip → ``wa-dialog`` fires
- *   ``wa-request-close`` as part of its hide sequence.
+ * - Escape key / outside-click / built-in X button →
+ *   ``wa-dialog`` fires ``wa-request-close`` directly.
+ * - Reactive ``?open`` flip from the host → ``wa-dialog``
+ *   fires ``wa-request-close`` as part of its hide
+ *   sequence.
  *
  * The wrapper never mutates its own ``open`` property in
- * response to user actions; closing is the host's
- * responsibility via ``?open=${false}`` (typically wired
- * inside the ``@after-hide`` listener). This keeps a
- * single source of truth on the host so a re-render
- * mid-close can't reopen the dialog.
+ * response to user actions. After a non-vetoed close,
+ * wa-dialog finishes hiding and fires ``wa-after-hide``;
+ * the host's ``@after-hide`` listener is the place to
+ * flip ``_open = false`` and clear local state, which
+ * flows back through the reactive ``?open`` binding so
+ * the next render's ``?open`` matches.
  *
  * **Slots**:
  *
@@ -95,10 +97,6 @@ import { localizeContext } from "../context/index.js";
  */
 @customElement("esphome-base-dialog")
 export class ESPHomeBaseDialog extends LitElement {
-  @consume({ context: localizeContext, subscribe: true })
-  @state()
-  private _localize: LocalizeFunc = (key) => key;
-
   /** Dialog title rendered in the header. Consumers pass
    *  the already-localised string. */
   @property() label = "";
@@ -111,9 +109,6 @@ export class ESPHomeBaseDialog extends LitElement {
    *  close-button is greyed out. Use for "WS round-trip in
    *  flight; don't let the user orphan it". */
   @property({ type: Boolean }) busy = false;
-
-  @query("wa-dialog")
-  private _waDialog?: HTMLElement & { hide?: () => void };
 
   private _onWaRequestClose = (e: Event): void => {
     // Busy gate first: refuse close regardless of source
@@ -143,18 +138,6 @@ export class ESPHomeBaseDialog extends LitElement {
     );
   };
 
-  private _onCloseClick = (): void => {
-    // Drive close through wa-dialog's hide() so the entire
-    // close flow (busy gate via wa-request-close + host
-    // veto + after-hide cleanup) runs uniformly. Mutating
-    // ``this.open`` directly would (a) bypass the host's
-    // veto opportunity and (b) desync with a state-driven
-    // host whose own ``_open`` is still true — a host
-    // re-render mid-close would flip ``?open`` back to
-    // true and re-open the dialog.
-    this._waDialog?.hide?.();
-  };
-
   protected render() {
     return html`
       <wa-dialog
@@ -165,77 +148,29 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label">${this.label}</header>
-        <button
-          class="dialog-close"
-          slot="header-actions"
-          aria-label=${this._localize("layout.close")}
-          ?disabled=${this.busy}
-          @click=${this._onCloseClick}
-        >
-          ✕
-        </button>
         <slot></slot>
       </wa-dialog>
     `;
   }
 
   static styles = [
+    dialogCloseButtonStyles,
     css`
       :host {
         display: contents;
       }
 
-      /* Hide wa-dialog's built-in close button — we render
-         our own in slot="header-actions" so we can bind
-         ?disabled to busy and gate the click through the
-         same close flow as Esc / outside-click. Without
-         this rule, both buttons render side-by-side
-         (header-actions content is additive next to the
-         built-in, not a replacement). The custom button
-         picks up its own styling from the .dialog-close
-         block below; dialogCloseButtonStyles is
-         intentionally NOT bundled here because it targets
-         wa-dialog::part(close-button__base) which we just
-         hid. */
-      wa-dialog::part(close-button) {
-        display: none;
-      }
-
-      /* Custom close button styling. Mirrors the shape
-         dialogCloseButtonStyles applies to wa-dialog's
-         built-in close (40x40 hit target, tinted hover /
-         focus background, currentColor focus outline) so
-         the visual is unchanged from the pre-base-dialog
-         shape every consumer used. */
-      .dialog-close {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-        font-size: 18px;
-      }
-
-      .dialog-close:hover:not(:disabled),
-      .dialog-close:focus-visible {
-        background: color-mix(
-          in srgb,
-          var(--esphome-on-primary),
-          transparent 85%
-        );
-      }
-
-      .dialog-close:focus-visible {
-        outline: 2px solid currentColor;
-        outline-offset: -2px;
-      }
-
-      .dialog-close:disabled {
+      /* Busy visual on wa-dialog's built-in close. The
+         functional gate is the wa-request-close veto
+         above — clicking the X while busy silently
+         absorbs the event and the dialog stays open. The
+         CSS here is the user-facing cue (button looks
+         disabled) so the silent absorption doesn't read
+         as a broken button. */
+      :host([busy]) wa-dialog::part(close-button__base) {
         opacity: 0.4;
         cursor: not-allowed;
+        pointer-events: none;
       }
     `,
   ];


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 2. Two pieces:

1. **Augment `<esphome-base-dialog>` so it actually works for
   the rest of the dialogs in the codebase** — part forwarding
   (so consumer `::part(*)` rules reach through) and a
   simpler close-button architecture that doesn't render two
   X buttons in the header.

2. **Migrate `api-key-dialog`** (smallest of the nine
   remaining, 197 lines) as the next contract pin under the
   amended base-dialog.

## Why the base-dialog work was needed

PR #281 shipped a regression that wasn't caught in review:
the custom `<button class="dialog-close" slot="header-actions">`
the wrapper rendered was **additive** to wa-dialog's built-in
close button, not a replacement. Every consumer that uses
the base-dialog ended up with two X buttons in the header.
This wasn't caught in PR #281 because:

- The contract-pin (`edit-pairing-endpoint-dialog`) inherited
  the custom-button shape from its own pre-#281 markup, which
  also had two close buttons as a latent visual bug nobody had
  reported.
- The PR's testing focus was on functional behaviour (open /
  close, busy gate, request-close veto), not the side-by-side
  visual inspection that would have surfaced the duplicate.

Caught on manual UI testing of this PR; fixed in commits
`226c2fe` (initial hide-the-built-in attempt — wrong direction)
and `7f1a02e` (drop the custom button entirely, use
wa-dialog's built-in close).

## What ships

### base-dialog: forward parts + simplify close button

```html
<wa-dialog
  exportparts="dialog,header,title,body,footer,close-button,close-button__base"
  ?open=${this.open}
  ?light-dismiss=${!this.busy}
  @wa-request-close=${this._onWaRequestClose}
  @wa-after-hide=${this._onWaAfterHide}
>
  <header slot="label">${this.label}</header>
  <slot></slot>
</wa-dialog>
```

Changes from PR #281:

- **`exportparts`** re-exposes the wa-dialog parts under the
  same names so the consumer's shadow can address them via
  `esphome-base-dialog::part(X)`. The forwarded set is the
  union of parts overridden across the nine remaining dialogs
  (`header`, `title`, `body`, `footer`, `dialog`,
  `close-button`, `close-button__base`).
- **Custom close button dropped entirely.** Used wa-dialog's
  built-in close instead, styled via the existing
  `dialogCloseButtonStyles` (which the base-dialog now
  bundles). This is the established pattern in the rest of
  the codebase (`api-key-dialog`, `logs-dialog`,
  `settings-dialog`, `archived-devices-dialog`,
  `friendly-name-dialog`, `firmware-install-dialog`,
  `install-method-dialog` all use the built-in). The
  custom-button pattern was an outlier from a few dialogs
  (`edit-pairing-endpoint-dialog`, `adopt-dialog`,
  `pair-build-server-dialog`) that had been quietly shipping
  with two close buttons; this PR's fix corrects that for
  every base-dialog consumer at once.
- **Busy visual via CSS** rather than `?disabled` on a
  custom button:
  ```css
  :host([busy]) wa-dialog::part(close-button__base) {
    opacity: 0.4;
    cursor: not-allowed;
    pointer-events: none;
  }
  ```
  The functional gate stays the wa-request-close veto added
  in PR #281's Copilot fix — Esc / X / outside-click /
  programmatic close all silently absorb when busy. The CSS
  is the user-facing cue so the silent absorption doesn't
  read as a broken button.

### Migrate api-key-dialog (197 lines)

Behaviour-preserving:

- Flipped from imperative `@query` + `_dialog.open = true`
  to reactive `?open` + a state-driven `_open` flag.
  `open()` / `close()` set the flag; the `@after-hide`
  listener flips it back to match wa-dialog's hide
  sequence (so the next render's `?open` binding doesn't
  reopen).
- `<wa-dialog>` → `<esphome-base-dialog>`, dropped the
  explicit `light-dismiss` attribute (default off-when-busy
  and this dialog has no busy state, so off-when-busy
  collapses to always-on, matching the previous behaviour).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)` for
  the header / title / body / footer overrides.
- Dropped the `wa-dialog::part(close-button__base)`
  override entirely — base-dialog bundles
  `dialogCloseButtonStyles` which gives the close button
  the same 40×40 hit target + hover/focus tint every
  consumer was applying inline.
- Dropped the `@query` / `_dialog` field and the imperative
  `_dialog?.open` access path.

## Side benefit: silent fix for edit-pairing-endpoint-dialog

`edit-pairing-endpoint-dialog` (migrated in PR #281) had been
rendering two close X buttons since #281 merged. The
base-dialog fix here also restores it to one button. The
dialog itself doesn't need any changes in this PR — the fix
flows through the base.

## What's NOT in this PR

The remaining eight dialogs (`adopt-`, `firmware-install-`,
`logs-`, `settings-`, `install-method-`, `friendly-name-`,
`pair-build-server-`, `archived-devices-`) keep their
existing shape; each carries imperative open mechanics +
its own `wa-dialog::part(*)` overrides and migrates in
follow-up batches. Splitting them keeps each diff
reviewable; the `api-key-dialog` migration here pins the
recipe under the new base-dialog shape.

## Manual UI verification

Confirmed working on the dev server:

- Single X button in the header (down from two pre-fix).
- Open / close / re-open works via X click, Esc, outside-click.
- Eye toggle reveals/hides the masked key.
- Copy button toasts + copies the full key.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 2; continues
  esphome/device-builder-frontend#281's base-dialog rollout
  and fixes the two-X-button regression that shipped with it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migrations are verified by the
type checker + the existing 1017 tests that exercise
dialogs through their public surface + manual UI testing
confirming the close button works correctly.
