### PR TITLE
Resolve dep ids to catalog names in missing-deps banner

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { mdiAlertCircleOutline } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../../api/index.js";
 import type {
   BoardCatalogEntry,
   ComponentCatalogEntry,
@@ -9,9 +10,14 @@ import type {
 } from "../../api/types.js";
 import { ConfigEntryType } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { localizeContext } from "../../context/index.js";
+import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import {
+  fetchComponent,
+  getCachedComponent,
+  subscribeComponentCache,
+} from "../../util/component-name-cache.js";
 import {
   validateEntries,
   type ValidationError,
@@ -43,6 +49,9 @@ export class ESPHomeAddComponentForm extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  private _api?: ESPHomeAPI;
 
   @property({ attribute: false })
   component!: ComponentCatalogEntry;
@@ -88,6 +97,16 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   @state()
   private _showYaml = false;
+
+  /**
+   * Bumped whenever a fresh entry lands in the component-name cache.
+   * Triggers a re-render so the missing-deps banner picks up freshly
+   * resolved catalog names without the user re-opening the form.
+   */
+  @state()
+  private _cacheTick = 0;
+
+  private _unsubscribeCache?: () => void;
 
   static styles = [
     espHomeStyles,
@@ -163,6 +182,19 @@ export class ESPHomeAddComponentForm extends LitElement {
   /** True once we've seeded `_values` for the current component. */
   private _initialized = false;
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._unsubscribeCache = subscribeComponentCache(() => {
+      this._cacheTick++;
+    });
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubscribeCache?.();
+    this._unsubscribeCache = undefined;
+  }
+
   willUpdate(changedProperties: Map<string, unknown>) {
     super.willUpdate(changedProperties);
     // Initialize the form values once we have both `component` and
@@ -181,7 +213,29 @@ export class ESPHomeAddComponentForm extends LitElement {
         // detour the form gets reused for) would leak into the next
         // component's form.
         this._localBlockMessage = "";
+        this._kickoffDepNameResolves(this.component.dependencies ?? []);
       }
+    }
+  }
+
+  /**
+   * Fire-and-forget catalog lookups for each declared dependency id,
+   * so the missing-deps banner can show the friendly catalog name
+   * (e.g. ``I²C Bus``) instead of the raw domain (``i2c``). Resolved
+   * entries land in the shared cache; the subscription bumps
+   * ``_cacheTick`` to trigger a re-render. Cache misses keep the raw
+   * id as fallback.
+   */
+  private _kickoffDepNameResolves(deps: string[]): void {
+    if (!this._api) return;
+    const platform = this.board?.esphome.platform || undefined;
+    for (const id of deps) {
+      if (getCachedComponent(id, platform) !== undefined) continue;
+      void fetchComponent(this._api, id, platform).catch(() => {
+        // Swallow — the banner falls back to the raw id when the
+        // lookup fails, so a transient backend hiccup shouldn't
+        // surface as an error here.
+      });
     }
   }
 
@@ -397,8 +451,14 @@ export class ESPHomeAddComponentForm extends LitElement {
    * disabled while this is showing. Each missing dep is rendered as a
    * button that takes the user back to the catalog filtered to that
    * domain — they pick one, add it, then come back to this component.
+   *
+   * The dep id is resolved to the catalog entry's friendly ``name`` so
+   * the button reads ``Add I²C Bus`` instead of ``Add i2c``. Falls
+   * back to the raw id until the cache lookup lands (kicked off in
+   * ``willUpdate``).
    */
   private _renderMissingDeps(missing: string[]) {
+    const platform = this.board?.esphome.platform || undefined;
     return html`
       <div class="deps-warning" role="alert">
         <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
@@ -410,17 +470,18 @@ export class ESPHomeAddComponentForm extends LitElement {
           </div>
           <div>${this._localize("device.missing_dependencies_body")}</div>
           <div class="deps-warning-actions">
-            ${missing.map(
-              (d) => html`<button
+            ${missing.map((d) => {
+              const label = getCachedComponent(d, platform)?.name ?? d;
+              return html`<button
                 type="button"
                 class="dep-button"
                 @click=${() => this._onAddDep(d)}
               >
                 ${this._localize("device.missing_dependencies_add", {
-                  domain: d,
+                  domain: label,
                 })}
-              </button>`,
-            )}
+              </button>`;
+            })}
           </div>
         </div>
       </div>

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -13,11 +13,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import {
-  fetchComponent,
-  getCachedComponent,
-  subscribeComponentCache,
-} from "../../util/component-name-cache.js";
+import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
 import {
   validateEntries,
   type ValidationError,
@@ -98,15 +94,14 @@ export class ESPHomeAddComponentForm extends LitElement {
   @state()
   private _showYaml = false;
 
-  /**
-   * Bumped whenever a fresh entry lands in the component-name cache.
-   * Triggers a re-render so the missing-deps banner picks up freshly
-   * resolved catalog names without the user re-opening the form.
-   */
-  @state()
-  private _cacheTick = 0;
-
-  private _unsubscribeCache?: () => void;
+  /** Resolves dep ids (``i2c``) to their catalog name (``I²C Bus``)
+   * for the missing-deps banner. Owns the cache subscription so a
+   * fresh entry triggers a re-render without bookkeeping here. */
+  private readonly _depResolver = new ComponentNameResolverController(
+    this,
+    () => this._api,
+    () => this.board?.esphome.platform || undefined,
+  );
 
   static styles = [
     espHomeStyles,
@@ -182,19 +177,6 @@ export class ESPHomeAddComponentForm extends LitElement {
   /** True once we've seeded `_values` for the current component. */
   private _initialized = false;
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    this._unsubscribeCache = subscribeComponentCache(() => {
-      this._cacheTick++;
-    });
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._unsubscribeCache?.();
-    this._unsubscribeCache = undefined;
-  }
-
   willUpdate(changedProperties: Map<string, unknown>) {
     super.willUpdate(changedProperties);
     // Initialize the form values once we have both `component` and
@@ -213,29 +195,8 @@ export class ESPHomeAddComponentForm extends LitElement {
         // detour the form gets reused for) would leak into the next
         // component's form.
         this._localBlockMessage = "";
-        this._kickoffDepNameResolves(this.component.dependencies ?? []);
+        this._depResolver.kickoff(this.component.dependencies ?? []);
       }
-    }
-  }
-
-  /**
-   * Fire-and-forget catalog lookups for each declared dependency id,
-   * so the missing-deps banner can show the friendly catalog name
-   * (e.g. ``I²C Bus``) instead of the raw domain (``i2c``). Resolved
-   * entries land in the shared cache; the subscription bumps
-   * ``_cacheTick`` to trigger a re-render. Cache misses keep the raw
-   * id as fallback.
-   */
-  private _kickoffDepNameResolves(deps: string[]): void {
-    if (!this._api) return;
-    const platform = this.board?.esphome.platform || undefined;
-    for (const id of deps) {
-      if (getCachedComponent(id, platform) !== undefined) continue;
-      void fetchComponent(this._api, id, platform).catch(() => {
-        // Swallow — the banner falls back to the raw id when the
-        // lookup fails, so a transient backend hiccup shouldn't
-        // surface as an error here.
-      });
     }
   }
 
@@ -458,7 +419,6 @@ export class ESPHomeAddComponentForm extends LitElement {
    * ``willUpdate``).
    */
   private _renderMissingDeps(missing: string[]) {
-    const platform = this.board?.esphome.platform || undefined;
     return html`
       <div class="deps-warning" role="alert">
         <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
@@ -470,18 +430,17 @@ export class ESPHomeAddComponentForm extends LitElement {
           </div>
           <div>${this._localize("device.missing_dependencies_body")}</div>
           <div class="deps-warning-actions">
-            ${missing.map((d) => {
-              const label = getCachedComponent(d, platform)?.name ?? d;
-              return html`<button
+            ${missing.map(
+              (d) => html`<button
                 type="button"
                 class="dep-button"
                 @click=${() => this._onAddDep(d)}
               >
                 ${this._localize("device.missing_dependencies_add", {
-                  domain: label,
+                  domain: this._depResolver.resolve(d),
                 })}
-              </button>`;
-            })}
+              </button>`,
+            )}
           </div>
         </div>
       </div>

--- a/src/util/component-name-resolver-controller.ts
+++ b/src/util/component-name-resolver-controller.ts
@@ -1,0 +1,65 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ESPHomeAPI } from "../api/index.js";
+import {
+  fetchComponent,
+  getCachedComponent,
+  subscribeComponentCache,
+} from "./component-name-cache.js";
+
+/**
+ * Reactive controller that resolves raw component ids (e.g.
+ * ``i2c``) to their catalog ``name`` (e.g. ``I²C Bus``) via the
+ * shared ``component-name-cache``. Hosts:
+ *
+ *   1. Call ``resolve(id)`` from render to get the friendly name,
+ *      or the raw id as fallback while the lookup is in flight.
+ *   2. Call ``kickoff(ids)`` from ``willUpdate`` to fire-and-forget
+ *      fetches for ids whose entry hasn't been cached yet. The
+ *      cache subscription requests a host update once a fresh
+ *      entry lands so labels appear without user interaction.
+ *
+ * The API and platform are read through getters so the host can
+ * drive context changes (board switch, late context provision)
+ * without re-wiring the controller.
+ */
+export class ComponentNameResolverController implements ReactiveController {
+  private _unsubscribe?: () => void;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost,
+    private readonly _getApi: () => ESPHomeAPI | undefined,
+    private readonly _getPlatform: () => string | undefined,
+  ) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {
+    this._unsubscribe = subscribeComponentCache(() => {
+      this._host.requestUpdate();
+    });
+  }
+
+  hostDisconnected(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+  }
+
+  /** Friendly catalog name for ``id`` if cached, else the raw id. */
+  resolve(id: string): string {
+    return getCachedComponent(id, this._getPlatform())?.name ?? id;
+  }
+
+  /** Fire-and-forget catalog lookups for any ids not yet cached. */
+  kickoff(ids: Iterable<string>): void {
+    const api = this._getApi();
+    if (!api) return;
+    const platform = this._getPlatform();
+    for (const id of ids) {
+      if (getCachedComponent(id, platform) !== undefined) continue;
+      void fetchComponent(api, id, platform).catch(() => {
+        // Swallow — callers fall back to the raw id on miss, so a
+        // transient backend hiccup shouldn't surface as an error.
+      });
+    }
+  }
+}

--- a/test/util/component-name-resolver-controller.test.ts
+++ b/test/util/component-name-resolver-controller.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { ComponentCatalogEntry } from "../../src/api/types.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { ComponentNameResolverController } from "../../src/util/component-name-resolver-controller.js";
+
+const entry = (id: string, name: string): ComponentCatalogEntry =>
+  ({
+    id,
+    name,
+    description: "",
+    category: "core" as ComponentCatalogEntry["category"],
+    docs_url: "",
+    image_url: "",
+    dependencies: [],
+    multi_conf: false,
+    supported_platforms: [],
+    config_entries: [],
+  }) as ComponentCatalogEntry;
+
+/** Minimal stub matching the slice of ``ReactiveControllerHost`` the
+ *  controller actually exercises. ``addController`` records the
+ *  registration so tests can drive lifecycle hooks directly. */
+const stubHost = () => {
+  let controller: ReactiveController | null = null;
+  const requestUpdate = vi.fn();
+  const host: ReactiveControllerHost = {
+    addController: (c) => {
+      controller = c;
+    },
+    removeController: () => {},
+    requestUpdate,
+    updateComplete: Promise.resolve(true),
+  };
+  return {
+    host,
+    requestUpdate,
+    connect: () => controller?.hostConnected?.(),
+    disconnect: () => controller?.hostDisconnected?.(),
+  };
+};
+
+const mockApi = (
+  impl: (id: string) => ComponentCatalogEntry | null,
+): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
+  const getComponent = vi.fn((id: string) => Promise.resolve(impl(id)));
+  return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
+};
+
+describe("ComponentNameResolverController", () => {
+  beforeEach(() => _clearComponentCache());
+  afterEach(() => _clearComponentCache());
+
+  it("resolves to the catalog name when the entry is cached", async () => {
+    const { host } = stubHost();
+    const { api } = mockApi((id) => entry(id, "I²C Bus"));
+    const ctl = new ComponentNameResolverController(
+      host,
+      () => api,
+      () => "esp32",
+    );
+
+    expect(ctl.resolve("i2c")).toBe("i2c"); // not yet fetched
+    ctl.kickoff(["i2c"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ctl.resolve("i2c")).toBe("I²C Bus");
+  });
+
+  it("falls back to the raw id when the cache has no entry", () => {
+    const { host } = stubHost();
+    const { api } = mockApi(() => null);
+    const ctl = new ComponentNameResolverController(host, () => api, () => undefined);
+
+    expect(ctl.resolve("uart")).toBe("uart");
+  });
+
+  it("requests a host update once a fresh entry lands", async () => {
+    const { host, requestUpdate, connect, disconnect } = stubHost();
+    const { api } = mockApi((id) => entry(id, "WiFi"));
+    const ctl = new ComponentNameResolverController(
+      host,
+      () => api,
+      () => undefined,
+    );
+
+    // No subscription before hostConnected — kickoff still fetches, but
+    // a fresh entry landing shouldn't surface as a host update yet.
+    connect();
+    ctl.kickoff(["wifi"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(requestUpdate).toHaveBeenCalled();
+
+    disconnect();
+    requestUpdate.mockClear();
+    // Unsubscribed — a new cache write should not bump the host.
+    const { api: api2 } = mockApi((id) => entry(id, "Logger"));
+    await api2.getComponent("logger");
+    expect(requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("skips kickoff when no API is available", async () => {
+    const { host } = stubHost();
+    const ctl = new ComponentNameResolverController(
+      host,
+      () => undefined,
+      () => undefined,
+    );
+    // Should be a no-op rather than throwing.
+    expect(() => ctl.kickoff(["i2c", "uart"])).not.toThrow();
+  });
+
+  it("does not re-fetch ids already present in the cache", async () => {
+    const { host, connect } = stubHost();
+    const { api, getComponent } = mockApi((id) => entry(id, "Cached"));
+    const ctl = new ComponentNameResolverController(
+      host,
+      () => api,
+      () => undefined,
+    );
+    connect();
+
+    ctl.kickoff(["spi"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getComponent).toHaveBeenCalledTimes(1);
+
+    ctl.kickoff(["spi"]);
+    await Promise.resolve();
+    expect(getComponent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The "Add component" form's missing-dependencies warning was rendering the raw dependency id straight into the localized `Add {domain}` string. For the AHT20 module on the Apollo ESPHome Starter Kit, this surfaced as **"Add i2c"** instead of **"Add I²C Bus"** — the catalog's actual display name for the parent component never appeared.

This change reuses the existing `component-name-cache` (already populated by the device navigator on page load) to resolve each dep id to its catalog `name`. Fire-and-forget fetches cover the cache-miss path, with a re-render once the entry lands; the raw id stays as the fallback so the banner is never blank.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#912

## Changes

- `add-component-form.ts`: consume the `apiContext`, subscribe to the shared component-name cache on connect, and kick off catalog lookups for `component.dependencies` whenever the form retargets.
- `_renderMissingDeps`: resolve each dep id via `getCachedComponent(...).name` with a raw-id fallback.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).