### PR TITLE
command-dialog: batch streamed output lines per animation frame

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -347,7 +347,15 @@ export class ESPHomeAnsiLog extends LitElement {
 
   protected updated(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("lines") && this.autoScroll && !this._isUserScrolled) {
-      this._scrollToBottom();
+      // Sync scroll: ``updated`` runs after Lit has committed the
+      // DOM mutation, so reading ``scrollHeight`` here forces a
+      // layout that reflects the just-appended lines. Deferring
+      // to rAF (as the public ``scrollToBottom`` does for the
+      // dialog-open path) lags by one frame, which is invisible
+      // when one line lands per render but produces a visible
+      // "bottom line clipped" cliff during the rAF-batched
+      // streaming bursts now coming from command-dialog.
+      this._syncScrollToBottom();
     }
   }
 
@@ -420,13 +428,14 @@ export class ESPHomeAnsiLog extends LitElement {
     this._isUserScrolled = scrollHeight - scrollTop - clientHeight > 40;
   }
 
+  private _syncScrollToBottom() {
+    if (!this._container) return;
+    this._ignoreNextScroll = true;
+    this._container.scrollTop = this._container.scrollHeight;
+  }
+
   private _scrollToBottom() {
-    requestAnimationFrame(() => {
-      if (this._container) {
-        this._ignoreNextScroll = true;
-        this._container.scrollTop = this._container.scrollHeight;
-      }
-    });
+    requestAnimationFrame(() => this._syncScrollToBottom());
   }
 
   /** Public method to scroll to bottom programmatically. */

--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -347,14 +347,8 @@ export class ESPHomeAnsiLog extends LitElement {
 
   protected updated(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("lines") && this.autoScroll && !this._isUserScrolled) {
-      // Sync scroll: ``updated`` runs after Lit has committed the
-      // DOM mutation, so reading ``scrollHeight`` here forces a
-      // layout that reflects the just-appended lines. Deferring
-      // to rAF (as the public ``scrollToBottom`` does for the
-      // dialog-open path) lags by one frame, which is invisible
-      // when one line lands per render but produces a visible
-      // "bottom line clipped" cliff during the rAF-batched
-      // streaming bursts now coming from command-dialog.
+      // Sync (not rAF-deferred): ``updated`` runs post-DOM-commit,
+      // and a one-frame lag clips the bottom line during bursts.
       this._syncScrollToBottom();
     }
   }

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -210,7 +210,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._port = options?.port ?? "OTA";
     this._state = null;
     this._lines = [];
-    this.resetPendingLines();
+    this._resetPendingLines();
     this._statusMessage = "";
     this._jobId = "";
     this._jobStatus = null;
@@ -240,7 +240,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._port = job.port || "OTA";
     this._state = "running";
     this._lines = [];
-    this.resetPendingLines();
+    this._resetPendingLines();
     this._statusMessage = "";
     this._userStopped = false;
     // Fresh attach is a fresh session — reset toggle defaults so a prior
@@ -362,12 +362,12 @@ export class ESPHomeCommandDialog extends LitElement {
   // O(n²) array-copy + render storm on historical replay (and
   // bursty live output: pip install, esptool block writes) is
   // bounded to ~one render per frame.
-  enqueueLine(line: string): void {
+  _enqueueLine(line: string): void {
     this._pendingLines.push(line);
     if (this._flushScheduled) return;
     this._flushScheduled = requestAnimationFrame(() => {
       this._flushScheduled = 0;
-      this.flushPendingLines();
+      this._flushPendingLines();
     });
   }
 
@@ -375,7 +375,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // to call at any time — terminal callbacks (onResult / onError),
   // detachStream, and _downloadOutput call it so downstream
   // consumers see the full buffer instead of racing the rAF.
-  flushPendingLines(): void {
+  _flushPendingLines(): void {
     if (this._pendingLines.length === 0) return;
     this._lines = [...this._lines, ...this._pendingLines];
     this._pendingLines = [];
@@ -385,7 +385,7 @@ export class ESPHomeCommandDialog extends LitElement {
   // ``_lines = []`` resets (open, followJob, startCommand,
   // toggleShowSecrets restart) so a stale frame can't paint
   // pre-reset lines onto the fresh buffer.
-  resetPendingLines(): void {
+  _resetPendingLines(): void {
     this._pendingLines = [];
     if (this._flushScheduled) {
       cancelAnimationFrame(this._flushScheduled);
@@ -394,7 +394,7 @@ export class ESPHomeCommandDialog extends LitElement {
   }
 
   _downloadOutput = () => {
-    this.flushPendingLines();
+    this._flushPendingLines();
     const stem = this.configuration.replace(/\.ya?ml$/, "") || "output";
     downloadAnsiText(this._lines, `${stem}-${this._commandType}.txt`);
   };

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -123,12 +123,8 @@ export class ESPHomeCommandDialog extends LitElement {
   @state() _lines: string[] = [];
   @state() _statusMessage = "";
 
-  // rAF batch buffer for streamed output. Replaying ~2000 historical
-  // lines as 2000 separate ``_lines = [...]`` writes is O(n²) array
-  // copies plus one ansi-log render per write (issue #348). Coalesce
-  // within a frame so the render count becomes proportional to the
-  // burst's wall-clock duration (at most one render per animation
-  // frame) instead of to the line count.
+  // rAF batch buffer for streamed output — coalesce per-line writes
+  // into one render per frame instead of one per line (#348).
   private _pendingLines: string[] = [];
   private _flushScheduled = 0;
 
@@ -357,11 +353,7 @@ export class ESPHomeCommandDialog extends LitElement {
     void onForceLocalClick(this);
   };
 
-  // Push a streamed output line through the rAF batcher. Both the
-  // validate-stream and follow_job callbacks call this so the
-  // O(n²) array-copy + render storm on historical replay (and
-  // bursty live output: pip install, esptool block writes) is
-  // bounded to ~one render per frame.
+  // Buffer a streamed line; flushed on the next animation frame.
   _enqueueLine(line: string): void {
     this._pendingLines.push(line);
     if (this._flushScheduled) return;
@@ -371,20 +363,17 @@ export class ESPHomeCommandDialog extends LitElement {
     });
   }
 
-  // Drain ``_pendingLines`` into ``_lines`` in one assignment. Safe
-  // to call at any time — terminal callbacks (onResult / onError),
-  // detachStream, and _downloadOutput call it so downstream
-  // consumers see the full buffer instead of racing the rAF.
+  // Drain pending lines into ``_lines`` now. Called from terminal
+  // callbacks, detachStream, and _downloadOutput so consumers
+  // don't race the rAF.
   _flushPendingLines(): void {
     if (this._pendingLines.length === 0) return;
     this._lines = [...this._lines, ...this._pendingLines];
     this._pendingLines = [];
   }
 
-  // Drop any pending lines and cancel a scheduled flush. Called on
-  // ``_lines = []`` resets (open, followJob, startCommand,
-  // toggleShowSecrets restart) so a stale frame can't paint
-  // pre-reset lines onto the fresh buffer.
+  // Drop the pending batch and cancel any scheduled flush. Paired
+  // with every ``_lines = []`` reset.
   _resetPendingLines(): void {
     this._pendingLines = [];
     if (this._flushScheduled) {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -123,6 +123,15 @@ export class ESPHomeCommandDialog extends LitElement {
   @state() _lines: string[] = [];
   @state() _statusMessage = "";
 
+  // rAF batch buffer for streamed output. Replaying ~2000 historical
+  // lines as 2000 separate ``_lines = [...]`` writes is O(n²) array
+  // copies plus one ansi-log render per write (issue #348). Coalesce
+  // within a frame so the render count becomes proportional to the
+  // burst's wall-clock duration (at most one render per animation
+  // frame) instead of to the line count.
+  private _pendingLines: string[] = [];
+  private _flushScheduled = 0;
+
   // Distinguishes user-stopped from backend-failed. Both flip _state to "error"
   // but only real failures get the reset-build-env hint.
   @state() _userStopped = false;
@@ -201,6 +210,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._port = options?.port ?? "OTA";
     this._state = null;
     this._lines = [];
+    this.resetPendingLines();
     this._statusMessage = "";
     this._jobId = "";
     this._jobStatus = null;
@@ -230,6 +240,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._port = job.port || "OTA";
     this._state = "running";
     this._lines = [];
+    this.resetPendingLines();
     this._statusMessage = "";
     this._userStopped = false;
     // Fresh attach is a fresh session — reset toggle defaults so a prior
@@ -346,7 +357,44 @@ export class ESPHomeCommandDialog extends LitElement {
     void onForceLocalClick(this);
   };
 
+  // Push a streamed output line through the rAF batcher. Both the
+  // validate-stream and follow_job callbacks call this so the
+  // O(n²) array-copy + render storm on historical replay (and
+  // bursty live output: pip install, esptool block writes) is
+  // bounded to ~one render per frame.
+  enqueueLine(line: string): void {
+    this._pendingLines.push(line);
+    if (this._flushScheduled) return;
+    this._flushScheduled = requestAnimationFrame(() => {
+      this._flushScheduled = 0;
+      this.flushPendingLines();
+    });
+  }
+
+  // Drain ``_pendingLines`` into ``_lines`` in one assignment. Safe
+  // to call at any time — terminal callbacks (onResult / onError),
+  // detachStream, and _downloadOutput call it so downstream
+  // consumers see the full buffer instead of racing the rAF.
+  flushPendingLines(): void {
+    if (this._pendingLines.length === 0) return;
+    this._lines = [...this._lines, ...this._pendingLines];
+    this._pendingLines = [];
+  }
+
+  // Drop any pending lines and cancel a scheduled flush. Called on
+  // ``_lines = []`` resets (open, followJob, startCommand,
+  // toggleShowSecrets restart) so a stale frame can't paint
+  // pre-reset lines onto the fresh buffer.
+  resetPendingLines(): void {
+    this._pendingLines = [];
+    if (this._flushScheduled) {
+      cancelAnimationFrame(this._flushScheduled);
+      this._flushScheduled = 0;
+    }
+  }
+
   _downloadOutput = () => {
+    this.flushPendingLines();
     const stem = this.configuration.replace(/\.ya?ml$/, "") || "output";
     downloadAnsiText(this._lines, `${stem}-${this._commandType}.txt`);
   };

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -27,13 +27,9 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
   if (!host._streamId) return;
   const streamId = host._streamId;
   host._streamId = "";
-  // Flush any rAF-batched lines so a teardown mid-burst that
-  // keeps the buffer visible (dialog close, follow → install
-  // hand-off, force-local switch) still shows the lines that
-  // arrived but hadn't been rendered yet. Restart paths that
-  // immediately clear ``_lines`` after this call (validate-
-  // secrets-toggle, startCommand) follow up with
-  // ``_resetPendingLines`` to drop the pending batch too.
+  // Flush the rAF batch so teardowns that keep the buffer visible
+  // (close, hand-off, force-local) paint every line that arrived.
+  // Restart paths follow up with ``_resetPendingLines``.
   host._flushPendingLines();
   try {
     await host._api.stopStream(streamId);

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -27,6 +27,11 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
   if (!host._streamId) return;
   const streamId = host._streamId;
   host._streamId = "";
+  // Flush any rAF-batched lines so a teardown mid-burst (user
+  // closed the dialog, switched to local, restarted with
+  // --show-secrets) still paints the lines that arrived but
+  // hadn't been rendered yet.
+  host.flushPendingLines();
   try {
     await host._api.stopStream(streamId);
   } catch {
@@ -39,6 +44,7 @@ export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
   host._jobId = "";
   host._state = "running";
   host._lines = [];
+  host.resetPendingLines();
   host._statusMessage = "";
   host._userStopped = false;
   host._failedDuringValidate = false;
@@ -62,11 +68,12 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
     host.configuration,
     {
       onOutput: (line) => {
-        host._lines = [...host._lines, line];
+        host.enqueueLine(line);
         if (isValidationFailureLine(line)) host._failedDuringValidate = true;
       },
       onResult: (data) => {
         host._streamId = "";
+        host.flushPendingLines();
         host._state = data.success ? "success" : "error";
         host._statusMessage = host._localize(
           data.success ? "command.validate_success" : "command.validate_failed",
@@ -74,6 +81,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
       },
       onError: (error) => {
         host._streamId = "";
+        host.flushPendingLines();
         host._state = "error";
         host._statusMessage = error;
       },
@@ -96,6 +104,7 @@ export async function toggleShowSecrets(host: ESPHomeCommandDialog): Promise<voi
   try {
     await detachStream(host);
     host._lines = [];
+    host.resetPendingLines();
     host._state = "running";
     host._statusMessage = "";
     host._resetAnsiLogScroll();
@@ -148,11 +157,12 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
   const wasLiveAtAttach = !isTerminalJobStatus(host._jobStatus);
   host._streamId = host._api.firmwareFollowJob(jobId, {
     onOutput: (line) => {
-      host._lines = [...host._lines, line];
+      host.enqueueLine(line);
       if (isValidationFailureLine(line)) host._failedDuringValidate = true;
     },
     onResult: (data) => {
       host._streamId = "";
+      host.flushPendingLines();
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
       host._state = success ? "success" : "error";
@@ -173,6 +183,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
     },
     onError: (error) => {
       host._streamId = "";
+      host.flushPendingLines();
       host._state = "error";
       host._statusMessage = error;
       host._jobId = "";
@@ -230,7 +241,10 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
     host._state = "error";
     host._statusMessage = host._localize("command.force_local_failed");
     const detail = formatForceLocalError(err);
-    if (detail) host._lines = [...host._lines, detail];
+    if (detail) {
+      host.flushPendingLines();
+      host._lines = [...host._lines, detail];
+    }
   } finally {
     host._switchingToLocal = false;
   }

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -27,11 +27,14 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
   if (!host._streamId) return;
   const streamId = host._streamId;
   host._streamId = "";
-  // Flush any rAF-batched lines so a teardown mid-burst (user
-  // closed the dialog, switched to local, restarted with
-  // --show-secrets) still paints the lines that arrived but
-  // hadn't been rendered yet.
-  host.flushPendingLines();
+  // Flush any rAF-batched lines so a teardown mid-burst that
+  // keeps the buffer visible (dialog close, follow → install
+  // hand-off, force-local switch) still shows the lines that
+  // arrived but hadn't been rendered yet. Restart paths that
+  // immediately clear ``_lines`` after this call (validate-
+  // secrets-toggle, startCommand) follow up with
+  // ``_resetPendingLines`` to drop the pending batch too.
+  host._flushPendingLines();
   try {
     await host._api.stopStream(streamId);
   } catch {
@@ -44,7 +47,7 @@ export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
   host._jobId = "";
   host._state = "running";
   host._lines = [];
-  host.resetPendingLines();
+  host._resetPendingLines();
   host._statusMessage = "";
   host._userStopped = false;
   host._failedDuringValidate = false;
@@ -68,12 +71,12 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
     host.configuration,
     {
       onOutput: (line) => {
-        host.enqueueLine(line);
+        host._enqueueLine(line);
         if (isValidationFailureLine(line)) host._failedDuringValidate = true;
       },
       onResult: (data) => {
         host._streamId = "";
-        host.flushPendingLines();
+        host._flushPendingLines();
         host._state = data.success ? "success" : "error";
         host._statusMessage = host._localize(
           data.success ? "command.validate_success" : "command.validate_failed",
@@ -81,7 +84,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
       },
       onError: (error) => {
         host._streamId = "";
-        host.flushPendingLines();
+        host._flushPendingLines();
         host._state = "error";
         host._statusMessage = error;
       },
@@ -104,7 +107,7 @@ export async function toggleShowSecrets(host: ESPHomeCommandDialog): Promise<voi
   try {
     await detachStream(host);
     host._lines = [];
-    host.resetPendingLines();
+    host._resetPendingLines();
     host._state = "running";
     host._statusMessage = "";
     host._resetAnsiLogScroll();
@@ -157,12 +160,12 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
   const wasLiveAtAttach = !isTerminalJobStatus(host._jobStatus);
   host._streamId = host._api.firmwareFollowJob(jobId, {
     onOutput: (line) => {
-      host.enqueueLine(line);
+      host._enqueueLine(line);
       if (isValidationFailureLine(line)) host._failedDuringValidate = true;
     },
     onResult: (data) => {
       host._streamId = "";
-      host.flushPendingLines();
+      host._flushPendingLines();
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
       host._state = success ? "success" : "error";
@@ -183,7 +186,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
     },
     onError: (error) => {
       host._streamId = "";
-      host.flushPendingLines();
+      host._flushPendingLines();
       host._state = "error";
       host._statusMessage = error;
       host._jobId = "";
@@ -242,7 +245,7 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
     host._statusMessage = host._localize("command.force_local_failed");
     const detail = formatForceLocalError(err);
     if (detail) {
-      host.flushPendingLines();
+      host._flushPendingLines();
       host._lines = [...host._lines, detail];
     }
   } finally {


### PR DESCRIPTION
# What does this implement/fix?

Replaying a 2000-line historical build log used to do
`host._lines = [...host._lines, line]` per chunk — 1 + 2 + … + n
array copies (~2M for n=2000) and one ansi-log render per write.
Dialog-open delay was a visible 2–4 s pause before the log painted.

Coalesce streamed lines through `enqueueLine` / `flushPendingLines`:
each `onOutput` callback pushes into a pending buffer and schedules
a single `requestAnimationFrame` flush. n=2000 collapses to ~60
renders (one per frame at 60 fps) and the array-copy work becomes
O(n) total. Flush is synchronous at stream-terminal callbacks
(`onResult` / `onError`), `detachStream`, and `_downloadOutput`,
so consumers never race the rAF. Reset on every `_lines = []`
site (`open`, `followJob`, `startCommand`, secrets-toggle restart)
cancels the pending frame so a stale batch can't paint onto the
fresh buffer.

The same path applies to both `validate` and `follow_job` streams,
so live bursty output (pip install, esptool block writes) benefits
too — not just the historical-replay burst at attach time.

### ansi-log auto-scroll fix (second commit)

Surfaced by the batching change: the pre-existing auto-scroll
path in `ansi-log.ts` did `scrollTop = scrollHeight` inside its
own `requestAnimationFrame`, deferring the scroll by one frame
after Lit committed the new DOM. With one line per render that
one-line gap was invisible. With many lines per render (the new
common case during chatty builds), the scroll lagged far enough
behind the new content height that the last line in each burst
was visibly clipped below the viewport — only catching up when
the stream slowed down.

Move the auto-scroll path to a synchronous `_syncScrollToBottom`
called directly from `updated()`. `updated()` runs after Lit's
DOM commit, so reading `scrollHeight` there forces a layout that
already accounts for the appended lines. The public
`scrollToBottom` keeps its rAF wrapper for the dialog-open path,
where the post-open animation needs a frame to settle before the
scroll target is meaningful.

### Verified locally

- Previously-completed compile log: dialog-open delay went from a
  visible 2–3 s pause to instant paint on the same buffer.
- Live ESP-IDF compile burst (~30 "Compiling …" lines per frame
  during the mbedtls stage): bottom line tracks the burst cleanly
  instead of getting clipped until the stream slows.

**Related issue or feature (if applicable):**

- fixes #348

Pairs naturally with the storage-side CR-collapse landing in
esphome/device-builder#903 — together, a chatty ninja build's
~2000 stored chunks become ~300–500 real lines, replayed in
~10 render frames instead of 2000.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1112 existing tests; no regressions).
- [ ] Tests have been added to verify that the new code works (where applicable).

Note on tests: rAF coalescence is awkward to assert cleanly without
a vitest fake-timer harness for `requestAnimationFrame`. Happy to
add one if you'd like — the natural shape is to drive a sequence
of `enqueueLine` calls, advance the frame, and assert `_lines`
contains the full batch in one write. Left out of the prototype to
keep the diff focused on the behaviour change.