### PR TITLE
Surface ESPHome version mismatch on paired-build-server rows (7b)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1450,6 +1450,20 @@ export interface PairingSummary {
    * subscribe after an in-flight failure.
    */
   last_connect_error: string;
+  /**
+   * Receiver-advertised `esphome.const.__version__` captured
+   * at handshake time and refreshed on every peer-link
+   * session-open. Empty string before the first successful
+   * handshake (PENDING row, or APPROVED row that has never
+   * connected). Used by Settings → Build server → paired
+   * build servers to surface a per-row version-mismatch
+   * sub-line ahead of the scheduler's
+   * allow-major-version-mismatch toggle landing in 7a-3 +
+   * 7b. Both sides are wire-typed `string`; comparison is
+   * structural (year+month vs patch) per
+   * `util/version-mismatch.ts`.
+   */
+  esphome_version: string;
 }
 
 /**

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -39,6 +39,7 @@ import {
   buildServerPeersContext,
   localizeContext,
   remoteBuildEnabledContext,
+  versionContext,
   yamlDiffButtonContext,
 } from "../context/index.js";
 import type { RemoteBuildJobState } from "../context/index.js";
@@ -53,6 +54,7 @@ import {
 } from "../util/hostname.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { remainingOf } from "../util/relative-time.js";
+import { classifyVersionMismatch } from "../util/version-mismatch.js";
 import "./accept-peer-dialog.js";
 import type { ESPHomeAcceptPeerDialog } from "./accept-peer-dialog.js";
 import "./confirm-dialog.js";
@@ -186,6 +188,20 @@ export class ESPHomeSettingsDialog extends LitElement {
   @consume({ context: remoteBuildEnabledContext, subscribe: true })
   @state()
   private _remoteBuildEnabled = false;
+
+  // Local dashboard's bundled ESPHome version. Compared
+  // against each paired build server's
+  // ``PairingSummary.esphome_version`` to drive the
+  // per-row mismatch sub-line in the paired-build-servers
+  // list. App-shell publishes this via ``versionContext``
+  // once the ServerInfo handshake completes; subscribers
+  // also pick up the value if it changes (rotate / restart
+  // path through the same context). Empty string before
+  // ServerInfo lands — the helper treats empty as "unknown,
+  // don't surface a mismatch."
+  @consume({ context: versionContext, subscribe: true })
+  @state()
+  private _appVersion = "";
 
   @consume({
     context: buildServerIdentityRotationCounterContext,
@@ -1521,6 +1537,26 @@ export class ESPHomeSettingsDialog extends LitElement {
         word-break: break-word;
       }
 
+      /* Sub-line under any APPROVED row whose receiver
+         reports a different esphome_version than the
+         offloader's bundled version. Two shades: --patch
+         is informational (same year+month, just a
+         different patch / dev / beta build) and inherits
+         the quiet row-desc colour; --release is
+         cautionary (different year+month; YAMLs may not
+         compile cleanly across the gap) and uses the
+         warning palette to draw the eye. Once 7b's
+         allow-major-version-mismatch toggle and 7a's
+         scheduler land, the --release case becomes the
+         signal the operator has to explicitly accept; the
+         banner here is the visible cue ahead of that. */
+      .pairing-version-mismatch {
+        word-break: break-word;
+      }
+      .pairing-version-mismatch--release {
+        color: var(--esphome-warning, #f59e0b);
+      }
+
       .pairing-status-pending {
         background: color-mix(
           in srgb,
@@ -2565,6 +2601,7 @@ export class ESPHomeSettingsDialog extends LitElement {
                 </span>
               `
             : nothing}
+          ${this._renderPairingVersionMismatch(pairing)}
         </div>
         ${pairing.status === "approved" && pairing.connected
           ? html`
@@ -2627,6 +2664,47 @@ export class ESPHomeSettingsDialog extends LitElement {
    *  peer-link is currently up; surfacing the last output of
    *  a build that finished before disconnect is the whole
    *  point of the deferred-dismiss behaviour. */
+  /** Per-row sub-line surfacing an esphome_version mismatch
+   *  between the offloader's bundled version and the
+   *  paired receiver's reported version. Helps the operator
+   *  spot the case the dispatched compile will run against
+   *  a different schema than the YAML was authored on —
+   *  especially the cross-release (year+month) gap, which
+   *  is what the future scheduler's
+   *  allow-major-version-mismatch toggle will key on (7a-3
+   *  + 7b). PENDING rows skip the line: the handshake-time
+   *  ``esphome_version`` capture only happens once the
+   *  receiver has accepted the pair, so PENDING rows always
+   *  carry an empty value the helper classifies as
+   *  unknown. Connection-state (connected / connecting /
+   *  disconnected) doesn't gate this — a long-disconnected
+   *  pairing still carries the version we captured at the
+   *  last handshake, and that version mismatch is still the
+   *  right thing to surface ahead of the next reconnect. */
+  private _renderPairingVersionMismatch(pairing: PairingSummary) {
+    if (pairing.status !== "approved") return nothing;
+    const kind = classifyVersionMismatch(
+      this._appVersion,
+      pairing.esphome_version,
+    );
+    if (kind === null) return nothing;
+    const key =
+      kind === "release"
+        ? "settings.build_offload_pairing_version_mismatch_release"
+        : "settings.build_offload_pairing_version_mismatch_patch";
+    return html`
+      <span
+        class=${`row-desc pairing-version-mismatch pairing-version-mismatch--${kind}`}
+        role="status"
+      >
+        ${this._localize(key, {
+          peer: pairing.esphome_version,
+          local: this._appVersion,
+        })}
+      </span>
+    `;
+  }
+
   private _renderViewRemoteBuildButton(pairing: PairingSummary) {
     const job = this._latestRemoteBuildJobForPin(pairing.pin_sha256);
     if (job === undefined) return nothing;

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -2652,18 +2652,6 @@ export class ESPHomeSettingsDialog extends LitElement {
     `;
   }
 
-  /** Render the "View build" affordance for a pairing row when
-   *  the in-flight remote-build jobs map carries an entry for
-   *  the row's pin. The dispatch dialog's openForJob() lands
-   *  directly on the running view so the user can re-attach
-   *  to a build they previously closed the dialog on (or see
-   *  the last terminal result before the user dismisses it).
-   *
-   *  Pairing-disconnected rows still get this button: the
-   *  job state lives client-side regardless of whether the
-   *  peer-link is currently up; surfacing the last output of
-   *  a build that finished before disconnect is the whole
-   *  point of the deferred-dismiss behaviour. */
   /** Per-row sub-line surfacing an esphome_version mismatch
    *  between the offloader's bundled version and the
    *  paired receiver's reported version. Helps the operator
@@ -2705,6 +2693,18 @@ export class ESPHomeSettingsDialog extends LitElement {
     `;
   }
 
+  /** Render the "View build" affordance for a pairing row when
+   *  the in-flight remote-build jobs map carries an entry for
+   *  the row's pin. The dispatch dialog's openForJob() lands
+   *  directly on the running view so the user can re-attach
+   *  to a build they previously closed the dialog on (or see
+   *  the last terminal result before the user dismisses it).
+   *
+   *  Pairing-disconnected rows still get this button: the
+   *  job state lives client-side regardless of whether the
+   *  peer-link is currently up; surfacing the last output of
+   *  a build that finished before disconnect is the whole
+   *  point of the deferred-dismiss behaviour. */
   private _renderViewRemoteBuildButton(pairing: PairingSummary) {
     const job = this._latestRemoteBuildJobForPin(pairing.pin_sha256);
     if (job === undefined) return nothing;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -804,6 +804,8 @@
     "build_offload_pairing_connecting": "Connecting…",
     "build_offload_pairing_disconnected": "Disconnected",
     "build_offload_pairing_last_error": "Last connection error: {detail}",
+    "build_offload_pairing_version_mismatch_patch": "Build server runs ESPHome {peer}; you're on {local}",
+    "build_offload_pairing_version_mismatch_release": "Build server runs ESPHome {peer}; you're on {local}. YAML may not compile across this release gap.",
     "remote_build_submit_action": "Build remotely",
     "remote_build_submit_aria": "Build remotely on {label}",
     "remote_build_view_action": "View build",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -741,6 +741,8 @@
     "build_offload_pairing_connecting": "Connexion…",
     "build_offload_pairing_disconnected": "Déconnecté",
     "build_offload_pairing_last_error": "Dernière erreur de connexion : {detail}",
+    "build_offload_pairing_version_mismatch_patch": "Le serveur de compilation utilise ESPHome {peer} ; vous êtes sur {local}",
+    "build_offload_pairing_version_mismatch_release": "Le serveur de compilation utilise ESPHome {peer} ; vous êtes sur {local}. Le YAML peut ne pas compiler à travers cet écart de version.",
     "remote_build_submit_action": "Compiler à distance",
     "remote_build_submit_aria": "Compiler à distance sur {label}",
     "remote_build_view_action": "Voir la compilation",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -741,6 +741,8 @@
     "build_offload_pairing_connecting": "Verbinden…",
     "build_offload_pairing_disconnected": "Niet verbonden",
     "build_offload_pairing_last_error": "Laatste verbindingsfout: {detail}",
+    "build_offload_pairing_version_mismatch_patch": "Build server gebruikt ESPHome {peer}; u gebruikt {local}",
+    "build_offload_pairing_version_mismatch_release": "Build server gebruikt ESPHome {peer}; u gebruikt {local}. YAML kan mogelijk niet compileren over dit versieverschil.",
     "remote_build_submit_action": "Bouw op afstand",
     "remote_build_submit_aria": "Bouw op afstand op {label}",
     "remote_build_view_action": "Bouw bekijken",

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -1,0 +1,73 @@
+/**
+ * Compare the local dashboard's bundled ESPHome version against
+ * a paired build-server's reported version and classify the
+ * result for the operator-facing mismatch sub-line in Settings →
+ * Build server → paired build servers.
+ *
+ * Versions are ESPHome's ``YYYY.M[.P][-suffix]`` shape (e.g.
+ * ``2026.5.0``, ``2026.5.0b1``, ``2026.5.0-dev``). The first
+ * two components (year + month) advance in lockstep with the
+ * monthly ESPHome release and are what the scheduler's
+ * allow-major-version-mismatch toggle keys on once 7a-3 +
+ * 7b-toggle land: a YAML produced by the offloader against
+ * ``2026.5`` is generally safe to compile on a receiver that
+ * is also ``2026.5.*`` (patch differences are bugfix-only by
+ * convention), but cross-month drift is the case the operator
+ * wants to know about and explicitly accept.
+ *
+ * Returned shape:
+ *   * ``null`` — versions match, or either side is unknown
+ *     (handshake hasn't completed yet, dev build, …). Hide
+ *     the sub-line.
+ *   * ``"patch"`` — same year+month, patch / suffix differs.
+ *     Informational; compile is almost always safe.
+ *   * ``"release"`` — year+month differs. Cautionary; the
+ *     YAML may reference fields the receiver's schema does
+ *     not recognise (or vice versa).
+ *
+ * Both strings are passed in verbatim so the caller can
+ * display them as-is — the comparison is purely structural,
+ * not normalising.
+ */
+export type VersionMismatchKind = "patch" | "release" | null;
+
+/**
+ * Returns the mismatch classification for two ESPHome version
+ * strings. See module docstring for the contract.
+ */
+export function classifyVersionMismatch(
+  local: string,
+  peer: string,
+): VersionMismatchKind {
+  // Either side unknown — handshake hasn't filled in the peer
+  // value yet (PENDING / first-session) or the local probe
+  // hasn't resolved. Don't surface a mismatch banner against
+  // a missing baseline; the operator can't act on "unknown".
+  if (!local || !peer) return null;
+  if (local === peer) return null;
+
+  // First two dot-separated components are year + month for
+  // ESPHome's CalVer scheme. Trim any pre-release / dev /
+  // build-metadata suffix off the second component before
+  // comparing so ``2026.5.0`` and ``2026.5.0b1`` classify as
+  // patch-level, not release-level.
+  const localParts = local.split(".");
+  const peerParts = peer.split(".");
+  const localRelease = `${localParts[0] ?? ""}.${stripSuffix(
+    localParts[1] ?? "",
+  )}`;
+  const peerRelease = `${peerParts[0] ?? ""}.${stripSuffix(
+    peerParts[1] ?? "",
+  )}`;
+  return localRelease === peerRelease ? "patch" : "release";
+}
+
+/**
+ * Trim any non-digit suffix off a CalVer component so
+ * ``5b1`` -> ``5``. Used by the release-level comparator so
+ * ``2026.5b1`` and ``2026.5`` classify as the same release.
+ */
+function stripSuffix(component: string): string {
+  const match = component.match(/^(\d+)/);
+  return match ? match[1] : component;
+}

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -25,9 +25,11 @@
  *     YAML may reference fields the receiver's schema does
  *     not recognise (or vice versa).
  *
- * Both strings are passed in verbatim so the caller can
- * display them as-is — the comparison is purely structural,
- * not normalising.
+ * The helper returns the classification kind only; it does
+ * not echo back the version strings. The caller already
+ * holds both values and renders them verbatim in the
+ * translated sub-line (see settings-dialog's
+ * ``_renderPairingVersionMismatch``).
  */
 export type VersionMismatchKind = "patch" | "release" | null;
 
@@ -47,10 +49,15 @@ export function classifyVersionMismatch(
   if (local === peer) return null;
 
   // First two dot-separated components are year + month for
-  // ESPHome's CalVer scheme. Trim any pre-release / dev /
-  // build-metadata suffix off the second component before
-  // comparing so ``2026.5.0`` and ``2026.5.0b1`` classify as
-  // patch-level, not release-level.
+  // ESPHome's CalVer scheme. Modern ESPHome puts pre-release
+  // suffixes on the patch component (e.g. 2026.5.0b1 -> the
+  // suffix lives on "0b1") so dropping the third component
+  // is enough to make 2026.5.0 and 2026.5.0b1 classify as
+  // patch-level. Older / hypothetical shapes occasionally
+  // put the suffix on the month component (2026.5b1) — the
+  // stripSuffix() call here is the defence against those:
+  // it trims trailing non-digits off the month component so
+  // 2026.5b1 and 2026.5 still classify as the same release.
   const localParts = local.split(".");
   const peerParts = peer.split(".");
   const localRelease = `${localParts[0] ?? ""}.${stripSuffix(

--- a/test/util/version-mismatch.test.ts
+++ b/test/util/version-mismatch.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { classifyVersionMismatch } from "../../src/util/version-mismatch.js";
+
+describe("classifyVersionMismatch", () => {
+  it("returns null when versions match exactly", () => {
+    expect(classifyVersionMismatch("2026.5.0", "2026.5.0")).toBeNull();
+  });
+
+  it("returns null when either side is empty (handshake not yet complete)", () => {
+    expect(classifyVersionMismatch("", "2026.5.0")).toBeNull();
+    expect(classifyVersionMismatch("2026.5.0", "")).toBeNull();
+    expect(classifyVersionMismatch("", "")).toBeNull();
+  });
+
+  it("classifies patch-level differences", () => {
+    expect(classifyVersionMismatch("2026.5.0", "2026.5.1")).toBe("patch");
+    expect(classifyVersionMismatch("2026.5.1", "2026.5.0")).toBe("patch");
+  });
+
+  it("classifies suffix-only differences (beta / dev) as patch-level", () => {
+    expect(classifyVersionMismatch("2026.5.0", "2026.5.0b1")).toBe("patch");
+    expect(classifyVersionMismatch("2026.5.0", "2026.5.0-dev")).toBe("patch");
+  });
+
+  it("classifies year+month differences as release-level", () => {
+    expect(classifyVersionMismatch("2026.5.0", "2026.4.0")).toBe("release");
+    expect(classifyVersionMismatch("2026.5.0", "2026.6.0")).toBe("release");
+    expect(classifyVersionMismatch("2026.12.0", "2027.1.0")).toBe("release");
+  });
+
+  it("classifies cross-year differences as release-level", () => {
+    expect(classifyVersionMismatch("2026.5.0", "2025.12.0")).toBe("release");
+  });
+
+  it("treats beta receiver against stable offloader as patch when same release", () => {
+    // Receiver might be running a beta build the offloader hasn't
+    // moved to yet; the YAML schemas are typically compatible at
+    // that point so the operator should see this as patch-level,
+    // not release-level.
+    expect(classifyVersionMismatch("2026.5.0", "2026.5.0b3")).toBe("patch");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

First-slice 7b — a purely informational ESPHome
version-mismatch sub-line under each paired-build-server
row in Settings → Build server. The data already flows
on the wire (esphome/device-builder#557 captured
`StoredPairing.esphome_version` at handshake time and
`PairingSummary` projects it through
`subscribe_events.initial_state.pairings` plus the live
`OFFLOADER_PAIR_STATUS_CHANGED` events); the frontend
just compares against the local version
(`versionContext`, already provided by app-shell) and
renders a sub-line on the row.

## Why this slice lands independently of 7a

- 7a's scheduler is the consumer of the
  allow-major-version-mismatch toggle; until that lands,
  there is no behavioural difference to surface.
- The mismatch banner itself is informational and useful
  in isolation: the operator can see today that their
  paired build server is on a different ESPHome release,
  ahead of the scheduler honouring the difference.
- No backend changes; reuses existing wire fields.
- Other 7b toggles (per-host enable, force-local,
  allow-major-version-mismatch) need persistent
  per-pairing settings backend, so they slot in after
  7a-3.

## What ships

- New `src/util/version-mismatch.ts` exporting
  `classifyVersionMismatch(local, peer)` returning
  `"patch" | "release" | null`. Year+month differs
  ⇒ `release` (cautionary, warning palette); same
  year+month differs ⇒ `patch` (informational, quiet
  style); either side empty or strings equal ⇒ `null`
  (hide the row). Suffix stripping makes `2026.5.0b1`
  vs `2026.5.0` classify as patch-level, not
  release-level.
- 7 unit tests pinning the classifier matrix
  (`test/util/version-mismatch.test.ts`).
- `settings-dialog` consumes `versionContext` and adds
  `_renderPairingVersionMismatch(pairing)` which the
  pairing row already passes through. PENDING rows skip
  (no captured version yet). Connection state doesn't
  gate; long-disconnected APPROVED rows still carry the
  last captured version, and that mismatch is still the
  right thing to surface ahead of the next reconnect.
- `PairingSummary` frontend type gains
  `esphome_version: string` matching the backend wire
  shape.
- en / fr / nl translation parity (2 keys, patch +
  release variants).

## Render shape

Same row affordances as before, with a new sub-line
under the hostname / last-error stack when the
classifier returns non-null:

```
build-mac (Approved · Connected)
mac.local:6055
Build server runs ESPHome 2026.5.0; you're on 2026.6.0.
  YAML may not compile across this release gap.        [warning colour]
```

Quiet "patch" variant (same year+month, just patch /
beta / dev difference):

```
Build server runs ESPHome 2026.5.0; you're on 2026.5.1
```

## Tests

- 1024 frontend tests pass (was 1017; +7 for the new
  classifier).
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- refs esphome/device-builder#106 (phase 7b first slice).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

The classifier has 7 unit tests; the render hook into
`_renderPairingRow` is verified by the type checker plus
manual inspection (no DOM env in vitest).

## Manual UI verification

Open Settings → Build server with at least one paired
receiver. Force a version skew by either:

- temporarily editing `_appVersion` in DevTools, or
- pairing against a receiver running an older / newer
  ESPHome release.

Verify:

- No banner when the local + peer versions match.
- Quiet (default text colour) sub-line for patch-level
  differences (e.g. `2026.5.0` vs `2026.5.1`,
  `2026.5.0` vs `2026.5.0-dev`).
- Warning-coloured sub-line for release-level differences
  (e.g. `2026.5.0` vs `2026.4.0`,
  `2026.5.0` vs `2026.6.0`).
- PENDING rows never show the banner.
- Banner remains visible on long-disconnected APPROVED
  rows (last-captured version stays informative).
