### PR TITLE
Fix progress-bar pop eating log lines above it (#840)

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -211,16 +211,7 @@ function parseAnsiLine(line: string, state: AnsiState): AnsiSpan[] {
   return spans;
 }
 
-/**
- * Strip trailing whitespace + leading non-SGR ANSI control sequences
- * (cursor moves, erase-line, OSC) from one chunk.
- *
- * Leading whitespace AND leading SGR colour codes are intentionally
- * preserved: ESPHome's multi-line WARNING records open the colour
- * on the first line and only reset it on the last, and the
- * continuation lines (``clk:`` / ``  mode: CLK_OUT`` / ``  pin: 0``)
- * use indentation as part of the rendered formatting.
- */
+/** Strip leading non-SGR ANSI controls and trailing whitespace. */
 export function cleanLine(line: string): string {
   return line
     .replace(
@@ -231,27 +222,12 @@ export function cleanLine(line: string): string {
 }
 
 /**
- * Fold an incoming stream of subprocess output chunks into the
- * sequence of "visual" lines we want to render. The backend splits
- * stdout at every ``\n`` *or* ``\r`` and forwards each chunk
- * including its terminator, which means progress updates (esptool's
- * ``Writing at 0x10000... (5%)\r``, PlatformIO's ``Downloading
- * [###] N%\r``) arrive as CR-terminated chunks.
+ * Fold ``\r``- and ``\n``-terminated output chunks into visual lines.
  *
- * Rules:
- *   - A *content* chunk that ends with ``\r`` replaces the previous
- *     visual line if the previous chunk also ended in ``\r`` (the
- *     progress-bar overwrite). Without a prior ``\r``, it's a new
- *     line at the bottom.
- *   - A content chunk that ends with ``\n`` (or ``\r\n``) appends a
- *     new line and finalises any prior ``\r``-overwrite intent.
- *   - An *empty-after-cleaning* chunk (PIO's ``\x1b[K\r`` clear-line
- *     between progress ticks, a bare ``\r``) is a terminal no-op:
- *     it doesn't push a line, and it doesn't toggle the overwrite
- *     flag. The next real progress tick still replaces the prior
- *     one, but a non-progress line above the bar isn't eaten by an
- *     accidental pop. An empty chunk ending in ``\n`` does reset
- *     the overwrite flag (it finalises the line).
+ * An empty-after-cleaning chunk (PIO's ``\x1b[K\r`` between progress
+ * ticks, a bare ``\r``) is a no-op that doesn't toggle the overwrite
+ * flag; without that, the next real tick pops a non-progress line
+ * above the bar instead of starting fresh (#840).
  */
 export function chunksToVisualLines(chunks: string[]): string[] {
   const visual: string[] = [];

--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -211,6 +211,67 @@ function parseAnsiLine(line: string, state: AnsiState): AnsiSpan[] {
   return spans;
 }
 
+/**
+ * Strip trailing whitespace + leading non-SGR ANSI control sequences
+ * (cursor moves, erase-line, OSC) from one chunk.
+ *
+ * Leading whitespace AND leading SGR colour codes are intentionally
+ * preserved: ESPHome's multi-line WARNING records open the colour
+ * on the first line and only reset it on the last, and the
+ * continuation lines (``clk:`` / ``  mode: CLK_OUT`` / ``  pin: 0``)
+ * use indentation as part of the rendered formatting.
+ */
+export function cleanLine(line: string): string {
+  return line
+    .replace(
+      /^(?:(?:\u001b|\\033)\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x6c\x6e-\x7e]|(?:\u001b|\\033)\][^\u0007\u001b]*(?:\u0007|\u001b\\|\\033\\)|(?:\u001b|\\033)[NOPVWX^_=>])*/g,
+      ""
+    )
+    .replace(/\s+$/, "");
+}
+
+/**
+ * Fold an incoming stream of subprocess output chunks into the
+ * sequence of "visual" lines we want to render. The backend splits
+ * stdout at every ``\n`` *or* ``\r`` and forwards each chunk
+ * including its terminator, which means progress updates (esptool's
+ * ``Writing at 0x10000... (5%)\r``, PlatformIO's ``Downloading
+ * [###] N%\r``) arrive as CR-terminated chunks.
+ *
+ * Rules:
+ *   - A *content* chunk that ends with ``\r`` replaces the previous
+ *     visual line if the previous chunk also ended in ``\r`` (the
+ *     progress-bar overwrite). Without a prior ``\r``, it's a new
+ *     line at the bottom.
+ *   - A content chunk that ends with ``\n`` (or ``\r\n``) appends a
+ *     new line and finalises any prior ``\r``-overwrite intent.
+ *   - An *empty-after-cleaning* chunk (PIO's ``\x1b[K\r`` clear-line
+ *     between progress ticks, a bare ``\r``) is a terminal no-op:
+ *     it doesn't push a line, and it doesn't toggle the overwrite
+ *     flag. The next real progress tick still replaces the prior
+ *     one, but a non-progress line above the bar isn't eaten by an
+ *     accidental pop. An empty chunk ending in ``\n`` does reset
+ *     the overwrite flag (it finalises the line).
+ */
+export function chunksToVisualLines(chunks: string[]): string[] {
+  const visual: string[] = [];
+  let prevEndedInCR = false;
+  for (const chunk of chunks) {
+    const text = cleanLine(chunk.replace(/[\r\n]+$/, ""));
+    const hasContent = text.replace(ANSI_ESCAPE_RE, "").trim().length > 0;
+    if (hasContent) {
+      if (prevEndedInCR && chunk !== "\n" && visual.length > 0) {
+        visual.pop();
+      }
+      visual.push(text);
+      prevEndedInCR = chunk.endsWith("\r");
+    } else if (chunk.endsWith("\n")) {
+      prevEndedInCR = false;
+    }
+  }
+  return visual;
+}
+
 @customElement("esphome-ansi-log")
 export class ESPHomeAnsiLog extends LitElement {
   /** Use light theme instead of dark. */
@@ -314,7 +375,7 @@ export class ESPHomeAnsiLog extends LitElement {
   }
 
   protected render() {
-    const visual = this._chunksToVisualLines(this.lines);
+    const visual = chunksToVisualLines(this.lines);
     // One state object threaded through every line so multi-line
     // records (a WARNING that opens ``\x1b[33m`` on line 1 and only
     // resets on line 5) keep their colour on the continuation lines.
@@ -326,59 +387,6 @@ export class ESPHomeAnsiLog extends LitElement {
           : visual.map((line) => this._renderLine(line, state))}
       </div>
     `;
-  }
-
-  /**
-   * Fold an incoming stream of subprocess output chunks into the
-   * sequence of "visual" lines we want to render. The backend splits
-   * stdout at every `\n` _or_ `\r` and forwards each chunk including
-   * its terminator, which means progress updates (esptool's
-   * `Writing at 0x10000... (5%)\r`) arrive as CR-terminated chunks.
-   * Same rules the old ESPHome dashboard uses:
-   *   - A chunk that ends with `\r` "owns" the last visual line; the
-   *     next chunk (unless it's a bare `\n`) replaces that line in
-   *     place — that's how progress bars overwrite themselves.
-   *   - A bare `\n` chunk (the trailing half of a `\r\n` pair)
-   *     finalises the line in place — no replacement.
-   *   - Everything else is a new line appended to the bottom.
-   * Empty visual lines are dropped so stray newlines don't punch
-   * blank gaps into the output.
-   */
-  private _chunksToVisualLines(chunks: string[]): string[] {
-    const visual: string[] = [];
-    let prevEndedInCR = false;
-    for (const chunk of chunks) {
-      if (prevEndedInCR && chunk !== "\n" && visual.length > 0) {
-        visual.pop();
-      }
-      const text = this._cleanLine(chunk.replace(/[\r\n]+$/, ""));
-      if (text.replace(ANSI_ESCAPE_RE, "").trim().length > 0) {
-        visual.push(text);
-      }
-      prevEndedInCR = chunk.endsWith("\r");
-    }
-    return visual;
-  }
-
-  /**
-   * Strip trailing whitespace and any leading non-SGR ANSI control
-   * sequences (cursor moves, erase-line, OSC) from one chunk.
-   *
-   * Leading whitespace AND leading SGR colour codes are intentionally
-   * preserved: ESPHome's multi-line WARNING records open the colour
-   * on the first line and only reset it on the last, and the
-   * continuation lines (``clk:`` / ``  mode: CLK_OUT`` / ``  pin: 0``)
-   * use indentation as part of the rendered formatting. Stripping
-   * either would left-align continuation lines and drop the colour
-   * carry-over.
-   */
-  private _cleanLine(line: string): string {
-    return line
-      .replace(
-        /^(?:(?:\u001b|\\033)\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x6c\x6e-\x7e]|(?:\u001b|\\033)\][^\u0007\u001b]*(?:\u0007|\u001b\\|\\033\\)|(?:\u001b|\\033)[NOPVWX^_=>])*/g,
-        ""
-      )
-      .replace(/\s+$/, "");
   }
 
   private _renderLine(line: string, state: AnsiState) {

--- a/test/components/ansi-log-chunks.test.ts
+++ b/test/components/ansi-log-chunks.test.ts
@@ -24,20 +24,13 @@ describe("chunksToVisualLines", () => {
     expect(chunksToVisualLines(chunks)).toEqual(["Downloading [###] 3%"]);
   });
 
-  it("appends the first \\r chunk after a \\n line — no over-pop (regression: #840)", () => {
-    /* The bug: when a control-only chunk like ``\x1b[K\r`` arrived
-       between a real log line and the first progress tick, the
-       prevEndedInCR flag was set without anything pushed; the next
-       progress chunk would then pop the real log line above it
-       instead of starting a fresh progress slot. Repeated across
-       every tick, the WARNING block above the bar disappeared one
-       line per tick. */
+  it("keeps lines above the progress bar despite empty-CR chunks (regression: #840)", () => {
     const chunks = [
       "INFO ESPHome 2026.6.0-dev\n",
       "INFO Reading config\n",
       "WARNING GPIO5 is a strapping PIN\n",
       "Attaching external pullup/down resistors\n",
-      "\u001b[K\r", // pure cursor-home + erase, between print and first tick
+      "\u001b[K\r",
       "Downloading [#] 1%\r",
       "\u001b[K\r",
       "Downloading [##] 2%\r",
@@ -59,9 +52,6 @@ describe("chunksToVisualLines", () => {
   });
 
   it("a bare \\n chunk after a \\r-terminated line finalises the overwrite", () => {
-    /* If a standalone \n arrives after a \r-terminated content line
-       (i.e. the chunker couldn't coalesce the pair), it should
-       finalise the prior line rather than pop it on the next chunk. */
     const chunks = ["Downloading 100%\r", "\n", "INFO Build finished\n"];
     expect(chunksToVisualLines(chunks)).toEqual([
       "Downloading 100%",
@@ -70,9 +60,6 @@ describe("chunksToVisualLines", () => {
   });
 
   it("strips leading non-SGR ANSI sequences but keeps SGR colour codes", () => {
-    /* Leading erase-line / cursor-move escapes are noise; leading SGR
-       (``\u001b[33m``) carries the WARNING colour that ESPHome opens on
-       the first line of a multi-line record. */
     const chunks = ["\u001b[K\u001b[33mWARNING something\n"];
     expect(chunksToVisualLines(chunks)).toEqual(["\u001b[33mWARNING something"]);
   });

--- a/test/components/ansi-log-chunks.test.ts
+++ b/test/components/ansi-log-chunks.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { chunksToVisualLines } from "../../src/components/ansi-log.js";
+
+describe("chunksToVisualLines", () => {
+  it("appends \\n-terminated chunks as discrete lines", () => {
+    const chunks = ["INFO ESPHome 2026.6.0-dev\n", "INFO Reading config\n"];
+    expect(chunksToVisualLines(chunks)).toEqual([
+      "INFO ESPHome 2026.6.0-dev",
+      "INFO Reading config",
+    ]);
+  });
+
+  it("coalesces \\r\\n the same as \\n (Windows print)", () => {
+    const chunks = ["WARNING GPIO5\r\n", "Attaching resistors\r\n"];
+    expect(chunksToVisualLines(chunks)).toEqual(["WARNING GPIO5", "Attaching resistors"]);
+  });
+
+  it("overwrites the previous progress tick on consecutive \\r chunks", () => {
+    const chunks = [
+      "Downloading [#] 1%\r",
+      "Downloading [##] 2%\r",
+      "Downloading [###] 3%\r",
+    ];
+    expect(chunksToVisualLines(chunks)).toEqual(["Downloading [###] 3%"]);
+  });
+
+  it("appends the first \\r chunk after a \\n line — no over-pop (regression: #840)", () => {
+    /* The bug: when a control-only chunk like ``\x1b[K\r`` arrived
+       between a real log line and the first progress tick, the
+       prevEndedInCR flag was set without anything pushed; the next
+       progress chunk would then pop the real log line above it
+       instead of starting a fresh progress slot. Repeated across
+       every tick, the WARNING block above the bar disappeared one
+       line per tick. */
+    const chunks = [
+      "INFO ESPHome 2026.6.0-dev\n",
+      "INFO Reading config\n",
+      "WARNING GPIO5 is a strapping PIN\n",
+      "Attaching external pullup/down resistors\n",
+      "\u001b[K\r", // pure cursor-home + erase, between print and first tick
+      "Downloading [#] 1%\r",
+      "\u001b[K\r",
+      "Downloading [##] 2%\r",
+      "\u001b[K\r",
+      "Downloading [###] 3%\r",
+    ];
+    expect(chunksToVisualLines(chunks)).toEqual([
+      "INFO ESPHome 2026.6.0-dev",
+      "INFO Reading config",
+      "WARNING GPIO5 is a strapping PIN",
+      "Attaching external pullup/down resistors",
+      "Downloading [###] 3%",
+    ]);
+  });
+
+  it("treats a bare \\r chunk as a no-op (no pop, no push, prev unchanged)", () => {
+    const chunks = ["Downloading 1%\r", "\r", "Downloading 2%\r"];
+    expect(chunksToVisualLines(chunks)).toEqual(["Downloading 2%"]);
+  });
+
+  it("a bare \\n chunk after a \\r-terminated line finalises the overwrite", () => {
+    /* If a standalone \n arrives after a \r-terminated content line
+       (i.e. the chunker couldn't coalesce the pair), it should
+       finalise the prior line rather than pop it on the next chunk. */
+    const chunks = ["Downloading 100%\r", "\n", "INFO Build finished\n"];
+    expect(chunksToVisualLines(chunks)).toEqual([
+      "Downloading 100%",
+      "INFO Build finished",
+    ]);
+  });
+
+  it("strips leading non-SGR ANSI sequences but keeps SGR colour codes", () => {
+    /* Leading erase-line / cursor-move escapes are noise; leading SGR
+       (``\u001b[33m``) carries the WARNING colour that ESPHome opens on
+       the first line of a multi-line record. */
+    const chunks = ["\u001b[K\u001b[33mWARNING something\n"];
+    expect(chunksToVisualLines(chunks)).toEqual(["\u001b[33mWARNING something"]);
+  });
+
+  it("drops empty-after-cleanup chunks", () => {
+    const chunks = ["INFO a\n", "   \n", "INFO b\n"];
+    expect(chunksToVisualLines(chunks)).toEqual(["INFO a", "INFO b"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes the install-dialog log "clearing upwards" while a compile is running. When the user closes the install dialog and reopens it via the "Installing..." pill, the log frame above the progress bar loses one real log line per progress tick until only the progress bar (and maybe a single INFO header line) remain.

Root cause is in `_chunksToVisualLines` (now renamed `chunksToVisualLines` and exported for testing). PlatformIO emits the download progress as a pair of chunks per tick: a control-only chunk (`[K\r` — erase-line + carriage-return) followed by the actual `Downloading [###] N%\r` content chunk. The old logic:

```ts
prevEndedInCR = chunk.endsWith("\r");   // set unconditionally
```

set the overwrite flag even when the control-only chunk had no content to push. The next *content* chunk then popped the visual line above the progress slot (a WARNING / Attaching / INFO line) instead of starting fresh, and the pattern repeats on every tick.

The fix is to only set / clear `prevEndedInCR` when something is actually pushed (or when an empty `\n` chunk finalises a prior overwrite). Empty `\r`-terminated chunks now carry the previous overwrite state through without armed-popping the wrong line.

While here:
- Extracted `chunksToVisualLines` + `cleanLine` to top-level pure functions so the test suite can exercise them directly without spinning up the LitElement.
- Added `test/components/ansi-log-chunks.test.ts` covering the happy path (consecutive `\r` overwrites, `\r\n` coalescing, bare-`\r` no-op), the regression case from #840, and a bare-`\n`-after-`\r` finalise.

I verified the new regression test fails on the pre-fix code (4-line context collapses to 1, matching the screenshots in the issue) and passes after the fix.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#840

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
