### PR TITLE
Forward --width through base-dialog so consumers' widths win

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -169,6 +169,32 @@ export class ESPHomeBaseDialog extends LitElement {
     css`
       :host {
         display: contents;
+
+        /* Alias the consumer-set --width into a wrapper-
+           private name. wa-dialog declares
+           :host { --width: 31rem } in its own shadow
+           root, and a property's :host declaration beats
+           inherited values from outside the shadow tree
+           per the CSS Scoping spec — so a consumer's
+           --width on this wrapper would be silently
+           clobbered by wa-dialog's default and the
+           dialog would always render at 31rem regardless
+           of what the consumer asked for. Forwarding via
+           an internal name + an external selector on the
+           inner wa-dialog (below) is the only CSS-only
+           way to make the consumer's --width win the
+           cascade race. */
+        --base-dialog-width: var(--width, 31rem);
+      }
+
+      /* External author rule from the wrapper's shadow
+         root targeting the inner wa-dialog. External
+         declarations beat the inner shadow root's :host
+         default, so this is where the consumer's
+         --width finally lands as wa-dialog's effective
+         width. */
+      wa-dialog {
+        --width: var(--base-dialog-width);
       }
 
       /* Busy visual on wa-dialog's built-in close. The


### PR DESCRIPTION
# What does this implement/fix?

Hotfix for `<esphome-base-dialog>`'s `--width`
forwarding. Every migrated dialog set `--width` on the
wrapper expecting it to size the inner `<wa-dialog>`; in
practice the value was silently dropped and every dialog
rendered at wa-dialog's 31rem default.

## How the breakage surfaced

The settings dialog (esphome/device-builder-frontend#286
- still open) made it visible — it asks for
`min(800px, 95vw)` and rendered at ~496px (31rem)
instead. With the right pane squeezed to ~80px after the
220px sidebar, the description text wrapped per-word and
`<wa-select>` floated awkwardly to the right. Screenshot
in the upstream comment thread.

The smaller dialogs (api-key 480px, adopt 460px,
friendly-name 460px, install-method 460px) silently
rendered at ~496px too — slightly wider than asked, but
not visually broken, so the bug went unnoticed through
the entire batch rollout.

## Root cause

- `wa-dialog` declares `:host { --width: 31rem }` in its
  own shadow root and reads `width: var(--width)` on
  `.dialog`.
- A consumer-set rule
  `esphome-base-dialog { --width: ...; }` sets `--width`
  on the wrapper. Custom properties inherit across
  shadow boundaries, so `--width` is visible to
  wa-dialog (which sits in the wrapper's shadow root).
- Per the CSS Scoping spec, an element's `:host`
  declaration beats values **inherited** from outside
  the shadow tree for the same property. wa-dialog's
  `:host { --width: 31rem }` always won and the
  consumer's inherited value never reached
  `width: var(--width)`.

## Fix

- `:host` on the wrapper aliases the consumer-set
  `--width` into a private `--base-dialog-width`.
- An external author rule from the wrapper's shadow
  root, targeting the inner `wa-dialog`, re-asserts
  `--width` from `--base-dialog-width`. External
  declarations beat the inner shadow root's `:host`
  default, so the consumer's `--width` finally wins the
  cascade race.
- `var(--width, 31rem)` fallback preserves wa-dialog's
  default for consumers that don't override width.

The alias indirection is necessary: a direct
`wa-dialog { --width: var(--width); }` would be a
self-referencing cycle on the same property name (the
`var()` would read the property being computed) and
resolve to invalid per the CSS Custom Properties spec.

## Effect

- `settings-dialog` finally renders at
  `min(800px, 95vw)`.
- `api-key`/`adopt`/`friendly-name`/`install-method`
  render at their actually-requested narrower widths.
- `archived-devices`/`firmware-install` (560/520) widen
  to the asked-for size.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

Component-internals aren't unit-tested in this codebase
(no DOM env in vitest); the fix is verified by the type
checker + visual inspection of every migrated dialog.

**Related issue or feature (if applicable):**

- Latent bug in
  esphome/device-builder-frontend#281's base-dialog
  rollout; surfaces visibly on
  esphome/device-builder-frontend#286.

## Manual UI verification

Open every migrated dialog and confirm widths now match
their declared `--width`:

- `api-key-dialog` (device card kebab → "API key…") — 480px.
- `friendly-name-dialog` (device card kebab → "Edit friendly name…") — 460px.
- `archived-devices-dialog` (dashboard kebab → "Archived devices") — 560px.
- `install-method-dialog` (device card → "Install" on YAML-only device) — 460px.
- `adopt-dialog` (header banner → "Take Control") — 460px.
- `edit-pairing-endpoint-dialog` (settings → Build server → "Edit endpoint…") — its declared width.
- `settings-dialog` (dashboard top-right kebab → Settings) —
  `min(800px, 95vw)`. Content layout should now read with
  the description wrapping at a comfortable column width
  and the dropdown / toggle sitting cleanly on the right.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
