### PR TITLE
Preserve hex-typed integer fields through the add-component coerce pass

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -1,0 +1,60 @@
+import type { ConfigEntry } from "../../api/types.js";
+import { ConfigEntryType } from "../../api/types.js";
+import { parseYamlBoolean } from "../../util/yaml-serialize.js";
+
+/**
+ * Convert raw form values into the API payload. Drops empty strings
+ * (unless required), keeps arrays as-is, recurses through NESTED
+ * groups. Numeric / boolean entries coerce so the backend sees `5`,
+ * not `"5"`; hex-display integers pass through verbatim as the
+ * renderer's canonical ``"0x..."`` string so the YAML serializer
+ * keeps the hex form on disk (#952).
+ */
+export function coerceFields(
+  entries: ConfigEntry[],
+  values: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const entry of entries) {
+    if (entry.hidden) continue;
+    const raw = values[entry.key];
+
+    if (entry.type === ConfigEntryType.NESTED) {
+      const childValues =
+        raw !== null && typeof raw === "object" && !Array.isArray(raw)
+          ? (raw as Record<string, unknown>)
+          : {};
+      const sub = coerceFields(entry.config_entries ?? [], childValues);
+      if (Object.keys(sub).length > 0) out[entry.key] = sub;
+      continue;
+    }
+
+    if (raw === undefined) continue;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) continue;
+      out[entry.key] = raw;
+      continue;
+    }
+    if (raw === "") {
+      if (entry.required) out[entry.key] = raw;
+      continue;
+    }
+
+    if (entry.type === ConfigEntryType.INTEGER) {
+      if (entry.display_format === "hex") {
+        out[entry.key] = raw;
+      } else {
+        const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+        if (!Number.isNaN(n)) out[entry.key] = n;
+      }
+    } else if (entry.type === ConfigEntryType.FLOAT) {
+      const n = typeof raw === "number" ? raw : Number.parseFloat(String(raw));
+      if (!Number.isNaN(n)) out[entry.key] = n;
+    } else if (entry.type === ConfigEntryType.BOOLEAN) {
+      out[entry.key] = parseYamlBoolean(raw) === true;
+    } else {
+      out[entry.key] = raw;
+    }
+  }
+  return out;
+}

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -3,12 +3,10 @@ import { ConfigEntryType } from "../../api/types.js";
 import { parseYamlBoolean } from "../../util/yaml-serialize.js";
 
 /**
- * Convert raw form values into the API payload. Drops empty strings
- * (unless required), keeps arrays as-is, recurses through NESTED
- * groups. Numeric / boolean entries coerce so the backend sees `5`,
- * not `"5"`; hex-display integers pass through verbatim as the
- * renderer's canonical ``"0x..."`` string so the YAML serializer
- * keeps the hex form on disk (#952).
+ * Coerce raw form values for the WS payload: numbers / booleans to
+ * their proper types so the backend sees `5`, not `"5"`. Hex-display
+ * integers stay strings; the renderer's canonical `"0x..."` survives
+ * to YAML and `cv.hex_int` accepts both forms on parse.
  */
 export function coerceFields(
   entries: ConfigEntry[],
@@ -40,13 +38,12 @@ export function coerceFields(
       continue;
     }
 
-    if (entry.type === ConfigEntryType.INTEGER) {
-      if (entry.display_format === "hex") {
-        out[entry.key] = raw;
-      } else {
-        const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
-        if (!Number.isNaN(n)) out[entry.key] = n;
-      }
+    if (
+      entry.type === ConfigEntryType.INTEGER &&
+      entry.display_format !== "hex"
+    ) {
+      const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+      if (!Number.isNaN(n)) out[entry.key] = n;
     } else if (entry.type === ConfigEntryType.FLOAT) {
       const n = typeof raw === "number" ? raw : Number.parseFloat(String(raw));
       if (!Number.isNaN(n)) out[entry.key] = n;

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -28,9 +28,9 @@ import { setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   parseTopLevelComponents,
-  parseYamlBoolean,
   serializeYamlValues,
 } from "../../util/yaml-serialize.js";
+import { coerceFields } from "./add-component-form-coerce.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
 import "./config-entry-form.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
@@ -623,7 +623,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     this._errors = new Map();
     this._localBlockMessage = "";
 
-    const fields = this._coerceFields(
+    const fields = coerceFields(
       this.component.config_entries,
       this._values,
     );
@@ -635,61 +635,6 @@ export class ESPHomeAddComponentForm extends LitElement {
         composed: true,
       }),
     );
-  }
-
-  /**
-   * Convert raw form values into the API payload. Drops empty strings
-   * (unless the entry is required), keeps arrays as-is, and recurses
-   * through NESTED groups. Numeric / boolean entries are coerced to
-   * their proper types so the backend sees `5` not `"5"`.
-   */
-  private _coerceFields(
-    entries: ConfigEntry[],
-    values: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const out: Record<string, unknown> = {};
-    for (const entry of entries) {
-      if (entry.hidden) continue;
-      const raw = values[entry.key];
-
-      if (entry.type === ConfigEntryType.NESTED) {
-        const childValues =
-          raw !== null && typeof raw === "object" && !Array.isArray(raw)
-            ? (raw as Record<string, unknown>)
-            : {};
-        const sub = this._coerceFields(
-          entry.config_entries ?? [],
-          childValues,
-        );
-        if (Object.keys(sub).length > 0) out[entry.key] = sub;
-        continue;
-      }
-
-      if (raw === undefined) continue;
-      if (Array.isArray(raw)) {
-        if (raw.length === 0) continue;
-        out[entry.key] = raw;
-        continue;
-      }
-      if (raw === "") {
-        if (entry.required) out[entry.key] = raw;
-        continue;
-      }
-
-      if (entry.type === ConfigEntryType.INTEGER) {
-        const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
-        if (!Number.isNaN(n)) out[entry.key] = n;
-      } else if (entry.type === ConfigEntryType.FLOAT) {
-        const n =
-          typeof raw === "number" ? raw : Number.parseFloat(String(raw));
-        if (!Number.isNaN(n)) out[entry.key] = n;
-      } else if (entry.type === ConfigEntryType.BOOLEAN) {
-        out[entry.key] = parseYamlBoolean(raw) === true;
-      } else {
-        out[entry.key] = raw;
-      }
-    }
-    return out;
   }
 }
 

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { coerceFields } from "../../../src/components/device/add-component-form-coerce.js";
+import { ConfigEntryType } from "../../../src/api/types.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+const hexAddress = makeConfigEntry({
+  key: "address",
+  type: ConfigEntryType.INTEGER,
+  display_format: "hex",
+  range: [0, 255],
+});
+
+const plainInt = makeConfigEntry({
+  key: "count",
+  type: ConfigEntryType.INTEGER,
+});
+
+describe("coerceFields hex-display integers (#952)", () => {
+  test("canonical 0x76 from the hex renderer passes through verbatim", () => {
+    expect(coerceFields([hexAddress], { address: "0x76" })).toEqual({
+      address: "0x76",
+    });
+  });
+
+  test("0x0 survives without collapsing to numeric 0", () => {
+    expect(coerceFields([hexAddress], { address: "0x0" })).toEqual({
+      address: "0x0",
+    });
+  });
+
+  test("a pre-existing JS number (catalog-default seed) is preserved", () => {
+    expect(coerceFields([hexAddress], { address: 118 })).toEqual({
+      address: 118,
+    });
+  });
+
+  test("empty + required keeps the empty marker so submit blocks downstream", () => {
+    const required = makeConfigEntry({
+      ...hexAddress,
+      required: true,
+    });
+    expect(coerceFields([required], { address: "" })).toEqual({ address: "" });
+  });
+
+  test("undefined drops out of the payload", () => {
+    expect(coerceFields([hexAddress], {})).toEqual({});
+  });
+});
+
+describe("coerceFields non-hex integers", () => {
+  test('"5" still coerces to numeric 5', () => {
+    expect(coerceFields([plainInt], { count: "5" })).toEqual({ count: 5 });
+  });
+});

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -16,7 +16,7 @@ const plainInt = makeConfigEntry({
   type: ConfigEntryType.INTEGER,
 });
 
-describe("coerceFields hex-display integers (#952)", () => {
+describe("coerceFields hex-display integers", () => {
   test("canonical 0x76 from the hex renderer passes through verbatim", () => {
     expect(coerceFields([hexAddress], { address: "0x76" })).toEqual({
       address: "0x76",


### PR DESCRIPTION
# What does this implement/fix?

In `_coerceFields` (the add-component form's pre-submit type-coercion
pass), a hex-display integer like an i2c `address` arrives as the
renderer's canonical lowercase `"0x..."` string. The integer branch ran
`Number.parseInt(String(raw), 10)` unconditionally, which yields `0` for
`"0x76"` (base-10 parsing stops at the `x`), so the YAML landed as
`address: 0` regardless of what the user typed.

This PR narrows the integer guard with `display_format !== "hex"`, so
hex-typed values fall through to the existing string pass-through.
The YAML serializer is schema-agnostic and round-trips a string scalar
verbatim; ESPHome's `cv.hex_int` validator accepts both `address: 0x76`
(unquoted) and `address: "0x76"` (quoted).

The pure helper moves to `add-component-form-coerce.ts` so the test
suite can exercise it directly. Six new cases pin:

1. canonical `"0x76"` passes through verbatim,
2. `"0x0"` does NOT collapse to numeric `0` (regression bait),
3. catalog-default numeric seeds are preserved,
4. empty + required keeps the empty marker,
5. undefined drops out,
6. plain (non-hex) `"5"` still coerces to `5`.

#378 (BigInt hex parsing) hardened `parseHexInt` and validation but did
not touch this code path; the bug survived intact. The earlier hex-
display work (#222 frontend, esphome/device-builder#414 backend) wired
the `display_format: "hex"` hint end-to-end except for this last
coerce-on-submit hop.

### Verification

- `npm test` (1248 tests pass, including the six new ones).
- `npm run lint` (tsc --noEmit clean).
- Not driven through the live dashboard in this PR; the unit tests pin
  the exact code path the bug report describes, and the surrounding
  renderer / validator / YAML-serializer pieces are untouched.

### Known latent shape (not bundled)

`src/components/device/config-entry-renderers-shared.ts:306` has the
same `parseInt(raw, 10)` shape inside the suggestions-dropdown coerce.
`renderNumberField` checks `entry.suggestions` *before*
`display_format === "hex"`, so a hex-int field with `suggestions` would
render as a plain string field and hit this path. The catalog has no
such entry today (i2c address has no `suggestions`); flagged here so a
future hex+suggestions combination doesn't reintroduce the same bug.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#952

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
