### PR TITLE
Migrate install-method and adopt dialogs to base-dialog

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { AdoptableDevice } from "../api/types.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -12,7 +12,7 @@ import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { renderInlineError } from "../util/render-error.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
+import "./base-dialog.js";
 
 @customElement("esphome-adopt-dialog")
 export class ESPHomeAdoptDialog extends LitElement {
@@ -35,39 +35,31 @@ export class ESPHomeAdoptDialog extends LitElement {
   @state() private _encryption = true;
   @state() private _busy = false;
   @state() private _error: string | null = null;
-
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
 
   static styles = [
     espHomeStyles,
     inputStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 460px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -250,37 +242,32 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._encryption = true;
     this._busy = false;
     this._error = null;
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close = () => {
     /* Arrow function so ``@click=${this.close}`` from the cancel
        button keeps ``this`` bound to the dialog. With a plain method,
        Lit hands the listener to ``addEventListener`` which calls it
-       with ``this === undefined`` (strict mode) and the
-       ``this._dialog`` access blows up. */
-    this._dialog.open = false;
+       with ``this === undefined`` (strict mode) and the property
+       access below would blow up. */
+    this._open = false;
   };
 
-  /** Block dialog dismissal while the import request is in flight,
-   *  so a stray click outside / Esc keypress can't hide an error
-   *  that's about to surface. ``light-dismiss`` is also gated on
-   *  ``!_busy`` for belt-and-suspenders, but the close-request hook
-   *  catches Esc and the close-button-base too. */
-  private _onRequestClose = (e: Event) => {
-    if (this._busy) {
-      e.preventDefault();
-    }
+  private _onAfterHide = (): void => {
+    // wa-dialog finished its hide sequence; flip our local
+    // open flag so the next render's ?open binding matches.
+    this._open = false;
   };
 
   protected render() {
-    /* Always render the wa-dialog with the same template shape, even
-       before a device is set. Returning a different template
-       (``<wa-dialog></wa-dialog>``) on the first render and then a
-       fully-populated one on the second made Lit swap the wa-dialog
-       instance — so the ``_dialog.open = true`` we set in ``open()``
-       was applied to a wa-dialog that was about to be thrown away,
-       and the user had to click Take Control twice for the dialog to
+    /* Always render the dialog with the same template shape,
+       even before a device is set. Returning a different
+       template on the first render and then a fully-populated
+       one on the second made Lit swap the element instance —
+       so the open-flag flip we set in ``open()`` was applied
+       to an element that was about to be thrown away, and the
+       user had to click Take Control twice for the dialog to
        actually appear. */
     const device = this._device;
     const nameTrimmed = this._name.trim();
@@ -289,10 +276,11 @@ export class ESPHomeAdoptDialog extends LitElement {
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
-      <wa-dialog
-        label=${this._localize("dashboard.adopt_title")}
-        ?light-dismiss=${!this._busy}
-        @wa-request-close=${this._onRequestClose}
+      <esphome-base-dialog
+        ?open=${this._open}
+        ?busy=${this._busy}
+        .label=${this._localize("dashboard.adopt_title")}
+        @after-hide=${this._onAfterHide}
       >
         ${device
           ? html`
@@ -391,7 +379,7 @@ export class ESPHomeAdoptDialog extends LitElement {
               </div>
             `
           : nothing}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -16,14 +16,13 @@ import { DeviceState } from "../api/types.js";
 import type { SerialPort } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "arrow-left": mdiArrowLeft,
@@ -115,35 +114,33 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
-    dialogCloseButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 460px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         background: var(--esphome-primary);
         padding: 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
       }
 
-      /* Close-button styling lives in
-         src/styles/dialog-close-button.ts — see the
-         dialogCloseButtonStyles import in the static-styles
-         array above. */
+      /* Close-button styling is bundled in
+         <esphome-base-dialog> via dialogCloseButtonStyles,
+         no per-dialog override needed. */
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -399,14 +396,13 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         : this._localize("dashboard.install_method_select_port");
 
     return html`
-      <wa-dialog
-        label=${label}
+      <esphome-base-dialog
+        .label=${label}
         ?open=${this.open}
-        @wa-after-hide=${this._onClose}
-        light-dismiss
+        @after-hide=${this._onClose}
       >
         ${this._view === "method" ? this._renderMethodList() : this._renderPortList()}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 4. Two more dialogs migrated to
`<esphome-base-dialog>` following the recipe pinned in
esphome/device-builder-frontend#282.

## What ships

### `install-method-dialog` (208 → 193 lines)

- `<wa-dialog>` → `<esphome-base-dialog>`; drop the direct
  `wa-dialog` import (base-dialog re-exports it transitively).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)` for
  header / title / body / footer.
- Drop the `wa-dialog::part(close-button__base)` override —
  base-dialog bundles `dialogCloseButtonStyles` so this is
  now styled centrally.
- The public `open` boolean prop already drove `?open`, so
  the reactive-binding swap is one-line.

### `adopt-dialog` (376 → 376 lines)

- Flip from imperative `@query` + `_dialog.open = true` to
  reactive `?open` + a `_open` state flag, matching the
  rest of the migrated dialogs.
- `_onRequestClose` veto handler removed: base-dialog
  already vetoes `wa-request-close` when `?busy` is set, so
  passing `?busy=${this._busy}` is enough to keep the
  dialog open during the in-flight adopt request.
- New `_onAfterHide` listener flips `_open = false` so a
  user-initiated close (Esc / X / outside-click) syncs the
  local flag with wa-dialog's hide sequence.
- All `wa-dialog::part(*)` selectors rewritten; close-button
  override dropped.

## Still to migrate

Four dialogs left for follow-up batches: `firmware-install-`,
`logs-`, `settings-`, `pair-build-server-`. The
settings-dialog is the load-bearing top-level so probably
its own PR; the others fan out in batches of 2.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 4; continues
  esphome/device-builder-frontend#283's base-dialog rollout.

## Manual UI verification

Both dialogs are reachable from the device card kebab menu (⋮):

- **Install method**: ⋮ → "Install" on a YAML-only device
  (one without a deployed binary yet)
- **Adopt**: header banner "Devices discovered" → "Take
  Control" on an unadopted device

Verify each:

- Opens cleanly.
- One X button in the header (not two — the fix from #282
  applies transitively here too).
- Close via X / Esc / outside-click works.
- Reopen after close works.
- For adopt-dialog: submitting the form keeps the dialog
  open while busy and disables outside-click / Esc close.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migrations are verified by the
type checker + the existing 1017 tests that exercise
dialogs through their public surface.
