### PR TITLE
Show 'Building on <receiver>' on REMOTE rows in Firmware tasks

### DIFF
--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -16,7 +16,7 @@ import {
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { JobStatus, JobType } from "../api/types.js";
+import { JobSource, JobStatus, JobType } from "../api/types.js";
 import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
 import { activeLocale } from "../common/localize.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -349,6 +349,18 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
         gap: var(--wa-space-xs);
       }
 
+      /* "Building on <receiver-label>" sub-line under the meta
+         row. Only renders when the job carries a REMOTE source
+         (see _renderSourceLine). Matches the meta line's quiet
+         palette but lives on its own line so a long receiver
+         label doesn't push the status / timestamp off-screen
+         on narrow viewports. */
+      .job-source {
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-quiet);
+        margin-top: 2px;
+      }
+
       .job-status {
         display: inline-flex;
         align-items: center;
@@ -548,6 +560,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
             ${this._renderStatus(job)}
             ${this._renderTimestamp(job)}
           </div>
+          ${this._renderSourceLine(job)}
           ${showProgress
             ? html`
                 <div class="progress">
@@ -592,6 +605,22 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       >
         <wa-icon library="mdi" name="close"></wa-icon>
       </button>
+    `;
+  }
+
+  /** Sub-line under the meta row naming the paired receiver a
+   *  REMOTE-routed install is building on. Picked up from
+   *  job.source_label, snapshotted at job-creation time so the
+   *  row text doesn't churn if the pairing is later renamed.
+   *  LOCAL jobs (and anything from before 7a-2a's source field
+   *  landed) carry an empty source_label, so this row is
+   *  effectively a no-op for them. */
+  private _renderSourceLine(job: FirmwareJob) {
+    if (job.source !== JobSource.REMOTE || !job.source_label) return nothing;
+    return html`
+      <div class="job-source">
+        ${this._localize("firmware_jobs.building_on", { label: job.source_label })}
+      </div>
     `;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1016,6 +1016,7 @@
     "type_rename": "Rename",
     "time_queued": "queued {time}",
     "time_started": "started {time}",
-    "time_finished": "finished {time}"
+    "time_finished": "finished {time}",
+    "building_on": "Building on {label}"
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

User-reported: the Firmware tasks dialog's active /
recent rows don't show which paired receiver a
REMOTE-routed install is building on. Screenshot from
the original report — the active row reads
"Install · Running… · started 3 seconds ago" with no
hint that the build is dispatched to a paired server.

Same operator-facing gap the install-dialog
`_primedSource` sub-line closed for the streaming view
(7a-2a / 7a-3); it just hadn't landed on the
firmware-tasks list yet.

## Fix

Both halves of the data already flow on the wire:
`FirmwareJob.source` (LOCAL / REMOTE discriminator) and
`FirmwareJob.source_label` (snapshot of the pairing's
label at job-creation time). All this PR needs is the
render branch.

- New `_renderSourceLine(job)` helper. Renders a
  "Building on {label}" sub-line under the meta row
  whenever a job carries `source === REMOTE` and a
  non-empty `source_label`. LOCAL jobs (and anything
  from before 7a-2a's source field landed) carry an
  empty `source_label`, so the helper short-circuits
  for them.
- Sub-line uses the existing quiet meta palette but
  lives on its own line so a long receiver label
  doesn't push the status / timestamp off-screen on
  narrow viewports.
- en translation key `firmware_jobs.building_on`. The
  fr/nl `firmware_jobs` blocks currently only carry
  `menu_item` / `menu_item_with_count` and pick up the
  en fallback for everything else; this key follows the
  same fallback path.

## Render shape

Before:

```
[icon] Athom Plug V3 4fe9f8
       Install · Running… · started 3 seconds ago
```

After (REMOTE-routed install):

```
[icon] Athom Plug V3 4fe9f8
       Install · Running… · started 3 seconds ago
       Building on Mac.koston.org
```

LOCAL installs render unchanged.

## Tests

- 1024 frontend tests pass (no regression).
- `npm run lint` clean.

## Manual UI verification

Open the Firmware tasks dialog (header → "Firmware
tasks") during a remote install. Verify the active row
carries a "Building on <receiver-label>" sub-line.
Trigger a local install to verify LOCAL rows don't
carry it. Check Recent rows for a finished remote
install — the sub-line stays.

## Out of scope

The user also flagged: "as soon as it finishes I can't
click on it and see the build log anymore." The row is
a `<button>` with an unconditional click handler routing
to `command-dialog.followJob(job)`, which documents
handling terminal jobs (backend's `firmware/follow_job`
replays buffered output for terminal status). I couldn't
reproduce locally so saving for a separate ticket once
there's a clearer repro path (output empty? dialog
opens but immediately closes? etc.).

**Related issue or feature (if applicable):**

- User-reported on the firmware-tasks dialog; ties back
  to esphome/device-builder#106 (remote build) 7a-3
  install integration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
