### PR TITLE
Match Home Assistant's default palette (brand, surfaces, text)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,9 +116,10 @@
       .wa-light,
       .wa-dark .wa-invert {
         /* Match Home Assistant's primary palette when embedded as an
-           HA panel; fall back to HA Material Light Blue 500 standalone
-           so the standalone palette stays consistent with HA rather
-           than reverting to WebAwesome cyan. */
+           HA panel; fall back to HA's current --ha-color-primary-40
+           (#009ac7) standalone so the standalone palette stays
+           consistent with HA's default theme rather than reverting
+           to WebAwesome cyan. */
         --wa-color-brand-fill-loud: var(--primary-color, #009ac7);
         --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
       }

--- a/public/index.html
+++ b/public/index.html
@@ -115,9 +115,12 @@
       :root,
       .wa-light,
       .wa-dark .wa-invert {
-        /* ESPHome brand color mapped to Web Awesome brand tokens */
-        --wa-color-brand-fill-loud: #009fee;
-        --wa-color-brand-on-loud: #ffffff;
+        /* Match Home Assistant's primary palette when embedded as an
+           HA panel; fall back to HA Material Light Blue 500 standalone
+           so the standalone palette stays consistent with HA rather
+           than reverting to WebAwesome cyan. */
+        --wa-color-brand-fill-loud: var(--primary-color, #009ac7);
+        --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
       }
 
       body {

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -37,6 +37,17 @@ function applyWaTheme(): void {
  * complementary hue rotation so any colour-tinted strokes survive
  * the round trip). Components apply it via
  * `filter: var(--esphome-svg-filter)` on `img[src$=".svg"]`.
+ *
+ * The ``--wa-color-brand-*`` overrides remap WebAwesome's default
+ * cyan brand palette to Home Assistant's primary palette when
+ * embedded as an HA panel. ``--primary-color`` and friends are set
+ * by HA's theme on the root; when the panel runs standalone those
+ * variables are undefined and the fallback values (HA Material
+ * Blue 500 / its translucent and white companions) keep the panel
+ * looking consistent with HA's palette anyway. Without this, the
+ * panel headers, primary buttons, FAB, and active view-toggle pip
+ * burst in WebAwesome cyan, which clashes hard against HA's blue
+ * sidebar and chrome.
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");
@@ -44,6 +55,10 @@ function applyEspHomeTokens(): void {
   style.textContent = `
     :root {
       --esphome-svg-filter: none;
+      --wa-color-brand-fill-loud: var(--primary-color, #03a9f4);
+      --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
+      --wa-color-brand-fill-quiet: var(--state-active-color, rgba(3, 169, 244, 0.12));
+      --wa-color-brand-on-quiet: var(--primary-color, #03a9f4);
     }
     .wa-dark {
       --esphome-svg-filter: invert(1) hue-rotate(180deg);

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -42,12 +42,15 @@ function applyWaTheme(): void {
  * cyan brand palette to Home Assistant's primary palette when
  * embedded as an HA panel. ``--primary-color`` and friends are set
  * by HA's theme on the root; when the panel runs standalone those
- * variables are undefined and the fallback values (HA Material
- * Blue 500 / its translucent and white companions) keep the panel
- * looking consistent with HA's palette anyway. Without this, the
- * panel headers, primary buttons, FAB, and active view-toggle pip
- * burst in WebAwesome cyan, which clashes hard against HA's blue
- * sidebar and chrome.
+ * variables are undefined and the fallback values (HA's current
+ * ``--ha-color-primary-40`` = #009ac7, plus matching translucent
+ * and white companions) keep the panel looking consistent with
+ * HA's default theme anyway. (Note: HA used to resolve
+ * ``--primary-color`` to the legacy Material Light Blue 500 value
+ * ``#03a9f4`` — that's been retired upstream in favour of
+ * ``#009ac7``.) Without this, the panel headers, primary buttons,
+ * FAB, and active view-toggle pip burst in WebAwesome cyan, which
+ * clashes hard against HA's blue sidebar and chrome.
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -55,13 +55,38 @@ function applyEspHomeTokens(): void {
   style.textContent = `
     :root {
       --esphome-svg-filter: none;
-      --wa-color-brand-fill-loud: var(--primary-color, #03a9f4);
+
+      /* Brand / primary — inherits HA's --primary-color when embedded,
+         falls back to HA's #009ac7 (ha-color-primary-40) standalone. */
+      --wa-color-brand-fill-loud: var(--primary-color, #009ac7);
       --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
-      --wa-color-brand-fill-quiet: var(--state-active-color, rgba(3, 169, 244, 0.12));
-      --wa-color-brand-on-quiet: var(--primary-color, #03a9f4);
+      --wa-color-brand-fill-quiet: var(--state-active-color, rgba(0, 154, 199, 0.12));
+      --wa-color-brand-on-quiet: var(--primary-color, #009ac7);
+    }
+
+    /* Surfaces and text — remap WebAwesome's surface/text tokens to
+       HA's palette so the panel doesn't only have an HA-coloured
+       accent on a WebAwesome-coloured page. HA's own variables are
+       mode-aware (different values in html.dark blocks on HA's side),
+       so when embedded they resolve correctly without our needing to
+       detect mode. Standalone, the fallbacks below mirror HA's
+       light/dark defaults exactly. */
+    .wa-light {
+      --wa-color-surface-default: var(--primary-background-color, #fafafa);
+      --wa-color-surface-raised: var(--card-background-color, #ffffff);
+      --wa-color-surface-lowered: var(--secondary-background-color, #e5e5e5);
+      --wa-color-surface-border: var(--divider-color, rgba(0, 0, 0, 0.12));
+      --wa-color-text-normal: var(--primary-text-color, #141414);
+      --wa-color-text-quiet: var(--secondary-text-color, #5e5e5e);
     }
     .wa-dark {
       --esphome-svg-filter: invert(1) hue-rotate(180deg);
+      --wa-color-surface-default: var(--primary-background-color, #111111);
+      --wa-color-surface-raised: var(--card-background-color, #1c1c1c);
+      --wa-color-surface-lowered: var(--secondary-background-color, #282828);
+      --wa-color-surface-border: var(--divider-color, rgba(225, 225, 225, 0.12));
+      --wa-color-text-normal: var(--primary-text-color, #e1e1e1);
+      --wa-color-text-quiet: var(--secondary-text-color, #9b9b9b);
     }
   `;
   document.head.appendChild(style);

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -13,9 +13,11 @@ export const espHomeStyles = css`
   :host {
     /* ─── Brand colors ─── */
     /* Resolve to Home Assistant's primary palette when embedded in HA;
-       fall back to HA Material Light Blue 500 (and matching derivatives)
-       standalone so the standalone palette stays consistent with HA
-       rather than reverting to WebAwesome cyan. */
+       fall back to HA's current --ha-color-primary-40 (#009ac7), which
+       is what HA's default theme resolves --primary-color to today
+       (the legacy Material Light Blue 500 value #03a9f4 was retired
+       upstream). Standalone deployments stay visually consistent with
+       HA's default theme rather than reverting to WebAwesome cyan. */
     --esphome-primary: var(--primary-color, #009ac7);
     --esphome-primary-light: color-mix(
       in srgb,

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -12,16 +12,28 @@ import { css } from "lit";
 export const espHomeStyles = css`
   :host {
     /* ─── Brand colors ─── */
-    --esphome-primary: #009fee;
-    --esphome-primary-light: #dff3fc;
-    --esphome-secondary: #009ac7;
+    /* Resolve to Home Assistant's primary palette when embedded in HA;
+       fall back to HA Material Light Blue 500 (and matching derivatives)
+       standalone so the standalone palette stays consistent with HA
+       rather than reverting to WebAwesome cyan. */
+    --esphome-primary: var(--primary-color, #009ac7);
+    --esphome-primary-light: color-mix(
+      in srgb,
+      var(--primary-color, #009ac7) 12%,
+      transparent
+    );
+    --esphome-secondary: color-mix(
+      in srgb,
+      var(--primary-color, #009ac7),
+      black 8%
+    );
     --esphome-success: #2ecc71;
     --esphome-warning: #f39c12;
     --esphome-error: #e74c3c;
     --esphome-offline: #95a5a6;
 
     /* Text color for use on primary / dark / colored backgrounds — white in both light and dark modes */
-    --esphome-on-primary: #ffffff;
+    --esphome-on-primary: var(--text-primary-color, #ffffff);
 
     /* ─── Layout ─── */
     --esphome-header-height: 56px;


### PR DESCRIPTION
## Summary

When embedded as a Home Assistant panel (or run standalone), the dashboard previously rendered every brand-coloured surface — **plus the page background, card surfaces, dividers, and primary / secondary text** — in WebAwesome's default palette. The result looked like a WebAwesome app glued into HA chrome, not a native HA panel.

This PR remaps both layers — accent **and** surfaces / text — to Home Assistant's default palette, with HA-matching fallback values pulled directly from `home-assistant/frontend/src/resources/theme/color/color.globals.ts`.

### Tokens covered

| WebAwesome / ESPHome token | HA source | Fallback (light) | Fallback (dark) |
|---|---|---:|---:|
| `--wa-color-brand-fill-loud` | `--primary-color` | `#009ac7` | `#009ac7` |
| `--wa-color-brand-on-loud` | `--text-primary-color` | `#ffffff` | `#ffffff` |
| `--wa-color-brand-fill-quiet` | `--state-active-color` | `rgba(0,154,199,0.12)` | `rgba(0,154,199,0.12)` |
| `--wa-color-brand-on-quiet` | `--primary-color` | `#009ac7` | `#009ac7` |
| `--wa-color-surface-default` | `--primary-background-color` | `#fafafa` | `#111111` |
| `--wa-color-surface-raised` | `--card-background-color` | `#ffffff` | `#1c1c1c` |
| `--wa-color-surface-lowered` | `--secondary-background-color` | `#e5e5e5` | `#282828` |
| `--wa-color-surface-border` | `--divider-color` | `rgba(0,0,0,0.12)` | `rgba(225,225,225,0.12)` |
| `--wa-color-text-normal` | `--primary-text-color` | `#141414` | `#e1e1e1` |
| `--wa-color-text-quiet` | `--secondary-text-color` | `#5e5e5e` | `#9b9b9b` |
| `--esphome-primary` | `--primary-color` | `#009ac7` | `#009ac7` |
| `--esphome-secondary` | `--primary-color` (×black 8%) | derived | derived |
| `--esphome-on-primary` | `--text-primary-color` | `#ffffff` | `#ffffff` |

Fallback hex values match HA's defaults exactly, so the standalone dev build / non-HA deployments visually match HA's default theme. **`#009ac7` is HA's actual current primary** (`--ha-color-primary-40`) — not the legacy `#03a9f4` (Material Light Blue 500) — verified by `getComputedStyle(document.documentElement).getPropertyValue('--primary-color').trim()` in a vanilla HA install returning `#009ac7`.

### Limitation: this matches HA's *default* palette, not custom themes

For full transparency: the device-builder loads as an HA ingress iframe, and HA does **not** currently send theme info across iframe boundaries. HA's `home-assistant/properties` postMessage protocol (`ha-panel-app.ts:382-417`) only carries `narrow` and `route`, no palette tokens. So:

- ✅ **Standalone**: matches HA's default theme exactly via the fallbacks.
- ✅ **HA-embedded, default theme**: matches HA's default exactly (fallback values are HA's defaults).
- ❌ **HA-embedded, custom theme** (Tile, Catppuccin, Nord, etc.): still renders in HA's default colours because the iframe can't read the parent's `--primary-color`. The `var(--ha-token, fallback)` pattern is in place for the day HA's protocol grows a theme channel — that day, no code change here is needed and the custom theme will flow through automatically.

The honest framing of this PR is therefore "match HA's default palette," not "inherit any active HA theme." Genuine custom-theme inheritance needs a coordinated upstream change to extend `home-assistant/properties` with palette tokens, which is a follow-up.

### Why this shape

- **One file, no JS-side detection.** The `var(--ha-token, fallback)` pattern means we don't need a runtime "are we in HA?" check. When HA's variables exist (today they don't reach the iframe, tomorrow they might), they win; otherwise fallback. No flicker, no race.
- **Light / dark handled.** The `.wa-light` / `.wa-dark` blocks each have HA-matching fallbacks for that mode. The device-builder picks dark/light from `prefers-color-scheme` (existing logic in `app-shell.ts:305-309`) and toggles the corresponding class on `document.documentElement`.
- **Backward-compatible.** No CSS variable consumers needed to change. Everything that was already using `var(--wa-color-surface-default)`, `var(--esphome-primary)`, etc. just resolves to a different (HA-matching) value now.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 86 test files / 1112 tests pass
- [x] Visual verification standalone (localhost:5173 in dark mode): header strip, FAB, Edit buttons, banner, view-toggle pip render in `#009ac7`. Page background `#111111`, cards `#1c1c1c`, text `#e1e1e1` — matches a vanilla HA dark-mode tab side-by-side.
- [ ] Visual verification in HA ingress iframe: should look identical to HA default theme. Maintainer to confirm on real HA install.
- [ ] Visual verification standalone in light mode: page background `#fafafa`, cards `#ffffff`, text `#141414` — matches HA default light theme.

## Related

Closes #351.
