### PR TITLE
Migrate remote-build-job-dialog to base-dialog (fixes two-X bug)

### DIFF
--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -1,5 +1,3 @@
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
-
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
@@ -22,7 +20,6 @@ import {
   type RemoteBuildJobState,
 } from "../context/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { inputStyles } from "../styles/inputs.js";
 import { jobStatusPillStyles } from "../styles/job-status-pill.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -30,6 +27,7 @@ import { isTerminalJobStatus } from "../util/firmware-job-status.js";
 import { renderErrorBanner } from "../util/render-error.js";
 
 import "./ansi-log.js";
+import "./base-dialog.js";
 
 type Step = "input" | "submitting" | "list";
 
@@ -568,48 +566,33 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         body = this._renderList();
         break;
     }
-    // Gate light-dismiss while the submit_job WS round-trip
-    // is in flight: outside-click / Esc / close-button can't
-    // dismiss between the submit and the ack returning, which
-    // would orphan the response (a successful ack would fire
-    // remote-build-job-submitted against an already-closed
-    // dialog). Mirrors pair-build-server-dialog's gate.
+    // ?busy gates outside-click + Esc + close-button while
+    // the submit_job WS round-trip is in flight: base-dialog
+    // flips light-dismiss off and vetoes wa-request-close
+    // when busy, so the dialog can't dismiss between the
+    // submit and the ack returning. Orphaning that response
+    // would fire remote-build-job-submitted against an
+    // already-closed dialog. Mirrors pair-build-server-dialog's
+    // gate.
     const busy = this._step === "submitting";
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         ?open=${this._open}
-        ?light-dismiss=${!busy}
-        @wa-request-close=${this._onRequestClose}
-        @wa-after-hide=${this._close}
+        ?busy=${busy}
+        .label=${title}
+        @after-hide=${this._close}
       >
-        <header slot="label">${title}</header>
-        <button
-          class="dialog-close"
-          slot="header-actions"
-          aria-label=${this._localize("layout.close")}
-          ?disabled=${busy}
-          @click=${this._close}
-        >
-          ✕
-        </button>
         ${body}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
-
-  private _onRequestClose = (e: Event): void => {
-    if (this._step === "submitting") {
-      e.preventDefault();
-    }
-  };
 
   static styles = [
     espHomeStyles,
     inputStyles,
-    dialogCloseButtonStyles,
     jobStatusPillStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 560px;
       }
 


### PR DESCRIPTION
# What does this implement/fix?

The Remote builds dialog renders **two X buttons** in the
header:

![Two X buttons](https://github.com/user-attachments/assets/dialog-two-x-bug)

Same shape as the latent bug that the base-dialog rollout
surfaced on api-key-dialog in
esphome/device-builder-frontend#282 — the custom
`<button class="dialog-close" slot="header-actions">`
rendered alongside wa-dialog's built-in close instead of
replacing it.

`remote-build-job-dialog` wasn't on the 10-dialog list when
the base-dialog rollout swept (#281 → #287); it was added
later in the 5c-4 multi-job UI follow-ups
(esphome/device-builder-frontend#272 / #273 / #275). It
kept the pre-base-dialog scaffolding and the two-X bug was
latent until someone opened the Remote builds dialog
during a running build.

## Fix

Migrate to `<esphome-base-dialog>`, matching the recipe
pinned in #282:

- Drop the direct `wa-dialog` import and
  `dialogCloseButtonStyles` import (base-dialog bundles
  both transitively).
- `<wa-dialog>` → `<esphome-base-dialog>`; the custom
  `<button class="dialog-close" slot="header-actions">`
  removed entirely. Base-dialog uses wa-dialog's built-in
  close, gates it visually + functionally on `?busy`.
- `_onRequestClose` veto handler removed: `?busy` on
  base-dialog already vetoes `wa-request-close` for the
  in-flight submit_job round-trip, so
  `?busy=${busy}` replaces the manual gate.
- `wa-dialog { --width: 560px }` →
  `esphome-base-dialog { --width: 560px }`.

## Tests

- 1024 frontend tests pass.
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- Visible regression on the Remote builds dialog —
  two close X icons in the header.

## Manual UI verification

Open Settings → Build server → click a paired server's
"View build" button on a running remote build. Verify:

- Only one X button in the header (the wa-dialog
  built-in).
- Close via X / Esc / outside-click works.
- During the submit step (input → submitting transition),
  X / Esc / outside-click are vetoed.
- Cancel build / Close affordances still function from
  inside the dialog body.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
