### PR TITLE
Normalize script/api-action ids on input to keep YAML valid

### DIFF
--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -26,6 +26,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { inputStyles } from "../../styles/inputs.js";
+import { normalizeEspHomeId } from "../../util/esphome-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
@@ -163,7 +164,9 @@ export class ESPHomeAddApiActionDialog extends LitElement {
           )}
           ?disabled=${this._saving}
           @input=${(e: Event) => {
-            this._name = (e.target as HTMLInputElement).value.trim();
+            this._name = normalizeEspHomeId(
+              (e.target as HTMLInputElement).value,
+            );
             this._error = "";
           }}
         />

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -31,6 +31,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { inputStyles } from "../../styles/inputs.js";
+import { normalizeEspHomeId } from "../../util/esphome-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import {
@@ -178,7 +179,9 @@ export class ESPHomeAddScriptDialog extends LitElement {
           )}
           ?disabled=${this._saving}
           @input=${(e: Event) => {
-            this._id = (e.target as HTMLInputElement).value.trim();
+            this._id = normalizeEspHomeId(
+              (e.target as HTMLInputElement).value,
+            );
             this._error = "";
           }}
         />

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -38,6 +38,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { inputStyles } from "../../../styles/inputs.js";
+import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -394,9 +395,12 @@ export class ESPHomeApiActionEditor extends LitElement {
   }
 
   private _onActionNameChange(name: string) {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    this.location = { kind: "api_action", action_name: trimmed };
+    // Normalize so the field reshapes invalid characters
+    // (``"my action"`` → ``"my_action"``) as the user types and the
+    // YAML key the upsert produces is always valid.
+    const normalized = normalizeEspHomeId(name);
+    if (!normalized) return;
+    this.location = { kind: "api_action", action_name: normalized };
     this._scheduleAutoApply();
   }
 

--- a/src/components/device/automation-editor/callable-params-editor.ts
+++ b/src/components/device/automation-editor/callable-params-editor.ts
@@ -22,6 +22,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { inputStyles } from "../../../styles/inputs.js";
+import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -132,7 +133,11 @@ export class ESPHomeCallableParamsEditor extends LitElement {
         @input=${(e: Event) =>
           this._updateRow(idx, {
             ...p,
-            name: (e.target as HTMLInputElement).value,
+            // Parameter names map to C++ lambda variables on the
+            // backend, so they have to be valid identifiers.
+            // Normalizing on input keeps the field's value and the
+            // wire-shape key in lockstep.
+            name: normalizeEspHomeId((e.target as HTMLInputElement).value),
           })}
       />
       <wa-select

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -49,6 +49,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { inputStyles } from "../../../styles/inputs.js";
+import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
@@ -482,13 +483,25 @@ export class ESPHomeScriptEditor extends LitElement {
     e.stopPropagation();
     const { path, value } = e.detail;
     const automation = this.value ?? emptyAutomationTree();
-    const next = this._patchParams(automation.trigger_params, path, value);
+    // ``id`` runs through the shared normalizer so a stray space or
+    // dash the user typed lands as a valid YAML key
+    // (``"my script"`` → ``"my_script"``) — without this the input
+    // would round-trip a value that breaks compilation on save.
+    const normalizedValue =
+      path.length === 1 && path[0] === "id"
+        ? normalizeEspHomeId(String(value ?? ""))
+        : value;
+    const next = this._patchParams(
+      automation.trigger_params,
+      path,
+      normalizedValue,
+    );
     if (path.length === 1 && path[0] === "id") {
       // Match wire shape: ``trigger_params.id`` round-trips with
-      // ``location.id``, so keep both pinned to whatever the user
-      // typed. Empty id falls back to the previous location so we
-      // don't dispatch a write with no destination.
-      const newId = String(value ?? "").trim();
+      // ``location.id``, so keep both pinned to the normalized id.
+      // Empty id falls back to the previous location so we don't
+      // dispatch a write with no destination.
+      const newId = String(normalizedValue ?? "");
       if (newId) {
         this.location = { kind: "script", id: newId };
       }

--- a/src/util/esphome-id.ts
+++ b/src/util/esphome-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize a user-typed identifier into a valid ESPHome id.
+ *
+ * ESPHome ids are Python-identifier-shaped: ``[a-zA-Z_][a-zA-Z0-9_]*``.
+ * Anything outside that alphabet — spaces, slashes, dots, dashes,
+ * diacritics, … — produces invalid YAML keys and breaks compilation.
+ *
+ * The frontend's add-script / add-api-action / script-editor / etc.
+ * inputs run user input through this helper on every keystroke so
+ * the value the user sees in the field IS the value that lands in
+ * YAML. That keeps the rule self-documenting (the field reshapes as
+ * the user types) and means we never have to surface a "your id is
+ * invalid" error: the field can't hold an invalid id long enough to
+ * be submitted.
+ *
+ * Rules:
+ *
+ * - Runs of disallowed characters collapse to a single underscore
+ *   (``"my cool script"`` → ``"my_cool_script"``).
+ * - Case is preserved — ESPHome accepts both, even though lowercase
+ *   snake_case is conventional, and forcing case would surprise a
+ *   user who deliberately typed ``MyScript``.
+ * - Empty input stays empty (we let the caller's required-field
+ *   check handle the empty case).
+ *
+ * Note that a normalized id can still start with a digit
+ * (``"1abc"`` → ``"1abc"``), which is technically invalid as a YAML
+ * key in ESPHome's grammar. That's a rare-enough case that we
+ * leave it to the backend to reject on save rather than mutate
+ * mid-type (prepending an underscore would make ``"1"`` → ``"_1"``
+ * the moment the user starts typing, which is more disruptive
+ * than helpful).
+ */
+export function normalizeEspHomeId(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_]+/g, "_");
+}

--- a/test/util/esphome-id.test.ts
+++ b/test/util/esphome-id.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { normalizeEspHomeId } from "../../src/util/esphome-id.js";
+
+describe("normalizeEspHomeId", () => {
+  it("passes already-valid ids through unchanged", () => {
+    expect(normalizeEspHomeId("morning_alarm")).toBe("morning_alarm");
+    expect(normalizeEspHomeId("Script1")).toBe("Script1");
+    expect(normalizeEspHomeId("_foo")).toBe("_foo");
+  });
+
+  it("preserves case (no forced lowercase)", () => {
+    expect(normalizeEspHomeId("MyScript")).toBe("MyScript");
+    expect(normalizeEspHomeId("camelCase")).toBe("camelCase");
+  });
+
+  it("collapses runs of invalid characters to a single underscore", () => {
+    // The screenshot's regression case: spaces and slashes all
+    // collapse into one underscore each, including the "is / a" run.
+    expect(normalizeEspHomeId("this is / a invalid id")).toBe(
+      "this_is_a_invalid_id",
+    );
+    expect(normalizeEspHomeId("my-script-name")).toBe("my_script_name");
+    expect(normalizeEspHomeId("kitchen.sensor")).toBe("kitchen_sensor");
+  });
+
+  it("collapses leading and trailing whitespace to bordering underscores", () => {
+    // Deliberately doesn't strip — stripping mid-type would jump the
+    // cursor for a user who hasn't finished typing yet.
+    expect(normalizeEspHomeId("  hello  ")).toBe("_hello_");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(normalizeEspHomeId("")).toBe("");
+  });
+
+  it("collapses non-ASCII characters", () => {
+    // No diacritic-folding (unlike friendlyNameSlugify) — non-ASCII
+    // letters aren't valid YAML keys in ESPHome's grammar, so they
+    // collapse to underscore alongside other invalid chars.
+    expect(normalizeEspHomeId("Café")).toBe("Caf_");
+    expect(normalizeEspHomeId("naïve")).toBe("na_ve");
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeEspHomeId("this is / a invalid id");
+    expect(normalizeEspHomeId(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Id / name inputs (new script, new api.action, script id field, api.action name field, script parameters / api.action variables) accepted any text — spaces, slashes, dots, dashes — and wrote it verbatim into the YAML, producing keys like `id: this is / a invalid id` that fail validation on save.

These inputs now normalize on every keystroke: any run of characters outside `[a-zA-Z0-9_]` collapses to a single underscore, so what the user sees in the field is always what lands in the YAML. Case is preserved.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Changes

- Add `normalizeEspHomeId()` in `src/util/esphome-id.ts` + tests.
- Apply it in `add-script-dialog`, `add-api-action-dialog`, `script-editor` (id field via the config-entry-form change handler), `api-action-editor` (action name), and `callable-params-editor` (parameter / variable names — they map to C++ identifiers).

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).