### PR TITLE
Show 'Open in editor' hint when build fails on YAML validation

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -130,12 +130,14 @@ export class ESPHomeCommandDialog extends LitElement {
   @state() private _showLogsAfterInstall = true;
   /** Flips true when the output stream contains an ESPHome
    *  validation-failure marker (``Failed config`` from the schema
-   *  validator, or ``Error while reading config:`` from the earlier
-   *  YAML load step). Lets the failure hint switch from "clean the
-   *  build files / reset the build environment" — which only help
-   *  for C++ compile failures — to "open this device in the
-   *  editor", which is the right action when the YAML itself is
-   *  broken. Reset per ``open()``. */
+   *  validator, or an anchored ``ERROR Error while reading
+   *  config:`` logger line from the earlier YAML load step — see
+   *  ``_isValidationFailureLine`` for the exact match rules).
+   *  Lets the failure hint switch from "clean the build files /
+   *  reset the build environment" — which only help for C++
+   *  compile failures — to "open this device in the editor",
+   *  which is the right action when the YAML itself is broken.
+   *  Reset per ``open()``. */
   @state() private _failedDuringValidate = false;
 
   /** Guard against re-entrancy on the show-secrets toggle.

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -128,6 +128,16 @@ export class ESPHomeCommandDialog extends LitElement {
    *  install finishes. Reset to default per ``open()`` so an opt-out
    *  on one run doesn't silently persist into unrelated future runs. */
   @state() private _showLogsAfterInstall = true;
+  /** Flips true when the output stream contains an ESPHome
+   *  validation-failure marker (``Failed config`` from the schema
+   *  validator, or ``Error while reading config:`` from the earlier
+   *  YAML load step). Lets the failure hint switch from "clean the
+   *  build files / reset the build environment" — which only help
+   *  for C++ compile failures — to "open this device in the
+   *  editor", which is the right action when the YAML itself is
+   *  broken. Reset per ``open()``. */
+  @state() private _failedDuringValidate = false;
+
   /** Guard against re-entrancy on the show-secrets toggle.
    *  ``_detachStream`` clears ``_streamId`` synchronously and only
    *  awaits the backend stop afterwards; without this flag a fast
@@ -480,6 +490,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._statusMessage = "";
     this._jobId = "";
     this._jobStatus = null;
+    this._failedDuringValidate = false;
     /* Always start with secrets redacted on a fresh open — the
        toggle is opt-in per session so a screen-share / pair-coding
        moment can't accidentally inherit a previous "show secrets"
@@ -708,27 +719,58 @@ export class ESPHomeCommandDialog extends LitElement {
     `;
   }
 
-  /** Hint shown after a failed install / compile pointing the user
-   *  at the recovery staircase: clean this device's build files
-   *  first (surgical, fast), then fall back to reset build
-   *  environment (nuclear, wipes every toolchain + cache, slow
-   *  recovery). Stale per-device build artifacts cause the bulk
-   *  of compile failures; the toolchain wipe is the heavier
-   *  hammer reserved for cases where clean doesn't help.
-   *  Limited to install / compile because the other command
-   *  types don't have a build step the recovery would help with.
+  /** Failure hint dispatcher. Picks between two messages based on
+   *  what failed:
    *
-   *  Rendered as two inline links inside the sentence rather than
-   *  separate buttons so the calls-to-action read as part of the
-   *  hint. The translation puts each link text behind a
-   *  ``{clean_action}`` / ``{reset_action}`` marker so other
-   *  locales can place them wherever reads naturally. */
+   *  * **YAML validation** (the ``validate`` command, or an
+   *    ``install`` / ``compile`` whose output stream included
+   *    ESPHome's validation-failure marker) — neither clean nor
+   *    reset will help a broken YAML; offer the editor instead.
+   *  * **Build / compile failure** (install / compile that got
+   *    past validation) — keep the clean → reset staircase.
+   *
+   *  Other command types (clean, reset, rename) don't get a hint;
+   *  their failure mode is its own thing. The ``_userStopped`` gate
+   *  is shared — a user-cancel isn't a build problem either way. */
   private _renderResetSuggestion() {
     if (this._state !== "error") return nothing;
     if (this._userStopped) return nothing;
+    if (this._commandType === "validate" || this._failedDuringValidate) {
+      return this._renderValidationFailureSuggestion();
+    }
     if (this._commandType !== "install" && this._commandType !== "compile") {
       return nothing;
     }
+    return this._renderBuildFailureSuggestion();
+  }
+
+  /** YAML validation failure → "open in editor" hint. The
+   *  translation puts the link text behind a ``{editor_action}``
+   *  marker. */
+  private _renderValidationFailureSuggestion() {
+    const text = this._localize("command.validation_failed_suggestion");
+    const [before, after = ""] = text.split("{editor_action}");
+    return html`
+      <div class="reset-suggestion" role="status">
+        ${before}<button
+          class="reset-suggestion-link"
+          @click=${this._tryOpenInEditor}
+        >
+          ${this._localize("command.try_open_editor_button")}</button>${after}
+      </div>
+    `;
+  }
+
+  /** Build-step failure → clean (surgical, per-device) → reset
+   *  (nuclear, wipes every toolchain and cache) staircase.
+   *  Stale per-device build artifacts cause the bulk of compile
+   *  failures; the toolchain wipe is the heavier hammer reserved
+   *  for cases where clean doesn't help. Both actions are inline
+   *  links inside the sentence so the CTAs read as part of the
+   *  hint. The translation puts each link text behind a
+   *  ``{clean_action}`` / ``{reset_action}`` marker so other
+   *  locales can place them wherever reads naturally. */
+  private _renderBuildFailureSuggestion() {
     const text = this._localize("command.try_reset_suggestion");
     const [before, rest = ""] = text.split("{clean_action}");
     const [middle, after = ""] = rest.split("{reset_action}");
@@ -746,6 +788,24 @@ export class ESPHomeCommandDialog extends LitElement {
       </div>
     `;
   }
+
+  /** Close the dialog and ask the host page to take the user to
+   *  the device-page editor for this configuration. Dashboard
+   *  handles this by navigating to ``/device/<config>``; the
+   *  device page just closes the dialog (the user is already on
+   *  the editor). */
+  private _tryOpenInEditor = () => {
+    const configuration = this.configuration;
+    this.close();
+    if (!configuration) return;
+    this.dispatchEvent(
+      new CustomEvent("request-open-editor", {
+        detail: { configuration },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
 
   /** Per-device clean: re-uses this same dialog instance — the
    *  ``configuration`` property is already set to the failing
@@ -972,12 +1032,49 @@ export class ESPHomeCommandDialog extends LitElement {
     this._lines = [];
     this._statusMessage = "";
     this._userStopped = false;
+    this._failedDuringValidate = false;
 
     if (this._commandType === "validate") {
       this._startValidateStream();
       return;
     }
     await this._startFirmwareJob();
+  }
+
+  /** Match a dashboard-escaped or raw ANSI SGR sequence (``\033[…m``
+   *  in dashboard mode, ``\x1b[…m`` in raw mode). The backend pins
+   *  ``--dashboard``, so we always see the four-character escaped
+   *  form; the raw branch is defensive in case that ever changes. */
+  private static readonly _ANSI_SGR = /(?:\\033|\x1b)\[[0-9;]*m/g;
+
+  /** Match an ESPHome logger line whose level is ``ERROR`` and
+   *  whose message starts with the canonical YAML-load-failure
+   *  prefix. The log format is ``"<asctime>? <LEVEL> <message>"``
+   *  (esphome/log.py), so an optional timestamp may precede
+   *  ``ERROR``. Anchored at start-of-line so a debug / info line
+   *  that happens to quote the phrase mid-message can't match. */
+  private static readonly _LOADER_ERROR =
+    /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
+
+  /** Detect ESPHome's validation-failure markers in a streamed
+   *  output line. Two distinct sources:
+   *
+   *  * ``Failed config`` — printed via ``safe_print`` as a
+   *    standalone bold-red banner from ``esphome/config.py`` when
+   *    the schema validator rejects a successfully-loaded YAML.
+   *    Strict equality after ANSI strip: the line *is* the marker.
+   *  * ``ERROR Error while reading config: …`` — earlier
+   *    ``_LOGGER.error`` from the YAML-load step (parse failure /
+   *    missing include / etc.). Anchored ERROR-prefix match so a
+   *    stack trace or doc string that happens to contain the
+   *    phrase mid-text can't match.
+   *
+   *  Both indicate the build never reached the C++ compile step;
+   *  clean / reset can't help. */
+  private static _isValidationFailureLine(line: string): boolean {
+    const stripped = line.replace(ESPHomeCommandDialog._ANSI_SGR, "").trim();
+    if (stripped === "Failed config") return true;
+    return ESPHomeCommandDialog._LOADER_ERROR.test(stripped);
   }
 
   /** Validate uses the per-connection streaming command (not a queued job). */
@@ -987,6 +1084,9 @@ export class ESPHomeCommandDialog extends LitElement {
       {
         onOutput: (line) => {
           this._lines = [...this._lines, line];
+          if (ESPHomeCommandDialog._isValidationFailureLine(line)) {
+            this._failedDuringValidate = true;
+          }
         },
         onResult: (data) => {
           this._streamId = "";
@@ -1094,6 +1194,9 @@ export class ESPHomeCommandDialog extends LitElement {
     this._streamId = this._api.firmwareFollowJob(jobId, {
       onOutput: (line) => {
         this._lines = [...this._lines, line];
+        if (ESPHomeCommandDialog._isValidationFailureLine(line)) {
+          this._failedDuringValidate = true;
+        }
       },
       onResult: (data) => {
         this._streamId = "";

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -81,12 +81,13 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
    *  errors where it can't help. */
   @state() private _failedDuringCompile = false;
   /** Flips true when the compile-step output stream contains an
-   *  ESPHome validation-failure marker (``Failed config`` /
-   *  ``Error while reading config:``). Drives the failure hint to
-   *  switch from clean / reset (which only help C++ build
-   *  failures) to "open this device in the editor" — the right
-   *  action when the YAML itself is broken. Reset alongside the
-   *  other per-attempt state. */
+   *  ESPHome validation-failure marker (``Failed config`` or an
+   *  anchored ``ERROR Error while reading config:`` logger line —
+   *  see ``_isValidationFailureLine`` for the exact match rules).
+   *  Drives the failure hint to switch from clean / reset (which
+   *  only help C++ build failures) to "open this device in the
+   *  editor" — the right action when the YAML itself is broken.
+   *  Reset alongside the other per-attempt state. */
   @state() private _failedDuringValidate = false;
   @state() private _logLines: string[] = [];
   @state() private _logsExpanded = false;

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -80,6 +80,14 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
    *  in front of users on chip-mismatch / Web Serial connection
    *  errors where it can't help. */
   @state() private _failedDuringCompile = false;
+  /** Flips true when the compile-step output stream contains an
+   *  ESPHome validation-failure marker (``Failed config`` /
+   *  ``Error while reading config:``). Drives the failure hint to
+   *  switch from clean / reset (which only help C++ build
+   *  failures) to "open this device in the editor" — the right
+   *  action when the YAML itself is broken. Reset alongside the
+   *  other per-attempt state. */
+  @state() private _failedDuringValidate = false;
   @state() private _logLines: string[] = [];
   @state() private _logsExpanded = false;
   @state() private _flashPercent = 0;
@@ -109,6 +117,33 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   private _device: ConfiguredDevice | null = null;
   private _jobId = "";
   private _streamId = "";
+
+  /** Match a dashboard-escaped or raw ANSI SGR sequence — backend
+   *  pins ``--dashboard`` so the four-character escaped form is
+   *  the live case; the raw branch is defensive. */
+  private static readonly _ANSI_SGR = /(?:\\033|\x1b)\[[0-9;]*m/g;
+
+  /** Match an ESPHome logger line whose level is ``ERROR`` and
+   *  whose message starts with the canonical YAML-load-failure
+   *  prefix. Anchored at start-of-line so a non-validation line
+   *  that happens to quote the phrase mid-message can't match. */
+  private static readonly _LOADER_ERROR =
+    /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
+
+  /** Detect ESPHome's validation-failure markers in a streamed
+   *  output line. ``Failed config`` is the standalone bold-red
+   *  banner from ``esphome/config.py`` (matched after ANSI strip
+   *  by strict equality — the line *is* the marker).
+   *  ``ERROR Error while reading config:`` is the earlier YAML-
+   *  load-stage error. Both indicate the build never reached the
+   *  C++ compile step, so clean / reset can't help. */
+  private static _isValidationFailureLine(line: string): boolean {
+    const stripped = line
+      .replace(ESPHomeFirmwareInstallDialog._ANSI_SGR, "")
+      .trim();
+    if (stripped === "Failed config") return true;
+    return ESPHomeFirmwareInstallDialog._LOADER_ERROR.test(stripped);
+  }
 
   /**
    * Reject hook for the in-flight ``_compileAndWait`` promise.
@@ -202,6 +237,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._showLogsAfterInstall = true;
     this._installer = null;
     this._failedDuringCompile = false;
+    this._failedDuringValidate = false;
     // ``_jobId`` is already cleared by ``_detachStream`` above; same
     // for ``_streamId`` and ``_compileReject``.
     this._detected = null;
@@ -591,21 +627,46 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     `;
   }
 
-  /** Hint shown after a compile-step failure pointing the user at
-   *  the recovery staircase: clean this device's build files
-   *  first (surgical, fast), then fall back to reset build
-   *  environment if that doesn't help. Only surfaced for failures
-   *  during the server-side compile (see ``_failedDuringCompile``)
-   *  — chip mismatch / Web Serial connection / flash errors don't
-   *  benefit from clearing the build cache.
+  /** Hint shown after a compile-step failure. Branches on what
+   *  actually failed:
    *
-   *  Inline-link rendering: both actions are clickable links inside
-   *  the sentence so the CTAs read as part of the hint. The
-   *  translation puts each link text behind a ``{clean_action}`` /
-   *  ``{reset_action}`` marker so other locales can place them
-   *  wherever reads naturally. */
+   *  * **YAML validation** (the output stream included ESPHome's
+   *    validation-failure marker) — neither clean nor reset can
+   *    help; offer the editor instead.
+   *  * **C++ build / compile** failure — keep the clean → reset
+   *    staircase (clean is surgical / fast; reset is the heavier
+   *    toolchain-wide wipe).
+   *
+   *  Only surfaced for failures during the server-side compile
+   *  (see ``_failedDuringCompile``) — chip mismatch / Web Serial
+   *  connection / flash errors don't benefit from any of these. */
   private _renderResetSuggestion() {
     if (!this._failedDuringCompile) return nothing;
+    if (this._failedDuringValidate) {
+      return this._renderValidationFailureSuggestion();
+    }
+    return this._renderBuildFailureSuggestion();
+  }
+
+  /** YAML validation failure → "open in editor" hint. */
+  private _renderValidationFailureSuggestion() {
+    const text = this._localize("command.validation_failed_suggestion");
+    const [before, after = ""] = text.split("{editor_action}");
+    return html`
+      <div class="reset-suggestion" role="status">
+        ${before}<button
+          class="reset-suggestion-link"
+          @click=${this._tryOpenInEditor}
+        >
+          ${this._localize("command.try_open_editor_button")}</button>${after}
+      </div>
+    `;
+  }
+
+  /** C++ build failure → clean (surgical) → reset (nuclear)
+   *  staircase. Both actions are inline links inside the sentence
+   *  so the CTAs read as part of the hint. */
+  private _renderBuildFailureSuggestion() {
     const text = this._localize("command.try_reset_suggestion");
     const [before, rest = ""] = text.split("{clean_action}");
     const [middle, after = ""] = rest.split("{reset_action}");
@@ -623,6 +684,24 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       </div>
     `;
   }
+
+  /** Close the dialog and ask the host page to take the user to
+   *  the device-page editor for the failing device. Mirrors the
+   *  clean / reset event-bubble pattern; minimal ``{configuration}``
+   *  payload so the host's handler is the same shape as the one
+   *  on ``command-dialog``. */
+  private _tryOpenInEditor = () => {
+    const device = this._device;
+    this._close();
+    if (!device) return;
+    this.dispatchEvent(
+      new CustomEvent("request-open-editor", {
+        detail: { configuration: device.configuration },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
 
   /** Per-device clean: closes the install dialog and asks the page
    *  to open the command-dialog in clean mode for ``_device``.
@@ -1059,6 +1138,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
               this._statusMessage = this._localize("firmware.status_compiling");
             }
             this._logLines = [...this._logLines, line];
+            if (ESPHomeFirmwareInstallDialog._isValidationFailureLine(line)) {
+              this._failedDuringValidate = true;
+            }
           },
           onResult: (data) => {
             this._streamId = "";

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1592,11 +1592,13 @@ export class ESPHomePageDashboard extends LitElement {
       <esphome-create-config-dialog></esphome-create-config-dialog>
       <esphome-command-dialog
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
+        @request-open-editor=${this._onRequestOpenEditor}
       ></esphome-command-dialog>
       <esphome-firmware-install-dialog
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
         @clean-build=${(e: CustomEvent<ConfiguredDevice>) =>
           this._openCommand(e.detail, "clean")}
+        @request-open-editor=${this._onRequestOpenEditor}
       ></esphome-firmware-install-dialog>
       <esphome-logs-dialog></esphome-logs-dialog>
       <esphome-install-method-dialog
@@ -2105,6 +2107,16 @@ export class ESPHomePageDashboard extends LitElement {
     this._commandDialog.name = device.friendly_name || device.name;
     this._commandDialog.open(type, port ? { port } : undefined);
   }
+
+  /** Catch the post-validation-failure "open in editor" hint from
+   *  the inner command / install dialogs and SPA-navigate to the
+   *  device page. The detail carries the YAML filename stem; the
+   *  device route is ``/device/<configuration>``. */
+  private _onRequestOpenEditor = (
+    e: CustomEvent<{ configuration: string }>
+  ) => {
+    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
+  };
 
   private _showJobProgress(device: ConfiguredDevice) {
     const job = this._activeJobs.get(device.configuration);

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -2110,8 +2110,9 @@ export class ESPHomePageDashboard extends LitElement {
 
   /** Catch the post-validation-failure "open in editor" hint from
    *  the inner command / install dialogs and SPA-navigate to the
-   *  device page. The detail carries the YAML filename stem; the
-   *  device route is ``/device/<configuration>``. */
+   *  device page. The detail carries the configuration filename
+   *  (extension included, e.g. ``foo.yaml``); the device route is
+   *  ``/device/<configuration>``. */
   private _onRequestOpenEditor = (
     e: CustomEvent<{ configuration: string }>
   ) => {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -706,6 +706,21 @@ export class ESPHomePageDevice extends LitElement {
     this._commandDialog.open("clean");
   };
 
+  /** Catch ``request-open-editor`` from the post-validation-failure
+   *  hint. We're already on the device editor for this device, so
+   *  the dialog closing itself is the whole UX — no navigation
+   *  needed when the requested configuration matches the page's
+   *  current device. Cross-device requests shouldn't reach this
+   *  handler (the dialogs only ever surface for the current
+   *  device), but guard with an explicit equality check so a
+   *  future regression can't silently send the user to a wrong
+   *  route. */
+  private _onRequestOpenEditor = (
+    e: CustomEvent<{ configuration: string }>
+  ) => {
+    if (e.detail.configuration === this._device?.configuration) return;
+  };
+
   static styles = [espHomeStyles, devicePageStyles];
 
   protected render() {
@@ -785,10 +800,12 @@ export class ESPHomePageDevice extends LitElement {
       ></esphome-unsaved-changes-dialog>
       <esphome-command-dialog
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
+        @request-open-editor=${this._onRequestOpenEditor}
       ></esphome-command-dialog>
       <esphome-firmware-install-dialog
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
         @clean-build=${this._onCleanBuild}
+        @request-open-editor=${this._onRequestOpenEditor}
       ></esphome-firmware-install-dialog>
       <esphome-logs-dialog></esphome-logs-dialog>
       <esphome-install-method-dialog

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -28,7 +28,7 @@ import {
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
 import { consumeJustCreated } from "../util/just-created.js";
-import { setLeaveGuard } from "../util/navigation.js";
+import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -707,18 +707,21 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   /** Catch ``request-open-editor`` from the post-validation-failure
-   *  hint. We're already on the device editor for this device, so
-   *  the dialog closing itself is the whole UX — no navigation
-   *  needed when the requested configuration matches the page's
-   *  current device. Cross-device requests shouldn't reach this
-   *  handler (the dialogs only ever surface for the current
-   *  device), but guard with an explicit equality check so a
-   *  future regression can't silently send the user to a wrong
-   *  route. */
+   *  hint. ``stopPropagation`` to prevent any future higher-level
+   *  listener from also acting on the event. Two cases:
+   *
+   *  * Same device — already on the right editor; the dialog
+   *    closing itself is the whole UX, no navigation needed.
+   *  * Different device — shouldn't happen in practice (the
+   *    dialogs only ever surface for the current page's device),
+   *    but defensively navigate to the requested device so the
+   *    hint can never become a silent no-op. */
   private _onRequestOpenEditor = (
     e: CustomEvent<{ configuration: string }>
   ) => {
+    e.stopPropagation();
     if (e.detail.configuration === this._device?.configuration) return;
+    navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };
 
   static styles = [espHomeStyles, devicePageStyles];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -335,6 +335,8 @@
     "try_reset_suggestion": "It looks like you're having trouble with your build. Try {clean_action} first; if that doesn't help, try {reset_action}.",
     "try_clean_button": "cleaning the build files for this device",
     "try_reset_button": "resetting the build environment",
+    "validation_failed_suggestion": "Looks like a configuration error. Try {editor_action} to fix the YAML.",
+    "try_open_editor_button": "opening this device in the editor",
     "validate_success": "Configuration is valid!",
     "validate_failed": "Validation failed.",
     "show_secrets": "Show secrets",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -278,6 +278,8 @@
     "try_reset_suggestion": "Il semble que vous ayez un problème avec votre compilation. Essayez d'abord de {clean_action} ; si cela ne résout pas le problème, essayez de {reset_action}.",
     "try_clean_button": "nettoyer les fichiers de compilation de cet appareil",
     "try_reset_button": "réinitialiser l'environnement de compilation",
+    "validation_failed_suggestion": "Cela ressemble à une erreur de configuration. Essayez d'{editor_action} pour corriger le YAML.",
+    "try_open_editor_button": "ouvrir cet appareil dans l'éditeur",
     "validate_success": "La configuration est valide !",
     "validate_failed": "Échec de la validation.",
     "clean_success": "Fichiers de compilation nettoyés.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -278,6 +278,8 @@
     "try_reset_suggestion": "Het lijkt erop dat je een probleem hebt met de compilatie. Probeer eerst {clean_action}; als dat niet helpt, probeer dan {reset_action}.",
     "try_clean_button": "de bouwbestanden voor dit apparaat op te schonen",
     "try_reset_button": "de bouw-omgeving te resetten",
+    "validation_failed_suggestion": "Dit lijkt op een configuratiefout. Probeer {editor_action} om de YAML te repareren.",
+    "try_open_editor_button": "dit apparaat in de editor te openen",
     "validate_success": "Configuratie is geldig!",
     "validate_failed": "Validatie mislukt.",
     "clean_success": "Bouwbestanden opgeschoond.",


### PR DESCRIPTION
# What does this implement/fix?

Followup to esphome/device-builder-frontend#293 (the clean-vs-reset staircase). That staircase only helps **C++ build failures** — but ESPHome runs YAML validation as the first step of every `compile` / `install`, and a schema error there currently lands in the same hint path. Neither cleaning the per-device build files nor resetting the toolchain cache can fix a broken YAML; the user needs the editor.

This PR adds a third branch to the post-failure hint: **when the failure happened during validation, offer "open this device in the editor" instead of the clean → reset staircase.**

## Detection

The dialogs (`command-dialog` and `firmware-install-dialog`) scan the streamed output for two canonical ESPHome markers and latch a `_failedDuringValidate` flag:

* **`Failed config`** — printed via `safe_print` as a standalone bold-red banner from `esphome/config.py` when the schema validator rejects a successfully-loaded YAML. Matched after ANSI-strip by **strict equality** — the line *is* the marker. A C++ build error that happens to quote the phrase mid-message can't false-positive.
* **`ERROR Error while reading config:`** — earlier `_LOGGER.error` from the YAML-load step (parse failure / missing include / etc.). Matched by an **anchored regex** that only fires at start-of-line (optionally after a timestamp), so a stack-trace line that happens to contain the phrase mid-message also can't false-positive.

Both matchers run after stripping ESPHome's dashboard-mode literal `\033[...m` SGR sequences (the backend pins `--dashboard`, so that escape form is the live wire shape; the raw `\x1b[...m` branch is defensive).

```ts
private static readonly _ANSI_SGR = /(?:\\033|\x1b)\[[0-9;]*m/g;
private static readonly _LOADER_ERROR =
  /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;

private static _isValidationFailureLine(line: string): boolean {
  const stripped = line.replace(/* _ANSI_SGR */).trim();
  if (stripped === "Failed config") return true;
  return _LOADER_ERROR.test(stripped);
}
```

## What lands

* **`src/components/command-dialog.ts`** — adds `_failedDuringValidate` state, the two static matchers, hooks them into both the validate-stream and firmware-follow-job `onOutput` callbacks, and splits `_renderResetSuggestion` into a dispatcher + two renderers (`_renderValidationFailureSuggestion` / `_renderBuildFailureSuggestion`). The `validate` command type always uses the validation-failure hint; `install` / `compile` failures branch on the latched flag. New `_tryOpenInEditor` handler closes the dialog and bubbles a `request-open-editor` event with the configuration.
* **`src/components/firmware-install-dialog.ts`** — same shape: `_failedDuringValidate` state + matchers + branched `_renderResetSuggestion` + `_tryOpenInEditor`. The Web Serial install dialog only runs the compile via the server-side firmware-follow-job stream, so detection only needs that one hook.
* **`src/pages/dashboard.ts`** — adds `@request-open-editor` on both dialog mounts, routes through `_onRequestOpenEditor` which SPA-navigates to `/device/<configuration>` via the existing `navigate` helper.
* **`src/pages/device.ts`** — same wiring, but the page is already the editor for the failing device. Handler is a no-op (the dialog closing itself is the whole UX); guards with an explicit equality check so a future cross-device regression can't silently land the user on the wrong route.
* **`src/translations/{en,fr,nl}.json`** — adds `validation_failed_suggestion` (uses `{editor_action}` placeholder) and `try_open_editor_button`. Translation parity en / fr / nl.

## UX

Sentence reads (en): "Looks like a configuration error. Try opening this device in the editor to fix the YAML."

Clean / Reset stays the hint when the build genuinely got past validation and the C++ compile fell over — that's still the right staircase. The new branch only fires when ESPHome itself signalled "this YAML didn't validate."

## Testing

* `npm run lint` passes (`tsc --noEmit`).
* `npm run test` passes (1024 tests, no regressions).
* Manual verification path documented in the PR: a YAML with a lambda referencing an undefined symbol fails C++ compile (gets clean → reset). A YAML with e.g. a malformed `wifi:` block fails schema validation (gets editor hint).

## Why frontend log-scraping and not a backend typed signal

The architecturally correct version is a `failure_phase` field on `FirmwareJob` set backend-side (where the marker actually lives), surfaced on `JobLifecycleData`, and consumed by typed event handlers. That's a larger change (model + wire shape + frontend consumer) that I'd land as a followup if the regex turns out to be fragile in practice. ESPHome's `Failed config` line has been stable for years and the matchers are explicit enough that a phrasing change would surface on the manual test path; this gets the UX fix landed without the wire churn.

**Related issue or feature (if applicable):**

- Followup to esphome/device-builder-frontend#293 — that PR introduced the clean → reset staircase, this one carves the YAML-validation case out of it.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
