### PR TITLE
Suppress password-manager autofill on the dashboard search input

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -180,9 +180,6 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
       name="dashboard-search"
       with-clear
       autocomplete="off"
-      autocorrect="off"
-      autocapitalize="off"
-      spellcheck="false"
       data-form-type="other"
       data-lpignore="true"
       data-1p-ignore="true"

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -177,8 +177,16 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
     <input
       class="search-input ${host._yamlMode ? "search-input--yaml" : ""}"
       type="search"
+      name="dashboard-search"
       with-clear
       autocomplete="off"
+      autocorrect="off"
+      autocapitalize="off"
+      spellcheck="false"
+      data-form-type="other"
+      data-lpignore="true"
+      data-1p-ignore="true"
+      aria-autocomplete="none"
       placeholder=${placeholder}
       .value=${host._search}
       @input=${(e: Event) => {


### PR DESCRIPTION
## Summary

When the dashboard runs as the ESPHome Home Assistant add-on (embedded via ingress on the HA origin), Chrome's password manager attaches the user's saved HA credentials to any text input it heuristically classifies as a username field. The dashboard's device-search input was being picked up that way — as soon as the user typed anything, a Chrome autofill dropdown appeared offering their HA username + password right below the search box.

<img width="541" height="245" alt="screenshot-2026-05-18_15-12-06" src="https://github.com/user-attachments/assets/1c6720d3-65d9-450f-9a04-d45f0fb0edf0" />

`type="search"` and `autocomplete="off"` alone are advisory: Chrome ignores them once a credential is saved against the origin, so the search input couldn't opt out of the autofill heuristic on its own.

This PR stacks a focused set of autofill-suppression hints so every common password manager (Chrome, 1Password, LastPass) treats this input as a non-credential search field:

- `name="dashboard-search"` — semantic name; password-manager heuristics weight known credential-field names (`user`, `username`, `email`, `login`, …) heavily and skip fields with obviously non-credential names.
- `autocomplete="off"` — standard advisory hint.
- `data-form-type="other"` — Chrome's heuristic hint that this isn't part of a credential form.
- `data-lpignore="true"` — LastPass opt-out.
- `data-1p-ignore="true"` — 1Password opt-out.
- `aria-autocomplete="none"` — assistive-tech hint, complementary.

## What this doesn't fix

Saved credentials Chrome already attached to the HA origin before this PR are still there. Users who hit the autofill dropdown before this fix may need to remove the spurious entry manually via `chrome://password-manager/passwords`. The code change prevents Chrome from associating future fields with credentials on the origin — the existing-credential dislodge is out of scope (and out of reach).

## Reproduction

1. Open the ESPHome add-on inside HA where you've signed in with username/password.
2. Use the device search box and start typing.
3. **Before this PR:** Chrome autofill dropdown shows your HA username + password.
4. **After this PR:** no dropdown.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Test plan

- [x] `npm run lint` clean.
- [x] `npm test` — 86 test files / 1112 tests pass.
- [ ] Manual: open HA, open the ESPHome add-on, type in the device search box → no autofill dropdown.
- [ ] Manual: confirm search behaviour itself unchanged (filtering, clear-button, keyboard navigation).

## Related

Independent of #352 (HA palette match) — different file, different concern, different reproduction context (autofill manifests inside HA-embedded mode specifically).
