### PR TITLE
yaml-editor: stop active-line bg from hiding the selection

### DIFF
--- a/src/util/yaml-editor-theme.ts
+++ b/src/util/yaml-editor-theme.ts
@@ -20,6 +20,9 @@ const DARK_FG = "#d4d4d4";
 const DARK_GUTTER_FG = "#858585";
 const DARK_SELECTION = "#264f78";
 const DARK_ACTIVE_LINE = "#2a2d2e";
+// Translucent variant for the content-layer overlay; opaque
+// active-line bg hides the selection layer behind it (#326).
+const DARK_ACTIVE_LINE_TINT = "#ffffff0a";
 const DARK_CURSOR = "#aeafad";
 
 const LIGHT_BG = "#ffffff";
@@ -27,6 +30,9 @@ const LIGHT_FG = "#1f2328";
 const LIGHT_GUTTER_FG = "#6e7781";
 const LIGHT_SELECTION = "#add6ff";
 const LIGHT_ACTIVE_LINE = "#f6f8fa";
+// Translucent variant for the content-layer overlay; opaque
+// active-line bg hides the selection layer behind it (#326).
+const LIGHT_ACTIVE_LINE_TINT = "#0000000a";
 const LIGHT_CURSOR = "#1f2328";
 
 const darkHighlight = HighlightStyle.define([
@@ -79,7 +85,7 @@ const darkBase = EditorView.theme(
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: DARK_CURSOR },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
       { backgroundColor: DARK_SELECTION },
-    ".cm-activeLine": { backgroundColor: DARK_ACTIVE_LINE },
+    ".cm-activeLine": { backgroundColor: DARK_ACTIVE_LINE_TINT },
     ".cm-activeLineGutter": { backgroundColor: DARK_ACTIVE_LINE },
     ".cm-gutters": {
       backgroundColor: DARK_BG,
@@ -116,7 +122,7 @@ const lightBase = EditorView.theme(
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: LIGHT_CURSOR },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
       { backgroundColor: LIGHT_SELECTION },
-    ".cm-activeLine": { backgroundColor: LIGHT_ACTIVE_LINE },
+    ".cm-activeLine": { backgroundColor: LIGHT_ACTIVE_LINE_TINT },
     ".cm-activeLineGutter": { backgroundColor: LIGHT_ACTIVE_LINE },
     ".cm-gutters": {
       backgroundColor: LIGHT_BG,


### PR DESCRIPTION
# What does this implement/fix?

`.cm-activeLine` is rendered as a line decoration on the
`.cm-line` div inside `.cm-content`, while the selection layer
(`.cm-selectionLayer`) sits *behind* the content. An opaque
`backgroundColor` on `.cm-activeLine` therefore completely covers
the selection rectangle on the active line — which produced the
symptom in #326: double-clicking a word inside the active line
showed the `.cm-selectionMatch` highlight on every *other*
matching word but left the selected word itself looking
unhighlighted (the search extension explicitly skips the
overlapping main match, so the active line was relying entirely
on the now-hidden selection background).

Switch the `.cm-activeLine` background to a translucent
white-on-dark / black-on-light overlay so the selection layer
beneath shows through. The gutter highlight
(`.cm-activeLineGutter`) keeps its opaque colour since nothing
sits behind it. CodeMirror's own base theme uses the same
translucent approach (`#99eeff33` dark / `#cceeff44` light) for
exactly this reason.

Tint is matched to the previous opaque value's perceived contrast
against the editor background, so the active-line affordance
reads the same as before in the absence of a selection.

### Verified locally

- Double-click on a word inside the active line: selected text
  now shows the VSCode-blue selection rectangle; identical words
  on other lines still get the green `.cm-selectionMatch` tint.
- Active-line affordance still reads as a subtle row highlight
  in both dark and light themes when no selection is present.

**Related issue or feature (if applicable):**

- fixes #326

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1112 existing tests; no regressions).
- [ ] Tests have been added to verify that the new code works (where applicable).