### PR TITLE
Wrap dashboard search input in role='search' form to suppress Chrome credential autofill

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -174,24 +174,30 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
       name=${host._yamlMode ? "code-braces" : "magnify"}
       aria-hidden="true"
     ></wa-icon>
-    <input
-      class="search-input ${host._yamlMode ? "search-input--yaml" : ""}"
-      type="search"
-      name="dashboard-search"
-      with-clear
+    <form
+      role="search"
       autocomplete="off"
-      data-form-type="other"
-      data-lpignore="true"
-      data-1p-ignore="true"
-      aria-autocomplete="none"
-      placeholder=${placeholder}
-      .value=${host._search}
-      @input=${(e: Event) => {
-        host._search = (e.currentTarget as HTMLInputElement).value;
-        host._syncYamlSearch();
-      }}
-      @keydown=${host._onSearchKeyDown}
-    />
+      class="search-form"
+      @submit=${(e: SubmitEvent) => e.preventDefault()}
+    >
+      <input
+        class="search-input ${host._yamlMode ? "search-input--yaml" : ""}"
+        type="search"
+        name="q"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+        aria-label=${placeholder}
+        placeholder=${placeholder}
+        .value=${host._search}
+        @input=${(e: Event) => {
+          host._search = (e.currentTarget as HTMLInputElement).value;
+          host._syncYamlSearch();
+        }}
+        @keydown=${host._onSearchKeyDown}
+      />
+    </form>
   </div>`;
 }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -239,6 +239,14 @@ export const dashboardStyles = css`
     min-width: 0;
   }
 
+  /* The <form role="search"> wrapper is what suppresses Chrome's
+     credential autofill on the search input; display: contents keeps
+     it out of the layout so the absolute-positioned leading icon
+     still aligns. */
+  .search-form {
+    display: contents;
+  }
+
   .search-wrap {
     position: relative;
     max-width: 380px;


### PR DESCRIPTION
Follow-up to #353. The field-level opt-out attributes (`autocomplete="off"`, `data-form-type`, `data-lpignore`, `data-1p-ignore`, `aria-autocomplete`, non-credential `name`) aren't enough once Chrome has a saved credential bound to the origin — Chrome's heuristic still classifies the input as a username slot and offers the saved credential.

Wrapping the input in `<form role="search" autocomplete="off">` works. `display: contents` keeps the form out of the layout so the absolute-positioned leading icon still aligns.

## Reproduction

Can't build the HA add-on locally; reproduced in the standalone dashboard instead by adding a manual Chrome saved credential for `http://localhost:5173` (via `chrome://password-manager/passwords`). Same symptom as the HA-ingress report.

Also tested and confirmed *not* sufficient: dropping `name`, `autocomplete="new-password"`, `autocomplete="search"`, `role="searchbox"` on the input, `readonly`-on-blur toggle, swapping `<input>` for `<wa-input>`.

A honeypot decoy pair (hidden username/password inputs ahead of the search) also works but is uglier and puts bogus credential-shaped inputs in the DOM.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1178 tests).
- [ ] Tests have been added to verify that the new code works (where applicable). — N/A; browser autofill heuristic behavior isn't reliably unit-testable.