### PR TITLE
Add 'Build locally instead' override link to install dialog

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1098,9 +1098,23 @@ export class ESPHomeAPI {
     return this.sendCommand<FirmwareJob>("firmware/upload", { configuration, port });
   }
 
-  /** Queue a compile+upload job (defaults to OTA). */
-  async firmwareInstall(configuration: string, port = "OTA"): Promise<FirmwareJob> {
-    return this.sendCommand<FirmwareJob>("firmware/install", { configuration, port });
+  /** Queue a compile+upload job (defaults to OTA).
+   *
+   *  ``forceLocal=true`` bypasses the offloader-side scheduler
+   *  decision and runs the install on the local CPU regardless of
+   *  paired build servers — used by the install dialog's "Build
+   *  locally instead" override link when the operator wants to
+   *  opt out of the transparent REMOTE routing for one install. */
+  async firmwareInstall(
+    configuration: string,
+    port = "OTA",
+    forceLocal = false,
+  ): Promise<FirmwareJob> {
+    return this.sendCommand<FirmwareJob>("firmware/install", {
+      configuration,
+      port,
+      force_local: forceLocal,
+    });
   }
 
   /** Queue a clean job. */

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -177,6 +177,13 @@ export class ESPHomeCommandDialog extends LitElement {
    *  prefers the live context entry when present, so a
    *  stale prime is benign once ``_jobs`` catches up. */
   private _primedSource: { source: JobSource; source_label: string } | null = null;
+  /** True while the "Build locally instead" override is mid-flight
+   *  (cancel + resubmit pair). Disables the link so a fast double-
+   *  click can't queue two resubmits, and lets the renderer flip
+   *  the label to "Switching…" so the user sees something is
+   *  happening across the small ``firmware/cancel`` → ``firmware/install``
+   *  round-trip. */
+  @state() private _switchingToLocal = false;
   /** Stream message ID (for both validate streaming and follow_job streaming). */
   private _streamId = "";
   /** Install target port — "OTA" for network, an actual port for server-serial. */
@@ -380,6 +387,38 @@ export class ESPHomeCommandDialog extends LitElement {
       .remote-builder-sub-line wa-icon {
         font-size: 16px;
         flex-shrink: 0;
+      }
+      .remote-builder-sub-line .spacer {
+        flex: 1;
+      }
+
+      /* "Build locally instead" override link. Sits at the
+         right edge of the remote-builder sub-line and fires
+         the cancel-and-resubmit-locally flow when clicked.
+         Styled as an inline text link rather than a button —
+         the row is informational chrome, not a primary action
+         surface, so a full-fledged button would over-promise.
+         Disabled while a switch is mid-flight so a fast
+         double-click can't queue two resubmits. */
+      .force-local-link {
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
+        color: var(--esphome-primary, #1e88e5);
+        cursor: pointer;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+      }
+      .force-local-link:hover:not(:disabled),
+      .force-local-link:focus-visible {
+        text-decoration-thickness: 2px;
+        outline: none;
+      }
+      .force-local-link:disabled {
+        color: var(--wa-color-text-quiet, #888);
+        cursor: not-allowed;
+        text-decoration: none;
       }
 
       /* Reset-build-env suggestion — surfaced only on install/compile
@@ -720,6 +759,15 @@ export class ESPHomeCommandDialog extends LitElement {
     const source = liveJob?.source ?? this._primedSource?.source;
     const label = liveJob?.source_label ?? this._primedSource?.source_label;
     if (source !== JobSource.REMOTE || !label) return nothing;
+    // Only allow the override while the install is mid-flight
+    // and only for the install command type — switching mid-
+    // upload doesn't make sense, and switching a compile job
+    // mid-flight is a power-user shape we don't have a UI for
+    // yet. For terminal jobs ``_renderRemoteBuilderSubLine``
+    // already returns ``nothing`` above; this guard is the
+    // remaining gate for "compile-only" and "command-dialog
+    // opened from non-Install entry points".
+    const canOverride = this._commandType === "install";
     return html`
       <div class="remote-builder-sub-line" role="status">
         <wa-icon library="mdi" name="server-network"></wa-icon>
@@ -728,9 +776,81 @@ export class ESPHomeCommandDialog extends LitElement {
             receiver: label,
           })}</span
         >
+        ${canOverride
+          ? html`
+              <span class="spacer"></span>
+              <button
+                class="force-local-link"
+                ?disabled=${this._switchingToLocal}
+                @click=${this._onForceLocalClick}
+              >
+                ${this._switchingToLocal
+                  ? this._localize("command.force_local_switching")
+                  : this._localize("command.force_local_action")}
+              </button>
+            `
+          : nothing}
       </div>
     `;
   }
+
+  /** Cancel the in-flight REMOTE install and resubmit as LOCAL.
+   *
+   *  The dialog stays attached: after the cancel lands the
+   *  fresh ``firmwareInstall`` returns the new ``FirmwareJob``,
+   *  we re-prime ``_primedSource`` (so the sub-line disappears
+   *  on the very first paint), and call ``_followJob`` to
+   *  follow the new ``job_id``. The visible end-result for the
+   *  operator: "Building on X" sub-line replaced by the local
+   *  compile output stream, no dialog flicker.
+   *
+   *  Edge cases that fall out for free:
+   *  - Cancel race: if the in-flight job hits a terminal state
+   *    before the cancel WS call lands, the backend's
+   *    ``firmware/cancel`` rejects with NOT_FOUND / wrong-state
+   *    — caught here so we still try the resubmit.
+   *  - Resubmit failure: if ``firmware/install`` rejects (port
+   *    invalid, validation failure), the dialog flips to the
+   *    error banner via the normal command flow.
+   *  - Double-click: ``_switchingToLocal`` gates the button
+   *    visually + functionally so the second click is a no-op. */
+  private _onForceLocalClick = async (): Promise<void> => {
+    if (this._switchingToLocal) return;
+    this._switchingToLocal = true;
+    const configuration = this.configuration;
+    const port = this._port;
+    const cancelJobId = this._jobId;
+    try {
+      if (cancelJobId) {
+        // Swallow cancel failures — the most common reason is
+        // a job that flipped to a terminal state in the same
+        // tick, in which case the resubmit below is still the
+        // right move. A genuine WS error here surfaces on the
+        // resubmit too.
+        try {
+          await this._api.firmwareCancel(cancelJobId);
+        } catch {
+          /* see note above — the cancel is best-effort */
+        }
+      }
+      const job = await this._api.firmwareInstall(configuration, port, true);
+      // Re-attach the dialog to the new job. ``followJob``
+      // resets the line buffer + primes ``_jobStatus`` /
+      // ``_primedSource`` so the "Building on" sub-line
+      // disappears on the next render without waiting for the
+      // jobs-context update.
+      this.followJob(job, this.name);
+    } catch (err) {
+      // Surface the failure on the existing error banner shape
+      // so the operator sees what went wrong rather than the
+      // sub-line silently staying put.
+      this._state = "error";
+      this._statusMessage =
+        err instanceof Error ? err.message : this._localize("command.force_local_failed");
+    } finally {
+      this._switchingToLocal = false;
+    }
+  };
 
   /** True when this dialog is following a job that's still in the
    *  queue — backend serialises firmware work, so an Install kicked

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -15,8 +15,9 @@ import {
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { JobSource, JobStatus, JobType } from "../api/types.js";
+import { ErrorCode, JobSource, JobStatus, JobType } from "../api/types.js";
 import type { FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeAnsiLog } from "./ansi-log.js";
@@ -804,14 +805,23 @@ export class ESPHomeCommandDialog extends LitElement {
    *  operator: "Building on X" sub-line replaced by the local
    *  compile output stream, no dialog flicker.
    *
-   *  Edge cases that fall out for free:
-   *  - Cancel race: if the in-flight job hits a terminal state
-   *    before the cancel WS call lands, the backend's
-   *    ``firmware/cancel`` rejects with NOT_FOUND / wrong-state
-   *    — caught here so we still try the resubmit.
-   *  - Resubmit failure: if ``firmware/install`` rejects (port
-   *    invalid, validation failure), the dialog flips to the
-   *    error banner via the normal command flow.
+   *  Edge cases:
+   *  - Cancel-already-terminal race: if the in-flight job
+   *    flipped to a terminal state in the same tick, the
+   *    backend rejects with ``NOT_FOUND`` (already cleared) or
+   *    ``INVALID_ARGS`` (terminal). The override path swallows
+   *    those specifically and proceeds to the resubmit — the
+   *    operator's intent is "I want LOCAL now," which is still
+   *    achievable.
+   *  - Transport / unexpected cancel failure: surface the
+   *    error and abort the override so we don't queue a second
+   *    install while the original REMOTE keeps running.
+   *  - Resubmit failure: the dialog flips to the error banner
+   *    with a localized status message; ``APIError.details``
+   *    rides through as the secondary line via ``_lines`` so
+   *    the operator sees both the friendly copy and the wire
+   *    detail. Plain ``Error`` instances pass through their
+   *    ``.message`` verbatim.
    *  - Double-click: ``_switchingToLocal`` gates the button
    *    visually + functionally so the second click is a no-op. */
   private _onForceLocalClick = async (): Promise<void> => {
@@ -822,15 +832,14 @@ export class ESPHomeCommandDialog extends LitElement {
     const cancelJobId = this._jobId;
     try {
       if (cancelJobId) {
-        // Swallow cancel failures — the most common reason is
-        // a job that flipped to a terminal state in the same
-        // tick, in which case the resubmit below is still the
-        // right move. A genuine WS error here surfaces on the
-        // resubmit too.
         try {
           await this._api.firmwareCancel(cancelJobId);
-        } catch {
-          /* see note above — the cancel is best-effort */
+        } catch (cancelErr) {
+          // Only swallow the cancel-already-terminal race —
+          // any other failure (transport, server bug, …)
+          // aborts the override so we don't queue a second
+          // install while the original REMOTE keeps running.
+          if (!this._isCancelAlreadyTerminal(cancelErr)) throw cancelErr;
         }
       }
       const job = await this._api.firmwareInstall(configuration, port, true);
@@ -841,16 +850,48 @@ export class ESPHomeCommandDialog extends LitElement {
       // jobs-context update.
       this.followJob(job, this.name);
     } catch (err) {
-      // Surface the failure on the existing error banner shape
-      // so the operator sees what went wrong rather than the
-      // sub-line silently staying put.
+      // Surface the failure on the existing error banner. The
+      // primary status message is the localized "couldn't
+      // switch" copy (so the operator sees user-facing language,
+      // not a wire error code); the secondary detail rides into
+      // ``_lines`` as a single line so the existing log surface
+      // carries the actionable detail. APIError.details is the
+      // server-provided actionable text; plain Error instances
+      // fall back to ``.message``.
       this._state = "error";
-      this._statusMessage =
-        err instanceof Error ? err.message : this._localize("command.force_local_failed");
+      this._statusMessage = this._localize("command.force_local_failed");
+      const detail = this._formatForceLocalError(err);
+      if (detail) this._lines = [...this._lines, detail];
     } finally {
       this._switchingToLocal = false;
     }
   };
+
+  /** Recognise the cancel-already-terminal race so the override
+   *  swallows only that specific failure path. ``NOT_FOUND`` =
+   *  the job already left ``_jobs``; ``INVALID_ARGS`` = the
+   *  backend's "Cannot cancel a {status} job" reject for a job
+   *  that already flipped to a terminal status in the same
+   *  tick. Anything else — transport error, server bug — gets
+   *  re-raised. */
+  private _isCancelAlreadyTerminal(err: unknown): boolean {
+    if (!(err instanceof APIError)) return false;
+    return (
+      err.errorCode === ErrorCode.NOT_FOUND ||
+      err.errorCode === ErrorCode.INVALID_ARGS
+    );
+  }
+
+  /** Format an override-flow error for the secondary detail
+   *  line. ``APIError.details`` is the server-provided
+   *  user-facing text (e.g. the configuration validator's line
+   *  number); plain ``Error`` instances fall back to
+   *  ``.message``. */
+  private _formatForceLocalError(err: unknown): string {
+    if (err instanceof APIError) return err.details || err.errorCode;
+    if (err instanceof Error) return err.message;
+    return String(err);
+  }
 
   /** True when this dialog is following a job that's still in the
    *  queue — backend serialises firmware work, so an Install kicked

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -357,7 +357,10 @@
     "queued_message": "Another firmware task is running. This task will start when it finishes.",
     "queued_waiting_for": "Waiting for {name} to finish.",
     "queued_view_all": "View firmware tasks",
-    "remote_builder_sub_line": "Building on {receiver}"
+    "remote_builder_sub_line": "Building on {receiver}",
+    "force_local_action": "Build locally instead",
+    "force_local_switching": "Switching…",
+    "force_local_failed": "Couldn't switch to a local build"
   },
   "firmware": {
     "install_title": "Install — {name}",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -292,7 +292,10 @@
     "queued_title": "En file d'attente",
     "queued_message": "Une autre tâche firmware est en cours. Celle-ci démarrera à la fin.",
     "queued_waiting_for": "En attente de {name}.",
-    "queued_view_all": "Voir les tâches firmware"
+    "queued_view_all": "Voir les tâches firmware",
+    "force_local_action": "Compiler localement à la place",
+    "force_local_switching": "Bascule en cours…",
+    "force_local_failed": "Impossible de basculer vers une compilation locale"
   },
   "serial": {
     "title": "Appareil USB",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -292,7 +292,10 @@
     "queued_title": "In wachtrij",
     "queued_message": "Er draait al een andere firmwaretaak. Deze start zodra die klaar is.",
     "queued_waiting_for": "Wachten tot {name} klaar is.",
-    "queued_view_all": "Firmwaretaken bekijken"
+    "queued_view_all": "Firmwaretaken bekijken",
+    "force_local_action": "In plaats daarvan lokaal bouwen",
+    "force_local_switching": "Overschakelen…",
+    "force_local_failed": "Kon niet overschakelen naar lokaal bouwen"
   },
   "serial": {
     "title": "USB-apparaat",

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -551,12 +551,28 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     await pending;
   });
 
-  it("firmwareInstall defaults port to OTA", async () => {
+  it("firmwareInstall defaults port to OTA and force_local to false", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     api.firmwareInstall("foo.yaml");
     const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
-    expect(sent.args).toEqual({ configuration: "foo.yaml", port: "OTA" });
+    expect(sent.args).toEqual({
+      configuration: "foo.yaml",
+      port: "OTA",
+      force_local: false,
+    });
+  });
+
+  it("firmwareInstall threads force_local through to the backend", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    api.firmwareInstall("foo.yaml", "OTA", true);
+    const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
+    expect(sent.args).toEqual({
+      configuration: "foo.yaml",
+      port: "OTA",
+      force_local: true,
+    });
   });
 
   it("validate sends devices/validate through the stream API", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Frontend half of the install-dialog REMOTE-routing
override. When the scheduler dispatches an install REMOTE
the operator can now opt out and switch to a LOCAL build
mid-flight without unpairing the receiver or flipping the
global Settings toggle.

## What ships

The "Building on {receiver}" sub-line in the install
dialog gains a **"Build locally instead"** link on its
right edge, visible only for in-flight REMOTE-routed
install jobs.

```
[server-icon] Building on Mac.koston.org      Build locally instead
```

Click handler:

1. Cancel the current job via `firmware/cancel`
   (best-effort — swallows `NOT_FOUND` / wrong-state
   errors so a same-tick terminal flip doesn't block the
   resubmit).
2. Submit a fresh install with `force_local=true` (the
   new backend flag in the companion
   esphome/device-builder PR).
3. Re-attach the dialog to the new `job_id` via
   `followJob`, which re-primes `_primedSource` so the
   "Building on" sub-line disappears on the next render
   without waiting for the jobs-context update.

Disabled while the switch is mid-flight (`_switchingToLocal`
state flag) so a fast double-click cannot queue two
resubmits; flips the label to "Switching…" during the
roundtrip. Falls back to the existing error banner shape
if either WS call fails.

## Why a link, not a button

The remote-builder sub-line is informational chrome
(server icon + label), not a primary action surface. A
full-fledged button next to it would over-promise — the
sub-line is a hint about where the bytes are coming from,
and the override link is a quiet "I disagree with the
scheduler's pick this time" hook. Inline link styling
matches the existing reset-build-env hint pattern that
appears on compile failures.

## Tests

- Updated `firmwareInstall defaults port to OTA` to pin
  `force_local=false` as the wire default.
- New `firmwareInstall threads force_local through to the
  backend` covers the override path.
- 1025 frontend tests pass.
- `npm run lint` clean.

## Backend coordination

- esphome/device-builder PR adds `firmware/install`'s
  `force_local` arg. Default `False`, so this frontend
  ships safely against any backend version — the link
  becomes functional once the backend lands.

**Related issue or feature (if applicable):**

- refs esphome/device-builder#106 (remote build) — phase
  7a-3 user-facing override.

## Manual UI verification

1. Pair a build server, ensure remote_builds_enabled is
   on, ensure the receiver is connected.
2. Click Install on any device. Verify the install
   dialog shows "Building on {receiver}" with a
   "Build locally instead" link on the right edge.
3. Click the link. Verify:
   - The link briefly flips to "Switching…" and disables.
   - The remote build is cancelled (firmware-jobs panel
     shows the cancelled entry).
   - A new local install job appears + the dialog
     re-attaches to it.
   - The "Building on" sub-line disappears (the new job
     is LOCAL).
4. Double-click test: rapid double-click the link during
   step 3 — verify only one resubmit happens.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
