### PR TITLE
Migrate firmware-install-dialog to base-dialog

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -255,10 +255,17 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
       esphome-base-dialog {
         --width: 520px;
-        transition: width 0.2s;
       }
       :host([expanded]) esphome-base-dialog {
         --width: min(900px, 90vw);
+      }
+
+      /* Animate the dialog's width when the user toggles the
+         expand button. Lives on ::part(dialog) (the inner
+         wa-dialog box) because esphome-base-dialog itself is
+         display: contents and has no layout box to transition. */
+      esphome-base-dialog::part(dialog) {
+        transition: width 0.2s;
       }
 
       esphome-base-dialog::part(header) {

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -10,13 +10,12 @@ import {
   mdiConsole,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { JobStatus } from "../api/types.js";
 import type { ConfiguredDevice } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { chipNameToVariant } from "../util/chip-variant.js";
 import { downloadBase64Binary } from "../util/download-text.js";
@@ -31,10 +30,10 @@ import {
   type DetectedChip,
 } from "../util/web-serial.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "./ansi-log.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "alert-circle": mdiAlertCircle,
@@ -123,9 +122,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   private _compileReject: ((err: Error) => void) | null = null;
   private _detected: DetectedChip | null = null;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
-
   // ─── Public API ────────────────────────────────────────
 
   /**
@@ -139,7 +135,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._installer = "web-serial";
     this._step = "connecting";
     this._statusMessage = this._localize("firmware.status_connecting");
-    this._dialog.open = true;
     this._startWebSerialInstall();
   }
 
@@ -155,7 +150,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._installer = "web-download";
     this._step = "queued";
     this._statusMessage = this._localize("firmware.status_queued");
-    this._dialog.open = true;
     this._startDownload();
   }
 
@@ -170,7 +164,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._installer = "binary-download";
     this._step = "queued";
     this._statusMessage = this._localize("firmware.status_queued");
-    this._dialog.open = true;
     this._startDownload();
   }
 
@@ -182,7 +175,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
    * preserved across the flip.
    */
   public reopen() {
-    this._dialog.open = true;
+    this._open = true;
   }
 
   private _init(device: ConfiguredDevice) {
@@ -244,7 +237,6 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
-    dialogCloseButtonStyles,
     css`
       :host {
         --term-bg: #1e1e1e;
@@ -261,33 +253,34 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         --term-error: #c72e2e;
       }
 
-      wa-dialog {
+      esphome-base-dialog {
         --width: 520px;
         transition: width 0.2s;
       }
-      :host([expanded]) wa-dialog {
+      :host([expanded]) esphome-base-dialog {
         --width: min(900px, 90vw);
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         background: var(--esphome-primary);
         padding: 0 var(--wa-space-m);
         height: 40px;
         box-sizing: border-box;
       }
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
       }
       /* Close-button styling lives in
-         src/styles/dialog-close-button.ts — see the
-         dialogCloseButtonStyles import below. */
+         src/styles/dialog-close-button.ts — base-dialog bundles
+         dialogCloseButtonStyles so the X-button sizing /
+         positioning is consistent across migrated dialogs. */
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);
       }
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -500,10 +493,14 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog label=${this._title} ?open=${this._open} @wa-after-hide=${this._onClose}>
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._title}
+        @after-hide=${this._onClose}
+      >
         ${this._renderStatus()} ${this._renderProgress()} ${this._renderLogs()}
         ${this._renderFooter()}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -942,7 +939,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       webSerialPort,
       reopenInstall: () => this.reopen(),
     });
-    if (handled) this._dialog.open = false;
+    if (handled) this._open = false;
   }
 
   // ─── Download flows (compile + save binary) ────────────────────


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up #3 batch 7 (final). The last dialog migrated
to `<esphome-base-dialog>`, completing the base-dialog
rollout started in esphome/device-builder-frontend#281.

## What ships

### `firmware-install-dialog` (1108 → 1105 lines)

- Flip from imperative `@query` + `_dialog.open = true` to
  reactive `?open` + the existing `_open` state flag.
- `<wa-dialog>` → `<esphome-base-dialog>`; drop the direct
  `wa-dialog` import and `dialogCloseButtonStyles` import
  (base-dialog bundles both transitively).
- `wa-dialog::part(*)` → `esphome-base-dialog::part(*)`
  for header / title / body / footer + the
  `:host([expanded])` width rule.
- Drop the redundant `_dialog.open = true` calls in
  `installWebSerial` / `installWebDownload` /
  `installBinaryDownload` — `_init` already sets
  `_open = true`, so the imperative trailer was a no-op
  once the reactive binding is in place.
- `reopen()` and `_flipToLogs` now flip `_open` directly
  instead of going through the `@query` handle. Same
  signal, one fewer DOM hop.

## Behaviour delta

Light-dismiss flips on by default (base-dialog's default;
the original dialog had light-dismiss off entirely).
Outside-click during install now closes the dialog via the
same `@after-hide` path that X / Esc already used — same
teardown (`_onClose` detaches the follow-job stream and
cancels the backend job).

Not using base-dialog's busy gate because it would also
block X / Esc, which the original dialog always allowed —
the busy gate is comprehensive (vetoes
`wa-request-close` on every close path), so it can't be
used as a light-dismiss-only switch. The Cancel button in
the footer remains the explicit cancel path; the outside-
click path is a soft duplicate that does the same teardown.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

## Done with the rollout

After this lands, every wa-dialog consumer in the codebase
goes through `<esphome-base-dialog>` and the ~20 lines of
scaffolding per dialog (the `?open` binding, the
`?light-dismiss` busy-gate, the `@wa-request-close` /
`@wa-after-hide` wiring, the close-button styling) are
all centralised in one place.

**Related issue or feature (if applicable):**

- DRY follow-up #3 batch 7; finishes the rollout started
  in esphome/device-builder-frontend#281.

## Manual UI verification

Three entry points on the install method picker (device
card kebab (⋮) → "Install"):

- **Web Serial install**: chip detect → compile → flash
  flow. Verify the dialog opens, the compile log expands
  on demand, the Cancel button cancels mid-compile, X /
  Esc / outside-click all close + tear down.
- **Web download**: server compile → binary download flow.
  Verify the success terminal shows the web.esphome.io
  steps and the dialog can dismiss cleanly.
- **Binary download**: server compile → raw binary save
  flow. Verify the success terminal shows the filename
  and Close button works.

For the Web Serial path: after a successful install,
verify the auto-flip to `logs-dialog` still fires
(toggle is on by default), and that "Back to install"
from the logs dialog brings the install dialog back with
the preserved log buffer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the migration is verified by the
type checker + the existing 1017 tests that exercise the
dialog through its public surface.
