### PR TITLE
Default port to OTA in logs-dialog openPassive (fixes device-builder#636)

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -431,7 +431,10 @@ export class ESPHomeLogsDialog extends LitElement {
     // with the old one's. Same shape as ``_detachStream`` in
     // command-dialog.ts; different stream type, identical bug.
     this._stopSerial();
-    this._port = "";
+    // _port is only consulted if the user hits Stop and then Start
+    // after the serial reader is gone — default to OTA so the
+    // restart targets the freshly flashed device, not "" (#636).
+    this._port = "OTA";
     this._lines = [];
     this._streaming = true;
     this._expanded = false;


### PR DESCRIPTION
# What does this implement/fix?

`openPassive()` sets `_port = ""` for the post-Web-Serial install flow, where live bytes feed into `_lines` via the reader registered with `setSerialCancel`. When the user hit **Stop** then **Start**, `_startStreaming()` forwarded that empty port to `api.logs(configuration, "")`, the backend ran `esphome logs <yaml>` without `--device`, and the stdin-less subprocess crashed with `EOFError` at the CLI's interactive port-choice prompt.

Default `_port = "OTA"` instead. Web Serial output bypasses `_port` entirely, so the live session is unchanged; the change only matters for a Stop → Start resume, which now targets the freshly flashed device via OTA.

The companion backend PR (esphome/device-builder#658) also defaults a missing/empty `port` to `OTA` on the server side, so the same crash can't reappear from any future caller leaving `port` empty.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#636

Companion backend PR: esphome/device-builder#658

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
