### PR TITLE
Skip save-time validate_yaml when the linter just validated the buffer

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -34,6 +34,7 @@ import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { sectionAtLine, sectionKeyOf } from "../util/yaml-sections.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
+import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
 import { summarizeValidation } from "../util/yaml-validation-summary.js";
 import { devicePageStyles } from "./device-styles.js";
 
@@ -564,7 +565,12 @@ export class ESPHomePageDevice extends LitElement {
     // toast at this layer would shout-down its result.
     if (this.id) {
       try {
-        const res = await this._api.validateYaml(this.id, this._yaml);
+        // Reuse the linter's last result when it matches the
+        // current buffer exactly — saves a WS round-trip and an
+        // ESPHome validate pass that just ran in the background.
+        const res =
+          getLastValidatedResult(this.id, this._yaml) ??
+          (await this._api.validateYaml(this.id, this._yaml));
         const summary = summarizeValidation(res);
         if (summary.count > 0) {
           this._validationErrorCount = summary.count;

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -23,17 +23,13 @@ interface BackendLinterOptions {
 }
 
 /**
- * Last successful linter result per configuration, keyed on the exact
- * content the linter saw. The save path consults this to skip its own
- * `validateYaml` call when the linter just validated the same buffer —
- * the backend has a content-hash cache too, but skipping the WS
- * round-trip entirely is a few tens of ms faster on slow networks and
- * keeps the editor's "Save" feel snappy.
+ * Last successful linter result per configuration, keyed on exact
+ * content. The save path consults this to skip its own `validateYaml`
+ * WS round-trip when the linter just validated the same buffer.
  *
- * TTL mirrors the backend's `_VALIDATE_CACHE_TTL` (60s). External
- * `!include` / `external_components` files mutated outside the editor
- * are stale on both sides; matching the window keeps staleness
- * semantics symmetric regardless of which cache served the result.
+ * TTL mirrors the backend's `_VALIDATE_CACHE_TTL` (60s) so staleness
+ * semantics for externally-mutated `!include` /
+ * `external_components` files are symmetric on both paths.
  */
 const _LAST_VALIDATED_TTL_MS = 60_000;
 const _lastValidated = new Map<
@@ -52,12 +48,7 @@ export function getLastValidatedResult(
   return entry.result;
 }
 
-/**
- * Test-only seed for ``_lastValidated``. Production code populates the
- * map exclusively through the linter; tests reach for this so they
- * don't have to spin up a CodeMirror EditorView just to exercise the
- * cache lookup helper.
- */
+/** Test-only seed; production populates the map only through the linter. */
 export function __setLastValidatedForTesting(
   configuration: string,
   content: string,

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -29,16 +29,27 @@ interface BackendLinterOptions {
  * the backend has a content-hash cache too, but skipping the WS
  * round-trip entirely is a few tens of ms faster on slow networks and
  * keeps the editor's "Save" feel snappy.
+ *
+ * TTL mirrors the backend's `_VALIDATE_CACHE_TTL` (60s). External
+ * `!include` / `external_components` files mutated outside the editor
+ * are stale on both sides; matching the window keeps staleness
+ * semantics symmetric regardless of which cache served the result.
  */
-const _lastValidated = new Map<string, { content: string; result: EditorValidateResponse }>();
+const _LAST_VALIDATED_TTL_MS = 60_000;
+const _lastValidated = new Map<
+  string,
+  { content: string; result: EditorValidateResponse; at: number }
+>();
 
-/** Return the linter's last result if it matches the current buffer exactly. */
+/** Return the linter's last result if it matches the current buffer and is fresh. */
 export function getLastValidatedResult(
   configuration: string,
   content: string,
 ): EditorValidateResponse | null {
   const entry = _lastValidated.get(configuration);
-  return entry !== undefined && entry.content === content ? entry.result : null;
+  if (entry === undefined || entry.content !== content) return null;
+  if (performance.now() - entry.at >= _LAST_VALIDATED_TTL_MS) return null;
+  return entry.result;
 }
 
 /**
@@ -52,7 +63,7 @@ export function __setLastValidatedForTesting(
   content: string,
   result: EditorValidateResponse,
 ): void {
-  _lastValidated.set(configuration, { content, result });
+  _lastValidated.set(configuration, { content, result, at: performance.now() });
 }
 
 /** Match `line N, column M` (1-indexed) anywhere in a YAML parse error message. */
@@ -143,7 +154,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         console.debug("[yaml-lint] validate_yaml failed:", err);
         return [];
       }
-      _lastValidated.set(configuration, { content, result: res });
+      _lastValidated.set(configuration, { content, result: res, at: performance.now() });
 
       const diagnostics: Diagnostic[] = [];
 

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -22,6 +22,39 @@ interface BackendLinterOptions {
   getConfiguration: () => string;
 }
 
+/**
+ * Last successful linter result per configuration, keyed on the exact
+ * content the linter saw. The save path consults this to skip its own
+ * `validateYaml` call when the linter just validated the same buffer —
+ * the backend has a content-hash cache too, but skipping the WS
+ * round-trip entirely is a few tens of ms faster on slow networks and
+ * keeps the editor's "Save" feel snappy.
+ */
+const _lastValidated = new Map<string, { content: string; result: EditorValidateResponse }>();
+
+/** Return the linter's last result if it matches the current buffer exactly. */
+export function getLastValidatedResult(
+  configuration: string,
+  content: string,
+): EditorValidateResponse | null {
+  const entry = _lastValidated.get(configuration);
+  return entry !== undefined && entry.content === content ? entry.result : null;
+}
+
+/**
+ * Test-only seed for ``_lastValidated``. Production code populates the
+ * map exclusively through the linter; tests reach for this so they
+ * don't have to spin up a CodeMirror EditorView just to exercise the
+ * cache lookup helper.
+ */
+export function __setLastValidatedForTesting(
+  configuration: string,
+  content: string,
+  result: EditorValidateResponse,
+): void {
+  _lastValidated.set(configuration, { content, result });
+}
+
 /** Match `line N, column M` (1-indexed) anywhere in a YAML parse error message. */
 const YAML_LINE_COL_RE = /line\s+(\d+)\s*,\s*column\s+(\d+)/i;
 /** Fallback: bare `line N` if the column is missing from the message. */
@@ -110,6 +143,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         console.debug("[yaml-lint] validate_yaml failed:", err);
         return [];
       }
+      _lastValidated.set(configuration, { content, result: res });
 
       const diagnostics: Diagnostic[] = [];
 

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -61,10 +61,7 @@ describe("getLastValidatedResult", () => {
   });
 
   it("returns null when the cached entry is past the TTL window", async () => {
-    // Stub ``performance.now`` so the seed lands in the past relative to the
-    // lookup — mirrors the backend's 60s TTL exactly, so a slow user who
-    // keeps the editor open for a minute after the linter runs gets a fresh
-    // validate at save time on either side.
+    // Stub ``performance.now`` so the seed lands past the TTL boundary.
     const real = performance.now;
     let fakeNow = 1_000_000;
     vi.spyOn(performance, "now").mockImplementation(() => fakeNow);

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -59,4 +59,25 @@ describe("getLastValidatedResult", () => {
       getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen \n"),
     ).toBeNull();
   });
+
+  it("returns null when the cached entry is past the TTL window", async () => {
+    // Stub ``performance.now`` so the seed lands in the past relative to the
+    // lookup — mirrors the backend's 60s TTL exactly, so a slow user who
+    // keeps the editor open for a minute after the linter runs gets a fresh
+    // validate at save time on either side.
+    const real = performance.now;
+    let fakeNow = 1_000_000;
+    vi.spyOn(performance, "now").mockImplementation(() => fakeNow);
+    try {
+      const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
+        "../../src/util/yaml-lint-backend.js"
+      );
+      const result = { yaml_errors: [], validation_errors: [] };
+      __setLastValidatedForTesting("kitchen.yaml", "esphome:\n", result);
+      fakeNow += 60_001;
+      expect(getLastValidatedResult("kitchen.yaml", "esphome:\n")).toBeNull();
+    } finally {
+      vi.spyOn(performance, "now").mockImplementation(real);
+    }
+  });
 });

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the linter's last-result cache exposed to the save flow.
+ *
+ * The CodeMirror linter populates `_lastValidated` after every
+ * successful backend call. The save path in ``pages/device.ts``
+ * reads it via ``getLastValidatedResult`` and skips its own
+ * ``validateYaml`` round-trip when the buffer matches exactly.
+ *
+ * Each test resets the module so the in-module map starts empty;
+ * a leaked entry from a prior test would surface here as a
+ * spurious cache hit and any save-flow regression that swapped
+ * the buffer-equality check for something looser would surface
+ * in ``returns_null_for_different_content``.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("getLastValidatedResult", () => {
+  it("returns null when nothing has been validated for the configuration", async () => {
+    const { getLastValidatedResult } = await import(
+      "../../src/util/yaml-lint-backend.js"
+    );
+    expect(getLastValidatedResult("kitchen.yaml", "esphome:\n")).toBeNull();
+  });
+
+  it("returns null for a configuration that has no entry yet", async () => {
+    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
+      "../../src/util/yaml-lint-backend.js"
+    );
+    const result = { yaml_errors: [], validation_errors: [] };
+    __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: a\n", result);
+    expect(
+      getLastValidatedResult("bedroom.yaml", "esphome:\n  name: a\n"),
+    ).toBeNull();
+  });
+
+  it("returns the cached result when content matches exactly", async () => {
+    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
+      "../../src/util/yaml-lint-backend.js"
+    );
+    const result = { yaml_errors: [], validation_errors: [] };
+    __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: kitchen\n", result);
+    expect(
+      getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen\n"),
+    ).toBe(result);
+  });
+
+  it("returns null when content differs by even one byte", async () => {
+    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
+      "../../src/util/yaml-lint-backend.js"
+    );
+    const result = { yaml_errors: [], validation_errors: [] };
+    __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: kitchen\n", result);
+    expect(
+      getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen \n"),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The editor's CodeMirror linter
(`util/yaml-lint-backend.ts`) runs `validateYaml` at typing-stop +
600ms, and `pages/device.ts._saveYaml` runs it again on Save
click. Same buffer, same backend pass, two round-trips — visible
as 7-9s click-to-popup latency on a slow machine when the
underlying `esphome vscode` validation is heavy
(`external_components` / `packages:` / `!include`).

Cache the linter's last successful result keyed on
`(configuration, content)` and expose `getLastValidatedResult`.
`_saveYaml` consults it first and skips its own `validateYaml`
call when the buffer matches exactly. Different content or no
linter result → original validate-then-save path unchanged, so
edge cases (network blip during linter, save fired before any
linter run) still validate authoritatively.

Companion to the backend PR esphome/device-builder#892 which
adds a `_EditorSession` content-hash cache. Either alone is an
improvement; together the save click on an already-linted buffer
makes zero validate work happen.

**Related issue or feature (if applicable):**

- fixes <Slack report from MasterOfNone, 2026-05-16>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
