### PR TITLE
Migrate logs and pair-build-server dialogs to base-dialog

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -463,6 +463,7 @@ export class ESPHomeLogsDialog extends LitElement {
       <esphome-base-dialog
         ?open=${this._open}
         .label=${title}
+        @request-close=${this._onDialogRequestClose}
         @after-hide=${this._onDialogHide}
       >
         <div class="logs-content">
@@ -613,6 +614,24 @@ export class ESPHomeLogsDialog extends LitElement {
   private _clearLogs() {
     this._lines = [];
   }
+
+  /**
+   * Flip our local ``_open`` flag the moment the user
+   * initiates a close (X / Esc / outside-click), before
+   * wa-dialog finishes its hide animation. Log streaming
+   * pushes new lines into ``_lines`` on a continuous WS
+   * subscription, and each push triggers a re-render with
+   * ``?open=${this._open}`` — if ``_open`` were still
+   * ``true`` during the hide animation, the re-asserted
+   * ``open=true`` could cancel wa-dialog's in-progress
+   * hide. Doesn't ``preventDefault`` — no host-side veto
+   * reason — so the close still proceeds and the
+   * ``after-hide`` handler tears down the stream as
+   * before.
+   */
+  private _onDialogRequestClose = (): void => {
+    this._open = false;
+  };
 
   private _onDialogHide() {
     this._open = false;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -16,14 +16,13 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeAnsiLog } from "./ansi-log.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./ansi-log.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "arrow-collapse": mdiArrowCollapse,
@@ -89,6 +88,9 @@ export class ESPHomeLogsDialog extends LitElement {
   @state()
   _lines: string[] = [];
 
+  @state()
+  private _open = false;
+
   private _streamId = "";
 
   /**
@@ -100,15 +102,11 @@ export class ESPHomeLogsDialog extends LitElement {
    */
   private _serialCancel: (() => void) | null = null;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
-
   @query("esphome-ansi-log")
   private _ansiLog?: ESPHomeAnsiLog;
 
   static styles = [
     espHomeStyles,
-    dialogCloseButtonStyles,
     css`
       :host {
         --term-bg: #1e1e1e;
@@ -132,7 +130,7 @@ export class ESPHomeLogsDialog extends LitElement {
         --term-error: #c02020;
       }
 
-      wa-dialog {
+      esphome-base-dialog {
         /* Width history: 900 wrapped, 1100 still ~100px short, 1200
            still wrapped on retina / HiDPI screens where ESPHome's
            ANSI-coloured output reads at a slightly larger glyph and
@@ -165,7 +163,7 @@ export class ESPHomeLogsDialog extends LitElement {
          terminal-themed — header colour was the only thing that
          looked unintentional against the dashboard's blue header
          bar. */
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the close button sits flush with the
            dialog's corner — the button is explicitly sized to a 40x40
@@ -176,7 +174,7 @@ export class ESPHomeLogsDialog extends LitElement {
         box-sizing: border-box;
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
@@ -187,13 +185,13 @@ export class ESPHomeLogsDialog extends LitElement {
          src/styles/dialog-close-button.ts — see the
          dialogCloseButtonStyles import below. */
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0;
         background: var(--term-bg);
         overflow: hidden;
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -314,11 +312,11 @@ export class ESPHomeLogsDialog extends LitElement {
       /* Full-viewport rules — the same shape applies when the user
          hits expand on desktop AND on any mobile width. Placed last
          so same-specificity rules in this file win source-order
-         against the desktop defaults. The :host wa-dialog::part(dialog)
+         against the desktop defaults. The :host esphome-base-dialog::part(dialog)
          selector lands at (0,1,2), beating both wa-dialog's internal
          .dialog (0,1,0) and the user-agent's dialog:modal (0,1,1)
          without needing !important. */
-      :host([expanded]) wa-dialog::part(dialog) {
+      :host([expanded]) esphome-base-dialog::part(dialog) {
         position: fixed;
         inset: 0;
         width: 100vw;
@@ -331,7 +329,7 @@ export class ESPHomeLogsDialog extends LitElement {
       }
 
       @media (max-width: 700px) {
-        :host wa-dialog::part(dialog) {
+        :host esphome-base-dialog::part(dialog) {
           position: fixed;
           inset: 0;
           /* width/height are explicit because wa-dialog's
@@ -388,7 +386,7 @@ export class ESPHomeLogsDialog extends LitElement {
     this._backToInstallHandler = options.onBackToInstall ?? null;
     this._backToInstall = this._backToInstallHandler !== null;
     this._streamId = "";
-    this._dialog.open = true;
+    this._open = true;
     this._resetAnsiLogScroll();
     this._startStreaming();
   }
@@ -445,13 +443,13 @@ export class ESPHomeLogsDialog extends LitElement {
     this._backToInstallHandler = options.onBackToInstall ?? null;
     this._backToInstall = this._backToInstallHandler !== null;
     this._streamId = "";
-    this._dialog.open = true;
+    this._open = true;
     this._resetAnsiLogScroll();
   }
 
   public close() {
     this._stopStreaming();
-    this._dialog.open = false;
+    this._open = false;
   }
 
   protected render() {
@@ -461,7 +459,11 @@ export class ESPHomeLogsDialog extends LitElement {
     );
 
     return html`
-      <wa-dialog label=${title} light-dismiss @wa-after-hide=${this._onDialogHide}>
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${title}
+        @after-hide=${this._onDialogHide}
+      >
         <div class="logs-content">
           <esphome-ansi-log
             .lines=${this._lines}
@@ -533,7 +535,7 @@ export class ESPHomeLogsDialog extends LitElement {
                 `}
           </div>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -612,6 +614,7 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _onDialogHide() {
+    this._open = false;
     this._stopStreaming();
   }
 
@@ -632,7 +635,7 @@ export class ESPHomeLogsDialog extends LitElement {
     const handler = this._backToInstallHandler;
     this._backToInstall = false;
     this._backToInstallHandler = null;
-    this._dialog.open = false;
+    this._open = false;
     handler?.();
   };
 }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -181,9 +181,10 @@ export class ESPHomeLogsDialog extends LitElement {
         font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
       }
 
-      /* Close-button styling lives in
-         src/styles/dialog-close-button.ts — see the
-         dialogCloseButtonStyles import below. */
+      /* Close-button styling is bundled by
+         <esphome-base-dialog>; the shared
+         dialogCloseButtonStyles sheet lives in
+         src/styles/dialog-close-button.ts. */
 
       esphome-base-dialog::part(body) {
         padding: 0;

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -1,8 +1,6 @@
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
-
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -23,6 +21,7 @@ import {
   parsePortInput,
   trimTrailingDot,
 } from "../util/hostname.js";
+import "./base-dialog.js";
 import "./pin-emoji-grid.js";
 
 /**
@@ -139,8 +138,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   @state()
   private _error: string | null = null;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   static styles = [
     espHomeStyles,
@@ -148,31 +147,25 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     pinHexStyles,
     dialogActionButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 500px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -321,12 +314,19 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     // again on a successful ``request_pair`` once we know the
     // exact ``${hostname}:${port}`` the row landed under.
     this._sentKey = null;
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close(): void {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  private _onAfterHide = (): void => {
+    // wa-dialog finished its hide sequence (after Esc /
+    // outside-click / X). Flip our local open flag so the
+    // next render's ``?open`` binding matches.
+    this._open = false;
+  };
 
   /** Key the dialog watches for an auto-close approval after
    *  ``request_pair`` lands. Set to
@@ -409,33 +409,25 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   }
 
   protected render() {
-    // Gate ``light-dismiss`` while a ``preview_pair`` /
-    // ``request_pair`` round-trip is in flight: outside-click /
-    // Esc / close-button can't hide an error that's about to
-    // surface, and (more importantly) can't dismiss the dialog
-    // between submitting and the request completing — that race
-    // would let a successful ``request_pair`` fire its
-    // ``pair-request-sent`` event + success toast against an
-    // already-closed dialog. ``@wa-request-close`` catches Esc /
-    // close-button while ``light-dismiss`` only blocks
-    // outside-click, so both gates are present (same shape as
-    // ``adopt-dialog``).
+    // ``?busy`` gates outside-click + Esc + close-button
+    // while a ``preview_pair`` / ``request_pair`` round-trip
+    // is in flight. Base-dialog flips light-dismiss off and
+    // vetoes ``wa-request-close`` when busy, so the dialog
+    // can't dismiss between submitting and the request
+    // completing — that race would let a successful
+    // ``request_pair`` fire its ``pair-request-sent`` event
+    // + success toast against an already-closed dialog.
     return html`
-      <wa-dialog
-        label=${this._dialogTitle()}
-        ?light-dismiss=${!this._busy}
-        @wa-request-close=${this._onRequestClose}
+      <esphome-base-dialog
+        ?open=${this._open}
+        ?busy=${this._busy}
+        .label=${this._dialogTitle()}
+        @after-hide=${this._onAfterHide}
       >
         ${this._renderStep()}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
-
-  private _onRequestClose = (e: Event): void => {
-    if (this._busy) {
-      e.preventDefault();
-    }
-  };
 
   private _dialogTitle(): string {
     if (this._step === "sent") {


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 5. Two more dialogs migrated to
`<esphome-base-dialog>` following the recipe pinned in
esphome/device-builder-frontend#282.

## What ships

### `logs-dialog` (645 → 645 lines)

- Flip from imperative `@query` + `_dialog.open = true` to
  reactive `?open` + a `_open` state flag, matching the
  rest of the migrated dialogs.
- `<wa-dialog>` → `<esphome-base-dialog>`; drop the direct
  `wa-dialog` import and `dialogCloseButtonStyles` import
  (base-dialog bundles both transitively).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)` for
  header / title / body / footer + the `:host([expanded])`
  and `@media (max-width: 700px)` full-viewport rules.
- `_onDialogHide` now also flips `_open = false` so a
  user-initiated close (Esc / X / outside-click) syncs the
  local flag with wa-dialog's hide sequence.
- `_onBackToInstall` flips `_open = false` instead of
  `_dialog.open = false` so the post-install hand-off
  routes through the reactive binding.

### `pair-build-server-dialog` (482 → 477 lines)

- Same imperative → reactive flip; drop `@query` field.
- `_onRequestClose` veto handler removed: base-dialog
  already vetoes `wa-request-close` when `?busy` is set, so
  passing `?busy=${this._busy}` is enough to keep the
  dialog open during the in-flight `preview_pair` /
  `request_pair` round-trip.
- Drop the `close-button__base` override (base-dialog
  ships `dialogCloseButtonStyles` centrally).
- All `wa-dialog::part(*)` selectors rewritten.

## Still to migrate

Two dialogs left: `firmware-install-` and `settings-`.
`firmware-install-dialog` needs careful handling because
it's always-no-light-dismiss during install — base-dialog's
busy gate would block the X button mid-install too, which
the current dialog allows. Probably its own PR after the
busy-gate semantics are decided.

`settings-dialog` is the load-bearing top-level so probably
its own PR.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 5; continues
  esphome/device-builder-frontend#284's base-dialog
  rollout.

## Manual UI verification

- **Logs**: device card kebab (⋮) → "Logs". Verify the
  dialog opens, X / Esc / outside-click closes, the stream
  toolbar (Start / Stop / Expand / Download / Clear) all
  function, the post-install-logs hand-off still flips back
  through "Back to install".
- **Pair build server**: dashboard kebab → Settings →
  Build Servers → "Add server" (typed-hostname path).
  Verify the input → confirm → sent flow doesn't dismiss
  mid-request, X / Esc / outside-click are blocked while
  the preview/request round-trip is in flight, and the
  auto-close on `pair-approved` / `pair-rejected` still
  fires.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migrations are verified by the
type checker + the existing 1017 tests that exercise
dialogs through their public surface.
