### PR TITLE
Disable browser autocomplete on search inputs

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -100,6 +100,7 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
       class="search-input ${host._yamlMode ? "search-input--yaml" : ""}"
       type="search"
       with-clear
+      autocomplete="off"
       placeholder=${placeholder}
       .value=${host._search}
       @input=${(e: Event) => {

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -212,6 +212,7 @@ export class ESPHomeComponentCatalog extends LitElement {
       <div class="main">
         <input
           type="search"
+          autocomplete="off"
           .value=${this._search}
           @input=${this._onSearchInput}
           placeholder=${this._localize("device.search_components_placeholder")}

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -385,6 +385,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
           <wa-input
             type="search"
             with-clear
+            autocomplete="off"
             placeholder=${this._localize("dashboard.labels_search_placeholder")}
             .value=${this._filter}
             @input=${(e: Event) => {

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -398,6 +398,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
     return html`
       <input
         type="search"
+        autocomplete="off"
         .value=${this._search}
         @input=${this._onSearchInput}
         placeholder=${this._localize("wizard.search_boards_placeholder")}


### PR DESCRIPTION
# What does this implement/fix?

Chrome's saved-credentials autofill was dropping the user's username into the dashboard "Search devices…" field on page load, which then filtered the device list down to nothing without the user typing anything. The four `type="search"` inputs in the app had no `autocomplete` attribute, so the browser was free to treat them as candidate form fields. Setting `autocomplete="off"` on each one tells the browser not to.

Touched fields:

- Dashboard toolbar "Search devices…" (the one in the bug report)
- Labels filter dialog
- Wizard board picker search
- Device component catalog search

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#642

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
