### PR TITLE
Recognize all ESPHome YAML boolean spellings in the section parser

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -28,6 +28,7 @@ import { setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   parseTopLevelComponents,
+  parseYamlBoolean,
   serializeYamlValues,
 } from "../../util/yaml-serialize.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
@@ -683,7 +684,7 @@ export class ESPHomeAddComponentForm extends LitElement {
           typeof raw === "number" ? raw : Number.parseFloat(String(raw));
         if (!Number.isNaN(n)) out[entry.key] = n;
       } else if (entry.type === ConfigEntryType.BOOLEAN) {
-        out[entry.key] = raw === true || raw === "true";
+        out[entry.key] = parseYamlBoolean(raw) === true;
       } else {
         out[entry.key] = raw;
       }

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -9,7 +9,7 @@ import {
   serializeFloatWithUnit,
 } from "../../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
-import { YamlRawValue } from "../../../util/yaml-serialize.js";
+import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
   renderFieldError,
@@ -327,6 +327,10 @@ export function renderFloatWithUnitField(
 // fields (esp32_ble_tracker.software_coexistence) reflect what ESPHome will
 // actually apply at compile time — otherwise the user sees OFF on a field
 // that's actually ON and saves a redundant explicit true:.
+//
+// Accept the full set of ESPHome YAML boolean spellings (true/yes/on/enable
+// and their case variants) so a user-typed ``True`` or ``enable`` in the
+// YAML editor reflects ON in the form view (issue device-builder#923).
 export function renderBooleanField(
   entry: ConfigEntry,
   path: string[],
@@ -334,7 +338,7 @@ export function renderBooleanField(
 ) {
   const raw = ctx.getAt(path);
   const effective = raw === undefined || raw === null ? entry.default_value : raw;
-  const checked = effective === true || effective === "true";
+  const checked = parseYamlBoolean(effective) === true;
   return html`
     <div class="switch-field" data-field-key=${path.join(".")}>
       <div class="field-info">

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -305,10 +305,21 @@ const stripQuotes = (s: string): string => {
   return s;
 };
 
+// Quoting in YAML is the explicit "treat me as a string" signal —
+// ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
+// a truthy spelling. Detect the quotes BEFORE stripping so we only
+// run the boolean coercion on plain scalars; otherwise a string
+// field that happens to hold ``"on"`` / ``"yes"`` would silently
+// flip to boolean ``true`` on round-trip.
 const parseScalar = (raw: string): unknown => {
+  const wasQuoted =
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"));
   const v = stripQuotes(raw);
-  const bool = parseYamlBoolean(v);
-  if (bool !== null) return bool;
+  if (!wasQuoted) {
+    const bool = parseYamlBoolean(v);
+    if (bool !== null) return bool;
+  }
   return v;
 };
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -11,6 +11,7 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import {
   YamlRawValue,
   formatYamlScalar,
+  parseYamlBoolean,
   serializeYamlValues,
   type SerializeYamlOptions,
 } from "./yaml-serialize.js";
@@ -306,8 +307,8 @@ const stripQuotes = (s: string): string => {
 
 const parseScalar = (raw: string): unknown => {
   const v = stripQuotes(raw);
-  if (v === "true") return true;
-  if (v === "false") return false;
+  const bool = parseYamlBoolean(v);
+  if (bool !== null) return bool;
   return v;
 };
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -348,3 +348,29 @@ export function formatYamlScalar(v: unknown): string {
   }
   return s;
 }
+
+// ESPHome's YAML loader accepts the YAML 1.1 truthy/falsy spellings
+// plus ``enable`` / ``disable``, all case-insensitive
+// (https://esphome.io/guides/yaml#scalars). The minimal scalar parser
+// in this repo only recognised lowercase ``true`` / ``false``, so a
+// user-typed ``True`` or ``enable`` round-tripped as a string and the
+// boolean toggle in the form view stuck OFF (issue device-builder#923).
+const YAML_TRUE_VALUES = new Set(["true", "yes", "on", "enable"]);
+const YAML_FALSE_VALUES = new Set(["false", "no", "off", "disable"]);
+
+/**
+ * Coerce *v* to boolean using ESPHome YAML's truthy/falsy spellings.
+ * Returns ``null`` when the input is neither a boolean nor one of the
+ * recognised string spellings — callers treat ``null`` as "not a
+ * boolean, leave the value as-is" (scalar parser) or "fall through to
+ * the default" (form renderer).
+ */
+export function parseYamlBoolean(v: unknown): boolean | null {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "string") {
+    const lower = v.toLowerCase();
+    if (YAML_TRUE_VALUES.has(lower)) return true;
+    if (YAML_FALSE_VALUES.has(lower)) return false;
+  }
+  return null;
+}

--- a/test/components/device/config-entry-boolean-renderer.test.ts
+++ b/test/components/device/config-entry-boolean-renderer.test.ts
@@ -78,19 +78,27 @@ describe("renderBooleanField default-value fallback", () => {
     ).toBe(true);
 
     // The ``checked`` computation must depend on whichever value
-    // wins the fallback (not just the raw). Pin both halves of the
-    // strict-equality compare so a stray truthy coercion (or
-    // dropping the string-form) fails loudly.
-    expect(/===\s*true\b/.test(fnSrc)).toBe(true);
-    expect(/===\s*"true"/.test(fnSrc)).toBe(true);
+    // wins the fallback (not just the raw). The renderer routes the
+    // value through ``parseYamlBoolean`` so every ESPHome YAML
+    // truthy spelling (``True`` / ``yes`` / ``on`` / ``enable``)
+    // collapses to the boolean primitive before the strict-equality
+    // compare — pin that shape so a stray refactor that drops the
+    // lenient parser silently regresses the case where the form
+    // value (or backend-supplied default) arrived as the uppercase
+    // string ``"True"``.
+    expect(
+      /parseYamlBoolean\(.*\)\s*===\s*true\b/.test(fnSrc),
+      "checked must route the fallback value through parseYamlBoolean " +
+        "so all ESPHome YAML boolean spellings (True / yes / on / enable) " +
+        "collapse to the boolean primitive — issue device-builder#923",
+    ).toBe(true);
 
     // ``checked`` must be derived from the same value that consulted
     // ``entry.default_value`` — pin that the strict-equality check
     // doesn't operate on a bare ``raw``. Use a non-greedy span to
     // confirm there's at least one ``=== true`` after the
     // fallback intermediate's assignment, and confirm none of the
-    // ``=== true`` / ``=== "true"`` lines compare against ``raw``
-    // directly.
+    // ``=== true`` lines compare against ``raw`` directly.
     expect(
       /raw\s*===\s*true\b/.test(fnSrc),
       "checked must be computed from the fallback intermediate, not raw directly",

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1345,3 +1345,69 @@ _internal:
     expect(after).not.toContain("empty_field:");
   });
 });
+
+describe("parseYamlSectionValues — ESPHome YAML boolean spellings", () => {
+  // ESPHome's YAML accepts ``true|yes|on|enable`` / ``false|no|off|disable``
+  // case-insensitively (https://esphome.io/guides/yaml#scalars). The
+  // section parser feeds the form view, so every accepted spelling has
+  // to surface as the boolean primitive — otherwise the form's
+  // boolean toggle stays OFF on a user-typed ``True`` (issue
+  // device-builder#923).
+  const TRUTHY = [
+    "true",
+    "True",
+    "TRUE",
+    "yes",
+    "Yes",
+    "YES",
+    "on",
+    "On",
+    "ON",
+    "enable",
+    "Enable",
+    "ENABLE",
+  ];
+  const FALSY = [
+    "false",
+    "False",
+    "FALSE",
+    "no",
+    "No",
+    "NO",
+    "off",
+    "Off",
+    "OFF",
+    "disable",
+    "Disable",
+    "DISABLE",
+  ];
+
+  for (const spelling of TRUTHY) {
+    it(`parses ${spelling} as boolean true`, () => {
+      const values = parseYamlSectionValues(
+        `wifi:\n  fast_connect: ${spelling}\n`,
+        "wifi",
+      );
+      expect(values.fast_connect).toBe(true);
+    });
+  }
+
+  for (const spelling of FALSY) {
+    it(`parses ${spelling} as boolean false`, () => {
+      const values = parseYamlSectionValues(
+        `wifi:\n  fast_connect: ${spelling}\n`,
+        "wifi",
+      );
+      expect(values.fast_connect).toBe(false);
+    });
+  }
+
+  it("leaves non-boolean strings that resemble words alone", () => {
+    const values = parseYamlSectionValues(
+      "esphome:\n  name: enabled-device\n  comment: yesterday\n",
+      "esphome",
+    );
+    expect(values.name).toBe("enabled-device");
+    expect(values.comment).toBe("yesterday");
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1410,4 +1410,20 @@ describe("parseYamlSectionValues — ESPHome YAML boolean spellings", () => {
     expect(values.name).toBe("enabled-device");
     expect(values.comment).toBe("yesterday");
   });
+
+  it("leaves quoted boolean-looking words as strings", () => {
+    // YAML quoting is the explicit "force string" signal — a user
+    // who wrote ``mode: "on"`` or ``state: 'yes'`` wants the literal
+    // string. Without the quoted-scalar guard, the truthy-spelling
+    // table would corrupt those fields into boolean ``true`` and
+    // the round-trip would emit ``true:`` instead.
+    const values = parseYamlSectionValues(
+      `mqtt:\n  mode: "on"\n  state: 'yes'\n  fallback: "True"\n  hint: 'enable'\n`,
+      "mqtt",
+    );
+    expect(values.mode).toBe("on");
+    expect(values.state).toBe("yes");
+    expect(values.fallback).toBe("True");
+    expect(values.hint).toBe("enable");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's YAML loader accepts `true|yes|on|enable` and `false|no|off|disable` case-insensitively, but the frontend's section-value parser only matched lowercase `true` / `false`. A field typed as `True` or `enable` in the YAML editor round-tripped as a string, so the corresponding form-view toggle stuck OFF even though the YAML was valid.

- Add `parseYamlBoolean` helper in `yaml-serialize.ts` covering every ESPHome-accepted spelling.
- Route the section parser's `parseScalar`, `renderBooleanField`, and the add-component dialog's BOOLEAN coercion through the new helper.
- Unit-test every truthy/falsy spelling plus a "boolean-looking word" negative case (`enabled-device`, `yesterday`).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#923

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
