### PR TITLE
Skip pr-labels job for bot-authored PRs

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -26,6 +26,10 @@ jobs:
   apply_label:
     name: Apply
     runs-on: ubuntu-latest
+    # Bot-authored PRs (Dependabot, etc.) don't follow the PR template
+    # and apply their own labels — release-drafter picks those up
+    # without this job's help.
+    if: github.event.pull_request.user.type != 'Bot'
     steps:
       - name: 🏷 Apply label from PR description checkbox
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0


### PR DESCRIPTION
# What does this implement/fix?

The `pr-labels` workflow fails on every Dependabot PR because Dependabot writes its own description and never ticks a "Types of changes" checkbox (e.g. the failure on #34: https://github.com/esphome/device-builder-frontend/actions/runs/25871812801/job/76028746468?pr=34). Dependabot already applies a `dependencies` label on its own, which release-drafter picks up without help from this job.

Skip the `apply_label` job entirely when the PR author is a Bot. The condition keys on `github.event.pull_request.user.type` rather than `github.actor` so it stays correct across `edited` / `synchronize` / `labeled` events, where the triggering actor might be a human even on a bot-authored PR.

**Related issue or feature (if applicable):**

- fixes the recurring `pr-labels` failure on Dependabot PRs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).