### PR TITLE
Rewrite remote_build_enable_desc to drop the AI-sounding hedge

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -753,7 +753,7 @@
     "build_offload": "Send builds",
     "build_offload_unimplemented_banner": "Sending builds to another dashboard isn't implemented yet. Hostnames added here are remembered, but no compile jobs are dispatched until pairing ships in a later release.",
     "remote_build_enable": "Enable remote build",
-    "remote_build_enable_desc": "Allow other dashboards on your network to send firmware compile jobs to this dashboard. Pairing with a peer grants it the ability to run code on this host — only enable for dashboards you already trust at a shell level.",
+    "remote_build_enable_desc": "Lets other dashboards on your network compile their YAML here. A paired peer can run arbitrary code on this machine; only pair with dashboards you'd give ssh access to.",
     "remote_build_known_dashboards": "Known dashboards",
     "remote_build_peers_loading": "Loading…",
     "remote_build_peers_empty": "No dashboards discovered yet.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -690,7 +690,7 @@
     "build_offload": "Envoyer les compilations",
     "build_offload_unimplemented_banner": "L'envoi de compilations à un autre tableau de bord n'est pas encore implémenté. Les noms d'hôte ajoutés ici sont mémorisés, mais aucune tâche de compilation n'est dispatchée tant que l'appairage n'est pas livré dans une version ultérieure.",
     "remote_build_enable": "Activer la compilation à distance",
-    "remote_build_enable_desc": "Permettre à d'autres tableaux de bord de votre réseau d'envoyer des tâches de compilation de firmware à ce tableau de bord. L'appairage avec un pair lui donne la possibilité d'exécuter du code sur cet hôte ; n'activez que pour les tableaux de bord auxquels vous faites déjà confiance au niveau shell.",
+    "remote_build_enable_desc": "Permet à d'autres tableaux de bord de votre réseau de compiler leur YAML ici. Un pair appairé peut exécuter n'importe quel code sur cette machine ; n'appairez qu'avec des tableaux de bord à qui vous donneriez un accès ssh.",
     "remote_build_known_dashboards": "Tableaux de bord connus",
     "remote_build_peers_loading": "Chargement…",
     "remote_build_peers_empty": "Aucun tableau de bord découvert pour le moment.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -690,7 +690,7 @@
     "build_offload": "Builds verzenden",
     "build_offload_unimplemented_banner": "Builds naar een ander dashboard verzenden is nog niet geïmplementeerd. Hostnamen die hier zijn toegevoegd worden onthouden, maar er worden geen compile-taken verzonden totdat koppeling in een latere release wordt uitgebracht.",
     "remote_build_enable": "Bouwen op afstand inschakelen",
-    "remote_build_enable_desc": "Sta toe dat andere dashboards op uw netwerk firmware-compile-taken naar dit dashboard sturen. Koppelen met een peer geeft die peer de mogelijkheid om code op deze host uit te voeren; schakel alleen in voor dashboards die u al op shell-niveau vertrouwt.",
+    "remote_build_enable_desc": "Laat andere dashboards in je netwerk hun YAML hier compileren. Een gekoppelde peer kan willekeurige code op deze machine uitvoeren; koppel alleen met dashboards waaraan je ssh-toegang zou geven.",
     "remote_build_known_dashboards": "Bekende dashboards",
     "remote_build_peers_loading": "Laden…",
     "remote_build_peers_empty": "Nog geen dashboards ontdekt.",


### PR DESCRIPTION
# What does this implement/fix?

The current copy for the "Enable remote build" toggle reads as machine-generated:

> Allow other dashboards on your network to send firmware compile jobs to this dashboard. Pairing with a peer grants it the ability to run code on this host — only enable for dashboards you already trust at a shell level.

AI-tells in the original:

* "Allow other dashboards on your network to send firmware compile jobs to this dashboard" — redundant ("dashboards on your network ... to this dashboard") and uses the noun-phrase "compile jobs" that humans don't say.
* "grants it the ability to run code on this host" — formal, indirect; humans say "can run code".
* "trust at a shell level" — abstract; the concrete user mental model is ssh access.
* The em-dash before the warning is the giveaway.

Rewrite all three locales to drop the hedge, use direct second-person voice, and split the warning with a semicolon:

| Locale | New copy |
|---|---|
| en | "Lets other dashboards on your network compile their YAML here. A paired peer can run arbitrary code on this machine; only pair with dashboards you'd give ssh access to." |
| fr | "Permet à d'autres tableaux de bord de votre réseau de compiler leur YAML ici. Un pair appairé peut exécuter n'importe quel code sur cette machine ; n'appairez qu'avec des tableaux de bord à qui vous donneriez un accès ssh." |
| nl | "Laat andere dashboards in je netwerk hun YAML hier compileren. Een gekoppelde peer kan willekeurige code op deze machine uitvoeren; koppel alleen met dashboards waaraan je ssh-toegang zou geven." |

No code paths touched; pure translation-file change.

## Testing

* `npx vitest run` — 1034 tests pass.

**Related issue or feature (if applicable):**

- Tone polish, no functional change.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation only — `docs`
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Backend coordination

- [x] No backend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] All three translation files updated in the same PR.
