### PR TITLE
dashboard: hide discovered banner when every importable is ignored

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -21,9 +21,6 @@ const discoveryCollator = new Intl.Collator(undefined, {
 export function renderDiscoveredSection(
   host: ESPHomePageDashboard,
 ): TemplateResult | string {
-  // Render when there are any importable devices, even if all are
-  // currently filtered out by the show-ignored flag — the banner is
-  // the only way to flip that flag now.
   if (host._importableDevices.length === 0) return "";
   // Non-ignored discoveries first, then ignored ones — both
   // alphabetical by friendly name (fallback hostname) within each
@@ -36,8 +33,13 @@ export function renderDiscoveredSection(
       b.friendly_name || b.name,
     );
   });
+  // Nothing to announce when every importable is ignored and the
+  // user has opted to hide them — the header kebab's "Show ignored
+  // discoveries" entry is the path back, not a "Discovered 0
+  // devices" stub.
+  if (visible.length === 0) return "";
   const ignoredCount = host._importableDevices.filter((d) => d.ignored).length;
-  const expanded = host._showDiscovered && visible.length > 0;
+  const expanded = host._showDiscovered;
   return html`
     <section class="discovered-section">
       <header class="discovered-section-header">
@@ -50,19 +52,17 @@ export function renderDiscoveredSection(
             { count: visible.length },
           )}</span
         >
-        ${visible.length > 0
-          ? html`<button
-              class="discovered-section-toggle"
-              type="button"
-              aria-expanded=${expanded}
-              aria-controls="discovered-grid"
-              @click=${() => {
-                host._showDiscovered = !host._showDiscovered;
-              }}
-            >
-              ${host._localize(expanded ? "dashboard.hide" : "dashboard.show")}
-            </button>`
-          : ""}
+        <button
+          class="discovered-section-toggle"
+          type="button"
+          aria-expanded=${expanded}
+          aria-controls="discovered-grid"
+          @click=${() => {
+            host._showDiscovered = !host._showDiscovered;
+          }}
+        >
+          ${host._localize(expanded ? "dashboard.hide" : "dashboard.show")}
+        </button>
         ${ignoredCount > 0
           ? html`<button
               class="discovered-section-toggle discovered-section-toggle--ignored"

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -6,6 +6,7 @@ import {
   mdiCogRefresh,
   mdiCommentQuestionOutline,
   mdiDotsVertical,
+  mdiEyeOffOutline,
   mdiEyeOutline,
   mdiKeyVariant,
   mdiPlaylistCheck,
@@ -14,11 +15,16 @@ import {
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { JobStatus } from "../api/types.js";
-import type { FirmwareJob, OffloaderAlertSnapshotEntry } from "../api/types.js";
+import type {
+  AdoptableDevice,
+  FirmwareJob,
+  OffloaderAlertSnapshotEntry,
+} from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   buildOffloadAlertsContext,
   firmwareJobsContext,
+  importableDevicesContext,
   localizeContext,
   onboardingPendingContext,
 } from "../context/index.js";
@@ -36,6 +42,7 @@ registerMdiIcons({
   "cog-refresh": mdiCogRefresh,
   "comment-question-outline": mdiCommentQuestionOutline,
   "dots-vertical": mdiDotsVertical,
+  "eye-off-outline": mdiEyeOffOutline,
   "eye-outline": mdiEyeOutline,
   "key-variant": mdiKeyVariant,
   "playlist-check": mdiPlaylistCheck,
@@ -77,6 +84,21 @@ export class ESPHomeHeaderActions extends LitElement {
   @consume({ context: onboardingPendingContext, subscribe: true })
   @state()
   private _onboardingPending = false;
+
+  /** Adoptable / ignored discoveries. Subscribed here so the
+   *  kebab can gate the "Show ignored discoveries" entry on the
+   *  presence of at least one ignored card — when there are no
+   *  ignored discoveries the action has nothing to flip. */
+  @consume({ context: importableDevicesContext, subscribe: true })
+  @state()
+  private _importableDevices: AdoptableDevice[] = [];
+
+  /** Mirror of the dashboard's ``_showIgnored`` flag (persisted
+   *  in ``localStorage``). The dashboard owns the write path; we
+   *  listen to the ``esphome-show-ignored-changed`` window event
+   *  so the menu label flips in real time. */
+  @state()
+  private _showIgnored = false;
 
   static styles = [
     espHomeStyles,
@@ -217,6 +239,27 @@ export class ESPHomeHeaderActions extends LitElement {
     `,
   ];
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
+    window.addEventListener(
+      "esphome-show-ignored-changed",
+      this._onShowIgnoredChanged,
+    );
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener(
+      "esphome-show-ignored-changed",
+      this._onShowIgnoredChanged,
+    );
+  }
+
+  private _onShowIgnoredChanged = (e: Event) => {
+    this._showIgnored = (e as CustomEvent<{ value: boolean }>).detail.value;
+  };
+
   protected render() {
     let activeCount = 0;
     for (const job of this._jobs.values()) {
@@ -229,6 +272,7 @@ export class ESPHomeHeaderActions extends LitElement {
         ? this._localize("layout.more_options_with_count", { count: activeCount })
         : this._localize("dashboard.more_options");
     const hasAlerts = this._offloaderAlertsCount() > 0;
+    const ignoredCount = this._importableDevices.filter((d) => d.ignored).length;
     return html`
       <button
         type="button"
@@ -297,6 +341,28 @@ export class ESPHomeHeaderActions extends LitElement {
                 <wa-icon library="mdi" name="archive-outline"></wa-icon>
                 ${this._localize("layout.archived_devices")}
               </div>
+              ${ignoredCount > 0
+                ? html`<div
+                    class="menu-item"
+                    role="menuitemcheckbox"
+                    tabindex="0"
+                    aria-checked=${this._showIgnored ? "true" : "false"}
+                    @click=${this._toggleShowIgnoredDiscoveries}
+                    @keydown=${this._onMenuItemKeydown}
+                  >
+                    <wa-icon
+                      library="mdi"
+                      name=${this._showIgnored ? "eye-off-outline" : "eye-outline"}
+                    ></wa-icon>
+                    <span class="menu-item-label"
+                      >${this._showIgnored
+                        ? this._localize("layout.hide_ignored_discoveries")
+                        : this._localize("layout.show_ignored_discoveries", {
+                            count: ignoredCount,
+                          })}</span
+                    >
+                  </div>`
+                : nothing}
               <div
                 class="menu-item"
                 role="menuitem"
@@ -373,6 +439,16 @@ export class ESPHomeHeaderActions extends LitElement {
        window event to open it. */
     this._close();
     window.dispatchEvent(new Event("esphome-show-archived-dialog"));
+  };
+
+  private _toggleShowIgnoredDiscoveries = () => {
+    /* Dashboard owns the ``_showIgnored`` flag and the
+       ``localStorage`` persistence. Fire the intent here; the
+       dashboard handler also pops the discovery section open so
+       the banner doesn't reappear collapsed after the user
+       explicitly asked to see those cards. */
+    this._close();
+    window.dispatchEvent(new Event("esphome-show-ignored-from-menu"));
   };
 
   private _openSecrets() {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -407,8 +407,15 @@ export class ESPHomePageDashboard extends LitElement {
 
   protected willUpdate(changed: PropertyValues) {
     if (changed.has("_view")) this.setAttribute("view", this._view);
-    if (changed.has("_importableDevices")) {
-      this.toggleAttribute("has-discovered", this._importableDevices.length > 0);
+    // ``has-discovered`` is the hook that adds top padding for the
+    // discovery banner. Track the same condition the banner renders
+    // under so an all-ignored / hide-ignored state doesn't leave
+    // empty space at the top of the view.
+    if (changed.has("_importableDevices") || changed.has("_showIgnored")) {
+      this.toggleAttribute(
+        "has-discovered",
+        this._visibleImportableDevices.length > 0,
+      );
     }
     if (changed.has("_devicesLoaded") && this._devicesLoaded) void loadPreferences(this);
     // The catalog arrives over WS after ``connectedCallback`` runs.

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -273,6 +273,14 @@ export class ESPHomePageDashboard extends LitElement {
       })
     );
   };
+  // Kebab path: the banner is hidden when every importable is
+  // ignored, so users seeking those cards reach the toggle here.
+  // Pop the section open on the way in so they don't land on a
+  // collapsed banner and have to click "Show" a second time.
+  private _onShowIgnoredFromMenu = () => {
+    if (!this._showIgnored) this._showDiscovered = true;
+    this._toggleShowIgnored();
+  };
   private _onShowArchivedDialog = () => this._archivedDialog?.open();
 
   _onEnterSelectMode = (configuration?: string) => {
@@ -291,6 +299,7 @@ export class ESPHomePageDashboard extends LitElement {
     this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
     window.addEventListener("esphome-serial-setup", this._onSerialSetup);
     window.addEventListener("esphome-show-ignored-changed", this._onShowIgnoredChanged);
+    window.addEventListener("esphome-show-ignored-from-menu", this._onShowIgnoredFromMenu);
     window.addEventListener("esphome-show-archived-dialog", this._onShowArchivedDialog);
     const pending = consumePendingHighlight();
     if (pending !== null) {
@@ -381,6 +390,10 @@ export class ESPHomePageDashboard extends LitElement {
     window.removeEventListener(
       "esphome-show-ignored-changed",
       this._onShowIgnoredChanged
+    );
+    window.removeEventListener(
+      "esphome-show-ignored-from-menu",
+      this._onShowIgnoredFromMenu
     );
     window.removeEventListener(
       "esphome-show-archived-dialog",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -807,6 +807,8 @@
     "theme_system": "System",
     "settings": "Settings",
     "archived_devices": "Archived devices",
+    "show_ignored_discoveries": "Show ignored discoveries ({count})",
+    "hide_ignored_discoveries": "Hide ignored discoveries",
     "reset_build_env": "Reset build environment",
     "feedback_menu": "Found a bug? Have an idea?",
     "back": "Back",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -685,6 +685,8 @@
     "theme_system": "Système",
     "settings": "Paramètres",
     "archived_devices": "Appareils archivés",
+    "show_ignored_discoveries": "Afficher les découvertes ignorées ({count})",
+    "hide_ignored_discoveries": "Masquer les découvertes ignorées",
     "reset_build_env": "Réinitialiser l'environnement de compilation",
     "feedback_menu": "Un bug ? Une idée ?",
     "back": "Retour",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -685,6 +685,8 @@
     "theme_system": "Systeem",
     "settings": "Instellingen",
     "archived_devices": "Gearchiveerde apparaten",
+    "show_ignored_discoveries": "Toon genegeerde ontdekkingen ({count})",
+    "hide_ignored_discoveries": "Verberg genegeerde ontdekkingen",
     "reset_build_env": "Bouw-omgeving resetten",
     "feedback_menu": "Probleem of idee?",
     "back": "Terug",


### PR DESCRIPTION
# What does this implement/fix?

When every importable discovery has been ignored, the dashboard
banner stays visible as a cosmetic stub ("Discovered 0 devices")
just to host the `Show ignored (N)` button. Hide the banner in
that case and move the resurface affordance to the header kebab
menu instead.

- `render-content.ts`: drop the banner when `visible.length === 0`
  (i.e. every importable is ignored and the user has them hidden).
- `esphome-header-actions.ts`: new `Show ignored discoveries (N)` /
  `Hide ignored discoveries` kebab entry, gated on
  `ignoredCount > 0`, with the count shown so it reads the same
  way as the in-banner toggle.
- `dashboard.ts`: the kebab path also expands the discovery
  section so the banner doesn't reappear collapsed and force a
  second click. In-banner toggle is unchanged.
- Translations for `en` / `fr` / `nl`.

The existing in-banner `Show ignored` button is untouched — when
there is at least one fresh discovery it still renders next to
`Show / Hide` exactly as before.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/349

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
