### PR TITLE
Render receiver-side remote-build job title + 'from {peer}' sub-line

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -982,6 +982,35 @@ export interface FirmwareJob {
    *  track later renames (the install dialog should show what the
    *  user saw when they clicked Install). */
   source_label: string;
+  /** Offloader's ``dashboard_id`` when this job came in via the
+   *  peer-link ``submit_job`` flow. Empty for locally-submitted
+   *  jobs. Receiver-side rendering surfaces this as a "from
+   *  <peer>" sub-line on the firmware-tasks dialog so a
+   *  build-server admin can distinguish their own work from
+   *  delegated builds. */
+  remote_peer: string;
+  /** Display label for the offloader, snapshotted from the
+   *  receiver's ``_approved_peers[dashboard_id].label`` at submit
+   *  time. Empty for locally-submitted jobs and for jobs from
+   *  before this field landed; the receiver-side renderer falls
+   *  back to the raw ``remote_peer`` dashboard_id when empty.
+   *  Symmetric to ``source_label`` on the offloader side. */
+  remote_peer_label: string;
+  /** The submitting device's ``esphome.name`` (machine handle),
+   *  sent by the offloader on the ``submit_job`` header. Empty
+   *  for locally-submitted jobs and for jobs whose offloader
+   *  didn't set the NotRequired wire field. The receiver-side
+   *  title surface uses this when ``remote_peer !== ""`` since
+   *  the receiver has no Device list of its own to look the
+   *  friendly name up against. */
+  device_name: string;
+  /** The submitting device's ``esphome.friendly_name`` (display
+   *  string), sent by the offloader on the ``submit_job`` header.
+   *  Empty for locally-submitted jobs, for jobs whose offloader
+   *  didn't set the NotRequired wire field, or for YAMLs that
+   *  don't define ``esphome.friendly_name``. The receiver-side
+   *  title surface prefers this over ``device_name`` when set. */
+  device_friendly_name: string;
 }
 
 export interface FirmwareBinary {

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -614,14 +614,33 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
    *  row text doesn't churn if the pairing is later renamed.
    *  LOCAL jobs (and anything from before 7a-2a's source field
    *  landed) carry an empty source_label, so this row is
-   *  effectively a no-op for them. */
+   *  effectively a no-op for them.
+   *
+   *  Symmetric receiver-side rendering: when ``remote_peer`` is
+   *  set, the job was submitted to this dashboard by another
+   *  dashboard's offloader. Render "from {peer}" with the
+   *  peer's snapshotted label (or the raw dashboard_id as a
+   *  fallback when an older offloader's submit didn't carry
+   *  ``remote_peer_label``). The same .job-source style runs
+   *  for both directions so the visual treatment matches.
+   */
   private _renderSourceLine(job: FirmwareJob) {
-    if (job.source !== JobSource.REMOTE || !job.source_label) return nothing;
-    return html`
-      <div class="job-source">
-        ${this._localize("firmware_jobs.building_on", { label: job.source_label })}
-      </div>
-    `;
+    if (job.source === JobSource.REMOTE && job.source_label) {
+      return html`
+        <div class="job-source">
+          ${this._localize("firmware_jobs.building_on", { label: job.source_label })}
+        </div>
+      `;
+    }
+    if (job.remote_peer) {
+      const peer = job.remote_peer_label || job.remote_peer;
+      return html`
+        <div class="job-source">
+          ${this._localize("firmware_jobs.submitted_by", { label: peer })}
+        </div>
+      `;
+    }
+    return nothing;
   }
 
   private _renderStatus(job: FirmwareJob) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1025,6 +1025,7 @@
     "time_queued": "queued {time}",
     "time_started": "started {time}",
     "time_finished": "finished {time}",
-    "building_on": "Building on {label}"
+    "building_on": "Building on {label}",
+    "submitted_by": "from {label}"
   }
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -597,7 +597,8 @@
   },
   "firmware_jobs": {
     "menu_item": "Tâches firmware",
-    "menu_item_with_count": "Tâches firmware ({count} active(s))"
+    "menu_item_with_count": "Tâches firmware ({count} active(s))",
+    "submitted_by": "de {label}"
   },
   "secrets": {
     "title": "Secrets",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -597,7 +597,8 @@
   },
   "firmware_jobs": {
     "menu_item": "Firmwaretaken",
-    "menu_item_with_count": "Firmwaretaken ({count} actief)"
+    "menu_item_with_count": "Firmwaretaken ({count} actief)",
+    "submitted_by": "van {label}"
   },
   "secrets": {
     "title": "Geheimen",

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -16,6 +16,16 @@ import type { LocalizeFunc } from "../common/localize.js";
  *   so reopening one from the firmware-tasks list still says *which*
  *   rename this stream belongs to. Friendly name is prepended in
  *   parentheses when it differs from the raw hostname.
+ * - **Receiver-side remote-build jobs** (``remote_peer !== ""``) —
+ *   the receiver has no Device list to look the friendly name up
+ *   against (the YAML lives at
+ *   ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``, useless
+ *   as a title), so prefer the offloader-sent
+ *   ``device_friendly_name`` → fall back to ``device_name`` → fall
+ *   back to the configuration path's device segment. The
+ *   ``from {peer}`` attribution lives in a separate sub-line
+ *   (rendered alongside the meta row, not folded into the title)
+ *   so the title stays consistent with offloader-side rendering.
  * - Otherwise prefer the configured device's friendly name → fall
  *   back to ``name`` → fall back to the raw configuration filename.
  */
@@ -26,6 +36,25 @@ export function firmwareJobDisplayName(
 ): string {
   if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
     return localize("firmware_jobs.build_env_label");
+  }
+  if (job.remote_peer) {
+    if (job.device_friendly_name) {
+      return job.device_friendly_name;
+    }
+    if (job.device_name) {
+      return job.device_name;
+    }
+    /* Configuration is ``.esphome/.remote_builds/<id>/<device>/<device>.yaml``.
+       The second-to-last segment is the device folder name — the
+       cleanest fallback when both display fields are empty (older
+       offloader didn't set the NotRequired wire fields). Strip
+       the YAML extension off the last segment if the path has
+       only the filename (defensive). */
+    const segments = job.configuration.split("/");
+    if (segments.length >= 2) {
+      return segments[segments.length - 2];
+    }
+    return job.configuration.replace(/\.ya?ml$/, "") || job.configuration;
   }
   if (job.job_type === JobType.RENAME && job.new_name) {
     /* job.configuration is the *old* YAML filename (``foo.yaml`` or

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { JobSource, JobStatus, JobType } from "../../src/api/types.js";
+import type {
+  ConfiguredDevice,
+  FirmwareJob,
+} from "../../src/api/types.js";
+import type { LocalizeFunc } from "../../src/common/localize.js";
+import { firmwareJobDisplayName } from "../../src/util/firmware-job-display.js";
+
+/**
+ * Build a structurally-accurate ``FirmwareJob`` for tests.
+ *
+ * Mirrors the wire shape so a future addition / rename to the
+ * interface makes the helper fail to compile rather than
+ * silently drift behind a forced cast.
+ */
+function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
+  return {
+    job_id: "job-1",
+    configuration: "kitchen.yaml",
+    job_type: JobType.INSTALL,
+    status: JobStatus.RUNNING,
+    created_at: "2026-05-11T00:00:00Z",
+    started_at: null,
+    completed_at: null,
+    exit_code: null,
+    output: [],
+    error: null,
+    port: "",
+    new_name: "",
+    progress: null,
+    source: JobSource.LOCAL,
+    source_pin_sha256: "",
+    source_label: "",
+    remote_peer: "",
+    remote_peer_label: "",
+    device_name: "",
+    device_friendly_name: "",
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal ``LocalizeFunc`` — returns the key verbatim so the
+ * tests assert on the discriminator without coupling to copy.
+ *
+ * The display helper only calls ``localize`` for the
+ * ``build_env_label`` fallback today; the receiver-side branch
+ * never falls through to it, so a key-verbatim stub keeps the
+ * test focused on the title-resolution logic.
+ */
+const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+
+const NO_DEVICES: ConfiguredDevice[] = [];
+
+describe("firmwareJobDisplayName (receiver-side remote-build jobs)", () => {
+  it("prefers device_friendly_name when set", () => {
+    const j = job({
+      remote_peer: "alpha-dashboard",
+      configuration:
+        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      device_name: "kitchen",
+      device_friendly_name: "AC Float Monitor 32",
+    });
+
+    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe(
+      "AC Float Monitor 32",
+    );
+  });
+
+  it("falls back to device_name when friendly_name is empty", () => {
+    const j = job({
+      remote_peer: "alpha-dashboard",
+      configuration:
+        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      device_name: "kitchen",
+      device_friendly_name: "",
+    });
+
+    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe("kitchen");
+  });
+
+  it("falls back to the path's device segment when both display fields are empty", () => {
+    /* Older offloader didn't set the NotRequired wire fields;
+       the receiver's title surface degrades to the path's
+       device segment rather than rendering the cryptic full
+       configuration path. */
+    const j = job({
+      remote_peer: "alpha-dashboard",
+      configuration:
+        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      device_name: "",
+      device_friendly_name: "",
+    });
+
+    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe("kitchen");
+  });
+
+  it("ignores the local Device list for receiver-side jobs", () => {
+    /* The receiver has its own Device list for its own
+       locally-configured YAMLs but those configurations don't
+       match the remote-build path. A stray same-stem entry
+       must NOT shadow the offloader-sent name. */
+    const j = job({
+      remote_peer: "alpha-dashboard",
+      configuration:
+        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      device_friendly_name: "AC Float Monitor 32",
+    });
+    const decoyDevices: ConfiguredDevice[] = [
+      {
+        name: "kitchen",
+        friendly_name: "Some Other Kitchen Device",
+        configuration: "kitchen.yaml",
+      } as ConfiguredDevice,
+    ];
+
+    expect(firmwareJobDisplayName(j, decoyDevices, localize)).toBe(
+      "AC Float Monitor 32",
+    );
+  });
+});
+
+describe("firmwareJobDisplayName (locally-submitted jobs)", () => {
+  it("prefers the configured device's friendly_name", () => {
+    const j = job({ configuration: "kitchen.yaml" });
+    const devices: ConfiguredDevice[] = [
+      {
+        name: "kitchen",
+        friendly_name: "Kitchen Sensor",
+        configuration: "kitchen.yaml",
+      } as ConfiguredDevice,
+    ];
+
+    expect(firmwareJobDisplayName(j, devices, localize)).toBe("Kitchen Sensor");
+  });
+
+  it("falls back to configuration when no matching device", () => {
+    const j = job({ configuration: "unknown.yaml" });
+
+    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe("unknown.yaml");
+  });
+});

--- a/test/util/firmware-job-status.test.ts
+++ b/test/util/firmware-job-status.test.ts
@@ -31,6 +31,10 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     source: JobSource.LOCAL,
     source_pin_sha256: "",
     source_label: "",
+    remote_peer: "",
+    remote_peer_label: "",
+    device_name: "",
+    device_friendly_name: "",
     ...overrides,
   };
 }


### PR DESCRIPTION
# What does this implement/fix?

Companion to [esphome/device-builder#587](https://github.com/esphome/device-builder/pull/587). The receiver-side firmware-tasks dialog renders the raw remote-build configuration path as the title:

```
.esphome/.remote_builds/8Ja02_-QQeziVZemmcO2BZOnaLAaVSgq/a...
Compile / Running... / started 18 seconds ago
```

This PR turns that into:

```
AC Float Monitor 32
Compile / Running... / started 18 seconds ago
from MacBook Pro
```

The backend PR adds three new fields on every `FirmwareJob` whose `remote_peer !== ""`:

* `device_name` / `device_friendly_name` — the YAML's `esphome.name` / `esphome.friendly_name`, sent by the offloader on the `submit_job` header (the offloader already has both off its local Device scanner at install time; the receiver doesn't re-parse the bundled YAML).
* `remote_peer_label` — snapshot of the offloader's pairing label at submit time.

## What lands

* **`src/api/types.ts`** — `FirmwareJob` interface gains the four new fields (the three above + `remote_peer`, which was already on the wire but missing from the TypeScript type).
* **`src/util/firmware-job-display.ts`** — `firmwareJobDisplayName` gains a receiver-side branch: prefer `device_friendly_name` → `device_name` → the configuration path's device segment. The receiver has no Device list of its own to look up the friendly name against (the YAML lives under `.esphome/.remote_builds/<id>/<device>/<device>.yaml`), so the offloader-sent fields are the authoritative source.
* **`src/components/firmware-jobs-dialog.ts`** — `_renderSourceLine` now renders a "from {peer}" sub-line for receiver-side jobs alongside the existing "Building on {receiver}" for offloader-side REMOTE jobs. Same `.job-source` style so the visual treatment matches. Falls back to `remote_peer` (the dashboard_id) when `remote_peer_label` is empty (older receivers).
* **`src/translations/en.json`** — new `firmware_jobs.submitted_by` key. fr/nl translations follow the same convention as the existing `building_on` key (en-only until the auto-translation tooling catches up).

## Tests

* `test/util/firmware-job-display.test.ts` (new) — 6 cases:
  - Receiver-side prefers `device_friendly_name`.
  - Falls back to `device_name` when friendly is empty.
  - Falls back to path device segment when both are empty.
  - Doesn't shadow with a decoy local Device entry sharing the basename.
  - Local-job rendering uses the local Device's friendly name (unchanged behaviour).
  - Local-job falls back to configuration when no matching device.
* `test/util/firmware-job-status.test.ts` — extended the test helper's `job()` shape with the four new fields so the type matches the interface.

1034 tests pass; `tsc --noEmit` clean.

## Backwards compatibility

* **Older receiver, new offloader**: receiver silently ignores the extra wire fields it doesn't know about. Frontend sees `remote_peer_label = ""` and falls back to `remote_peer` (dashboard_id) for the sub-line; sees `device_*` empty and falls back to the path's device segment. UI degrades gracefully.
* **New receiver, older offloader**: receiver creates the FirmwareJob with `device_name = device_friendly_name = ""`. Same UI fallback path. The `remote_peer_label` still populates because that comes from the receiver's own `_approved_peers` lookup.

## Lockstep deployment

This PR's interface changes match esphome/device-builder#587's wire-shape additions exactly. Land them together so the prebuilt frontend bundled in the next backend release renders the new sub-line; landing the frontend alone before the backend leaves the new sub-line invisible (because `remote_peer` is always empty in the wire payload), which is also a safe state.

**Related issue or feature (if applicable):**

- Companion to esphome/device-builder#587 — receiver-side UI follow-up to phase 7a-5.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Backend coordination

- [ ] No backend change needed
- [x] Companion backend PR: esphome/device-builder#587

## Checklist

- [x] The code change is tested and works locally.
- [x] `npx tsc --noEmit` and `npx vitest run` both clean.
- [x] New translation key added (en); fr/nl follow the existing auto-translation cadence.
