### PR TITLE
Migrate friendly-name-dialog + archived-devices-dialog to base-dialog (DRY #3 batch 3)

### DIFF
--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -5,7 +5,7 @@ import {
   mdiTrashCanOutline,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ArchivedDevice } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -13,8 +13,8 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "archive-arrow-up-outline": mdiArchiveArrowUpOutline,
@@ -58,14 +58,12 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   @state() private _devices: ArchivedDevice[] = [];
   @state() private _loading = false;
   @state() private _error: string | null = null;
-
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
 
   static styles = [
     espHomeStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 560px;
       }
 
@@ -75,31 +73,25 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
          itself scrolls (see the .body rule below) so the visible
          chrome (header / desc / footer) always fits in the
          remaining space. */
-      wa-dialog::part(dialog) {
+      esphome-base-dialog::part(dialog) {
         max-block-size: calc(100vh - 160px);
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0;
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -249,13 +241,20 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
 
   /** Open the dialog and (re)fetch the archive list. */
   async open() {
-    this._dialog.open = true;
+    this._open = true;
     await this.refresh();
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  private _onAfterHide = (): void => {
+    // wa-dialog finished its hide sequence (after Esc /
+    // outside-click / X). Flip our local open flag so the
+    // next render's ``?open`` binding matches.
+    this._open = false;
+  };
 
   /** Re-pull the list. Caller invokes after unarchive / delete to
    *  reflect the new state without closing the dialog. */
@@ -276,9 +275,10 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
-        label=${this._localize("dashboard.archived_dialog_title")}
-        light-dismiss
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("dashboard.archived_dialog_title")}
+        @after-hide=${this._onAfterHide}
       >
         <div class="body">
           <p class="desc">${this._localize("dashboard.archived_dialog_desc")}</p>
@@ -289,7 +289,7 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
             ${this._localize("dashboard.archived_dialog_close")}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -1,14 +1,14 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { renderInlineError } from "../util/render-error.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
+import "./base-dialog.js";
 
 /**
  * Edit-friendly-name dialog. Single input + an "Install
@@ -48,38 +48,32 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
   @state()
   private _install = true;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   static styles = [
     espHomeStyles,
     inputStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 460px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -173,12 +167,19 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     // want a YAML-only edit (offline device, batch later) can
     // toggle off — but the common case is "rename and apply."
     this._install = true;
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  private _onAfterHide = (): void => {
+    // wa-dialog finished its hide sequence (after Esc /
+    // outside-click / X). Flip our local open flag so the
+    // next render's ``?open`` binding matches.
+    this._open = false;
+  };
 
   protected render() {
     const trimmed = this._value.trim();
@@ -190,11 +191,12 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     const canSubmit = !empty && !unchanged && !err;
 
     return html`
-      <wa-dialog
-        label=${this._localize("dashboard.action_friendly_name_title", {
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("dashboard.action_friendly_name_title", {
           name: this.deviceName,
         })}
-        light-dismiss
+        @after-hide=${this._onAfterHide}
       >
         <div class="field">
           <label for="friendly-name-input"
@@ -253,7 +255,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
             ${this._localize("dashboard.action_friendly_name_confirm")}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 3. Two more dialogs migrated to
`<esphome-base-dialog>` following the recipe pinned in
esphome/device-builder-frontend#282.

## What ships

### `friendly-name-dialog` (283 → 283 lines)

- Flip from imperative `@query` + `_dialog.open = true` to
  reactive `?open` + a `_open` state flag.
- `<wa-dialog>` → `<esphome-base-dialog>`; drop the explicit
  `light-dismiss` (default off-when-busy with no busy state
  collapses to always-on, matching previous behaviour).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)` for
  header / title / body / footer.
- Drop the `wa-dialog::part(close-button__base)` override —
  base-dialog bundles `dialogCloseButtonStyles` so this is
  now styled centrally.
- Drop `@query` / `_dialog` field and the `wa-dialog`
  import (base-dialog re-exports it transitively).
- New `_onAfterHide` listener flips `_open = false` so a
  user-initiated close (Esc / X / outside-click) syncs the
  local flag with wa-dialog's hide sequence.

### `archived-devices-dialog` (366 → 367 lines)

- Same recipe as friendly-name-dialog.
- One additional `::part(dialog)` rule — the `max-block-size:
  calc(100vh - 160px)` cap that prevents long archive lists
  from covering bottom-right toasts. Migrated from
  `wa-dialog::part(dialog)` → `esphome-base-dialog::part(dialog)`.

## Still to migrate

Six dialogs left for follow-up batches: `adopt-`,
`firmware-install-`, `logs-`, `settings-`,
`install-method-`, `pair-build-server-`. The settings-dialog
is the load-bearing top-level so probably its own PR; the
others fan out in batches of 2-3.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 3; continues
  esphome/device-builder-frontend#281 +
  esphome/device-builder-frontend#282's base-dialog rollout.

## Manual UI verification

Both dialogs are reachable from the device card kebab menu
(⋮):
- **Friendly name**: ⋮ → "Edit friendly name…"
- **Archived devices**: dashboard kebab (top-right) → "Archived devices"

Verify each:
- Opens cleanly.
- One X button in the header (not two — the fix from #282
  applies transitively here too).
- Close via X / Esc / outside-click works.
- Reopen after close works.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migrations are verified by the
type checker + the existing 1017 tests that exercise
dialogs through their public surface.
