### PR TITLE
Disable programming-ligatures in code and log views

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -290,6 +290,7 @@ export class ESPHomeAnsiLog extends LitElement {
         font-family:
           ui-monospace, "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", Menlo,
           Consolas, monospace;
+        font-variant-ligatures: none;
         font-size: 12px;
         padding: 8px 12px;
         border-radius: 8px;

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -27,6 +27,7 @@ export class ESPHomeYamlDiff extends LitElement {
       position: relative;
       overflow: auto;
       font-family: "JetBrains Mono", "Fira Code", monospace;
+      font-variant-ligatures: none;
       font-size: 13px;
       line-height: 1.5;
       background: var(--diff-bg);

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -27,7 +27,6 @@ export class ESPHomeYamlDiff extends LitElement {
       position: relative;
       overflow: auto;
       font-family: "JetBrains Mono", "Fira Code", monospace;
-      font-variant-ligatures: none;
       font-size: 13px;
       line-height: 1.5;
       background: var(--diff-bg);
@@ -102,6 +101,7 @@ export class ESPHomeYamlDiff extends LitElement {
       white-space: pre-wrap;
       word-break: break-word;
       overflow-wrap: anywhere;
+      font-variant-ligatures: none;
     }
 
     tr.add .marker,

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -127,6 +127,7 @@ export class ESPHomeYamlEditor extends LitElement {
         ".cm-scroller": {
           overflow: "auto",
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+          fontVariantLigatures: "none",
           fontSize: "13px",
         },
         ".cm-esphome-highlight": {


### PR DESCRIPTION
# What does this implement/fix?

Reported on Discord; the Validate dialog rendered C++ with `->` shown as an arrow glyph and `!=` shown as the not-equal sign. Our code surfaces list Fira Code and Cascadia Code in the font stack, and both ship programming ligatures on by default, so the rendering stopped matching the underlying bytes (copy still worked, only the glyph was off).

Setting `font-variant-ligatures: none` on the three surfaces that show code keeps the same fonts while turning the substitution off: `ansi-log` (validate / install / log output), `yaml-diff`, and `yaml-editor`. Toolbar buttons and title bars are unchanged since those carry fixed UI strings.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
