### PR TITLE
Drop ellipsis from row-menu items that open dialogs

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -102,8 +102,8 @@
     "action_show_api_key": "Show API key",
     "action_download_yaml": "Download YAML",
     "action_rename": "Rename hostname",
-    "action_clone": "Duplicate…",
-    "action_edit_friendly_name": "Edit friendly name…",
+    "action_clone": "Duplicate",
+    "action_edit_friendly_name": "Edit friendly name",
     "action_clean_build": "Clean build files",
     "action_clean_build_busy": "Wait for the current build to finish before cleaning",
     "action_download_elf": "Download ELF file",
@@ -780,7 +780,7 @@
     "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks"
   },
   "onboarding": {
-    "menu_item_setup_wifi": "Set up Wi-Fi…",
+    "menu_item_setup_wifi": "Set up Wi-Fi",
     "wifi": {
       "title": "Set up Wi-Fi credentials",
       "intro": "Your devices use these to join your network. They're stored once in secrets.yaml and shared across every config you create.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -69,7 +69,7 @@
     "action_show_api_key": "Afficher la clé API",
     "action_download_yaml": "Télécharger le YAML",
     "action_rename": "Renommer l'hôte",
-    "action_edit_friendly_name": "Modifier le nom convivial…",
+    "action_edit_friendly_name": "Modifier le nom convivial",
     "action_clean_build": "Nettoyer les fichiers de compilation",
     "action_download_elf": "Télécharger le fichier ELF",
     "action_visit_web_ui": "Ouvrir l'interface web",
@@ -658,7 +658,7 @@
     "save_and_leave": "Enregistrer"
   },
   "onboarding": {
-    "menu_item_setup_wifi": "Configurer le Wi-Fi…",
+    "menu_item_setup_wifi": "Configurer le Wi-Fi",
     "wifi": {
       "title": "Configurer les identifiants Wi-Fi",
       "intro": "Vos appareils s'en servent pour rejoindre le réseau. Ils sont enregistrés une seule fois dans secrets.yaml et partagés entre toutes vos configurations.",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -102,8 +102,8 @@
     "action_show_api_key": "API-kulcs megjelenítése",
     "action_download_yaml": "YAML letöltése",
     "action_rename": "Hosztnév átnevezése",
-    "action_clone": "Duplikálás…",
-    "action_edit_friendly_name": "Megjelenítési név szerkesztése…",
+    "action_clone": "Duplikálás",
+    "action_edit_friendly_name": "Megjelenítési név szerkesztése",
     "action_clean_build": "Összeállító fájlok törlése",
     "action_clean_build_busy": "Várd meg az aktuális összeállítás befejezését a törlés előtt",
     "action_download_elf": "ELF fájl letöltése",
@@ -699,7 +699,7 @@
     "device_name_edge_hyphen": "A kötőjellel kezdődő vagy végződő nevek nem érvényes mDNS-hosztnévként – az eszköz esetleg nem oldható fel RFC-szigorú hálózatokon"
   },
   "onboarding": {
-    "menu_item_setup_wifi": "Wi-Fi beállítása…",
+    "menu_item_setup_wifi": "Wi-Fi beállítása",
     "wifi": {
       "title": "Wi-Fi hitelesítő adatok beállítása",
       "intro": "Az eszközei ezeket használják a hálózathoz való csatlakozáshoz. Egyszer tárolódnak a secrets.yaml fájlban, és minden létrehozott konfiguráció megosztja őket.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -69,7 +69,7 @@
     "action_show_api_key": "API-sleutel tonen",
     "action_download_yaml": "YAML downloaden",
     "action_rename": "Hostnaam hernoemen",
-    "action_edit_friendly_name": "Vriendelijke naam bewerken…",
+    "action_edit_friendly_name": "Vriendelijke naam bewerken",
     "action_clean_build": "Bouwbestanden opschonen",
     "action_download_elf": "ELF-bestand downloaden",
     "action_visit_web_ui": "Webinterface openen",
@@ -658,7 +658,7 @@
     "save_and_leave": "Opslaan"
   },
   "onboarding": {
-    "menu_item_setup_wifi": "Wi-Fi instellen…",
+    "menu_item_setup_wifi": "Wi-Fi instellen",
     "wifi": {
       "title": "Wi-Fi-inloggegevens instellen",
       "intro": "Uw apparaten gebruiken deze om verbinding te maken met uw netwerk. Ze worden één keer opgeslagen in secrets.yaml en gedeeld door elke configuratie die u maakt.",


### PR DESCRIPTION
# What does this implement/fix?

The `…` menu-item suffix is a macOS/Windows-era convention indicating "this opens a dialog needing more input." Modern web dashboards (including Home Assistant itself) have largely dropped it. In our menu it was applied unevenly — `Duplicate…` / `Edit friendly name…` had it, while `Rename hostname` / `Install` / `Archive` etc. did not — which is what the bug report flags.

Going the other direction: strip the `…` from the menu items that had it so every entry reads the same. Progress / placeholder ellipses (`Installing…`, `Search devices…`) are untouched — those signal an ongoing state, not a menu action.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/927

## Changes

- `action_clone`, `action_edit_friendly_name` (device row menu) — drop trailing `…`
- `menu_item_setup_wifi` (header dropdown) — drop trailing `…`
- Applied to `en.json`, `fr.json`, `nl.json`, `hu.json` (where the keys exist).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`