### PR TITLE
Migrate settings-dialog to base-dialog

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -411,13 +411,30 @@ export class ESPHomeSettingsDialog extends LitElement {
   }
 
   close() {
-    // ``wa-dialog`` fires ``wa-after-hide`` for every dismissal
-    // path (close button, Esc, light-dismiss outside-click), so
-    // the cleanup lives in ``_onDialogAfterHide`` to make sure
-    // it runs regardless of how the dialog closed. Programmatic
-    // close still flows through here.
+    // ``<esphome-base-dialog>`` re-emits ``after-hide`` for
+    // every dismissal path (close button, Esc, light-dismiss
+    // outside-click), so the cleanup lives in
+    // ``_onDialogAfterHide`` to make sure it runs regardless
+    // of how the dialog closed. Programmatic close still
+    // flows through here.
     this._open = false;
   }
+
+  /**
+   * Flip our local ``_open`` flag the moment the user
+   * initiates a close (X / Esc / outside-click), before
+   * wa-dialog finishes its hide animation. Without this,
+   * the 1Hz ``_pairingTick`` interval can fire a re-render
+   * mid-hide while ``_open`` is still ``true``, which
+   * re-asserts ``?open=true`` on the inner wa-dialog and
+   * cancels the in-progress hide. Doesn't ``preventDefault``
+   * — we don't have a host-side veto reason — so the close
+   * still proceeds and ``_onDialogAfterHide`` fires for the
+   * server-side window cleanup.
+   */
+  private _onDialogRequestClose = (): void => {
+    this._open = false;
+  };
 
   disconnectedCallback() {
     // Drop any in-flight tick interval so a remove-from-DOM (HMR,
@@ -1755,6 +1772,7 @@ export class ESPHomeSettingsDialog extends LitElement {
       <esphome-base-dialog
         ?open=${this._open}
         .label="${this._localize("settings.title")} - ${this._localize(current.labelKey)}"
+        @request-close=${this._onDialogRequestClose}
         @after-hide=${this._onDialogAfterHide}
       >
         <div class="layout">

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -43,7 +43,6 @@ import {
 } from "../context/index.js";
 import type { RemoteBuildJobState } from "../context/index.js";
 import { warningBannerStyles } from "../styles/banners.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { formatPinSha256 } from "../util/cert-pin-format.js";
@@ -68,10 +67,10 @@ import type { ESPHomePairBuildServerDialog } from "./pair-build-server-dialog.js
 import type { ESPHomeReauthWizardDialog } from "./reauth-wizard-dialog.js";
 import type { ESPHomeRemoteBuildJobDialog } from "./remote-build-job-dialog.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/option/option.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   close: mdiClose,
@@ -380,8 +379,8 @@ export class ESPHomeSettingsDialog extends LitElement {
   @state()
   private _language: LanguageChoice = readStoredLocale() ?? "system";
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   open() {
     this._theme = localStorage.getItem("esphome-theme") ?? "system";
@@ -408,7 +407,7 @@ export class ESPHomeSettingsDialog extends LitElement {
     // does need clearing — a stale value would mis-target the
     // confirm dialog on the next visit.
     this._pendingPeerRemove = null;
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close() {
@@ -417,7 +416,7 @@ export class ESPHomeSettingsDialog extends LitElement {
     // the cleanup lives in ``_onDialogAfterHide`` to make sure
     // it runs regardless of how the dialog closed. Programmatic
     // close still flows through here.
-    this._dialog.open = false;
+    this._open = false;
   }
 
   disconnectedCallback() {
@@ -440,6 +439,10 @@ export class ESPHomeSettingsDialog extends LitElement {
    * receiver's idle timer is the safety net.
    */
   private _onDialogAfterHide = () => {
+    // wa-dialog finished its hide sequence (after Esc /
+    // outside-click / X). Flip our local open flag so the
+    // next render's ``?open`` binding matches.
+    this._open = false;
     this._stopPairingTick();
     if (this._section === "pairing_requests" && this._api !== undefined) {
       void this._api
@@ -507,7 +510,7 @@ export class ESPHomeSettingsDialog extends LitElement {
         state?.open &&
         state.expires_in_seconds !== null &&
         this._section === "pairing_requests" &&
-        this._dialog?.open
+        this._open
       ) {
         this._pairingBaselineSeconds = state.expires_in_seconds;
         this._pairingAnchorMs = Date.now();
@@ -953,14 +956,13 @@ export class ESPHomeSettingsDialog extends LitElement {
   static styles = [
     espHomeStyles,
     warningBannerStyles,
-    dialogCloseButtonStyles,
     pinHexStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: min(800px, 95vw);
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the 40x40 close button (sized via
            dialogCloseButtonStyles) sits flush with the dialog's
@@ -970,17 +972,17 @@ export class ESPHomeSettingsDialog extends LitElement {
         box-sizing: border-box;
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0;
       }
 
@@ -1750,10 +1752,10 @@ export class ESPHomeSettingsDialog extends LitElement {
     const current = SECTIONS.find((s) => s.id === this._section) ?? SECTIONS[0];
 
     return html`
-      <wa-dialog
-        light-dismiss
-        label="${this._localize("settings.title")} - ${this._localize(current.labelKey)}"
-        @wa-after-hide=${this._onDialogAfterHide}
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label="${this._localize("settings.title")} - ${this._localize(current.labelKey)}"
+        @after-hide=${this._onDialogAfterHide}
       >
         <div class="layout">
           <aside class="sidebar">
@@ -1775,7 +1777,7 @@ export class ESPHomeSettingsDialog extends LitElement {
             <div class="content-body">${this._renderSection()}</div>
           </main>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 6. The load-bearing top-level
settings dialog migrated to `<esphome-base-dialog>`
following the recipe pinned in
esphome/device-builder-frontend#282.

## What ships

### `settings-dialog` (2308 → 2310 lines)

- Flip from imperative `@query` + `_dialog.open = true` to
  reactive `?open` + a `_open` state flag, matching the
  rest of the migrated dialogs.
- `<wa-dialog>` → `<esphome-base-dialog>`; drop the direct
  `wa-dialog` import and `dialogCloseButtonStyles` import
  (base-dialog bundles both transitively).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)` for
  header / title / body / footer.
- `_onDialogAfterHide` now also flips `_open = false` so a
  user-initiated close (Esc / X / outside-click) syncs the
  local flag with wa-dialog's hide sequence.
- The `willUpdate` pairing-tick gate that checked
  `this._dialog?.open` now checks `this._open` directly —
  same signal (is the dialog visible), one fewer DOM hop.

## Why the migration is keyhole here

Settings is the dialog with the most cross-tab listeners
and context-driven state in the codebase: receiver identity
rotation, build-host discovery, pairing requests inbox with
a live countdown, peer list with confirm-modal flows, etc.
The migration touches the dialog *element* and its
open/close hooks only — the rotate / remove confirm flows,
the pairing-requests tick, and every per-section render
path are unchanged. The `@query` references for the child
dialogs (rotate-confirm, peer-remove-confirm, accept-peer,
pair-build-server, reauth-wizard, edit-pairing-endpoint,
remote-build-job, unpair-confirm) all stay on `@query`
since they're not wa-dialog elements being controlled
directly.

## Still to migrate

`firmware-install-dialog` is the last one. It needs careful
handling because it's always-no-light-dismiss during
install — base-dialog's busy gate would block the X button
mid-install too, which the current dialog allows. Probably
its own PR after the busy-gate semantics are decided.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 6; continues
  esphome/device-builder-frontend#285's base-dialog
  rollout.

## Manual UI verification

- **Settings → Appearance**: dashboard top-right kebab →
  Settings. Verify the dialog opens, X / Esc /
  outside-click closes, theme + language pickers function.
- **Settings → Build server**: switch to Build server tab.
  Verify identity card loads, Rotate confirm modal opens
  on top of settings and dismisses cleanly back to
  settings.
- **Settings → Pairing requests**: switch to Pairing
  requests tab. Verify the window-open toggle works, the
  countdown tick runs while the dialog is open, and the
  receiver's `setRemoteBuildPairingWindow({open: false})`
  hook fires on close (network tab).
- **Cross-tab**: open settings in two tabs. Rotate from
  tab A. Verify tab B's identity card refreshes when on
  the Build server section, and lazy-reloads on entry
  otherwise.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migration is verified by the
type checker + the existing 1017 tests that exercise the
dialog through its public surface.
