### PR TITLE
Include Types-of-changes checklist in auto-bump PR body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,25 @@ jobs:
             Bumps `${{ env.PACKAGE_NAME }}` to [`${{ inputs.version }}`](https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}).
 
             ${{ steps.notes.outputs.body }}
+
+            ## Types of changes
+
+            <!--
+            The backend's ``pr-labels`` workflow parses this checklist
+            to apply the release-notes label. Auto-bump PRs are always
+            a ``dependencies`` bump by definition; the box is ticked
+            here so the check passes without manual editing.
+            -->
+
+            - [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
+            - [ ] New feature (non-breaking change which adds functionality) — `new-feature`
+            - [ ] Enhancement to an existing feature — `enhancement`
+            - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
+            - [ ] Refactor (no behaviour change) — `refactor`
+            - [ ] Documentation only — `docs`
+            - [ ] Maintenance / chore — `maintenance`
+            - [ ] CI / workflow change — `ci`
+            - [x] Dependencies bump — `dependencies`
           labels: |
             dependencies
             frontend


### PR DESCRIPTION
# What does this implement/fix?

Auto-bump PRs (the "Bump frontend to X.Y.Z" PRs this workflow opens against `esphome/device-builder`) currently land with no `Types of changes` checklist in the body. The backend's `pr-labels` workflow parses that checklist to apply the release-notes label, and fails the check when no box is ticked — so every auto-bump PR required a manual body edit before the Apply job went green (most recently esphome/device-builder#564).

Embed the checklist in the `peter-evans/create-pull-request` body template with the `dependencies` box pre-ticked, so future auto-bump PRs label cleanly on creation. By definition every bump from this workflow is a `dependencies` change, so the pre-tick is correct without needing per-bump editorial judgement.

The HTML comment above the checklist explains the why so a future reader doesn't accidentally rip out the duplication with the PR template that landed in the backend.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder#564 (needed manual body edit to land the bump for 0.1.58 — the bump carrying esphome/device-builder-frontend#291's 6c TTL UI).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
