### PR TITLE
Move toasts to the bottom left so they don't cover the Install button

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -317,11 +317,11 @@ export class ESPHomeApp extends LitElement {
   private async _init() {
     toast.config({
       toastOptions: {
-        position: "bottom-right",
+        // bottom-left keeps toasts clear of the editor's bottom-right
+        // Install/Validate/Save FAB cluster (#921, prior fix #171).
+        position: "bottom-left",
         richColors: true,
         duration: 4000,
-        // bottom-right can land on top of editor Save/Install (#171); X gives a
-        // guaranteed dismissal beyond swipe and beyond the 4s auto-close timer.
         closeButton: true,
       },
     });


### PR DESCRIPTION
# What does this implement/fix?

After saving a YAML file, the success toast lands on top of the Install button in the bottom right of the editor, so the user has to dismiss the toast before installing. This flips sonner's global default to bottom left so the FAB cluster stays clickable; bottom left is also where Home Assistant puts its toasts, so the two dashboards stay visually consistent.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/921

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
