### PR TITLE
Tighten _onAfterHide comments across migrated dialogs

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -255,8 +255,10 @@ export class ESPHomeAdoptDialog extends LitElement {
   };
 
   private _onAfterHide = (): void => {
-    // wa-dialog finished its hide sequence; flip our local
-    // open flag so the next render's ?open binding matches.
+    // <esphome-base-dialog> re-emits after-hide for every
+    // dismissal path (Esc / outside-click / X / reactive
+    // ?open flip). Flip our local open flag so the next
+    // render's ?open binding matches.
     this._open = false;
   };
 

--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -125,10 +125,12 @@ export class ESPHomeApiKeyDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // ``base-dialog`` drives close via wa-dialog's hide()
-    // path which fires wa-after-hide; flip our local open
-    // state to match so the next render's ``?open`` binding
-    // doesn't reopen the dialog.
+    // ``<esphome-base-dialog>`` re-emits ``after-hide``
+    // after the inner wa-dialog finishes its hide
+    // animation (Esc / outside-click / X / reactive
+    // ``?open`` flip all route here). Flip our local
+    // open flag so the next render's ``?open`` binding
+    // matches and the dialog stays closed.
     this._open = false;
   };
 

--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -125,12 +125,10 @@ export class ESPHomeApiKeyDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // ``<esphome-base-dialog>`` re-emits ``after-hide``
-    // after the inner wa-dialog finishes its hide
-    // animation (Esc / outside-click / X / reactive
-    // ``?open`` flip all route here). Flip our local
-    // open flag so the next render's ``?open`` binding
-    // matches and the dialog stays closed.
+    // <esphome-base-dialog> re-emits after-hide for every
+    // dismissal path (Esc / outside-click / X / reactive
+    // ?open flip). Flip our local open flag so the next
+    // render's ?open binding matches.
     this._open = false;
   };
 

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -250,11 +250,10 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // ``<esphome-base-dialog>`` re-emits ``after-hide``
-    // for every dismissal path (Esc / outside-click / X
-    // / reactive ``?open`` flip). Flip our local open
-    // flag so the next render's ``?open`` binding
-    // matches.
+    // <esphome-base-dialog> re-emits after-hide for every
+    // dismissal path (Esc / outside-click / X / reactive
+    // ?open flip). Flip our local open flag so the next
+    // render's ?open binding matches.
     this._open = false;
   };
 

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -250,9 +250,11 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // wa-dialog finished its hide sequence (after Esc /
-    // outside-click / X). Flip our local open flag so the
-    // next render's ``?open`` binding matches.
+    // ``<esphome-base-dialog>`` re-emits ``after-hide``
+    // for every dismissal path (Esc / outside-click / X
+    // / reactive ``?open`` flip). Flip our local open
+    // flag so the next render's ``?open`` binding
+    // matches.
     this._open = false;
   };
 

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -175,9 +175,11 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // wa-dialog finished its hide sequence (after Esc /
-    // outside-click / X). Flip our local open flag so the
-    // next render's ``?open`` binding matches.
+    // ``<esphome-base-dialog>`` re-emits ``after-hide``
+    // for every dismissal path (Esc / outside-click / X
+    // / reactive ``?open`` flip). Flip our local open
+    // flag so the next render's ``?open`` binding
+    // matches.
     this._open = false;
   };
 

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -175,11 +175,10 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
   }
 
   private _onAfterHide = (): void => {
-    // ``<esphome-base-dialog>`` re-emits ``after-hide``
-    // for every dismissal path (Esc / outside-click / X
-    // / reactive ``?open`` flip). Flip our local open
-    // flag so the next render's ``?open`` binding
-    // matches.
+    // <esphome-base-dialog> re-emits after-hide for every
+    // dismissal path (Esc / outside-click / X / reactive
+    // ?open flip). Flip our local open flag so the next
+    // render's ?open binding matches.
     this._open = false;
   };
 


### PR DESCRIPTION
# What does this implement/fix?

Audit follow-up after Copilot's
esphome/device-builder-frontend#286 nit about a similar
stale comment in `settings-dialog.ts`. Four merged
dialogs carried `_onAfterHide` comments that described
the underlying `<wa-dialog>` directly without
acknowledging the `<esphome-base-dialog>` re-emit hop.

## What's wrong

`api-key-dialog.ts` was the worst offender:

```ts
// ``base-dialog`` drives close via wa-dialog's hide()
// path which fires wa-after-hide; flip our local open
// state to match so the next render's ``?open`` binding
// doesn't reopen the dialog.
```

`base-dialog` does **not** call `hide()` — it uses the
reactive `?open` binding. The comment was actively
misleading.

`friendly-name-dialog.ts`, `archived-devices-dialog.ts`,
and `adopt-dialog.ts` all said:

```ts
// wa-dialog finished its hide sequence (after Esc /
// outside-click / X). Flip our local open flag so the
// next render's ``?open`` binding matches.
```

Technically accurate (the inner wa-dialog *does* finish
hiding before the listener fires), but doesn't mention
the wrapper layer the listener is actually attached to.

## Fix

Normalised the four comments to the same wording:

```ts
// ``<esphome-base-dialog>`` re-emits ``after-hide`` for
// every dismissal path (Esc / outside-click / X /
// reactive ``?open`` flip). Flip our local open flag
// so the next render's ``?open`` binding matches.
```

Same effective contract, accurate name for the layer the
listener attaches to, matches the wording already in
settings-dialog after #286's fix.

## Why now

Spot audit prompted by Copilot's feedback on
esphome/device-builder-frontend#286: do the other
already-merged dialogs in the base-dialog rollout carry
the same staleness shape? Three other classes of issue
Copilot flagged on the recent batches don't apply to the
merged dialogs:

- **Race during hide** (#285 / #286): needs a continuous
  re-render source (1Hz tick, log stream). None of the
  audited dialogs have that.
- **No-op `transition` under `display: contents`**
  (#287): no merged dialog has
  `esphome-base-dialog { transition: ... }`.
- **`--width` clobber**: already fixed centrally in
  esphome/device-builder-frontend#288.

So this cleanup is the only loose thread left from the
rollout.

## Tests

- 1017 frontend tests pass (no regression).
- `npm run lint` clean.

Pure comment cleanup; no runtime behaviour change.

**Related issue or feature (if applicable):**

- Audit follow-up after
  esphome/device-builder-frontend#286.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
