### PR TITLE
Show receiver ESPHome version next to "Building on …"

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1006,6 +1006,14 @@ export interface FirmwareJob {
    *  track later renames (the install dialog should show what the
    *  user saw when they clicked Install). */
   source_label: string;
+  /** Receiver's bundled ``esphome`` version at job-creation time,
+   *  snapshotted from the pairing's last-known
+   *  ``esphome_version``. Empty for LOCAL jobs and for REMOTE jobs
+   *  whose pairing hadn't yet completed a peer-link session. The
+   *  install dialog renders this next to ``source_label`` so the
+   *  operator can spot a version skew between the offloader and
+   *  the receiver actually compiling the firmware. */
+  source_esphome_version: string;
   /** Offloader's ``dashboard_id`` when this job came in via the
    *  peer-link ``submit_job`` flow. Empty for locally-submitted
    *  jobs. Receiver-side rendering surfaces this as a "from

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -144,7 +144,11 @@ export class ESPHomeCommandDialog extends LitElement {
   // sub-line paint on the first frame instead of waiting for the next jobs
   // context update.
   @state() _jobStatus: JobStatus | null = null;
-  _primedSource: { source: JobSource; source_label: string } | null = null;
+  _primedSource: {
+    source: JobSource;
+    source_label: string;
+    source_esphome_version: string;
+  } | null = null;
 
   // True while "Build locally instead" override is mid-flight.
   @state() _switchingToLocal = false;
@@ -231,6 +235,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._primedSource = {
       source: job.source,
       source_label: job.source_label,
+      source_esphome_version: job.source_esphome_version,
     };
     // Cancel any prior follow before starting a new one — without this,
     // every reopen layered fresh streams while previous ones still pumped

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -130,6 +130,7 @@ export async function startFirmwareJob(host: ESPHomeCommandDialog): Promise<void
   host._primedSource = {
     source: job.source,
     source_label: job.source_label,
+    source_esphome_version: job.source_esphome_version,
   };
   followJob(host, job.job_id);
 }

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -23,6 +23,14 @@ export function renderRemoteBuilderSubLine(
   const source = liveJob?.source ?? host._primedSource?.source;
   const label = liveJob?.source_label ?? host._primedSource?.source_label;
   if (source !== JobSource.REMOTE || !label) return nothing;
+  // source_esphome_version is also a job-creation-time snapshot; empty when
+  // the pairing hadn't completed a peer-link session yet. Render "<label>
+  // (<version>)" so the operator can spot version skew vs the offloader.
+  const version =
+    liveJob?.source_esphome_version ??
+    host._primedSource?.source_esphome_version ??
+    "";
+  const display = version ? `${label} (${version})` : label;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.
   const canOverride = host._commandType === "install";
@@ -31,7 +39,7 @@ export function renderRemoteBuilderSubLine(
       <wa-icon library="mdi" name="server-network"></wa-icon>
       <span
         >${host._localize("command.remote_builder_sub_line", {
-          receiver: label,
+          receiver: display,
         })}</span
       >
       ${canOverride

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -146,10 +146,13 @@ function renderSourceLine(
   job: FirmwareJob,
 ): TemplateResult | typeof nothing {
   if (job.source === JobSource.REMOTE && job.source_label) {
+    const display = job.source_esphome_version
+      ? `${job.source_label} (${job.source_esphome_version})`
+      : job.source_label;
     return html`
       <div class="job-source">
         ${host._localize("firmware_jobs.building_on", {
-          label: job.source_label,
+          label: display,
         })}
       </div>
     `;

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -32,6 +32,7 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     source: JobSource.LOCAL,
     source_pin_sha256: "",
     source_label: "",
+    source_esphome_version: "",
     remote_peer: "",
     remote_peer_label: "",
     device_name: "",

--- a/test/util/firmware-job-status.test.ts
+++ b/test/util/firmware-job-status.test.ts
@@ -31,6 +31,7 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     source: JobSource.LOCAL,
     source_pin_sha256: "",
     source_label: "",
+    source_esphome_version: "",
     remote_peer: "",
     remote_peer_label: "",
     device_name: "",


### PR DESCRIPTION
# What does this implement/fix?

Appends the receiver's bundled ESPHome version to the "Building on
<receiver>" sub-line in the install dialog and to the per-job
source line in the firmware-tasks dialog ("Building on macbook-pro
(2026.5.0)"). The version is what the receiver is actually
compiling against — surfaces a version skew between the offloader
and the receiver before the user wonders why their cache is cold
or a feature is missing.

Reads `FirmwareJob.source_esphome_version` (snapshotted at
job-creation time on the backend in the companion PR); falls back
to label-only when the field is empty: LOCAL jobs, REMOTE jobs
whose pairing hadn't yet completed a peer-link session, jobs from
older backends. The install dialog's locally-primed source seed is
widened to carry the version too so the first frame paints with it
instead of jittering on the next jobs-context update.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#716

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
