### PR TITLE
Surface job.error in the install dialog's failure banner

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -615,7 +615,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
             name="alert-circle"
           ></wa-icon>
           <span class="status-text">${this._statusMessage}</span>
-          <span class="status-detail">${this._errorMessage}</span>
+          ${this._errorMessage
+            ? html`<span class="status-detail">${this._errorMessage}</span>`
+            : nothing}
         </div>
         ${this._renderResetSuggestion()}
       `;
@@ -976,7 +978,10 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       await this._compileAndWait(device.configuration);
     } catch (err) {
       this._failedDuringCompile = true;
-      this._fail(this._compileFailureMessage(err));
+      this._fail(
+        this._localize("firmware.compile_failed"),
+        this._compileFailureDetail(err)
+      );
       return;
     }
 
@@ -1099,7 +1104,10 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
       await this._compileAndWait(device.configuration);
     } catch (err) {
       this._failedDuringCompile = true;
-      this._fail(this._compileFailureMessage(err));
+      this._fail(
+        this._localize("firmware.compile_failed"),
+        this._compileFailureDetail(err)
+      );
       return;
     }
 
@@ -1210,33 +1218,41 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._showLogsAfterInstall = !this._showLogsAfterInstall;
   };
 
-  private _fail(message: string) {
+  /** Drop the dialog into the red error state.
+   *
+   *  ``title`` is the bold heading (shown next to the alert
+   *  icon). ``detail`` is the optional smaller caption beneath
+   *  it. Pass ``detail`` only when it adds information the
+   *  heading doesn't already carry; the render skips the
+   *  caption span entirely when ``detail`` is empty, so a
+   *  single-string call doesn't paint the same text twice. */
+  private _fail(title: string, detail = "") {
     this._step = "error";
-    this._statusMessage = message;
-    this._errorMessage = message;
+    this._statusMessage = title;
+    this._errorMessage = detail;
     this._logsExpanded = true;
   }
 
-  /** Pick the most informative copy for a compile-step failure.
+  /** Specific cause text for a compile-step failure, used as
+   *  the caption beneath the generic "Install failed." heading.
    *
    *  ``_compileAndWait`` rejects with an ``Error`` whose
    *  ``message`` is the backend's ``FirmwareJob.error`` text
-   *  (when ``firmware/follow_job``'s RESULT carried one — newer
+   *  (when ``firmware/follow_job``'s RESULT carried one; newer
    *  backend, see esphome/device-builder#597) or an empty
    *  string (older backend that didn't put ``error`` on the
-   *  wire). Prefer the specific backend text so the red banner
-   *  names the actual cause; fall back to the generic localised
-   *  "Install failed." copy when nothing useful came back.
+   *  wire). Return that text so the red banner names the
+   *  actual cause; return an empty string when nothing useful
+   *  came back so ``_fail`` shows the generic heading alone
+   *  instead of repeating it.
    *
    *  The session-lost case is the user-visible motivator:
    *  ``remote build: peer-link session lost (transport_error: …)``
    *  is a much better operator signal than a generic failure
    *  string followed by a "try cleaning the build files" hint
-   *  that doesn't help when the receiver just restarted.
-   */
-  private _compileFailureMessage(err: unknown): string {
-    const text = err instanceof Error ? err.message.trim() : String(err ?? "").trim();
-    return text || this._localize("firmware.compile_failed");
+   *  that doesn't help when the receiver just restarted. */
+  private _compileFailureDetail(err: unknown): string {
+    return err instanceof Error ? err.message.trim() : String(err ?? "").trim();
   }
 
   private async _cancel() {

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -634,6 +634,12 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
    *  * **YAML validation** (the output stream included ESPHome's
    *    validation-failure marker) — neither clean nor reset can
    *    help; offer the editor instead.
+   *  * **Receiver session lost** (REMOTE compile that dropped
+   *    mid-build because the build server restarted / dropped
+   *    network) — neither clean nor reset helps; the build
+   *    environment was fine, the connection wasn't. Skip the
+   *    hint entirely so the operator just sees the specific
+   *    error text and the Retry button.
    *  * **C++ build / compile** failure — keep the clean → reset
    *    staircase (clean is surgical / fast; reset is the heavier
    *    toolchain-wide wipe).
@@ -646,7 +652,25 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (this._failedDuringValidate) {
       return this._renderValidationFailureSuggestion();
     }
+    if (this._isPeerLinkSessionLostError(this._errorMessage)) {
+      return nothing;
+    }
     return this._renderBuildFailureSuggestion();
+  }
+
+  /** Returns ``true`` when the failure text matches the
+   *  receiver-side ``_fail_locally`` "peer-link session lost"
+   *  shape from the backend's ``remote_runner``. Used to skip
+   *  the misleading clean / reset hint for failures that
+   *  weren't actually about the build environment.
+   *
+   *  Match by substring rather than a regex / structured error
+   *  code because the wire shape today is a free-form string
+   *  (``FirmwareJob.error``). If a future backend lands a
+   *  typed error code that carries the same signal, this is
+   *  the call site to switch over to. */
+  private _isPeerLinkSessionLostError(message: string): boolean {
+    return message.includes("peer-link session lost");
   }
 
   /** YAML validation failure → "open in editor" hint. */
@@ -950,9 +974,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = this._localize("firmware.status_queued");
     try {
       await this._compileAndWait(device.configuration);
-    } catch {
+    } catch (err) {
       this._failedDuringCompile = true;
-      this._fail(this._localize("firmware.compile_failed"));
+      this._fail(this._compileFailureMessage(err));
       return;
     }
 
@@ -1073,9 +1097,9 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
 
     try {
       await this._compileAndWait(device.configuration);
-    } catch {
+    } catch (err) {
       this._failedDuringCompile = true;
-      this._fail(this._localize("firmware.compile_failed"));
+      this._fail(this._compileFailureMessage(err));
       return;
     }
 
@@ -1147,10 +1171,24 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
             this._streamId = "";
             this._jobId = "";
             this._compileReject = null;
-            const result = data as unknown as { status: string };
-            result.status === JobStatus.COMPLETED
-              ? resolve()
-              : reject(new Error("Compilation failed"));
+            const result = data as unknown as {
+              status: string;
+              error?: string | null;
+            };
+            if (result.status === JobStatus.COMPLETED) {
+              resolve();
+              return;
+            }
+            /* Prefer the backend's specific failure text so the
+             * red error banner names the actual cause (e.g.
+             * "remote build: peer-link session lost (transport_error: …)")
+             * instead of a generic "Install failed.". Older
+             * backends that don't set ``error`` on the wire
+             * still produce the generic message because the
+             * catch in ``_startInstall`` falls back to
+             * ``firmware.compile_failed`` when the rejection's
+             * message is empty. */
+            reject(new Error(result.error || ""));
           },
           onError: (error) => {
             this._streamId = "";
@@ -1177,6 +1215,28 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._statusMessage = message;
     this._errorMessage = message;
     this._logsExpanded = true;
+  }
+
+  /** Pick the most informative copy for a compile-step failure.
+   *
+   *  ``_compileAndWait`` rejects with an ``Error`` whose
+   *  ``message`` is the backend's ``FirmwareJob.error`` text
+   *  (when ``firmware/follow_job``'s RESULT carried one — newer
+   *  backend, see esphome/device-builder#597) or an empty
+   *  string (older backend that didn't put ``error`` on the
+   *  wire). Prefer the specific backend text so the red banner
+   *  names the actual cause; fall back to the generic localised
+   *  "Install failed." copy when nothing useful came back.
+   *
+   *  The session-lost case is the user-visible motivator:
+   *  ``remote build: peer-link session lost (transport_error: …)``
+   *  is a much better operator signal than a generic failure
+   *  string followed by a "try cleaning the build files" hint
+   *  that doesn't help when the receiver just restarted.
+   */
+  private _compileFailureMessage(err: unknown): string {
+    const text = err instanceof Error ? err.message.trim() : String(err ?? "").trim();
+    return text || this._localize("firmware.compile_failed");
   }
 
   private async _cancel() {


### PR DESCRIPTION
# What does this implement/fix?

Companion to [esphome/device-builder#597](https://github.com/esphome/device-builder/pull/597). The install dialog's red error banner currently always renders a generic "Install failed." copy when the compile step fails, regardless of the specific cause. Surface the backend's `FirmwareJob.error` text so the banner names what actually happened.

Before — when the remote build server restarted mid-build (the user-reported case):

```
*** Install failed.
It looks like you're having trouble with your build. Try cleaning the build
files for this device first; if that doesn't help, try resetting the build
environment.
```

After:

```
*** remote build: peer-link session lost (transport_error: …)
    (no misleading clean / reset hint — just the Retry button)
```

## What lands

* **`_compileAndWait.onResult`** — read `error` off the RESULT payload (extends the existing `as unknown as` cast to the new field that #597 adds on the backend). Reject the compile promise with that text; an empty string falls through to today's generic copy.
* **`_startInstall` / `_startDownload`** catch — pass the rejection through a new `_compileFailureMessage` helper that prefers the backend's specific text, falling back to `firmware.compile_failed` when nothing useful came back. Older backend / older job without the field stays on today's behaviour.
* **`_renderResetSuggestion`** — skip the clean / reset hint entirely when `_errorMessage` matches the "peer-link session lost" shape. The build environment was fine, the connection wasn't — the Retry button is the right and only affordance there.

The session-lost detection is a substring check against the backend's free-form `FirmwareJob.error` text today; if a future backend lands a typed error code on the wire, `_isPeerLinkSessionLostError` is the call site to switch over.

## Testing

* `npx tsc --noEmit` clean.
* `npx vitest run` — 1034 tests pass; no dialog-level unit test file exists yet (the install dialog is exercised end-to-end against a live backend in the wider integration suite).

## Backwards compatibility

* **Older backend, new frontend**: backend doesn't set `error` on the wire; `result.error` is `undefined`; fallback to today's `firmware.compile_failed` copy. No regression.
* **New backend, older frontend**: frontend ignores the extra `error` field on the RESULT payload. No regression.

Either order of deployment is safe.

**Related issue or feature (if applicable):**

- Companion to esphome/device-builder#597. Pairs with esphome/device-builder#596 (synthetic log line for the same case).

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation only
- [ ] Maintenance / chore
- [ ] CI / workflow change
- [ ] Dependencies bump

## Backend coordination

- [ ] No backend change needed
- [x] Companion backend PR: esphome/device-builder#597

## Checklist

- [x] Tested and works locally.
- [x] `npx tsc --noEmit` and `npx vitest run` both clean.
