### PR TITLE
Skip auto-id for top-level singleton components

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -17,6 +17,10 @@ import {
   type ValidationError,
 } from "../../util/config-validation.js";
 import { seedBoardPinDefaults } from "../../util/board-pin-defaults.js";
+import {
+  collectExistingIds,
+  generateDefaultComponentId,
+} from "../../util/default-component-id.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -297,39 +301,11 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   private _generateDefaultId(): string {
-    // "switch.gpio" -> "switch_gpio"; "wifi" -> "wifi"
-    const slug = this.component.id.replace(/\./g, "_").toLowerCase();
-    const existing = this._collectExistingIds(this.yaml);
-
-    // Always start from `_1`. Even single-instance components get a
-    // numeric suffix because the bare slug clashes with the
-    // top-level YAML key — `web_server:` block with `id: web_server`
-    // means `id(web_server)` references are ambiguous and can also
-    // collide with ESPHome's auto-generated component-typed
-    // identifiers. The suffix is cheap insurance.
-    let n = 1;
-    let candidate = `${slug}_${n}`;
-    while (existing.has(candidate)) {
-      n++;
-      candidate = `${slug}_${n}`;
-    }
-    return candidate;
-  }
-
-  /**
-   * Scan the YAML for every `id:` line and return the set of values.
-   * Best-effort regex match — same approach the ID-reference picker
-   * uses, deliberately simple (we only need a uniqueness check, not
-   * a full parse).
-   */
-  private _collectExistingIds(yaml: string): Set<string> {
-    const ids = new Set<string>();
-    if (!yaml) return ids;
-    for (const line of yaml.split("\n")) {
-      const m = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
-      if (m) ids.add(m[1]);
-    }
-    return ids;
+    return generateDefaultComponentId(
+      this.component.id,
+      this.component.multi_conf,
+      collectExistingIds(this.yaml),
+    );
   }
 
   protected render() {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -206,7 +206,8 @@ export class ESPHomeAddComponentForm extends LitElement {
       (e) => e.key === "id" && e.type === ConfigEntryType.ID,
     );
     if (idEntry && next["id"] === undefined) {
-      next = { ...next, id: this._generateDefaultId() };
+      const seeded = this._generateDefaultId();
+      if (seeded !== null) next = { ...next, id: seeded };
     }
 
     // Seed pin entries from the board's manifest when the board has
@@ -300,7 +301,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     return out;
   }
 
-  private _generateDefaultId(): string {
+  private _generateDefaultId(): string | null {
     return generateDefaultComponentId(
       this.component.id,
       this.component.multi_conf,

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,0 +1,53 @@
+/**
+ * Auto-generate a default `id:` value for a component being added
+ * via the catalog. Used by `esphome-add-component-form` to seed the
+ * id field — the user can edit it before submitting.
+ *
+ * Naming policy:
+ *   - Platform entries (id contains `.`, e.g. `switch.gpio`) and
+ *     repeatable top-level blocks (`multi_conf: true`) get a numeric
+ *     suffix: `switch_gpio_1`, `switch_gpio_2`, ... — users routinely
+ *     add several of these, so the suffix disambiguates.
+ *   - Top-level singletons (no `.`, `multi_conf: false`, e.g.
+ *     `web_server`, `mdns`, `logger`, `api`) get the bare slug.
+ *     There can only ever be one of them, so a `_1` suffix implies
+ *     a non-existent `_2` and is misleading.
+ *
+ * The bare slug for a singleton can still collide with a user-defined
+ * id elsewhere in the YAML (e.g. they renamed a sensor to
+ * `web_server`); on collision we fall through to the suffixed path
+ * so the generated id stays unique.
+ */
+export function generateDefaultComponentId(
+  componentId: string,
+  multiConf: boolean,
+  existing: ReadonlySet<string>,
+): string {
+  const slug = componentId.replace(/\./g, "_").toLowerCase();
+  const isSingleton = !multiConf && !componentId.includes(".");
+  if (isSingleton && !existing.has(slug)) return slug;
+
+  let n = 1;
+  let candidate = `${slug}_${n}`;
+  while (existing.has(candidate)) {
+    n++;
+    candidate = `${slug}_${n}`;
+  }
+  return candidate;
+}
+
+/**
+ * Scan the YAML for every `id:` line and return the set of values.
+ * Best-effort regex match — same approach the ID-reference picker
+ * uses, deliberately simple (we only need a uniqueness check, not
+ * a full parse).
+ */
+export function collectExistingIds(yaml: string): Set<string> {
+  const ids = new Set<string>();
+  if (!yaml) return ids;
+  for (const line of yaml.split("\n")) {
+    const m = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
+    if (m) ids.add(m[1]);
+  }
+  return ids;
+}

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,32 +1,36 @@
 /**
  * Auto-generate a default `id:` value for a component being added
  * via the catalog. Used by `esphome-add-component-form` to seed the
- * id field — the user can edit it before submitting.
+ * id field — the user can edit it (or leave it blank) before
+ * submitting.
  *
  * Naming policy:
  *   - Platform entries (id contains `.`, e.g. `switch.gpio`) and
- *     repeatable top-level blocks (`multi_conf: true`) get a numeric
- *     suffix: `switch_gpio_1`, `switch_gpio_2`, ... — users routinely
- *     add several of these, so the suffix disambiguates.
+ *     repeatable top-level blocks (`multi_conf: true`, e.g. `script`,
+ *     `i2c`) get a numeric suffix: `switch_gpio_1`, `script_1`, ...
+ *     Users routinely add several of these AND link to them by id
+ *     from automations / lambdas / bus references, so a prefilled
+ *     unique id is useful.
  *   - Top-level singletons (no `.`, `multi_conf: false`, e.g.
- *     `web_server`, `mdns`, `logger`, `api`) get the bare slug.
- *     There can only ever be one of them, so a `_1` suffix implies
- *     a non-existent `_2` and is misleading.
- *
- * The bare slug for a singleton can still collide with a user-defined
- * id elsewhere in the YAML (e.g. they renamed a sensor to
- * `web_server`); on collision we fall through to the suffixed path
- * so the generated id stays unique.
+ *     `web_server`, `mdns`, `logger`, `api`, `ota`, `captive_portal`,
+ *     `wifi`) return `null` — no id is seeded at all. These
+ *     components are never referenced by id from elsewhere in the
+ *     YAML, and the bare slug as an id would collide with the C++
+ *     namespace of the same name in ESPHome's generated code (e.g.
+ *     `id: web_server` shadows the `web_server::` namespace). The
+ *     numeric-suffix form (`web_server_1`) was also wrong because
+ *     it implied a non-existent `_2`. Power users who need an id
+ *     for `!extend` overrides in packages can type one in.
  */
 export function generateDefaultComponentId(
   componentId: string,
   multiConf: boolean,
   existing: ReadonlySet<string>,
-): string {
-  const slug = componentId.replace(/\./g, "_").toLowerCase();
+): string | null {
   const isSingleton = !multiConf && !componentId.includes(".");
-  if (isSingleton && !existing.has(slug)) return slug;
+  if (isSingleton) return null;
 
+  const slug = componentId.replace(/\./g, "_").toLowerCase();
   let n = 1;
   let candidate = `${slug}_${n}`;
   while (existing.has(candidate)) {

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectExistingIds,
+  generateDefaultComponentId,
+} from "../../src/util/default-component-id.js";
+
+describe("generateDefaultComponentId", () => {
+  it("emits the bare slug for top-level singletons", () => {
+    // `web_server` is the canonical case from issue #776: a
+    // `multi_conf: false` top-level block where `_1` is misleading.
+    expect(generateDefaultComponentId("web_server", false, new Set())).toBe(
+      "web_server",
+    );
+    expect(generateDefaultComponentId("mdns", false, new Set())).toBe("mdns");
+    expect(generateDefaultComponentId("captive_portal", false, new Set())).toBe(
+      "captive_portal",
+    );
+  });
+
+  it("suffixes top-level multi_conf components", () => {
+    expect(generateDefaultComponentId("script", true, new Set())).toBe(
+      "script_1",
+    );
+  });
+
+  it("suffixes platform entries even when multi_conf is false", () => {
+    // Platform-style ids (containing `.`) always get a suffix because
+    // users routinely add multiple entries of the same platform; the
+    // suffix is what disambiguates them in the generated YAML.
+    expect(generateDefaultComponentId("switch.gpio", false, new Set())).toBe(
+      "switch_gpio_1",
+    );
+    expect(generateDefaultComponentId("sensor.dht", true, new Set())).toBe(
+      "sensor_dht_1",
+    );
+  });
+
+  it("walks the suffix counter on collision", () => {
+    const existing = new Set(["switch_gpio_1", "switch_gpio_2"]);
+    expect(generateDefaultComponentId("switch.gpio", true, existing)).toBe(
+      "switch_gpio_3",
+    );
+  });
+
+  it("falls back to a numeric suffix when the bare singleton slug is taken", () => {
+    // A user could have manually assigned `id: web_server` elsewhere
+    // (e.g. renamed a sensor). The generator must still emit a
+    // unique id rather than producing a duplicate.
+    const existing = new Set(["web_server"]);
+    expect(generateDefaultComponentId("web_server", false, existing)).toBe(
+      "web_server_1",
+    );
+  });
+
+  it("lowercases mixed-case component ids", () => {
+    expect(generateDefaultComponentId("Web_Server", false, new Set())).toBe(
+      "web_server",
+    );
+  });
+});
+
+describe("collectExistingIds", () => {
+  it("returns an empty set for empty input", () => {
+    expect(collectExistingIds("")).toEqual(new Set());
+  });
+
+  it("picks up ids on indented and list-item lines", () => {
+    const yaml = `web_server:
+  id: web_server
+sensor:
+  - id: temp_1
+    platform: dht
+  - id: "humid_1"
+    platform: dht
+`;
+    expect(collectExistingIds(yaml)).toEqual(
+      new Set(["web_server", "temp_1", "humid_1"]),
+    );
+  });
+
+  it("ignores top-level (zero-indent) keys named id", () => {
+    // `id:` only counts when it's a component field (indented or in a
+    // list item), not when it's somehow appearing at column 0.
+    const yaml = `id: something\n`;
+    expect(collectExistingIds(yaml)).toEqual(new Set());
+  });
+});

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -5,28 +5,47 @@ import {
 } from "../../src/util/default-component-id.js";
 
 describe("generateDefaultComponentId", () => {
-  it("emits the bare slug for top-level singletons", () => {
-    // `web_server` is the canonical case from issue #776: a
-    // `multi_conf: false` top-level block where `_1` is misleading.
+  it("returns null for top-level singletons", () => {
+    // Issue #776: `web_server_1` implied a non-existent `_2`, and the
+    // bare slug `web_server` would collide with the `web_server::` C++
+    // namespace in ESPHome codegen. These components aren't referenced
+    // by id from elsewhere, so we just don't seed one — power users
+    // can type a value if they need it for `!extend` overrides.
     expect(generateDefaultComponentId("web_server", false, new Set())).toBe(
-      "web_server",
+      null,
     );
-    expect(generateDefaultComponentId("mdns", false, new Set())).toBe("mdns");
+    expect(generateDefaultComponentId("mdns", false, new Set())).toBe(null);
     expect(generateDefaultComponentId("captive_portal", false, new Set())).toBe(
-      "captive_portal",
+      null,
+    );
+    expect(generateDefaultComponentId("logger", false, new Set())).toBe(null);
+    expect(generateDefaultComponentId("api", false, new Set())).toBe(null);
+    expect(generateDefaultComponentId("ota", false, new Set())).toBe(null);
+  });
+
+  it("ignores the existing-id set for singletons", () => {
+    // Singletons return null regardless of what's already in the YAML.
+    // Even an unrelated id collision shouldn't flip them back into
+    // suffix-generation mode.
+    const existing = new Set(["web_server", "web_server_1", "web_server_2"]);
+    expect(generateDefaultComponentId("web_server", false, existing)).toBe(
+      null,
     );
   });
 
   it("suffixes top-level multi_conf components", () => {
+    // `script`, `i2c`, `spi`, etc. — users add several and reference
+    // them by id from automations / bus consumers, so a prefilled
+    // unique id earns its keep.
     expect(generateDefaultComponentId("script", true, new Set())).toBe(
       "script_1",
     );
   });
 
   it("suffixes platform entries even when multi_conf is false", () => {
-    // Platform-style ids (containing `.`) always get a suffix because
-    // users routinely add multiple entries of the same platform; the
-    // suffix is what disambiguates them in the generated YAML.
+    // Platform-style ids (containing `.`) always get a suffix. Users
+    // routinely add multiple entries of the same platform and reference
+    // them by id (`id(my_switch).turn_on()`), so the suffix is useful.
     expect(generateDefaultComponentId("switch.gpio", false, new Set())).toBe(
       "switch_gpio_1",
     );
@@ -51,19 +70,9 @@ describe("generateDefaultComponentId", () => {
     );
   });
 
-  it("falls back to a numeric suffix when the bare singleton slug is taken", () => {
-    // A user could have manually assigned `id: web_server` elsewhere
-    // (e.g. renamed a sensor). The generator must still emit a
-    // unique id rather than producing a duplicate.
-    const existing = new Set(["web_server"]);
-    expect(generateDefaultComponentId("web_server", false, existing)).toBe(
-      "web_server_1",
-    );
-  });
-
-  it("lowercases mixed-case component ids", () => {
-    expect(generateDefaultComponentId("Web_Server", false, new Set())).toBe(
-      "web_server",
+  it("lowercases mixed-case platform ids", () => {
+    expect(generateDefaultComponentId("Switch.GPIO", true, new Set())).toBe(
+      "switch_gpio_1",
     );
   });
 });

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -42,6 +42,15 @@ describe("generateDefaultComponentId", () => {
     );
   });
 
+  it("walks the suffix counter for top-level multi_conf blocks too", () => {
+    // Counter-walk for a top-level (no `.`) multi_conf entry is a
+    // distinct code path from the platform case above — pin it.
+    const existing = new Set(["script_1"]);
+    expect(generateDefaultComponentId("script", true, existing)).toBe(
+      "script_2",
+    );
+  });
+
   it("falls back to a numeric suffix when the bare singleton slug is taken", () => {
     // A user could have manually assigned `id: web_server` elsewhere
     // (e.g. renamed a sensor). The generator must still emit a
@@ -76,6 +85,11 @@ sensor:
     expect(collectExistingIds(yaml)).toEqual(
       new Set(["web_server", "temp_1", "humid_1"]),
     );
+  });
+
+  it("handles single-quoted id values", () => {
+    const yaml = `sensor:\n  - id: 'humid_2'\n    platform: dht\n`;
+    expect(collectExistingIds(yaml)).toEqual(new Set(["humid_2"]));
   });
 
   it("ignores top-level (zero-indent) keys named id", () => {


### PR DESCRIPTION
# What does this implement/fix?

When a top-level singleton component (`multi_conf: false`, no `.` in the catalog id — e.g. `web_server`, `mdns`, `logger`, `api`, `ota`, `captive_portal`, `wifi`, `improv_serial`, `safe_mode`, `time`) is added via the catalog, the dashboard no longer pre-fills its `id:` field. The previous `id: web_server_1` was misleading (it implied a non-existent `_2`), and the bare-slug alternative would collide with ESPHome's `web_server::` C++ namespace at codegen time. These components aren't referenced by id from elsewhere in the YAML, so skipping the auto-id is harmless; power users who need an id for `!extend` overrides in packages can type one in.

Platform entries (`switch.gpio`, `sensor.dht`, ...) and repeatable top-level blocks (`multi_conf: true`, e.g. `script`, `i2c`, `spi`) keep their suffixed auto-ids (`switch_gpio_1`, `script_1`, ...). The dashboard's id-reference pickers (`config-entry-id-reference-renderer.ts` → `findReferencedComponents` in `util/config-entry-yaml-scan.ts`) only surface components whose YAML block has an `id:` line — a switch without an id is invisible to every "pick a switch" dropdown in the editor (automation actions, `on_press → switch.toggle`, etc.); an `i2c:` bus without an id can't be selected as `i2c_id:` from devices on it. So the prefilled id is load-bearing for cross-references inside the dashboard, not just convenience for hand-edited YAML.

The singletons we skip have no such pickers pointing at them — nothing in the schema has `references_component: web_server` (or `mdns`, `api`, ...) — so omitting the id costs nothing in the editor.

The id-generation and YAML id-scanning helpers were extracted from `esphome-add-component-form` into `src/util/default-component-id.ts` so the policy is unit-testable; the form delegates to those helpers and skips id-seeding when `generateDefaultComponentId` returns `null`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/776

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
