### PR TITLE
Make the entire component card clickable to add

### DIFF
--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -11,14 +11,8 @@ import {
 } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 
-// Click anywhere on the card adds (issue #778). Inner anchors / buttons
-// keep their own behavior — `closest('a, button')` skips the add path
-// when the click originated from one (more-info link, expand button,
-// the explicit "+ Add" button, markdown-rendered links in the
-// description). The "+ Add" button stays a real <button> so keyboard
-// users have a focusable, Enter-activatable equivalent of the
-// card-surface click — making the <article> itself focusable would
-// nest a button inside a button (an ARIA anti-pattern).
+// Skip when the click landed on an inner anchor or button so they
+// keep their own behavior (more-info, expand, "+ Add", md links).
 function shouldHandleCardClick(ev: MouseEvent): boolean {
   const target = ev.target as Element | null;
   return !target?.closest("a, button");

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -11,12 +11,26 @@ import {
 } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 
+// Click anywhere on the card adds (issue #778). Inner anchors / buttons
+// keep their own behavior — `closest('a, button')` skips the add path
+// when the click originated from one (more-info link, expand button,
+// markdown-rendered links inside the description).
+function shouldHandleCardClick(ev: MouseEvent): boolean {
+  const target = ev.target as Element | null;
+  return !target?.closest("a, button");
+}
+
 export function renderBundleCard(
   host: ESPHomeComponentCatalog,
   bundle: FeaturedBundle,
 ): TemplateResult {
   return html`
-    <article class="component-card component-card--featured">
+    <article
+      class="component-card component-card--featured"
+      @click=${(ev: MouseEvent) => {
+        if (shouldHandleCardClick(ev)) host._onAddBundle(bundle);
+      }}
+    >
       <div class="component-card-header">
         <div class="component-image--placeholder">
           <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
@@ -36,7 +50,7 @@ export function renderBundleCard(
         : nothing}
       <div class="card-footer">
         <span></span>
-        <div class="select-component" @click=${() => host._onAddBundle(bundle)}>
+        <div class="select-component">
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${host._localize("device.add_component_action")}
         </div>
@@ -64,6 +78,9 @@ export function renderCard(
       class="component-card ${expanded ? "component-card--expanded" : ""} ${featured
         ? "component-card--featured"
         : ""}"
+      @click=${(ev: MouseEvent) => {
+        if (shouldHandleCardClick(ev)) host._onAdd(component);
+      }}
     >
       <div class="component-card-header">
         ${hasImage
@@ -106,7 +123,7 @@ export function renderCard(
           ${localize("device.more_info")}
           <wa-icon library="mdi" name="open-in-new"></wa-icon>
         </a>
-        <div class="select-component" @click=${() => host._onAdd(component)}>
+        <div class="select-component">
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${localize("device.add_component_action")}
         </div>

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -13,7 +13,7 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 
 // Skip when the click landed on an inner anchor or button so they
 // keep their own behavior (more-info, expand, "+ Add", md links).
-function shouldHandleCardClick(ev: MouseEvent): boolean {
+export function shouldHandleCardClick(ev: MouseEvent): boolean {
   const target = ev.target as Element | null;
   return !target?.closest("a, button");
 }

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -14,7 +14,11 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 // Click anywhere on the card adds (issue #778). Inner anchors / buttons
 // keep their own behavior — `closest('a, button')` skips the add path
 // when the click originated from one (more-info link, expand button,
-// markdown-rendered links inside the description).
+// the explicit "+ Add" button, markdown-rendered links in the
+// description). The "+ Add" button stays a real <button> so keyboard
+// users have a focusable, Enter-activatable equivalent of the
+// card-surface click — making the <article> itself focusable would
+// nest a button inside a button (an ARIA anti-pattern).
 function shouldHandleCardClick(ev: MouseEvent): boolean {
   const target = ev.target as Element | null;
   return !target?.closest("a, button");
@@ -50,10 +54,14 @@ export function renderBundleCard(
         : nothing}
       <div class="card-footer">
         <span></span>
-        <div class="select-component">
+        <button
+          class="select-component"
+          type="button"
+          @click=${() => host._onAddBundle(bundle)}
+        >
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${host._localize("device.add_component_action")}
-        </div>
+        </button>
       </div>
     </article>
   `;
@@ -123,10 +131,14 @@ export function renderCard(
           ${localize("device.more_info")}
           <wa-icon library="mdi" name="open-in-new"></wa-icon>
         </a>
-        <div class="select-component">
+        <button
+          class="select-component"
+          type="button"
+          @click=${() => host._onAdd(component)}
+        >
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${localize("device.add_component_action")}
-        </div>
+        </button>
       </div>
     </article>
   `;

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -329,8 +329,7 @@ export const componentCatalogStyles = css`
     gap: 3px;
     border: none;
     background: none;
-    padding: 2px 4px;
-    margin: -2px -4px;
+    padding: 0;
     border-radius: 4px;
     font-family: inherit;
     font-size: var(--wa-font-size-2xs);
@@ -341,7 +340,7 @@ export const componentCatalogStyles = css`
 
   .select-component:focus-visible {
     outline: 2px solid var(--esphome-primary);
-    outline-offset: 1px;
+    outline-offset: 3px;
   }
 
   .empty {

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -182,9 +182,6 @@ export const componentCatalogStyles = css`
     background: color-mix(in srgb, var(--esphome-primary), transparent 96%);
   }
 
-  /* Mirror the hover treatment when the inner "+ Add" / expand /
-     more-info control is keyboard-focused, so keyboard users see the
-     same "this card is the active one" cue mouse users get. */
   .component-card:focus-within {
     border-color: var(--esphome-primary);
   }
@@ -326,8 +323,6 @@ export const componentCatalogStyles = css`
     font-size: 11px;
   }
 
-  /* Real <button> so keyboard users can tab to it and Enter to add —
-     reset browser button chrome to keep the existing visual. */
   .select-component {
     display: flex;
     align-items: center;

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -172,11 +172,14 @@ export const componentCatalogStyles = css`
     display: flex;
     flex-direction: column;
     gap: 6px;
-    transition: border-color var(--wa-transition-normal) var(--wa-transition-easing);
+    cursor: pointer;
+    transition: border-color var(--wa-transition-normal) var(--wa-transition-easing),
+      background var(--wa-transition-normal) var(--wa-transition-easing);
   }
 
   .component-card:hover {
     border-color: var(--esphome-primary);
+    background: color-mix(in srgb, var(--esphome-primary), transparent 96%);
   }
 
   .component-card--expanded {

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -182,6 +182,13 @@ export const componentCatalogStyles = css`
     background: color-mix(in srgb, var(--esphome-primary), transparent 96%);
   }
 
+  /* Mirror the hover treatment when the inner "+ Add" / expand /
+     more-info control is keyboard-focused, so keyboard users see the
+     same "this card is the active one" cue mouse users get. */
+  .component-card:focus-within {
+    border-color: var(--esphome-primary);
+  }
+
   .component-card--expanded {
     grid-column: 1 / -1;
   }
@@ -197,6 +204,11 @@ export const componentCatalogStyles = css`
     flex-shrink: 0;
     color: var(--esphome-primary);
     font-size: 15px;
+  }
+
+  .expand-button:focus-visible {
+    outline: 2px solid var(--esphome-primary);
+    outline-offset: 1px;
   }
 
   .expand-button wa-icon {
@@ -314,14 +326,27 @@ export const componentCatalogStyles = css`
     font-size: 11px;
   }
 
+  /* Real <button> so keyboard users can tab to it and Enter to add —
+     reset browser button chrome to keep the existing visual. */
   .select-component {
     display: flex;
     align-items: center;
     gap: 3px;
+    border: none;
+    background: none;
+    padding: 2px 4px;
+    margin: -2px -4px;
+    border-radius: 4px;
+    font-family: inherit;
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-bold);
     color: var(--esphome-primary);
     cursor: pointer;
+  }
+
+  .select-component:focus-visible {
+    outline: 2px solid var(--esphome-primary);
+    outline-offset: 1px;
   }
 
   .empty {

--- a/test/components/device/component-catalog-renderers.test.ts
+++ b/test/components/device/component-catalog-renderers.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { shouldHandleCardClick } from "../../../src/components/device/component-catalog/renderers.js";
+
+function clickFrom(target: Element): MouseEvent {
+  const ev = new MouseEvent("click", { bubbles: true });
+  Object.defineProperty(ev, "target", { value: target });
+  return ev;
+}
+
+describe("shouldHandleCardClick", () => {
+  it("adds when the click landed on a non-interactive part of the card", () => {
+    // Card surface (description text, image, header, etc.) is the
+    // primary motivation for the article-level handler — issue #778.
+    const card = document.createElement("article");
+    const description = document.createElement("p");
+    card.append(description);
+    expect(shouldHandleCardClick(clickFrom(description))).toBe(true);
+  });
+
+  it("skips when the click landed on the inner + Add button", () => {
+    // The "+ Add" indicator is a real <button> so keyboard users
+    // can tab + Enter; the article-level handler must defer to its
+    // own onAdd to avoid a double-add.
+    const card = document.createElement("article");
+    const addButton = document.createElement("button");
+    card.append(addButton);
+    expect(shouldHandleCardClick(clickFrom(addButton))).toBe(false);
+  });
+
+  it("skips when the click landed inside the inner + Add button", () => {
+    // The button contains a <wa-icon> child — the click target is
+    // the icon, not the button. closest() must walk up to find it.
+    const card = document.createElement("article");
+    const addButton = document.createElement("button");
+    const icon = document.createElement("wa-icon");
+    addButton.append(icon);
+    card.append(addButton);
+    expect(shouldHandleCardClick(clickFrom(icon))).toBe(false);
+  });
+
+  it("skips when the click landed on the more-info anchor", () => {
+    // External docs link must navigate, not add.
+    const card = document.createElement("article");
+    const moreInfo = document.createElement("a");
+    moreInfo.href = "https://example.test/docs";
+    card.append(moreInfo);
+    expect(shouldHandleCardClick(clickFrom(moreInfo))).toBe(false);
+  });
+
+  it("skips when the click landed on a markdown link inside the description", () => {
+    // Catalog descriptions render embedded [text](url) as <a>;
+    // those should navigate without triggering add.
+    const card = document.createElement("article");
+    const description = document.createElement("p");
+    const mdLink = document.createElement("a");
+    mdLink.href = "https://example.test/rest-api";
+    description.append(mdLink);
+    card.append(description);
+    expect(shouldHandleCardClick(clickFrom(mdLink))).toBe(false);
+  });
+
+  it("skips when the click landed on the expand button", () => {
+    // Toggling the expanded view is its own action; the card
+    // surface around the expand icon still adds.
+    const card = document.createElement("article");
+    const expandButton = document.createElement("button");
+    card.append(expandButton);
+    expect(shouldHandleCardClick(clickFrom(expandButton))).toBe(false);
+  });
+
+  it("does not crash when ev.target is null", () => {
+    // ev.target is `EventTarget | null` per the DOM types — the
+    // optional chain has to tolerate the null branch.
+    const ev = new MouseEvent("click");
+    Object.defineProperty(ev, "target", { value: null });
+    expect(shouldHandleCardClick(ev)).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Inside the component picker, each component is rendered as a large card but only the small `+ Add` button in the bottom-right corner triggered the add action. This makes the full card surface a click target for adding the component (or the bundle, for featured-bundle cards), so the most visually prominent target is also the actionable one.

Existing controls keep their behavior:

- the `More info` link still navigates to the docs
- the expand icon (top-right) still toggles the in-card detail view
- in-description Markdown links (e.g. `REST API`) still navigate

These are detected via `target.closest('a, button')` inside the article-level click handler — anchors and buttons short-circuit the add path, while clicks anywhere else on the card add the component. The `+ Add` indicator stays as the visual "what this card does" cue (per discussion on the issue).

The card now has `cursor: pointer` and a subtle background tint on hover so the affordance reads as clickable.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#778

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).