### PR TITLE
Fix post-install logs after Web Serial flash

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -415,26 +415,42 @@ export async function fetchApiKey(
  *     readable would throw.
  */
 export function streamSerialToDialog(port: any, dialog: any): () => void {
-  const decoder = new TextDecoderStream();
-  port.readable.pipeTo(decoder.writable).catch(() => {
-    /* Pipe rejection happens when the reader is cancelled below;
-       swallow it so the unhandled promise rejection doesn't bubble
-       up into the console. */
-  });
-  const reader = decoder.readable.getReader();
+  // Defence in depth: ``port.readable`` is ``null`` when the port is
+  // closed. Without this guard the caller (e.g. post-install-logs
+  // handler) hangs with a dialog stuck on "Waiting for logs…".
+  if (!port.readable) {
+    console.error("[Web Serial] streamSerialToDialog called on a closed port");
+    return () => {};
+  }
+  /* Read directly from ``port.readable.getReader()`` and decode in
+     userland rather than going through ``port.readable.pipeTo()`` +
+     a ``TextDecoderStream``. The pipeTo plumbing has been observed
+     to silently swallow bytes on some bridge chips (notably CH9102F)
+     after a close/reopen within the same USB session — direct reads
+     do not. */
+  const reader = port.readable.getReader();
+  const decoder = new TextDecoder();
   let buffer = "";
   let cancelled = false;
   const readLoop = async () => {
     try {
       while (true) {
         const { value, done } = await reader.read();
-        if (done) break;
-        if (cancelled) break;
-        buffer += value;
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          dialog._lines = [...dialog._lines, line];
+        if (done || cancelled) break;
+        if (value && value.length) {
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            /* Strip trailing CR (CRLF endings from the ROM
+               bootloader and many serial sources). ``ansi-log``
+               treats any chunk ending in ``\r`` as a progress-style
+               overwrite — it pops the previous visual line and
+               replaces it in place — so a stream of CRLF-terminated
+               boot lines would collapse to just the last one. */
+            const cleaned = line.endsWith("\r") ? line.slice(0, -1) : line;
+            dialog._lines = [...dialog._lines, cleaned];
+          }
         }
       }
     } catch {

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -415,13 +415,6 @@ export async function fetchApiKey(
  *     readable would throw.
  */
 export function streamSerialToDialog(port: any, dialog: any): () => void {
-  // Defence in depth: ``port.readable`` is ``null`` when the port is
-  // closed. Without this guard the caller (e.g. post-install-logs
-  // handler) hangs with a dialog stuck on "Waiting for logs…".
-  if (!port.readable) {
-    console.error("[Web Serial] streamSerialToDialog called on a closed port");
-    return () => {};
-  }
   /* Read directly from ``port.readable.getReader()`` and decode in
      userland rather than going through ``port.readable.pipeTo()`` +
      a ``TextDecoderStream``. The pipeTo plumbing has been observed

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -162,7 +162,11 @@ export async function startWebSerialInstall(
   // 6. Reset
   host._statusMessage = host._localize("firmware.status_resetting");
   try {
-    await resetAndDisconnect(flashDetected.loader, flashDetected.transport);
+    await resetAndDisconnect(
+      flashDetected.loader,
+      flashDetected.transport,
+      flashDetected.port,
+    );
   } catch {
     /* ignore reset errors */
   }

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -76,6 +76,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
   private _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
+    () => this._localize,
   );
 
   // Ticker for live relative-time strings ("started 2m ago"). Open-only.

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -416,6 +416,21 @@ export class ESPHomeLogsDialog extends LitElement {
     this._serialCancel = cancel;
   }
 
+  /**
+   * Surface a failure to reopen the Web Serial port for post-install
+   * logs. Appends the message into the log pane (so a user who looked
+   * away during the install still sees the cause) and flips
+   * ``_streaming`` off so the toolbar shows "Start" — the right
+   * affordance for "this is broken, try again" — instead of "Stop".
+   * The caller pairs this with a ``toast.error`` for at-a-glance
+   * surfacing.
+   */
+  public setSerialOpenFailed(message: string) {
+    this._stopSerial();
+    this._lines = [...this._lines, message];
+    this._streaming = false;
+  }
+
   private _stopSerial() {
     if (this._serialCancel) {
       const cancel = this._serialCancel;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -506,7 +506,10 @@ export class ESPHomePageDashboard extends LitElement {
   _onInstallMethodSelect = (e: CustomEvent<{ method: string; port?: string }>) =>
     onInstallMethodSelect(this, e);
   _openLogs = (device: ConfiguredDevice) => openLogs(this, device);
-  _onPostInstallShowLogs = postInstallShowLogsHandler(() => this._logsDialog);
+  _onPostInstallShowLogs = postInstallShowLogsHandler(
+    () => this._logsDialog,
+    () => this._localize,
+  );
   _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
   };

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -191,6 +191,7 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
+    () => this._localize,
   );
 
   private _installCtrl = this._createInstallController();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -69,6 +69,7 @@
     "logs_show_states": "Show states",
     "logs_back_to_install": "Back to install",
     "logs_back_to_install_tooltip": "Return to the install output",
+    "logs_port_reopen_failed": "Failed to reopen the serial port for logs. The device may still be restarting — click Start to reconnect.",
     "select_all": "Select all",
     "deselect_all": "Deselect all",
     "selected_count": "{count} selected",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -217,6 +217,7 @@
     "logs_states": "États",
     "logs_hide_states": "Masquer les états",
     "logs_show_states": "Afficher les états",
+    "logs_port_reopen_failed": "Échec de la réouverture du port série pour les journaux. L'appareil redémarre peut-être encore — cliquez sur Démarrer pour reconnecter.",
     "install_method_title": "Comment voulez-vous installer le firmware ?",
     "install_method_network": "Sur le réseau",
     "install_method_network_desc": "Nécessite que l'appareil soit en ligne",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -217,6 +217,7 @@
     "logs_states": "Statussen",
     "logs_hide_states": "Statussen verbergen",
     "logs_show_states": "Statussen tonen",
+    "logs_port_reopen_failed": "Kon de seriële poort niet heropenen voor logs. Het apparaat start mogelijk nog op — klik op Start om opnieuw te verbinden.",
     "install_method_title": "Hoe wilt u de firmware installeren?",
     "install_method_network": "Via het netwerk",
     "install_method_network_desc": "Vereist dat het apparaat online is",

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -1,3 +1,5 @@
+import toast from "sonner-js";
+import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 
@@ -64,22 +66,70 @@ export function dispatchShowLogsAfterInstall(
  *
  *     private _onPostInstallShowLogs = postInstallShowLogsHandler(
  *       () => this._logsDialog,
+ *       () => this._localize,
  *     );
  *
- * The getter is deferred so the host's ``@query`` decorator can
- * resolve the logs-dialog at event-fire time (after first render),
+ * The getters are deferred so the host's ``@query`` and ``@consume``
+ * decorators can resolve at event-fire time (after first render),
  * not at field-initialisation time when the shadow DOM hasn't been
- * rendered yet.
+ * rendered yet and the localize context hasn't been bound.
  */
 export function postInstallShowLogsHandler(
   getLogsDialog: () => ESPHomeLogsDialog,
+  getLocalize: () => LocalizeFunc,
 ): (e: CustomEvent<PostInstallShowLogsDetail>) => Promise<void> {
-  return (e) => handlePostInstallShowLogs(e, getLogsDialog());
+  return (e) => handlePostInstallShowLogs(e, getLogsDialog(), getLocalize());
+}
+
+/**
+ * Reopen a SerialPort that the post-install hard-reset just closed,
+ * retrying through the brief native-USB re-enumeration window.
+ *
+ * ESP32-S3 / C3 / C6 (USB-Serial/JTAG) drop their USB device for a
+ * few hundred ms after the EN-pulse reset, so a synchronous
+ * ``port.open()`` immediately after ``transport.disconnect()`` races
+ * the re-enumeration and throws ``NetworkError``. UART-bridge chips
+ * (CP2102 / CH340) don't re-enumerate and the first attempt succeeds.
+ *
+ * Returns ``true`` on success (or "already open" — a race that left
+ * the port usable). Returns ``false`` if no attempt succeeded inside
+ * ``timeoutMs``.
+ */
+async function openSerialWithRetry(
+  port: SerialPort,
+  baudRate: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown = null;
+  while (true) {
+    try {
+      await port.open({ baudRate });
+      return true;
+    } catch (err) {
+      lastErr = err;
+      const name = err instanceof DOMException ? err.name : "";
+      const message = err instanceof Error ? err.message : "";
+      // Chrome's message for "InvalidStateError: The port is already
+      // open." has no specific DOMException code; string-match is
+      // unavoidable. Web Serial is Chromium-only today so the surface
+      // is one-browser — acceptable.
+      if (name === "InvalidStateError" && /already open/i.test(message)) {
+        return true;
+      }
+      if (name !== "NetworkError" || Date.now() >= deadline) {
+        console.error("[Web Serial] Failed to reopen port for logs:", lastErr);
+        return false;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
 }
 
 export async function handlePostInstallShowLogs(
   e: CustomEvent<PostInstallShowLogsDetail>,
-  logsDialog: ESPHomeLogsDialog
+  logsDialog: ESPHomeLogsDialog,
+  localize: LocalizeFunc,
 ) {
   e.preventDefault();
   const { configuration, name, port, webSerialPort, reopenInstall } = e.detail;
@@ -87,16 +137,37 @@ export async function handlePostInstallShowLogs(
   logsDialog.name = name;
   if (webSerialPort) {
     logsDialog.openPassive({ onBackToInstall: reopenInstall });
+    /* Settling delay — some USB-UART bridges (notably the CH9102F on
+       M5Stamp boards) don't resync their internal CDC state cleanly
+       when port.open() lands immediately after a port.close() within
+       the same USB session. The reader then sees no bytes even though
+       the chip is booting and outputting on UART. A few hundred ms is
+       enough for the bridge to settle. */
+    await new Promise((r) => setTimeout(r, 500));
     /* Reopen the port at the logs baud — the install just left it
        closed via ``resetAndDisconnect``. The grant from the
        original ``requestPort()`` is still in effect for this
-       origin, so this doesn't re-prompt the user. */
+       origin, so this doesn't re-prompt the user. Retry through
+       the native-USB re-enumeration window. */
+    const opened = await openSerialWithRetry(webSerialPort, 115200, 5000);
+    if (!opened) {
+      const message = localize("dashboard.logs_port_reopen_failed");
+      logsDialog.setSerialOpenFailed(message);
+      toast.error(message, { richColors: true });
+      return;
+    }
+    /* Explicitly clear DTR/RTS — on some bridges (CH9102F again)
+       these can stick at unexpected values across a close/reopen,
+       and a residual asserted DTR can hold the strap pin / EN line
+       low and keep the chip mute. */
     try {
-      await webSerialPort.open({ baudRate: 115200 });
+      await webSerialPort.setSignals({
+        dataTerminalReady: false,
+        requestToSend: false,
+      });
     } catch {
-      /* port might already be open if the user mashed buttons —
-         streamSerialToDialog will surface its own error if read
-         fails. */
+      /* setSignals failures are recoverable; the chip might be in
+         a fine state already. Continue. */
     }
     const cancel = streamSerialToDialog(webSerialPort, logsDialog);
     logsDialog.setSerialCancel(cancel);

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -5,7 +5,15 @@
  * Web Serial API. No backend involvement — talks directly to the
  * USB-connected ESP device.
  */
-import { ESPLoader, Transport } from "esptool-js";
+import {
+  ClassicReset,
+  ESPLoader,
+  Transport,
+  UsbJtagSerialReset,
+} from "esptool-js";
+
+/** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
+const ESPRESSIF_USB_VID = 0x303a;
 
 export interface DetectedChip {
   chipName: string;
@@ -216,14 +224,158 @@ export async function flashFirmware(
   });
 }
 
+/**
+ * RTC-WDT register layout for chips that support the
+ * watchdog-triggered reset trick. Same layout (offsets +0x94 /
+ * +0x98 / +0xAC from RTC_CNTL_BASE) across ESP32-S2 / S3 / C2 / C3;
+ * only the RTC_CNTL_BASE address differs by chip.
+ *
+ * Watchdog reset is the most reliable way to exit the stub bootloader
+ * on these chips. esptool's ``--after watchdog-reset`` uses the same
+ * trick precisely because DTR/RTS-based resets are unreliable on
+ * native-USB / USB-Serial-JTAG chips and on boards whose auto-reset
+ * circuit doesn't have the cross-coupled "cancellation" behaviour the
+ * standard ClassicReset sequence assumes (M5Stamp C3 with CH9102F is
+ * one such combination — the user-reported repro of this fix).
+ *
+ * Disabled on ESP32-C6 (causes full system freeze per Espressif docs)
+ * and on chips without RTC_WDT (ESP8266, classic ESP32, ESP32-H2 /
+ * H4 / E22).
+ */
+/* WDT register addresses per chip. Offsets vary by chip — verified
+   against esptool python's per-target files (S2/S3/C2/C3.py). */
+const WDT_RESET_CHIPS: Record<
+  string,
+  { wdtConfig0: number; wdtConfig1: number; wdtWProtect: number }
+> = {
+  "ESP32-S2": {
+    wdtConfig0: 0x3f408094, // base 0x3F408000 + 0x94
+    wdtConfig1: 0x3f408098, // + 0x98
+    wdtWProtect: 0x3f4080ac, // + 0xAC
+  },
+  "ESP32-S3": {
+    wdtConfig0: 0x60008098, // base 0x60008000 + 0x98
+    wdtConfig1: 0x6000809c, // + 0x9C
+    wdtWProtect: 0x600080b0, // + 0xB0
+  },
+  "ESP32-C2": {
+    wdtConfig0: 0x60008084, // + 0x84
+    wdtConfig1: 0x60008088, // + 0x88
+    wdtWProtect: 0x6000809c, // + 0x9C
+  },
+  "ESP32-C3": {
+    wdtConfig0: 0x60008090, // + 0x90
+    wdtConfig1: 0x60008094, // + 0x94
+    wdtWProtect: 0x600080a8, // + 0xA8
+  },
+};
+
+/** Magic key that unlocks the RTC WDT write-protect register. */
+const RTC_CNTL_WDT_WKEY = 0x50d83aa1;
+
+/**
+ * Trigger a full chip reset via the RTC watchdog. The chip's stub
+ * bootloader processes the writeReg commands, the WDT fires shortly
+ * after, and the chip resets all the way through ROM bootloader to
+ * the user firmware. Works even when DTR/RTS-based reset doesn't
+ * reach the chip (CH9102F / native USB-Serial-JTAG / boards with
+ * non-cross-coupled auto-reset circuits).
+ *
+ * Returns ``false`` for chip types where this isn't safe (ESP32-C6
+ * freezes; classic ESP32 / ESP8266 don't have the WDT at all).
+ */
+async function watchdogReset(
+  loader: ESPLoader,
+  transport: Transport,
+): Promise<boolean> {
+  const regs = loader.chip?.CHIP_NAME
+    ? WDT_RESET_CHIPS[loader.chip.CHIP_NAME]
+    : undefined;
+  if (!regs) return false;
+  /* Release the boot-strap pin (IO9 on C3 / IO0 on others) before
+     the WDT fires so the chip boots from flash on the new reset, not
+     back into download mode. The DTR line is wired to the strap pin
+     via the auto-reset circuit on most dev boards. */
+  try {
+    await transport.setDTR(false);
+    await transport.setRTS(false);
+  } catch {
+    /* If setSignals fails the chip might still WDT-reset OK; don't
+       abort the reset path. */
+  }
+  /* Exact sequence + magic value from esptool python's
+     ``watchdog_reset()`` (esptool/targets/esp32c3.py and siblings).
+     Order: unlock → set timeout → enable+arm → re-lock. The
+     ``(1<<31) | (5<<28) | (1<<8) | 2`` config0 bit pattern is what
+     esptool ships — exact bit semantics aren't documented per-chip;
+     trust the authoritative source. */
+  try {
+    await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
+    await loader.writeReg(regs.wdtConfig1, 2000);
+    await loader.writeReg(
+      regs.wdtConfig0,
+      (1 << 31) | (5 << 28) | (1 << 8) | 2,
+    );
+    await loader.writeReg(regs.wdtWProtect, 0);
+  } catch {
+    /* A writeReg may race the actual reset firing — the chip is
+       supposed to reset within ~14ms of the timeout write. If the
+       last writeReg throws because the chip is mid-reset, the WDT
+       has already done its job. */
+  }
+  /* WDT timeout ≈ 2000 ticks of the slow clock (~14ms on the
+     150kHz default). Wait for the chip to reset + reach ROM
+     bootloader before we close the port — closing mid-reset can
+     leave the kernel-side handle in a weird state on some OSes. */
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  return true;
+}
+
+/**
+ * Pick a reset strategy based on the chip and how it's connected.
+ *
+ * esptool-js's ``loader.after("hard_reset")`` resolves to its
+ * ``HardReset`` class which only calls ``setRTS(false)`` — that does
+ * not pulse DTR / EN and leaves the chip running the stub bootloader
+ * after ``writeFlash``, so the just-flashed firmware never boots and
+ * the post-install logs view stays empty forever.
+ *
+ * - ESP32-S2 / S3 / C2 / C3: trigger an RTC-watchdog reset (the same
+ *   trick esptool's ``--after watchdog-reset`` uses). Most reliable
+ *   on these chips — works through external UART bridges (CH9102F,
+ *   CP210x, etc.) and the chip's own USB-Serial-JTAG alike, and
+ *   doesn't depend on the board's auto-reset circuit having the
+ *   "cancellation" behaviour the DTR/RTS sequence implicitly assumes.
+ * - Native USB-Serial/JTAG (VID 0x303A) for chips not in the WDT
+ *   list (mostly fall-through; safety net): esptool-js's
+ *   ``UsbJtagSerialReset``.
+ * - Everything else (classic ESP32 / ESP8266 via CP210x / CH340 /
+ *   FTDI / etc. bridges): the standard DTR/RTS pulse esptool's
+ *   ``--after hard-reset`` uses (``ClassicReset``).
+ */
+async function hardResetChip(
+  loader: ESPLoader,
+  transport: Transport,
+  port: SerialPort,
+): Promise<void> {
+  if (await watchdogReset(loader, transport)) return;
+  const vendorId = port.getInfo().usbVendorId;
+  if (vendorId === ESPRESSIF_USB_VID) {
+    await new UsbJtagSerialReset(transport).reset();
+  } else {
+    await new ClassicReset(transport, 50).reset();
+  }
+}
+
 /** Hard-reset the device and disconnect. */
 export async function resetAndDisconnect(
   loader: ESPLoader,
-  transport: Transport
+  transport: Transport,
+  port: SerialPort,
 ): Promise<void> {
   markSerialActivity();
   try {
-    await loader.after("hard_reset");
+    await hardResetChip(loader, transport, port);
   } finally {
     await transport.disconnect();
     // hard_reset triggers a USB re-enumeration on native-USB chips;

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -225,10 +225,12 @@ export async function flashFirmware(
 }
 
 /**
- * RTC-WDT register layout for chips that support the
- * watchdog-triggered reset trick. Same layout (offsets +0x94 /
- * +0x98 / +0xAC from RTC_CNTL_BASE) across ESP32-S2 / S3 / C2 / C3;
- * only the RTC_CNTL_BASE address differs by chip.
+ * RTC-WDT register addresses per chip — verified against esptool
+ * python's per-target files (esptool/targets/{esp32s2,esp32s3,
+ * esp32c2,esp32c3}.py). Both the RTC_CNTL_BASE address AND the
+ * register offsets within it vary by chip (e.g. WDTCONFIG0 is at
+ * +0x84 on C2, +0x90 on C3, +0x94 on S2, +0x98 on S3), so each
+ * entry has to spell out the full absolute address.
  *
  * Watchdog reset is the most reliable way to exit the stub bootloader
  * on these chips. esptool's ``--after watchdog-reset`` uses the same
@@ -242,8 +244,6 @@ export async function flashFirmware(
  * and on chips without RTC_WDT (ESP8266, classic ESP32, ESP32-H2 /
  * H4 / E22).
  */
-/* WDT register addresses per chip. Offsets vary by chip — verified
-   against esptool python's per-target files (S2/S3/C2/C3.py). */
 const WDT_RESET_CHIPS: Record<
   string,
   { wdtConfig0: number; wdtConfig1: number; wdtWProtect: number }


### PR DESCRIPTION
# What does this implement/fix?

After a Web Serial install with "Logs after" enabled, the logs viewer hung on "Waiting for logs…" forever. esptool-js's `loader.after("hard_reset")` only toggles RTS, so the chip stayed in the stub bootloader and never booted the just-flashed firmware. Even once that was fixed, a few smaller bugs on the reopen / decode / render path between the reset and the dialog kept the output blank or collapsed.

- Replace `HardReset` with a chip-aware reset: RTC watchdog reset for ESP32-S2/S3/C2/C3 (matches esptool's `--after watchdog-reset`), `UsbJtagSerialReset` for native-USB chips, `ClassicReset` for UART bridges.
- Retry `port.open()` with backoff to ride out the native-USB re-enumeration window after reset; surface a localized toast + inline error in the dialog if the retry exhausts.
- Add a 500ms settle delay + explicit `setSignals(DTR/RTS=false)` on reopen — works around CH9102F bridges that don't resync cleanly across close/reopen within one USB session.
- Read directly from `port.readable.getReader()` instead of `pipeTo` + `TextDecoderStream`, and strip trailing `\r` from each line so CRLF boot output isn't collapsed by `ansi-log`'s progress-overwrite path.
- Add `dashboard.logs_port_reopen_failed` key to en/fr/nl translations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).