### PR TITLE
Point CLAUDE.md at README.md's Code structure policies as authoritative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,17 @@
 
 A short orientation file for an LLM working in this repo. Skim
 before making changes; keep edits to existing code consistent
-with what's described here. Read [README.md](README.md) for the
-user-facing intro.
+with what's described here.
+
+**Before writing code, read [README.md → "Code structure
+policies"](README.md#code-structure-policies).** Those rules
+(500-600 line file cap, component decomposition, folder layout,
+TypeScript / DOM / localization / comment policies) are the
+authoritative coding standard for this repo, set and maintained
+by the human maintainers; everything in this CLAUDE.md sits on
+top of them. When a rule in README.md and a rule here disagree,
+README.md wins; flag the conflict in the PR so this file can be
+brought back into line.
 
 ## What this project is
 
@@ -62,6 +71,25 @@ Frontend-backend deployment is lockstep") is the canonical reply.
 
 ## Code style
 
+See [README.md → "Code structure
+policies"](README.md#code-structure-policies) first; the file
+size, component-decomposition, folder layout, and DOM / a11y
+rules there are authoritative. The bullets below are practical
+expansions, not substitutes. The high-leverage ones to keep in
+working memory while editing:
+
+- **File size cap: 500-600 lines.** Split before crossing it; no
+  exemptions for "it's just one big component." If a render
+  block exceeds ~100 lines, that's the signal to extract a
+  sub-component.
+- **One `@customElement` per file.** File name matches element
+  name (`esphome-foo-bar.ts` → `<esphome-foo-bar>`). When a
+  feature grows beyond ~3 files, give it its own subfolder
+  (`src/components/settings-dialog/` is the pattern).
+- **No `document.querySelector`, no direct DOM mutation.** Go
+  through shadow DOM via `@query` / refs, and use reactive
+  properties to re-render. No business logic in `render()`;
+  extract it to private methods or computed values.
 - **TypeScript strict** throughout. No `any` in new code; use
   `unknown` and narrow when truly necessary. Existing `as never`
   casts are legacy and shouldn't be cargoed.
@@ -152,6 +180,14 @@ on failure assign the previous value back and surface a
 
 ## Commit / PR conventions
 
+- **Don't self-merge frontend PRs.** The frontend codebase
+  carries a high volume of AI-assisted contributions and the
+  maintainers (Steven, Marcel) are actively curating quality
+  and consistency. Push PRs, hand them off for human review,
+  and let a maintainer merge; don't `gh pr merge` your own
+  work on this repo even when CI is green and Copilot is
+  satisfied. The CLAUDE-side review pass and the human
+  curation pass catch different things; both are required.
 - **No `Co-Authored-By: Claude` trailer.** Project preference.
 - Imperative-mood subject line ("Add X", not "Added X").
 - Tick exactly one "Types of changes" box in the PR body. CI


### PR DESCRIPTION
# What does this implement/fix?

esphome/device-builder-frontend#307 added a **"Code structure policies"** section to README.md (500-600 line file cap, component decomposition, one-element-per-file, folder layout past ~3 files, no `document.querySelector`, no direct DOM mutation, no business logic in `render()`, etc.). Those rules are now the maintainer-set authoritative coding standard for this repo.

CLAUDE.md didn't reference them, so an LLM reading CLAUDE.md in isolation (the common case) could land code that satisfies the older CLAUDE.md guidance while violating the new README rules. This PR closes that gap:

* **Top-of-file pointer** naming the README section as the authoritative source, with an explicit "README.md wins on conflict; flag the disagreement in the PR" tiebreaker so the two files don't silently drift again.
* **"Code style" section** now opens with the same pointer and promotes the three highest-leverage rules (file size, one-element-per-file, no DOM mutation / business logic in `render()`) into the body so they catch a Claude run that skipped opening README.md.
* **No self-merge** convention added to "Commit / PR conventions". The frontend codebase carries a high volume of AI-assisted contributions and the maintainers (Steven, Marcel) are actively curating quality and consistency; let a maintainer merge rather than `gh pr merge`-ing when CI goes green. CLAUDE-side review and human curation catch different things; both are required.

## What's not in this PR

No code changes. No README.md changes either; the README section is already in place from PR #307. This PR's job is to make sure CLAUDE.md points at it.

**Related issue or feature (if applicable):**

- Follow-up on esphome/device-builder-frontend#307 (added the README section this points at).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes (no code touched; tsc still clean).
- [x] `npm run test` passes (1034/1034; doc-only change).
- [x] Tests have been added to verify that the new code works (where applicable).
