### PR TITLE
Group remote-build settings panes under an EXPERIMENTAL nav header

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -149,9 +149,17 @@ const SECTIONS: SectionDef[] = [
     // "build server" rather than "build host" because the
     // CI/CD term is broadly recognised; "build host" reads
     // as jargon for users who haven't seen it before.
+    // Grouped under the EXPERIMENTAL nav header alongside its
+    // sibling Pairing requests + Send builds entries: the
+    // remote-build flow as a whole is still in development
+    // (the receiver site binds and accepts pair requests, but
+    // the operator-facing UX, pair-approval modal, scheduler,
+    // and the offloader's submit_job pipeline are landing
+    // across multiple phases).
     id: "build_server",
     icon: "server-network",
     labelKey: "settings.build_server",
+    group: "experimental",
   },
   {
     // "Pairing requests" is its own sidebar entry rather than a
@@ -164,18 +172,21 @@ const SECTIONS: SectionDef[] = [
     // Senders' "ask the receiver to open Settings → Pairing
     // requests" copy is now an accurate navigation prompt
     // because the path it names exists as a discrete screen.
+    // Marked experimental alongside Build server / Send builds
+    // because the pair-approval surface is still maturing.
     id: "pairing_requests",
     icon: "handshake-outline",
     labelKey: "settings.pairing_requests",
+    group: "experimental",
   },
   {
     // "Send builds" = Offload role: this dashboard
-    // dispatching its compiles to another dashboard. Grouped
-    // under the EXPERIMENTAL nav header because the compile-
-    // dispatch flow is still in development -- the typed
-    // hostnames + paired-build-server rows on this screen are
-    // remembered, but no compile job is actually dispatched
-    // until the offloader's submit_job pipeline lands.
+    // dispatching its compiles to another dashboard. The
+    // offload direction is the least-finished of the three
+    // remote-build screens: the typed hostnames +
+    // paired-build-server rows here are remembered, but no
+    // compile job is actually dispatched until the
+    // offloader's submit_job pipeline lands.
     id: "build_offload",
     icon: "send-outline",
     labelKey: "settings.build_offload",
@@ -1249,9 +1260,10 @@ export class ESPHomeSettingsDialog extends LitElement {
          container. */
 
       /* Nav-sidebar group header. Renders above grouped
-         sections in the left rail (currently just the
-         EXPERIMENTAL group containing 'Send builds'). Same
-         visual treatment as the in-content '.section-heading'
+         sections in the left rail (currently the EXPERIMENTAL
+         group containing Build server, Pairing requests, and
+         Send builds). Same visual treatment as the in-content
+         '.section-heading'
          small-caps subtitles -- uppercase, tracked, quiet
          colour, hairline divider above -- so the eye reads the
          group as "sectioning" rather than "another nav item".
@@ -1921,10 +1933,12 @@ export class ESPHomeSettingsDialog extends LitElement {
    * list. Grouped sections render after, each group preceded
    * by a small uppercase header (currently only the
    * 'experimental' group is used, surfaced as 'EXPERIMENTAL'
-   * above 'Send builds'). The grouped pattern replaces the
-   * previous inline-banner approach -- "this feature is still
-   * in development" lives in the nav structure rather than as
-   * a paragraph at the top of the section content.
+   * above the three remote-build screens: Build server,
+   * Pairing requests, and Send builds). The grouped pattern
+   * replaces the previous inline-banner approach -- "this
+   * feature is still in development" lives in the nav
+   * structure rather than as a paragraph at the top of the
+   * section content.
    */
   private _renderNav() {
     const flat = SECTIONS.filter((s) => !s.group);

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -132,6 +132,11 @@ interface SectionDef {
   id: Section;
   icon: string;
   labelKey: string;
+  // Optional group tag. Sections that share a non-empty group
+  // are rendered together in the nav under a small uppercase
+  // group header (currently used only for 'experimental').
+  // Sections with no group are rendered first as a flat list.
+  group?: "experimental";
 }
 
 const SECTIONS: SectionDef[] = [
@@ -165,10 +170,16 @@ const SECTIONS: SectionDef[] = [
   },
   {
     // "Send builds" = Offload role: this dashboard
-    // dispatching its compiles to another dashboard.
+    // dispatching its compiles to another dashboard. Grouped
+    // under the EXPERIMENTAL nav header because the compile-
+    // dispatch flow is still in development -- the typed
+    // hostnames + paired-build-server rows on this screen are
+    // remembered, but no compile job is actually dispatched
+    // until the offloader's submit_job pipeline lands.
     id: "build_offload",
     icon: "send-outline",
     labelKey: "settings.build_offload",
+    group: "experimental",
   },
 ];
 
@@ -1237,30 +1248,26 @@ export class ESPHomeSettingsDialog extends LitElement {
          via .row: zero horizontal padding, rely on the
          container. */
 
-      /* Inline 'EXPERIMENTAL' tag rendered next to the section
-         heading at the top of an in-development settings pane.
-         Same visual language as esphome-layout's .preview-badge
-         but recoloured for the settings dialog's neutral surface
-         (the header's --esphome-on-primary tones read as
-         low-contrast on this background). Carries the same
-         lightweight "feature is in development, no detailed
-         caveat banner" signal a Preview tag carries for the
-         whole app; replaces the verbose
-         build_offload_unimplemented_banner copy. */
-      .experimental-tag {
-        display: inline-block;
-        font-size: 9px;
+      /* Nav-sidebar group header. Renders above grouped
+         sections in the left rail (currently just the
+         EXPERIMENTAL group containing 'Send builds'). Same
+         visual treatment as the in-content '.section-heading'
+         small-caps subtitles -- uppercase, tracked, quiet
+         colour, hairline divider above -- so the eye reads the
+         group as "sectioning" rather than "another nav item".
+         Lives in the nav layer rather than as an inline content
+         banner: replaces the previous verbose
+         'build_offload_unimplemented_banner' copy with a
+         lightweight structural signal in the navigation. */
+      .nav-group-header {
+        font-size: var(--wa-font-size-2xs);
         font-weight: var(--wa-font-weight-bold);
-        letter-spacing: 0.06em;
+        letter-spacing: 0.08em;
         text-transform: uppercase;
-        padding: 2px 6px;
-        border-radius: var(--wa-border-radius-s);
-        background: color-mix(in srgb, var(--wa-color-warning-fill-loud), transparent 85%);
-        color: var(--wa-color-warning-fill-loud);
-        border: 1px solid color-mix(in srgb, var(--wa-color-warning-fill-loud), transparent 60%);
-        line-height: 1;
-        flex-shrink: 0;
-        margin: 0 0 var(--wa-space-m);
+        color: var(--wa-color-text-quiet);
+        padding: var(--wa-space-s) var(--wa-space-s) var(--wa-space-2xs);
+        margin-top: var(--wa-space-s);
+        border-top: 1px solid var(--wa-color-surface-border);
       }
 
       /* Binding-mismatch alert rows. Same shape as
@@ -1896,17 +1903,7 @@ export class ESPHomeSettingsDialog extends LitElement {
         <div class="layout">
           <aside class="sidebar">
             <nav class="nav">
-              ${SECTIONS.map(
-                (s) => html`
-                  <button
-                    class="nav-item ${s.id === this._section ? "nav-item--active" : ""}"
-                    @click=${() => this._selectSection(s.id)}
-                  >
-                    <wa-icon library="mdi" name=${s.icon}></wa-icon>
-                    <span>${this._localize(s.labelKey)}</span>
-                  </button>
-                `
-              )}
+              ${this._renderNav()}
             </nav>
           </aside>
           <main class="content">
@@ -1914,6 +1911,43 @@ export class ESPHomeSettingsDialog extends LitElement {
           </main>
         </div>
       </esphome-base-dialog>
+    `;
+  }
+
+  /**
+   * Render the nav sidebar.
+   *
+   * Flat sections (no 'group') render first as a single
+   * list. Grouped sections render after, each group preceded
+   * by a small uppercase header (currently only the
+   * 'experimental' group is used, surfaced as 'EXPERIMENTAL'
+   * above 'Send builds'). The grouped pattern replaces the
+   * previous inline-banner approach -- "this feature is still
+   * in development" lives in the nav structure rather than as
+   * a paragraph at the top of the section content.
+   */
+  private _renderNav() {
+    const flat = SECTIONS.filter((s) => !s.group);
+    const experimental = SECTIONS.filter((s) => s.group === "experimental");
+    const renderItem = (s: SectionDef) => html`
+      <button
+        class="nav-item ${s.id === this._section ? "nav-item--active" : ""}"
+        @click=${() => this._selectSection(s.id)}
+      >
+        <wa-icon library="mdi" name=${s.icon}></wa-icon>
+        <span>${this._localize(s.labelKey)}</span>
+      </button>
+    `;
+    return html`
+      ${flat.map(renderItem)}
+      ${experimental.length
+        ? html`
+            <div class="nav-group-header">
+              ${this._localize("settings.experimental_tag")}
+            </div>
+            ${experimental.map(renderItem)}
+          `
+        : nothing}
     `;
   }
 
@@ -2342,17 +2376,15 @@ export class ESPHomeSettingsDialog extends LitElement {
    *    cross-subnet / non-mDNS receivers.
    *
    * Pairing-window + peer-link + scheduler land across phases
-   * 4 / 5 / 7. The inline EXPERIMENTAL tag at the top of the
-   * pane is the only "feature is in development" signal —
-   * lighter touch than the verbose banner this replaced, same
-   * visual language as the dashboard header's PREVIEW badge.
+   * 4 / 5 / 7. The section's "still in development" signal
+   * lives in the nav sidebar (this section is grouped under
+   * the EXPERIMENTAL header, see SectionDef.group) rather
+   * than as an inline banner at the top of the content pane —
+   * lighter touch, doesn't push the actual settings down the
+   * screen.
    */
   private _renderBuildOffload() {
     return html`
-      <span class="experimental-tag" role="status">
-        ${this._localize("settings.experimental_tag")}
-      </span>
-
       ${this._renderOffloaderAlerts()}
       ${this._renderOffloaderRemoteBuildsToggle()}
 

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -48,7 +48,6 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import type { RemoteBuildJobState } from "../context/index.js";
-import { warningBannerStyles } from "../styles/banners.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { formatPinSha256 } from "../util/cert-pin-format.js";
@@ -1017,7 +1016,6 @@ export class ESPHomeSettingsDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
-    warningBannerStyles,
     pinHexStyles,
     css`
       esphome-base-dialog {
@@ -1239,8 +1237,29 @@ export class ESPHomeSettingsDialog extends LitElement {
          via .row: zero horizontal padding, rely on the
          container. */
 
-      /* Per-consumer spacing for warningBannerStyles' .warning-banner. */
-      .warning-banner {
+      /* Inline 'EXPERIMENTAL' tag rendered next to the section
+         heading at the top of an in-development settings pane.
+         Same visual language as esphome-layout's .preview-badge
+         but recoloured for the settings dialog's neutral surface
+         (the header's --esphome-on-primary tones read as
+         low-contrast on this background). Carries the same
+         lightweight "feature is in development, no detailed
+         caveat banner" signal a Preview tag carries for the
+         whole app; replaces the verbose
+         build_offload_unimplemented_banner copy. */
+      .experimental-tag {
+        display: inline-block;
+        font-size: 9px;
+        font-weight: var(--wa-font-weight-bold);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 2px 6px;
+        border-radius: var(--wa-border-radius-s);
+        background: color-mix(in srgb, var(--wa-color-warning-fill-loud), transparent 85%);
+        color: var(--wa-color-warning-fill-loud);
+        border: 1px solid color-mix(in srgb, var(--wa-color-warning-fill-loud), transparent 60%);
+        line-height: 1;
+        flex-shrink: 0;
         margin: 0 0 var(--wa-space-m);
       }
 
@@ -2323,15 +2342,16 @@ export class ESPHomeSettingsDialog extends LitElement {
    *    cross-subnet / non-mDNS receivers.
    *
    * Pairing-window + peer-link + scheduler land across phases
-   * 4 / 5 / 7; the in-section banner still says "not
-   * implemented yet" because no compile job is actually
-   * dispatched until phase 5+ wires the build session.
+   * 4 / 5 / 7. The inline EXPERIMENTAL tag at the top of the
+   * pane is the only "feature is in development" signal —
+   * lighter touch than the verbose banner this replaced, same
+   * visual language as the dashboard header's PREVIEW badge.
    */
   private _renderBuildOffload() {
     return html`
-      <div class="warning-banner" role="status">
-        ${this._localize("settings.build_offload_unimplemented_banner")}
-      </div>
+      <span class="experimental-tag" role="status">
+        ${this._localize("settings.experimental_tag")}
+      </span>
 
       ${this._renderOffloaderAlerts()}
       ${this._renderOffloaderRemoteBuildsToggle()}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -751,7 +751,7 @@
     "build_server": "Build server",
     "pairing_requests": "Pairing requests",
     "build_offload": "Send builds",
-    "build_offload_unimplemented_banner": "Sending builds to another dashboard isn't implemented yet. Hostnames added here are remembered, but no compile jobs are dispatched until pairing ships in a later release.",
+    "experimental_tag": "Experimental",
     "remote_build_enable": "Enable remote build",
     "remote_build_enable_desc": "Lets other dashboards on your network compile their YAML here. A paired peer can run arbitrary code on this machine; only pair with dashboards you'd give ssh access to.",
     "remote_build_known_dashboards": "Known dashboards",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -688,7 +688,7 @@
     "build_server": "Serveur de compilation",
     "pairing_requests": "Demandes d'appairage",
     "build_offload": "Envoyer les compilations",
-    "build_offload_unimplemented_banner": "L'envoi de compilations à un autre tableau de bord n'est pas encore implémenté. Les noms d'hôte ajoutés ici sont mémorisés, mais aucune tâche de compilation n'est dispatchée tant que l'appairage n'est pas livré dans une version ultérieure.",
+    "experimental_tag": "Expérimental",
     "remote_build_enable": "Activer la compilation à distance",
     "remote_build_enable_desc": "Permet à d'autres tableaux de bord de votre réseau de compiler leur YAML ici. Un pair appairé peut exécuter n'importe quel code sur cette machine ; n'appairez qu'avec des tableaux de bord à qui vous donneriez un accès ssh.",
     "remote_build_known_dashboards": "Tableaux de bord connus",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -688,7 +688,7 @@
     "build_server": "Build-server",
     "pairing_requests": "Koppelingsverzoeken",
     "build_offload": "Builds verzenden",
-    "build_offload_unimplemented_banner": "Builds naar een ander dashboard verzenden is nog niet geïmplementeerd. Hostnamen die hier zijn toegevoegd worden onthouden, maar er worden geen compile-taken verzonden totdat koppeling in een latere release wordt uitgebracht.",
+    "experimental_tag": "Experimenteel",
     "remote_build_enable": "Bouwen op afstand inschakelen",
     "remote_build_enable_desc": "Laat andere dashboards in je netwerk hun YAML hier compileren. Een gekoppelde peer kan willekeurige code op deze machine uitvoeren; koppel alleen met dashboards waaraan je ssh-toegang zou geven.",
     "remote_build_known_dashboards": "Bekende dashboards",


### PR DESCRIPTION
# What does this implement/fix?

Mark the three remote-build settings screens (**Build server**, **Pairing requests**, **Send builds**) as experimental by grouping them under a new **EXPERIMENTAL** header in the Settings dialog's left nav. Drops the verbose `build_offload_unimplemented_banner` warning at the top of the **Send builds** pane in favour of the structural placement.

## Why

**The old banner was lying.** It read "Sending builds to another dashboard isn't implemented yet. Hostnames added here are remembered, but no compile jobs are dispatched until pairing ships in a later release." That was true when the copy was written, but the offload pipeline has since shipped — pairing works, `submit_job` streams over the peer-link, the scheduler picks a paired receiver, and compile jobs actually run on the remote host. Leaving the "not implemented" banner up was misleading users about a feature that was sitting in front of them, working.

But the feature isn't *finished* either — the receiver-site UX and scheduler decisions are still maturing across multiple phases. So the right shape is a lighter-weight "still in development" signal across all three remote-build panes, not a "doesn't work yet" paragraph on one of them.

The previous shape had two specific problems:

1. The long paragraph banner at the top of **Send builds** pushed the actual settings down the screen, AND its claim ("isn't implemented yet") was no longer accurate.
2. **Build server** and **Pairing requests** had no in-development signal at all, despite being in the same maturing state as Send builds.

## How

- New `SectionDef.group` field on the nav-section definitions. Sections sharing a non-empty group render together under a small uppercase header (currently only the `experimental` group is used).
- All three remote-build sections (`build_server`, `pairing_requests`, `build_offload`) get `group: "experimental"`.
- `_renderNav` splits sections into flat (no group) and grouped, renders flat first, then each group preceded by its localised header.
- `_renderBuildOffload` drops the old `.warning-banner` div and its `experimental_tag` inline span — the structural placement in the nav *is* the "in development" signal.
- New `.nav-group-header` CSS rule matches the in-content `.section-heading` visual treatment (uppercase, tracked, quiet colour, hairline divider above).
- Dead code cleanup: dropped the `warningBannerStyles` import + `.warning-banner` CSS rule (no remaining consumer in this file).
- `build_offload_unimplemented_banner` translation key removed in en / fr / nl; replaced with `experimental_tag` (`"Experimental"` / `"Expérimental"` / `"Experimenteel"`). CSS `text-transform: uppercase` renders it as `EXPERIMENTAL` on the wire.

## Resulting nav layout

```
🎨 Appearance
🌐 Language
📐 Editor
─── EXPERIMENTAL ───
🖥 Build server
🤝 Pairing requests
➤  Send builds
```

Sections drop the `group: "experimental"` flag individually as each flow finalises.

## Tests

- Vitest: 1034/1034 pass.
- Typecheck: clean.

A TS error caught during this PR (`CSSResult has no call signatures`) was traced to unescaped double-backticks inside a `css\`...\`` template-literal comment — the backticks were terminating the literal. Fixed in the same branch; matches the project-wide convention of using single quotes (not backticks) inside JS/TS comments.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder#593 (default-on receiver for non-HA-addon). Removes the now-stale banner copy that assumed the feature was completely unimplemented while surfacing a clearer "still in development" signal across all three remote-build panes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass.
- [x] Tests have been added or updated where applicable.

