### PR TITLE
Migrate reauth-wizard-dialog to base-dialog (fixes two-X bug)

### DIFF
--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -1,19 +1,17 @@
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
-
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import type { OffloaderPinMismatchAlert } from "../api/types.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { formatPinSha256 } from "../util/cert-pin-format.js";
 import { trimTrailingDot } from "../util/hostname.js";
 
+import "./base-dialog.js";
 import "./pin-emoji-grid.js";
 
 type Step = 1 | 2 | 3;
@@ -81,9 +79,6 @@ export class ESPHomeReauthWizardDialog extends LitElement {
    *  operator can't bypass the "I've checked with the receiver
    *  admin" acknowledgment. Resets on every ``open()``. */
   @state() private _verified = false;
-
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
 
   open(alert: OffloaderPinMismatchAlert): void {
     this._alert = alert;
@@ -241,35 +236,27 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           : this._renderStep3(alert);
     const title = this._localize(`settings.reauth_wizard_step${this._step}_title`);
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         ?open=${this._open}
-        light-dismiss
-        @wa-after-hide=${this._onClose}
+        .label=${title}
+        @after-hide=${this._onClose}
       >
-        <header slot="label">
-          <div class="title">${title}</div>
-          <div class="step-indicator" aria-label=${this._localize(
+        <div
+          class="step-indicator"
+          aria-label=${this._localize(
             "settings.reauth_wizard_step_progress",
             { step: this._step, total: 3 },
-          )}>
-            ${[1, 2, 3].map(
-              (n) => html`
-                <span
-                  class=${`dot ${this._step === n ? "dot-active" : ""}`}
-                  aria-hidden="true"
-                ></span>
-              `,
-            )}
-          </div>
-        </header>
-        <button
-          class="dialog-close"
-          slot="header-actions"
-          aria-label=${this._localize("layout.close")}
-          @click=${this._onClose}
+          )}
         >
-          ✕
-        </button>
+          ${[1, 2, 3].map(
+            (n) => html`
+              <span
+                class=${`dot ${this._step === n ? "dot-active" : ""}`}
+                aria-hidden="true"
+              ></span>
+            `,
+          )}
+        </div>
         <div class="step-body">${stepBody}</div>
         <div class="actions">
           <button class="btn btn--cancel" type="button" @click=${this._onClose}>
@@ -293,35 +280,32 @@ export class ESPHomeReauthWizardDialog extends LitElement {
                 ${this._localize("settings.reauth_wizard_repair_action")}
               </button>`}
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
   static styles = [
     espHomeStyles,
-    dialogCloseButtonStyles,
     pinHexStyles,
     dialogActionButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 560px;
       }
 
-      header[slot="label"] {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-2xs);
-      }
-
-      .title {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-      }
-
+      /* Step-progress dots sit at the top of the body. The
+         pre-migration shape rendered them inside the
+         slot=label header next to the wizard title;
+         base-dialog's .label property only takes a string,
+         so the indicator moved into the body where it reads
+         as the first row above the step content. Wizard
+         title still renders in the dialog header via the
+         .label property. */
       .step-indicator {
         display: flex;
         gap: 6px;
         align-items: center;
+        padding-bottom: var(--wa-space-s);
       }
 
       .dot {


### PR DESCRIPTION
# What does this implement/fix?

`reauth-wizard-dialog.ts` has the same two-X-button latent
bug that `remote-build-job-dialog` had (fixed in
esphome/device-builder-frontend#296): the custom
`<button class="dialog-close" slot="header-actions">`
rendered alongside wa-dialog's built-in close, so the
re-auth wizard's header shows two X icons during a
pin-mismatch walk-through.

This dialog wasn't on the 10-dialog base-dialog rollout
list (it landed later in 8a, esphome/device-builder-frontend#277)
and kept the pre-base-dialog scaffolding.

## Fix

Migrate to `<esphome-base-dialog>`, matching the recipe
pinned in #282 + #296:

- Drop the direct `wa-dialog` import +
  `dialogCloseButtonStyles` import (base-dialog bundles
  both transitively).
- `<wa-dialog>` → `<esphome-base-dialog>`; the custom
  `slot="header-actions"` close button removed entirely.
- `@query("wa-dialog")` field dropped — it was unused.
- Step-indicator dots moved from inside the custom
  `slot="label"` header into the top of the dialog body.
  Base-dialog's `.label` property only takes a string, so
  the dots had to leave the header. They render as the
  first row above the step content with a small bottom
  pad to separate from the lede paragraph.
- Wizard title still renders in the dialog header via the
  new `.label` property.
- `light-dismiss` flag dropped at the call site;
  base-dialog defaults to `light-dismiss=on` (no busy
  state on this dialog).

## Tests

- 1024 frontend tests pass.
- `npm run lint` clean.

**Related issue or feature (if applicable):**

- Same shape as esphome/device-builder-frontend#296. After
  this lands the audit grep
  (`slot="header-actions"` ∩ `class="dialog-close"`)
  returns nothing.

## Manual UI verification

Reproduce a pin_mismatch alert (rotate a paired
receiver's identity) and open the re-auth wizard from the
alert banner. Verify:

- Only one X button in the header (the wa-dialog
  built-in).
- The three-dot step indicator is visible at the top of
  the body, with the active step highlighted.
- Step navigation (Back / Continue) still works.
- Close via X / Esc / outside-click works on every step.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
