### PR TITLE
Parse hex-int form fields with BigInt to preserve 64-bit precision

### DIFF
--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry } from "../api/types.js";
 import { ConfigEntryType } from "../api/types.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
+import { parseHexInt } from "./hex-int.js";
 import { asMappingList, asRecord } from "./nested-values.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
@@ -29,7 +30,7 @@ export function isEntryVisible(
   entry: ConfigEntry,
   values: Record<string, unknown>,
   presentComponents?: Set<string>,
-  targetPlatform?: string | null,
+  targetPlatform?: string | null
 ): boolean {
   if (entry.hidden) return false;
 
@@ -114,10 +115,7 @@ export function getDeviceNameWarning(name: string): ValidationError | null {
   return null;
 }
 
-export function validateEntry(
-  entry: ConfigEntry,
-  raw: unknown,
-): ValidationError | null {
+export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError | null {
   if (entry.hidden) return null;
 
   const isEmpty =
@@ -131,7 +129,36 @@ export function validateEntry(
   }
   if (isEmpty) return null;
 
-  if (entry.type === ConfigEntryType.INTEGER || entry.type === ConfigEntryType.FLOAT) {
+  if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {
+    // BigInt-route the hex-typed integer check so cv.hex_uint64_t
+    // range bounds stay honest (#944 follow-up). ``Number(String(raw))``
+    // would round any value above 2^53 before the comparison, and the
+    // catalog's max for uint64 (2^64 - 1) is already imprecise after
+    // JSON.parse — comparing a precise input against an imprecise
+    // bound is wrong. ``parseHexInt`` accepts the canonical strings
+    // the renderer emits and any non-negative decimal a fixture / test
+    // might pass; numbers / bigints stringify through the same path.
+    const canonical = parseHexInt(String(raw));
+    if (canonical === null) {
+      return { key: entry.key, code: "validation.not_a_number" };
+    }
+    if (entry.range) {
+      const n = BigInt(canonical);
+      const [min, max] = entry.range;
+      // ``Math.floor`` / ``Math.ceil`` widen the bounds at sub-integer
+      // edges in the lenient direction; the backend's cv.hex_int
+      // validator is the source of truth either way.
+      if (n < BigInt(Math.floor(min))) {
+        return { key: entry.key, code: "validation.min", params: { min } };
+      }
+      if (n > BigInt(Math.ceil(max))) {
+        return { key: entry.key, code: "validation.max", params: { max } };
+      }
+    }
+  } else if (
+    entry.type === ConfigEntryType.INTEGER ||
+    entry.type === ConfigEntryType.FLOAT
+  ) {
     const num = typeof raw === "number" ? raw : Number(String(raw));
     if (Number.isNaN(num)) {
       return { key: entry.key, code: "validation.not_a_number" };
@@ -190,7 +217,7 @@ export function validateEntries(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   presentComponents?: Set<string>,
-  targetPlatform?: string | null,
+  targetPlatform?: string | null
 ): Map<string, ValidationError> {
   const errors = new Map<string, ValidationError>();
   _validateEntriesRecursive(
@@ -199,7 +226,7 @@ export function validateEntries(
     presentComponents,
     targetPlatform,
     [],
-    errors,
+    errors
   );
   return errors;
 }
@@ -216,7 +243,7 @@ function _validateEntriesRecursive(
   presentComponents: Set<string> | undefined,
   targetPlatform: string | null | undefined,
   pathPrefix: string[],
-  errors: Map<string, ValidationError>,
+  errors: Map<string, ValidationError>
 ): void {
   for (const entry of entries) {
     // Skip hidden entries and those whose visibility predicates fail —
@@ -259,7 +286,7 @@ function _validateEntriesRecursive(
             presentComponents,
             targetPlatform,
             [...pathPrefix, entry.key, String(idx)],
-            errors,
+            errors
           );
         });
         continue;
@@ -282,7 +309,7 @@ function _validateEntriesRecursive(
         presentComponents,
         targetPlatform,
         [...pathPrefix, entry.key],
-        errors,
+        errors
       );
       continue;
     }
@@ -317,7 +344,7 @@ function _validateEntriesRecursive(
     // surface as ``validation.required`` even though the catalog
     // pre-supplies a valid value.
     const raw = entry.required
-      ? values[entry.key] ?? entry.default_value
+      ? (values[entry.key] ?? entry.default_value)
       : values[entry.key];
     const err = validateEntry(entry, raw);
     if (err) {

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -231,9 +231,14 @@ export function formatHexInt(value: unknown): string {
     return parseHexInt(value) ?? "";
   }
   if (typeof value === "number") {
-    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
-      return "";
-    }
+    // ``Number.isSafeInteger`` rejects NaN, +/-Infinity, fractional
+    // values, and anything above 2^53 in one shot. The upper bound
+    // matters: a caller that hands us 0xbe030c9794184728 as a JS
+    // Number has already lost precision before we see it; stringifying
+    // the rounded double would silently reintroduce the #944 bug.
+    // Bigint / canonical-string callers stay on their precision-safe
+    // branches above.
+    if (!Number.isSafeInteger(value) || value < 0) return "";
     return "0x" + value.toString(16);
   }
   if (typeof value === "bigint") {

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -95,16 +95,19 @@ export function parseHexInt(raw: string): string | null {
 }
 
 /**
- * Walk a values dict and rewrite numeric values whose corresponding
- * config entry has ``display_format === "hex"`` to their canonical
- * ``"0x..."`` string form.
+ * Walk a values dict and rewrite every hex-typed entry's value to
+ * its canonical lowercase ``"0x..."`` string form. Numeric (number
+ * or bigint) values stringify through ``formatHexInt``; string
+ * values (including uppercase, leading-zero, and decimal-typed-as-
+ * string shapes) round-trip through ``parseHexInt``; already-
+ * canonical strings short-circuit without allocating a copy.
  *
- * Why: YAML's hex literal grammar (`address: 0x76`) parses to a
- * plain integer (118) on the way in, so by the time the form
- * receives a values dict the hex notation is gone. Without this
- * normalisation, a user who edits an unrelated field in the same
- * section and clicks Save sees their hex address flip to decimal
- * (`address: 118`) on disk — the YAML serializer emits numbers
+ * Why: the form's values dict carries heterogeneous types
+ * (``parseYamlSectionValues`` hands hex literals back as raw
+ * strings; ``add-component`` paths can produce numbers / bigints).
+ * Without this pass, a user who edits an unrelated field in the
+ * same section and clicks Save sees their hex address flip shape
+ * on disk — the YAML serializer emits whatever's in the dict
  * verbatim, with no schema knowledge to reach for the hex form.
  *
  * Pre-formatting once at parse time means every save preserves the

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -10,18 +10,21 @@
  * Two-way conversion shape:
  *
  * - **YAML → form display**: any integer (`118`, `0x76`, `"0x76"`)
- *   resolves to a single number. We render it as
+ *   resolves to a canonical hex string. We render it as
  *   `formatHexInt(value)` → `"0x76"` (lowercase, no padding —
  *   `value.toString(16)`-style; ESPHome's own `cv.hex_int`
  *   formatter uses uppercase, but the dashboard standardised on
  *   lowercase for user-facing display since that's what HA docs
  *   and most i2c datasheets use).
  * - **Form input → emit**: `parseHexInt("0x76" | "0X76" | "118")`
- *   → number. Both hex (with explicit `0x` prefix) and decimal
- *   input are accepted; the user can type whichever is most
- *   natural for the value at hand. Empty string → `null` (so
- *   optional entries get stripped from the payload by the form's
- *   coerce pass).
+ *   → canonical `"0x..."` string. Both hex (with explicit `0x`
+ *   prefix) and decimal input are accepted; the user can type
+ *   whichever is most natural for the value at hand. Parsing is
+ *   `BigInt`-backed, so 64-bit values like a DS18B20 ROM
+ *   (`0xbe030c9794184728`, range up to `2^64 - 1` per the catalog)
+ *   round-trip without IEEE-754 precision loss (#944). Empty
+ *   string → `null` (so optional entries get stripped from the
+ *   payload by the form's coerce pass).
  *
  * Round-trip preservation: when the YAML had `address: 0x76`, the
  * form shows `0x76` and the user can save without forcing the
@@ -36,47 +39,57 @@
  */
 
 /**
- * Parse user-typed input into an integer.
+ * Parse user-typed input into a canonical lowercase ``"0x..."``
+ * hex string.
  *
  * Accepts:
  *  - hex with `0x` / `0X` prefix (`"0x76"`, `"0X1A"`);
- *  - decimal (`"118"`, `"-1"`);
+ *  - non-negative decimal (`"118"`);
  *  - leading/trailing whitespace around either form.
  *
- * Returns `null` for empty input or any value that doesn't parse
- * as a finite integer. The caller decides whether to clear the
- * field, surface a validation error, etc.
+ * Returns `null` for empty input, negative numbers, or any value
+ * that doesn't parse as a non-negative integer. The caller
+ * decides whether to clear the field, surface a validation
+ * error, etc.
+ *
+ * Backed by `BigInt`, not `Number`, so 64-bit values like a
+ * DS18B20 ROM (`0xbe030c9794184728`) and the catalog's full
+ * `cv.hex_uint64_t` range (up to `2^64 - 1`) survive the
+ * round-trip. `Number.parseInt(s, 16)` rounded to the nearest
+ * representable double for any hex over 2^53, silently mutating
+ * the user's value on save (#944).
  *
  * **Bare hex without `0x` is intentionally rejected.** The i2c
  * address `76` would otherwise be ambiguous — could be the user
  * typing decimal 76 (intending `0x4C`) or "0x76 with the prefix
  * dropped" (intending `0x76` = 118). YAML and ESPHome both treat
  * unprefixed input as decimal, so we follow that: typing `76`
- * saves as `address: 76` (decimal), typing `0x76` saves as
- * `address: 0x76`. Bare hex letters (`"abc"`, `"ff"`) hit
- * neither regex and return `null`.
+ * saves as `address: 0x4c` (decimal canonicalised to hex),
+ * typing `0x76` saves as `address: 0x76`. Bare hex letters
+ * (`"abc"`, `"ff"`) hit neither regex and return `null`.
  */
-export function parseHexInt(raw: string): number | null {
+export function parseHexInt(raw: string): string | null {
   const trimmed = raw.trim();
   if (trimmed === "") return null;
-  // Strict regex gate. ``Number.parseInt`` happily eats trailing
-  // junk (``parseInt("0x76xyz") === 118``), which would silently
-  // swallow user typos. The two regexes accept only:
+  // Strict regex gate. ``BigInt`` is more permissive than we want
+  // (``BigInt("")`` is ``0n``); the two regexes accept only:
   //   - ``0x`` / ``0X`` prefix followed by one or more hex digits;
-  //   - an optional leading ``-`` and one or more decimal digits.
-  // Everything else — internal whitespace, ``+`` sign, exponents
-  // (``1e3``), fractional (``3.14``), trailing characters,
-  // unprefixed hex letters — falls through to ``return null``.
-  let value: number;
+  //   - one or more decimal digits (negatives intentionally
+  //     rejected — uint64 only for the address fields this
+  //     targets).
+  // Everything else — internal whitespace, ``+`` / ``-`` sign,
+  // exponents (``1e3``), fractional (``3.14``), trailing
+  // characters, unprefixed hex letters — falls through to
+  // ``return null``.
+  let n: bigint;
   if (/^0[xX][0-9a-fA-F]+$/.test(trimmed)) {
-    value = Number.parseInt(trimmed.slice(2), 16);
-  } else if (/^-?\d+$/.test(trimmed)) {
-    value = Number.parseInt(trimmed, 10);
+    n = BigInt(trimmed);
+  } else if (/^\d+$/.test(trimmed)) {
+    n = BigInt(trimmed);
   } else {
     return null;
   }
-  if (!Number.isFinite(value)) return null;
-  return value;
+  return "0x" + n.toString(16);
 }
 
 /**
@@ -127,14 +140,33 @@ import type { ConfigEntry } from "../api/types.js";
 
 export function normalizeHexValues(
   values: Record<string, unknown>,
-  entries: ConfigEntry[],
+  entries: ConfigEntry[]
 ): Record<string, unknown> {
   let out: Record<string, unknown> | null = null;
   for (const entry of entries) {
     if (entry.display_format !== "hex") continue;
     const v = values[entry.key];
-    if (typeof v !== "number") continue;
-    const formatted = formatHexInt(v);
+    let formatted: string;
+    if (typeof v === "number" || typeof v === "bigint") {
+      formatted = formatHexInt(v);
+    } else if (typeof v === "string") {
+      // Already-canonical lowercase ``"0x..."``: nothing to rewrite,
+      // and the identity-return shortcut for non-hex sections
+      // depends on us not allocating a copy here.
+      if (/^0x[0-9a-f]+$/.test(v)) continue;
+      // The `parseYamlSectionValues` parser hands hex literals back
+      // as strings (`parseScalar` only special-cases true/false), so
+      // this is the live path for fresh YAML loads. Canonicalising
+      // here is what makes `address: 0xBE030C9794184728` (uppercase)
+      // round-trip losslessly through the visual editor — without
+      // it the renderer's `formatHexInt` re-parses every render and
+      // the values dict drifts from on-disk on the next save.
+      const parsed = parseHexInt(v);
+      if (parsed === null) continue;
+      formatted = parsed;
+    } else {
+      continue;
+    }
     // ``formatHexInt`` returns ``""`` for non-finite / negative /
     // non-integer numbers — leave those alone so the form's
     // existing validation can flag them, no copy needed.
@@ -148,7 +180,7 @@ export function normalizeHexValues(
       // null-proto defence, ``Object.prototype`` for fixtures.
       out = Object.create(
         Object.getPrototypeOf(values),
-        Object.getOwnPropertyDescriptors(values),
+        Object.getOwnPropertyDescriptors(values)
       );
     }
     out![entry.key] = formatted;
@@ -174,29 +206,37 @@ export function normalizeHexValues(
  * casing only matters in the dashboard's user-facing display.
  *
  * Accepts `unknown` so callers can pass straight from the form
- * value bag without retyping. The parser only handles
- * non-negative finite integers (passed numerically) or strings
- * (which round-trip through `parseHexInt`); every other shape
- * — `null`, `undefined`, `""`, `NaN`, `3.14`, `-1`, `true`,
- * objects, arrays — returns `""` so the form field clears
- * rather than showing `0xNaN` / a fractional value the YAML
- * parser would reject.
+ * value bag without retyping. Already-canonical hex strings
+ * (`"0x..."`, lowercase) pass through identity-equal — that's
+ * the hot path for values that came out of `parseHexInt` /
+ * `normalizeHexValues` and avoids re-parsing 64-bit hex on every
+ * render (#944). Numbers / bigints / non-canonical strings flow
+ * through the parse path; every other shape — `null`, `undefined`,
+ * `""`, `NaN`, `3.14`, `-1`, `true`, objects, arrays — returns
+ * `""` so the form field clears rather than showing `0xNaN` / a
+ * fractional value the YAML parser would reject.
  *
  * Negative numbers — not meaningful for the i2c-address /
  * register-address fields this targets — also clear.
  */
 export function formatHexInt(value: unknown): string {
   if (value === null || value === undefined || value === "") return "";
-  let n: number | null;
+  if (typeof value === "string") {
+    // Hot path: a canonical lowercase hex string from the parser
+    // (or a prior `formatHexInt` call) flows through verbatim,
+    // sidestepping `BigInt` allocation on every keystroke.
+    if (/^0x[0-9a-f]+$/.test(value)) return value;
+    return parseHexInt(value) ?? "";
+  }
   if (typeof value === "number") {
-    n = value;
-  } else if (typeof value === "string") {
-    n = parseHexInt(value);
-  } else {
-    return "";
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+      return "";
+    }
+    return "0x" + value.toString(16);
   }
-  if (n === null || !Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
-    return "";
+  if (typeof value === "bigint") {
+    if (value < 0n) return "";
+    return "0x" + value.toString(16);
   }
-  return "0x" + n.toString(16);
+  return "";
 }

--- a/src/util/hex-int.ts
+++ b/src/util/hex-int.ts
@@ -68,28 +68,30 @@
  * typing `0x76` saves as `address: 0x76`. Bare hex letters
  * (`"abc"`, `"ff"`) hit neither regex and return `null`.
  */
+// ``BigInt`` is more permissive than we want (``BigInt("")`` is
+// ``0n``, ``BigInt(" 1 ")`` is ``1n``); this regex gate accepts
+// only the two forms we route through it:
+//   - ``0x`` / ``0X`` prefix followed by one or more hex digits;
+//   - one or more decimal digits (negatives intentionally
+//     rejected — uint64 only for the address fields this targets).
+// Everything else — internal whitespace, ``+`` / ``-`` sign,
+// exponents (``1e3``), fractional (``3.14``), trailing characters,
+// unprefixed hex letters — falls through to ``return null``.
+const ACCEPTED_INPUT_RE = /^(?:0[xX][0-9a-fA-F]+|\d+)$/;
+
+// What ``parseHexInt`` / ``formatHexInt`` emit — minimum-width
+// lowercase ``"0x..."``. Tighter than the input regex on purpose:
+// ``"0x076"`` is rejected here so the canonical-form fast path in
+// ``formatHexInt`` / ``normalizeHexValues`` agrees bit-for-bit
+// with what the BigInt slow path would produce (which strips the
+// leading zero). Without this tightening the two paths return
+// different strings for the same input.
+const CANONICAL_HEX_RE = /^0x(?:[1-9a-f][0-9a-f]*|0)$/;
+
 export function parseHexInt(raw: string): string | null {
   const trimmed = raw.trim();
-  if (trimmed === "") return null;
-  // Strict regex gate. ``BigInt`` is more permissive than we want
-  // (``BigInt("")`` is ``0n``); the two regexes accept only:
-  //   - ``0x`` / ``0X`` prefix followed by one or more hex digits;
-  //   - one or more decimal digits (negatives intentionally
-  //     rejected — uint64 only for the address fields this
-  //     targets).
-  // Everything else — internal whitespace, ``+`` / ``-`` sign,
-  // exponents (``1e3``), fractional (``3.14``), trailing
-  // characters, unprefixed hex letters — falls through to
-  // ``return null``.
-  let n: bigint;
-  if (/^0[xX][0-9a-fA-F]+$/.test(trimmed)) {
-    n = BigInt(trimmed);
-  } else if (/^\d+$/.test(trimmed)) {
-    n = BigInt(trimmed);
-  } else {
-    return null;
-  }
-  return "0x" + n.toString(16);
+  if (!ACCEPTED_INPUT_RE.test(trimmed)) return null;
+  return "0x" + BigInt(trimmed).toString(16);
 }
 
 /**
@@ -153,7 +155,7 @@ export function normalizeHexValues(
       // Already-canonical lowercase ``"0x..."``: nothing to rewrite,
       // and the identity-return shortcut for non-hex sections
       // depends on us not allocating a copy here.
-      if (/^0x[0-9a-f]+$/.test(v)) continue;
+      if (CANONICAL_HEX_RE.test(v)) continue;
       // The `parseYamlSectionValues` parser hands hex literals back
       // as strings (`parseScalar` only special-cases true/false), so
       // this is the live path for fresh YAML loads. Canonicalising
@@ -225,7 +227,7 @@ export function formatHexInt(value: unknown): string {
     // Hot path: a canonical lowercase hex string from the parser
     // (or a prior `formatHexInt` call) flows through verbatim,
     // sidestepping `BigInt` allocation on every keystroke.
-    if (/^0x[0-9a-f]+$/.test(value)) return value;
+    if (CANONICAL_HEX_RE.test(value)) return value;
     return parseHexInt(value) ?? "";
   }
   if (typeof value === "number") {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -44,19 +44,15 @@ describe("validateDeviceName", () => {
 describe("getDeviceNameWarning", () => {
   it("warns about underscores (mDNS hostname concern)", () => {
     expect(getDeviceNameWarning("my_device")?.code).toBe(
-      "validation.device_name_underscore",
+      "validation.device_name_underscore"
     );
   });
 
   it("warns about leading or trailing hyphens", () => {
     /* RFC 952/1123 forbids edge hyphens in DNS labels, so they
        have the same mDNS-resolution risk as underscores. */
-    expect(getDeviceNameWarning("-foo")?.code).toBe(
-      "validation.device_name_edge_hyphen",
-    );
-    expect(getDeviceNameWarning("foo-")?.code).toBe(
-      "validation.device_name_edge_hyphen",
-    );
+    expect(getDeviceNameWarning("-foo")?.code).toBe("validation.device_name_edge_hyphen");
+    expect(getDeviceNameWarning("foo-")?.code).toBe("validation.device_name_edge_hyphen");
   });
 
   it("returns null for clean hyphenated names", () => {
@@ -94,6 +90,35 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "abc")?.code).toBe("validation.not_a_number");
   });
 
+  it("validates hex-typed INTEGER fields via BigInt (#944 range honesty)", () => {
+    // ``Number(String(raw))`` rounds 0xbe030c9794184728 to
+    // 0xbe030c9794184800 before the comparison; a precise input would
+    // pass an imprecise bound by accident. BigInt routing keeps the
+    // comparison exact at the catalog's full cv.hex_uint64_t range.
+    const entry = makeEntry({
+      type: ConfigEntryType.INTEGER,
+      display_format: "hex",
+      range: [0, 18446744073709551615],
+    });
+    expect(validateEntry(entry, "0xbe030c9794184728")).toBeNull();
+    expect(validateEntry(entry, "0xffffffffffffffff")).toBeNull();
+    expect(validateEntry(entry, "0x76")).toBeNull();
+    expect(validateEntry(entry, "abc")?.code).toBe("validation.not_a_number");
+  });
+
+  it("enforces hex range bounds when both fit safely", () => {
+    // i2c-style hex field with a tight range; pre-#944 behaviour stays
+    // intact for the small-range case.
+    const entry = makeEntry({
+      type: ConfigEntryType.INTEGER,
+      display_format: "hex",
+      range: [0x08, 0x77],
+    });
+    expect(validateEntry(entry, "0x07")?.code).toBe("validation.min");
+    expect(validateEntry(entry, "0x78")?.code).toBe("validation.max");
+    expect(validateEntry(entry, "0x76")).toBeNull();
+  });
+
   it("accepts floats on FLOAT fields", () => {
     const entry = makeEntry({ type: ConfigEntryType.FLOAT });
     expect(validateEntry(entry, 3.5)).toBeNull();
@@ -106,9 +131,7 @@ describe("validateEntry", () => {
     });
     expect(validateEntry(entry, "50kHz")).toBeNull();
     expect(validateEntry(entry, "3.3 V")?.code).toBe("validation.not_a_number");
-    expect(validateEntry(entry, "abckHz")?.code).toBe(
-      "validation.not_a_number",
-    );
+    expect(validateEntry(entry, "abckHz")?.code).toBe("validation.not_a_number");
   });
 
   it("applies range only when FLOAT_WITH_UNIT value is in canonical unit", () => {
@@ -388,8 +411,9 @@ describe("validateEntries", () => {
         default_value: null,
       }),
     ];
-    expect(validateEntries(entries, { frequency: "abc" }).get("frequency")?.code)
-      .toBe("validation.not_a_number");
+    expect(validateEntries(entries, { frequency: "abc" }).get("frequency")?.code).toBe(
+      "validation.not_a_number"
+    );
     expect(validateEntries(entries, { frequency: 100 }).size).toBe(0);
   });
 
@@ -441,14 +465,12 @@ describe("validateEntries", () => {
         supported_platforms: ["esp32"],
       }),
     ];
-    expect(
-      validateEntries(entries, {}, undefined, "esp8266").size,
-    ).toBe(0);
+    expect(validateEntries(entries, {}, undefined, "esp8266").size).toBe(0);
     // On the matching platform the gate is a no-op and the missing
     // required field is still flagged.
-    expect(
-      validateEntries(entries, {}, undefined, "esp32").get("psram")?.code,
-    ).toBe("validation.required");
+    expect(validateEntries(entries, {}, undefined, "esp32").get("psram")?.code).toBe(
+      "validation.required"
+    );
   });
 
   it("treats a null/undefined targetPlatform as 'no gate'", () => {
@@ -464,12 +486,10 @@ describe("validateEntries", () => {
         supported_platforms: ["esp32"],
       }),
     ];
-    expect(
-      validateEntries(entries, {}).get("psram")?.code,
-    ).toBe("validation.required");
-    expect(
-      validateEntries(entries, {}, undefined, null).get("psram")?.code,
-    ).toBe("validation.required");
+    expect(validateEntries(entries, {}).get("psram")?.code).toBe("validation.required");
+    expect(validateEntries(entries, {}, undefined, null).get("psram")?.code).toBe(
+      "validation.required"
+    );
   });
 
   it("recurses through NESTED groups with the platform gate", () => {
@@ -493,13 +513,9 @@ describe("validateEntries", () => {
     // group" short-circuit doesn't skip validation — we want to
     // exercise the platform gate on the leaf.
     const values = { diagnostics: { psram: undefined } };
+    expect(validateEntries(entries, values, undefined, "esp8266").size).toBe(0);
     expect(
-      validateEntries(entries, values, undefined, "esp8266").size,
-    ).toBe(0);
-    expect(
-      validateEntries(entries, values, undefined, "esp32").get(
-        "diagnostics.psram",
-      )?.code,
+      validateEntries(entries, values, undefined, "esp32").get("diagnostics.psram")?.code
     ).toBe("validation.required");
   });
 });

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -18,27 +18,44 @@ const entry = (key: string, overrides: Partial<ConfigEntry> = {}): ConfigEntry =
   makeConfigEntry({ key, type: ConfigEntryType.INTEGER, label: key, ...overrides });
 
 describe("parseHexInt", () => {
-  it("parses 0x-prefixed lowercase hex", () => {
-    expect(parseHexInt("0x76")).toBe(0x76);
-    expect(parseHexInt("0xff")).toBe(255);
+  it("parses 0x-prefixed lowercase hex to canonical 0x-string", () => {
+    expect(parseHexInt("0x76")).toBe("0x76");
+    expect(parseHexInt("0xff")).toBe("0xff");
   });
 
-  it("parses 0X-prefixed uppercase hex", () => {
+  it("lowercases 0X-prefixed uppercase hex", () => {
     // ESPHome's cv.hex_int lowercases before parsing, but the user
-    // can type either case in the form.
-    expect(parseHexInt("0X1A")).toBe(0x1a);
+    // can type either case in the form. We standardised on lowercase
+    // for display.
+    expect(parseHexInt("0X1A")).toBe("0x1a");
   });
 
-  it("parses bare decimal", () => {
+  it("canonicalises bare decimal to its hex form", () => {
     // Hardware datasheets sometimes list the address as a decimal
-    // (``119`` for the BME280); accept that too.
-    expect(parseHexInt("118")).toBe(118);
-    expect(parseHexInt("0")).toBe(0);
+    // (``119`` for the BME280); accept that and rewrite to the
+    // hex-typed field's canonical shape so the on-disk YAML matches
+    // the catalog's display_format intent.
+    expect(parseHexInt("118")).toBe("0x76");
+    expect(parseHexInt("0")).toBe("0x0");
+  });
+
+  it("preserves precision for 64-bit hex (DS18B20 ROM, #944)", () => {
+    // ``Number.parseInt("0xbe030c9794184728", 16)`` rounds to
+    // 0xbe030c9794184800 because the value exceeds 2^53. The
+    // BigInt-backed parser must round-trip the exact bits.
+    expect(parseHexInt("0xbe030c9794184728")).toBe("0xbe030c9794184728");
+    expect(parseHexInt("0xBE030C9794184728")).toBe("0xbe030c9794184728");
+  });
+
+  it("round-trips uint64 max (cv.hex_uint64_t range)", () => {
+    // Catalog declares dallas_temp.address range up to 2^64 − 1.
+    expect(parseHexInt("0xffffffffffffffff")).toBe("0xffffffffffffffff");
+    expect(parseHexInt("18446744073709551615")).toBe("0xffffffffffffffff");
   });
 
   it("trims surrounding whitespace", () => {
-    expect(parseHexInt("  0x76 ")).toBe(0x76);
-    expect(parseHexInt("\t118\n")).toBe(118);
+    expect(parseHexInt("  0x76 ")).toBe("0x76");
+    expect(parseHexInt("\t118\n")).toBe("0x76");
   });
 
   it("returns null for empty / whitespace-only input", () => {
@@ -50,16 +67,14 @@ describe("parseHexInt", () => {
   });
 
   it("rejects 0x with no digits", () => {
-    // ``parseInt("", 16) === NaN`` would silently coerce; the
-    // explicit regex gate avoids that.
+    // ``BigInt("0x")`` throws; the explicit regex gate filters
+    // this before the constructor.
     expect(parseHexInt("0x")).toBeNull();
   });
 
   it("rejects mixed garbage and trailing-junk hex", () => {
-    // ``Number.parseInt`` happily eats trailing junk
-    // (``parseInt("0x76xyz", 16) === 118``); the strict regex
-    // gate keeps typos surfacing as "invalid" instead of being
-    // silently swallowed.
+    // The strict regex gate keeps typos surfacing as "invalid"
+    // instead of being silently swallowed.
     expect(parseHexInt("0x76xyz")).toBeNull();
     expect(parseHexInt("76abc")).toBeNull();
     expect(parseHexInt("not a number")).toBeNull();
@@ -74,11 +89,13 @@ describe("parseHexInt", () => {
     expect(parseHexInt("ff")).toBeNull();
   });
 
-  it("accepts negative decimal", () => {
-    // Negatives aren't meaningful for the address fields this
-    // targets, but the parser stays general — ``formatHexInt``
-    // is the one that filters non-representable inputs out.
-    expect(parseHexInt("-1")).toBe(-1);
+  it("rejects negatives at parse time", () => {
+    // Negatives aren't meaningful for the uint64 address / register
+    // fields this targets. Rejecting at the parser keeps the
+    // renderer's ``formatHexInt(parseHexInt(raw)) || raw`` chain
+    // falling through to the raw string so the inline validator can
+    // flag it, identical to today's end-user behaviour.
+    expect(parseHexInt("-1")).toBeNull();
   });
 });
 
@@ -93,6 +110,22 @@ describe("formatHexInt", () => {
     expect(formatHexInt("0x76")).toBe("0x76");
     expect(formatHexInt("118")).toBe("0x76");
     expect(formatHexInt("0X1A")).toBe("0x1a");
+  });
+
+  it("passes canonical 0x-strings through losslessly (64-bit, #944)", () => {
+    // Hot path: a value that already came out of ``parseHexInt`` or
+    // ``normalizeHexValues`` skips the BigInt round-trip and the
+    // canonical regex shortcut returns the exact bits. Pinning the
+    // 64-bit case keeps the renderer's per-keystroke render from
+    // regressing into the lossy Number.parseInt path.
+    expect(formatHexInt("0xbe030c9794184728")).toBe("0xbe030c9794184728");
+    expect(formatHexInt("0xffffffffffffffff")).toBe("0xffffffffffffffff");
+  });
+
+  it("formats bigint inputs as 0x-prefixed lowercase hex", () => {
+    expect(formatHexInt(0x76n)).toBe("0x76");
+    expect(formatHexInt(0xbe030c9794184728n)).toBe("0xbe030c9794184728");
+    expect(formatHexInt(-1n)).toBe("");
   });
 
   it("returns empty string for null / undefined / empty inputs", () => {
@@ -157,6 +190,44 @@ describe("normalizeHexValues", () => {
     });
   });
 
+  it("canonicalises uppercase hex strings from parseYamlSectionValues", () => {
+    // The live path post-#944: parseYamlSectionValues returns hex
+    // literals as raw strings (parseScalar only special-cases
+    // true/false). Loading needs to lowercase so the dict / on-disk
+    // / display agree on a single shape.
+    const entries = [entry("address", { display_format: "hex" })];
+    expect(normalizeHexValues({ address: "0xBE030C9794184728" }, entries)).toEqual({
+      address: "0xbe030c9794184728",
+    });
+  });
+
+  it("preserves 64-bit precision through string canonicalisation (#944)", () => {
+    // Direct pin against the bug: a DS18B20 ROM address must
+    // round-trip the exact bits, not be rounded by Number.parseInt.
+    const entries = [entry("address", { display_format: "hex" })];
+    expect(normalizeHexValues({ address: "0xbe030c9794184728" }, entries)).toEqual({
+      address: "0xbe030c9794184728",
+    });
+  });
+
+  it("rewrites bigint hex values to canonical 0x-strings", () => {
+    // The form's value bag is heterogeneous; bigints flow through
+    // the same canonicalisation pass as numbers.
+    const entries = [entry("address", { display_format: "hex" })];
+    expect(normalizeHexValues({ address: 0xbe030c9794184728n }, entries)).toEqual({
+      address: "0xbe030c9794184728",
+    });
+  });
+
+  it("leaves unparseable hex-typed strings alone for the validator", () => {
+    // ``!lambda`` / templated values / typos shouldn't be silently
+    // rewritten — the form's inline validator flags them.
+    const entries = [entry("address", { display_format: "hex" })];
+    expect(normalizeHexValues({ address: "!lambda return 1;" }, entries)).toEqual({
+      address: "!lambda return 1;",
+    });
+  });
+
   it("returns the same object reference when nothing needs rewriting", () => {
     // Cheap shortcut so a non-hex section doesn't allocate a copy
     // on every form load. ``identity-equal`` is the cue downstream
@@ -175,8 +246,8 @@ describe("normalizeHexValues", () => {
     expect(
       normalizeHexValues(
         { address: 119, id: "my_sensor", on_value: { lambda: "x" } },
-        entries,
-      ),
+        entries
+      )
     ).toEqual({
       address: "0x77",
       id: "my_sensor",

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -61,6 +61,17 @@ describe("parseHexInt", () => {
     expect(parseHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
   });
 
+  it("canonicalises zero to 0x0 regardless of input shape", () => {
+    // Pin the zero corner of CANONICAL_HEX_RE so a future tweak to
+    // the regex can't desynchronise the slow path's BigInt(0) output
+    // from the canonical-form gate ``formatHexInt`` /
+    // ``normalizeHexValues`` use to skip rewriting.
+    expect(parseHexInt("0")).toBe("0x0");
+    expect(parseHexInt("0x0")).toBe("0x0");
+    expect(parseHexInt("0x00")).toBe("0x0");
+    expect(parseHexInt("0x000")).toBe("0x0");
+  });
+
   it("trims surrounding whitespace", () => {
     expect(parseHexInt("  0x76 ")).toBe("0x76");
     expect(parseHexInt("\t118\n")).toBe("0x76");
@@ -136,6 +147,27 @@ describe("formatHexInt", () => {
     // must agree on the output for a single value.
     expect(formatHexInt("0x076")).toBe("0x76");
     expect(formatHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
+  });
+
+  it("agrees with parseHexInt at the zero edge", () => {
+    // ``formatHexInt`` must not return ``"0x00"`` for a string that
+    // ``parseHexInt`` canonicalises to ``"0x0"``; otherwise the
+    // ``normalizeHexValues`` fast-path skip would diverge from a
+    // subsequent re-format.
+    expect(formatHexInt("0x0")).toBe("0x0");
+    expect(formatHexInt("0x00")).toBe("0x0");
+    expect(formatHexInt(0)).toBe("0x0");
+  });
+
+  it("rejects numbers above Number.MAX_SAFE_INTEGER (#944 latent footgun)", () => {
+    // ``Number.isInteger`` returns true for any double whose
+    // fractional part is zero, including values past 2^53 where the
+    // double has already been rounded. Stringifying those would
+    // re-introduce the precision loss this PR fixes. Pin the
+    // ``Number.isSafeInteger`` gate so a future relaxation can't
+    // silently regress the bug.
+    expect(formatHexInt(Number.MAX_SAFE_INTEGER + 1)).toBe("");
+    expect(formatHexInt(2 ** 60)).toBe("");
   });
 
   it("formats bigint inputs as 0x-prefixed lowercase hex", () => {

--- a/test/util/hex-int.test.ts
+++ b/test/util/hex-int.test.ts
@@ -53,6 +53,14 @@ describe("parseHexInt", () => {
     expect(parseHexInt("18446744073709551615")).toBe("0xffffffffffffffff");
   });
 
+  it("strips leading zeros from hex input", () => {
+    // ``BigInt("0x076").toString(16)`` is ``"76"``; the canonical
+    // form is unique so the form's display, the values dict, and
+    // on-disk YAML all agree on a single shape.
+    expect(parseHexInt("0x076")).toBe("0x76");
+    expect(parseHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
+  });
+
   it("trims surrounding whitespace", () => {
     expect(parseHexInt("  0x76 ")).toBe("0x76");
     expect(parseHexInt("\t118\n")).toBe("0x76");
@@ -120,6 +128,14 @@ describe("formatHexInt", () => {
     // regressing into the lossy Number.parseInt path.
     expect(formatHexInt("0xbe030c9794184728")).toBe("0xbe030c9794184728");
     expect(formatHexInt("0xffffffffffffffff")).toBe("0xffffffffffffffff");
+  });
+
+  it("canonicalises non-canonical hex strings (leading zeros)", () => {
+    // ``"0x076"`` matches the input regex but not the canonical-form
+    // gate, so the slow path strips the leading zero. Both formatters
+    // must agree on the output for a single value.
+    expect(formatHexInt("0x076")).toBe("0x76");
+    expect(formatHexInt("0x00be030c9794184728")).toBe("0xbe030c9794184728");
   });
 
   it("formats bigint inputs as 0x-prefixed lowercase hex", () => {
@@ -207,6 +223,17 @@ describe("normalizeHexValues", () => {
     const entries = [entry("address", { display_format: "hex" })];
     expect(normalizeHexValues({ address: "0xbe030c9794184728" }, entries)).toEqual({
       address: "0xbe030c9794184728",
+    });
+  });
+
+  it("strips leading zeros from non-canonical hex strings", () => {
+    // Without canonicalisation here the fast path returns the
+    // string verbatim while a later edit re-renders the value
+    // through ``parseHexInt`` and the leading zero disappears; the
+    // values dict and on-disk YAML would silently disagree.
+    const entries = [entry("address", { display_format: "hex" })];
+    expect(normalizeHexValues({ address: "0x076" }, entries)).toEqual({
+      address: "0x76",
     });
   });
 


### PR DESCRIPTION
# What does this implement/fix?

DS18B20 ROM addresses like `0xbe030c9794184728` silently mutated to `0xbe030c9794184800` after a user opened the sensor in the visual section editor. `parseHexInt` ran every hex string through `Number.parseInt`, which rounds any value above 2^53; the catalog's `cv.hex_uint64_t` range goes up to 2^64 minus 1, so the entire DS18B20 / dallas_temp address space hit precision loss.

Switched `parseHexInt`, `formatHexInt`, and `normalizeHexValues` to `BigInt` and return canonical lowercase `"0x..."` strings. The YAML serializer already passes string scalars through verbatim, so the exact bits land on disk.

Contract notes for reviewers; both end-user-equivalent to the prior behaviour:

- `parseHexInt` now returns `string | null` rather than `number | null`. The two production call sites (`primitives.ts`, `loading.ts`) compose unchanged because `formatHexInt` already accepts `unknown`.
- Negative decimal input is rejected at parse time, not at the formatter; the renderer's `formatHexInt(parseHexInt(raw)) || raw` fallback still surfaces the raw string for the inline validator.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/944

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
