### PR TITLE
Run prettier --check in CI and pre-commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Revisions listed here are skipped by ``git blame --ignore-revs-file``
+# and by GitHub's blame view (which honours the file automatically).
+# Use sparingly; only for whole-tree reformats whose authorship would
+# otherwise obscure the substantive change a reader is hunting for.
+#
+# To enable locally:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Format src and test with prettier (chore: close the CI / pre-commit
+# prettier gap).
+0c6a3911b8854ed4951bf008c2c282a2f621415c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prettier format check
+        run: npm run format:check
+
       - name: Lint (TypeScript type check)
         run: npm run lint
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
+npm run format:check
 npm run lint
 npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "node build-scripts/dev-server.cjs",
     "build": "node build-scripts/build.cjs",
     "lint": "tsc --noEmit",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepare": "husky"

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -601,7 +601,7 @@ export class ESPHomeAPI {
    */
   async subscribeDeviceReachability(
     deviceName: string,
-    callback: (state: ReachabilityStateEvent) => void,
+    callback: (state: ReachabilityStateEvent) => void
   ): Promise<ReachabilitySubscription> {
     if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
       throw new Error("WebSocket not connected");
@@ -649,9 +649,7 @@ export class ESPHomeAPI {
         const timer = setTimeout(() => {
           this._pendingRequests.delete(messageId);
           reject(
-            new Error(
-              `subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`,
-            ),
+            new Error(`subscribe_reachability timed out after ${SUBSCRIBE_TIMEOUT_MS}ms`)
           );
         }, SUBSCRIBE_TIMEOUT_MS);
         this._pendingRequests.set(messageId, {
@@ -792,9 +790,7 @@ export class ESPHomeAPI {
     return this.sendCommand<{ configuration: string }>("devices/clone", {
       configuration,
       new_name: newName,
-      ...(newFriendlyName !== undefined
-        ? { new_friendly_name: newFriendlyName }
-        : {}),
+      ...(newFriendlyName !== undefined ? { new_friendly_name: newFriendlyName } : {}),
     });
   }
 
@@ -963,7 +959,7 @@ export class ESPHomeAPI {
    *  state without waiting for the ``device_updated`` event. */
   async setDeviceLabels(
     configuration: string,
-    labelIds: string[],
+    labelIds: string[]
   ): Promise<ConfiguredDevice> {
     return this.sendCommand<ConfiguredDevice>("devices/set_labels", {
       configuration,
@@ -981,10 +977,7 @@ export class ESPHomeAPI {
   /** Create a new label. ``name`` 1-50 chars, unique
    *  case-insensitively. ``color`` is ``#rrggbb`` (lowercased on
    *  save) or ``null`` / omitted for "no explicit color". */
-  async createLabel(args: {
-    name: string;
-    color?: string | null;
-  }): Promise<Label> {
+  async createLabel(args: { name: string; color?: string | null }): Promise<Label> {
     return this.sendCommand<Label>("labels/create", args);
   }
 
@@ -1119,7 +1112,7 @@ export class ESPHomeAPI {
   async firmwareInstall(
     configuration: string,
     port = "OTA",
-    forceLocal = false,
+    forceLocal = false
   ): Promise<FirmwareJob> {
     return this.sendCommand<FirmwareJob>("firmware/install", {
       configuration,
@@ -1303,7 +1296,7 @@ export class ESPHomeAPI {
    */
   async getAutomationTriggers(
     platform?: string,
-    boardId?: string,
+    boardId?: string
   ): Promise<AutomationTrigger[]> {
     return this.sendCommand<AutomationTrigger[]>("automations/get_triggers", {
       ...(platform ? { platform } : {}),
@@ -1315,7 +1308,7 @@ export class ESPHomeAPI {
    *  ``getAutomationTriggers``. */
   async getAutomationActions(
     platform?: string,
-    boardId?: string,
+    boardId?: string
   ): Promise<AutomationAction[]> {
     return this.sendCommand<AutomationAction[]>("automations/get_actions", {
       ...(platform ? { platform } : {}),
@@ -1327,25 +1320,19 @@ export class ESPHomeAPI {
    *  ``getAutomationTriggers``. */
   async getAutomationConditions(
     platform?: string,
-    boardId?: string,
+    boardId?: string
   ): Promise<AutomationCondition[]> {
-    return this.sendCommand<AutomationCondition[]>(
-      "automations/get_conditions",
-      {
-        ...(platform ? { platform } : {}),
-        ...(boardId ? { board_id: boardId } : {}),
-      },
-    );
+    return this.sendCommand<AutomationCondition[]>("automations/get_conditions", {
+      ...(platform ? { platform } : {}),
+      ...(boardId ? { board_id: boardId } : {}),
+    });
   }
 
   /** Catalog of every light effect registered with ESPHome.
    *  Surfaced as a separate command because effects sit on a
    *  different editor surface (per-light list ergonomics) than the
    *  trigger/action/condition tree. */
-  async getLightEffects(
-    platform?: string,
-    boardId?: string,
-  ): Promise<LightEffect[]> {
+  async getLightEffects(platform?: string, boardId?: string): Promise<LightEffect[]> {
     return this.sendCommand<LightEffect[]>("automations/get_light_effects", {
       ...(platform ? { platform } : {}),
       ...(boardId ? { board_id: boardId } : {}),
@@ -1365,13 +1352,10 @@ export class ESPHomeAPI {
    * contents — callers should re-fetch on each YAML change rather
    * than caching across edits.
    */
-  async getAvailableAutomations(
-    configuration: string,
-  ): Promise<AvailableAutomations> {
-    return this.sendCommand<AvailableAutomations>(
-      "automations/get_available",
-      { configuration },
-    );
+  async getAvailableAutomations(configuration: string): Promise<AvailableAutomations> {
+    return this.sendCommand<AvailableAutomations>("automations/get_available", {
+      configuration,
+    });
   }
 
   /**
@@ -1397,7 +1381,7 @@ export class ESPHomeAPI {
      * saved yet (e.g. the editor's post-add hydrate that runs
      * before global save).
      */
-    yaml?: string,
+    yaml?: string
   ): Promise<ParsedAutomation[]> {
     return this.sendCommand<ParsedAutomation[]>("automations/parse", {
       configuration,
@@ -1430,7 +1414,7 @@ export class ESPHomeAPI {
      * ``_yaml`` here so the backend works with the same text the
      * frontend is about to splice into.
      */
-    yaml?: string,
+    yaml?: string
   ): Promise<{ yaml_diff: YamlDiff }> {
     return this.sendCommand<{ yaml_diff: YamlDiff }>("automations/upsert", {
       configuration,
@@ -1450,7 +1434,7 @@ export class ESPHomeAPI {
     location: AutomationLocation,
     /** Optional in-memory YAML override — same purpose as for
      *  ``upsertAutomation``. */
-    yaml?: string,
+    yaml?: string
   ): Promise<{ yaml_diff: YamlDiff }> {
     return this.sendCommand<{ yaml_diff: YamlDiff }>("automations/delete", {
       configuration,
@@ -1515,14 +1499,11 @@ export class ESPHomeAPI {
    * (32 char SSID, 64 char password) and surfaces violations as
    * ``CommandError(INVALID_ARGS)`` for the UI to render.
    */
-  async setOnboardingWifi(
-    ssid: string,
-    password: string,
-  ): Promise<OnboardingState> {
-    return this.sendCommand<OnboardingState>(
-      "onboarding/set_wifi_credentials",
-      { ssid, password },
-    );
+  async setOnboardingWifi(ssid: string, password: string): Promise<OnboardingState> {
+    return this.sendCommand<OnboardingState>("onboarding/set_wifi_credentials", {
+      ssid,
+      password,
+    });
   }
 
   /**
@@ -1564,10 +1545,7 @@ export class ESPHomeAPI {
     enabled: boolean;
     cleanup_ttl_seconds?: number;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/set_settings",
-      args
-    );
+    return this.sendCommand<RemoteBuildSettings>("remote_build/set_settings", args);
   }
 
   /**
@@ -1627,10 +1605,7 @@ export class ESPHomeAPI {
     pin_sha256: string;
     enabled: boolean;
   }): Promise<PairingSummary> {
-    return this.sendCommand<PairingSummary>(
-      "remote_build/set_pairing_enabled",
-      args
-    );
+    return this.sendCommand<PairingSummary>("remote_build/set_pairing_enabled", args);
   }
 
   /**
@@ -1672,10 +1647,7 @@ export class ESPHomeAPI {
   async approveRemoteBuildPeer(args: {
     dashboard_id: string;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/approve_peer",
-      args
-    );
+    return this.sendCommand<RemoteBuildSettings>("remote_build/approve_peer", args);
   }
 
   /**
@@ -1690,10 +1662,7 @@ export class ESPHomeAPI {
   async removeRemoteBuildPeer(args: {
     dashboard_id: string;
   }): Promise<RemoteBuildSettings> {
-    return this.sendCommand<RemoteBuildSettings>(
-      "remote_build/remove_peer",
-      args
-    );
+    return this.sendCommand<RemoteBuildSettings>("remote_build/remove_peer", args);
   }
 
   /**
@@ -1716,10 +1685,7 @@ export class ESPHomeAPI {
   async setRemoteBuildPairingWindow(args: {
     open: boolean;
   }): Promise<PairingWindowState> {
-    return this.sendCommand<PairingWindowState>(
-      "remote_build/set_pairing_window",
-      args
-    );
+    return this.sendCommand<PairingWindowState>("remote_build/set_pairing_window", args);
   }
 
   // ─── Remote build: offloader-side pair flow (phase 4a-o) ──
@@ -1742,10 +1708,7 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<{ pin_sha256: string }> {
-    return this.sendCommand<{ pin_sha256: string }>(
-      "remote_build/preview_pair",
-      args
-    );
+    return this.sendCommand<{ pin_sha256: string }>("remote_build/preview_pair", args);
   }
 
   /**
@@ -1816,9 +1779,7 @@ export class ESPHomeAPI {
    * "stale on receiver, removed locally" case as a UI
    * affordance for the receiver-side admin.
    */
-  async unpairRemoteBuild(args: {
-    pin_sha256: string;
-  }): Promise<{ removed: boolean }> {
+  async unpairRemoteBuild(args: { pin_sha256: string }): Promise<{ removed: boolean }> {
     return this.sendCommand<{ removed: boolean }>("remote_build/unpair", args);
   }
 
@@ -1860,10 +1821,7 @@ export class ESPHomeAPI {
     hostname: string;
     port: number;
   }): Promise<PairingSummary> {
-    return this.sendCommand<PairingSummary>(
-      "remote_build/edit_pairing_endpoint",
-      args,
-    );
+    return this.sendCommand<PairingSummary>("remote_build/edit_pairing_endpoint", args);
   }
 
   /**
@@ -1944,10 +1902,7 @@ export class ESPHomeAPI {
     pin_sha256: string;
     job_id: string;
   }): Promise<{ sent: boolean }> {
-    return this.sendCommand<{ sent: boolean }>(
-      "remote_build/cancel_job",
-      args,
-    );
+    return this.sendCommand<{ sent: boolean }>("remote_build/cancel_job", args);
   }
 
   // ─── Remote build: receiver identity ──────────

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -820,8 +820,8 @@ export enum ConfigEntryType {
 
 /** A trigger that can start an automation. */
 export interface AutomationTrigger {
-  id: string;                  // "on_press", "binary_sensor.on_click", "on_boot"
-  name: string;                // "On Press"
+  id: string; // "on_press", "binary_sensor.on_click", "on_boot"
+  name: string; // "On Press"
   description: string;
   docs_url: string;
   /** Platform types this trigger applies to (``["binary_sensor"]``).
@@ -837,11 +837,11 @@ export interface AutomationTrigger {
 
 /** An action that can run inside an automation. */
 export interface AutomationAction {
-  id: string;                  // "light.turn_on", "delay", "if", "lambda"
+  id: string; // "light.turn_on", "delay", "if", "lambda"
   name: string;
   description: string;
   docs_url: string;
-  domain: string;              // "light", "core" for built-ins
+  domain: string; // "light", "core" for built-ins
   config_entries: ConfigEntry[];
   /** True for ``if`` / ``while`` / ``repeat`` / ``wait_until`` —
    *  the action embeds nested action lists addressed by the keys in
@@ -859,11 +859,11 @@ export interface AutomationAction {
 /** A condition usable inside an automation's ``if`` / ``while`` /
  *  ``wait_until`` action, or as a trigger gate. */
 export interface AutomationCondition {
-  id: string;                  // "binary_sensor.is_on", "and", "lambda"
+  id: string; // "binary_sensor.is_on", "and", "lambda"
   name: string;
   description: string;
   docs_url: string;
-  domain: string;              // "binary_sensor", "core"
+  domain: string; // "binary_sensor", "core"
   config_entries: ConfigEntry[];
   /** True for ``and`` / ``or`` / ``all`` / ``any`` / ``not`` /
    *  ``xor`` — the condition embeds a recursive list of child
@@ -877,7 +877,7 @@ export interface AutomationCondition {
  *  list ergonomics differ from actions (effects compose into a list
  *  on a single ``light`` block; actions form a tree). */
 export interface LightEffect {
-  id: string;                  // "pulse", "flicker", "addressable_lambda"
+  id: string; // "pulse", "flicker", "addressable_lambda"
   name: string;
   config_entries: ConfigEntry[];
   /** Light platform types this effect is valid on
@@ -2150,8 +2150,7 @@ export type PeerLinkCloseReason =
  * (true on non-orphan reasons; false on `pin_mismatch` /
  * `superseded` where the run loop won't retry).
  */
-export interface OffloaderPeerLinkClosedEventData
-  extends OffloaderPeerLinkSessionEventData {
+export interface OffloaderPeerLinkClosedEventData extends OffloaderPeerLinkSessionEventData {
   reason: PeerLinkCloseReason;
   error_detail: string;
 }

--- a/src/common/localize.ts
+++ b/src/common/localize.ts
@@ -100,15 +100,9 @@ function resolve(obj: Record<string, unknown>, key: string): string | undefined 
   return typeof current === "string" ? current : undefined;
 }
 
-function interpolate(
-  template: string,
-  values?: Record<string, string | number>
-): string {
+function interpolate(template: string, values?: Record<string, string | number>): string {
   if (!values) return template;
-  return template.replace(
-    /\{(\w+)\}/g,
-    (_, key) => String(values[key] ?? `{${key}}`)
-  );
+  return template.replace(/\{(\w+)\}/g, (_, key) => String(values[key] ?? `{${key}}`));
 }
 
 /** Deep-merge `override` onto `base`, preserving unoverridden nested keys. */
@@ -121,8 +115,10 @@ function deepMerge(
     const baseVal = base[key];
     const overrideVal = override[key];
     if (
-      typeof baseVal === "object" && baseVal !== null &&
-      typeof overrideVal === "object" && overrideVal !== null
+      typeof baseVal === "object" &&
+      baseVal !== null &&
+      typeof overrideVal === "object" &&
+      overrideVal !== null
     ) {
       result[key] = deepMerge(
         baseVal as Record<string, unknown>,
@@ -151,14 +147,10 @@ export const defaultLocalize: LocalizeFunc = buildLocalize(
  * If `force` is omitted, picks the stored locale (from a previous user
  * selection) or falls back to the browser locale.
  */
-export async function loadLocalize(
-  force?: SupportedLocale
-): Promise<LocalizeFunc> {
+export async function loadLocalize(force?: SupportedLocale): Promise<LocalizeFunc> {
   const locale = force ?? activeLocale();
   if (locale === "en") return defaultLocalize;
 
   const localeMessages = await loadLocaleMessages(locale);
-  return buildLocalize(
-    deepMerge(enMessages as Record<string, unknown>, localeMessages)
-  );
+  return buildLocalize(deepMerge(enMessages as Record<string, unknown>, localeMessages));
 }

--- a/src/components/accept-peer-dialog.ts
+++ b/src/components/accept-peer-dialog.ts
@@ -178,9 +178,7 @@ export class ESPHomeAcceptPeerDialog extends LitElement {
           </div>
           <ul class="checklist">
             <li>
-              ${this._localize(
-                "settings.build_server_peer_accept_confirm_checklist_pin"
-              )}
+              ${this._localize("settings.build_server_peer_accept_confirm_checklist_pin")}
             </li>
             <li>
               ${this._localize(
@@ -204,9 +202,7 @@ export class ESPHomeAcceptPeerDialog extends LitElement {
                     ? html`
                         <div class="peer-row">
                           <span class="label">
-                            ${this._localize(
-                              "settings.build_server_peer_ip_label"
-                            )}
+                            ${this._localize("settings.build_server_peer_ip_label")}
                           </span>
                           <code class="value">${peer.peer_ip}</code>
                         </div>

--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -94,7 +94,9 @@ export class ESPHomeApiKeyDialog extends LitElement {
         cursor: pointer;
         padding: 0;
         flex-shrink: 0;
-        transition: background 0.12s, color 0.12s;
+        transition:
+          background 0.12s,
+          color 0.12s;
       }
 
       .key-btn:hover {
@@ -156,8 +158,14 @@ export class ESPHomeApiKeyDialog extends LitElement {
         <span class="key-value">${masked}</span>
         <button
           class="key-btn"
-          title=${this._localize(this._visible ? "dashboard.action_api_key_hide" : "dashboard.action_api_key_show")}
-          @click=${() => { this._visible = !this._visible; }}
+          title=${this._localize(
+            this._visible
+              ? "dashboard.action_api_key_hide"
+              : "dashboard.action_api_key_show"
+          )}
+          @click=${() => {
+            this._visible = !this._visible;
+          }}
         >
           <wa-icon library="mdi" name=${this._visible ? "eye-off" : "eye"}></wa-icon>
         </button>

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -3,11 +3,7 @@ import { css, html, LitElement, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { ESPHomeAPI } from "../api/index.js";
-import {
-  CLEANUP_TTL_DEFAULT_SECONDS,
-  JobStatus,
-  Theme,
-} from "../api/types.js";
+import { CLEANUP_TTL_DEFAULT_SECONDS, JobStatus, Theme } from "../api/types.js";
 import type {
   AdoptableDevice,
   ConfiguredDevice,
@@ -21,11 +17,7 @@ import type {
   RemoteBuildSubmitTarget,
   ServerInfoMessage,
 } from "../api/types.js";
-import {
-  defaultLocalize,
-  loadLocalize,
-  type LocalizeFunc,
-} from "../common/localize.js";
+import { defaultLocalize, loadLocalize, type LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
   darkModeContext,
@@ -57,10 +49,7 @@ import {
 import type { RemoteBuildJobState } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { BASE_PATH } from "../util/base-path.js";
-import {
-  isRecentSerialActivity,
-  markSerialActivity,
-} from "../util/web-serial.js";
+import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import {
   loadIntegrationDocs,
   loadLabels,
@@ -107,30 +96,65 @@ export type AuthState = "connecting" | "needs-login" | "authing" | "authed";
 export class ESPHomeApp extends LitElement {
   @provide({ context: apiContext }) _api = new ESPHomeAPI();
   @provide({ context: devicesContext }) @state() _devices: ConfiguredDevice[] = [];
-  @provide({ context: importableDevicesContext }) @state() _importableDevices: AdoptableDevice[] = [];
+  @provide({ context: importableDevicesContext })
+  @state()
+  _importableDevices: AdoptableDevice[] = [];
   @provide({ context: devicesLoadedContext }) @state() _devicesLoaded = false;
   @provide({ context: versionContext }) @state() _version = "";
   @provide({ context: serverVersionContext }) @state() _serverVersion = "";
   @provide({ context: darkModeContext }) @state() _darkMode = false;
   @provide({ context: isHaIngressContext }) @state() _isHaIngress = false;
-  @provide({ context: activeJobsContext }) @state() _activeJobs: Map<string, FirmwareJob> = new Map();
-  @provide({ context: recentJobsContext }) @state() _recentJobs: Map<string, FirmwareJob> = new Map();
-  @provide({ context: firmwareJobsContext }) @state() _firmwareJobs: Map<string, FirmwareJob> = new Map();
-  @provide({ context: localizeContext }) @state() _localize: LocalizeFunc = defaultLocalize;
+  @provide({ context: activeJobsContext }) @state() _activeJobs: Map<
+    string,
+    FirmwareJob
+  > = new Map();
+  @provide({ context: recentJobsContext }) @state() _recentJobs: Map<
+    string,
+    FirmwareJob
+  > = new Map();
+  @provide({ context: firmwareJobsContext }) @state() _firmwareJobs: Map<
+    string,
+    FirmwareJob
+  > = new Map();
+  @provide({ context: localizeContext }) @state() _localize: LocalizeFunc =
+    defaultLocalize;
   @provide({ context: yamlDiffButtonContext }) @state() _yamlDiffButton = false;
   @provide({ context: remoteBuildEnabledContext }) @state() _remoteBuildEnabled = false;
-  @provide({ context: remoteBuildCleanupTtlContext }) @state() _remoteBuildCleanupTtl = CLEANUP_TTL_DEFAULT_SECONDS;
-  @provide({ context: integrationDocsContext }) @state() _integrationDocs: Record<string, string> = {};
+  @provide({ context: remoteBuildCleanupTtlContext }) @state() _remoteBuildCleanupTtl =
+    CLEANUP_TTL_DEFAULT_SECONDS;
+  @provide({ context: integrationDocsContext }) @state() _integrationDocs: Record<
+    string,
+    string
+  > = {};
   @provide({ context: labelsContext }) @state() _labels: Label[] = [];
   @provide({ context: onboardingPendingContext }) @state() _onboardingPending = false;
-  @provide({ context: buildServerIdentityRotationCounterContext }) @state() _buildServerIdentityRotationCounter = 0;
-  @provide({ context: buildServerPeersContext }) @state() _buildServerPeers: PeerSummary[] | null = null;
-  @provide({ context: buildServerPairingWindowStateContext }) @state() _buildServerPairingWindowState: PairingWindowState | null = null;
-  @provide({ context: buildOffloadDiscoveredHostsContext }) @state() _buildOffloadDiscoveredHosts: Map<string, RemoteBuildPeer> | null = null;
-  @provide({ context: buildOffloadPairingsContext }) @state() _buildOffloadPairings: Map<string, PairingSummary> | null = null;
-  @provide({ context: offloaderRemoteBuildsEnabledContext }) @state() _offloaderRemoteBuildsEnabled: boolean | null = null;
-  @provide({ context: buildOffloadAlertsContext }) @state() _buildOffloadAlerts: Map<string, OffloaderAlertSnapshotEntry> | null = null;
-  @provide({ context: buildOffloadJobsContext }) @state() _buildOffloadJobs: Map<string, RemoteBuildJobState> = new Map();
+  @provide({ context: buildServerIdentityRotationCounterContext })
+  @state()
+  _buildServerIdentityRotationCounter = 0;
+  @provide({ context: buildServerPeersContext }) @state() _buildServerPeers:
+    | PeerSummary[]
+    | null = null;
+  @provide({ context: buildServerPairingWindowStateContext })
+  @state()
+  _buildServerPairingWindowState: PairingWindowState | null = null;
+  @provide({ context: buildOffloadDiscoveredHostsContext })
+  @state()
+  _buildOffloadDiscoveredHosts: Map<string, RemoteBuildPeer> | null = null;
+  @provide({ context: buildOffloadPairingsContext }) @state() _buildOffloadPairings: Map<
+    string,
+    PairingSummary
+  > | null = null;
+  @provide({ context: offloaderRemoteBuildsEnabledContext })
+  @state()
+  _offloaderRemoteBuildsEnabled: boolean | null = null;
+  @provide({ context: buildOffloadAlertsContext }) @state() _buildOffloadAlerts: Map<
+    string,
+    OffloaderAlertSnapshotEntry
+  > | null = null;
+  @provide({ context: buildOffloadJobsContext }) @state() _buildOffloadJobs: Map<
+    string,
+    RemoteBuildJobState
+  > = new Map();
 
   @state() _onboardingShouldShow = false;
   @state() _onboardingSessionDismissed = false;
@@ -147,7 +171,8 @@ export class ESPHomeApp extends LitElement {
   private _router = createRouter(this);
 
   @query("esphome-settings-dialog") private _settingsDialog!: ESPHomeSettingsDialog;
-  @query("esphome-firmware-jobs-dialog") private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
+  @query("esphome-firmware-jobs-dialog")
+  private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
   @query("esphome-feedback-dialog") private _feedbackDialog!: ESPHomeFeedbackDialog;
   @query("esphome-onboarding-wifi-dialog")
   private _onboardingDialog?: HTMLElement & { open(): void };
@@ -268,7 +293,7 @@ export class ESPHomeApp extends LitElement {
           markSerialActivity();
           toast.dismiss("esphome-usb-device-connected");
           window.dispatchEvent(
-            new CustomEvent("esphome-serial-setup", { detail: { port } }),
+            new CustomEvent("esphome-serial-setup", { detail: { port } })
           );
         },
       },
@@ -452,8 +477,9 @@ export class ESPHomeApp extends LitElement {
           ?disconnected=${!this._apiConnected}
           .error=${this._authError}
           rate-limited-until=${this._rateLimitedUntil}
-          @submit-credentials=${(e: CustomEvent<{ username: string; password: string }>) =>
-            onLoginSubmit(this, e)}
+          @submit-credentials=${(
+            e: CustomEvent<{ username: string; password: string }>
+          ) => onLoginSubmit(this, e)}
         ></esphome-login>
       `;
     }
@@ -488,18 +514,18 @@ export class ESPHomeApp extends LitElement {
         @set-offloader-remote-builds-enabled=${(e: CustomEvent<boolean>) =>
           onSetOffloaderRemoteBuildsEnabled(this, e)}
         @set-offloader-pairing-enabled=${(
-          e: CustomEvent<{ pin_sha256: string; enabled: boolean }>,
+          e: CustomEvent<{ pin_sha256: string; enabled: boolean }>
         ) => onSetOffloaderPairingEnabled(this, e)}
         @set-language=${(e: CustomEvent<Parameters<typeof onSetLanguage>[1]["detail"]>) =>
           onSetLanguage(this, e as Parameters<typeof onSetLanguage>[1])}
         @pair-request-sent=${(e: CustomEvent<{ summary: PairingSummary }>) =>
           onPairRequestSent(this, e)}
         @remote-build-job-submitted=${(
-          e: CustomEvent<Parameters<typeof onRemoteBuildJobSubmitted>[1]["detail"]>,
+          e: CustomEvent<Parameters<typeof onRemoteBuildJobSubmitted>[1]["detail"]>
         ) =>
           onRemoteBuildJobSubmitted(
             this,
-            e as Parameters<typeof onRemoteBuildJobSubmitted>[1],
+            e as Parameters<typeof onRemoteBuildJobSubmitted>[1]
           )}
         @remote-build-job-dismissed=${(e: CustomEvent<{ job_id: string }>) =>
           onRemoteBuildJobDismissed(this, e)}

--- a/src/components/app-shell/auth.ts
+++ b/src/components/app-shell/auth.ts
@@ -12,7 +12,7 @@ export function parseRateLimitSeconds(details: string): number {
 
 export async function onLoginSubmit(
   host: ESPHomeApp,
-  e: CustomEvent<{ username: string; password: string }>,
+  e: CustomEvent<{ username: string; password: string }>
 ): Promise<void> {
   if (host._authState === "authing") return;
   host._authState = "authing";

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -10,7 +10,7 @@ export async function loadOnboardingState(host: ESPHomeApp): Promise<void> {
     host._onboardingPending = isOnboardingPending(state);
     host._onboardingShouldShow = shouldAutoShowOnboarding(
       state,
-      host._onboardingSessionDismissed,
+      host._onboardingSessionDismissed
     );
   } catch (err) {
     // Non-critical — clear the badge (latest data unknown, "no nudge" is safer

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -39,7 +39,7 @@ import type { ESPHomeApp } from "../app-shell.js";
 export function patchOffloadPairing(
   host: ESPHomeApp,
   pin: string,
-  diff: Partial<PairingSummary>,
+  diff: Partial<PairingSummary>
 ): void {
   if (host._buildOffloadPairings === null) return;
   const existing = host._buildOffloadPairings.get(pin);
@@ -102,23 +102,21 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     case DeviceEventType.DEVICE_UPDATED: {
       const { device } = data as DeviceEventData;
       host._devices = host._devices.map((d) =>
-        d.configuration === device.configuration ? device : d,
+        d.configuration === device.configuration ? device : d
       );
       break;
     }
     case DeviceEventType.DEVICE_REMOVED: {
       const { device } = data as DeviceEventData;
       host._devices = host._devices.filter(
-        (d) => d.configuration !== device.configuration,
+        (d) => d.configuration !== device.configuration
       );
       break;
     }
     case DeviceEventType.DEVICE_STATE_CHANGED: {
       const { configuration, state } = data as DeviceStateChangedEventData;
       host._devices = host._devices.map((d) =>
-        d.configuration === configuration
-          ? { ...d, state: state as DeviceState }
-          : d,
+        d.configuration === configuration ? { ...d, state: state as DeviceState } : d
       );
       break;
     }
@@ -179,9 +177,7 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         connected: false,
       };
       const current = host._buildServerPeers ?? [];
-      const idx = current.findIndex(
-        (p) => p.dashboard_id === incoming.dashboard_id,
-      );
+      const idx = current.findIndex((p) => p.dashboard_id === incoming.dashboard_id);
       host._buildServerPeers =
         idx === -1
           ? [...current, incoming]
@@ -193,13 +189,11 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       const current = host._buildServerPeers ?? [];
       if (evt.status === "removed") {
         host._buildServerPeers = current.filter(
-          (p) => p.dashboard_id !== evt.dashboard_id,
+          (p) => p.dashboard_id !== evt.dashboard_id
         );
       } else {
         host._buildServerPeers = current.map((p) =>
-          p.dashboard_id === evt.dashboard_id
-            ? { ...p, status: "approved" as const }
-            : p,
+          p.dashboard_id === evt.dashboard_id ? { ...p, status: "approved" as const } : p
         );
       }
       break;
@@ -210,7 +204,7 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
       const evt = data as ReceiverPeerLinkSessionEventData;
       const connected = event === DeviceEventType.RECEIVER_PEER_LINK_SESSION_OPENED;
       host._buildServerPeers = host._buildServerPeers.map((p) =>
-        p.dashboard_id === evt.dashboard_id ? { ...p, connected } : p,
+        p.dashboard_id === evt.dashboard_id ? { ...p, connected } : p
       );
       break;
     }
@@ -353,4 +347,3 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     }
   }
 }
-

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -45,11 +45,7 @@ export function subscribeToFollowJobs(host: ESPHomeApp): void {
   }
 }
 
-export function handleJobEvent(
-  host: ESPHomeApp,
-  event: string,
-  data: unknown,
-): void {
+export function handleJobEvent(host: ESPHomeApp, event: string, data: unknown): void {
   switch (event) {
     case "snapshot":
     case "job_queued":
@@ -102,7 +98,7 @@ function terminateJob(host: ESPHomeApp, job: FirmwareJob): void {
       (j) =>
         j.job_id !== job.job_id &&
         j.configuration === job.configuration &&
-        !isTerminalJobStatus(j.status),
+        !isTerminalJobStatus(j.status)
     );
     if (supersededByActive) {
       const next = new Map(host._firmwareJobs);

--- a/src/components/app-shell/router.ts
+++ b/src/components/app-shell/router.ts
@@ -35,9 +35,7 @@ export function createRouter(host: ReactiveControllerHost & HTMLElement): Router
         return true;
       },
       render: ({ id }) =>
-        html`<esphome-page-device
-          .id=${decodeIdParam(id)}
-        ></esphome-page-device>`,
+        html`<esphome-page-device .id=${decodeIdParam(id)}></esphome-page-device>`,
     },
   ]);
 }

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -21,10 +21,7 @@ export function onSetTheme(host: ESPHomeApp, e: CustomEvent<string>): void {
   host._api.updatePreferences({ theme }).catch(() => {});
 }
 
-export function onSetYamlDiffButton(
-  host: ESPHomeApp,
-  e: CustomEvent<boolean>,
-): void {
+export function onSetYamlDiffButton(host: ESPHomeApp, e: CustomEvent<boolean>): void {
   const enabled = e.detail;
   host._yamlDiffButton = enabled;
   host._api.updatePreferences({ yaml_diff_button: enabled }).catch(() => {});
@@ -35,7 +32,7 @@ export function onSetYamlDiffButton(
 // racing the write can't clobber the optimistic value.
 export async function onSetRemoteBuildEnabled(
   host: ESPHomeApp,
-  e: CustomEvent<boolean>,
+  e: CustomEvent<boolean>
 ): Promise<void> {
   const enabled = e.detail;
   const previous = host._remoteBuildEnabled;
@@ -59,7 +56,7 @@ export async function onSetRemoteBuildEnabled(
 
 export async function onSetRemoteBuildCleanupTtl(
   host: ESPHomeApp,
-  e: CustomEvent<number>,
+  e: CustomEvent<number>
 ): Promise<void> {
   const requested = e.detail;
   if (
@@ -93,7 +90,7 @@ export async function onSetRemoteBuildCleanupTtl(
 
 export async function onSetOffloaderRemoteBuildsEnabled(
   host: ESPHomeApp,
-  e: CustomEvent<boolean>,
+  e: CustomEvent<boolean>
 ): Promise<void> {
   const enabled = e.detail;
   const previous = host._offloaderRemoteBuildsEnabled;
@@ -112,7 +109,7 @@ export async function onSetOffloaderRemoteBuildsEnabled(
 
 export async function onSetOffloaderPairingEnabled(
   host: ESPHomeApp,
-  e: CustomEvent<{ pin_sha256: string; enabled: boolean }>,
+  e: CustomEvent<{ pin_sha256: string; enabled: boolean }>
 ): Promise<void> {
   const { pin_sha256, enabled } = e.detail;
   const previous = host._buildOffloadPairings?.get(pin_sha256)?.enabled;
@@ -131,7 +128,7 @@ export async function onSetOffloaderPairingEnabled(
 
 export function onPairRequestSent(
   host: ESPHomeApp,
-  e: CustomEvent<{ summary: PairingSummary }>,
+  e: CustomEvent<{ summary: PairingSummary }>
 ): void {
   // Backend persists the row but doesn't fire OFFLOADER_PAIR_STATUS_CHANGED
   // for create (events only mark status flips), so seed the row locally.
@@ -149,21 +146,21 @@ export function onRemoteBuildJobSubmitted(
     receiver_label: string;
     configuration: string;
     target: RemoteBuildSubmitTarget;
-  }>,
+  }>
 ): void {
   host.registerRemoteBuildJob(e.detail);
 }
 
 export function onRemoteBuildJobDismissed(
   host: ESPHomeApp,
-  e: CustomEvent<{ job_id: string }>,
+  e: CustomEvent<{ job_id: string }>
 ): void {
   host.dismissRemoteBuildJob(e.detail.job_id);
 }
 
 export async function onSetLanguage(
   host: ESPHomeApp,
-  e: CustomEvent<SupportedLocale | "system">,
+  e: CustomEvent<SupportedLocale | "system">
 ): Promise<void> {
   const choice = e.detail;
   if (choice === "system") {

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -156,7 +156,7 @@ export class ESPHomeBaseDialog extends LitElement {
     // descendant ``wa-dialog`` rather than our own.
     if (e.target !== e.currentTarget) return;
     this.dispatchEvent(
-      new CustomEvent("after-hide", { bubbles: false, composed: false }),
+      new CustomEvent("after-hide", { bubbles: false, composed: false })
     );
   };
 

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -92,7 +92,9 @@ const JOB_TYPE_TO_COMMAND: Record<string, CommandType> = {
 
 @customElement("esphome-command-dialog")
 export class ESPHomeCommandDialog extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
   @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode = true;
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
@@ -192,10 +194,7 @@ export class ESPHomeCommandDialog extends LitElement {
     // running → terminal transition.
     if (changedProperties.has("_state")) {
       const prev = changedProperties.get("_state") as CommandState | null;
-      if (
-        prev === "running" &&
-        (this._state === "success" || this._state === "error")
-      ) {
+      if (prev === "running" && (this._state === "success" || this._state === "error")) {
         this._resetAnsiLogScroll();
       }
     }
@@ -311,7 +310,7 @@ export class ESPHomeCommandDialog extends LitElement {
     // follow_job will reattach if they click back into this device's job.
     this.close();
     this.dispatchEvent(
-      new CustomEvent("open-firmware-jobs", { bubbles: true, composed: true }),
+      new CustomEvent("open-firmware-jobs", { bubbles: true, composed: true })
     );
   };
 
@@ -326,7 +325,7 @@ export class ESPHomeCommandDialog extends LitElement {
         detail: { configuration },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -337,7 +336,7 @@ export class ESPHomeCommandDialog extends LitElement {
   _tryResetBuildEnv = () => {
     this.close();
     this.dispatchEvent(
-      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true }),
+      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true })
     );
   };
 
@@ -407,8 +406,7 @@ export class ESPHomeCommandDialog extends LitElement {
             ></esphome-ansi-log>
             ${renderQueuedOverlay(this)}
           </div>
-          ${renderBanner(this)} ${renderResetSuggestion(this)}
-          ${renderToolbar(this)}
+          ${renderBanner(this)} ${renderResetSuggestion(this)} ${renderToolbar(this)}
         </div>
       </wa-dialog>
     `;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,9 +1,5 @@
 import { APIError } from "../../api/api-error.js";
-import {
-  ErrorCode,
-  JobStatus,
-  type FirmwareJob,
-} from "../../api/types.js";
+import { ErrorCode, JobStatus, type FirmwareJob } from "../../api/types.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import type { ESPHomeCommandDialog } from "../command-dialog.js";
 
@@ -75,7 +71,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
         host._flushPendingLines();
         host._state = data.success ? "success" : "error";
         host._statusMessage = host._localize(
-          data.success ? "command.validate_success" : "command.validate_failed",
+          data.success ? "command.validate_success" : "command.validate_failed"
         );
       },
       onError: (error) => {
@@ -85,7 +81,7 @@ export function startValidateStream(host: ESPHomeCommandDialog): void {
         host._statusMessage = error;
       },
     },
-    { showSecrets: host._showSecrets },
+    { showSecrets: host._showSecrets }
   );
 }
 
@@ -168,7 +164,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       host._statusMessage = host._localize(
         success
           ? `command.${host._commandType}_success`
-          : `command.${host._commandType}_failed`,
+          : `command.${host._commandType}_failed`
       );
       host._jobId = "";
       if (
@@ -206,8 +202,7 @@ export function stopCommand(host: ESPHomeCommandDialog): void {
 function isCancelAlreadyTerminal(err: unknown): boolean {
   if (!(err instanceof APIError)) return false;
   return (
-    err.errorCode === ErrorCode.NOT_FOUND ||
-    err.errorCode === ErrorCode.INVALID_ARGS
+    err.errorCode === ErrorCode.NOT_FOUND || err.errorCode === ErrorCode.INVALID_ARGS
   );
 }
 

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -1,9 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import {
-  JobSource,
-  JobStatus,
-  type FirmwareJob,
-} from "../../api/types.js";
+import { JobSource, JobStatus, type FirmwareJob } from "../../api/types.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { splitTemplate } from "../../util/template-split.js";
@@ -14,7 +10,7 @@ import type { ESPHomeCommandDialog } from "../command-dialog.js";
 // the locally-primed snapshot for the gap between followJob and the first
 // jobs-context update.
 export function renderRemoteBuilderSubLine(
-  host: ESPHomeCommandDialog,
+  host: ESPHomeCommandDialog
 ): TemplateResult | typeof nothing {
   if (!host._jobId) return nothing;
   const liveJob = host._jobs.get(host._jobId);
@@ -29,9 +25,7 @@ export function renderRemoteBuilderSubLine(
   // the pairing hadn't completed a peer-link session yet. Render "<label>
   // (<version>)" so the operator can spot version skew vs the offloader.
   const version =
-    liveJob?.source_esphome_version ??
-    host._primedSource?.source_esphome_version ??
-    "";
+    liveJob?.source_esphome_version ?? host._primedSource?.source_esphome_version ?? "";
   const display = version ? `${label} (${version})` : label;
   // Only allow override for in-flight install — switching mid-upload or
   // mid-compile is a power-user shape without a UI today.
@@ -70,7 +64,7 @@ function runningJob(jobs: Map<string, FirmwareJob>): FirmwareJob | null {
 }
 
 export function renderQueuedOverlay(
-  host: ESPHomeCommandDialog,
+  host: ESPHomeCommandDialog
 ): TemplateResult | typeof nothing {
   if (!host._isQueued && !host._isRemoteQueued) return nothing;
   // Only surface the "waiting for <device>" hint for same-offloader queues
@@ -97,7 +91,9 @@ export function renderQueuedOverlay(
   `;
 }
 
-export function renderBanner(host: ESPHomeCommandDialog): TemplateResult | typeof nothing {
+export function renderBanner(
+  host: ESPHomeCommandDialog
+): TemplateResult | typeof nothing {
   if (host._state !== "success" && host._state !== "error") return nothing;
   const isSuccess = host._state === "success";
   const icon = isSuccess ? "check-circle" : "alert-circle";
@@ -113,7 +109,7 @@ export function renderBanner(host: ESPHomeCommandDialog): TemplateResult | typeo
 // YAML validation failure → "open in editor". Build failure → clean → reset
 // staircase. _userStopped is shared — a user-cancel isn't a build problem.
 export function renderResetSuggestion(
-  host: ESPHomeCommandDialog,
+  host: ESPHomeCommandDialog
 ): TemplateResult | typeof nothing {
   if (host._state !== "error") return nothing;
   if (host._userStopped) return nothing;
@@ -154,11 +150,7 @@ function renderBuildFailureSuggestion(host: ESPHomeCommandDialog): TemplateResul
     return renderRemoteBuildFailureSuggestion(host, remoteLabel);
   }
   const text = host._localize("command.try_reset_suggestion");
-  const [before, middle, after] = splitTemplate(
-    text,
-    "{clean_action}",
-    "{reset_action}",
-  );
+  const [before, middle, after] = splitTemplate(text, "{clean_action}", "{reset_action}");
   return html`
     <div class="reset-suggestion" role="status">
       ${before}<button class="reset-suggestion-link" @click=${host._tryCleanBuild}>
@@ -183,7 +175,7 @@ interface ToolbarToggleOpts {
 
 function renderToolbarToggle(
   host: ESPHomeCommandDialog,
-  opts: ToolbarToggleOpts,
+  opts: ToolbarToggleOpts
 ): TemplateResult {
   const labelKey = opts.active ? opts.labelKeyActive : opts.labelKeyInactive;
   const tooltipKey = opts.active ? opts.tooltipKeyActive : opts.tooltipKeyInactive;
@@ -202,7 +194,7 @@ function renderToolbarToggle(
 // --show-secrets is an `esphome config` flag — hide the toggle on every other
 // command type to keep the toolbar from accumulating inert buttons.
 function renderShowSecretsToggle(
-  host: ESPHomeCommandDialog,
+  host: ESPHomeCommandDialog
 ): TemplateResult | typeof nothing {
   if (host._commandType !== "validate") return nothing;
   return renderToolbarToggle(host, {
@@ -220,7 +212,7 @@ function renderShowSecretsToggle(
 // Disappears once the install settles — the user already declared their
 // preference, no point in showing a no-op control after.
 function renderShowLogsAfterInstallToggle(
-  host: ESPHomeCommandDialog,
+  host: ESPHomeCommandDialog
 ): TemplateResult | typeof nothing {
   if (host._commandType !== "install") return nothing;
   if (host._state === "success" || host._state === "error") return nothing;

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -122,11 +122,7 @@ export class ESPHomeConfirmDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
-        label=${this.heading}
-        light-dismiss
-        @wa-after-hide=${this._onAfterHide}
-      >
+      <wa-dialog label=${this.heading} light-dismiss @wa-after-hide=${this._onAfterHide}>
         <div class="body">
           ${this.destructive
             ? html`<div class="icon-wrap destructive">

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -1,10 +1,6 @@
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
-import type {
-  AdoptableDevice,
-  ConfiguredDevice,
-  Label,
-} from "../../api/types.js";
+import type { AdoptableDevice, ConfiguredDevice, Label } from "../../api/types.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { clearJustCreated } from "../../util/just-created.js";
 import { streamSerialToDialog } from "./actions.js";
@@ -12,7 +8,7 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 
 export async function executeFriendlyName(
   host: ESPHomePageDashboard,
-  e: CustomEvent<{ newFriendlyName: string; install: boolean }>,
+  e: CustomEvent<{ newFriendlyName: string; install: boolean }>
 ): Promise<void> {
   const device = host._actionDevice;
   if (!device) return;
@@ -27,7 +23,7 @@ export async function executeFriendlyName(
         name: device.name,
         reason,
       }),
-      { richColors: true },
+      { richColors: true }
     );
     return;
   }
@@ -42,7 +38,7 @@ export async function executeFriendlyName(
       host._localize("dashboard.action_friendly_name_success", {
         name: newFriendlyName,
       }),
-      { richColors: true },
+      { richColors: true }
     );
     return;
   }
@@ -50,14 +46,14 @@ export async function executeFriendlyName(
     host._localize("dashboard.action_friendly_name_success", {
       name: newFriendlyName,
     }),
-    { richColors: true },
+    { richColors: true }
   );
   host._openInstallMethod(device);
 }
 
 export async function executeClone(
   host: ESPHomePageDashboard,
-  e: CustomEvent<{ newName: string; newFriendlyName: string }>,
+  e: CustomEvent<{ newName: string; newFriendlyName: string }>
 ): Promise<void> {
   const device = host._actionDevice;
   if (!device) return;
@@ -72,7 +68,7 @@ export async function executeClone(
         name: device.name,
         reason,
       }),
-      { richColors: true },
+      { richColors: true }
     );
     return;
   }
@@ -83,7 +79,7 @@ export async function executeClone(
 
 export async function executeRename(
   host: ESPHomePageDashboard,
-  e: CustomEvent<string>,
+  e: CustomEvent<string>
 ): Promise<void> {
   const device = host._actionDevice;
   if (!device) return;
@@ -93,17 +89,16 @@ export async function executeRename(
   try {
     response = await host._api.renameDevice(device.configuration, newName);
   } catch {
-    toast.error(
-      host._localize("dashboard.action_rename_failed", { name: device.name }),
-      { richColors: true },
-    );
+    toast.error(host._localize("dashboard.action_rename_failed", { name: device.name }), {
+      richColors: true,
+    });
     return;
   }
   clearJustCreated();
   if (response.job) {
     host._commandDialog.followJob(
       response.job,
-      firmwareJobDisplayName(response.job, host._devices, host._localize),
+      firmwareJobDisplayName(response.job, host._devices, host._localize)
     );
     return;
   }
@@ -114,7 +109,7 @@ export async function executeRename(
 
 export async function toggleIgnore(
   host: ESPHomePageDashboard,
-  device: AdoptableDevice,
+  device: AdoptableDevice
 ): Promise<void> {
   try {
     await host._api.ignoreDevice(device.name, !device.ignored);
@@ -125,16 +120,16 @@ export async function toggleIgnore(
         device.ignored
           ? "dashboard.action_unignore_failed"
           : "dashboard.action_ignore_failed",
-        { name },
+        { name }
       ),
-      { richColors: true },
+      { richColors: true }
     );
   }
 }
 
 export async function deleteLabel(
   host: ESPHomePageDashboard,
-  label: Label,
+  label: Label
 ): Promise<void> {
   if (!host._api) return;
   try {
@@ -154,7 +149,7 @@ export async function openLogsWithMethod(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice,
   method: string,
-  port?: string,
+  port?: string
 ): Promise<void> {
   if (method === "ota") {
     host._logsDialog.configuration = device.configuration;
@@ -172,9 +167,11 @@ export async function openLogsWithMethod(
       return;
     }
     try {
-      const serialPort = await (navigator as unknown as {
-        serial: { requestPort: () => Promise<SerialPortLike> };
-      }).serial.requestPort();
+      const serialPort = await (
+        navigator as unknown as {
+          serial: { requestPort: () => Promise<SerialPortLike> };
+        }
+      ).serial.requestPort();
       await serialPort.open({ baudRate: 115200 });
       host._logsDialog.configuration = device.configuration;
       host._logsDialog.name = device.friendly_name || device.name;
@@ -193,22 +190,19 @@ interface SerialPortLike {
 
 export function scheduleScrollIntoView(
   host: ESPHomePageDashboard,
-  configuration: string,
+  configuration: string
 ): void {
   requestAnimationFrame(() =>
-    requestAnimationFrame(() => scrollAdoptedIntoView(host, configuration)),
+    requestAnimationFrame(() => scrollAdoptedIntoView(host, configuration))
   );
 }
 
-function scrollAdoptedIntoView(
-  host: ESPHomePageDashboard,
-  configuration: string,
-): void {
+function scrollAdoptedIntoView(host: ESPHomePageDashboard, configuration: string): void {
   const root = host.shadowRoot;
   if (!root) return;
   const escaped = CSS.escape(configuration);
   const card = root.querySelector<HTMLElement>(
-    `esphome-device-card[data-configuration="${escaped}"]`,
+    `esphome-device-card[data-configuration="${escaped}"]`
   );
   if (card) {
     card.scrollIntoView({ behavior: "instant", block: "center" });

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -34,7 +34,7 @@ export function editDevice(device: ConfiguredDevice) {
 export async function archiveDevice(
   device: ConfiguredDevice,
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): Promise<boolean> {
   const name = device.friendly_name || device.name;
   try {
@@ -76,23 +76,21 @@ export async function archiveDevice(
 export async function unarchiveDevice(
   device: ArchivedDevice,
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): Promise<boolean> {
   const name = device.friendly_name || device.name || device.configuration;
   try {
     await api.unarchiveDevice(device.configuration);
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    toast.error(
-      localize("dashboard.action_unarchive_failed", { name, error }),
-      { richColors: true },
-    );
+    toast.error(localize("dashboard.action_unarchive_failed", { name, error }), {
+      richColors: true,
+    });
     return false;
   }
-  toast.success(
-    localize("dashboard.action_unarchive_success", { name }),
-    { richColors: true },
-  );
+  toast.success(localize("dashboard.action_unarchive_success", { name }), {
+    richColors: true,
+  });
   return true;
 }
 
@@ -105,23 +103,21 @@ export async function unarchiveDevice(
 export async function deleteArchivedDevice(
   device: ArchivedDevice,
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): Promise<boolean> {
   const name = device.friendly_name || device.name || device.configuration;
   try {
     await api.deleteArchivedDevice(device.configuration);
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    toast.error(
-      localize("dashboard.action_delete_archived_failed", { name, error }),
-      { richColors: true },
-    );
+    toast.error(localize("dashboard.action_delete_archived_failed", { name, error }), {
+      richColors: true,
+    });
     return false;
   }
-  toast.success(
-    localize("dashboard.action_delete_archived_success", { name }),
-    { richColors: true },
-  );
+  toast.success(localize("dashboard.action_delete_archived_success", { name }), {
+    richColors: true,
+  });
   return true;
 }
 
@@ -162,7 +158,7 @@ async function runBulkAction(
     successKey: string;
     failureKey: string;
     successOptions?: Parameters<typeof toast.success>[1];
-  },
+  }
 ) {
   let results: BulkActionResult[];
   try {
@@ -176,15 +172,15 @@ async function runBulkAction(
   const failed = results.filter((r) => !r.success);
 
   if (succeeded > 0) {
-    toast.success(
-      localize(copy.successKey, { count: succeeded }),
-      { richColors: true, ...copy.successOptions },
-    );
+    toast.success(localize(copy.successKey, { count: succeeded }), {
+      richColors: true,
+      ...copy.successOptions,
+    });
   }
   // Index by configuration up front so failure-toast naming is
   // O(failures) instead of O(failures × devices) on big selections.
   const devicesByConfiguration = new Map(
-    devices.map((d) => [d.configuration, d] as const),
+    devices.map((d) => [d.configuration, d] as const)
   );
   const fallbackError = localize("dashboard.bulk_failure_unknown_error");
   for (const result of failed) {
@@ -197,7 +193,7 @@ async function runBulkAction(
     // ``action_unarchive_failed`` interpolate ``{error}`` directly.
     toast.error(
       localize(copy.failureKey, { name, error: result.error || fallbackError }),
-      { richColors: true },
+      { richColors: true }
     );
   }
 }
@@ -211,30 +207,42 @@ export async function archiveBulkDevices(
   configurations: string[],
   devices: ConfiguredDevice[],
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ) {
-  await runBulkAction(configurations, devices, localize, (c) => api.archiveBulkDevices(c), {
-    catchAllKey: "dashboard.archive_bulk_failed",
-    successKey: "dashboard.archive_bulk_success",
-    failureKey: "dashboard.action_archive_failed",
-    successOptions: {
-      description: localize("dashboard.action_archive_success_hint"),
-      duration: 8000,
-    },
-  });
+  await runBulkAction(
+    configurations,
+    devices,
+    localize,
+    (c) => api.archiveBulkDevices(c),
+    {
+      catchAllKey: "dashboard.archive_bulk_failed",
+      successKey: "dashboard.archive_bulk_success",
+      failureKey: "dashboard.action_archive_failed",
+      successOptions: {
+        description: localize("dashboard.action_archive_success_hint"),
+        duration: 8000,
+      },
+    }
+  );
 }
 
 export async function deleteBulkDevices(
   configurations: string[],
   devices: ConfiguredDevice[],
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ) {
-  await runBulkAction(configurations, devices, localize, (c) => api.deleteBulkDevices(c), {
-    catchAllKey: "dashboard.delete_bulk_failed",
-    successKey: "dashboard.delete_bulk_success",
-    failureKey: "dashboard.delete_failed",
-  });
+  await runBulkAction(
+    configurations,
+    devices,
+    localize,
+    (c) => api.deleteBulkDevices(c),
+    {
+      catchAllKey: "dashboard.delete_bulk_failed",
+      successKey: "dashboard.delete_bulk_success",
+      failureKey: "dashboard.delete_failed",
+    }
+  );
 }
 
 export async function downloadYaml(
@@ -268,7 +276,7 @@ export async function downloadYaml(
 export async function downloadFirmware(
   device: ConfiguredDevice,
   api: ESPHomeAPI,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): Promise<void> {
   const name = device.friendly_name || device.name;
   try {
@@ -311,7 +319,7 @@ export async function detectAndOpenWizard(
      *  this function stays UI-agnostic. */
     onRecognized?: (device: ConfiguredDevice) => void;
     localize?: LocalizeFunc;
-  } = {},
+  } = {}
 ): Promise<void> {
   try {
     const detected = options.port
@@ -327,7 +335,7 @@ export async function detectAndOpenWizard(
         const mac = await readMacAddress(detected.loader);
         recognized =
           options.devices.find(
-            (d) => d.mac_address && d.mac_address.toUpperCase() === mac,
+            (d) => d.mac_address && d.mac_address.toUpperCase() === mac
           ) ?? null;
       } catch {
         // MAC read failed (unsupported chip family, transport flap);
@@ -338,9 +346,7 @@ export async function detectAndOpenWizard(
     // Manifest lookup — runs only when MAC didn't match an existing
     // device. ``readDeviceManifest`` already swallows read / parse
     // failures and returns null, so this can't throw.
-    const manifest = recognized
-      ? null
-      : await readDeviceManifest(detected.loader);
+    const manifest = recognized ? null : await readDeviceManifest(detected.loader);
 
     await disconnect(detected.transport);
 
@@ -350,7 +356,7 @@ export async function detectAndOpenWizard(
           options.localize("dashboard.serial_recognized", {
             name: recognized.friendly_name || recognized.name,
           }),
-          { richColors: true },
+          { richColors: true }
         );
       }
       options.onRecognized(recognized);
@@ -365,7 +371,7 @@ export async function detectAndOpenWizard(
             options.localize("dashboard.serial_starterkit_detected", {
               name: board.name,
             }),
-            { richColors: true },
+            { richColors: true }
           );
         }
         createDialog.openWithBoard(board);
@@ -506,4 +512,3 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
       });
   };
 }
-

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -103,8 +103,12 @@ registerMdiIcons({
 
 @customElement("esphome-device-drawer-content")
 export class ESPHomeDeviceDrawerContent extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
-  @consume({ context: integrationDocsContext, subscribe: true }) @state() _integrationDocs: Record<string, string> = {};
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
+  @consume({ context: integrationDocsContext, subscribe: true })
+  @state()
+  _integrationDocs: Record<string, string> = {};
   @consume({ context: apiContext }) @state() _api?: ESPHomeAPI;
 
   @property({ attribute: false }) device!: ConfiguredDevice;
@@ -180,24 +184,46 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
         : nothing}
       <div class="section">
         <h4 class="section-title">${this._localize("dashboard.drawer_device_info")}</h4>
-        ${renderRow("information-outline", this._localize("dashboard.drawer_name"), d.friendly_name || d.name)}
-        ${renderRow("network-outline", this._localize("dashboard.drawer_address"), d.address, true)}
-        ${renderIpAddressRow(this, d)}
-        ${renderMacAddressRow(d, this._localize)}
+        ${renderRow(
+          "information-outline",
+          this._localize("dashboard.drawer_name"),
+          d.friendly_name || d.name
+        )}
+        ${renderRow(
+          "network-outline",
+          this._localize("dashboard.drawer_address"),
+          d.address,
+          true
+        )}
+        ${renderIpAddressRow(this, d)} ${renderMacAddressRow(d, this._localize)}
         ${renderEthernetMacRow(d, this._localize)}
         ${renderBluetoothMacRow(d, this._localize)}
-        ${renderRow("memory", this._localize("dashboard.drawer_platform"), d.target_platform)}
+        ${renderRow(
+          "memory",
+          this._localize("dashboard.drawer_platform"),
+          d.target_platform
+        )}
         ${renderBuildSizeRow(this, d)}
-        ${d.area ? renderRow("map-marker-outline", this._localize("dashboard.drawer_area"), d.area) : nothing}
+        ${d.area
+          ? renderRow(
+              "map-marker-outline",
+              this._localize("dashboard.drawer_area"),
+              d.area
+            )
+          : nothing}
       </div>
 
-      ${renderLabelsSection(d, this._localize)}
-      ${renderReachabilitySection(this)}
+      ${renderLabelsSection(d, this._localize)} ${renderReachabilitySection(this)}
       ${renderVersionSection(d, this._localize)}
 
       <div class="section">
         <h4 class="section-title">${this._localize("dashboard.drawer_configuration")}</h4>
-        ${renderRow("file-document-outline", this._localize("dashboard.drawer_config_file"), d.configuration, true)}
+        ${renderRow(
+          "file-document-outline",
+          this._localize("dashboard.drawer_config_file"),
+          d.configuration,
+          true
+        )}
         ${renderRow("text-short", this._localize("dashboard.drawer_comment"), d.comment)}
       </div>
 
@@ -215,8 +241,7 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const previousDevice = changed.get("device") as ConfiguredDevice | null | undefined;
     const deviceTargetMoved =
       changed.has("device") &&
-      (previousDevice?.configuration ?? null) !==
-        (this.device?.configuration ?? null);
+      (previousDevice?.configuration ?? null) !== (this.device?.configuration ?? null);
     if (deviceTargetMoved) {
       this._ipExpanded = false;
     }

--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -1,9 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { activeLocale, type LocalizeFunc } from "../../../common/localize.js";
-import type {
-  ReachabilitySource,
-  ReachabilityStateEvent,
-} from "../../../api/types.js";
+import type { ReachabilitySource, ReachabilityStateEvent } from "../../../api/types.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
 import {
   ageOf,
@@ -23,7 +20,7 @@ interface ReachabilityRowSpec {
 }
 
 export function renderReachabilitySection(
-  host: ESPHomeDeviceDrawerContent,
+  host: ESPHomeDeviceDrawerContent
 ): TemplateResult | typeof nothing {
   const r = host._reachability;
   if (r === null) return nothing;
@@ -61,15 +58,13 @@ export function renderReachabilitySection(
 
   return html`
     <div class="section">
-      <h4 class="section-title">
-        ${host._localize("dashboard.drawer_reachability")}
-      </h4>
+      <h4 class="section-title">${host._localize("dashboard.drawer_reachability")}</h4>
       ${!anySignal
         ? html`<div class="value muted">
             ${host._localize("dashboard.drawer_waiting_for_signal")}
           </div>`
         : rows.map((row) =>
-            renderReachabilityRow(row, r.active_source, lang, host._localize),
+            renderReachabilityRow(row, r.active_source, lang, host._localize)
           )}
     </div>
   `;
@@ -79,7 +74,7 @@ function renderReachabilityRow(
   row: ReachabilityRowSpec,
   activeSource: ReachabilitySource,
   lang: string | undefined,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   if (row.age === null) return nothing;
   const ageText = formatSecondsAgo(row.age, lang);
@@ -122,12 +117,10 @@ function renderReachabilityRow(
 // (which catches WS reconnects — the API clears event listeners on close so
 // the stale _subscribedDevice would otherwise block resubscribe).
 export function reconcileSubscription(host: ESPHomeDeviceDrawerContent): void {
-  const wantName =
-    host.drawerOpen && host.device && host._api ? host.device.name : null;
+  const wantName = host.drawerOpen && host.device && host._api ? host.device.name : null;
   const currentGeneration = host._api?.connectionGeneration ?? 0;
   const generationChanged =
-    host._subscribedDevice !== null &&
-    currentGeneration !== host._subscribedGeneration;
+    host._subscribedDevice !== null && currentGeneration !== host._subscribedGeneration;
   if (wantName === host._subscribedDevice && !generationChanged) return;
 
   teardownSubscription(host);
@@ -149,7 +142,7 @@ async function openSubscription(
   deviceName: string,
   attemptGeneration: number,
   attemptKey: string,
-  api: ESPHomeAPI,
+  api: ESPHomeAPI
 ): Promise<void> {
   // A WS reconnect (gen bump) or different-device selection between
   // subscribe-start and resolve/reject makes this attempt stale; catch
@@ -166,7 +159,7 @@ async function openSubscription(
         if (!isCurrent()) return;
         host._reachability = state;
         host._reachabilityAnchorMs = Date.now();
-      },
+      }
     );
     if (!isCurrent()) {
       void subscription.unsubscribe();

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -23,7 +23,7 @@ export function renderRow(
   icon: string,
   label: string,
   value: string | null,
-  mono = false,
+  mono = false
 ): TemplateResult {
   const empty = !value;
   return html`
@@ -43,7 +43,7 @@ export function renderRow(
 
 export function renderEncryptionBadge(
   localize: LocalizeFunc,
-  state: "active" | "plaintext" | "pending" | "mismatch" | "none",
+  state: "active" | "plaintext" | "pending" | "mismatch" | "none"
 ): TemplateResult | typeof nothing {
   const variants = {
     active: {
@@ -81,15 +81,11 @@ export function renderEncryptionBadge(
 
 function renderIntegrationTag(
   name: string,
-  integrationDocs: Record<string, string>,
+  integrationDocs: Record<string, string>
 ): TemplateResult {
   const url = integrationDocs[name];
   return url && isSafeDocsUrl(url)
-    ? html`<a
-        class="tag tag--link"
-        href=${url}
-        target="_blank"
-        rel="noopener noreferrer"
+    ? html`<a class="tag tag--link" href=${url} target="_blank" rel="noopener noreferrer"
         >${name}</a
       >`
     : html`<span class="tag">${name}</span>`;
@@ -102,20 +98,18 @@ function renderIntegrationTag(
 export function renderLoadedIntegrationsSection(
   d: ConfiguredDevice,
   localize: LocalizeFunc,
-  integrationDocs: Record<string, string>,
+  integrationDocs: Record<string, string>
 ): TemplateResult | typeof nothing {
   if (!d.loaded_integrations || d.loaded_integrations.length === 0) {
     return nothing;
   }
   const { direct, indirect } = splitIntegrations(
     d.loaded_integrations,
-    d.directly_referenced_integrations,
+    d.directly_referenced_integrations
   );
   return html`
     <div class="section">
-      <h4 class="section-title">
-        ${localize("dashboard.drawer_loaded_integrations")}
-      </h4>
+      <h4 class="section-title">${localize("dashboard.drawer_loaded_integrations")}</h4>
       <div class="tags-wrap">
         ${direct.map((i) => renderIntegrationTag(i, integrationDocs))}
       </div>
@@ -139,7 +133,7 @@ export function renderLoadedIntegrationsSection(
 
 export function renderLabelsSection(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult {
   return html`
     <div class="section">
@@ -155,7 +149,7 @@ export function renderLabelsSection(
 // reported yet (brand-new device, never compiled, never broadcast).
 export function renderVersionSection(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const local = d.current_version || "";
   const deployed = d.deployed_version || "";
@@ -185,13 +179,13 @@ export function renderVersionSection(
               "tag-multiple",
               localize("dashboard.drawer_current_version"),
               local,
-              true,
+              true
             )}
             ${renderRow(
               "upload",
               localize("dashboard.drawer_deployed_version"),
               deployed,
-              true,
+              true
             )}
           `}
     </div>
@@ -202,7 +196,7 @@ export function renderVersionSection(
 // "the modified dot is on but the YAML hasn't changed — what's mismatched?".
 export function renderConfigHashSection(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
   const deployed = d.deployed_config_hash || "";
@@ -218,9 +212,7 @@ export function renderConfigHashSection(
   const showStatus = !!expected && !!deployed;
   return html`
     <div class="section">
-      <h4 class="section-title">
-        ${localize("dashboard.drawer_config_hash_title")}
-      </h4>
+      <h4 class="section-title">${localize("dashboard.drawer_config_hash_title")}</h4>
       ${showStatus
         ? html`<div class=${statusCls}>
             <wa-icon library="mdi" name=${statusIcon}></wa-icon>
@@ -232,20 +224,20 @@ export function renderConfigHashSection(
             "fingerprint",
             localize("dashboard.drawer_config_hash_value"),
             expected,
-            true,
+            true
           )
         : html`
             ${renderRow(
               "fingerprint",
               localize("dashboard.drawer_config_hash_local"),
               expected,
-              true,
+              true
             )}
             ${renderRow(
               "fingerprint",
               localize("dashboard.drawer_config_hash_deployed"),
               deployed,
-              true,
+              true
             )}
           `}
     </div>
@@ -256,7 +248,7 @@ export function renderConfigHashSection(
 // primary with a chevron toggle so the drawer stays scannable.
 export function renderIpAddressRow(
   host: ESPHomeDeviceDrawerContent,
-  d: ConfiguredDevice,
+  d: ConfiguredDevice
 ): TemplateResult {
   const list = d.ip_addresses;
   const label = host._localize("dashboard.drawer_ip_address");
@@ -324,13 +316,13 @@ export function renderIpAddressRow(
 
 export function renderMacAddressRow(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult {
   return renderRow(
     "ethernet",
     localize("dashboard.drawer_mac_address"),
     d.mac_address,
-    true,
+    true
   );
 }
 
@@ -338,40 +330,40 @@ export function renderMacAddressRow(
 // (single-MAC RP2040 / RP2350 platforms).
 export function renderEthernetMacRow(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   if (!d.ethernet_mac || d.ethernet_mac === d.mac_address) return nothing;
   return renderRow(
     "ethernet",
     localize("dashboard.drawer_ethernet_mac"),
     d.ethernet_mac,
-    true,
+    true
   );
 }
 
 export function renderBluetoothMacRow(
   d: ConfiguredDevice,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   if (!d.bluetooth_mac || d.bluetooth_mac === d.mac_address) return nothing;
   return renderRow(
     "bluetooth",
     localize("dashboard.drawer_bluetooth_mac"),
     d.bluetooth_mac,
-    true,
+    true
   );
 }
 
 function emitCleanBuild(
   host: ESPHomeDeviceDrawerContent,
-  device: ConfiguredDevice,
+  device: ConfiguredDevice
 ): void {
   host.dispatchEvent(
     new CustomEvent("clean-build", {
       detail: device,
       bubbles: true,
       composed: true,
-    }),
+    })
   );
 }
 
@@ -381,7 +373,7 @@ function emitCleanBuild(
 // kebab — same backend job, same job-completion build-size refresh hook.
 export function renderBuildSizeRow(
   host: ESPHomeDeviceDrawerContent,
-  d: ConfiguredDevice,
+  d: ConfiguredDevice
 ): TemplateResult | typeof nothing {
   if (!d.build_size_bytes) return nothing;
   return html`
@@ -390,9 +382,7 @@ export function renderBuildSizeRow(
         <wa-icon library="mdi" name="harddisk"></wa-icon>
       </div>
       <div class="content">
-        <div class="label">
-          ${host._localize("dashboard.drawer_build_size")}
-        </div>
+        <div class="label">${host._localize("dashboard.drawer_build_size")}</div>
         <div class="value build-size-value">
           <span>${formatFileSize(d.build_size_bytes)}</span>
           <button

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -24,17 +24,11 @@ import type { LocalizeFunc } from "../../common/localize.js";
  * known" branch so the visit affordance isn't gated on the first
  * mDNS A-record.
  */
-export function renderIpValue(
-  ip: string,
-  url: string,
-  localize: LocalizeFunc,
-) {
+export function renderIpValue(ip: string, url: string, localize: LocalizeFunc) {
   const isPlaceholder = !ip;
   const display = ip || "—";
   if (!url) {
-    return html`<div
-      class="value mono ${isPlaceholder ? "muted" : ""}"
-    >${display}</div>`;
+    return html`<div class="value mono ${isPlaceholder ? "muted" : ""}">${display}</div>`;
   }
   const visitLabel = localize("dashboard.action_visit_web_ui");
   return html`
@@ -82,7 +76,7 @@ export function renderIpValue(
  */
 export function renderMdnsTxtRecords(
   records: Record<string, string> | null | undefined,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ) {
   if (records === null || records === undefined) return nothing;
   const entries = Object.entries(records);
@@ -105,15 +99,13 @@ export function renderMdnsTxtRecords(
       : "dashboard.drawer_show_mdns_txt_records_plural";
   return html`
     <details class="mdns-txt-details">
-      <summary>
-        ${localize(summaryKey, { count: entries.length })}
-      </summary>
+      <summary>${localize(summaryKey, { count: entries.length })}</summary>
       <dl class="mdns-txt-list">
         ${entries.map(
           ([key, value]) => html`
             <dt>${key}</dt>
             <dd>${value}</dd>
-          `,
+          `
         )}
       </dl>
     </details>

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -100,8 +100,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: var(--wa-space-l);
-        border-bottom: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         flex-shrink: 0;
       }
 
@@ -127,8 +126,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
         margin: 0;
         font-size: var(--wa-font-size-xs);
         color: var(--wa-color-text-quiet);
-        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-          monospace;
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
       }
 
       .close-btn {
@@ -142,7 +140,9 @@ export class ESPHomeDeviceDrawer extends LitElement {
         background: transparent;
         color: var(--wa-color-text-quiet);
         cursor: pointer;
-        transition: background 0.12s, color 0.12s;
+        transition:
+          background 0.12s,
+          color 0.12s;
         flex-shrink: 0;
         margin-left: var(--wa-space-s);
       }
@@ -175,11 +175,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
       }
 
       .status-banner.online {
-        background: color-mix(
-          in srgb,
-          var(--esphome-success),
-          transparent 88%
-        );
+        background: color-mix(in srgb, var(--esphome-success), transparent 88%);
         color: var(--esphome-success);
         border: var(--wa-border-width-s) solid
           color-mix(in srgb, var(--esphome-success), transparent 70%);
@@ -211,14 +207,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
 
       .status-dot.online {
         background: var(--esphome-success);
-        box-shadow: 0 0 8px
-          color-mix(in srgb, var(--esphome-success), transparent 40%);
+        box-shadow: 0 0 8px color-mix(in srgb, var(--esphome-success), transparent 40%);
       }
 
       .status-dot.offline {
         background: var(--esphome-error);
-        box-shadow: 0 0 8px
-          color-mix(in srgb, var(--esphome-error), transparent 50%);
+        box-shadow: 0 0 8px color-mix(in srgb, var(--esphome-error), transparent 50%);
       }
 
       .status-dot.unknown {
@@ -240,8 +234,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
         display: flex;
         gap: var(--wa-space-xs);
         padding: var(--wa-space-m) var(--wa-space-l);
-        border-top: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         flex-shrink: 0;
       }
 
@@ -258,7 +251,9 @@ export class ESPHomeDeviceDrawer extends LitElement {
         font-family: inherit;
         cursor: pointer;
         border: var(--wa-border-width-s) solid transparent;
-        transition: background 0.12s, border-color 0.12s;
+        transition:
+          background 0.12s,
+          border-color 0.12s;
         white-space: nowrap;
       }
 
@@ -275,24 +270,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
       }
 
       .action--accent {
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 90%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
         color: var(--esphome-primary);
-        border-color: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 70%
-        );
+        border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
       }
       .action--accent:hover {
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 82%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 82%);
         border-color: var(--esphome-primary);
       }
 
@@ -343,7 +326,11 @@ export class ESPHomeDeviceDrawer extends LitElement {
             <h2 class="title">${device.friendly_name || device.name}</h2>
             <p class="subtitle">${device.configuration}</p>
           </div>
-          <button class="close-btn" @click=${this._close} aria-label=${this._localize("dashboard.drawer_close")}>
+          <button
+            class="close-btn"
+            @click=${this._close}
+            aria-label=${this._localize("dashboard.drawer_close")}
+          >
             <wa-icon library="mdi" name="close"></wa-icon>
           </button>
         </div>
@@ -405,7 +392,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
   private _close() {
     this.open = false;
     this.dispatchEvent(
-      new CustomEvent("drawer-close", { bubbles: true, composed: true }),
+      new CustomEvent("drawer-close", { bubbles: true, composed: true })
     );
   }
 
@@ -424,7 +411,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
         detail: this.device,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -38,10 +38,7 @@ import type { ConfiguredDevice, FirmwareJob, Label } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import {
-  labelChipStyles,
-  resolveLabelIds,
-} from "../../util/label-chip-template.js";
+import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { tableCellStyles } from "./table-cell-styles.js";
 import type { ToggleableColumn } from "./table-column-toggle.js";
@@ -255,7 +252,10 @@ export class ESPHomeDeviceTable extends LitElement {
     }
     if (changed.has("initialColumnVisibility") && this.initialColumnVisibility !== null) {
       // Merge defaults so columns the user hasn't explicitly toggled stay hidden.
-      this._columnVisibility = { ...DEFAULT_HIDDEN_COLUMNS, ...this.initialColumnVisibility };
+      this._columnVisibility = {
+        ...DEFAULT_HIDDEN_COLUMNS,
+        ...this.initialColumnVisibility,
+      };
     }
     if (changed.has("initialPageSize")) {
       this._pageSize = this.initialPageSize;
@@ -334,9 +334,7 @@ export class ESPHomeDeviceTable extends LitElement {
     });
 
     const rows = table.getRowModel().rows;
-    this._visibleConfigs = table
-      .getFilteredRowModel()
-      .rows.map((r) => r.original.config);
+    this._visibleConfigs = table.getFilteredRowModel().rows.map((r) => r.original.config);
     const pgState = table.getState().pagination;
     const toggleCols: ToggleableColumn[] = table
       .getAllColumns()
@@ -376,7 +374,9 @@ export class ESPHomeDeviceTable extends LitElement {
         .device=${this._contextMenuDevice}
         .position=${this._contextMenuPos}
         ?anchor-right=${this._contextMenuAnchorRight}
-        ?busy=${this._contextMenuDevice ? this.activeJobs.has(this._contextMenuDevice.configuration) : false}
+        ?busy=${this._contextMenuDevice
+          ? this.activeJobs.has(this._contextMenuDevice.configuration)
+          : false}
         @menu-close=${this._closeContextMenu}
         @edit-device=${(e: CustomEvent) => {
           e.stopPropagation();
@@ -487,7 +487,9 @@ export class ESPHomeDeviceTable extends LitElement {
                       : sorted === "desc"
                         ? "descending"
                         : "none"}
-                    class="${canSort ? "sortable" : ""} ${sorted ? "sorted" : ""} col-${header.column.id}"
+                    class="${canSort ? "sortable" : ""} ${sorted
+                      ? "sorted"
+                      : ""} col-${header.column.id}"
                     style="width:${header.getSize()}px"
                     @click=${canSort ? () => header.column.toggleSorting() : nothing}
                   >
@@ -530,10 +532,8 @@ export class ESPHomeDeviceTable extends LitElement {
                   data-configuration=${row.original.config}
                   class=${classMap({
                     selected:
-                      this.selectMode &&
-                      this.selectedDevices.has(row.original.config),
-                    highlight:
-                      this.highlightConfiguration === row.original.config,
+                      this.selectMode && this.selectedDevices.has(row.original.config),
+                    highlight: this.highlightConfiguration === row.original.config,
                   })}
                   @click=${() =>
                     this.selectMode
@@ -635,7 +635,7 @@ export class ESPHomeDeviceTable extends LitElement {
     const root = this.shadowRoot;
     if (!root) return;
     const row = root.querySelector<HTMLElement>(
-      `tr[data-configuration="${CSS.escape(configuration)}"]`,
+      `tr[data-configuration="${CSS.escape(configuration)}"]`
     );
     row?.scrollIntoView({ behavior: "instant", block: "center" });
   }

--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -6,7 +6,7 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 
 export function openInstallMethod(
   host: ESPHomePageDashboard,
-  device: ConfiguredDevice,
+  device: ConfiguredDevice
 ): void {
   host._installMethodDevice = device;
   host._installMethodMode = "install";
@@ -15,7 +15,7 @@ export function openInstallMethod(
 
 export function onInstallMethodSelect(
   host: ESPHomePageDashboard,
-  e: CustomEvent<{ method: string; port?: string }>,
+  e: CustomEvent<{ method: string; port?: string }>
 ): void {
   const device = host._installMethodDevice;
   host._installMethodOpen = false;
@@ -42,7 +42,7 @@ export function openCommand(
   host: ESPHomePageDashboard,
   device: ConfiguredDevice,
   type: CommandType,
-  port?: string,
+  port?: string
 ): void {
   host._commandDialog.configuration = device.configuration;
   host._commandDialog.name = device.friendly_name || device.name;
@@ -51,20 +51,17 @@ export function openCommand(
 
 export function showJobProgress(
   host: ESPHomePageDashboard,
-  device: ConfiguredDevice,
+  device: ConfiguredDevice
 ): void {
   const job = host._activeJobs.get(device.configuration);
   if (!job) return;
   host._commandDialog.followJob(
     job,
-    firmwareJobDisplayName(job, host._devices, host._localize),
+    firmwareJobDisplayName(job, host._devices, host._localize)
   );
 }
 
-export function openLogs(
-  host: ESPHomePageDashboard,
-  device: ConfiguredDevice,
-): void {
+export function openLogs(host: ESPHomePageDashboard, device: ConfiguredDevice): void {
   if (device.state === DeviceState.ONLINE) {
     host._logsDialog.configuration = device.configuration;
     host._logsDialog.name = device.friendly_name || device.name;

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -10,15 +10,12 @@ import {
   renderSelectToggle,
   renderViewToggle,
 } from "./render-toolbar.js";
-import {
-  DEVICE_SORT_COLLATOR,
-  deviceSortKey,
-} from "../../util/device-sort.js";
+import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 
 export function renderDiscoveredSection(
-  host: ESPHomePageDashboard,
+  host: ESPHomePageDashboard
 ): TemplateResult | string {
   if (host._importableDevices.length === 0) return "";
   // Non-ignored discoveries first, then ignored ones — both
@@ -45,7 +42,7 @@ export function renderDiscoveredSection(
             visible.length === 1
               ? "dashboard.discovered_count_singular"
               : "dashboard.discovered_count_plural",
-            { count: visible.length },
+            { count: visible.length }
           )}</span
         >
         <button
@@ -74,11 +71,7 @@ export function renderDiscoveredSection(
             </button>`
           : ""}
       </header>
-      <div
-        id="discovered-grid"
-        class="discovered-section-grid"
-        ?hidden=${!expanded}
-      >
+      <div id="discovered-grid" class="discovered-section-grid" ?hidden=${!expanded}>
         ${visible.map(
           (device: AdoptableDevice) => html`
             <esphome-discovered-device-card
@@ -87,7 +80,7 @@ export function renderDiscoveredSection(
               @adopt=${() => host._adoptDialog.open(device)}
               @toggle-ignore=${() => host._toggleIgnore(device)}
             ></esphome-discovered-device-card>
-          `,
+          `
         )}
       </div>
     </section>
@@ -96,7 +89,7 @@ export function renderDiscoveredSection(
 
 export function renderCardGrid(
   host: ESPHomePageDashboard,
-  filtered: ConfiguredDevice[],
+  filtered: ConfiguredDevice[]
 ): TemplateResult {
   return html`
     <div class="devices-grid devices-grid--configured">
@@ -155,20 +148,17 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
       ?select-mode=${host._selectMode}
       .selectedDevices=${host._selectedDevices}
       .highlightConfiguration=${host._recentlyAdopted}
-      @table-sort-change=${(e: CustomEvent<SortingState>) =>
-        host._saveTablePreference(e)}
+      @table-sort-change=${(e: CustomEvent<SortingState>) => host._saveTablePreference(e)}
       @table-visibility-change=${(e: CustomEvent<VisibilityState>) =>
         host._saveTablePreference(e)}
-      @table-page-size-change=${(e: CustomEvent<number>) =>
-        host._saveTablePreference(e)}
+      @table-page-size-change=${(e: CustomEvent<number>) => host._saveTablePreference(e)}
       @row-click=${(e: CustomEvent<ConfiguredDevice>) =>
         host._toggleDrawerForDevice(e.detail)}
       @show-progress=${(e: CustomEvent<ConfiguredDevice>) =>
         host._showJobProgress(e.detail)}
       @toggle-select=${(e: CustomEvent<string>) => host._toggleDevice(e.detail)}
       @select-all=${(e: CustomEvent<string[]>) => host._addToSelection(e.detail)}
-      @deselect-all=${(e: CustomEvent<string[]>) =>
-        host._removeFromSelection(e.detail)}
+      @deselect-all=${(e: CustomEvent<string[]>) => host._removeFromSelection(e.detail)}
       @edit-device=${(e: CustomEvent<ConfiguredDevice>) => editDevice(e.detail)}
       @update-device=${(e: CustomEvent<ConfiguredDevice>) =>
         host._openCommand(e.detail, "install")}
@@ -192,13 +182,11 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         host._confirmArchive(e.detail)}
       @delete-device=${(e: CustomEvent<ConfiguredDevice>) =>
         host._confirmDeleteSingle(e.detail)}
-      @enter-select-mode=${(e: CustomEvent<string>) =>
-        host._onEnterSelectMode(e.detail)}
+      @enter-select-mode=${(e: CustomEvent<string>) => host._onEnterSelectMode(e.detail)}
     >
       <div slot="toolbar" class="toolbar-stack">
         <div class="toolbar-row">
-          ${renderSearchInput(host)} ${renderViewToggle(host)}
-          ${renderFacets(host)}
+          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         </div>
       </div>
       <div slot="before-columns">${renderSelectToggle(host)}</div>

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -1,16 +1,8 @@
 import { html, type TemplateResult } from "lit";
-import type {
-  ArchivedDevice,
-  ConfiguredDevice,
-  Label,
-} from "../../api/types.js";
+import type { ArchivedDevice, ConfiguredDevice, Label } from "../../api/types.js";
 import { DeviceState } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import {
-  archiveBulkDevices,
-  deleteBulkDevices,
-  deleteDevice,
-} from "./actions.js";
+import { archiveBulkDevices, deleteBulkDevices, deleteDevice } from "./actions.js";
 import { computeLabelUsage, deleteConfirmKey } from "../../util/label-usage.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 
@@ -33,7 +25,7 @@ export function confirmDialogCopy(
   pending: PendingConfirm | null,
   localize: LocalizeFunc,
   selectedDevicesSize: number,
-  labelUsage: () => Record<string, number>,
+  labelUsage: () => Record<string, number>
 ): ConfirmCopy {
   const t = localize;
   if (!pending) {
@@ -106,8 +98,11 @@ export function confirmDialogCopy(
 
 export function computeLabelUsageCached(
   source: ConfiguredDevice[],
-  cache: { source: ConfiguredDevice[]; map: Record<string, number> } | null,
-): { map: Record<string, number>; cache: { source: ConfiguredDevice[]; map: Record<string, number> } } {
+  cache: { source: ConfiguredDevice[]; map: Record<string, number> } | null
+): {
+  map: Record<string, number>;
+  cache: { source: ConfiguredDevice[]; map: Record<string, number> };
+} {
   if (cache?.source === source) return { map: cache.map, cache };
   const map = computeLabelUsage(source);
   return { map, cache: { source, map } };
@@ -115,7 +110,7 @@ export function computeLabelUsageCached(
 
 export function executeConfirm(
   host: ESPHomePageDashboard,
-  pending: PendingConfirm,
+  pending: PendingConfirm
 ): void {
   switch (pending.kind) {
     case "delete-bulk": {
@@ -152,7 +147,7 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
     host._pendingConfirm,
     host._localize,
     host._selectedDevices.size,
-    () => host._computeLabelUsage(),
+    () => host._computeLabelUsage()
   );
   return html`
     <esphome-confirm-dialog
@@ -200,8 +195,7 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
       @select-method=${host._onInstallMethodSelect}
     ></esphome-install-method-dialog>
     <esphome-archived-devices-dialog
-      @unarchive=${(e: CustomEvent<ArchivedDevice>) =>
-        host._unarchiveDevice(e.detail)}
+      @unarchive=${(e: CustomEvent<ArchivedDevice>) => host._unarchiveDevice(e.detail)}
       @delete-archived=${(e: CustomEvent<ArchivedDevice>) =>
         host._confirmDeleteArchived(e.detail)}
     ></esphome-archived-devices-dialog>

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -220,14 +220,11 @@ export function renderToolbar(
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)}
-        ${renderFacets(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         <span class="toolbar-spacer"></span>
         ${renderSelectToggle(host)}
       </div>
-      <span class="device-count"
-        ><strong>${matchCount}</strong> ${unit}${suffix}</span
-      >
+      <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
     </div>
   `;
 }
@@ -243,8 +240,7 @@ export function renderYamlToolbar(host: ESPHomePageDashboard): TemplateResult {
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)}
-        ${renderFacets(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         <span class="toolbar-spacer"></span>
       </div>
       ${matchCount !== null
@@ -259,7 +255,7 @@ export function renderNoResultsExtras(host: ESPHomePageDashboard): TemplateResul
   return html`
     ${hasSearch
       ? renderYamlPreviewPivot(host._localize, host._yamlPreviewCount, () =>
-          host._setSearchMode(true),
+          host._setSearchMode(true)
         )
       : ""}
     <button class="empty-search-clear" @click=${host._clearAllFilters}>

--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -32,7 +32,7 @@ export function highlightMatch(text: string, needle: string): unknown {
 
 export function renderYamlEmptyState(
   localize: LocalizeFunc,
-  messageKey: string,
+  messageKey: string
 ): TemplateResult {
   return html`
     <div class="empty-search">
@@ -45,7 +45,7 @@ export function renderYamlEmptyState(
 function renderSnippetBlock(
   hit: YamlSearchHit,
   block: YamlSnippetBlock,
-  query: string,
+  query: string
 ): TemplateResult {
   const href = yamlSnippetBlockHref(hit, block);
   return html`
@@ -64,7 +64,9 @@ function renderSnippetBlock(
         return html`
           <div class="yaml-snippet-line ${isMatch ? "yaml-snippet-line--match" : ""}">
             <span class="yaml-snippet-gutter">${lineNumber}</span>
-            <span class="yaml-snippet-text">${isMatch ? highlightMatch(text, query) : text}</span>
+            <span class="yaml-snippet-text"
+              >${isMatch ? highlightMatch(text, query) : text}</span
+            >
           </div>
         `;
       })}
@@ -75,7 +77,7 @@ function renderSnippetBlock(
 function renderYamlDeviceTitle(
   configuration: string,
   trailing: TemplateResult | string,
-  body: TemplateResult | string,
+  body: TemplateResult | string
 ): TemplateResult {
   const deviceHref = `/device/${encodeURIComponent(configuration)}`;
   return html`
@@ -99,9 +101,7 @@ function renderYamlDeviceTitle(
   `;
 }
 
-function renderYamlTitleList(
-  devices: ConfiguredDevice[],
-): TemplateResult {
+function renderYamlTitleList(devices: ConfiguredDevice[]): TemplateResult {
   return html`
     <div class="yaml-hits">
       ${devices.map((d) => renderYamlDeviceTitle(d.configuration, "", ""))}
@@ -112,7 +112,7 @@ function renderYamlTitleList(
 function renderYamlHits(
   localize: LocalizeFunc,
   hits: YamlSearchHit[],
-  query: string,
+  query: string
 ): TemplateResult {
   return html`
     <div class="yaml-hits">
@@ -122,14 +122,12 @@ function renderYamlHits(
         const countUnit = localize(
           matchCount === 1
             ? "yaml_search.match_count_singular"
-            : "yaml_search.match_count_plural",
+            : "yaml_search.match_count_plural"
         );
         const trailing = html`<span class="yaml-hit-group-count"
           >${matchCount} ${countUnit}</span
         >`;
-        const body = html`${blocks.map((block) =>
-          renderSnippetBlock(hit, block, query),
-        )}`;
+        const body = html`${blocks.map((block) => renderSnippetBlock(hit, block, query))}`;
         return renderYamlDeviceTitle(yamlHitDeviceLabel(hit), trailing, body);
       })}
     </div>
@@ -148,7 +146,7 @@ export function renderYamlMode(host: ESPHomePageDashboard): TemplateResult {
 export function renderYamlPreviewPivot(
   localize: LocalizeFunc,
   previewCount: number,
-  onPivot: () => void,
+  onPivot: () => void
 ): TemplateResult | string {
   if (previewCount === 0) return "";
   return html`<button class="empty-search-yaml-pivot" @click=${onPivot}>
@@ -157,7 +155,7 @@ export function renderYamlPreviewPivot(
       previewCount === 1
         ? "yaml_search.no_match_yaml_preview"
         : "yaml_search.no_match_yaml_preview_plural",
-      { count: previewCount },
+      { count: previewCount }
     )}
   </button>`;
 }

--- a/src/components/dashboard/search.ts
+++ b/src/components/dashboard/search.ts
@@ -44,7 +44,7 @@ export function syncYamlSearch(host: ESPHomePageDashboard): void {
 export function setSearchMode(
   host: ESPHomePageDashboard,
   yamlMode: boolean,
-  search?: string,
+  search?: string
 ): void {
   host._yamlMode = yamlMode;
   if (search !== undefined) host._search = search;
@@ -56,7 +56,7 @@ export function setSearchMode(
 // the empty state can show "Try YAML — N matches" with a real count.
 export function maybeFireEmptyStatePreview(
   host: ESPHomePageDashboard,
-  changed: PropertyValues,
+  changed: PropertyValues
 ): void {
   if (!changed.has("_search") && !changed.has("_yamlMode")) return;
   if (!host._isDeviceSearchActive) return;
@@ -66,9 +66,7 @@ export function maybeFireEmptyStatePreview(
     return;
   }
   const lowered = trimmed.toLowerCase();
-  const anyDeviceMatches = host._sortedDevices.some((d) =>
-    matchesDeviceName(d, lowered),
-  );
+  const anyDeviceMatches = host._sortedDevices.some((d) => matchesDeviceName(d, lowered));
   if (anyDeviceMatches) {
     host._yamlSearch.clear();
     return;

--- a/src/components/dashboard/skeletons.ts
+++ b/src/components/dashboard/skeletons.ts
@@ -2,25 +2,37 @@ import { html } from "lit";
 
 export const cardSkeletonTemplate = html`
   <div class="devices-grid">
-    ${Array.from({ length: 10 }, () => html`
-      <div class="skeleton-card" aria-hidden="true">
-        <div class="skeleton-line skeleton-line--title"></div>
-        <div class="skeleton-line skeleton-line--subtitle"></div>
-        <div class="skeleton-line skeleton-line--actions"></div>
-      </div>
-    `)}
+    ${Array.from(
+      { length: 10 },
+      () => html`
+        <div class="skeleton-card" aria-hidden="true">
+          <div class="skeleton-line skeleton-line--title"></div>
+          <div class="skeleton-line skeleton-line--subtitle"></div>
+          <div class="skeleton-line skeleton-line--actions"></div>
+        </div>
+      `
+    )}
   </div>
 `;
 
 export const tableSkeletonTemplate = html`
   <div class="skeleton-table" aria-hidden="true">
     <div class="skeleton-table-header">
-      ${Array.from({ length: 5 }, () => html`<div class="skeleton-line skeleton-line--header"></div>`)}
+      ${Array.from(
+        { length: 5 },
+        () => html`<div class="skeleton-line skeleton-line--header"></div>`
+      )}
     </div>
-    ${Array.from({ length: 8 }, () => html`
-      <div class="skeleton-table-row">
-        ${Array.from({ length: 5 }, () => html`<div class="skeleton-line skeleton-line--cell"></div>`)}
-      </div>
-    `)}
+    ${Array.from(
+      { length: 8 },
+      () => html`
+        <div class="skeleton-table-row">
+          ${Array.from(
+            { length: 5 },
+            () => html`<div class="skeleton-line skeleton-line--cell"></div>`
+          )}
+        </div>
+      `
+    )}
   </div>
 `;

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -365,11 +365,7 @@ export const dashboardStyles = css`
       border-color 0.12s;
   }
   .yaml-hits:not(:has(.yaml-snippet)) .yaml-hit-group:hover {
-    border-color: color-mix(
-      in srgb,
-      var(--esphome-primary),
-      transparent 50%
-    );
+    border-color: color-mix(in srgb, var(--esphome-primary), transparent 50%);
     background: var(--wa-color-surface-lowered);
   }
   .yaml-hit-group-header {
@@ -541,19 +537,14 @@ export const dashboardStyles = css`
   }
 
   .select-toggle-btn:hover {
-    background: color-mix(
-      in srgb,
-      var(--wa-color-text-normal),
-      transparent 94%
-    );
+    background: color-mix(in srgb, var(--wa-color-text-normal), transparent 94%);
     color: var(--wa-color-text-normal);
   }
 
   .select-toggle-btn:focus-visible {
     outline: none;
     color: var(--wa-color-text-normal);
-    box-shadow: 0 0 0 2px
-      color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
   }
 
   .select-toggle-btn.active {

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -39,13 +39,11 @@ export const tableCellStyles = css`
   }
   .status-dot.online {
     background: var(--esphome-success);
-    box-shadow: 0 0 6px
-      color-mix(in srgb, var(--esphome-success), transparent 50%);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--esphome-success), transparent 50%);
   }
   .status-dot.offline {
     background: var(--esphome-error);
-    box-shadow: 0 0 6px
-      color-mix(in srgb, var(--esphome-error), transparent 60%);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--esphome-error), transparent 60%);
   }
   .status-dot.unknown {
     background: var(--wa-color-text-quiet);
@@ -100,7 +98,8 @@ export const tableCellStyles = css`
     color: var(--wa-color-text-quiet);
   }
   @keyframes cell-status-completed-pulse {
-    0%, 100% {
+    0%,
+    100% {
       opacity: 1;
     }
     50% {
@@ -135,7 +134,8 @@ export const tableCellStyles = css`
 
   .cell-indicator--modified {
     background: var(--esphome-warning, #f59e0b);
-    box-shadow: 0 0 5px color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 50%);
+    box-shadow: 0 0 5px
+      color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 50%);
   }
 
   .cell-indicator--update {
@@ -144,8 +144,7 @@ export const tableCellStyles = css`
   }
 
   .cell-mono {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-      monospace;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);
   }
@@ -156,11 +155,7 @@ export const tableCellStyles = css`
     border-radius: 999px;
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-bold);
-    background: color-mix(
-      in srgb,
-      var(--esphome-primary),
-      transparent 88%
-    );
+    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
     color: var(--esphome-primary);
     letter-spacing: 0.02em;
   }

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -3,10 +3,7 @@ import type { ColumnDef } from "@tanstack/lit-table";
 import { DeviceState, JobStatus } from "../../api/types.js";
 import type { ConfiguredDevice, FirmwareJob, Label } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import {
-  DEVICE_SORT_COLLATOR,
-  deviceSortKey,
-} from "../../util/device-sort.js";
+import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
@@ -68,7 +65,7 @@ const RECENT_LABEL_KEY: Record<JobStatus, string> = {
 const dispatchRowEvent = (e: Event, name: string, device: ConfiguredDevice) => {
   e.stopPropagation();
   (e.currentTarget as HTMLElement).dispatchEvent(
-    new CustomEvent(name, { detail: device, bubbles: true, composed: true }),
+    new CustomEvent(name, { detail: device, bubbles: true, composed: true })
   );
 };
 
@@ -92,7 +89,11 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
                 dispatchRowEvent(e, "show-progress", row._device);
               }
             }}
-          ><wa-spinner class="status-spinner" style="font-size:14px;--indicator-color:var(--esphome-primary);--track-color:transparent;"></wa-spinner></span>`;
+            ><wa-spinner
+              class="status-spinner"
+              style="font-size:14px;--indicator-color:var(--esphome-primary);--track-color:transparent;"
+            ></wa-spinner
+          ></span>`;
         }
         if (row.recentJob) {
           const status = row.recentJob.status;
@@ -101,20 +102,26 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             return html`<span
               class="cell-status status-recent ${RECENT_CLASS[status]}"
               title=${localize(RECENT_LABEL_KEY[status])}
-            ><wa-icon library="mdi" name=${icon}></wa-icon></span>`;
+              ><wa-icon library="mdi" name=${icon}></wa-icon
+            ></span>`;
           }
         }
         const state = info.getValue() as DeviceState;
-        const dotClass = state === DeviceState.ONLINE ? "online" : state === DeviceState.OFFLINE ? "offline" : "unknown";
-        const title = state === DeviceState.ONLINE
-          ? localize("dashboard.table_status_online")
-          : state === DeviceState.OFFLINE
-            ? localize("dashboard.table_status_offline")
-            : localize("dashboard.table_status_unknown");
-        return html`<span class="cell-status"><span
-          class="status-dot ${dotClass}"
-          title="${title}"
-        ></span></span>`;
+        const dotClass =
+          state === DeviceState.ONLINE
+            ? "online"
+            : state === DeviceState.OFFLINE
+              ? "offline"
+              : "unknown";
+        const title =
+          state === DeviceState.ONLINE
+            ? localize("dashboard.table_status_online")
+            : state === DeviceState.OFFLINE
+              ? localize("dashboard.table_status_offline")
+              : localize("dashboard.table_status_unknown");
+        return html`<span class="cell-status"
+          ><span class="status-dot ${dotClass}" title="${title}"></span
+        ></span>`;
       },
       size: 80,
       enableHiding: true,
@@ -140,10 +147,16 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
           ${row.hasPendingChanges
-            ? html`<span class="cell-indicator cell-indicator--modified" title=${localize("dashboard.status_modified")}></span>`
+            ? html`<span
+                class="cell-indicator cell-indicator--modified"
+                title=${localize("dashboard.status_modified")}
+              ></span>`
             : nothing}
           ${row.hasUpdateAvailable
-            ? html`<span class="cell-indicator cell-indicator--update" title=${localize("dashboard.status_update_available")}></span>`
+            ? html`<span
+                class="cell-indicator cell-indicator--update"
+                title=${localize("dashboard.status_update_available")}
+              ></span>`
             : nothing}
           ${encVisual
             ? html`<wa-icon
@@ -158,7 +171,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
       sortingFn: (rowA, rowB) =>
         DEVICE_SORT_COLLATOR.compare(
           deviceSortKey(rowA.original),
-          deviceSortKey(rowB.original),
+          deviceSortKey(rowB.original)
         ),
       size: 200,
       enableHiding: true,
@@ -166,16 +179,14 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
     {
       accessorKey: "address",
       header: localize("dashboard.table_col_address"),
-      cell: (info) =>
-        html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
       size: 180,
       enableHiding: true,
     },
     {
       accessorKey: "ip",
       header: localize("dashboard.table_col_ip"),
-      cell: (info) =>
-        html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
       size: 140,
       enableHiding: true,
     },
@@ -206,24 +217,21 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
     {
       accessorKey: "version",
       header: localize("dashboard.table_col_version"),
-      cell: (info) =>
-        html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
       size: 150,
       enableHiding: true,
     },
     {
       accessorKey: "comment",
       header: localize("dashboard.table_col_comment"),
-      cell: (info) =>
-        html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
+      cell: (info) => html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
       size: 180,
       enableHiding: true,
     },
     {
       accessorKey: "area",
       header: localize("dashboard.table_col_area"),
-      cell: (info) =>
-        html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
+      cell: (info) => html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
       size: 160,
       enableHiding: true,
     },
@@ -247,8 +255,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
     {
       accessorKey: "config",
       header: localize("dashboard.table_col_config"),
-      cell: (info) =>
-        html`<span class="cell-mono cell-config">${info.getValue()}</span>`,
+      cell: (info) => html`<span class="cell-mono cell-config">${info.getValue()}</span>`,
       size: 180,
       enableHiding: true,
     },

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -1,10 +1,5 @@
 import { consume } from "@lit/context";
-import {
-  mdiChevronLeft,
-  mdiChevronRight,
-  mdiPageFirst,
-  mdiPageLast,
-} from "@mdi/js";
+import { mdiChevronLeft, mdiChevronRight, mdiPageFirst, mdiPageLast } from "@mdi/js";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -60,8 +55,7 @@ export class ESPHomeTablePagination extends LitElement {
         padding: var(--wa-space-m) var(--wa-space-l);
         flex-wrap: wrap;
         gap: var(--wa-space-s);
-        border-top: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       }
 
       .info {
@@ -119,7 +113,9 @@ export class ESPHomeTablePagination extends LitElement {
         background: var(--wa-color-surface-raised);
         color: var(--wa-color-text-normal);
         cursor: pointer;
-        transition: background 0.12s, border-color 0.12s;
+        transition:
+          background 0.12s,
+          border-color 0.12s;
         padding: 0;
       }
 
@@ -142,7 +138,11 @@ export class ESPHomeTablePagination extends LitElement {
   protected render() {
     return html`
       <div class="pagination">
-        <span class="info">${this._localize("dashboard.pagination_total", { count: this.totalRows })}</span>
+        <span class="info"
+          >${this._localize("dashboard.pagination_total", {
+            count: this.totalRows,
+          })}</span
+        >
         <div class="controls">
           <div class="page-size">
             <span>${this._localize("dashboard.pagination_rows_per_page")}</span>
@@ -151,12 +151,15 @@ export class ESPHomeTablePagination extends LitElement {
                 (size) =>
                   html`<option value=${size} ?selected=${this.pageSize === size}>
                     ${size}
-                  </option>`,
+                  </option>`
               )}
             </select>
           </div>
           <span class="page-info">
-            ${this._localize("dashboard.pagination_page_of", { current: this.pageIndex + 1, total: this.pageCount || 1 })}
+            ${this._localize("dashboard.pagination_page_of", {
+              current: this.pageIndex + 1,
+              total: this.pageCount || 1,
+            })}
           </span>
           <div class="buttons">
             <button
@@ -203,7 +206,7 @@ export class ESPHomeTablePagination extends LitElement {
         detail: Number((e.target as HTMLSelectElement).value),
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -213,7 +216,7 @@ export class ESPHomeTablePagination extends LitElement {
         detail: pageIndex,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -218,11 +218,12 @@ export class ESPHomeTableRowMenu extends LitElement {
     if (!this.device || !this.position) return nothing;
 
     return html`
-      <div class="backdrop" @click=${this._close} @contextmenu=${this._preventAndClose}></div>
       <div
-        class="menu"
-        style=${this._initialStyle()}
-      >
+        class="backdrop"
+        @click=${this._close}
+        @contextmenu=${this._preventAndClose}
+      ></div>
+      <div class="menu" style=${this._initialStyle()}>
         <div class="menu-item" @click=${() => this._emit("validate-device")}>
           <wa-icon library="mdi" name="check-decagram"></wa-icon>
           ${this._localize("dashboard.action_validate")}
@@ -252,9 +253,7 @@ export class ESPHomeTableRowMenu extends LitElement {
         </div>
         <div
           class="menu-item ${this.busy ? "menu-item--disabled" : ""}"
-          @click=${this.busy
-            ? undefined
-            : () => this._emit("edit-friendly-name")}
+          @click=${this.busy ? undefined : () => this._emit("edit-friendly-name")}
         >
           <wa-icon library="mdi" name="form-textbox"></wa-icon>
           ${this._localize("dashboard.action_edit_friendly_name")}
@@ -365,9 +364,7 @@ export class ESPHomeTableRowMenu extends LitElement {
   private _close() {
     this.device = null;
     this.position = null;
-    this.dispatchEvent(
-      new CustomEvent("menu-close", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("menu-close", { bubbles: true, composed: true }));
   }
 
   private _preventAndClose(e: Event) {
@@ -381,7 +378,7 @@ export class ESPHomeTableRowMenu extends LitElement {
         detail: this.device,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     this._close();
   }

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -74,9 +74,12 @@ export const tableLayoutStyles = css`
     min-height: 0;
     /* Horizontal scroll shadows — appear only when content overflows */
     background:
-      linear-gradient(to right, var(--wa-color-surface-raised) 30%, transparent) left center,
-      linear-gradient(to left, var(--wa-color-surface-raised) 30%, transparent) right center,
-      radial-gradient(farthest-side at 0 50%, rgba(0, 0, 0, 0.12), transparent) left center,
+      linear-gradient(to right, var(--wa-color-surface-raised) 30%, transparent) left
+        center,
+      linear-gradient(to left, var(--wa-color-surface-raised) 30%, transparent) right
+        center,
+      radial-gradient(farthest-side at 0 50%, rgba(0, 0, 0, 0.12), transparent) left
+        center,
       radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.12), transparent) right
         center;
     background-repeat: no-repeat;

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -28,10 +28,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { deviceCardStyles } from "./device-card/styles.js";
-import {
-  navigateCards,
-  onHostContextMenu,
-} from "./device-card/keyboard-nav.js";
+import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
   renderEncryptionIcon,
   renderLabels,
@@ -63,8 +60,11 @@ registerMdiIcons({
 
 @customElement("esphome-device-card")
 export class ESPHomeDeviceCard extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
-  @consume({ context: labelsContext, subscribe: true }) @state() _labelCatalog: Label[] = [];
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
+  @consume({ context: labelsContext, subscribe: true }) @state() _labelCatalog: Label[] =
+    [];
 
   // Resolved against the catalog at render time so a recolor / rename in
   // another client repaints every card without per-card state.
@@ -73,8 +73,10 @@ export class ESPHomeDeviceCard extends LitElement {
   @property({ attribute: false }) name = "";
   @property() configuration = "";
   @property() state: DeviceState = DeviceState.UNKNOWN;
-  @property({ type: Boolean, attribute: "has-pending-changes" }) hasPendingChanges = false;
-  @property({ type: Boolean, attribute: "has-update-available" }) hasUpdateAvailable = false;
+  @property({ type: Boolean, attribute: "has-pending-changes" }) hasPendingChanges =
+    false;
+  @property({ type: Boolean, attribute: "has-update-available" }) hasUpdateAvailable =
+    false;
   @property({ type: Boolean, attribute: "api-enabled" }) apiEnabled = false;
   @property({ type: Boolean, attribute: "api-encrypted" }) apiEncrypted = false;
 
@@ -322,7 +324,7 @@ export class ESPHomeDeviceCard extends LitElement {
         detail: { x: rect.right, y: rect.bottom },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 

--- a/src/components/device-card/keyboard-nav.ts
+++ b/src/components/device-card/keyboard-nav.ts
@@ -7,7 +7,7 @@ export function navigateCards(card: ESPHomeDeviceCard, key: string): void {
   const grid = card.parentElement;
   if (!grid) return;
   const cards = Array.from(
-    grid.querySelectorAll<ESPHomeDeviceCard>("esphome-device-card"),
+    grid.querySelectorAll<ESPHomeDeviceCard>("esphome-device-card")
   );
   const idx = cards.indexOf(card);
   if (idx < 0) return;
@@ -31,7 +31,7 @@ export function navigateCards(card: ESPHomeDeviceCard, key: string): void {
   sameRow.sort(
     (a, b) =>
       Math.abs(a.r.left + a.r.width / 2 - myCenter) -
-      Math.abs(b.r.left + b.r.width / 2 - myCenter),
+      Math.abs(b.r.left + b.r.width / 2 - myCenter)
   );
   sameRow[0]?.c.focus();
 }
@@ -68,6 +68,6 @@ export function onHostContextMenu(card: ESPHomeDeviceCard, e: MouseEvent): void 
       detail: { x: e.clientX, y: e.clientY },
       bubbles: true,
       composed: true,
-    }),
+    })
   );
 }

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -1,10 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { DeviceState, JobStatus, JobType } from "../../api/types.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
-import {
-  renderLabelChips,
-  resolveLabelIds,
-} from "../../util/label-chip-template.js";
+import { renderLabelChips, resolveLabelIds } from "../../util/label-chip-template.js";
 import type { ESPHomeDeviceCard } from "../device-card.js";
 
 const RECENT_JOB_ICON: Record<JobStatus, string | null> = {
@@ -46,7 +43,7 @@ export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof n
 // fleet) while keeping every other state including "waiting / unknown"
 // visible. (issue #141)
 export function renderEncryptionIcon(
-  card: ESPHomeDeviceCard,
+  card: ESPHomeDeviceCard
 ): TemplateResult | typeof nothing {
   const visual = getCompactEncryptionVisual({
     api_enabled: card.apiEnabled,

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -62,16 +62,13 @@ export const deviceCardStyles = [
     }
     @keyframes card-highlight-glow {
       0% {
-        box-shadow: 0 0 0 0
-          color-mix(in srgb, var(--esphome-primary), transparent 40%);
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 40%);
       }
       50% {
-        box-shadow: 0 0 0 8px
-          color-mix(in srgb, var(--esphome-primary), transparent 65%);
+        box-shadow: 0 0 0 8px color-mix(in srgb, var(--esphome-primary), transparent 65%);
       }
       100% {
-        box-shadow: 0 0 0 0
-          color-mix(in srgb, var(--esphome-primary), transparent 100%);
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 100%);
       }
     }
     @media (prefers-reduced-motion: reduce) {
@@ -214,7 +211,8 @@ export const deviceCardStyles = [
 
     /* RECENT_JOB_TTL_MS_COMPLETED is short; throb signals "transient". */
     @keyframes completed-pulse {
-      0%, 100% {
+      0%,
+      100% {
         opacity: 1;
       }
       50% {

--- a/src/components/device/add-component-dialog-dep-nav.ts
+++ b/src/components/device/add-component-dialog-dep-nav.ts
@@ -23,10 +23,7 @@ export interface DepNavHost {
  * Domain-level deps (``output``, ``sensor``) fall back to the
  * category-filtered catalog where the user picks a variant.
  */
-export async function navigateToDep(
-  host: DepNavHost,
-  domain: string,
-): Promise<void> {
+export async function navigateToDep(host: DepNavHost, domain: string): Promise<void> {
   if (host._submitting) return;
   // Snapshot, don't commit, until the lookup resolves: the original
   // form is still rendered + submit-enabled (request-add-component
@@ -39,7 +36,7 @@ export async function navigateToDep(
     direct = await host._api.getComponent(
       domain,
       host.platform || undefined,
-      host.board?.id ?? undefined,
+      host.board?.id ?? undefined
     );
   } catch {
     direct = null;
@@ -66,7 +63,7 @@ export async function navigateToDep(
  */
 export function matchesDepDomain(
   added: ComponentCatalogEntry,
-  depDomain: string,
+  depDomain: string
 ): boolean {
   return added.id === depDomain || added.category === depDomain;
 }

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -222,11 +222,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         gap: var(--wa-space-2xs);
         margin-bottom: var(--wa-space-m);
         padding: var(--wa-space-2xs) var(--wa-space-s);
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 92%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
         border-left: 3px solid var(--esphome-primary);
         border-radius: var(--wa-border-radius-s);
         font-size: var(--wa-font-size-xs);
@@ -244,11 +240,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         gap: var(--wa-space-xs);
         margin-bottom: var(--wa-space-m);
         padding: var(--wa-space-xs) var(--wa-space-s);
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 92%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
         border-left: 3px solid var(--esphome-primary);
         border-radius: var(--wa-border-radius-s);
         font-size: var(--wa-font-size-xs);
@@ -399,14 +391,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
    * with the regular flow.
    */
   private async _onBundleSelected(
-    e: CustomEvent<{ bundle: FeaturedBundle; boardId: string }>,
+    e: CustomEvent<{ bundle: FeaturedBundle; boardId: string }>
   ) {
     e.stopPropagation();
     if (this._submitting) return;
     const { bundle, boardId } = e.detail;
     if (!boardId || bundle.component_ids.length === 0) return;
     const fullIds = bundle.component_ids.map(
-      (localId) => `featured.${boardId}.${localId}`,
+      (localId) => `featured.${boardId}.${localId}`
     );
     const [first, ...rest] = fullIds;
     // The WS layer can throw on a transient disconnect / timeout; an
@@ -419,13 +411,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
       component = await this._api.getComponent(
         first,
         this.platform || undefined,
-        boardId,
+        boardId
       );
     } catch (err) {
       this._submitError =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.add_component_error");
+        err instanceof Error ? err.message : this._localize("device.add_component_error");
       return;
     }
     if (!component) {
@@ -504,7 +494,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
           detail: { yaml },
           bubbles: true,
           composed: true,
-        }),
+        })
       );
 
       if (this._returnTo) {
@@ -551,7 +541,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         const nextComponent = await this._api.getComponent(
           nextId,
           this.platform || undefined,
-          this.board?.id ?? undefined,
+          this.board?.id ?? undefined
         );
         if (!nextComponent) {
           this._submitError = this._localize("device.add_component_error");
@@ -590,7 +580,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         const target = findAddedSection(
           yaml,
           componentId,
-          typeof newId === "string" ? newId : undefined,
+          typeof newId === "string" ? newId : undefined
         );
         if (target) {
           this.dispatchEvent(
@@ -598,7 +588,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
               detail: target,
               bubbles: true,
               composed: true,
-            }),
+            })
           );
         }
         this._dialog.open = false;
@@ -606,9 +596,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this._resetDetourState();
       }
     } catch (err) {
-      this._submitError = err instanceof Error
-        ? err.message
-        : this._localize("device.add_component_error");
+      this._submitError =
+        err instanceof Error ? err.message : this._localize("device.add_component_error");
     } finally {
       this._submitting = false;
     }

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -38,10 +38,7 @@ export function coerceFields(
       continue;
     }
 
-    if (
-      entry.type === ConfigEntryType.INTEGER &&
-      entry.display_format !== "hex"
-    ) {
+    if (entry.type === ConfigEntryType.INTEGER && entry.display_format !== "hex") {
       const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
       if (!Number.isNaN(n)) out[entry.key] = n;
     } else if (entry.type === ConfigEntryType.FLOAT) {

--- a/src/components/device/add-component-form.styles.ts
+++ b/src/components/device/add-component-form.styles.ts
@@ -52,8 +52,7 @@ export const addComponentFormStyles = css`
 
   select:focus {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px
-      color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
   }
 
   select.invalid {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -14,10 +14,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
-import {
-  validateEntries,
-  type ValidationError,
-} from "../../util/config-validation.js";
+import { validateEntries, type ValidationError } from "../../util/config-validation.js";
 import { seedBoardPinDefaults } from "../../util/board-pin-defaults.js";
 import {
   collectExistingIds,
@@ -101,7 +98,7 @@ export class ESPHomeAddComponentForm extends LitElement {
   private readonly _depResolver = new ComponentNameResolverController(
     this,
     () => this._api,
-    () => this.board?.esphome.platform || undefined,
+    () => this.board?.esphome.platform || undefined
   );
 
   static styles = [
@@ -115,13 +112,8 @@ export class ESPHomeAddComponentForm extends LitElement {
         display: flex;
         gap: var(--wa-space-s);
         padding: var(--wa-space-s) var(--wa-space-m);
-        background: color-mix(
-          in srgb,
-          var(--esphome-warning, #d97706),
-          transparent 88%
-        );
-        border: var(--wa-border-width-s) solid
-          var(--esphome-warning, #d97706);
+        background: color-mix(in srgb, var(--esphome-warning, #d97706), transparent 88%);
+        border: var(--wa-border-width-s) solid var(--esphome-warning, #d97706);
         border-radius: var(--wa-border-radius-m);
         color: var(--wa-color-text-normal);
         font-size: var(--wa-font-size-s);
@@ -219,7 +211,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     let next = this._seedDefaults(this.component.config_entries, seedAll);
 
     const idEntry = this.component.config_entries.find(
-      (e) => e.key === "id" && e.type === ConfigEntryType.ID,
+      (e) => e.key === "id" && e.type === ConfigEntryType.ID
     );
     if (idEntry && next["id"] === undefined) {
       const seeded = this._generateDefaultId();
@@ -237,14 +229,14 @@ export class ESPHomeAddComponentForm extends LitElement {
       this.component.id,
       this.component.config_entries,
       this.board,
-      next,
+      next
     );
 
     if (this.prefillReference) {
       const targetPath = this._findReferencePath(
         this.component.config_entries,
         this.prefillReference.domain,
-        [],
+        []
       );
       if (targetPath) {
         next = setIn(next, targetPath, this.prefillReference.id);
@@ -263,15 +255,14 @@ export class ESPHomeAddComponentForm extends LitElement {
   private _findReferencePath(
     entries: ConfigEntry[],
     domain: string,
-    prefix: string[],
+    prefix: string[]
   ): string[] | null {
     for (const entry of entries) {
       if (entry.type === ConfigEntryType.NESTED) {
-        const found = this._findReferencePath(
-          entry.config_entries ?? [],
-          domain,
-          [...prefix, entry.key],
-        );
+        const found = this._findReferencePath(entry.config_entries ?? [], domain, [
+          ...prefix,
+          entry.key,
+        ]);
         if (found) return found;
         continue;
       }
@@ -296,7 +287,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    */
   private _seedDefaults(
     entries: ConfigEntry[],
-    seedAll: boolean = false,
+    seedAll: boolean = false
   ): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     for (const entry of entries) {
@@ -321,7 +312,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     return generateDefaultComponentId(
       this.component.id,
       this.component.multi_conf,
-      collectExistingIds(this.yaml),
+      collectExistingIds(this.yaml)
     );
   }
 
@@ -333,7 +324,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // configured first. Surface these to the user instead of letting
     // them submit a config that won't validate.
     const missingDeps = (this.component.dependencies ?? []).filter(
-      (d) => !presentComponents.has(d),
+      (d) => !presentComponents.has(d)
     );
 
     // The shared form filters its own visibility — but we still need
@@ -344,16 +335,14 @@ export class ESPHomeAddComponentForm extends LitElement {
       this.component.config_entries,
       this._values,
       presentComponents,
-      this.board?.esphome.platform ?? null,
+      this.board?.esphome.platform ?? null
     );
     const isComplete = !this._hasRequiredErrors(validation);
 
     return html`
       <div class="form">
         <p class="form-desc">${renderMarkdown(this.component.description)}</p>
-        ${missingDeps.length > 0
-          ? this._renderMissingDeps(missingDeps)
-          : nothing}
+        ${missingDeps.length > 0 ? this._renderMissingDeps(missingDeps) : nothing}
         <esphome-config-entry-form
           .entries=${this.component.config_entries}
           .values=${this._values}
@@ -379,9 +368,7 @@ export class ESPHomeAddComponentForm extends LitElement {
         ${this._showYaml
           ? html`<pre class="yaml-preview">${this._generateYamlPreview()}</pre>`
           : nothing}
-        ${this.submitError
-          ? html`<p class="error">${this.submitError}</p>`
-          : nothing}
+        ${this.submitError ? html`<p class="error">${this.submitError}</p>` : nothing}
         ${this._localBlockMessage
           ? html`<p class="error">${this._localBlockMessage}</p>`
           : nothing}
@@ -432,15 +419,16 @@ export class ESPHomeAddComponentForm extends LitElement {
           <div>${this._localize("device.missing_dependencies_body")}</div>
           <div class="deps-warning-actions">
             ${missing.map(
-              (d) => html`<button
-                type="button"
-                class="dep-button"
-                @click=${() => this._onAddDep(d)}
-              >
-                ${this._localize("device.missing_dependencies_add", {
-                  domain: this._depResolver.resolve(d),
-                })}
-              </button>`,
+              (d) =>
+                html`<button
+                  type="button"
+                  class="dep-button"
+                  @click=${() => this._onAddDep(d)}
+                >
+                  ${this._localize("device.missing_dependencies_add", {
+                    domain: this._depResolver.resolve(d),
+                  })}
+                </button>`
             )}
           </div>
         </div>
@@ -458,7 +446,7 @@ export class ESPHomeAddComponentForm extends LitElement {
         detail: { domain },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -491,9 +479,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       entry = entries.find((e) => e.key === seg);
       if (!entry) break;
       entries =
-        entry.type === ConfigEntryType.NESTED
-          ? entry.config_entries ?? []
-          : null;
+        entry.type === ConfigEntryType.NESTED ? (entry.config_entries ?? []) : null;
     }
     return entry ? resolveEntryLabel(entry, this._localize) : errKey;
   }
@@ -511,7 +497,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    */
   private _anyErrorIsVisible(
     errors: Map<string, ValidationError>,
-    presentComponents: Set<string>,
+    presentComponents: Set<string>
   ): boolean {
     // The caller (``_onSubmit``) only enters this branch when
     // ``errors.size > 0``, but we keep the guard so the helper is
@@ -525,7 +511,7 @@ export class ESPHomeAddComponentForm extends LitElement {
         showAdvanced: false,
         presentComponents,
         targetPlatform: this.board?.esphome.platform ?? null,
-      },
+      }
     );
     for (const key of errors.keys()) {
       if (renderedPaths.has(key)) return true;
@@ -557,9 +543,7 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   private _onCancel() {
-    this.dispatchEvent(
-      new CustomEvent("form-cancel", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("form-cancel", { bubbles: true, composed: true }));
   }
 
   private _onSubmit() {
@@ -573,17 +557,16 @@ export class ESPHomeAddComponentForm extends LitElement {
     // The button should already be disabled in that case, but defend
     // here too in case the YAML changed under us between renders.
     const missingDeps = (this.component.dependencies ?? []).filter(
-      (d) => !presentComponents.has(d),
+      (d) => !presentComponents.has(d)
     );
     if (missingDeps.length > 0) {
       // Should be unreachable — the button-disabled predicate uses the
       // same check. If we get here, the YAML changed under us between
       // renders. Surface a visible message that names the missing
       // domain(s) so the user can act, instead of returning silently.
-      this._localBlockMessage = `${this._localize(
-        "device.missing_dependencies_title",
-        { name: this.component.name },
-      )} (${missingDeps.join(", ")})`;
+      this._localBlockMessage = `${this._localize("device.missing_dependencies_title", {
+        name: this.component.name,
+      })} (${missingDeps.join(", ")})`;
       return;
     }
 
@@ -593,7 +576,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       this.component.config_entries,
       this._values,
       presentComponents,
-      this.board?.esphome.platform ?? null,
+      this.board?.esphome.platform ?? null
     );
     if (errors.size > 0) {
       this._errors = errors;
@@ -610,12 +593,13 @@ export class ESPHomeAddComponentForm extends LitElement {
         // ``key: code`` when the schema lookup misses (defensive
         // against nested paths the heuristic can't follow).
         const summary = [...errors.entries()]
-          .map(([key, err]) =>
-            `${this._labelForErrorKey(key)}: ${this._localize(err.code, err.params)}`,
+          .map(
+            ([key, err]) =>
+              `${this._labelForErrorKey(key)}: ${this._localize(err.code, err.params)}`
           )
           .join("; ");
         this._localBlockMessage = `${this._localize(
-          "device.add_component_hidden_validation_error",
+          "device.add_component_hidden_validation_error"
         )} (${summary})`;
       }
       return;
@@ -623,17 +607,14 @@ export class ESPHomeAddComponentForm extends LitElement {
     this._errors = new Map();
     this._localBlockMessage = "";
 
-    const fields = coerceFields(
-      this.component.config_entries,
-      this._values,
-    );
+    const fields = coerceFields(this.component.config_entries, this._values);
 
     this.dispatchEvent(
       new CustomEvent("form-submit", {
         detail: { fields },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -153,9 +153,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
             title=${this._localize("device.automation_action_pick")}
             @click=${this._openPicker}
           >
-            <span class="ae-row-picker-name">
-              ${def?.name ?? this.value.action_id}
-            </span>
+            <span class="ae-row-picker-name"> ${def?.name ?? this.value.action_id} </span>
             <wa-icon library="mdi" name="pencil-outline"></wa-icon>
           </button>
           <div class="ae-row-controls">
@@ -211,14 +209,10 @@ export class ESPHomeAutomationActionNode extends LitElement {
           ? nothing
           : html`<div class="ae-row-body">
               ${def?.description
-                ? html`<p class="ae-row-desc">
-                    ${renderMarkdown(def.description)}
-                  </p>`
+                ? html`<p class="ae-row-desc">${renderMarkdown(def.description)}</p>`
                 : nothing}
-              ${this._renderActionParams(def)}
-              ${this._renderScriptParams(def)}
-              ${this._renderConditionGate(def)}
-              ${this._renderNestedLists(def)}
+              ${this._renderActionParams(def)} ${this._renderScriptParams(def)}
+              ${this._renderConditionGate(def)} ${this._renderNestedLists(def)}
             </div>`}
       </div>
     `;
@@ -239,29 +233,30 @@ export class ESPHomeAutomationActionNode extends LitElement {
         ${this._localize("device.automation_script_parameters")}
       </p>
       ${script.parameters.map(
-        (p) => html`<label class="ae-section-label" for="script-${p.name}"
-            >${p.name} <span class="ae-muted">${p.type}</span></label
-          >
-          <input
-            id="script-${p.name}"
-            type=${p.type === "int" || p.type === "float" ? "number" : "text"}
-            ?disabled=${this.disabled}
-            .value=${String(this.value.params[p.name] ?? "")}
-            @input=${(e: Event) => {
-              const raw = (e.target as HTMLInputElement).value;
-              const next =
-                p.type === "int"
-                  ? raw === ""
-                    ? ""
-                    : parseInt(raw, 10)
-                  : p.type === "float"
+        (p) =>
+          html`<label class="ae-section-label" for="script-${p.name}"
+              >${p.name} <span class="ae-muted">${p.type}</span></label
+            >
+            <input
+              id="script-${p.name}"
+              type=${p.type === "int" || p.type === "float" ? "number" : "text"}
+              ?disabled=${this.disabled}
+              .value=${String(this.value.params[p.name] ?? "")}
+              @input=${(e: Event) => {
+                const raw = (e.target as HTMLInputElement).value;
+                const next =
+                  p.type === "int"
                     ? raw === ""
                       ? ""
-                      : Number(raw)
-                    : raw;
-              this._patchParams({ [p.name]: next });
-            }}
-          />`,
+                      : parseInt(raw, 10)
+                    : p.type === "float"
+                      ? raw === ""
+                        ? ""
+                        : Number(raw)
+                      : raw;
+                this._patchParams({ [p.name]: next });
+              }}
+            />`
       )}
     </div>`;
   }
@@ -279,9 +274,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     if (!def) return nothing;
     if (def.id !== "if" && def.id !== "wait_until") return nothing;
     return html`<div class="ae-nested">
-      <p class="ae-nested-label">
-        ${this._localize("device.automation_only_when")}
-      </p>
+      <p class="ae-nested-label">${this._localize("device.automation_only_when")}</p>
       <esphome-automation-condition-tree
         no-header
         .conditions=${this.value.conditions ?? []}
@@ -309,38 +302,39 @@ export class ESPHomeAutomationActionNode extends LitElement {
       return nothing;
     }
     return def.accepts_action_list.map(
-      (key) => html`<div class="ae-nested">
-        <p class="ae-nested-label">
-          ${key === "else"
-            ? this._localize("device.automation_else")
-            : this._localize("device.automation_action")}
-        </p>
-        <esphome-automation-action-list
-          no-header
-          .actions=${this.value.children?.[key] ?? []}
-          .catalog=${this.catalog}
-          .conditionCatalog=${this.conditionCatalog}
-          .scripts=${this.scripts}
-          .devices=${this.devices}
-          .board=${this.board}
-          .yaml=${this.yaml}
-          ?disabled=${this.disabled}
-          @actions-change=${(e: CustomEvent<{ actions: ActionNode[] }>) => {
-            // The nested list dispatches ``actions-change`` to mean
-            // "my list of actions changed". This action-node folds
-            // that into its own ``children[key]`` slot and re-emits
-            // as ``action-change`` (the event our PARENT list
-            // listens to). Without ``stopPropagation`` here the
-            // bubbling ``actions-change`` would ALSO be caught by
-            // the outer action-list — which would replace the
-            // entire ``if`` node's slot with the nested list. Net
-            // effect: adding a delay inside an if's then-branch
-            // wipes the if and leaves just the delay.
-            e.stopPropagation();
-            this._onChildrenChange(key, e.detail.actions);
-          }}
-        ></esphome-automation-action-list>
-      </div>`,
+      (key) =>
+        html`<div class="ae-nested">
+          <p class="ae-nested-label">
+            ${key === "else"
+              ? this._localize("device.automation_else")
+              : this._localize("device.automation_action")}
+          </p>
+          <esphome-automation-action-list
+            no-header
+            .actions=${this.value.children?.[key] ?? []}
+            .catalog=${this.catalog}
+            .conditionCatalog=${this.conditionCatalog}
+            .scripts=${this.scripts}
+            .devices=${this.devices}
+            .board=${this.board}
+            .yaml=${this.yaml}
+            ?disabled=${this.disabled}
+            @actions-change=${(e: CustomEvent<{ actions: ActionNode[] }>) => {
+              // The nested list dispatches ``actions-change`` to mean
+              // "my list of actions changed". This action-node folds
+              // that into its own ``children[key]`` slot and re-emits
+              // as ``action-change`` (the event our PARENT list
+              // listens to). Without ``stopPropagation`` here the
+              // bubbling ``actions-change`` would ALSO be caught by
+              // the outer action-list — which would replace the
+              // entire ``if`` node's slot with the nested list. Net
+              // effect: adding a delay inside an if's then-branch
+              // wipes the if and leaves just the delay.
+              e.stopPropagation();
+              this._onChildrenChange(key, e.detail.actions);
+            }}
+          ></esphome-automation-action-list>
+        </div>`
     );
   }
 
@@ -402,10 +396,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
           placeholder="0"
           ?disabled=${this.disabled}
           @input=${(e: Event) =>
-            this._writeDelay(
-              (e.target as HTMLInputElement).value,
-              unit,
-            )}
+            this._writeDelay((e.target as HTMLInputElement).value, unit)}
         />
       </div>
       <div class="ae-delay-unit">
@@ -418,13 +409,14 @@ export class ESPHomeAutomationActionNode extends LitElement {
           @change=${(e: Event) =>
             this._writeDelay(
               numericValue,
-              (e.target as HTMLSelectElement).value as DelayUnit,
+              (e.target as HTMLSelectElement).value as DelayUnit
             )}
         >
           ${DELAY_UNITS.map(
-            (u) => html`<option value=${u} ?selected=${u === unit}>
-              ${this._localize(`device.automation_action_delay_unit_${u}`)}
-            </option>`,
+            (u) =>
+              html`<option value=${u} ?selected=${u === unit}>
+                ${this._localize(`device.automation_action_delay_unit_${u}`)}
+              </option>`
           )}
         </select>
       </div>
@@ -511,11 +503,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
 
   private _onParamChange = (e: CustomEvent<ConfigEntryValueChange>) => {
     e.stopPropagation();
-    const params = applyParamChange(
-      this.value.params,
-      e.detail.path,
-      e.detail.value,
-    );
+    const params = applyParamChange(this.value.params, e.detail.path, e.detail.value);
     this._emit({ ...this.value, params });
   };
 
@@ -523,9 +511,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     this._emit({ ...this.value, params: { ...this.value.params, ...patch } });
   }
 
-  private _onConditionsChange = (
-    e: CustomEvent<{ conditions: ConditionNode[] }>,
-  ) => {
+  private _onConditionsChange = (e: CustomEvent<{ conditions: ConditionNode[] }>) => {
     e.stopPropagation();
     this._emit({ ...this.value, conditions: e.detail.conditions });
   };
@@ -541,7 +527,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
         detail: { delta },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -550,7 +536,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
       new CustomEvent("action-delete", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -560,7 +546,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
         detail: { value },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/automation-editor/automation-condition-tree.ts
+++ b/src/components/device/automation-editor/automation-condition-tree.ts
@@ -117,9 +117,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
               >${this._localize("device.automation_only_when")}</label
             >`}
         ${this.conditions.length === 0
-          ? html`<p class="ae-empty">
-              ${this._localize("device.add_condition")}
-            </p>`
+          ? html`<p class="ae-empty">${this._localize("device.add_condition")}</p>`
           : this.conditions.map((node, idx) => this._renderNode(node, idx))}
         <button
           type="button"
@@ -152,9 +150,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
             ?disabled=${this.disabled}
             @click=${() => this._openPickerForChange(idx)}
           >
-            <span class="ae-row-picker-name">
-              ${def?.name ?? node.condition_id}
-            </span>
+            <span class="ae-row-picker-name"> ${def?.name ?? node.condition_id} </span>
             <wa-icon library="mdi" name="pencil-outline"></wa-icon>
           </button>
           <div class="ae-row-controls">
@@ -187,9 +183,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
         </div>
         <div class="ae-row-body">
           ${def?.description
-            ? html`<p class="ae-row-desc">
-                ${renderMarkdown(def.description)}
-              </p>`
+            ? html`<p class="ae-row-desc">${renderMarkdown(def.description)}</p>`
             : nothing}
           ${def && def.config_entries.length > 0
             ? html`<esphome-config-entry-form
@@ -216,7 +210,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
                   .yaml=${this.yaml}
                   ?disabled=${this.disabled}
                   @conditions-change=${(
-                    e: CustomEvent<{ conditions: ConditionNode[] }>,
+                    e: CustomEvent<{ conditions: ConditionNode[] }>
                   ) => this._onChildrenChange(idx, e)}
                 ></esphome-automation-condition-tree>
               </div>`
@@ -265,12 +259,12 @@ export class ESPHomeAutomationConditionTree extends LitElement {
 
   private _onChildrenChange(
     idx: number,
-    e: CustomEvent<{ conditions: ConditionNode[] }>,
+    e: CustomEvent<{ conditions: ConditionNode[] }>
   ) {
     e.stopPropagation();
     const old = this.conditions[idx];
     this._emit(
-      replaceAt(this.conditions, idx, { ...old, children: e.detail.conditions }),
+      replaceAt(this.conditions, idx, { ...old, children: e.detail.conditions })
     );
   }
 
@@ -288,7 +282,7 @@ export class ESPHomeAutomationConditionTree extends LitElement {
         detail: { conditions },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/automation-editor/automation-target-picker.ts
+++ b/src/components/device/automation-editor/automation-target-picker.ts
@@ -108,9 +108,10 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
           @change=${this._onKindChange}
         >
           ${ORDER.map(
-            (k) => html`<wa-option value=${k} ?selected=${k === kind}
-              >${this._kindLabel(k)}</wa-option
-            >`,
+            (k) =>
+              html`<wa-option value=${k} ?selected=${k === kind}
+                >${this._kindLabel(k)}</wa-option
+              >`
           )}
         </wa-select>
         ${this._renderKindBody(kind)}
@@ -165,9 +166,11 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             this._onComponentChange((e.target as HTMLSelectElement).value)}
         >
           ${this.devices.map(
-            (d) => html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
-              >${d.name ?? d.id} <span class="ae-muted">(${d.component_id})</span></wa-option
-            >`,
+            (d) =>
+              html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
+                >${d.name ?? d.id}
+                <span class="ae-muted">(${d.component_id})</span></wa-option
+              >`
           )}
         </wa-select>
       `;
@@ -198,9 +201,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
           id="script-id-input"
           type="text"
           .value=${selectedId}
-          placeholder=${this._localize(
-            "device.automation_target_script_id_placeholder",
-          )}
+          placeholder=${this._localize("device.automation_target_script_id_placeholder")}
           ?disabled=${this.disabled}
           @input=${(e: Event) =>
             this._onScriptChange((e.target as HTMLInputElement).value)}
@@ -225,9 +226,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
     if (kind === "light_effect") {
       const selectedId =
         this.value?.kind === "light_effect" ? this.value.component_id : "";
-      const lights = this.devices.filter((d) =>
-        d.component_id.startsWith("light."),
-      );
+      const lights = this.devices.filter((d) => d.component_id.startsWith("light."));
       if (lights.length === 0) {
         return html`<p class="ae-empty" role="status">
           ${this._localize("device.automation_target_no_lights")}
@@ -245,9 +244,10 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             this._onLightChange((e.target as HTMLSelectElement).value)}
         >
           ${lights.map(
-            (d) => html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
-              >${d.name ?? d.id}</wa-option
-            >`,
+            (d) =>
+              html`<wa-option value=${d.id} ?selected=${d.id === selectedId}
+                >${d.name ?? d.id}</wa-option
+              >`
           )}
         </wa-select>
       `;
@@ -283,9 +283,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
             id: this.scripts.length ? this.scripts[0].id : "",
           };
         case "light_effect": {
-          const light = this.devices.find((d) =>
-            d.component_id.startsWith("light."),
-          );
+          const light = this.devices.find((d) => d.component_id.startsWith("light."));
           return light ? { kind, component_id: light.id, index: 0 } : null;
         }
         case "api_action":
@@ -318,7 +316,7 @@ export class ESPHomeAutomationTargetPicker extends LitElement {
         detail: { target },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/automation-editor/automation-trigger-picker.ts
+++ b/src/components/device/automation-editor/automation-trigger-picker.ts
@@ -91,7 +91,7 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
     const componentId =
       this.target.kind === "component_on" ? this.target.component_id : null;
     const boundDevice = componentId
-      ? this.devices.find((d) => d.id === componentId) ?? null
+      ? (this.devices.find((d) => d.id === componentId) ?? null)
       : null;
     return html`
       <div class="ae-section">
@@ -117,17 +117,14 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
               @change=${this._onTriggerChange}
             >
               ${filtered.map(
-                (t) => html`<wa-option
-                  value=${t.id}
-                  ?selected=${t.id === this.triggerId}
-                  >${t.name}</wa-option
-                >`,
+                (t) =>
+                  html`<wa-option value=${t.id} ?selected=${t.id === this.triggerId}
+                    >${t.name}</wa-option
+                  >`
               )}
             </wa-select>`}
         ${active?.description
-          ? html`<p class="ae-section-desc">
-              ${renderMarkdown(active.description)}
-            </p>`
+          ? html`<p class="ae-section-desc">${renderMarkdown(active.description)}</p>`
           : nothing}
         ${active && active.config_entries.length > 0
           ? html`<esphome-config-entry-form
@@ -160,8 +157,7 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
       return this.triggers.filter(
         (t) =>
           !t.is_device_level &&
-          (t.applies_to.includes(device.component_id) ||
-            t.applies_to.includes(domain)),
+          (t.applies_to.includes(device.component_id) || t.applies_to.includes(domain))
       );
     }
     return [];
@@ -174,23 +170,19 @@ export class ESPHomeAutomationTriggerPicker extends LitElement {
         detail: { triggerId: id, params: {} },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
   private _onParamChange = (e: CustomEvent<ConfigEntryValueChange>) => {
     e.stopPropagation();
-    const next = applyParamChange(
-      this.triggerParams,
-      e.detail.path,
-      e.detail.value,
-    );
+    const next = applyParamChange(this.triggerParams, e.detail.path, e.detail.value);
     this.dispatchEvent(
       new CustomEvent("trigger-params-change", {
         detail: { params: next },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 }

--- a/src/components/device/automation-editor/callable-params-editor.ts
+++ b/src/components/device/automation-editor/callable-params-editor.ts
@@ -91,7 +91,7 @@ export class ESPHomeCallableParamsEditor extends LitElement {
     const matches =
       localNamed.length === fromWire.length &&
       localNamed.every(
-        (p, i) => p.name === fromWire[i].name && p.type === fromWire[i].type,
+        (p, i) => p.name === fromWire[i].name && p.type === fromWire[i].type
       );
     if (!matches) this._params = fromWire;
   }
@@ -102,9 +102,7 @@ export class ESPHomeCallableParamsEditor extends LitElement {
         ? html`<label class="field-label">${this.fieldLabel}</label>`
         : nothing}
       ${this.description
-        ? html`<p class="field-description">
-            ${renderMarkdown(this.description)}
-          </p>`
+        ? html`<p class="field-description">${renderMarkdown(this.description)}</p>`
         : nothing}
       ${this._params.length === 0
         ? nothing
@@ -150,9 +148,7 @@ export class ESPHomeCallableParamsEditor extends LitElement {
           })}
       >
         ${PARAM_TYPES.map(
-          (t) => html`<wa-option value=${t} ?selected=${t === p.type}
-            >${t}</wa-option
-          >`,
+          (t) => html`<wa-option value=${t} ?selected=${t === p.type}>${t}</wa-option>`
         )}
       </wa-select>
       <button
@@ -186,7 +182,7 @@ export class ESPHomeCallableParamsEditor extends LitElement {
         detail: { value: dict },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 

--- a/src/components/device/automation-editor/serialise.ts
+++ b/src/components/device/automation-editor/serialise.ts
@@ -52,7 +52,7 @@ export function emptyConditionNode(conditionId: string): ConditionNode {
 export function applyParamChange(
   params: Record<string, unknown>,
   path: string[],
-  value: unknown,
+  value: unknown
 ): Record<string, unknown> {
   if (path.length === 0) {
     if (value && typeof value === "object" && !Array.isArray(value)) {
@@ -169,9 +169,7 @@ export function applyYamlDiff(yaml: string, diff: YamlDiff): string {
  * parser emits ``automation:unscoped:…`` for unscoped handlers; those
  * have no canonical location).
  */
-export function locationFromSectionKey(
-  key: string,
-): AutomationLocation | null {
+export function locationFromSectionKey(key: string): AutomationLocation | null {
   if (!key.startsWith("automation:")) return null;
   const parts = key.split(":");
   // parts[0] = "automation"

--- a/src/components/device/component-card-category-label.ts
+++ b/src/components/device/component-card-category-label.ts
@@ -22,11 +22,7 @@
  * render the card.
  */
 
-const ACRONYMS = new Set([
-  "adc",
-  "dac",
-  "ota",
-]);
+const ACRONYMS = new Set(["adc", "dac", "ota"]);
 
 export function categoryChipLabel(category: string): string {
   if (!category) return "";

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -28,10 +28,7 @@ import {
   filteredBundles,
   visibleComponents,
 } from "./component-catalog/filters.js";
-import {
-  renderBundleCard,
-  renderCard,
-} from "./component-catalog/renderers.js";
+import { renderBundleCard, renderCard } from "./component-catalog/renderers.js";
 
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -47,7 +44,9 @@ registerMdiIcons({
 
 @customElement("esphome-component-catalog")
 export class ESPHomeComponentCatalog extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
   // Forwarded to the backend so per-platform cv.SplitDefault defaults are pre-resolved.
@@ -100,9 +99,7 @@ export class ESPHomeComponentCatalog extends LitElement {
       (this.board?.featured_components?.length ?? 0) +
       (this.board?.featured_bundles?.length ?? 0);
     const hasFeatured =
-      this.lockedCategories.length === 0 &&
-      !!this.boardId &&
-      featuredCount > 0;
+      this.lockedCategories.length === 0 && !!this.boardId && featuredCount > 0;
     if (hasFeatured) {
       this._category = ComponentCategory.FEATURED;
     } else if (this._category === ComponentCategory.FEATURED) {
@@ -116,7 +113,7 @@ export class ESPHomeComponentCatalog extends LitElement {
   // output.gpio, output.ledc, …); otherwise fall back to the search query.
   public filterByDomain(domain: string) {
     const isCategory = Object.values(ComponentCategory).includes(
-      domain as ComponentCategory,
+      domain as ComponentCategory
     );
     if (isCategory) {
       this._search = "";
@@ -141,9 +138,7 @@ export class ESPHomeComponentCatalog extends LitElement {
           ? this._category
           : undefined;
       const exclude_category: string[] | undefined =
-        !locked && this.excludeCategories.length > 0
-          ? this.excludeCategories
-          : undefined;
+        !locked && this.excludeCategories.length > 0 ? this.excludeCategories : undefined;
       const response = await this._api.getComponents({
         query,
         category,
@@ -185,9 +180,7 @@ export class ESPHomeComponentCatalog extends LitElement {
     return html`
       ${showSidebar
         ? html`<div class="sidebar">
-            <p class="sidebar-label">
-              ${this._localize("device.component_categories")}
-            </p>
+            <p class="sidebar-label">${this._localize("device.component_categories")}</p>
             ${categories.map(
               ({ id, label, count }) => html`
                 <button
@@ -205,7 +198,7 @@ export class ESPHomeComponentCatalog extends LitElement {
                     <span class="category-count">${count}</span>
                   </span>
                 </button>
-              `,
+              `
             )}
           </div>`
         : nothing}
@@ -219,16 +212,14 @@ export class ESPHomeComponentCatalog extends LitElement {
         />
         ${!this._loading
           ? html`<span class="result-count"
-              >${visible.length + bundles.length} of
-              ${this._total + bundles.length} components</span
+              >${visible.length + bundles.length} of ${this._total + bundles.length}
+              components</span
             >`
           : ""}
         <div class="grid-scroll">
           <div class="components-grid">
             ${this._loading
-              ? html`<p class="empty">
-                  ${this._localize("device.loading_components")}
-                </p>`
+              ? html`<p class="empty">${this._localize("device.loading_components")}</p>`
               : visible.length + bundles.length
                 ? html`
                     ${bundles.map((b) => renderBundleCard(this, b))}
@@ -238,8 +229,8 @@ export class ESPHomeComponentCatalog extends LitElement {
                         c,
                         c.id === this._expandedId,
                         this._category === ComponentCategory.FEATURED,
-                        this._localize,
-                      ),
+                        this._localize
+                      )
                     )}
                   `
                 : html`<p class="empty">
@@ -273,7 +264,7 @@ export class ESPHomeComponentCatalog extends LitElement {
         detail: { component },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -283,7 +274,7 @@ export class ESPHomeComponentCatalog extends LitElement {
         detail: { bundle, boardId: this.boardId },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -19,18 +19,14 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 //     satisfied from this dialog. A dep counts as satisfied when it's
 //     already in the user's YAML OR one of the IDs in this response.
 export function visibleComponents(
-  host: ESPHomeComponentCatalog,
+  host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
-  const present = host.yaml
-    ? parseTopLevelComponents(host.yaml)
-    : new Set<string>();
+  const present = host.yaml ? parseTopLevelComponents(host.yaml) : new Set<string>();
   const presentPlatforms = host.yaml
     ? parseConfiguredPlatforms(host.yaml)
     : new Set<string>();
   const lockedToCore = host.lockedCategories.length > 0;
-  const coreCompatible = lockedToCore
-    ? new Set(host._components.map((c) => c.id))
-    : null;
+  const coreCompatible = lockedToCore ? new Set(host._components.map((c) => c.id)) : null;
 
   return host._components.filter((c) => {
     if (!c.multi_conf) {
@@ -42,7 +38,7 @@ export function visibleComponents(
     }
     if (coreCompatible && c.id.includes(".") && c.dependencies.length > 0) {
       const allSatisfied = c.dependencies.every(
-        (dep) => coreCompatible.has(dep) || present.has(dep),
+        (dep) => coreCompatible.has(dep) || present.has(dep)
       );
       if (!allSatisfied) return false;
     }
@@ -52,9 +48,7 @@ export function visibleComponents(
 
 // Bundles live on boards/get_board (not components/*) — filter client-side
 // so a search behaves consistently across featured + bundles + components.
-export function filteredBundles(
-  host: ESPHomeComponentCatalog,
-): FeaturedBundle[] {
+export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[] {
   const bundles = host.board?.featured_bundles ?? [];
   const q = host._search.trim().toLowerCase();
   if (!q) return bundles;
@@ -62,7 +56,7 @@ export function filteredBundles(
     (b) =>
       b.name.toLowerCase().includes(q) ||
       b.description.toLowerCase().includes(q) ||
-      b.id.toLowerCase().includes(q),
+      b.id.toLowerCase().includes(q)
   );
 }
 
@@ -74,21 +68,17 @@ interface CategoryEntry {
 
 export function buildCategories(
   host: ESPHomeComponentCatalog,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): CategoryEntry[] {
   const excluded = new Set(host.excludeCategories);
   const visibleCats = host._categories.filter((c) => !excluded.has(c.id));
   // Pin "Featured" — peel it out so it doesn't appear twice in the alpha list.
-  const featuredCat = visibleCats.find(
-    (c) => c.id === ComponentCategory.FEATURED,
-  );
+  const featuredCat = visibleCats.find((c) => c.id === ComponentCategory.FEATURED);
   const bundleCount = host.board?.featured_bundles?.length ?? 0;
   // Bundles live on the board manifest, not in components categories —
   // add them to the headline count so the badge matches the rendered grid.
   const featuredBadge = featuredCat ? featuredCat.count + bundleCount : bundleCount;
-  const sortableCats = visibleCats.filter(
-    (c) => c.id !== ComponentCategory.FEATURED,
-  );
+  const sortableCats = visibleCats.filter((c) => c.id !== ComponentCategory.FEATURED);
   const visibleTotal = excluded.size
     ? sortableCats.reduce((sum, c) => sum + c.count, 0)
     : host._total;

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -1,8 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type {
-  ComponentCatalogEntry,
-  FeaturedBundle,
-} from "../../../api/types.js";
+import type { ComponentCatalogEntry, FeaturedBundle } from "../../../api/types.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import {
@@ -20,7 +17,7 @@ export function shouldHandleCardClick(ev: MouseEvent): boolean {
 
 export function renderBundleCard(
   host: ESPHomeComponentCatalog,
-  bundle: FeaturedBundle,
+  bundle: FeaturedBundle
 ): TemplateResult {
   return html`
     <article
@@ -66,7 +63,7 @@ export function renderCard(
   component: ComponentCatalogEntry,
   expanded: boolean,
   featured: boolean,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): TemplateResult {
   const hasImage = !!component.image_url && !host._imageFailed.has(component.id);
   // Skip the chip entirely when the label is empty (defensive against an

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -173,7 +173,8 @@ export const componentCatalogStyles = css`
     flex-direction: column;
     gap: 6px;
     cursor: pointer;
-    transition: border-color var(--wa-transition-normal) var(--wa-transition-easing),
+    transition:
+      border-color var(--wa-transition-normal) var(--wa-transition-easing),
       background var(--wa-transition-normal) var(--wa-transition-easing);
   }
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -30,13 +30,8 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import {
-  type ValidationError,
-} from "../../util/config-validation.js";
-import {
-  _isStructuralType,
-  filterRenderable,
-} from "./config-entry-render-filter.js";
+import { type ValidationError } from "../../util/config-validation.js";
+import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
@@ -179,7 +174,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    */
   private _filterRenderable = (
     entries: ConfigEntry[],
-    values: Record<string, unknown>,
+    values: Record<string, unknown>
   ): ConfigEntry[] =>
     filterRenderable(entries, values, {
       requiredOnly: this.requiredOnly,
@@ -196,7 +191,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // the component itself is the map. Pass ``[]`` so the entry's
     // renderer sees the values dict directly via ``ctx.getAt([])``.
     return html`${visible.map((entry) =>
-      this._renderEntry(entry, entry.key ? [entry.key] : [], ctx),
+      this._renderEntry(entry, entry.key ? [entry.key] : [], ctx)
     )}`;
   }
 
@@ -234,9 +229,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   private async _syncSelectValues() {
     if (!this.shadowRoot) return;
-    const fields = this.shadowRoot.querySelectorAll<HTMLElement>(
-      "[data-field-key]",
-    );
+    const fields = this.shadowRoot.querySelectorAll<HTMLElement>("[data-field-key]");
     for (const field of fields) {
       const select = field.querySelector("wa-select") as
         | (HTMLElement & {
@@ -285,8 +278,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // binding instead.
       if (!isPrimitiveOrNullish(value)) {
         const current = Array.isArray(select.value)
-          ? select.value[0] ?? ""
-          : select.value ?? "";
+          ? (select.value[0] ?? "")
+          : (select.value ?? "");
         if (current !== "") select.value = "";
         continue;
       }
@@ -305,19 +298,18 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // i2c bus on ESP32-C3 lands on the right option instead of
       // showing an empty select.
       const options = Array.from(
-        select.querySelectorAll<HTMLElement & { value: string }>("wa-option"),
+        select.querySelectorAll<HTMLElement & { value: string }>("wa-option")
       );
       const rawGpio = raw.match(/^\s*(?:GPIO)?(\d+)\s*$/i)?.[1];
       const findByValue = (v: string) =>
         options.find((o) => o.value?.toLowerCase() === v.toLowerCase());
       const matched = raw
-        ? (findByValue(raw) ??
-            (rawGpio ? findByValue(`GPIO${rawGpio}`) : undefined))
+        ? (findByValue(raw) ?? (rawGpio ? findByValue(`GPIO${rawGpio}`) : undefined))
         : null;
       const desired = matched?.value ?? raw;
       const current = Array.isArray(select.value)
-        ? select.value[0] ?? ""
-        : select.value ?? "";
+        ? (select.value[0] ?? "")
+        : (select.value ?? "");
       if (current !== desired) {
         select.value = desired;
       }
@@ -335,7 +327,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     select: HTMLElement & {
       value: string | string[] | null;
       updateComplete?: Promise<unknown>;
-    },
+    }
   ) {
     if (select.updateComplete) {
       try {
@@ -344,14 +336,14 @@ export class ESPHomeConfigEntryForm extends LitElement {
         // ignore
       }
     }
-    const selectedOption = select.querySelector<
-      HTMLElement & { value: string }
-    >("wa-option[selected]");
+    const selectedOption = select.querySelector<HTMLElement & { value: string }>(
+      "wa-option[selected]"
+    );
     const desired = selectedOption?.value ?? "";
     if (!desired) return;
     const current = Array.isArray(select.value)
-      ? select.value[0] ?? ""
-      : select.value ?? "";
+      ? (select.value[0] ?? "")
+      : (select.value ?? "");
     if (current !== desired) {
       select.value = desired;
     }
@@ -373,15 +365,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
       console.error(
         "esphome-config-entry-form: render failed for entry",
         { key: entry.key, type: entry.type, path },
-        err,
+        err
       );
       const message = err instanceof Error ? err.message : String(err);
       return html`<div class="render-error" role="alert">
         <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
         <div>
-          <strong>
-            ${this._localize("device.entry_render_error_title")}
-          </strong>
+          <strong> ${this._localize("device.entry_render_error_title")} </strong>
           <code class="render-error-key"
             >${entry.key || "(empty key)"} · ${entry.type}</code
           >
@@ -394,7 +384,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _renderEntryUnsafe(
     entry: ConfigEntry,
     path: string[],
-    ctx: RenderCtx,
+    ctx: RenderCtx
   ): unknown {
     // Templatable wrapper pre-empts the type switch for any leaf
     // entry that accepts a literal-or-lambda value. Structural
@@ -404,17 +394,13 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // a thunk so we don't need to duplicate the type switch here.
     if (entry.templatable && !_isStructuralType(entry.type)) {
       return renderTemplatableField(entry, path, ctx, () =>
-        this._renderEntryLeaf(entry, path, ctx),
+        this._renderEntryLeaf(entry, path, ctx)
       );
     }
     return this._renderEntryLeaf(entry, path, ctx);
   }
 
-  private _renderEntryLeaf(
-    entry: ConfigEntry,
-    path: string[],
-    ctx: RenderCtx,
-  ): unknown {
+  private _renderEntryLeaf(entry: ConfigEntry, path: string[], ctx: RenderCtx): unknown {
     if (entry.type === ConfigEntryType.DIVIDER) {
       return html`<wa-divider></wa-divider>`;
     }
@@ -563,7 +549,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         detail: { path, value },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -606,7 +592,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         detail: { domain },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -20,7 +20,7 @@ export const ADD_NEW_SENTINEL = "__esphome_add_new__";
 export function renderIdReferenceField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   const domain = entry.references_component || "";
   const candidates = findReferencedComponents(ctx.yaml, domain);
@@ -98,7 +98,7 @@ export function renderIdReferenceField(
                   >${c.name ? `${c.id} · ${domain}` : domain}</span
                 >
               </span>
-            </wa-option>`,
+            </wa-option>`
         )}
         ${addOption}
       </wa-select>

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -8,10 +8,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { BoardPin, ConfigEntry } from "../../api/types.js";
 import { PinFeature, PinMode } from "../../api/types.js";
-import {
-  findUsedPins,
-  sectionEndLine,
-} from "../../util/config-entry-yaml-scan.js";
+import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.js";
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   effectiveDisabled,
@@ -58,15 +55,14 @@ function buildPinOption(
   pin: BoardPin,
   entry: ConfigEntry,
   usedPins: Map<number, string>,
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ): PinOptionView {
   const optValue = `GPIO${pin.gpio}`;
   const primary = pin.label || optValue;
   const occupiedBy = pin.occupied_by || "";
   const usedBy = usedPins.get(pin.gpio) || "";
   const needsOutput =
-    entry.pin_mode === PinMode.OUTPUT ||
-    entry.pin_mode === PinMode.INPUT_OUTPUT;
+    entry.pin_mode === PinMode.OUTPUT || entry.pin_mode === PinMode.INPUT_OUTPUT;
   const isInputOnly = pin.features.includes(PinFeature.INPUT_ONLY);
   const inputOnlyConflict = needsOutput && isInputOnly;
   const disabled = pin.available === false || inputOnlyConflict;
@@ -100,7 +96,7 @@ function buildPinOption(
 export function renderPinField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ): TemplateResult {
   if (!ctx.board || ctx.board.pins.length === 0) {
     return renderStringField(entry, "text", path, ctx);
@@ -137,9 +133,7 @@ export function renderPinField(
   // feature-filtered set instead, with a visible error for the field).
   if (entry.suggestions && entry.suggestions.length > 0) {
     const allowed = new Set(
-      entry.suggestions
-        .map(parsePinGpio)
-        .filter((g): g is number => g !== null),
+      entry.suggestions.map(parsePinGpio).filter((g): g is number => g !== null)
     );
     if (allowed.size > 0) {
       const narrowed = visible.filter((p) => allowed.has(p.gpio));
@@ -170,7 +164,7 @@ export function renderPinField(
   const usedPins = findUsedPins(
     ctx.yaml,
     ctx.fromLine,
-    sectionEndLine(ctx.yaml, ctx.fromLine),
+    sectionEndLine(ctx.yaml, ctx.fromLine)
   );
   const fieldDisabled = effectiveDisabled(entry, ctx);
   const isLongForm = isPlainObject(rawValue);
@@ -261,7 +255,7 @@ function renderPinAdvanced(
   ctx: RenderCtx,
   rawValue: unknown,
   isLongForm: boolean,
-  fieldDisabled: boolean,
+  fieldDisabled: boolean
 ): TemplateResult | typeof nothing {
   // Apply the same visibility filter every other nested renderer
   // uses so requiredOnly / showAdvanced / platform-gating rules
@@ -271,7 +265,7 @@ function renderPinAdvanced(
   // sub-fields the rest of the form has hidden.
   const longFormFields = ctx.filterRenderable(
     entry.config_entries ?? [],
-    ctx.scopeValues(path),
+    ctx.scopeValues(path)
   );
   if (longFormFields.length === 0) return nothing;
 
@@ -317,17 +311,12 @@ function renderPinAdvanced(
         ?disabled=${fieldDisabled}
         @click=${onAdvancedToggle}
       >
-        <wa-icon
-          library="mdi"
-          name=${isOpen ? "chevron-up" : "chevron-down"}
-        ></wa-icon>
+        <wa-icon library="mdi" name=${isOpen ? "chevron-up" : "chevron-down"}></wa-icon>
         <span>${ctx.localize("device.pin_advanced")}</span>
       </button>
       ${isOpen
         ? html`<div class="pin-advanced-fields">
-            ${longFormFields.map((child) =>
-              ctx.renderEntry(child, [...path, child.key]),
-            )}
+            ${longFormFields.map((child) => ctx.renderEntry(child, [...path, child.key]))}
           </div>`
         : nothing}
     </div>

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -24,11 +24,7 @@
 import type { ConfigEntry } from "../../api/types.js";
 import { ConfigEntryType } from "../../api/types.js";
 import { isEntryVisible } from "../../util/config-validation.js";
-import {
-  asMappingList,
-  asRecord,
-  isPlainObject,
-} from "../../util/nested-values.js";
+import { asMappingList, asRecord, isPlainObject } from "../../util/nested-values.js";
 import { YamlRawValue } from "../../util/yaml-serialize.js";
 
 /**
@@ -102,10 +98,7 @@ export interface RenderFilterOptions {
  * any descendant leaf is set; an advanced group with at least one
  * filled child needs to render so the child is reachable.
  */
-function hasMaterialValue(
-  entry: ConfigEntry,
-  values: Record<string, unknown>,
-): boolean {
+function hasMaterialValue(entry: ConfigEntry, values: Record<string, unknown>): boolean {
   const value = values[entry.key];
   if (entry.type === ConfigEntryType.NESTED) {
     if (entry.multi_value) {
@@ -122,9 +115,7 @@ function hasMaterialValue(
       return Array.isArray(value) && value.length > 0;
     }
     if (!isPlainObject(value)) return false;
-    return (entry.config_entries ?? []).some((child) =>
-      hasMaterialValue(child, value),
-    );
+    return (entry.config_entries ?? []).some((child) => hasMaterialValue(child, value));
   }
   return value !== undefined;
 }
@@ -132,25 +123,14 @@ function hasMaterialValue(
 export function filterRenderable(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
-  opts: RenderFilterOptions,
+  opts: RenderFilterOptions
 ): ConfigEntry[] {
   const out: ConfigEntry[] = [];
   for (const entry of entries) {
-    if (
-      !isEntryVisible(
-        entry,
-        values,
-        opts.presentComponents,
-        opts.targetPlatform,
-      )
-    ) {
+    if (!isEntryVisible(entry, values, opts.presentComponents, opts.targetPlatform)) {
       continue;
     }
-    if (
-      entry.advanced &&
-      !opts.showAdvanced &&
-      !hasMaterialValue(entry, values)
-    ) {
+    if (entry.advanced && !opts.showAdvanced && !hasMaterialValue(entry, values)) {
       continue;
     }
     if (entry.type === ConfigEntryType.NESTED) {
@@ -163,7 +143,7 @@ export function filterRenderable(
         const renderableChildren = filterRenderable(
           entry.config_entries ?? [],
           asRecord(values[entry.key]),
-          opts,
+          opts
         );
         if (renderableChildren.length === 0) continue;
       }
@@ -204,7 +184,7 @@ export function collectRenderablePaths(
   values: Record<string, unknown>,
   opts: RenderFilterOptions,
   pathPrefix: string[] = [],
-  out: Set<string> = new Set(),
+  out: Set<string> = new Set()
 ): Set<string> {
   for (const entry of filterRenderable(entries, values, opts)) {
     if (entry.type === ConfigEntryType.NESTED) {
@@ -220,7 +200,7 @@ export function collectRenderablePaths(
             itemValues,
             opts,
             [...pathPrefix, entry.key, String(idx)],
-            out,
+            out
           );
         });
       } else {
@@ -229,7 +209,7 @@ export function collectRenderablePaths(
           asRecord(values[entry.key]),
           opts,
           [...pathPrefix, entry.key],
-          out,
+          out
         );
       }
       out.add([...pathPrefix, entry.key].join("."));

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -115,10 +115,7 @@ export interface RenderCtx {
  * `RenderCtx` (e.g. the add-component dialog's hidden-validation
  * summary) can share the same chain.
  */
-export function resolveEntryLabel(
-  entry: ConfigEntry,
-  localize: LocalizeFunc,
-): string {
+export function resolveEntryLabel(entry: ConfigEntry, localize: LocalizeFunc): string {
   if (entry.translation_key) {
     const params = (entry.translation_params || undefined) as
       | Record<string, string | number>
@@ -175,18 +172,14 @@ export function renderLabel(
       ${includeHelpLink && entry.help_link ? renderHelpLink(entry, ctx) : nothing}
     </label>
     ${entry.description
-      ? html`<p class="field-description">
-          ${renderMarkdown(entry.description)}
-        </p>`
+      ? html`<p class="field-description">${renderMarkdown(entry.description)}</p>`
       : nothing}
   `;
 }
 
 export function renderFieldError(path: string[], ctx: RenderCtx) {
   const err = ctx.errorAt(path);
-  return renderInlineError(
-    err ? ctx.localize(err.code, err.params) : undefined,
-  );
+  return renderInlineError(err ? ctx.localize(err.code, err.params) : undefined);
 }
 
 /**
@@ -211,12 +204,11 @@ export function renderFieldShell(
   path: string[],
   ctx: RenderCtx,
   input: unknown,
-  trailing: unknown = nothing,
+  trailing: unknown = nothing
 ) {
   return html`
     <div class="field" data-field-key=${path.join(".")}>
-      ${renderLabel(entry, ctx)} ${input} ${trailing}
-      ${renderFieldError(path, ctx)}
+      ${renderLabel(entry, ctx)} ${input} ${trailing} ${renderFieldError(path, ctx)}
     </div>
   `;
 }
@@ -289,7 +281,7 @@ function renderSuggestionSelect(
   value: string,
   invalid: boolean,
   disabled: boolean,
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   const valueLower = value.toLowerCase();
   const placeholder = String(entry.default_value ?? "");
@@ -298,8 +290,7 @@ function renderSuggestionSelect(
   // entry's YAML value must be a number or downstream validation
   // (and the backend's locked-value comparison) will reject it.
   const isNumeric =
-    entry.type === ConfigEntryType.INTEGER ||
-    entry.type === ConfigEntryType.FLOAT;
+    entry.type === ConfigEntryType.INTEGER || entry.type === ConfigEntryType.FLOAT;
   const coerce = (raw: string): string | number => {
     if (!isNumeric) return raw;
     if (raw === "") return raw;
@@ -318,9 +309,7 @@ function renderSuggestionSelect(
       >
         ${(entry.suggestions ?? []).map((s) => {
           const v = String(s);
-          return html`<wa-option
-            value=${v}
-            ?selected=${v.toLowerCase() === valueLower}
+          return html`<wa-option value=${v} ?selected=${v.toLowerCase() === valueLower}
             >${v}</wa-option
           >`;
         })}

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -91,14 +91,14 @@ export class ESPHomeLambdaEditor extends LitElement {
     if (changed.has("_darkMode")) {
       this._view.dispatch({
         effects: this._themeCompartment.reconfigure(
-          this._darkMode ? vscodeDark : vscodeLight,
+          this._darkMode ? vscodeDark : vscodeLight
         ),
       });
     }
     if (changed.has("disabled")) {
       this._view.dispatch({
         effects: this._editableCompartment.reconfigure(
-          EditorView.editable.of(!this.disabled),
+          EditorView.editable.of(!this.disabled)
         ),
       });
     }
@@ -128,9 +128,7 @@ export class ESPHomeLambdaEditor extends LitElement {
           indentUnit.of("  "),
           keymap.of([indentWithTab]),
           this._editableCompartment.of(EditorView.editable.of(!this.disabled)),
-          this._themeCompartment.of(
-            this._darkMode ? vscodeDark : vscodeLight,
-          ),
+          this._themeCompartment.of(this._darkMode ? vscodeDark : vscodeLight),
           EditorView.theme({
             "&": { height: "100%" },
           }),
@@ -142,7 +140,7 @@ export class ESPHomeLambdaEditor extends LitElement {
                   detail: { value },
                   bubbles: true,
                   composed: true,
-                }),
+                })
               );
             }
           }),

--- a/src/components/device/config-entry-renderers/lambda.ts
+++ b/src/components/device/config-entry-renderers/lambda.ts
@@ -35,11 +35,7 @@ function bodyOf(raw: unknown): string {
   return String(raw);
 }
 
-export function renderLambdaField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderLambdaField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
   const value = bodyOf(raw);
   const invalid = ctx.errorAt(path) !== null;
@@ -55,6 +51,6 @@ export function renderLambdaField(
       placeholder=${String(entry.default_value ?? "")}
       @lambda-change=${(e: CustomEvent<{ value: string }>) =>
         ctx.emitChange(path, { _lambda: e.detail.value })}
-    ></esphome-lambda-editor>`,
+    ></esphome-lambda-editor>`
   );
 }

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -23,31 +23,24 @@ function readArrayAt(ctx: RenderCtx, path: string[]): readonly unknown[] {
 function arrayItemHandlers(
   ctx: RenderCtx,
   path: string[],
-  makeNewItem: () => unknown,
+  makeNewItem: () => unknown
 ): { addItem: () => void; removeAt: (idx: number) => void } {
   const removeAt = (idx: number) =>
     ctx.emitChange(
       path,
-      readArrayAt(ctx, path).filter((_, i) => i !== idx),
+      readArrayAt(ctx, path).filter((_, i) => i !== idx)
     );
-  const addItem = () =>
-    ctx.emitChange(path, [...readArrayAt(ctx, path), makeNewItem()]);
+  const addItem = () => ctx.emitChange(path, [...readArrayAt(ctx, path), makeNewItem()]);
   return { addItem, removeAt };
 }
 
 function renderListEmptyHint(items: readonly unknown[], ctx: RenderCtx) {
   return items.length === 0
-    ? html`<p class="field-description">
-        ${ctx.localize("device.multi_value_empty")}
-      </p>`
+    ? html`<p class="field-description">${ctx.localize("device.multi_value_empty")}</p>`
     : nothing;
 }
 
-function renderListRemoveButton(
-  ctx: RenderCtx,
-  disabled: boolean,
-  onClick: () => void,
-) {
+function renderListRemoveButton(ctx: RenderCtx, disabled: boolean, onClick: () => void) {
   return html`
     <button
       type="button"
@@ -61,11 +54,7 @@ function renderListRemoveButton(
   `;
 }
 
-function renderListAddButton(
-  ctx: RenderCtx,
-  disabled: boolean,
-  onClick: () => void,
-) {
+function renderListAddButton(ctx: RenderCtx, disabled: boolean, onClick: () => void) {
   return html`
     <button
       type="button"
@@ -82,7 +71,7 @@ function renderListAddButton(
 export function renderMultiValueField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   const items: string[] = readArrayAt(ctx, path).map((v) => String(v));
   const invalid = ctx.errorAt(path) !== null;
@@ -105,15 +94,13 @@ export function renderMultiValueField(
               class="multi-input ${invalid ? "invalid" : ""}"
               .value=${item}
               ?disabled=${disabled}
-              @input=${(e: Event) =>
-                updateAt(i, (e.target as HTMLInputElement).value)}
+              @input=${(e: Event) => updateAt(i, (e.target as HTMLInputElement).value)}
             />
             ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
           </div>
-        `,
+        `
       )}
-      ${renderListAddButton(ctx, disabled, addItem)}
-      ${renderFieldError(path, ctx)}
+      ${renderListAddButton(ctx, disabled, addItem)} ${renderFieldError(path, ctx)}
     </div>
   `;
 }
@@ -123,11 +110,7 @@ export function renderMultiValueField(
 // logger.logs:, substitutions:, globals:, api.actions:. Storage:
 // values[key] = { userKey: userValue, ... }. Renames rebuild to preserve
 // order; deletes remove the entry; adds inject new_1, new_2, ….
-export function renderMapField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const valueTemplate = (entry.config_entries ?? [])[0];
   const raw = ctx.getAt(path);
   const map: Record<string, unknown> =
@@ -141,9 +124,8 @@ export function renderMapField(
   // __proto__ / constructor stay as own property data instead of mutating
   // Object.prototype. A naive {...obj} spread would silently swap the
   // protection out on the first mutation. (Copilot-flagged.)
-  const cloneMap = (
-    src: Record<string, unknown>,
-  ): Record<string, unknown> => Object.assign(Object.create(null), src);
+  const cloneMap = (src: Record<string, unknown>): Record<string, unknown> =>
+    Object.assign(Object.create(null), src);
 
   const readMap = (): Record<string, unknown> => {
     const cur = ctx.getAt(path);
@@ -196,8 +178,7 @@ export function renderMapField(
           class="multi-input map-key-input"
           .value=${rowKey}
           ?disabled=${disabled}
-          @change=${(e: Event) =>
-            renameKey(rowKey, (e.target as HTMLInputElement).value)}
+          @change=${(e: Event) => renameKey(rowKey, (e.target as HTMLInputElement).value)}
         />
         <div class="map-value">
           ${complex
@@ -225,9 +206,7 @@ export function renderMapField(
     <div class="field" data-field-key=${path.join(".")}>
       ${renderLabel(entry, ctx)}
       ${keys.length === 0
-        ? html`<p class="field-description">
-            ${ctx.localize("device.map_empty")}
-          </p>`
+        ? html`<p class="field-description">${ctx.localize("device.map_empty")}</p>`
         : nothing}
       ${keys.map((k) => renderRow(k))}
       <button
@@ -252,7 +231,7 @@ export function renderMapField(
 export function renderNestedListField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   // YamlRawValue means the parser preserved the block byte-for-byte (the
   // catalog's flat-mapping contract didn't fit). Bail to a YAML-only notice;
@@ -263,9 +242,7 @@ export function renderNestedListField(
     return html`
       <div class="nested-list" data-field-key=${path.join(".")}>
         ${renderLabel(entry, ctx)}
-        <p class="field-description">
-          ${ctx.localize("device.multi_value_yaml_only")}
-        </p>
+        <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
         ${renderFieldError(path, ctx)}
       </div>
     `;
@@ -286,21 +263,18 @@ export function renderNestedListField(
         return html`
           <div class="nested-list-item" data-field-key=${itemPath.join(".")}>
             <div class="nested-list-item-header">
-              <span class="nested-list-item-title">
-                ${itemTitle} ${i + 1}
-              </span>
+              <span class="nested-list-item-title"> ${itemTitle} ${i + 1} </span>
               ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}
             </div>
             <div class="nested-fields">
               ${renderableChildren.map((child) =>
-                ctx.renderEntry(child, [...itemPath, child.key]),
+                ctx.renderEntry(child, [...itemPath, child.key])
               )}
             </div>
           </div>
         `;
       })}
-      ${renderListAddButton(ctx, disabled, addItem)}
-      ${renderFieldError(path, ctx)}
+      ${renderListAddButton(ctx, disabled, addItem)} ${renderFieldError(path, ctx)}
     </div>
   `;
 }

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -10,17 +10,13 @@ import {
 // In requiredOnly mode (add-component dialog) groups default open and the
 // set tracks groups the user explicitly *collapsed*. Otherwise groups default
 // closed and the set tracks groups they *opened*.
-export function renderNestedField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderNestedField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const key = path.join(".");
   const inSet = ctx.nestedOpenSections.has(key);
   const isOpen = ctx.requiredOnly ? !inSet : inSet;
   const renderableChildren = ctx.filterRenderable(
     entry.config_entries ?? [],
-    ctx.scopeValues(path),
+    ctx.scopeValues(path)
   );
   return html`
     <div class="nested-group" data-field-key=${path.join(".")}>
@@ -31,10 +27,7 @@ export function renderNestedField(
           aria-expanded=${isOpen}
           @click=${() => ctx.toggleNested(key)}
         >
-          <wa-icon
-            library="mdi"
-            name=${isOpen ? "chevron-up" : "chevron-down"}
-          ></wa-icon>
+          <wa-icon library="mdi" name=${isOpen ? "chevron-up" : "chevron-down"}></wa-icon>
           <span class="nested-title">${labelFor(entry, ctx)}</span>
           ${entry.platform_type
             ? html`<span class="nested-platform">${entry.platform_type}</span>`
@@ -43,14 +36,12 @@ export function renderNestedField(
         ${renderHelpLink(entry, ctx)}
       </div>
       ${entry.description
-        ? html`<p class="nested-desc">
-            ${renderMarkdown(entry.description)}
-          </p>`
+        ? html`<p class="nested-desc">${renderMarkdown(entry.description)}</p>`
         : nothing}
       ${isOpen
         ? html`<div class="nested-fields">
             ${renderableChildren.map((child) =>
-              ctx.renderEntry(child, [...path, child.key]),
+              ctx.renderEntry(child, [...path, child.key])
             )}
           </div>`
         : nothing}

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -20,11 +20,7 @@ import {
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
-export function renderNumberField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderNumberField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   // A featured-entry preset can pin the choice to a short list — defer to
   // the suggestion-aware string renderer which converts back to number on change.
   if (entry.suggestions && entry.suggestions.length > 0) {
@@ -55,7 +51,7 @@ export function renderNumberField(
         const raw = (e.target as HTMLInputElement).value;
         ctx.emitChange(path, raw === "" ? "" : Number(raw));
       }}
-    />`,
+    />`
   );
 }
 
@@ -63,11 +59,7 @@ export function renderNumberField(
 // (display_format=hex from cv.hex_uint*_t — every i2c address) need a text
 // input with explicit hex parsing + display formatting. Round-trips to
 // "0x" + lower-hex; accepts 0x76 / 0X76 (hex) and 118 (decimal).
-function renderHexIntField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+function renderHexIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const rawValue = ctx.getAt(path);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
@@ -103,7 +95,7 @@ function renderHexIntField(
         ctx.emitChange(path, formatHexInt(parseHexInt(raw)) || raw);
       }}
       @blur=${() => ctx.clearEditingMagnitude(path)}
-    />`,
+    />`
   );
 }
 
@@ -146,7 +138,7 @@ function parseTimePeriod(raw: unknown): {
     const [, num, suf] = m;
     return {
       value: num,
-      unit: ((suf as TimePeriodUnit) ?? "s"),
+      unit: (suf as TimePeriodUnit) ?? "s",
       parseable: true,
     };
   }
@@ -164,7 +156,7 @@ function serializeTimePeriod(value: string, unit: TimePeriodUnit): string {
 export function renderTimePeriodField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   const raw = ctx.getAt(path);
   const parsed = parseTimePeriod(raw);
@@ -213,17 +205,15 @@ export function renderTimePeriodField(
           data-no-value-sync
           ?disabled=${disabled}
           @change=${(e: Event) => {
-            const nextUnit = (e.target as HTMLSelectElement)
-              .value as TimePeriodUnit;
+            const nextUnit = (e.target as HTMLSelectElement).value as TimePeriodUnit;
             ctx.emitChange(path, serializeTimePeriod(parsed.value, nextUnit));
           }}
         >
           ${TIME_PERIOD_UNITS.map(
-            (u) => html`<wa-option
-              value=${u}
-              ?selected=${u === displayUnit}
-              >${ctx.localize(`device.automation_action_delay_unit_${u}`)}</wa-option
-            >`,
+            (u) =>
+              html`<wa-option value=${u} ?selected=${u === displayUnit}
+                >${ctx.localize(`device.automation_action_delay_unit_${u}`)}</wa-option
+              >`
           )}
         </wa-select>
       </div>
@@ -239,7 +229,7 @@ export function renderTimePeriodField(
 export function renderFloatWithUnitField(
   entry: ConfigEntry,
   path: string[],
-  ctx: RenderCtx,
+  ctx: RenderCtx
 ) {
   const unitOptions = entry.unit_options ?? [];
   const canonicalUnit = unitOptions[0] ?? "";
@@ -248,18 +238,14 @@ export function renderFloatWithUnitField(
   // Edit buffer survives intermediate typing states ("-", "1e", "1.") that
   // the parser turns into null/"". Cleared on blur and on entries change.
   const editingText = ctx.getEditingMagnitude(path);
-  const numberValue =
-    editingText ?? (parsed.value === null ? "" : String(parsed.value));
+  const numberValue = editingText ?? (parsed.value === null ? "" : String(parsed.value));
   const unit = chooseDisplayUnit(
     rawValue,
     entry.default_value,
     ctx.getPendingUnit(path),
-    unitOptions,
+    unitOptions
   );
-  const placeholder = placeholderForFloatWithUnit(
-    entry.default_value,
-    unitOptions,
-  );
+  const placeholder = placeholderForFloatWithUnit(entry.default_value, unitOptions);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const isCanonical = unit === canonicalUnit;
@@ -308,11 +294,10 @@ export function renderFloatWithUnitField(
                 }}
               >
                 ${unitOptions.map(
-                  (option) => html`<wa-option
-                    value=${option}
-                    ?selected=${option === unit}
-                    >${option}</wa-option
-                  >`,
+                  (option) =>
+                    html`<wa-option value=${option} ?selected=${option === unit}
+                      >${option}</wa-option
+                    >`
                 )}
               </wa-select>
             `
@@ -331,19 +316,13 @@ export function renderFloatWithUnitField(
 // Accept the full set of ESPHome YAML boolean spellings (true/yes/on/enable
 // and their case variants) so a user-typed ``True`` or ``enable`` in the
 // YAML editor reflects ON in the form view (issue device-builder#923).
-export function renderBooleanField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
   const effective = raw === undefined || raw === null ? entry.default_value : raw;
   const checked = parseYamlBoolean(effective) === true;
   return html`
     <div class="switch-field" data-field-key=${path.join(".")}>
-      <div class="field-info">
-        ${renderLabel(entry, ctx, { includeHelpLink: false })}
-      </div>
+      <div class="field-info">${renderLabel(entry, ctx, { includeHelpLink: false })}</div>
       ${renderHelpLink(entry, ctx)}
       <wa-switch
         ?checked=${checked}
@@ -351,18 +330,14 @@ export function renderBooleanField(
         @change=${(e: Event) =>
           ctx.emitChange(
             path,
-            (e.target as HTMLInputElement & { checked: boolean }).checked,
+            (e.target as HTMLInputElement & { checked: boolean }).checked
           )}
       ></wa-switch>
     </div>
   `;
 }
 
-export function renderSelectField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderSelectField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const value = String(ctx.getAt(path) ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
@@ -382,9 +357,7 @@ export function renderSelectField(
         >
           ${entry.suggestions.map((s) => {
             const v = String(s);
-            return html`<wa-option
-              value=${v}
-              ?selected=${v.toLowerCase() === valueLower}
+            return html`<wa-option value=${v} ?selected=${v.toLowerCase() === valueLower}
               >${v}</wa-option
             >`;
           })}
@@ -410,7 +383,7 @@ export function renderSelectField(
         />
         <datalist id=${listId}>
           ${entry.options.map(
-            (opt) => html`<option value=${opt.value}>${opt.label}</option>`,
+            (opt) => html`<option value=${opt.value}>${opt.label}</option>`
           )}
         </datalist>
         ${renderFieldError(path, ctx)}
@@ -421,10 +394,9 @@ export function renderSelectField(
   // (ESP32C6 vs esp32c6) — case-insensitive compare so the matching option
   // still flags as selected.
   const valueLower = value.toLowerCase();
-  const defaultStr =
-    entry.default_value != null ? String(entry.default_value) : "";
+  const defaultStr = entry.default_value != null ? String(entry.default_value) : "";
   const defaultOption = entry.options?.find(
-    (o) => o.value.toLowerCase() === defaultStr.toLowerCase(),
+    (o) => o.value.toLowerCase() === defaultStr.toLowerCase()
   );
   const placeholder = defaultOption?.label ?? defaultStr;
   return html`
@@ -443,7 +415,7 @@ export function renderSelectField(
               value=${opt.value}
               ?selected=${opt.value.toLowerCase() === valueLower}
               >${opt.label}</wa-option
-            >`,
+            >`
         )}
       </wa-select>
       ${renderFieldError(path, ctx)}
@@ -454,11 +426,7 @@ export function renderSelectField(
 // YAML block-scalar values (lambda: |-) come through as YamlRawValue so the
 // on-disk style round-trips. Re-wrap edited text as YamlRawValue so the |-
 // marker survives the next save (#428).
-export function renderTextareaField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderTextareaField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
   const isRaw = raw instanceof YamlRawValue;
   const value = isRaw ? raw.body : String(raw ?? "");
@@ -474,10 +442,7 @@ export function renderTextareaField(
         placeholder=${String(entry.default_value ?? "")}
         @input=${(e: Event) => {
           const text = (e.target as HTMLTextAreaElement).value;
-          ctx.emitChange(
-            path,
-            isRaw ? YamlRawValue.fromBodyText(text, raw) : text,
-          );
+          ctx.emitChange(path, isRaw ? YamlRawValue.fromBodyText(text, raw) : text);
         }}
       ></textarea>
       ${renderFieldError(path, ctx)}
@@ -485,11 +450,7 @@ export function renderTextareaField(
   `;
 }
 
-export function renderIconField(
-  entry: ConfigEntry,
-  path: string[],
-  ctx: RenderCtx,
-) {
+export function renderIconField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const value = String(ctx.getAt(path) ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`

--- a/src/components/device/config-entry-renderers/templatable.ts
+++ b/src/components/device/config-entry-renderers/templatable.ts
@@ -71,7 +71,7 @@ export function renderTemplatableField(
   entry: ConfigEntry,
   path: string[],
   ctx: RenderCtx,
-  innerRender: () => unknown,
+  innerRender: () => unknown
 ) {
   const raw = ctx.getAt(path);
   const isLambda = isLambdaValue(raw);

--- a/src/components/device/device-board-info-helpers.ts
+++ b/src/components/device/device-board-info-helpers.ts
@@ -25,7 +25,7 @@
  */
 export function isEmptyToPopulatedYamlChange(
   prev: string | undefined | null,
-  next: string,
+  next: string
 ): boolean {
   return !prev && !!next;
 }

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -204,7 +204,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                   const sensitiveLabel = this._localize(
                     this._revealSensitive
                       ? "device.yaml_mask_sensitive"
-                      : "device.yaml_reveal_sensitive",
+                      : "device.yaml_reveal_sensitive"
                   );
                   return html`<button
                     type="button"
@@ -413,11 +413,7 @@ export class ESPHomeDeviceEditor extends LitElement {
       this._showDiff = false;
       return;
     }
-    if (
-      this._showDiff &&
-      changed.has("savedYaml") &&
-      this.yaml === this.savedYaml
-    ) {
+    if (this._showDiff && changed.has("savedYaml") && this.yaml === this.savedYaml) {
       this._showDiff = false;
     }
   }

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -136,7 +136,10 @@ export class ESPHomeDeviceNavigator extends LitElement {
       .card {
         background: var(--wa-color-surface-default);
         border-radius: var(--navigator-border-radius, var(--wa-border-radius-l));
-        border: var(--navigator-border, var(--wa-border-width-s) solid var(--wa-color-surface-border));
+        border: var(
+          --navigator-border,
+          var(--wa-border-width-s) solid var(--wa-color-surface-border)
+        );
         box-shadow: var(--wa-elevation-02);
         display: flex;
         flex-direction: column;
@@ -378,8 +381,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
       const match =
         (this.selectedFromLine !== undefined
           ? allSections.find((s) => s.fromLine === this.selectedFromLine)
-          : undefined) ??
-        allSections.find((s) => sectionKeyOf(s) === this.selectedKey);
+          : undefined) ?? allSections.find((s) => sectionKeyOf(s) === this.selectedKey);
       if (match) {
         this._selectedLine = match.fromLine;
         this._selectedRange = {
@@ -404,7 +406,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
     // those bare keys here so each automation shows up exactly once.
     const detailed = parseYamlAutomations(this.yaml);
     const filteredTopLevel = topLevelAutomations.filter(
-      (s) => s.key !== "script" && s.key !== "interval",
+      (s) => s.key !== "script" && s.key !== "interval"
     );
     // Light effects belong to their parent light component now, not
     // the automations surface — clicking one in the navigator
@@ -423,7 +425,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
       .filter(
         (s) =>
           !s.key.startsWith("automation:light_effect:") &&
-          !s.key.startsWith("automation:unscoped:"),
+          !s.key.startsWith("automation:unscoped:")
       )
       .sort((a, b) => a.fromLine - b.fromLine);
 
@@ -552,8 +554,10 @@ export class ESPHomeDeviceNavigator extends LitElement {
                       ? html`
                           <div class="nav-items">
                             ${items.map((item) => {
-                              const { primary, secondary } =
-                                this._navItemLabels(item, category);
+                              const { primary, secondary } = this._navItemLabels(
+                                item,
+                                category
+                              );
                               return html`
                                 <div
                                   class="nav-item ${this._selectedLine === item.fromLine
@@ -562,7 +566,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
                                     ? "nav-item--hovered"
                                     : ""}"
                                   @mouseenter=${() =>
-                                    this._onItemHover(item.fromLine, item.fromLine, item.toLine)}
+                                    this._onItemHover(
+                                      item.fromLine,
+                                      item.fromLine,
+                                      item.toLine
+                                    )}
                                   @mouseleave=${() => this._onItemLeave()}
                                   @click=${() => this._onItemClick(item)}
                                 >
@@ -583,16 +591,14 @@ export class ESPHomeDeviceNavigator extends LitElement {
                       : nothing}
                     <div class="nav-items">
                       ${actions.map(
-                        (action) => html`<div
-                          class="action-item"
-                          @click=${() => action.onClick()}
-                        >
-                          <div>
-                            <wa-icon library="mdi" name=${action.icon}></wa-icon>
-                            <p>${action.label}</p>
-                          </div>
-                          <wa-icon library="mdi" name="plus-circle-outline"></wa-icon>
-                        </div>`,
+                        (action) =>
+                          html`<div class="action-item" @click=${() => action.onClick()}>
+                            <div>
+                              <wa-icon library="mdi" name=${action.icon}></wa-icon>
+                              <p>${action.label}</p>
+                            </div>
+                            <wa-icon library="mdi" name="plus-circle-outline"></wa-icon>
+                          </div>`
                       )}
                     </div>
                   `
@@ -623,7 +629,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
       new CustomEvent("nav-collapse", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -664,7 +670,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
         },
         () => {
           /* swallow — same rationale as the component fetch above. */
-        },
+        }
       );
     }
   }
@@ -684,7 +690,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
    */
   private _navItemLabels(
     item: YamlSection,
-    category: "core" | "component" | "automation",
+    category: "core" | "component" | "automation"
   ): { primary: string; secondary?: string } {
     const raw = sectionKeyOf(item);
 
@@ -718,7 +724,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
    */
   private _automationLabels(
     item: YamlSection,
-    raw: string,
+    raw: string
   ): { primary: string; secondary?: string } {
     // Script: line 1 = "Script", line 2 = id.
     if (item.parentKey === "script") {
@@ -745,7 +751,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
       const primary = this._resolveTriggerName(
         "esphome",
         item.eventKey,
-        `${this._prettyDomain("esphome")} → ${item.eventKey}`,
+        `${this._prettyDomain("esphome")} → ${item.eventKey}`
       );
       return { primary };
     }
@@ -753,11 +759,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
     // catalog; "Warmtepomp" on line 2).
     if (item.parentKey && item.eventKey) {
       const fallback = `${this._prettyDomain(item.parentKey)} → ${item.eventKey}`;
-      const primary = this._resolveTriggerName(
-        item.parentKey,
-        item.eventKey,
-        fallback,
-      );
+      const primary = this._resolveTriggerName(item.parentKey, item.eventKey, fallback);
       const named = item.name || item.id;
       const secondary = named && named !== primary ? named : undefined;
       return { primary, secondary };
@@ -775,15 +777,14 @@ export class ESPHomeDeviceNavigator extends LitElement {
   private _resolveTriggerName(
     domain: string,
     eventKey: string,
-    fallback: string,
+    fallback: string
   ): string {
     const triggers = getCachedAutomationTriggers(
       this.platform || undefined,
-      this.board?.id,
+      this.board?.id
     );
     if (!triggers) return fallback;
-    const catalogId =
-      domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
+    const catalogId = domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
     const hit = triggers.find((t) => t.id === catalogId);
     return hit?.name || fallback;
   }
@@ -815,7 +816,10 @@ export class ESPHomeDeviceNavigator extends LitElement {
       this.selectedKey = null;
       this._selectedLine = null;
       this._selectedRange = null;
-      this._emitHighlight(this._hoveredLine === fromLine ? { fromLine, toLine } : null, false);
+      this._emitHighlight(
+        this._hoveredLine === fromLine ? { fromLine, toLine } : null,
+        false
+      );
       this._emitSectionSelect(null, undefined);
     } else {
       this.selectedKey = sectionKey;
@@ -855,9 +859,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
    * the same key parseYamlAutomations will produce on the next
    * navigator render once the YAML refresh propagates.
    */
-  private _onAutomationAdded = (
-    e: CustomEvent<{ sectionKey: string }>,
-  ) => {
+  private _onAutomationAdded = (e: CustomEvent<{ sectionKey: string }>) => {
     e.stopPropagation();
     this._emitSectionSelect(e.detail.sectionKey, undefined);
   };

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -21,22 +21,15 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   host._draftTimer = null;
   if (!host._config) return;
 
-  const renderEntries = resolveSectionEntries(
-    host.sectionKey,
-    host._config.entries,
-  );
+  const renderEntries = resolveSectionEntries(host.sectionKey, host._config.entries);
   host._fieldErrors = validateEntries(
     renderEntries,
     host._values,
     host._presentComponents,
-    host.board?.esphome.platform ?? null,
+    host.board?.esphome.platform ?? null
   );
 
-  const fromLine = resolveCurrentFromLine(
-    host.yaml,
-    host.sectionKey,
-    host.fromLine,
-  );
+  const fromLine = resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine);
   if (fromLine === undefined) {
     // Section was removed from live YAML between keystroke and debounce
     // (paste / external edit). Drop the splice silently — next picker
@@ -54,7 +47,7 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
     // and must round-trip. Other MAP sections (packages) treat empty value
     // as an unfilled placeholder — packages schema validator rejects
     // empty-string definitions, so dropping placeholders keeps it loadable.
-    { keepEmptyStrings: KEEP_EMPTY_STRING_SECTIONS.has(host.sectionKey) },
+    { keepEmptyStrings: KEEP_EMPTY_STRING_SECTIONS.has(host.sectionKey) }
   );
 
   host._setDirty(false);
@@ -67,13 +60,13 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
       detail: { yaml: newYaml },
       bubbles: true,
       composed: true,
-    }),
+    })
   );
 }
 
 export function onValueChange(
   host: ESPHomeDeviceSectionConfig,
-  e: CustomEvent<ConfigEntryValueChange>,
+  e: CustomEvent<ConfigEntryValueChange>
 ): void {
   const { path, value } = e.detail;
   host._values = setIn(host._values, path, value);
@@ -87,15 +80,9 @@ export function onValueChange(
   host._scheduleDraftFlush();
 }
 
-export async function onDeleteConfirmed(
-  host: ESPHomeDeviceSectionConfig,
-): Promise<void> {
+export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promise<void> {
   if (!host._config) return;
-  const fromLine = resolveCurrentFromLine(
-    host.yaml,
-    host.sectionKey,
-    host.fromLine,
-  );
+  const fromLine = resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine);
   if (fromLine === undefined) {
     host._error = host._localize("device.section_delete_error");
     return;
@@ -116,23 +103,21 @@ export async function onDeleteConfirmed(
         detail: { yaml: newYaml },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     host.dispatchEvent(
       new CustomEvent("section-select", {
         detail: { sectionKey: null },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     toast.success(host._localize("device.section_deleted", { name: title }), {
       richColors: true,
     });
   } catch (e) {
     host._error =
-      e instanceof Error
-        ? e.message
-        : host._localize("device.section_delete_error");
+      e instanceof Error ? e.message : host._localize("device.section_delete_error");
   } finally {
     host._deleting = false;
   }

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -1,9 +1,7 @@
 import type { ConfigEntry } from "../../../api/types.js";
 import { fetchComponent } from "../../../util/component-name-cache.js";
 import { normalizeHexValues } from "../../../util/hex-int.js";
-import {
-  parseYamlSectionValues,
-} from "../../../util/yaml-section-values.js";
+import { parseYamlSectionValues } from "../../../util/yaml-section-values.js";
 import { resolveCurrentFromLine } from "../../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../../util/yaml-serialize.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
@@ -78,16 +76,8 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
     // Asymmetric with save/delete paths: undefined here means "section
     // not in live yaml" — surface an empty form (silent), since this load
     // is reactive to external mutations, not explicit user intent.
-    const resolvedFromLine = resolveCurrentFromLine(
-      yaml,
-      host.sectionKey,
-      host.fromLine,
-    );
-    const parsedValues = parseYamlSectionValues(
-      yaml,
-      host.sectionKey,
-      resolvedFromLine,
-    );
+    const resolvedFromLine = resolveCurrentFromLine(yaml, host.sectionKey, host.fromLine);
+    const parsedValues = parseYamlSectionValues(yaml, host.sectionKey, resolvedFromLine);
     // Pre-format hex values to canonical "0x…" string form (#410) so a
     // save preserves the user's hex notation even when they only edited
     // an unrelated field. Without this, i2c addresses round-trip from

--- a/src/components/device/password-input-event.ts
+++ b/src/components/device/password-input-event.ts
@@ -49,14 +49,11 @@ export const PASSWORD_INPUT_VALUE_CHANGE_EVENT = "password-input-change";
  * listeners fire regardless of `bubbles`.
  */
 export function buildPasswordValueChangeEvent(
-  value: string,
+  value: string
 ): CustomEvent<PasswordInputValueChange> {
-  return new CustomEvent<PasswordInputValueChange>(
-    PASSWORD_INPUT_VALUE_CHANGE_EVENT,
-    {
-      detail: { value },
-      bubbles: false,
-      composed: false,
-    },
-  );
+  return new CustomEvent<PasswordInputValueChange>(PASSWORD_INPUT_VALUE_CHANGE_EVENT, {
+    detail: { value },
+    bubbles: false,
+    composed: false,
+  });
 }

--- a/src/components/device/password-input.ts
+++ b/src/components/device/password-input.ts
@@ -120,11 +120,7 @@ export class ESPHomePasswordInput extends LitElement {
       }
 
       .toggle:hover {
-        background: color-mix(
-          in srgb,
-          var(--wa-color-text-normal),
-          transparent 92%
-        );
+        background: color-mix(in srgb, var(--wa-color-text-normal), transparent 92%);
         color: var(--wa-color-text-normal);
       }
 
@@ -141,7 +137,7 @@ export class ESPHomePasswordInput extends LitElement {
 
   protected render() {
     const label = this._localize(
-      this._revealed ? "device.password_hide" : "device.password_reveal",
+      this._revealed ? "device.password_hide" : "device.password_reveal"
     );
     return html`
       <div class="wrap">
@@ -165,10 +161,7 @@ export class ESPHomePasswordInput extends LitElement {
           aria-pressed=${this._revealed}
           @click=${this._onToggle}
         >
-          <wa-icon
-            library="mdi"
-            name=${this._revealed ? "eye-off" : "eye"}
-          ></wa-icon>
+          <wa-icon library="mdi" name=${this._revealed ? "eye-off" : "eye"}></wa-icon>
         </button>
       </div>
     `;

--- a/src/components/device/yaml-only-sections.ts
+++ b/src/components/device/yaml-only-sections.ts
@@ -34,9 +34,6 @@ export const YAML_ONLY_SECTIONS: ReadonlySet<string> = new Set([
 
 /** True when the section should fall back to the YAML notice — either
  *  always-YAML, or the backend returned no schema entries to render. */
-export function isYamlOnlySection(
-  sectionKey: string,
-  entryCount: number,
-): boolean {
+export function isYamlOnlySection(sectionKey: string, entryCount: number): boolean {
   return YAML_ONLY_SECTIONS.has(sectionKey) || entryCount === 0;
 }

--- a/src/components/discovered-device-card.ts
+++ b/src/components/discovered-device-card.ts
@@ -1,10 +1,5 @@
 import { consume } from "@lit/context";
-import {
-  mdiDownload,
-  mdiEyeOffOutline,
-  mdiEyeOutline,
-  mdiOpenInNew,
-} from "@mdi/js";
+import { mdiDownload, mdiEyeOffOutline, mdiEyeOutline, mdiOpenInNew } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { AdoptableDevice } from "../api/types.js";
@@ -121,8 +116,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
 
       .hostname {
         font-family:
-          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-          monospace;
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
         font-size: var(--wa-font-size-2xs);
         background: var(--wa-color-surface-lowered);
         border-radius: var(--wa-border-radius-s);
@@ -286,10 +280,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
           ${this.device.ignored
             ? nothing
             : html`
-                <button
-                  class="btn btn--primary"
-                  @click=${() => this._emit("adopt")}
-                >
+                <button class="btn btn--primary" @click=${() => this._emit("adopt")}>
                   <wa-icon library="mdi" name="download"></wa-icon>
                   ${this._localize("dashboard.action_take_control")}
                 </button>
@@ -312,7 +303,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
             title=${this._localize(
               this.device.ignored
                 ? "dashboard.action_unignore"
-                : "dashboard.action_ignore",
+                : "dashboard.action_ignore"
             )}
             @click=${() => this._emit("toggle-ignore")}
           >
@@ -323,7 +314,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
             ${this._localize(
               this.device.ignored
                 ? "dashboard.action_unignore"
-                : "dashboard.action_ignore",
+                : "dashboard.action_ignore"
             )}
           </button>
         </div>
@@ -337,7 +328,7 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
         detail: this.device,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -152,7 +152,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             hostname,
             port,
           },
-        }),
+        })
       );
       this._open = false;
     } catch (err) {
@@ -171,10 +171,10 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
     if (err instanceof APIError) {
       switch (err.errorCode) {
         case ErrorCode.UNAVAILABLE:
-          return this._localize(
-            "settings.edit_pairing_endpoint_unavailable",
-            { host, port: String(port) },
-          );
+          return this._localize("settings.edit_pairing_endpoint_unavailable", {
+            host,
+            port: String(port),
+          });
         case ErrorCode.PRECONDITION_FAILED:
           // Backend folds four distinct preconditions onto this
           // code: not-APPROVED, identity-not-loaded, no-op
@@ -186,17 +186,15 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
           // Detail string carries the diagnostic verbatim from
           // the backend; the dialog surfaces it inline so the
           // user sees which precondition tripped.
-          return this._localize(
-            "settings.edit_pairing_endpoint_precondition_failed",
-            { detail: err.details },
-          );
+          return this._localize("settings.edit_pairing_endpoint_precondition_failed", {
+            detail: err.details,
+          });
         case ErrorCode.NOT_FOUND:
           return this._localize("settings.edit_pairing_endpoint_not_found");
         case ErrorCode.INVALID_ARGS:
-          return this._localize(
-            "settings.edit_pairing_endpoint_invalid_args",
-            { detail: err.details },
-          );
+          return this._localize("settings.edit_pairing_endpoint_invalid_args", {
+            detail: err.details,
+          });
         default:
           return this._localize("settings.edit_pairing_endpoint_generic_error");
       }
@@ -230,8 +228,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
     const initialPort = parsePortInput(this._initialPort);
     return (
       normalizeHostnameForCompare(this._hostname) ===
-        normalizeHostnameForCompare(this._initialHostname) &&
-      port === initialPort
+        normalizeHostnameForCompare(this._initialHostname) && port === initialPort
     );
   }
 
@@ -256,9 +253,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
         @request-close=${this._onRequestClose}
         @after-hide=${this._close}
       >
-        <p class="desc">
-          ${this._localize("settings.edit_pairing_endpoint_desc")}
-        </p>
+        <p class="desc">${this._localize("settings.edit_pairing_endpoint_desc")}</p>
         <div class="field">
           <label for="ep-hostname">
             ${this._localize("settings.edit_pairing_endpoint_hostname_label")}
@@ -308,7 +303,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             ${this._localize(
               this._submitting
                 ? "settings.edit_pairing_endpoint_saving"
-                : "settings.edit_pairing_endpoint_save",
+                : "settings.edit_pairing_endpoint_save"
             )}
           </button>
         </div>

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -120,7 +120,9 @@ export class ESPHomeHeaderActions extends LitElement {
         padding: 6px;
         border-radius: var(--wa-border-radius-m);
         opacity: 0.85;
-        transition: opacity 0.12s, background 0.12s;
+        transition:
+          opacity 0.12s,
+          background 0.12s;
       }
 
       .menu-btn:hover {
@@ -168,8 +170,14 @@ export class ESPHomeHeaderActions extends LitElement {
       }
 
       @keyframes menu-in {
-        from { opacity: 0; transform: scale(0.95); }
-        to { opacity: 1; transform: scale(1); }
+        from {
+          opacity: 0;
+          transform: scale(0.95);
+        }
+        to {
+          opacity: 1;
+          transform: scale(1);
+        }
       }
 
       .menu-item {
@@ -242,17 +250,14 @@ export class ESPHomeHeaderActions extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
-    window.addEventListener(
-      "esphome-show-ignored-changed",
-      this._onShowIgnoredChanged,
-    );
+    window.addEventListener("esphome-show-ignored-changed", this._onShowIgnoredChanged);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener(
       "esphome-show-ignored-changed",
-      this._onShowIgnoredChanged,
+      this._onShowIgnoredChanged
     );
   }
 
@@ -302,7 +307,9 @@ export class ESPHomeHeaderActions extends LitElement {
                 @keydown=${this._onMenuItemKeydown}
               >
                 <wa-icon library="mdi" name="playlist-check"></wa-icon>
-                <span class="menu-item-label">${this._localize("firmware_jobs.menu_item")}</span>
+                <span class="menu-item-label"
+                  >${this._localize("firmware_jobs.menu_item")}</span
+                >
                 ${activeCount > 0
                   ? html`<span class="menu-item-count">${activeCount}</span>`
                   : nothing}
@@ -384,7 +391,9 @@ export class ESPHomeHeaderActions extends LitElement {
                 <wa-icon library="mdi" name="cog"></wa-icon>
                 <span class="menu-item-label">${this._localize("layout.settings")}</span>
                 ${hasAlerts
-                  ? html`<span class="menu-item-count">${this._offloaderAlertsCount()}</span>`
+                  ? html`<span class="menu-item-count"
+                      >${this._offloaderAlertsCount()}</span
+                    >`
                   : nothing}
               </div>
               <div class="menu-divider" role="separator"></div>
@@ -467,7 +476,7 @@ export class ESPHomeHeaderActions extends LitElement {
       new CustomEvent("open-onboarding-wifi", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -477,7 +486,7 @@ export class ESPHomeHeaderActions extends LitElement {
       new CustomEvent("open-firmware-jobs", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -487,7 +496,7 @@ export class ESPHomeHeaderActions extends LitElement {
       new CustomEvent("open-reset-build-env", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -497,7 +506,7 @@ export class ESPHomeHeaderActions extends LitElement {
       new CustomEvent("open-settings", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -511,7 +520,7 @@ export class ESPHomeHeaderActions extends LitElement {
       new CustomEvent("open-feedback", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -3,7 +3,12 @@ import { mdiArrowCollapseRight } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { isHaIngressContext, localizeContext, serverVersionContext, versionContext } from "../context/index.js";
+import {
+  isHaIngressContext,
+  localizeContext,
+  serverVersionContext,
+  versionContext,
+} from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
 import { navigate } from "../util/navigation.js";
@@ -177,10 +182,7 @@ export class ESPHomeLayout extends LitElement {
     // page load (deep link / refresh) so there's nothing useful to
     // pop and we fall back to ``navigate("/")`` to stay inside the
     // SPA instead of exiting to the previous site.
-    if (
-      window.history.state !== null &&
-      typeof window.history.state === "object"
-    ) {
+    if (window.history.state !== null && typeof window.history.state === "object") {
       window.history.back();
       return;
     }
@@ -221,8 +223,12 @@ export class ESPHomeLayout extends LitElement {
       </div>
       <slot></slot>
       <div class="app-footer">
-        ${this._serverVersion ? html`<span>ESPHome Device Builder v${this._serverVersion}</span>` : nothing}
-        ${this._esphomeVersion ? html`<span>ESPHome ${this._esphomeVersion}</span>` : nothing}
+        ${this._serverVersion
+          ? html`<span>ESPHome Device Builder v${this._serverVersion}</span>`
+          : nothing}
+        ${this._esphomeVersion
+          ? html`<span>ESPHome ${this._esphomeVersion}</span>`
+          : nothing}
       </div>
     `;
   }

--- a/src/components/esphome-login.ts
+++ b/src/components/esphome-login.ts
@@ -174,7 +174,7 @@ export class ESPHomeLogin extends LitElement {
   protected render() {
     const secondsLeft = Math.max(
       0,
-      Math.ceil((this.rateLimitedUntil - this._now) / 1000),
+      Math.ceil((this.rateLimitedUntil - this._now) / 1000)
     );
     const rateLimited = secondsLeft > 0;
     const submitDisabled = this.submitting || rateLimited || this.disconnected;
@@ -197,9 +197,7 @@ export class ESPHomeLogin extends LitElement {
         </div>
         <form @submit=${this._onSubmit}>
           <div class="field">
-            <label for="login-username">
-              ${this._localize("auth.username")}
-            </label>
+            <label for="login-username"> ${this._localize("auth.username")} </label>
             <input
               id="login-username"
               name="username"
@@ -211,9 +209,7 @@ export class ESPHomeLogin extends LitElement {
             />
           </div>
           <div class="field">
-            <label for="login-password">
-              ${this._localize("auth.password")}
-            </label>
+            <label for="login-password"> ${this._localize("auth.password")} </label>
             <input
               id="login-password"
               name="password"
@@ -227,9 +223,7 @@ export class ESPHomeLogin extends LitElement {
           ${this.error
             ? html`<div class="error" role="alert">${this.error}</div>`
             : nothing}
-          <button type="submit" ?disabled=${submitDisabled}>
-            ${submitLabel}
-          </button>
+          <button type="submit" ?disabled=${submitDisabled}>${submitLabel}</button>
         </form>
       </div>
     `;
@@ -253,7 +247,7 @@ export class ESPHomeLogin extends LitElement {
         detail: { username: this._username, password: this._password },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 }

--- a/src/components/facets/facet-filter.ts
+++ b/src/components/facets/facet-filter.ts
@@ -177,10 +177,7 @@ export class ESPHomeFacetFilter extends LitElement {
         ${count > 2
           ? html`<span class="facet-trigger-badge">
               <span class="facet-trigger-badge-label"
-                >${this.multiSelectedLabel.replace(
-                  "{count}",
-                  String(count),
-                )}</span
+                >${this.multiSelectedLabel.replace("{count}", String(count))}</span
               >
               <button
                 class="facet-trigger-badge-remove"
@@ -220,9 +217,7 @@ export class ESPHomeFacetFilter extends LitElement {
       : this.options;
     return html`
       <div
-        class="facet-popover ${this.anchorRight
-          ? "facet-popover--anchor-right"
-          : ""}"
+        class="facet-popover ${this.anchorRight ? "facet-popover--anchor-right" : ""}"
         role="group"
         aria-label=${this.name}
       >
@@ -277,11 +272,7 @@ export class ESPHomeFacetFilter extends LitElement {
             </div>`}
         ${this.selected.length > 0
           ? html`<div class="facet-footer">
-              <button
-                class="facet-clear-link"
-                type="button"
-                @click=${this._clear}
-              >
+              <button class="facet-clear-link" type="button" @click=${this._clear}>
                 ${this.clearLabel}
               </button>
             </div>`
@@ -334,7 +325,7 @@ export class ESPHomeFacetFilter extends LitElement {
         detail: next,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/facets/facet-styles.ts
+++ b/src/components/facets/facet-styles.ts
@@ -59,22 +59,13 @@ export const facetStyles = css`
      darker border reads as "interactive" without competing with the
      active-state badges that already carry the facet's colour. */
   .facet-trigger:hover {
-    background: color-mix(
-      in srgb,
-      var(--wa-color-text-normal),
-      transparent 94%
-    );
-    border-color: color-mix(
-      in srgb,
-      var(--wa-color-text-normal),
-      transparent 70%
-    );
+    background: color-mix(in srgb, var(--wa-color-text-normal), transparent 94%);
+    border-color: color-mix(in srgb, var(--wa-color-text-normal), transparent 70%);
   }
 
   .facet-trigger:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px
-      color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
   }
 
   /* Leading + icon — sits before the facet name in every state. */
@@ -163,8 +154,7 @@ export const facetStyles = css`
   .facet-trigger-badge-remove:focus-visible {
     outline: none;
     opacity: 1;
-    box-shadow: 0 0 0 2px
-      color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 60%);
   }
 
   .facet-trigger-badge-remove wa-icon {
@@ -275,11 +265,7 @@ export const facetStyles = css`
 
   .facet-row:hover,
   .facet-row:focus-visible {
-    background: color-mix(
-      in srgb,
-      var(--wa-color-text-normal),
-      transparent 94%
-    );
+    background: color-mix(in srgb, var(--wa-color-text-normal), transparent 94%);
     outline: none;
   }
 
@@ -373,11 +359,7 @@ export const facetStyles = css`
   .facet-clear-link:hover,
   .facet-clear-link:focus-visible {
     color: var(--wa-color-text-normal);
-    background: color-mix(
-      in srgb,
-      var(--wa-color-text-normal),
-      transparent 94%
-    );
+    background: color-mix(in srgb, var(--wa-color-text-normal), transparent 94%);
     outline: none;
   }
 `;

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -139,7 +139,9 @@ export class ESPHomeFeedbackDialog extends LitElement {
         color: var(--wa-color-text-normal);
         font-size: var(--wa-font-size-s);
         text-decoration: none;
-        transition: background 0.12s, border-color 0.12s;
+        transition:
+          background 0.12s,
+          border-color 0.12s;
       }
 
       .link:hover {
@@ -201,10 +203,7 @@ export class ESPHomeFeedbackDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
-        label=${this._localize("feedback.title")}
-        light-dismiss
-      >
+      <wa-dialog label=${this._localize("feedback.title")} light-dismiss>
         <p class="description">${this._localize("feedback.description")}</p>
         <div class="links">
           <a
@@ -216,11 +215,7 @@ export class ESPHomeFeedbackDialog extends LitElement {
           >
             <wa-icon class="link-icon" library="mdi" name=${SURVEY_LINK.icon}></wa-icon>
             <span class="link-label">${this._localize(SURVEY_LINK.labelKey)}</span>
-            <wa-icon
-              class="link-external"
-              library="mdi"
-              name="open-in-new"
-            ></wa-icon>
+            <wa-icon class="link-external" library="mdi" name="open-in-new"></wa-icon>
           </a>
           ${LINKS.map(
             (link) => html`
@@ -233,13 +228,9 @@ export class ESPHomeFeedbackDialog extends LitElement {
               >
                 <wa-icon class="link-icon" library="mdi" name=${link.icon}></wa-icon>
                 <span class="link-label">${this._localize(link.labelKey)}</span>
-                <wa-icon
-                  class="link-external"
-                  library="mdi"
-                  name="open-in-new"
-                ></wa-icon>
+                <wa-icon class="link-external" library="mdi" name="open-in-new"></wa-icon>
               </a>
-            `,
+            `
           )}
         </div>
       </wa-dialog>

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -62,7 +62,9 @@ export type Installer = "web-serial" | "web-download" | "binary-download" | null
 
 @customElement("esphome-firmware-install-dialog")
 export class ESPHomeFirmwareInstallDialog extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
   @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode = true;
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
@@ -227,7 +229,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         detail: { configuration: device.configuration },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -241,14 +243,14 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
         detail: device,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
   _tryResetBuildEnv = () => {
     this._close();
     this.dispatchEvent(
-      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true }),
+      new CustomEvent("open-reset-build-env", { bubbles: true, composed: true })
     );
   };
 

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -29,7 +29,7 @@ export function compileFailureDetail(err: unknown): string {
 }
 
 export async function startWebSerialInstall(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): Promise<void> {
   const device = host._device;
   if (!device) return;
@@ -82,7 +82,7 @@ export async function startWebSerialInstall(
       host._localize("firmware.chip_mismatch", {
         detected: detected.chipName,
         expected,
-      }),
+      })
     );
     return;
   }
@@ -153,7 +153,7 @@ export async function startWebSerialInstall(
         /* ignore */
       }
       host._fail(
-        err instanceof Error ? err.message : host._localize("firmware.flash_failed"),
+        err instanceof Error ? err.message : host._localize("firmware.flash_failed")
       );
       return;
     }
@@ -165,7 +165,7 @@ export async function startWebSerialInstall(
     await resetAndDisconnect(
       flashDetected.loader,
       flashDetected.transport,
-      flashDetected.port,
+      flashDetected.port
     );
   } catch {
     /* ignore reset errors */
@@ -183,7 +183,7 @@ export async function startWebSerialInstall(
 
 export function flipToLogs(
   host: ESPHomeFirmwareInstallDialog,
-  webSerialPort: SerialPort,
+  webSerialPort: SerialPort
 ): void {
   const device = host._device;
   if (!device) return;
@@ -200,9 +200,7 @@ export function flipToLogs(
 // in which binaries are eligible — web.esphome.io needs a self-contained image
 // (factory.bin / firmware.bin); manual gives whatever artefact was produced
 // (including .uf2 for RP2040 / nrf52 / libretiny).
-export async function startDownload(
-  host: ESPHomeFirmwareInstallDialog,
-): Promise<void> {
+export async function startDownload(host: ESPHomeFirmwareInstallDialog): Promise<void> {
   const device = host._device;
   if (!device) return;
   const isWebFlasher = host._installer === "web-download";
@@ -229,15 +227,12 @@ export async function startDownload(
       // Web-flasher path with no match almost always = UF2 platform.
       host._fail(
         host._localize(
-          isWebFlasher ? "firmware.no_flashable_binary" : "firmware.no_binaries",
-        ),
+          isWebFlasher ? "firmware.no_flashable_binary" : "firmware.no_binaries"
+        )
       );
       return;
     }
-    const result = await host._api.firmwareDownload(
-      device.configuration,
-      flashable.file,
-    );
+    const result = await host._api.firmwareDownload(device.configuration, flashable.file);
     downloadBase64Binary(result.data, result.filename);
     host._downloadedFilename = result.filename;
   } catch {
@@ -251,7 +246,7 @@ export async function startDownload(
 
 export function compileAndWait(
   host: ESPHomeFirmwareInstallDialog,
-  configuration: string,
+  configuration: string
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     // Capture reject on the dialog so a mid-flight detach (header-X / Escape /

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -11,7 +11,7 @@ function isPeerLinkSessionLostError(message: string): boolean {
 }
 
 function renderValidationFailureSuggestion(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): TemplateResult {
   const text = host._localize("command.validation_failed_suggestion");
   const [before, after] = splitTemplate(text, "{editor_action}");
@@ -30,17 +30,13 @@ function renderValidationFailureSuggestion(
 // on the paired receiver. Per esphome/device-builder#608 we deliberately
 // don't fan reset out to receivers; the operator-action model handles it.
 function renderBuildFailureSuggestion(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): TemplateResult {
   if (host._jobSource === JobSource.REMOTE && host._jobSourceLabel) {
     return renderRemoteBuildFailureSuggestion(host, host._jobSourceLabel);
   }
   const text = host._localize("command.try_reset_suggestion");
-  const [before, middle, after] = splitTemplate(
-    text,
-    "{clean_action}",
-    "{reset_action}",
-  );
+  const [before, middle, after] = splitTemplate(text, "{clean_action}", "{reset_action}");
   return html`
     <div class="reset-suggestion" role="status">
       ${before}<button class="reset-suggestion-link" @click=${host._tryCleanBuild}>
@@ -55,7 +51,7 @@ function renderBuildFailureSuggestion(
 // Compile-step failure hint. Validation → editor. Receiver-session-lost →
 // skip (build env was fine, connection wasn't). C++ build → clean/reset.
 function renderResetSuggestion(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
   if (!host._failedDuringCompile) return nothing;
   if (host._failedDuringValidate) return renderValidationFailureSuggestion(host);
@@ -63,9 +59,7 @@ function renderResetSuggestion(
   return renderBuildFailureSuggestion(host);
 }
 
-export function renderStatus(
-  host: ESPHomeFirmwareInstallDialog,
-): TemplateResult {
+export function renderStatus(host: ESPHomeFirmwareInstallDialog): TemplateResult {
   if (host._step === "done") {
     return html`
       <div class="status">
@@ -147,7 +141,7 @@ export function renderStatus(
 }
 
 export function renderProgress(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
   if (host._step !== "flashing") return nothing;
   return html`
@@ -158,7 +152,7 @@ export function renderProgress(
 }
 
 export function renderLogs(
-  host: ESPHomeFirmwareInstallDialog,
+  host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
   if (host._logLines.length === 0) return nothing;
   return html`
@@ -189,13 +183,9 @@ export function renderLogs(
   `;
 }
 
-export function renderFooter(
-  host: ESPHomeFirmwareInstallDialog,
-): TemplateResult {
+export function renderFooter(host: ESPHomeFirmwareInstallDialog): TemplateResult {
   const isRunning =
-    host._step !== "done" &&
-    host._step !== "error" &&
-    host._step !== "download-ready";
+    host._step !== "done" && host._step !== "error" && host._step !== "download-ready";
   if (isRunning) {
     // Web Serial only — installWebDownload doesn't connect to a device.
     const showToggle = host._installer === "web-serial";
@@ -249,9 +239,7 @@ export function renderFooter(
   // _onClose but not _close, so the button only renders while the SerialPort
   // reference is still around.
   const canShowLogs =
-    host._installer === "web-serial" &&
-    host._step === "done" &&
-    host._detected !== null;
+    host._installer === "web-serial" && host._step === "done" && host._detected !== null;
   return html`
     <div class="footer">
       ${canShowLogs

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -62,10 +62,17 @@ registerMdiIcons({
 
 @customElement("esphome-firmware-jobs-dialog")
 export class ESPHomeFirmwareJobsDialog extends LitElement {
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
-  @consume({ context: firmwareJobsContext, subscribe: true }) @state() _jobs: Map<string, FirmwareJob> = new Map();
-  @consume({ context: devicesContext, subscribe: true }) @state() _devices: ConfiguredDevice[] = [];
+  @consume({ context: firmwareJobsContext, subscribe: true }) @state() _jobs: Map<
+    string,
+    FirmwareJob
+  > = new Map();
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  _devices: ConfiguredDevice[] = [];
 
   @query("wa-dialog") private _dialog!: HTMLElement & { open: boolean };
   @query("esphome-command-dialog") private _commandDialog!: ESPHomeCommandDialog;
@@ -76,7 +83,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
   private _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
-    () => this._localize,
+    () => this._localize
   );
 
   // Ticker for live relative-time strings ("started 2m ago"). Open-only.
@@ -153,9 +160,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
               `
             : nothing}
         </div>
-        ${hasJobs
-          ? renderGroups(this, active, terminal)
-          : renderEmpty(this._localize)}
+        ${hasJobs ? renderGroups(this, active, terminal) : renderEmpty(this._localize)}
       </wa-dialog>
       <esphome-command-dialog
         @open-reset-build-env=${this._onLocalResetEvent}
@@ -234,7 +239,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       new CustomEvent("firmware-history-cleared", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 }

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -1,10 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { JobSource, JobStatus, JobType, type FirmwareJob } from "../../api/types.js";
 import { activeLocale, type LocalizeFunc } from "../../common/localize.js";
-import {
-  formatAbsoluteTime,
-  formatRelativeTime,
-} from "../../util/format-job-time.js";
+import { formatAbsoluteTime, formatRelativeTime } from "../../util/format-job-time.js";
 import { isTerminalJob as isTerminal } from "../../util/firmware-job-status.js";
 import type { ESPHomeFirmwareJobsDialog } from "../firmware-jobs-dialog.js";
 
@@ -30,15 +27,13 @@ export function renderEmpty(localize: LocalizeFunc): TemplateResult {
 export function renderGroups(
   host: ESPHomeFirmwareJobsDialog,
   active: FirmwareJob[],
-  terminal: FirmwareJob[],
+  terminal: FirmwareJob[]
 ): TemplateResult {
   return html`
     <div class="jobs">
       ${active.length > 0
         ? html`
-            <div class="group-label">
-              ${host._localize("firmware_jobs.group_active")}
-            </div>
+            <div class="group-label">${host._localize("firmware_jobs.group_active")}</div>
             ${active.map((j) => renderJob(host, j))}
           `
         : nothing}
@@ -54,10 +49,7 @@ export function renderGroups(
   `;
 }
 
-function renderJob(
-  host: ESPHomeFirmwareJobsDialog,
-  job: FirmwareJob,
-): TemplateResult {
+function renderJob(host: ESPHomeFirmwareJobsDialog, job: FirmwareJob): TemplateResult {
   const name = host._jobDisplayName(job);
   const typeIcon = TYPE_ICONS[job.job_type] ?? "hammer-wrench";
   const typeLabel = host._localize(`firmware_jobs.type_${job.job_type}`);
@@ -93,7 +85,7 @@ function renderJob(
 
 function renderRowAction(
   host: ESPHomeFirmwareJobsDialog,
-  job: FirmwareJob,
+  job: FirmwareJob
 ): TemplateResult {
   if (job.status === JobStatus.COMPLETED) {
     return html`
@@ -143,7 +135,7 @@ function renderRowAction(
 // dashboard's offloader.
 function renderSourceLine(
   host: ESPHomeFirmwareJobsDialog,
-  job: FirmwareJob,
+  job: FirmwareJob
 ): TemplateResult | typeof nothing {
   if (job.source === JobSource.REMOTE && job.source_label) {
     const display = job.source_esphome_version
@@ -170,7 +162,7 @@ function renderSourceLine(
 
 function renderStatus(
   host: ESPHomeFirmwareJobsDialog,
-  job: FirmwareJob,
+  job: FirmwareJob
 ): TemplateResult | typeof nothing {
   if (job.status === JobStatus.RUNNING) {
     return html`
@@ -218,7 +210,7 @@ function renderStatus(
 // terminal rows show absolute ("finished HH:MM") since the moment is fixed.
 function renderTimestamp(
   host: ESPHomeFirmwareJobsDialog,
-  job: FirmwareJob,
+  job: FirmwareJob
 ): TemplateResult | typeof nothing {
   const locale = activeLocale();
   if (job.status === JobStatus.RUNNING && job.started_at) {
@@ -258,11 +250,7 @@ function renderTimestamp(
 // most recent first so the latest finished job tops the history.
 export function compareJobs(a: FirmwareJob, b: FirmwareJob): number {
   const rank = (j: FirmwareJob) =>
-    j.status === JobStatus.RUNNING
-      ? 0
-      : j.status === JobStatus.QUEUED
-        ? 1
-        : 2;
+    j.status === JobStatus.RUNNING ? 0 : j.status === JobStatus.QUEUED ? 1 : 2;
   const ra = rank(a);
   const rb = rank(b);
   if (ra !== rb) return ra - rb;

--- a/src/components/firmware-jobs-dialog/styles.ts
+++ b/src/components/firmware-jobs-dialog/styles.ts
@@ -63,7 +63,10 @@ export const firmwareJobsDialogStyles = css`
     font-weight: var(--wa-font-weight-bold);
     color: var(--wa-color-text-normal);
     cursor: pointer;
-    transition: background 0.1s, border-color 0.1s, color 0.1s;
+    transition:
+      background 0.1s,
+      border-color 0.1s,
+      color 0.1s;
   }
 
   .tool-btn:hover {
@@ -263,7 +266,9 @@ export const firmwareJobsDialogStyles = css`
     background: transparent;
     color: var(--wa-color-text-quiet);
     cursor: pointer;
-    transition: background 0.1s, color 0.1s;
+    transition:
+      background 0.1s,
+      color 0.1s;
   }
 
   .row-action:hover {

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -24,12 +24,7 @@
  * override.
  */
 import { consume } from "@lit/context";
-import {
-  mdiCheck,
-  mdiClose,
-  mdiPencil,
-  mdiTagMultiple,
-} from "@mdi/js";
+import { mdiCheck, mdiClose, mdiPencil, mdiTagMultiple } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
@@ -39,10 +34,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { labelChipStyleString } from "../../util/label-style.js";
-import {
-  labelChipStyles,
-  resolveLabelIds,
-} from "../../util/label-chip-template.js";
+import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import "./label-form.js";
 import type { ESPHomeLabelForm } from "./label-form.js";
@@ -263,8 +255,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       .option:focus-visible {
         outline: none;
         background: var(--wa-color-surface-lowered);
-        box-shadow: 0 0 0 2px
-          color-mix(in srgb, var(--esphome-primary), transparent 70%);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
       }
 
       .option-check {
@@ -299,10 +290,8 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       .create-section {
         margin-top: var(--wa-space-l);
         padding-top: var(--wa-space-m);
-        border-top: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       }
-
     `,
   ];
 
@@ -341,25 +330,24 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
           ? html`<span class="empty">${this._localize("dashboard.labels_none")}</span>`
           : nothing}
         ${assigned.map(
-          (label) => html`<span
-            class="label-chip assigned-chip"
-            style=${labelChipStyleString(label.color)}
-            title=${label.name}
-            >${label.name}<button
-              class="remove-btn"
-              type="button"
-              aria-label=${this._localize("dashboard.labels_remove", { name: label.name })}
-              @click=${() => this._unassign(label.id)}
-            >
-              <wa-icon library="mdi" name="close"></wa-icon>
-            </button>
-          </span>`,
+          (label) =>
+            html`<span
+              class="label-chip assigned-chip"
+              style=${labelChipStyleString(label.color)}
+              title=${label.name}
+              >${label.name}<button
+                class="remove-btn"
+                type="button"
+                aria-label=${this._localize("dashboard.labels_remove", {
+                  name: label.name,
+                })}
+                @click=${() => this._unassign(label.id)}
+              >
+                <wa-icon library="mdi" name="close"></wa-icon>
+              </button>
+            </span>`
         )}
-        <button
-          class="edit-btn"
-          type="button"
-          @click=${this._openDialog}
-        >
+        <button class="edit-btn" type="button" @click=${this._openDialog}>
           <wa-icon library="mdi" name="pencil"></wa-icon>
           ${this._localize("dashboard.labels_edit")}
         </button>
@@ -376,7 +364,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         light-dismiss
         @wa-after-hide=${this._onDialogClose}
       >
-        <div class="options" role="group" aria-label=${this._localize("dashboard.drawer_labels")}>
+        <div
+          class="options"
+          role="group"
+          aria-label=${this._localize("dashboard.drawer_labels")}
+        >
           ${this._catalog.length === 0
             ? html`<div class="option-empty">
                 ${this._localize("dashboard.labels_dialog_empty")}

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -205,16 +205,11 @@ export class ESPHomeLabelsFilter extends LitElement {
       .row-action:focus-visible {
         outline: none;
         color: var(--wa-color-text-normal);
-        box-shadow: 0 0 0 2px
-          color-mix(in srgb, var(--esphome-primary), transparent 70%);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
       }
 
       .row-action--danger:hover {
-        background: color-mix(
-          in srgb,
-          var(--wa-color-danger-fill-loud),
-          transparent 88%
-        );
+        background: color-mix(in srgb, var(--wa-color-danger-fill-loud), transparent 88%);
         border-color: color-mix(
           in srgb,
           var(--wa-color-danger-fill-loud),
@@ -275,8 +270,7 @@ export class ESPHomeLabelsFilter extends LitElement {
          visually separated from the list by a divider so the user
          reads the rows + create form as distinct sections. */
       .create-section {
-        border-top: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
         padding: var(--wa-space-2xs);
         flex-shrink: 0;
       }
@@ -317,8 +311,7 @@ export class ESPHomeLabelsFilter extends LitElement {
 
       .create-trigger:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 2px
-          color-mix(in srgb, var(--esphome-primary), transparent 60%);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 60%);
       }
 
       .create-trigger wa-icon {
@@ -495,10 +488,9 @@ export class ESPHomeLabelsFilter extends LitElement {
               const label = this._catalog.find((l) => l.id === id);
               if (!label) return nothing;
               const display = label.name;
-              const removeAria = this._localize(
-                "dashboard.labels_remove",
-                { name: display },
-              );
+              const removeAria = this._localize("dashboard.labels_remove", {
+                name: display,
+              });
               // Trigger badges stay neutral on purpose — the
               // popover shows the colour-tinted chips, but
               // surfacing label colour up in the toolbar pill
@@ -560,15 +552,11 @@ export class ESPHomeLabelsFilter extends LitElement {
                       : nothing}
                   </span>
                   <span class="facet-row-name">
-                    <span
-                      class="label-chip"
-                      style=${labelChipStyleString(label.color)}
+                    <span class="label-chip" style=${labelChipStyleString(label.color)}
                       >${label.name}</span
                     >
                   </span>
-                  <span class="facet-row-count" aria-hidden="true"
-                    >${count}</span
-                  >
+                  <span class="facet-row-count" aria-hidden="true">${count}</span>
                 </button>
                 <div class="row-actions">
                   <button
@@ -610,7 +598,7 @@ export class ESPHomeLabelsFilter extends LitElement {
                           detail: label,
                           bubbles: true,
                           composed: true,
-                        }),
+                        })
                       );
                     }}
                   >
@@ -628,11 +616,7 @@ export class ESPHomeLabelsFilter extends LitElement {
           </div>`
         : nothing}
       <div class="create-section ${isEmpty ? "create-section--empty" : ""}">
-        <button
-          class="create-trigger"
-          type="button"
-          @click=${this._openCreateDialog}
-        >
+        <button class="create-trigger" type="button" @click=${this._openCreateDialog}>
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${this._localize("dashboard.labels_create")}
         </button>
@@ -652,9 +636,7 @@ export class ESPHomeLabelsFilter extends LitElement {
         >
           <wa-icon library="mdi" name="arrow-left"></wa-icon>
         </button>
-        <span class="edit-title"
-          >${this._localize("dashboard.labels_edit_label")}</span
-        >
+        <span class="edit-title">${this._localize("dashboard.labels_edit_label")}</span>
       </div>
       <div class="create-section create-section--empty">
         <esphome-label-form
@@ -735,7 +717,7 @@ export class ESPHomeLabelsFilter extends LitElement {
         detail: next,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 

--- a/src/components/logs-method-dialog.ts
+++ b/src/components/logs-method-dialog.ts
@@ -131,22 +131,34 @@ export class ESPHomeLogsMethodDialog extends LitElement {
           <div class="option option--disabled">
             <wa-icon library="mdi" name="wifi"></wa-icon>
             <div class="info">
-              <span class="title">${this._localize("dashboard.logs_method_wireless")}</span>
-              <span class="desc">${this._localize("dashboard.logs_method_wireless_desc")}</span>
+              <span class="title"
+                >${this._localize("dashboard.logs_method_wireless")}</span
+              >
+              <span class="desc"
+                >${this._localize("dashboard.logs_method_wireless_desc")}</span
+              >
             </div>
           </div>
           <div class="option" @click=${this._onWebSerial}>
             <wa-icon library="mdi" name="usb"></wa-icon>
             <div class="info">
-              <span class="title">${this._localize("dashboard.logs_method_usb_local")}</span>
-              <span class="desc">${this._localize("dashboard.logs_method_usb_local_desc")}</span>
+              <span class="title"
+                >${this._localize("dashboard.logs_method_usb_local")}</span
+              >
+              <span class="desc"
+                >${this._localize("dashboard.logs_method_usb_local_desc")}</span
+              >
             </div>
           </div>
           <div class="option option--disabled">
             <wa-icon library="mdi" name="serial-port"></wa-icon>
             <div class="info">
-              <span class="title">${this._localize("dashboard.logs_method_usb_server")}</span>
-              <span class="desc">${this._localize("dashboard.logs_method_usb_server_desc")}</span>
+              <span class="title"
+                >${this._localize("dashboard.logs_method_usb_server")}</span
+              >
+              <span class="desc"
+                >${this._localize("dashboard.logs_method_usb_server_desc")}</span
+              >
             </div>
           </div>
         </div>
@@ -155,15 +167,11 @@ export class ESPHomeLogsMethodDialog extends LitElement {
   }
 
   private _onClose() {
-    this.dispatchEvent(
-      new CustomEvent("close", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }));
   }
 
   private _onWebSerial() {
-    this.dispatchEvent(
-      new CustomEvent("web-serial", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("web-serial", { bubbles: true, composed: true }));
   }
 }
 

--- a/src/components/mdi-icon-picker.ts
+++ b/src/components/mdi-icon-picker.ts
@@ -151,8 +151,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
       .trigger:focus,
       :host([open]) .trigger {
         border-color: var(--esphome-primary);
-        box-shadow: 0 0 0 3px
-          color-mix(in srgb, var(--esphome-primary), transparent 80%);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
       }
 
       .trigger.invalid {
@@ -160,8 +159,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
       }
 
       .trigger.invalid:focus {
-        box-shadow: 0 0 0 3px
-          color-mix(in srgb, var(--esphome-error), transparent 80%);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-error), transparent 80%);
       }
 
       .trigger:disabled {
@@ -405,7 +403,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
       e.stopPropagation();
       this._close();
     },
-    { target: document },
+    { target: document }
   );
 
   private _onDocumentClick = (e: Event) => {
@@ -453,7 +451,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
         detail: { value: next },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     this._close();
   }
@@ -466,7 +464,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
         detail: { value: "" },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
@@ -549,7 +547,7 @@ export class ESPHomeMdiIconPicker extends LitElement {
                         <path fill="currentColor" d=${entry.path}></path>
                       </svg>
                     </button>
-                  `,
+                  `
                 )}
               </div>`}
         </div>

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -182,7 +182,9 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
             ${this._localize("onboarding.wifi.intro")}
           </p>
           <div class="field">
-            <label for="onboarding-ssid">${this._localize("onboarding.wifi.ssid_label")}</label>
+            <label for="onboarding-ssid"
+              >${this._localize("onboarding.wifi.ssid_label")}</label
+            >
             <input
               id="onboarding-ssid"
               type="text"
@@ -196,7 +198,9 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
             />
           </div>
           <div class="field">
-            <label for="onboarding-password">${this._localize("onboarding.wifi.password_label")}</label>
+            <label for="onboarding-password"
+              >${this._localize("onboarding.wifi.password_label")}</label
+            >
             <esphome-password-input
               id="onboarding-password"
               .value=${this._password}
@@ -204,9 +208,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               .maxlength=${64}
               .label=${this._localize("onboarding.wifi.password_label")}
               ?disabled=${this._saving}
-              @password-input-change=${(
-                e: CustomEvent<PasswordInputValueChange>,
-              ) => {
+              @password-input-change=${(e: CustomEvent<PasswordInputValueChange>) => {
                 this._password = e.detail.value;
               }}
             ></esphome-password-input>
@@ -275,9 +277,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     // circuit. Fired before ``markOnboardingAcknowledged`` so a
     // failure on the second call doesn't suppress the refresh
     // — the wifi write is the user-visible state change.
-    window.dispatchEvent(
-      new CustomEvent("secrets-saved", { detail: { source: this } }),
-    );
+    window.dispatchEvent(new CustomEvent("secrets-saved", { detail: { source: this } }));
     try {
       // Acknowledge so the dialog doesn't re-pop on next load even
       // if the badge logic wants to keep the menu indicator.
@@ -378,7 +378,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       new CustomEvent("onboarding-dismissed-session", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     this.close();
   };
@@ -388,7 +388,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
       new CustomEvent("onboarding-acknowledged", {
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -46,7 +46,9 @@ import {
 @customElement("esphome-pair-build-server-dialog")
 export class ESPHomePairBuildServerDialog extends LitElement {
   @consume({ context: apiContext, subscribe: true }) @state() _api?: ESPHomeAPI;
-  @consume({ context: localizeContext, subscribe: true }) @state() _localize: LocalizeFunc = (key) => key;
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  _localize: LocalizeFunc = (key) => key;
 
   // Auto-close watcher: matches the offloader pairings row by pin_sha256
   // and closes on status→approved. removed → rejection toast + close.

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -5,7 +5,7 @@ import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.j
 
 export function previewErrorMessage(
   host: ESPHomePairBuildServerDialog,
-  err: unknown,
+  err: unknown
 ): string {
   if (err instanceof APIError) {
     if (err.errorCode === ErrorCode.UNAVAILABLE) {
@@ -25,7 +25,7 @@ export function previewErrorMessage(
 
 export function requestErrorMessage(
   host: ESPHomePairBuildServerDialog,
-  err: unknown,
+  err: unknown
 ): string {
   if (err instanceof APIError) {
     if (err.errorCode === ErrorCode.PRECONDITION_FAILED) {
@@ -49,9 +49,7 @@ export function requestErrorMessage(
   return host._localize("settings.pair_build_server_request_failed");
 }
 
-export async function onPreviewSubmit(
-  host: ESPHomePairBuildServerDialog,
-): Promise<void> {
+export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promise<void> {
   if (host._api === undefined || host._busy) return;
   const hostname = host._hostname.trim();
   const port = parsePortInput(host._port);
@@ -72,9 +70,7 @@ export async function onPreviewSubmit(
   }
 }
 
-export async function onConfirmSubmit(
-  host: ESPHomePairBuildServerDialog,
-): Promise<void> {
+export async function onConfirmSubmit(host: ESPHomePairBuildServerDialog): Promise<void> {
   if (host._api === undefined || host._busy) return;
   const hostname = host._hostname.trim();
   const port = parsePortInput(host._port);
@@ -110,7 +106,7 @@ export async function onConfirmSubmit(
         detail: { summary },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   } catch (err) {
     host._error = requestErrorMessage(host, err);
@@ -125,7 +121,7 @@ export async function onConfirmSubmit(
 // watching" signal — fire a toast event and close.
 export function watchPairingApproval(
   host: ESPHomePairBuildServerDialog,
-  changed: Map<string, unknown>,
+  changed: Map<string, unknown>
 ): void {
   if (
     host._sentKey === null ||
@@ -147,7 +143,7 @@ export function watchPairingApproval(
         },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     host._sentKey = null;
     host.close();
@@ -167,7 +163,7 @@ export function watchPairingApproval(
         },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     host._sentKey = null;
     host.close();

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -7,12 +7,9 @@ import {
 } from "../../util/hostname.js";
 import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.js";
 
-export function renderInputStep(
-  host: ESPHomePairBuildServerDialog,
-): TemplateResult {
+export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateResult {
   const portValid = parsePortInput(host._port) !== null;
-  const canSubmit =
-    !host._busy && host._hostname.trim().length > 0 && portValid;
+  const canSubmit = !host._busy && host._hostname.trim().length > 0 && portValid;
   return html`
     <div class="description">
       ${host._localize("settings.pair_build_server_input_desc")}
@@ -29,9 +26,7 @@ export function renderInputStep(
           autocomplete="off"
           spellcheck="false"
           ?disabled=${host._busy}
-          placeholder=${host._localize(
-            "settings.pair_build_server_hostname_placeholder",
-          )}
+          placeholder=${host._localize("settings.pair_build_server_hostname_placeholder")}
           .value=${host._hostname}
           @input=${(e: Event) => {
             host._hostname = (e.target as HTMLInputElement).value;
@@ -63,18 +58,12 @@ export function renderInputStep(
         />
       </div>
     </div>
-    <div class="helper">
-      ${host._localize("settings.pair_build_server_port_helper")}
-    </div>
+    <div class="helper">${host._localize("settings.pair_build_server_port_helper")}</div>
     ${host._error
       ? html`<div class="step-error" role="alert">${host._error}</div>`
       : nothing}
     <div class="actions">
-      <button
-        class="btn btn--cancel"
-        ?disabled=${host._busy}
-        @click=${host.close}
-      >
+      <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
         ${host._localize("layout.cancel")}
       </button>
       <button
@@ -90,9 +79,7 @@ export function renderInputStep(
   `;
 }
 
-export function renderConfirmStep(
-  host: ESPHomePairBuildServerDialog,
-): TemplateResult {
+export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateResult {
   const canSubmit =
     !host._busy &&
     host._receiverLabel.trim().length > 0 &&
@@ -107,9 +94,7 @@ export function renderConfirmStep(
       </span>
       <esphome-pin-emoji-grid .pin=${host._previewedPin}></esphome-pin-emoji-grid>
       <details class="pin-hex">
-        <summary>
-          ${host._localize("settings.pair_build_server_pin_hex_summary")}
-        </summary>
+        <summary>${host._localize("settings.pair_build_server_pin_hex_summary")}</summary>
         <code>${formatPinSha256(host._previewedPin)}</code>
       </details>
       <span class="pin-card-target">
@@ -133,7 +118,7 @@ export function renderConfirmStep(
         ?disabled=${host._busy}
         .value=${host._receiverLabel}
         placeholder=${host._localize(
-          "settings.pair_build_server_receiver_label_placeholder",
+          "settings.pair_build_server_receiver_label_placeholder"
         )}
         @input=${(e: Event) => {
           host._receiverLabel = (e.target as HTMLInputElement).value;
@@ -156,7 +141,7 @@ export function renderConfirmStep(
         ?disabled=${host._busy}
         .value=${host._offloaderLabel}
         placeholder=${host._localize(
-          "settings.pair_build_server_offloader_label_placeholder",
+          "settings.pair_build_server_offloader_label_placeholder"
         )}
         @input=${(e: Event) => {
           host._offloaderLabel = (e.target as HTMLInputElement).value;
@@ -191,9 +176,7 @@ export function renderConfirmStep(
   `;
 }
 
-export function renderSentStep(
-  host: ESPHomePairBuildServerDialog,
-): TemplateResult {
+export function renderSentStep(host: ESPHomePairBuildServerDialog): TemplateResult {
   return html`
     <div class="sent-body">
       ${host._localize("settings.pair_build_server_sent_desc", {

--- a/src/components/pin-emoji-grid.ts
+++ b/src/components/pin-emoji-grid.ts
@@ -81,19 +81,14 @@ export class ESPHomePinEmojiGrid extends LitElement {
     // fingerprint once via the grid's aria-label rather than
     // repeating each name twice (container label + cell text).
     return html`
-      <div
-        class="grid"
-        role="img"
-        lang="en"
-        aria-label=${this._ariaLabel(slots)}
-      >
+      <div class="grid" role="img" lang="en" aria-label=${this._ariaLabel(slots)}>
         ${slots.map(
           (slot) => html`
             <div class="cell">
               <span class="emoji" aria-hidden="true">${slot.emoji}</span>
               <span class="name" aria-hidden="true">${slot.name}</span>
             </div>
-          `,
+          `
         )}
       </div>
     `;

--- a/src/components/reauth-wizard-dialog-helpers.ts
+++ b/src/components/reauth-wizard-dialog-helpers.ts
@@ -1,8 +1,5 @@
 import { APIError } from "../api/api-error.js";
-import {
-  ErrorCode,
-  type OffloaderPinMismatchAlert,
-} from "../api/types.js";
+import { ErrorCode, type OffloaderPinMismatchAlert } from "../api/types.js";
 
 /** Args shape of {@link ESPHomeAPI.requestRemoteBuildPair}.
  *  Mirrored locally rather than imported because the API
@@ -54,7 +51,7 @@ export interface ReauthPairRequestArgs {
  */
 export function buildReauthPairRequest(
   alert: OffloaderPinMismatchAlert,
-  offloaderLabel: string,
+  offloaderLabel: string
 ): ReauthPairRequestArgs {
   return {
     hostname: alert.receiver_hostname,

--- a/src/components/reauth-wizard-dialog-styles.ts
+++ b/src/components/reauth-wizard-dialog-styles.ts
@@ -120,11 +120,7 @@ export const reauthWizardDialogStyles = css`
     gap: var(--wa-space-s);
     margin-top: var(--wa-space-m);
     padding: var(--wa-space-s) var(--wa-space-m);
-    background: color-mix(
-      in srgb,
-      var(--esphome-warning, #f59e0b),
-      transparent 92%
-    );
+    background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 92%);
     border-radius: var(--wa-border-radius-m);
     font-size: var(--wa-font-size-s);
     cursor: pointer;
@@ -145,11 +141,7 @@ export const reauthWizardDialogStyles = css`
     margin-top: var(--wa-space-m);
     padding: var(--wa-space-s) var(--wa-space-m);
     border-left: 3px solid var(--wa-color-warning-fill-loud);
-    background: color-mix(
-      in srgb,
-      var(--wa-color-warning-fill-loud),
-      transparent 88%
-    );
+    background: color-mix(in srgb, var(--wa-color-warning-fill-loud), transparent 88%);
     border-radius: var(--wa-border-radius-s);
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-normal);

--- a/src/components/reauth-wizard-dialog.ts
+++ b/src/components/reauth-wizard-dialog.ts
@@ -3,10 +3,7 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../api/esphome-api.js";
-import type {
-  OffloaderPinMismatchAlert,
-  PairingSummary,
-} from "../api/types.js";
+import type { OffloaderPinMismatchAlert, PairingSummary } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
@@ -198,7 +195,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
     // stored pairing.
     const args = buildReauthPairRequest(
       alert,
-      friendlyHostname(window.location.hostname),
+      friendlyHostname(window.location.hostname)
     );
     this._busy = true;
     this._errorKey = null;
@@ -255,7 +252,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
         detail: { summary },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
     this._dispatchResult("success", alert.receiver_label);
     this._open = false;
@@ -263,14 +260,14 @@ export class ESPHomeReauthWizardDialog extends LitElement {
 
   private _dispatchResult(
     outcome: "success" | "pin_changed",
-    receiverLabel: string,
+    receiverLabel: string
   ): void {
     this.dispatchEvent(
       new CustomEvent("reauth-result", {
         bubbles: true,
         composed: true,
         detail: { outcome, receiver_label: receiverLabel },
-      }),
+      })
     );
   }
 
@@ -288,13 +285,9 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           <div class="pin-block-label">
             ${this._localize("settings.reauth_wizard_expected_label")}
           </div>
-          <esphome-pin-emoji-grid
-            .pin=${alert.expected_pin}
-          ></esphome-pin-emoji-grid>
+          <esphome-pin-emoji-grid .pin=${alert.expected_pin}></esphome-pin-emoji-grid>
           <details class="pin-hex">
-            <summary>
-              ${this._localize("settings.remote_build_pin_hex_summary")}
-            </summary>
+            <summary>${this._localize("settings.remote_build_pin_hex_summary")}</summary>
             <code>${formatPinSha256(alert.expected_pin)}</code>
           </details>
         </div>
@@ -302,13 +295,9 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           <div class="pin-block-label pin-block-label-observed">
             ${this._localize("settings.reauth_wizard_observed_label")}
           </div>
-          <esphome-pin-emoji-grid
-            .pin=${alert.observed_pin}
-          ></esphome-pin-emoji-grid>
+          <esphome-pin-emoji-grid .pin=${alert.observed_pin}></esphome-pin-emoji-grid>
           <details class="pin-hex">
-            <summary>
-              ${this._localize("settings.remote_build_pin_hex_summary")}
-            </summary>
+            <summary>${this._localize("settings.remote_build_pin_hex_summary")}</summary>
             <code>${formatPinSha256(alert.observed_pin)}</code>
           </details>
         </div>
@@ -318,9 +307,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
 
   private _renderStep2() {
     return html`
-      <p class="lede">
-        ${this._localize("settings.reauth_wizard_step2_lede")}
-      </p>
+      <p class="lede">${this._localize("settings.reauth_wizard_step2_lede")}</p>
       <div class="possibilities">
         <div class="possibility possibility-benign">
           <div class="possibility-title">
@@ -353,13 +340,9 @@ export class ESPHomeReauthWizardDialog extends LitElement {
         <div class="pin-block-label pin-block-label-observed">
           ${this._localize("settings.reauth_wizard_observed_label")}
         </div>
-        <esphome-pin-emoji-grid
-          .pin=${alert.observed_pin}
-        ></esphome-pin-emoji-grid>
+        <esphome-pin-emoji-grid .pin=${alert.observed_pin}></esphome-pin-emoji-grid>
         <details class="pin-hex">
-          <summary>
-            ${this._localize("settings.remote_build_pin_hex_summary")}
-          </summary>
+          <summary>${this._localize("settings.remote_build_pin_hex_summary")}</summary>
           <code>${formatPinSha256(alert.observed_pin)}</code>
         </details>
       </div>
@@ -370,9 +353,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
           @change=${this._onVerifiedChange}
           ?disabled=${this._busy}
         />
-        <span>
-          ${this._localize("settings.reauth_wizard_verified_checkbox")}
-        </span>
+        <span> ${this._localize("settings.reauth_wizard_verified_checkbox")} </span>
       </label>
       ${this._errorKey !== null
         ? html`
@@ -405,10 +386,10 @@ export class ESPHomeReauthWizardDialog extends LitElement {
       >
         <div
           class="step-indicator"
-          aria-label=${this._localize(
-            "settings.reauth_wizard_step_progress",
-            { step: this._step, total: 3 },
-          )}
+          aria-label=${this._localize("settings.reauth_wizard_step_progress", {
+            step: this._step,
+            total: 3,
+          })}
         >
           ${[1, 2, 3].map(
             (n) => html`
@@ -416,7 +397,7 @@ export class ESPHomeReauthWizardDialog extends LitElement {
                 class=${`dot ${this._step === n ? "dot-active" : ""}`}
                 aria-hidden="true"
               ></span>
-            `,
+            `
           )}
         </div>
         <div class="step-body">${stepBody}</div>
@@ -440,7 +421,11 @@ export class ESPHomeReauthWizardDialog extends LitElement {
               </button>`
             : nothing}
           ${this._step < 3
-            ? html`<button class="btn btn--primary" type="button" @click=${this._onContinue}>
+            ? html`<button
+                class="btn btn--primary"
+                type="button"
+                @click=${this._onContinue}
+              >
                 ${this._localize("settings.reauth_wizard_continue")}
               </button>`
             : html`<button

--- a/src/components/remote-build-hint.ts
+++ b/src/components/remote-build-hint.ts
@@ -43,14 +43,10 @@ export interface RemoteBuildHintHost {
 // is a presentational guard, not an XSS defense.
 export function renderRemoteBuildFailureSuggestion(
   host: RemoteBuildHintHost,
-  receiver: string,
+  receiver: string
 ): TemplateResult {
   const template = host._localize("command.try_reset_suggestion_remote");
-  const [before, middle, after] = splitTemplate(
-    template,
-    "{clean_action}",
-    "{receiver}",
-  );
+  const [before, middle, after] = splitTemplate(template, "{clean_action}", "{receiver}");
   return html`
     <div class="reset-suggestion" role="status">
       ${before}<button class="reset-suggestion-link" @click=${host._tryCleanBuild}>

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -182,7 +182,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
               bubbles: true,
               composed: true,
               detail: { job_id: job.job_id },
-            }),
+            })
           );
         }
       }
@@ -218,7 +218,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         // mismatch, hash mismatch). reason carries the code.
         this._submitErrorMessage = this._localize(
           "settings.remote_build_submit_rejected",
-          { reason: result.reason ?? "" },
+          { reason: result.reason ?? "" }
         );
         this._step = "input";
         return;
@@ -238,7 +238,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
             configuration: this._configuration,
             target: this._target,
           },
-        }),
+        })
       );
       this._expandedJobId = result.job_id;
       this._step = "list";
@@ -280,9 +280,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         // settles.
         this._patchRowState(job.job_id, {
           cancelInFlight: false,
-          errorMessage: this._localize(
-            "settings.remote_build_cancel_generic_error",
-          ),
+          errorMessage: this._localize("settings.remote_build_cancel_generic_error"),
         });
       }
     } catch (err) {
@@ -317,7 +315,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         bubbles: true,
         composed: true,
         detail: { job_id },
-      }),
+      })
     );
     if (this._expandedJobId === job_id) this._expandedJobId = "";
   };
@@ -326,9 +324,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     if (err instanceof APIError) {
       switch (err.errorCode) {
         case ErrorCode.PRECONDITION_FAILED:
-          return this._localize(
-            "settings.remote_build_cancel_precondition_failed",
-          );
+          return this._localize("settings.remote_build_cancel_precondition_failed");
         case ErrorCode.NOT_FOUND:
           return this._localize("settings.remote_build_cancel_not_found");
         default:
@@ -342,9 +338,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     if (err instanceof APIError) {
       switch (err.errorCode) {
         case ErrorCode.PRECONDITION_FAILED:
-          return this._localize(
-            "settings.remote_build_submit_precondition_failed",
-          );
+          return this._localize("settings.remote_build_submit_precondition_failed");
         case ErrorCode.UNAVAILABLE:
           return this._localize("settings.remote_build_submit_unavailable");
         case ErrorCode.NOT_FOUND:
@@ -363,9 +357,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
   private _renderInput() {
     if (this._devices.length === 0) {
       return html`
-        <p class="empty">
-          ${this._localize("settings.remote_build_submit_no_devices")}
-        </p>
+        <p class="empty">${this._localize("settings.remote_build_submit_no_devices")}</p>
         <div class="actions">
           <button class="btn-secondary" type="button" @click=${this._close}>
             ${this._localize("layout.close")}
@@ -384,7 +376,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
           @change=${this._onConfigurationChange}
         >
           ${this._devices.map(
-            (d) => html`<option value=${d.configuration}>${d.name}</option>`,
+            (d) => html`<option value=${d.configuration}>${d.name}</option>`
           )}
         </select>
       </div>
@@ -392,11 +384,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         <label for="rb-target">
           ${this._localize("settings.remote_build_submit_target_label")}
         </label>
-        <select
-          id="rb-target"
-          .value=${this._target}
-          @change=${this._onTargetChange}
-        >
+        <select id="rb-target" .value=${this._target} @change=${this._onTargetChange}>
           <option value=${JobType.COMPILE}>
             ${this._localize("settings.remote_build_submit_target_compile")}
           </option>
@@ -439,18 +427,14 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
    *  ordering. */
   private _sortedJobs(): RemoteBuildJobState[] {
     if (!this._jobs) return [];
-    return [...this._jobs.values()].sort(
-      (a, b) => b.started_at - a.started_at,
-    );
+    return [...this._jobs.values()].sort((a, b) => b.started_at - a.started_at);
   }
 
   private _renderList() {
     const jobs = this._sortedJobs();
     if (jobs.length === 0) {
       return html`
-        <p class="empty">
-          ${this._localize("settings.remote_build_list_empty")}
-        </p>
+        <p class="empty">${this._localize("settings.remote_build_list_empty")}</p>
         <div class="actions">
           <button class="btn-secondary" type="button" @click=${this._close}>
             ${this._localize("layout.close")}
@@ -474,10 +458,10 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     const terminal = isTerminalJobStatus(job.status);
     const expanded = this._expandedJobId === job.job_id;
     const row = this._rowState.get(job.job_id) ?? FRESH_ROW_STATE;
-    const headerLabel = job.receiver_label ||
-      this._localize("settings.remote_build_unknown_receiver");
-    const headerConfig = job.configuration ||
-      this._localize("settings.remote_build_unknown_configuration");
+    const headerLabel =
+      job.receiver_label || this._localize("settings.remote_build_unknown_receiver");
+    const headerConfig =
+      job.configuration || this._localize("settings.remote_build_unknown_configuration");
     return html`
       <li class="job-row">
         <button
@@ -493,14 +477,10 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
             <span class="job-receiver">${headerLabel}</span>
             <span class="job-meta-line">
               ${headerConfig} &middot;
-              ${this._localize(
-                `settings.remote_build_submit_target_${job.target}`,
-              )}
+              ${this._localize(`settings.remote_build_submit_target_${job.target}`)}
             </span>
           </span>
-          <span class="chevron" aria-hidden="true">
-            ${expanded ? "▾" : "▸"}
-          </span>
+          <span class="chevron" aria-hidden="true"> ${expanded ? "▾" : "▸"} </span>
         </button>
         ${expanded
           ? html`
@@ -533,7 +513,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
                             ? "settings.remote_build_cancel_pending"
                             : row.cancelInFlight
                               ? "settings.remote_build_cancel_in_flight"
-                              : "settings.remote_build_cancel_action",
+                              : "settings.remote_build_cancel_action"
                         )}
                       </button>`}
                 </div>
@@ -719,8 +699,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
 
       .job-body {
         padding: 0 var(--wa-space-m) var(--wa-space-m);
-        border-top: var(--wa-border-width-s) solid
-          var(--wa-color-surface-border);
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
       }
 
       .logs-container {

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -32,7 +32,6 @@ export class ESPHomeSelectBar extends LitElement {
   @property({ type: Boolean, attribute: "all-visible-selected" })
   allVisibleSelected = false;
 
-
   static styles = [
     espHomeStyles,
     css`
@@ -210,8 +209,7 @@ export class ESPHomeSelectBar extends LitElement {
         <div class="left">
           <button
             class="toggle"
-            @click=${() =>
-              this._emit(allSelected ? "deselect-all" : "select-all")}
+            @click=${() => this._emit(allSelected ? "deselect-all" : "select-all")}
           >
             ${allSelected
               ? this._localize("dashboard.deselect_all")
@@ -265,9 +263,7 @@ export class ESPHomeSelectBar extends LitElement {
   }
 
   private _emit(name: string) {
-    this.dispatchEvent(
-      new CustomEvent(name, { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
   }
 }
 

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -17,10 +17,7 @@ import { customElement, state } from "lit/decorators.js";
 
 import type { OffloaderAlertSnapshotEntry } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import {
-  buildOffloadAlertsContext,
-  localizeContext,
-} from "../context/index.js";
+import { buildOffloadAlertsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -147,8 +144,7 @@ export class ESPHomeSettingsDialog extends LitElement {
       // Icons without an outline/filled pair (e.g. translate)
       // fall back to the same name.
       const isActive = s.id === this._section;
-      const iconName =
-        isActive && s.iconActive !== undefined ? s.iconActive : s.icon;
+      const iconName = isActive && s.iconActive !== undefined ? s.iconActive : s.icon;
       return html`
         <button
           class="nav-item ${isActive ? "nav-item--active" : ""}"

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -20,12 +20,7 @@ export class ESPHomeSettingsAppearance extends LitElement {
   @state()
   private _theme: string = localStorage.getItem("esphome-theme") ?? "system";
 
-  static styles = [
-    espHomeStyles,
-    inputStyles,
-    settingsSharedStyles,
-    settingsRowStyles,
-  ];
+  static styles = [espHomeStyles, inputStyles, settingsSharedStyles, settingsRowStyles];
 
   protected render() {
     return html`
@@ -51,7 +46,7 @@ export class ESPHomeSettingsAppearance extends LitElement {
         detail: theme,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/settings-dialog/build-offload-alert.ts
+++ b/src/components/settings-dialog/build-offload-alert.ts
@@ -11,7 +11,7 @@ interface AlertContext {
 
 export function renderOffloaderAlert(
   alert: OffloaderAlertSnapshotEntry,
-  { localize, onRepair, onUnpair }: AlertContext,
+  { localize, onRepair, onUnpair }: AlertContext
 ): TemplateResult {
   const target = `${alert.receiver_hostname}:${alert.receiver_port}`;
   if (alert.kind === "pin_mismatch") {

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -11,10 +11,7 @@ interface PillResult {
   pillLabel: string;
 }
 
-export function pillFor(
-  pairing: PairingSummary,
-  localize: LocalizeFunc,
-): PillResult {
+export function pillFor(pairing: PairingSummary, localize: LocalizeFunc): PillResult {
   if (pairing.status !== "approved") {
     return {
       pillClass: "pairing-status-pill pairing-status-pending",
@@ -52,7 +49,7 @@ interface PairingRowContext {
 
 export function renderPairingRow(
   pairing: PairingSummary,
-  ctx: PairingRowContext,
+  ctx: PairingRowContext
 ): TemplateResult {
   const {
     localize,
@@ -93,10 +90,9 @@ export function renderPairingRow(
             <button
               class="toggle"
               role="switch"
-              aria-label=${localize(
-                "settings.build_offload_pairing_enabled_aria",
-                { label: pairing.label },
-              )}
+              aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
+                label: pairing.label,
+              })}
               aria-checked=${pairing.enabled}
               title=${localize("settings.build_offload_pairing_enabled_title")}
               @click=${() => onToggleEnabled(pairing)}
@@ -163,7 +159,7 @@ export function renderPairingRow(
 function renderVersionMismatch(
   pairing: PairingSummary,
   localize: LocalizeFunc,
-  appVersion: string,
+  appVersion: string
 ): TemplateResult | typeof nothing {
   if (pairing.status !== "approved") return nothing;
   const kind = classifyVersionMismatch(appVersion, pairing.esphome_version);
@@ -184,7 +180,7 @@ function renderVersionMismatch(
 
 export function latestJobForPin(
   jobs: Map<string, RemoteBuildJobState> | null,
-  pin_sha256: string,
+  pin_sha256: string
 ): RemoteBuildJobState | undefined {
   if (jobs === null) return undefined;
   let best: RemoteBuildJobState | undefined;

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -23,10 +23,7 @@ import {
 } from "../../context/index.js";
 import type { RemoteBuildJobState } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import {
-  normalizeHostnameForCompare,
-  trimTrailingDot,
-} from "../../util/hostname.js";
+import { normalizeHostnameForCompare, trimTrailingDot } from "../../util/hostname.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeEditPairingEndpointDialog } from "../edit-pairing-endpoint-dialog.js";
@@ -34,10 +31,7 @@ import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.j
 import type { ESPHomeReauthWizardDialog } from "../reauth-wizard-dialog.js";
 import type { ESPHomeRemoteBuildJobDialog } from "../remote-build-job-dialog.js";
 import { renderOffloaderAlert } from "./build-offload-alert.js";
-import {
-  latestJobForPin,
-  renderPairingRow,
-} from "./build-offload-pairing-row.js";
+import { latestJobForPin, renderPairingRow } from "./build-offload-pairing-row.js";
 import { offloaderAlertStyles, pairingRowStyles } from "./offload-styles.js";
 import {
   peerRowStyles,
@@ -121,8 +115,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
 
   protected render() {
     return html`
-      ${this._renderAlerts()}
-      ${this._renderRemoteBuildsToggle()}
+      ${this._renderAlerts()} ${this._renderRemoteBuildsToggle()}
 
       <div class="section-heading">
         ${this._localize("settings.paired_build_servers_heading")}
@@ -149,11 +142,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
             ${this._localize("settings.pair_build_server_row_helper")}
           </span>
         </div>
-        <button
-          class="btn-pair-build-server"
-          type="button"
-          @click=${this._onPairClick}
-        >
+        <button class="btn-pair-build-server" type="button" @click=${this._onPairClick}>
           <wa-icon library="mdi" name="lan-connect"></wa-icon>
           ${this._localize("settings.pair_build_server_open_action")}
         </button>
@@ -189,9 +178,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
               ${this._localize("settings.offloader_remote_builds_enabled")}
             </span>
             <span class="row-desc">
-              ${this._localize(
-                "settings.offloader_remote_builds_enabled_loading",
-              )}
+              ${this._localize("settings.offloader_remote_builds_enabled_loading")}
             </span>
           </div>
         </div>
@@ -225,7 +212,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         localize: this._localize,
         onRepair: this._onAlertRepair,
         onUnpair: this._onAlertUnpair,
-      }),
+      })
     );
   }
 
@@ -246,7 +233,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         onViewBuild: (jobId) => this._jobDialog?.openForJob(jobId),
         onEditEndpoint: this._onEditEndpointClick,
         onUnpair: this._onUnpairRequest,
-      }),
+      })
     );
   }
 
@@ -265,7 +252,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       return this._statusRow("settings.remote_build_peers_loading");
     }
     const peers = Array.from(this._discoveredHosts.values()).filter(
-      (peer) => !this._hasPairingFor(peer.hostname),
+      (peer) => !this._hasPairingFor(peer.hostname)
     );
     if (peers.length === 0) {
       return this._statusRow("settings.remote_build_peers_empty");
@@ -332,7 +319,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         detail: !this._remoteBuildsEnabled,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -342,7 +329,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         detail: { pin_sha256: pairing.pin_sha256, enabled: !pairing.enabled },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   };
 
@@ -378,7 +365,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     e: CustomEvent<{
       outcome: "success" | "pin_changed";
       receiver_label: string;
-    }>,
+    }>
   ): void => {
     // The wizard now owns the request_pair call and the
     // retry-on-NO_PAIRING_WINDOW / UNAVAILABLE UX (operator's
@@ -397,7 +384,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         this._localize("settings.reauth_repair_success", {
           label: e.detail.receiver_label,
         }),
-        { richColors: true },
+        { richColors: true }
       );
       return;
     }
@@ -405,7 +392,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       this._localize("settings.reauth_repair_pin_changed", {
         label: e.detail.receiver_label,
       }),
-      { richColors: true },
+      { richColors: true }
     );
   };
 
@@ -455,7 +442,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   };
 
   private _onPairApproved = (
-    e: CustomEvent<{ hostname: string; port: number }>,
+    e: CustomEvent<{ hostname: string; port: number }>
   ): void => {
     this._toast("success", "settings.pair_build_server_approved_toast", {
       hostname: e.detail.hostname,
@@ -464,7 +451,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   };
 
   private _onPairRejected = (
-    e: CustomEvent<{ hostname: string; port: number }>,
+    e: CustomEvent<{ hostname: string; port: number }>
   ): void => {
     this._toast("warning", "settings.pair_build_server_rejected_toast", {
       hostname: e.detail.hostname,
@@ -472,9 +459,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     });
   };
 
-  private _onPairRequestSent = (
-    e: CustomEvent<{ summary: PairingSummary }>,
-  ): void => {
+  private _onPairRequestSent = (e: CustomEvent<{ summary: PairingSummary }>): void => {
     // Bubbles past us to app-shell, which seeds the new pending
     // row into the pairings map. We just surface the toast.
     this._toast("success", "settings.pair_build_server_sent_toast", {
@@ -486,7 +471,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   private _toast(
     level: "success" | "warning" | "error",
     key: string,
-    values?: Record<string, string | number>,
+    values?: Record<string, string | number>
   ) {
     toast[level](this._localize(key, values), { richColors: true });
   }

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -221,32 +221,22 @@ export class ESPHomeSettingsBuildServer extends LitElement {
               ${pairedAgoSeconds !== null
                 ? html`
                     <dt>
-                      ${this._localize(
-                        "settings.build_server_peer_paired_at_label",
-                      )}
+                      ${this._localize("settings.build_server_peer_paired_at_label")}
                     </dt>
                     <dd>${formatSecondsAgo(pairedAgoSeconds, activeLocale())}</dd>
                   `
                 : nothing}
               ${peer.peer_ip
                 ? html`
-                    <dt>
-                      ${this._localize("settings.build_server_peer_ip_label")}
-                    </dt>
+                    <dt>${this._localize("settings.build_server_peer_ip_label")}</dt>
                     <dd><code>${peer.peer_ip}</code></dd>
                   `
                 : nothing}
-              <dt>
-                ${this._localize(
-                  "settings.build_server_peer_dashboard_id_label",
-                )}
-              </dt>
+              <dt>${this._localize("settings.build_server_peer_dashboard_id_label")}</dt>
               <dd>
                 <code class="peer-dashboard-id">${peer.dashboard_id}</code>
                 <span class="peer-details-desc">
-                  ${this._localize(
-                    "settings.build_server_peer_dashboard_id_desc",
-                  )}
+                  ${this._localize("settings.build_server_peer_dashboard_id_desc")}
                 </span>
               </dd>
             </dl>

--- a/src/components/settings-dialog/build-server-styles.ts
+++ b/src/components/settings-dialog/build-server-styles.ts
@@ -139,8 +139,7 @@ export const cleanupTtlStyles = css`
   .cleanup-ttl-number:focus {
     outline: none;
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 2px
-      color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 80%);
   }
 
   .cleanup-ttl-unit {

--- a/src/components/settings-dialog/editor-section.ts
+++ b/src/components/settings-dialog/editor-section.ts
@@ -51,7 +51,7 @@ export class ESPHomeSettingsEditor extends LitElement {
         detail: !this._yamlDiffButton,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -21,12 +21,7 @@ export class ESPHomeSettingsLanguage extends LitElement {
   @state()
   private _language: LanguageChoice = readStoredLocale() ?? "system";
 
-  static styles = [
-    espHomeStyles,
-    inputStyles,
-    settingsSharedStyles,
-    settingsRowStyles,
-  ];
+  static styles = [espHomeStyles, inputStyles, settingsSharedStyles, settingsRowStyles];
 
   protected render() {
     return html`
@@ -41,7 +36,7 @@ export class ESPHomeSettingsLanguage extends LitElement {
               <wa-option value=${l.value}
                 >${l.flag} ${this._localize(l.labelKey)}</wa-option
               >
-            `,
+            `
           )}
         </wa-select>
       </div>
@@ -56,7 +51,7 @@ export class ESPHomeSettingsLanguage extends LitElement {
         detail: lang,
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 }

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -9,20 +9,12 @@ export const offloaderAlertStyles = css`
     margin: var(--wa-space-s) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);
     border-left: 4px solid var(--esphome-warning, #f59e0b);
-    background: color-mix(
-      in srgb,
-      var(--esphome-warning, #f59e0b),
-      transparent 92%
-    );
+    background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 92%);
   }
 
   .offloader-alert-peer-revoked {
     border-left-color: var(--esphome-error, #dc2626);
-    background: color-mix(
-      in srgb,
-      var(--esphome-error, #dc2626),
-      transparent 92%
-    );
+    background: color-mix(in srgb, var(--esphome-error, #dc2626), transparent 92%);
   }
 
   .offloader-alert-body {
@@ -91,8 +83,7 @@ export const pairingRowStyles = css`
 
   .btn-pair-build-server:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px
-      color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 70%);
   }
 
   .btn-pair-build-server:disabled {

--- a/src/components/settings-dialog/pairing-requests-section.ts
+++ b/src/components/settings-dialog/pairing-requests-section.ts
@@ -5,11 +5,7 @@ import toast from "sonner-js";
 
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
-import {
-  ErrorCode,
-  type PairingWindowState,
-  type PeerSummary,
-} from "../../api/types.js";
+import { ErrorCode, type PairingWindowState, type PeerSummary } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import {
   apiContext,
@@ -74,10 +70,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
     // Refcounted server-side; closes on disconnect or 5min idle.
     if (this._api !== undefined) {
       void this._api.setRemoteBuildPairingWindow({ open: true }).catch(() => {
-        this._toast(
-          "warning",
-          "settings.build_server_pairing_window_open_failed",
-        );
+        this._toast("warning", "settings.build_server_pairing_window_open_failed");
       });
     }
   }
@@ -161,18 +154,14 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
               class="pairing-window-countdown"
               aria-label=${this._localize(
                 "settings.build_server_pairing_window_remaining_aria",
-                { duration: this._formatDuration(remaining) },
+                { duration: this._formatDuration(remaining) }
               )}
             >
               ${this._formatDuration(remaining)}
             </span>
           `
         : nothing}
-      <button
-        type="button"
-        class="pairing-window-extend"
-        @click=${this._onExtend}
-      >
+      <button type="button" class="pairing-window-extend" @click=${this._onExtend}>
         ${this._localize("settings.build_server_pairing_window_extend")}
       </button>
     `;
@@ -195,10 +184,9 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
         <div class="peer-actions">
           <button
             type="button"
-            aria-label=${this._localize(
-              "settings.build_server_peer_review_aria",
-              { label: peer.label },
-            )}
+            aria-label=${this._localize("settings.build_server_peer_review_aria", {
+              label: peer.label,
+            })}
             @click=${() => this._onReviewRequest(peer)}
           >
             ${this._localize("settings.build_server_peer_review")}
@@ -259,10 +247,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
   private _onExtend = () => {
     if (this._api === undefined) return;
     void this._api.setRemoteBuildPairingWindow({ open: true }).catch(() => {
-      this._toast(
-        "warning",
-        "settings.build_server_pairing_window_extend_failed",
-      );
+      this._toast("warning", "settings.build_server_pairing_window_extend_failed");
     });
   };
 
@@ -295,7 +280,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
   private _toast(
     level: "success" | "warning" | "error",
     key: string,
-    values?: Record<string, string | number>,
+    values?: Record<string, string | number>
   ) {
     toast[level](this._localize(key, values), { richColors: true });
   }

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -293,29 +293,17 @@ export const peerRowStyles = css`
   }
 
   .peer-connection-connected {
-    background: color-mix(
-      in srgb,
-      var(--esphome-success, #16a34a),
-      transparent 80%
-    );
+    background: color-mix(in srgb, var(--esphome-success, #16a34a), transparent 80%);
     color: var(--esphome-success, #16a34a);
   }
 
   .peer-connection-disconnected {
-    background: color-mix(
-      in srgb,
-      var(--wa-color-neutral-500, #6b7280),
-      transparent 80%
-    );
+    background: color-mix(in srgb, var(--wa-color-neutral-500, #6b7280), transparent 80%);
     color: var(--wa-color-neutral-500, #6b7280);
   }
 
   .peer-connection-connecting {
-    background: color-mix(
-      in srgb,
-      var(--esphome-warning, #f59e0b),
-      transparent 80%
-    );
+    background: color-mix(in srgb, var(--esphome-warning, #f59e0b), transparent 80%);
     color: var(--esphome-warning, #f59e0b);
   }
 

--- a/src/components/settings-dialog/types.ts
+++ b/src/components/settings-dialog/types.ts
@@ -53,4 +53,3 @@ export const SECTIONS: SectionDef[] = [
     group: "experimental",
   },
 ];
-

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -110,7 +110,9 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
         font-family: inherit;
         cursor: pointer;
         border: none;
-        transition: background 0.12s, color 0.12s;
+        transition:
+          background 0.12s,
+          color 0.12s;
       }
 
       .btn--ghost {
@@ -179,24 +181,18 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   private _onDiscard() {
     this._resolved = true;
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("discard", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("discard", { bubbles: true, composed: true }));
   }
 
   private _onSave() {
     this._resolved = true;
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("save", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("save", { bubbles: true, composed: true }));
   }
 
   private _onAfterHide() {
     if (!this._resolved) {
-      this.dispatchEvent(
-        new CustomEvent("cancel", { bubbles: true, composed: true }),
-      );
+      this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
     }
   }
 }

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -28,7 +28,12 @@ type WizardStep = "method" | "board" | "setup" | "empty-config";
 type CreationMethod = "basic" | "empty" | "import";
 type WizardStepDetail =
   | WizardStep
-  | { step: WizardStep; board?: BoardCatalogEntry | null; method?: CreationMethod; file?: File };
+  | {
+      step: WizardStep;
+      board?: BoardCatalogEntry | null;
+      method?: CreationMethod;
+      file?: File;
+    };
 
 @customElement("esphome-create-config-dialog")
 export class ESPHomeCreateConfigDialog extends LitElement {
@@ -254,12 +259,8 @@ export class ESPHomeCreateConfigDialog extends LitElement {
           ${this._title}
         </span>
         ${this._renderStep()}
-        ${this._importError
-          ? html`<p class="error">${this._importError}</p>`
-          : nothing}
-        ${this._createError
-          ? html`<p class="error">${this._createError}</p>`
-          : nothing}
+        ${this._importError ? html`<p class="error">${this._importError}</p>` : nothing}
+        ${this._createError ? html`<p class="error">${this._createError}</p>` : nothing}
       </wa-dialog>
     `;
   }
@@ -267,7 +268,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   private _renderStep() {
     // Show loading message while import creation is in progress
     if (this._submitting && this._creationMethod === "import") {
-      return html`<p style="text-align:center;color:var(--wa-color-text-quiet);padding:var(--wa-space-xl) 0">
+      return html`<p
+        style="text-align:center;color:var(--wa-color-text-quiet);padding:var(--wa-space-xl) 0"
+      >
         ${this._localize("wizard.importing_device")}
       </p>`;
     }
@@ -280,7 +283,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
           .presetFilterLabel=${this._initialBoardFilter}
         ></esphome-wizard-step-board>`;
       case "setup":
-        return html`<esphome-wizard-step-setup .board=${this._selectedBoard}></esphome-wizard-step-setup>`;
+        return html`<esphome-wizard-step-setup
+          .board=${this._selectedBoard}
+        ></esphome-wizard-step-setup>`;
       case "empty-config":
         return html`<esphome-wizard-step-empty-config></esphome-wizard-step-empty-config>`;
     }
@@ -349,7 +354,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     window.history.pushState(
       {},
       "",
-      withBase(`/device/${encodeURIComponent(configuration)}`),
+      withBase(`/device/${encodeURIComponent(configuration)}`)
     );
     window.dispatchEvent(new PopStateEvent("popstate"));
   }
@@ -362,7 +367,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         board_id: this._selectedBoard?.id ?? "",
         config_type: "empty",
       },
-      { board: this._selectedBoard ?? null },
+      { board: this._selectedBoard ?? null }
     );
   }
 
@@ -438,7 +443,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         ssid: wifiSsid,
         psk: wifiPassword,
       },
-      { board },
+      { board }
     );
   }
 
@@ -464,7 +469,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       psk?: string;
       file_content?: string;
     },
-    options: { board?: BoardCatalogEntry | null } = {},
+    options: { board?: BoardCatalogEntry | null } = {}
   ): Promise<void> {
     if (this._submitting) return;
     this._resetCreateErrors();
@@ -474,10 +479,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       this._navigateToCreated(configuration);
     } catch (err) {
       console.error("Failed to create device:", err);
-      this._createError = this._extractCreateErrorMessage(
-        err,
-        options.board ?? null,
-      );
+      this._createError = this._extractCreateErrorMessage(err, options.board ?? null);
     } finally {
       this._submitting = false;
     }
@@ -503,7 +505,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
    */
   private _extractCreateErrorMessage(
     err: unknown,
-    board: BoardCatalogEntry | null,
+    board: BoardCatalogEntry | null
   ): string {
     let message: string;
     if (err instanceof APIError && err.details.trim()) {

--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -56,7 +56,7 @@ export function chipNameToFilterLabel(chipName: string): string | null {
   const byVariant = WIZARD_BOARD_PLATFORMS.find((p) => p.variant === family);
   if (byVariant) return byVariant.label;
   const byPlatform = WIZARD_BOARD_PLATFORMS.find(
-    (p) => p.platform === family && !p.variant,
+    (p) => p.platform === family && !p.variant
   );
   return byPlatform?.label ?? null;
 }

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -204,27 +204,21 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
     }
     if (this.ports.length === 0) {
       return html`
-        <div class="empty">
-          ${this._localize("wizard.connect_your_board_no_ports")}
-        </div>
+        <div class="empty">${this._localize("wizard.connect_your_board_no_ports")}</div>
       `;
     }
     return html`
       <div class="list">
         ${this.ports.map(
           (p) => html`
-            <button
-              type="button"
-              class="option"
-              @click=${() => this._onSelect(p.port)}
-            >
+            <button type="button" class="option" @click=${() => this._onSelect(p.port)}>
               <wa-icon library="mdi" name="serial-port"></wa-icon>
               <div class="info">
                 <span class="title">${p.port}</span>
                 ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
               </div>
             </button>
-          `,
+          `
         )}
       </div>
     `;
@@ -248,7 +242,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
         detail: { port },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -510,11 +510,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
                   family: this._selectedFilter,
                 })}
               </span>
-              <button
-                class="helper-link"
-                type="button"
-                @click=${this._exitDetectionMode}
-              >
+              <button class="helper-link" type="button" @click=${this._exitDetectionMode}>
                 ${this._localize("wizard.show_all_boards")}
               </button>
             </div>
@@ -793,7 +789,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
       this._serverPorts = [];
       this._detectError = this._extractErrorDetail(
         e,
-        this._localize("wizard.connect_your_board_detect_failed"),
+        this._localize("wizard.connect_your_board_detect_failed")
       );
     } finally {
       this._loadingServerPorts = false;
@@ -832,7 +828,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
     } catch (err) {
       this._detectError = this._extractErrorDetail(
         err,
-        this._localize("wizard.connect_your_board_detect_failed"),
+        this._localize("wizard.connect_your_board_detect_failed")
       );
     } finally {
       this._detectingChip = false;

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -138,8 +138,8 @@ export class ESPHomeYamlEditor extends LitElement {
         // ─── Diagnostics: red wavy underline only (no gutter pill) ──
         ".cm-lintRange-error": {
           backgroundImage: this._darkMode
-            ? "url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 6 3\"><path d=\"M0 3 L1.5 0 L3 3 L4.5 0 L6 3\" fill=\"none\" stroke=\"%23ff6b6b\" stroke-width=\"0.9\" stroke-linecap=\"round\"/></svg>')"
-            : "url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 6 3\"><path d=\"M0 3 L1.5 0 L3 3 L4.5 0 L6 3\" fill=\"none\" stroke=\"%23d92d20\" stroke-width=\"0.9\" stroke-linecap=\"round\"/></svg>')",
+            ? 'url(\'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 3"><path d="M0 3 L1.5 0 L3 3 L4.5 0 L6 3" fill="none" stroke="%23ff6b6b" stroke-width="0.9" stroke-linecap="round"/></svg>\')'
+            : 'url(\'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 3"><path d="M0 3 L1.5 0 L3 3 L4.5 0 L6 3" fill="none" stroke="%23d92d20" stroke-width="0.9" stroke-linecap="round"/></svg>\')',
           backgroundRepeat: "repeat-x",
           backgroundPosition: "left bottom",
           backgroundSize: "6px 3px",
@@ -158,9 +158,7 @@ export class ESPHomeYamlEditor extends LitElement {
         },
         ".cm-diagnostic": {
           padding: "10px 14px 10px 12px",
-          borderLeft: this._darkMode
-            ? "3px solid #ff6b6b"
-            : "3px solid #d92d20",
+          borderLeft: this._darkMode ? "3px solid #ff6b6b" : "3px solid #d92d20",
           background: "transparent",
           color: this._darkMode ? "#f0f0f5" : "#1a1a1a",
           fontFamily: "inherit",
@@ -207,10 +205,9 @@ export class ESPHomeYamlEditor extends LitElement {
           background: this._darkMode ? "#2c5fb3" : "#0b5cad",
           color: "#ffffff",
         },
-        ".cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail":
-          {
-            color: "rgba(255,255,255,0.78)",
-          },
+        ".cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail": {
+          color: "rgba(255,255,255,0.78)",
+        },
         ".cm-completionLabel": {
           fontFamily: '"JetBrains Mono", "Fira Code", monospace',
           fontSize: "12.5px",
@@ -221,11 +218,10 @@ export class ESPHomeYamlEditor extends LitElement {
           fontWeight: "700",
           color: this._darkMode ? "#7fc4ff" : "#0b5cad",
         },
-        ".cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionMatchedText":
-          {
-            color: "#ffffff",
-            textShadow: "0 0 0.5px currentColor",
-          },
+        ".cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionMatchedText": {
+          color: "#ffffff",
+          textShadow: "0 0 0.5px currentColor",
+        },
         ".cm-completionDetail": {
           fontStyle: "normal",
           fontSize: "11px",
@@ -294,7 +290,7 @@ export class ESPHomeYamlEditor extends LitElement {
               detail: { value: update.state.doc.toString() },
               bubbles: true,
               composed: true,
-            }),
+            })
           );
         }
         // Cursor moved (click, arrow keys, find-jump). Emit the
@@ -313,7 +309,7 @@ export class ESPHomeYamlEditor extends LitElement {
                 detail: { line },
                 bubbles: true,
                 composed: true,
-              }),
+              })
             );
           }
         }
@@ -327,7 +323,7 @@ export class ESPHomeYamlEditor extends LitElement {
         createBackendYamlLinter({
           api: this._api,
           getConfiguration: () => this.configuration,
-        }),
+        })
       );
       // Schema-driven completion off the components catalog.
       extensions.push(
@@ -337,7 +333,7 @@ export class ESPHomeYamlEditor extends LitElement {
           icons: true,
           closeOnBlur: true,
           maxRenderedOptions: 60,
-        }),
+        })
       );
     }
 
@@ -397,9 +393,7 @@ export class ESPHomeYamlEditor extends LitElement {
     // across the rebuild by writing it back into `this.value`
     // before remounting.
     if (
-      (changed.has("_darkMode") ||
-        changed.has("_api") ||
-        changed.has("maskAllValues")) &&
+      (changed.has("_darkMode") || changed.has("_api") || changed.has("maskAllValues")) &&
       this._view
     ) {
       this.value = this._view.state.doc.toString();
@@ -492,8 +486,12 @@ export class ESPHomeYamlEditor extends LitElement {
       this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
       if (this.highlightRange && this.scrollToHighlight) {
         const line = Math.max(1, this.highlightRange.fromLine);
-        const pos = this._view.state.doc.line(Math.min(line, this._view.state.doc.lines)).from;
-        this._view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }) });
+        const pos = this._view.state.doc.line(
+          Math.min(line, this._view.state.doc.lines)
+        ).from;
+        this._view.dispatch({
+          effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }),
+        });
       }
     }
 

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -141,11 +141,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
           <button class="btn btn--cancel" @click=${this.close}>
             ${this._localize("layout.cancel")}
           </button>
-          <button
-            class="btn btn--goto"
-            ?disabled=${!canGoToError}
-            @click=${this._goto}
-          >
+          <button class="btn btn--goto" ?disabled=${!canGoToError} @click=${this._goto}>
             ${this._localize("device.yaml_invalid_go_to_error")}
           </button>
           <button class="btn btn--save-anyway" @click=${this._saveAnyway}>
@@ -164,23 +160,19 @@ export class ESPHomeYamlValidationDialog extends LitElement {
         detail: { line: this.firstErrorLine, col: this.firstErrorCol },
         bubbles: true,
         composed: true,
-      }),
+      })
     );
   }
 
   private _saveAnyway() {
     this._resolvedExit = "save-anyway";
     this.close();
-    this.dispatchEvent(
-      new CustomEvent("save-anyway", { bubbles: true, composed: true }),
-    );
+    this.dispatchEvent(new CustomEvent("save-anyway", { bubbles: true, composed: true }));
   }
 
   private _onAfterHide() {
     if (this._resolvedExit === null) {
-      this.dispatchEvent(
-        new CustomEvent("cancel", { bubbles: true, composed: true }),
-      );
+      this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
     }
   }
 }

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -39,15 +39,15 @@ export const importableDevicesContext = createContext<AdoptableDevice[]>(
 export const versionContext = createContext<string>(Symbol("esphome-version"));
 
 /** Context for the Device Builder server version string. */
-export const serverVersionContext = createContext<string>(Symbol("esphome-server-version"));
+export const serverVersionContext = createContext<string>(
+  Symbol("esphome-server-version")
+);
 
 /** Context for dark mode state. */
 export const darkModeContext = createContext<boolean>(Symbol("esphome-dark-mode"));
 
 /** Context for the localize function. */
-export const localizeContext = createContext<LocalizeFunc>(
-  Symbol("esphome-localize")
-);
+export const localizeContext = createContext<LocalizeFunc>(Symbol("esphome-localize"));
 
 /** Context for whether the initial device list has been loaded. */
 export const devicesLoadedContext = createContext<boolean>(
@@ -55,9 +55,7 @@ export const devicesLoadedContext = createContext<boolean>(
 );
 
 /** Context for whether the frontend is running inside HA ingress. */
-export const isHaIngressContext = createContext<boolean>(
-  Symbol("esphome-is-ha-ingress")
-);
+export const isHaIngressContext = createContext<boolean>(Symbol("esphome-is-ha-ingress"));
 
 /** Context for active firmware jobs, keyed by device configuration.
  *  Tracks the latest non-terminal job per device (used for the busy
@@ -134,9 +132,7 @@ export const integrationDocsContext = createContext<Record<string, string>>(
  *  events. Per-device assignments live on each
  *  ``ConfiguredDevice.labels`` (an array of ids); consumers join
  *  against this map at render time to resolve name + color. */
-export const labelsContext = createContext<Label[]>(
-  Symbol("esphome-labels")
-);
+export const labelsContext = createContext<Label[]>(Symbol("esphome-labels"));
 
 /**
  * Context for whether onboarding still has work to do.
@@ -249,9 +245,10 @@ export const buildServerPairingWindowStateContext =
  * surface as inconsistent UI ordering between snapshot and
  * post-event renders.
  */
-export const buildOffloadDiscoveredHostsContext = createContext<
-  Map<string, RemoteBuildPeer> | null
->(Symbol("esphome-build-offload-discovered-hosts"));
+export const buildOffloadDiscoveredHostsContext = createContext<Map<
+  string,
+  RemoteBuildPeer
+> | null>(Symbol("esphome-build-offload-discovered-hosts"));
 
 /**
  * Offloader-side pairings (PENDING + APPROVED rows from the
@@ -280,9 +277,10 @@ export const buildOffloadDiscoveredHostsContext = createContext<
  * ``OFFLOADER_PAIR_STATUS_CHANGED`` after a sent
  * ``request_pair``.
  */
-export const buildOffloadPairingsContext = createContext<
-  Map<string, PairingSummary> | null
->(Symbol("esphome-build-offload-pairings"));
+export const buildOffloadPairingsContext = createContext<Map<
+  string,
+  PairingSummary
+> | null>(Symbol("esphome-build-offload-pairings"));
 
 /**
  * Offloader-side master "Remote builds enabled" toggle (7b).
@@ -302,9 +300,9 @@ export const buildOffloadPairingsContext = createContext<
  * pre-7b semantic where any APPROVED + connected + idle
  * pairing was eligible).
  */
-export const offloaderRemoteBuildsEnabledContext = createContext<
-  boolean | null
->(Symbol("esphome-offloader-remote-builds-enabled"));
+export const offloaderRemoteBuildsEnabledContext = createContext<boolean | null>(
+  Symbol("esphome-offloader-remote-builds-enabled")
+);
 
 /**
  * Offloader-side pair alerts (pin_mismatch / peer_revoked).
@@ -334,9 +332,10 @@ export const offloaderRemoteBuildsEnabledContext = createContext<
  * controller / still loading" from "loaded with zero
  * alerts".
  */
-export const buildOffloadAlertsContext = createContext<
-  Map<string, OffloaderAlertSnapshotEntry> | null
->(Symbol("esphome-build-offload-alerts"));
+export const buildOffloadAlertsContext = createContext<Map<
+  string,
+  OffloaderAlertSnapshotEntry
+> | null>(Symbol("esphome-build-offload-alerts"));
 
 /**
  * One in-flight (or recently terminal) remote-build job the
@@ -407,7 +406,7 @@ export const buildOffloadJobsContext = createContext<Map<
  */
 export function stubRemoteBuildJobState(
   job_id: string,
-  pin_sha256: string,
+  pin_sha256: string
 ): RemoteBuildJobState {
   return {
     job_id,

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -13,7 +13,9 @@ import "urlpattern-polyfill";
 if (typeof crypto !== "undefined" && !crypto.randomUUID) {
   crypto.randomUUID = () =>
     "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
-      (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),
+      (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(
+        16
+      )
     ) as `${string}-${string}-${string}-${string}-${string}`;
 }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -92,10 +92,7 @@ import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { readDashboardUrl, writeDashboardUrl } from "../util/dashboard-url.js";
 import { matchesDeviceName } from "../util/device-search.js";
-import {
-  DEVICE_SORT_COLLATOR,
-  deviceSortKey,
-} from "../util/device-sort.js";
+import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../util/device-sort.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
@@ -299,7 +296,10 @@ export class ESPHomePageDashboard extends LitElement {
     this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
     window.addEventListener("esphome-serial-setup", this._onSerialSetup);
     window.addEventListener("esphome-show-ignored-changed", this._onShowIgnoredChanged);
-    window.addEventListener("esphome-show-ignored-from-menu", this._onShowIgnoredFromMenu);
+    window.addEventListener(
+      "esphome-show-ignored-from-menu",
+      this._onShowIgnoredFromMenu
+    );
     window.addEventListener("esphome-show-archived-dialog", this._onShowArchivedDialog);
     const pending = consumePendingHighlight();
     if (pending !== null) {
@@ -412,10 +412,7 @@ export class ESPHomePageDashboard extends LitElement {
     // under so an all-ignored / hide-ignored state doesn't leave
     // empty space at the top of the view.
     if (changed.has("_importableDevices") || changed.has("_showIgnored")) {
-      this.toggleAttribute(
-        "has-discovered",
-        this._visibleImportableDevices.length > 0,
-      );
+      this.toggleAttribute("has-discovered", this._visibleImportableDevices.length > 0);
     }
     if (changed.has("_devicesLoaded") && this._devicesLoaded) void loadPreferences(this);
     // The catalog arrives over WS after ``connectedCallback`` runs.
@@ -517,7 +514,7 @@ export class ESPHomePageDashboard extends LitElement {
     if (this._sortedDevicesCache?.source === source)
       return this._sortedDevicesCache.sorted;
     const sorted = [...source].sort((a, b) =>
-      DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b)),
+      DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
     );
     this._sortedDevicesCache = { source, sorted };
     return sorted;
@@ -727,7 +724,7 @@ export class ESPHomePageDashboard extends LitElement {
   _openLogs = (device: ConfiguredDevice) => openLogs(this, device);
   _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
-    () => this._localize,
+    () => this._localize
   );
   _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -16,8 +16,9 @@ export const devicePageStyles = css`
     grid-template-columns: minmax(230px, 1fr) minmax(0, 5fr);
     gap: var(--wa-space-l);
     height: calc(
-      100vh - var(--esphome-header-height) - var(--esphome-footer-height) -
-        var(--wa-space-l)
+      100vh - var(--esphome-header-height) - var(--esphome-footer-height) - var(
+          --wa-space-l
+        )
     );
     transition: grid-template-columns 0.25s ease;
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -210,7 +210,7 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
-    () => this._localize,
+    () => this._localize
   );
 
   private _installCtrl = this._createInstallController();
@@ -679,9 +679,7 @@ export class ESPHomePageDevice extends LitElement {
    *  navigator's selection to the containing section so the user
    *  isn't left looking at a different section's form panel after
    *  the scroll lands. */
-  private _onValidationGoTo = (
-    e: CustomEvent<{ line: number; col: number }>,
-  ) => {
+  private _onValidationGoTo = (e: CustomEvent<{ line: number; col: number }>) => {
     const line = e.detail.line;
     if (line && line >= 1) {
       // Sections-only layout would scroll a hidden editor — flip
@@ -721,8 +719,7 @@ export class ESPHomePageDevice extends LitElement {
   private _onValidateClick = () => {
     if (!this._device) return;
     this._commandDialog.configuration = this._device.configuration;
-    this._commandDialog.name =
-      this._device.friendly_name || this._device.name;
+    this._commandDialog.name = this._device.friendly_name || this._device.name;
     this._commandDialog.open("validate");
   };
 
@@ -748,9 +745,7 @@ export class ESPHomePageDevice extends LitElement {
    *    dialogs only ever surface for the current page's device),
    *    but defensively navigate to the requested device so the
    *    hint can never become a silent no-op. */
-  private _onRequestOpenEditor = (
-    e: CustomEvent<{ configuration: string }>
-  ) => {
+  private _onRequestOpenEditor = (e: CustomEvent<{ configuration: string }>) => {
     e.stopPropagation();
     if (e.detail.configuration === this._device?.configuration) return;
     navigate(`/device/${encodeURIComponent(e.detail.configuration)}`);
@@ -765,9 +760,7 @@ export class ESPHomePageDevice extends LitElement {
       this.id ||
       this._localize("dashboard.create_device");
 
-    const showEdgeTab = this._isMobile
-      ? !this._drawerOpen
-      : this._navCollapsed;
+    const showEdgeTab = this._isMobile ? !this._drawerOpen : this._navCollapsed;
     const backLabel = this._localize("device.back");
 
     return html`
@@ -924,9 +917,7 @@ export class ESPHomePageDevice extends LitElement {
       return;
     }
     this._navCollapsed = false;
-    this._api
-      .updatePreferences({ navigator_visible: true })
-      .catch(() => {});
+    this._api.updatePreferences({ navigator_visible: true }).catch(() => {});
   };
 
   /** Collapse request bubbling up from the navigator's own chevron.
@@ -938,9 +929,7 @@ export class ESPHomePageDevice extends LitElement {
       return;
     }
     this._navCollapsed = true;
-    this._api
-      .updatePreferences({ navigator_visible: false })
-      .catch(() => {});
+    this._api.updatePreferences({ navigator_visible: false }).catch(() => {});
   };
 
   /**

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -54,7 +54,7 @@ export class ESPHomePageSecrets extends LitElement {
     super.connectedCallback();
     window.addEventListener(
       "secrets-saved",
-      this._onExternalSecretsSaved as EventListener,
+      this._onExternalSecretsSaved as EventListener
     );
     await this._loadFromServer();
   }
@@ -62,7 +62,7 @@ export class ESPHomePageSecrets extends LitElement {
   disconnectedCallback() {
     window.removeEventListener(
       "secrets-saved",
-      this._onExternalSecretsSaved as EventListener,
+      this._onExternalSecretsSaved as EventListener
     );
     super.disconnectedCallback();
   }
@@ -169,7 +169,10 @@ export class ESPHomePageSecrets extends LitElement {
         font-weight: var(--wa-font-weight-bold);
         font-family: inherit;
         box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
-        transition: background 0.12s, box-shadow 0.12s, transform 0.12s;
+        transition:
+          background 0.12s,
+          box-shadow 0.12s,
+          transform 0.12s;
       }
 
       .save-button:hover:not(:disabled) {
@@ -194,11 +197,7 @@ export class ESPHomePageSecrets extends LitElement {
 
       .reveal-toggle {
         border: var(--wa-border-width-s) solid var(--esphome-primary);
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 90%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
         color: var(--esphome-primary);
         padding: 6px 12px;
         border-radius: var(--wa-border-radius-m);
@@ -213,11 +212,7 @@ export class ESPHomePageSecrets extends LitElement {
       }
 
       .reveal-toggle:hover {
-        background: color-mix(
-          in srgb,
-          var(--esphome-primary),
-          transparent 80%
-        );
+        background: color-mix(in srgb, var(--esphome-primary), transparent 80%);
       }
 
       .reveal-toggle wa-icon {
@@ -228,7 +223,7 @@ export class ESPHomePageSecrets extends LitElement {
 
   protected render() {
     const revealLabel = this._localize(
-      this._revealSensitive ? "secrets.hide_values" : "secrets.reveal_values",
+      this._revealSensitive ? "secrets.hide_values" : "secrets.reveal_values"
     );
     return html`
       <div class="page">
@@ -296,7 +291,7 @@ export class ESPHomePageSecrets extends LitElement {
         // can react regardless of where they live in the tree.
         // ``detail.source`` lets self-listeners short-circuit.
         window.dispatchEvent(
-          new CustomEvent("secrets-saved", { detail: { source: this } }),
+          new CustomEvent("secrets-saved", { detail: { source: this } })
         );
       })
       .catch((e) => {

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -81,7 +81,7 @@ function _fetch<K extends CatalogKind>(
   kind: K,
   fetcher: (platform?: string, boardId?: string) => Promise<CatalogValue[K]>,
   platform: string | undefined,
-  boardId: string | undefined,
+  boardId: string | undefined
 ): Promise<CatalogValue[K]> {
   const key = _key(platform, boardId);
   const cached = _cache[kind].get(key);
@@ -108,7 +108,7 @@ function _fetch<K extends CatalogKind>(
 
 export function getCachedAutomationTriggers(
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): AutomationTrigger[] | undefined {
   return _cache.triggers.get(_key(platform, boardId));
 }
@@ -116,19 +116,14 @@ export function getCachedAutomationTriggers(
 export function fetchAutomationTriggers(
   api: ESPHomeAPI,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): Promise<AutomationTrigger[]> {
-  return _fetch(
-    "triggers",
-    (p, b) => api.getAutomationTriggers(p, b),
-    platform,
-    boardId,
-  );
+  return _fetch("triggers", (p, b) => api.getAutomationTriggers(p, b), platform, boardId);
 }
 
 export function getCachedAutomationActions(
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): AutomationAction[] | undefined {
   return _cache.actions.get(_key(platform, boardId));
 }
@@ -136,19 +131,14 @@ export function getCachedAutomationActions(
 export function fetchAutomationActions(
   api: ESPHomeAPI,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): Promise<AutomationAction[]> {
-  return _fetch(
-    "actions",
-    (p, b) => api.getAutomationActions(p, b),
-    platform,
-    boardId,
-  );
+  return _fetch("actions", (p, b) => api.getAutomationActions(p, b), platform, boardId);
 }
 
 export function getCachedAutomationConditions(
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): AutomationCondition[] | undefined {
   return _cache.conditions.get(_key(platform, boardId));
 }
@@ -156,19 +146,19 @@ export function getCachedAutomationConditions(
 export function fetchAutomationConditions(
   api: ESPHomeAPI,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): Promise<AutomationCondition[]> {
   return _fetch(
     "conditions",
     (p, b) => api.getAutomationConditions(p, b),
     platform,
-    boardId,
+    boardId
   );
 }
 
 export function getCachedLightEffects(
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): LightEffect[] | undefined {
   return _cache.light_effects.get(_key(platform, boardId));
 }
@@ -176,22 +166,15 @@ export function getCachedLightEffects(
 export function fetchLightEffects(
   api: ESPHomeAPI,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): Promise<LightEffect[]> {
-  return _fetch(
-    "light_effects",
-    (p, b) => api.getLightEffects(p, b),
-    platform,
-    boardId,
-  );
+  return _fetch("light_effects", (p, b) => api.getLightEffects(p, b), platform, boardId);
 }
 
 /** Subscribe to cache updates. Returns an unsubscribe function.
  *  Listeners fire once per fresh entry (across any of the four
  *  catalogues); failed fetches do not fire. */
-export function subscribeAutomationCatalogCache(
-  listener: () => void,
-): () => void {
+export function subscribeAutomationCatalogCache(listener: () => void): () => void {
   _listeners.add(listener);
   return () => {
     _listeners.delete(listener);

--- a/src/util/board-pin-defaults.ts
+++ b/src/util/board-pin-defaults.ts
@@ -32,7 +32,7 @@ export function seedBoardPinDefaults(
   componentId: string,
   configEntries: ConfigEntry[],
   board: BoardCatalogEntry | null,
-  values: Record<string, unknown>,
+  values: Record<string, unknown>
 ): Record<string, unknown> {
   if (!board?.pins?.length) return values;
   // Platform-qualified ids (``audio_adc.es7210``) → skip. Bus-like

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -38,7 +38,7 @@ function _key(componentId: string, platform?: string, boardId?: string): string 
 export function getCachedComponent(
   componentId: string,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): CacheValue | undefined {
   return _cache.get(_key(componentId, platform, boardId));
 }
@@ -53,7 +53,7 @@ export function fetchComponent(
   api: ESPHomeAPI,
   componentId: string,
   platform?: string,
-  boardId?: string,
+  boardId?: string
 ): Promise<CacheValue> {
   const key = _key(componentId, platform, boardId);
   if (_cache.has(key)) return Promise.resolve(_cache.get(key) ?? null);

--- a/src/util/component-name-resolver-controller.ts
+++ b/src/util/component-name-resolver-controller.ts
@@ -28,7 +28,7 @@ export class ComponentNameResolverController implements ReactiveController {
   constructor(
     private readonly _host: ReactiveControllerHost,
     private readonly _getApi: () => ESPHomeAPI | undefined,
-    private readonly _getPlatform: () => string | undefined,
+    private readonly _getPlatform: () => string | undefined
   ) {
     _host.addController(this);
   }

--- a/src/util/config-entry-defaults.ts
+++ b/src/util/config-entry-defaults.ts
@@ -20,9 +20,7 @@
  */
 import { ConfigEntryType, type ConfigEntry } from "../api/types.js";
 
-export function makeConfigEntry(
-  overrides: Partial<ConfigEntry> = {},
-): ConfigEntry {
+export function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return {
     key: "",
     type: ConfigEntryType.STRING,

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -32,7 +32,7 @@ export function findFirstErrorTarget(
   entries: ConfigEntry[],
   errors: Map<string, ValidationError>,
   pathPrefix: string[] = [],
-  ancestorAdvanced = false,
+  ancestorAdvanced = false
 ): { path: string[]; hasAdvancedAncestor: boolean } | null {
   for (const entry of entries) {
     const path = [...pathPrefix, entry.key];
@@ -42,7 +42,7 @@ export function findFirstErrorTarget(
         entry.config_entries ?? [],
         errors,
         path,
-        advancedHere,
+        advancedHere
       );
       if (found) return found;
       continue;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -109,7 +109,7 @@ const pinMemo = createScanMemo<PinKey, Map<number, string>>(pinKeyEquals);
 export function findUsedPins(
   yaml: string,
   excludeFromLine?: number,
-  excludeToLine?: number,
+  excludeToLine?: number
 ): Map<number, string> {
   const probe: PinKey = { yaml, excludeFromLine, excludeToLine };
   const cached = pinMemo.get(probe);
@@ -157,10 +157,7 @@ export function findUsedPins(
  * section starting at `fromLine`. Used to bound `excludeToLine` for
  * `findUsedPins`. Returns `lines.length` if the section runs to EOF.
  */
-export function sectionEndLine(
-  yaml: string,
-  fromLine?: number,
-): number | undefined {
+export function sectionEndLine(yaml: string, fromLine?: number): number | undefined {
   if (fromLine === undefined) return undefined;
   const lines = yaml.split("\n");
   for (let i = fromLine; i < lines.length; i++) {
@@ -180,16 +177,12 @@ interface RefKey {
   yaml: string;
   domain: string;
 }
-const refKeyEquals = (a: RefKey, b: RefKey) =>
-  a.yaml === b.yaml && a.domain === b.domain;
-const refMemo = createScanMemo<
-  RefKey,
-  Array<{ id: string; name: string }>
->(refKeyEquals);
+const refKeyEquals = (a: RefKey, b: RefKey) => a.yaml === b.yaml && a.domain === b.domain;
+const refMemo = createScanMemo<RefKey, Array<{ id: string; name: string }>>(refKeyEquals);
 
 export function findReferencedComponents(
   yaml: string,
-  domain: string,
+  domain: string
 ): Array<{ id: string; name: string }> {
   if (!domain) return [];
   const probe: RefKey = { yaml, domain };

--- a/src/util/copy-to-clipboard.ts
+++ b/src/util/copy-to-clipboard.ts
@@ -130,9 +130,7 @@ function copyViaExecCommand(text: string): boolean {
   // our hijacked range. Cheap to be a good citizen — the user
   // might have text selected before clicking Copy.
   const previousRange =
-    selection && selection.rangeCount > 0
-      ? selection.getRangeAt(0).cloneRange()
-      : null;
+    selection && selection.rangeCount > 0 ? selection.getRangeAt(0).cloneRange() : null;
 
   // ``execCommand("copy")`` won't fire the ``copy`` event
   // without an active non-empty selection. Use a hidden span

--- a/src/util/dashboard-url.ts
+++ b/src/util/dashboard-url.ts
@@ -65,8 +65,7 @@ function toCsv(arr: readonly string[] | undefined): string | undefined {
 export function readDashboardUrl(): DashboardUrlState {
   const p = new URLSearchParams(window.location.search);
   const search = p.get("q") ?? undefined;
-  const view =
-    p.get("view") === "table" ? DashboardView.TABLE : undefined;
+  const view = p.get("view") === "table" ? DashboardView.TABLE : undefined;
   return {
     search: search && search.length > 0 ? search : undefined,
     labels: fromCsv(p.get("labels")),

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -25,7 +25,7 @@
 export function generateDefaultComponentId(
   componentId: string,
   multiConf: boolean,
-  existing: ReadonlySet<string>,
+  existing: ReadonlySet<string>
 ): string | null {
   const isSingleton = !multiConf && !componentId.includes(".");
   if (isSingleton) return null;

--- a/src/util/diff-lines.ts
+++ b/src/util/diff-lines.ts
@@ -18,9 +18,10 @@ export function diffLines(oldText: string, newText: string): DiffLine[] {
 
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      lcs[i][j] = a[i - 1] === b[j - 1]
-        ? lcs[i - 1][j - 1] + 1
-        : Math.max(lcs[i - 1][j], lcs[i][j - 1]);
+      lcs[i][j] =
+        a[i - 1] === b[j - 1]
+          ? lcs[i - 1][j - 1] + 1
+          : Math.max(lcs[i - 1][j], lcs[i][j - 1]);
     }
   }
 

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -25,11 +25,7 @@ import { stripAnsi } from "./strip-ansi.js";
  * (:func:`downloadAnsiText`, :func:`downloadBase64Binary`)
  * rather than touching this directly.
  */
-function _downloadBlob(
-  bytes: BlobPart,
-  filename: string,
-  mimeType: string,
-): void {
+function _downloadBlob(bytes: BlobPart, filename: string, mimeType: string): void {
   const blob = new Blob([bytes], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
@@ -89,9 +85,7 @@ export function downloadAnsiText(lines: string[], filename: string): string {
      per entry before the join so the output reads as one real log
      line per file row regardless of which terminator the upstream
      used. */
-  const text = lines
-    .map((line) => stripAnsi(line).replace(/[\r\n]+$/, ""))
-    .join("\n");
+  const text = lines.map((line) => stripAnsi(line).replace(/[\r\n]+$/, "")).join("\n");
   _downloadBlob(text, filename, "text/plain");
   return text;
 }

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -126,9 +126,7 @@ const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
 };
 
 /** Returns ``null`` for the ``"none"`` state so callers can skip rendering. */
-export function getEncryptionVisual(
-  state: EncryptionState,
-): EncryptionVisual | null {
+export function getEncryptionVisual(state: EncryptionState): EncryptionVisual | null {
   return state === "none" ? null : VISUALS[state];
 }
 
@@ -145,9 +143,7 @@ export function getEncryptionVisual(
  * single-device contexts (drawer / details pane) where confirmation
  * is useful. (issue #141)
  */
-export function getCompactEncryptionVisual(
-  d: EncryptionInputs,
-): EncryptionVisual | null {
+export function getCompactEncryptionVisual(d: EncryptionInputs): EncryptionVisual | null {
   const state = getEncryptionState(d);
   if (state === "active" && d.api_encryption_active) return null;
   return getEncryptionVisual(state);

--- a/src/util/escape-controller.ts
+++ b/src/util/escape-controller.ts
@@ -33,7 +33,7 @@ export class EscapeController implements ReactiveController {
   constructor(
     host: ReactiveControllerHost,
     private readonly onEscape: (e: KeyboardEvent) => void,
-    options: EscapeControllerOptions = {},
+    options: EscapeControllerOptions = {}
   ) {
     this._target = options.target ?? window;
     host.addController(this);

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -98,12 +98,7 @@ export interface SchemaSchema {
  *  these names; pinning the union keeps callsites that index by
  *  registry name (``getRegistryEntries``) honest about which
  *  slots are valid. */
-export const SCHEMA_REGISTRY_KEYS = [
-  "action",
-  "condition",
-  "filter",
-  "effects",
-] as const;
+export const SCHEMA_REGISTRY_KEYS = ["action", "condition", "filter", "effects"] as const;
 export type SchemaRegistryKey = (typeof SCHEMA_REGISTRY_KEYS)[number];
 
 const REGISTRY_KEY_SET = new Set<string>(SCHEMA_REGISTRY_KEYS);
@@ -127,10 +122,7 @@ export interface SchemaComponent {
 
 export interface SchemaCore extends SchemaComponent {
   platforms?: Record<string, { docs?: string } | undefined>;
-  components?: Record<
-    string,
-    { docs?: string; dependencies?: string[] } | undefined
-  >;
+  components?: Record<string, { docs?: string; dependencies?: string[] } | undefined>;
 }
 
 export interface SchemaBundle {
@@ -186,10 +178,9 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
   const promise = (async () => {
     const { esphome_version } = await api.getVersion();
     if (esphome_version.endsWith("dev")) return "dev";
-    const probe = await fetch(
-      `${SCHEMA_HOST}/${esphome_version}/esphome.json`,
-      { method: "HEAD" },
-    );
+    const probe = await fetch(`${SCHEMA_HOST}/${esphome_version}/esphome.json`, {
+      method: "HEAD",
+    });
     if (probe.ok) return esphome_version;
     // Only fall back to ``dev`` for a definitive
     // "this version isn't published" answer (404). Transient
@@ -200,9 +191,7 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
     // probe used to silently downgrade to ``dev`` for the page
     // lifetime.)
     if (probe.status === 404) return "dev";
-    throw new Error(
-      `schema-host probe returned ${probe.status} for ${esphome_version}`,
-    );
+    throw new Error(`schema-host probe returned ${probe.status} for ${esphome_version}`);
   })();
   versionPromise = promise;
   // Evict on failure so subsequent calls retry. A successful
@@ -220,10 +209,7 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
  * ``null`` on any failure — callers gracefully skip the
  * schema-driven extras when ``null``.
  */
-export function fetchBundle(
-  api: ESPHomeAPI,
-  name: string,
-): Promise<SchemaBundle | null> {
+export function fetchBundle(api: ESPHomeAPI, name: string): Promise<SchemaBundle | null> {
   // First-line dedupe: concurrent callers asking for the same
   // bundle name (before we know the version) share one promise.
   // Once the version resolves, the entry gets re-keyed under
@@ -292,7 +278,7 @@ export function fetchBundle(
 export async function getTriggerKeys(
   api: ESPHomeAPI,
   bundleName: string,
-  componentKey: string,
+  componentKey: string
 ): Promise<{ key: string; docs?: string }[]> {
   const out: { key: string; docs?: string }[] = [];
   const seen = new Set<string>();
@@ -303,7 +289,7 @@ export async function getTriggerKeys(
     "CONFIG_SCHEMA",
     out,
     seen,
-    new Set(),
+    new Set()
   );
   return out;
 }
@@ -322,15 +308,9 @@ async function collectTriggers(
   schemaName: string,
   out: { key: string; docs?: string }[],
   seenKeys: Set<string>,
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<void> {
-  const cv = await loadSchemaCv(
-    api,
-    bundleName,
-    componentKey,
-    schemaName,
-    visited,
-  );
+  const cv = await loadSchemaCv(api, bundleName, componentKey, schemaName, visited);
   if (!cv) return;
   const schema = "schema" in cv ? cv.schema : undefined;
   if (!schema) return;
@@ -352,7 +332,7 @@ async function collectTriggers(
       ref.schemaName,
       out,
       seenKeys,
-      visited,
+      visited
     );
   }
 }
@@ -401,7 +381,7 @@ const configVarKeysCache = new Map<string, Promise<SchemaConfigVarKey[]>>();
 export async function getConfigVarKeys(
   api: ESPHomeAPI,
   bundleName: string,
-  componentKey: string,
+  componentKey: string
 ): Promise<SchemaConfigVarKey[]> {
   const cacheKey = `${bundleName}|${componentKey}`;
   const cached = configVarKeysCache.get(cacheKey);
@@ -416,7 +396,7 @@ export async function getConfigVarKeys(
       "CONFIG_SCHEMA",
       out,
       seen,
-      new Set(),
+      new Set()
     );
     return out;
   })();
@@ -433,15 +413,9 @@ async function collectConfigVars(
   schemaName: string,
   out: SchemaConfigVarKey[],
   seenKeys: Set<string>,
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<void> {
-  const cv = await loadSchemaCv(
-    api,
-    bundleName,
-    componentKey,
-    schemaName,
-    visited,
-  );
+  const cv = await loadSchemaCv(api, bundleName, componentKey, schemaName, visited);
   if (!cv) return;
 
   // Discriminated union narrows on ``cv.type``.
@@ -453,13 +427,7 @@ async function collectConfigVars(
     for (const variant of Object.values(cv.types ?? {})) {
       if (!variant) continue;
       pushConfigVars(variant.config_vars, out, seenKeys);
-      await walkConfigVarExtends(
-        api,
-        variant.extends,
-        out,
-        seenKeys,
-        visited,
-      );
+      await walkConfigVarExtends(api, variant.extends, out, seenKeys, visited);
     }
     return;
   }
@@ -480,7 +448,7 @@ async function walkConfigVarExtends(
   extendsList: string[] | undefined,
   out: SchemaConfigVarKey[],
   seenKeys: Set<string>,
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<void> {
   for (const ext of extendsList ?? []) {
     const ref = parseExtendsRef(ext);
@@ -492,7 +460,7 @@ async function walkConfigVarExtends(
       ref.schemaName,
       out,
       seenKeys,
-      visited,
+      visited
     );
   }
 }
@@ -501,7 +469,7 @@ async function walkConfigVarExtends(
 function pushConfigVars(
   vars: Record<string, SchemaConfigVar | undefined> | undefined,
   out: SchemaConfigVarKey[],
-  seenKeys: Set<string>,
+  seenKeys: Set<string>
 ): void {
   if (!vars) return;
   for (const [key, decl] of Object.entries(vars)) {
@@ -531,7 +499,7 @@ function pushConfigVars(
  *  dispatch.
  */
 function parseExtendsRef(
-  ext: string,
+  ext: string
 ): { bundle: string; componentKey: string; schemaName: string } | null {
   const parts = ext.split(".");
   if (parts.length === 2) {
@@ -557,7 +525,7 @@ async function loadSchemaCv(
   bundleName: string,
   componentKey: string,
   schemaName: string,
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<SchemaConfigVar | null> {
   const visitKey = `${bundleName}|${componentKey}|${schemaName}`;
   if (visited.has(visitKey)) return null;
@@ -566,8 +534,9 @@ async function loadSchemaCv(
   if (!bundle) return null;
   const component = bundle[componentKey];
   if (!component) return null;
-  const cv: SchemaConfigVar | undefined = (component as SchemaComponent)
-    .schemas?.[schemaName];
+  const cv: SchemaConfigVar | undefined = (component as SchemaComponent).schemas?.[
+    schemaName
+  ];
   if (!cv || typeof cv !== "object") return null;
   return cv;
 }
@@ -592,7 +561,7 @@ export async function getConfigVarValueOptions(
   api: ESPHomeAPI,
   bundleName: string,
   componentKey: string,
-  varKey: string,
+  varKey: string
 ): Promise<SchemaEnumValue[]> {
   const out: SchemaEnumValue[] = [];
   await collectEnumValues(
@@ -602,7 +571,7 @@ export async function getConfigVarValueOptions(
     "CONFIG_SCHEMA",
     varKey,
     out,
-    new Set(),
+    new Set()
   );
   return out;
 }
@@ -614,20 +583,14 @@ async function collectEnumValues(
   schemaName: string,
   varKey: string,
   out: SchemaEnumValue[],
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<void> {
   if (out.length > 0) return; // first hit wins
-  const cv = await loadSchemaCv(
-    api,
-    bundleName,
-    componentKey,
-    schemaName,
-    visited,
-  );
+  const cv = await loadSchemaCv(api, bundleName, componentKey, schemaName, visited);
   if (!cv) return;
 
   const tryVars = (
-    vars: Record<string, SchemaConfigVar | undefined> | undefined,
+    vars: Record<string, SchemaConfigVar | undefined> | undefined
   ): boolean => {
     const decl = vars?.[varKey];
     // Discriminated union narrows ``decl`` to ``SchemaConfigVarEnum``
@@ -667,7 +630,7 @@ async function walkEnumExtends(
   extendsList: string[] | undefined,
   varKey: string,
   out: SchemaEnumValue[],
-  visited: Set<string>,
+  visited: Set<string>
 ): Promise<void> {
   for (const ext of extendsList ?? []) {
     const ref = parseExtendsRef(ext);
@@ -679,7 +642,7 @@ async function walkEnumExtends(
       ref.schemaName,
       varKey,
       out,
-      visited,
+      visited
     );
     if (out.length > 0) return;
   }
@@ -723,7 +686,7 @@ export async function getRegistryEntryKeys(
   api: ESPHomeAPI,
   bundleName: string,
   componentName: string,
-  entryName: string,
+  entryName: string
 ): Promise<SchemaConfigVarKey[]> {
   const bundle = await fetchBundle(api, bundleName);
   if (!bundle) return [];
@@ -743,7 +706,7 @@ export async function getRegistryEntryKeys(
  *  schemas. Shared between every registry-entry path. */
 async function readRegistryEntrySchema(
   api: ESPHomeAPI,
-  entry: SchemaConfigVar,
+  entry: SchemaConfigVar
 ): Promise<SchemaConfigVarKey[]> {
   const out: SchemaConfigVarKey[] = [];
   const seen = new Set<string>();
@@ -755,13 +718,7 @@ async function readRegistryEntrySchema(
     for (const variant of Object.values(entry.types ?? {})) {
       if (!variant) continue;
       pushConfigVars(variant.config_vars, out, seen);
-      await walkConfigVarExtends(
-        api,
-        variant.extends,
-        out,
-        seen,
-        new Set(),
-      );
+      await walkConfigVarExtends(api, variant.extends, out, seen, new Set());
     }
     return out;
   }
@@ -794,7 +751,7 @@ async function readRegistryEntrySchema(
  *  actions just to translate ``"core" → bundle "esphome"``.)
  */
 export function parseRegistryLabel(
-  label: string,
+  label: string
 ): { bundleName: string; componentName: string; entryName: string } | null {
   const parts = label.split(".");
   if (parts.length === 1) {
@@ -829,7 +786,7 @@ export async function lookupRegistryRef(
   api: ESPHomeAPI,
   bundleName: string,
   componentKey: string,
-  varKey: string,
+  varKey: string
 ): Promise<string | null> {
   // Read off the memoised key list — ``getConfigVarKeys`` walks
   // the typed/extends chain once per ``<bundle>|<componentKey>``
@@ -850,7 +807,7 @@ export async function lookupRegistryRef(
  */
 export async function getRegistryEntries(
   api: ESPHomeAPI,
-  registryRef: string,
+  registryRef: string
 ): Promise<SchemaRegistryEntry[]> {
   const dot = registryRef.indexOf(".");
   if (dot < 0) return [];
@@ -898,11 +855,9 @@ export async function getRegistryEntries(
 export async function getActions(
   api: ESPHomeAPI,
   bundleNames: string[],
-  componentKeys: string[],
+  componentKeys: string[]
 ): Promise<SchemaAction[]> {
-  const bundles = await Promise.all(
-    bundleNames.map((name) => fetchBundle(api, name)),
-  );
+  const bundles = await Promise.all(bundleNames.map((name) => fetchBundle(api, name)));
   const wantedKeys = new Set(componentKeys);
   const out: SchemaAction[] = [];
   const seen = new Set<string>();

--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -10,11 +10,7 @@
  */
 import { parser as yamlParser } from "@lezer/yaml";
 import { cppLanguage } from "@codemirror/lang-cpp";
-import {
-  LRLanguage,
-  LanguageSupport,
-  indentService,
-} from "@codemirror/language";
+import { LRLanguage, LanguageSupport, indentService } from "@codemirror/language";
 import { parseMixed } from "@lezer/common";
 import type { SyntaxNodeRef, Input } from "@lezer/common";
 

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -33,7 +33,7 @@ const collator = new Intl.Collator(undefined, {
 /** Tally a (raw → count) map and turn it into a sorted FacetOption[]. */
 function tallyToFacet(
   counts: Map<string, number>,
-  displayName: (raw: string) => string,
+  displayName: (raw: string) => string
 ): FacetOption[] {
   const entries: FacetOption[] = [];
   for (const [id, count] of counts) {
@@ -44,11 +44,7 @@ function tallyToFacet(
   // break keeps equal-count entries in a predictable order
   // between renders (and matches the order on the device cards /
   // table sort by name).
-  entries.sort(
-    (a, b) =>
-      b.count - a.count ||
-      collator.compare(a.name, b.name),
-  );
+  entries.sort((a, b) => b.count - a.count || collator.compare(a.name, b.name));
   return entries;
 }
 
@@ -72,9 +68,7 @@ export function computeAreaFacet(devices: ConfiguredDevice[]): FacetOption[] {
  *  exactly as-is; the dashboard pill carries the raw stem because
  *  that's what users see in YAML / docs and an aliasing layer
  *  would lie about what the device actually runs. */
-export function computePlatformFacet(
-  devices: ConfiguredDevice[],
-): FacetOption[] {
+export function computePlatformFacet(devices: ConfiguredDevice[]): FacetOption[] {
   const counts = new Map<string, number>();
   for (const d of devices) {
     const platform = d.target_platform?.trim();
@@ -92,7 +86,7 @@ export function computePlatformFacet(
  *  fleet wakes up). */
 export function computeStateFacet(
   devices: ConfiguredDevice[],
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): FacetOption[] {
   const counts = new Map<string, number>();
   // Seed every enum value at zero so a missing bucket still
@@ -111,6 +105,6 @@ export function computeStateFacet(
     [DeviceState.UNKNOWN]: "dashboard.unknown",
   };
   return tallyToFacet(counts, (raw) =>
-    localize(labelKeyByState[raw as DeviceState] ?? "dashboard.unknown"),
+    localize(labelKeyByState[raw as DeviceState] ?? "dashboard.unknown")
   );
 }

--- a/src/util/firmware-job-display.ts
+++ b/src/util/firmware-job-display.ts
@@ -32,7 +32,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 export function firmwareJobDisplayName(
   job: FirmwareJob,
   devices: ConfiguredDevice[],
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ): string {
   if (job.job_type === JobType.RESET_BUILD_ENV || !job.configuration) {
     return localize("firmware_jobs.build_env_label");
@@ -63,10 +63,7 @@ export function firmwareJobDisplayName(
        for the new YAML so devices using ``.yml`` keep matching. */
     const oldExtMatch = job.configuration.match(/\.ya?ml$/);
     const ext = oldExtMatch ? oldExtMatch[0] : ".yaml";
-    const oldName = job.configuration.slice(
-      0,
-      job.configuration.length - ext.length,
-    );
+    const oldName = job.configuration.slice(0, job.configuration.length - ext.length);
     const newConfiguration = `${job.new_name}${ext}`;
     /* Look the configured device up under either side of the rename.
        Mid-flight both YAMLs can briefly exist (the new one written

--- a/src/util/firmware-job-status.ts
+++ b/src/util/firmware-job-status.ts
@@ -24,9 +24,7 @@ export const TERMINAL_JOB_STATUSES: ReadonlySet<JobStatus> = new Set([
  * meaning we haven't observed the job's status yet — counts as
  * non-terminal so the caller waits for an actual signal.
  */
-export function isTerminalJobStatus(
-  status: JobStatus | null | undefined,
-): boolean {
+export function isTerminalJobStatus(status: JobStatus | null | undefined): boolean {
   return status != null && TERMINAL_JOB_STATUSES.has(status);
 }
 

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -44,15 +44,14 @@ export interface FloatWithUnit {
  */
 export function parseFloatWithUnit(
   raw: unknown,
-  unitOptions: readonly string[],
+  unitOptions: readonly string[]
 ): FloatWithUnit {
   const fallbackUnit = unitOptions[0] ?? "";
   // Funnel everything through `String().trim()` so the rest of the
   // function only deals with strings. NaN/Infinity numbers stringify
   // to "NaN"/"Infinity" which `Number()` round-trips back to non-finite
   // — caught by the final `Number.isFinite` guard.
-  const text =
-    raw === null || raw === undefined ? "" : String(raw).trim();
+  const text = raw === null || raw === undefined ? "" : String(raw).trim();
   if (text === "") return { value: null, unit: fallbackUnit };
 
   const lowerText = text.toLowerCase();
@@ -77,10 +76,7 @@ export function parseFloatWithUnit(
     // captures more of the user's input — ``"50mHz"`` should match
     // ``mHz`` over ``Hz`` so the ``m`` prefix isn't stranded as
     // part of the numeric portion).
-    if (
-      score > bestScore ||
-      (score === bestScore && option.length > bestLength)
-    ) {
+    if (score > bestScore || (score === bestScore && option.length > bestLength)) {
       match = option;
       bestScore = score;
       bestLength = option.length;
@@ -124,7 +120,7 @@ export function serializeFloatWithUnit(parsed: FloatWithUnit): string {
  */
 export function placeholderForFloatWithUnit(
   defaultValue: unknown,
-  unitOptions: readonly string[],
+  unitOptions: readonly string[]
 ): string {
   if (defaultValue === null || defaultValue === undefined) return "";
   const parsed = parseFloatWithUnit(defaultValue, unitOptions);
@@ -139,7 +135,7 @@ export function placeholderForFloatWithUnit(
  */
 export function defaultUnitForFloatWithUnit(
   defaultValue: unknown,
-  unitOptions: readonly string[],
+  unitOptions: readonly string[]
 ): string {
   if (defaultValue !== null && defaultValue !== undefined) {
     const parsed = parseFloatWithUnit(defaultValue, unitOptions);
@@ -169,11 +165,10 @@ export function chooseDisplayUnit(
   rawValue: unknown,
   defaultValue: unknown,
   pendingUnit: string | undefined,
-  unitOptions: readonly string[],
+  unitOptions: readonly string[]
 ): string {
   const canonicalUnit = unitOptions[0] ?? "";
-  const hasValue =
-    rawValue !== null && rawValue !== undefined && rawValue !== "";
+  const hasValue = rawValue !== null && rawValue !== undefined && rawValue !== "";
   if (hasValue) {
     return parseFloatWithUnit(rawValue, unitOptions).unit || canonicalUnit;
   }

--- a/src/util/format-job-time.ts
+++ b/src/util/format-job-time.ts
@@ -5,11 +5,7 @@
  * `now` is passed in so callers can drive re-renders from a ticker
  * and tests are deterministic.
  */
-export function formatRelativeTime(
-  iso: string,
-  now: number,
-  locale?: string,
-): string {
+export function formatRelativeTime(iso: string, now: number, locale?: string): string {
   const past = new Date(iso).getTime();
   const diffSec = Math.round((past - now) / 1000);
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
@@ -28,11 +24,7 @@ export function formatRelativeTime(
  * drop the date so they stay short; older stamps prefix a short
  * month/day.
  */
-export function formatAbsoluteTime(
-  iso: string,
-  now: number,
-  locale?: string,
-): string {
+export function formatAbsoluteTime(iso: string, now: number, locale?: string): string {
   const date = new Date(iso);
   const today = new Date(now);
   const isSameDay =

--- a/src/util/integration-split.ts
+++ b/src/util/integration-split.ts
@@ -48,7 +48,7 @@ export interface IntegrationSplit {
 
 export function splitIntegrations(
   loaded: readonly string[] | null | undefined,
-  directlyReferenced: readonly string[] | null | undefined,
+  directlyReferenced: readonly string[] | null | undefined
 ): IntegrationSplit {
   const loadedList = loaded ?? [];
   const direct = directlyReferenced ?? [];

--- a/src/util/label-chip-template.ts
+++ b/src/util/label-chip-template.ts
@@ -78,14 +78,12 @@ export function renderLabelChip(label: Label): TemplateResult {
  *  doesn't have to gate. */
 export function renderLabelChips(
   labels: Label[],
-  options: { max?: number | null } = {},
+  options: { max?: number | null } = {}
 ): TemplateResult | typeof nothing {
   if (labels.length === 0) return nothing;
   const max = options.max ?? null;
   if (max === null || labels.length <= max) {
-    return html`<span class="label-chips">
-      ${labels.map(renderLabelChip)}
-    </span>`;
+    return html`<span class="label-chips"> ${labels.map(renderLabelChip)} </span>`;
   }
   const visible = labels.slice(0, max);
   const hidden = labels.slice(max);
@@ -108,7 +106,7 @@ export function renderLabelChips(
  *  rendering a placeholder chip alongside the resolved set. */
 export function resolveLabelIds(
   ids: readonly string[] | null | undefined,
-  catalog: readonly Label[],
+  catalog: readonly Label[]
 ): Label[] {
   if (!ids || ids.length === 0) return [];
   const byId = new Map(catalog.map((l) => [l.id, l]));

--- a/src/util/label-usage.ts
+++ b/src/util/label-usage.ts
@@ -33,7 +33,7 @@ export interface LabelUsageDevice {
  * zero.
  */
 export function computeLabelUsage(
-  devices: readonly LabelUsageDevice[],
+  devices: readonly LabelUsageDevice[]
 ): Record<string, number> {
   const usage: Record<string, number> = {};
   for (const d of devices) {
@@ -75,7 +75,7 @@ export function deleteConfirmKey(usage: number): string {
 export function isLabelNameDuplicate(
   name: string,
   existingNames: readonly string[],
-  editingName: string | null,
+  editingName: string | null
 ): boolean {
   const lower = name.trim().toLowerCase();
   if (!lower) return false;

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -125,7 +125,7 @@ function renderSegment(seg: Segment): TemplateResult | string {
  * conditional. Output is a Lit template; safe to interpolate.
  */
 export function renderMarkdown(
-  input: string | null | undefined,
+  input: string | null | undefined
 ): TemplateResult | typeof nothing {
   if (!input) return nothing;
   const segments = parseMarkdown(input);

--- a/src/util/nested-values.ts
+++ b/src/util/nested-values.ts
@@ -19,7 +19,7 @@
 export function setIn(
   obj: Record<string, unknown>,
   path: string[],
-  value: unknown,
+  value: unknown
 ): Record<string, unknown> {
   // Empty path → caller is replacing the whole object with *value*
   // (used by top-level map sections like ``substitutions:``, where
@@ -56,11 +56,7 @@ function _parseArrayIndex(segment: string): number | null {
  * existing child's shape (Array → ``_setInArray``; anything else
  * is coerced to ``{}`` and handed to ``setIn``).
  */
-function _newChild(
-  currentChild: unknown,
-  rest: string[],
-  value: unknown,
-): unknown {
+function _newChild(currentChild: unknown, rest: string[], value: unknown): unknown {
   if (rest.length === 0) return value;
   if (Array.isArray(currentChild)) {
     return _setInArray(currentChild, rest, value);
@@ -82,7 +78,7 @@ function _newChild(
 function _setInArray(
   arr: readonly unknown[],
   path: string[],
-  value: unknown,
+  value: unknown
 ): readonly unknown[] {
   const [head, ...rest] = path;
   const idx = _parseArrayIndex(head);
@@ -98,10 +94,7 @@ function _setInArray(
  * intermediate. Numeric path segments index into arrays (mirrors
  * the array-aware writes in :func:`setIn`).
  */
-export function getIn(
-  obj: Record<string, unknown>,
-  path: string[],
-): unknown {
+export function getIn(obj: Record<string, unknown>, path: string[]): unknown {
   let cur: unknown = obj;
   for (const k of path) {
     if (cur === null || cur === undefined || typeof cur !== "object") {
@@ -143,7 +136,7 @@ export function getIn(
  * object.
  */
 export function isPrimitiveOrNullish(
-  value: unknown,
+  value: unknown
 ): value is string | number | boolean | null | undefined {
   if (value === null || value === undefined) return true;
   const t = typeof value;
@@ -161,9 +154,7 @@ export function isPrimitiveOrNullish(
  * fresh ``{}``. Centralised so both call sites can share one
  * definition of "object I can deep-merge into".
  */
-export function isPlainObject(
-  value: unknown,
-): value is Record<string, unknown> {
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
@@ -189,8 +180,6 @@ export function asRecord(value: unknown): Record<string, unknown> {
  * ``Record<string, unknown>[]`` regardless of mid-edit YAML
  * weirdness.
  */
-export function asMappingList(
-  value: unknown,
-): Record<string, unknown>[] {
+export function asMappingList(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.map(asRecord) : [];
 }

--- a/src/util/onboarding-gate.ts
+++ b/src/util/onboarding-gate.ts
@@ -3,10 +3,7 @@
  * header-actions, broken out so it can be unit-tested without
  * dragging in the WebSocket client + Lit lifecycle.
  */
-import {
-  type OnboardingState,
-  OnboardingStepStatus,
-} from "../api/types.js";
+import { type OnboardingState, OnboardingStepStatus } from "../api/types.js";
 
 /** True when any onboarding step is data-derived ``pending``.
  *  Drives the ``Set up Wi-Fi…`` kebab entry's visibility. */
@@ -36,7 +33,7 @@ export function isOnboardingPending(state: OnboardingState): boolean {
  */
 export function shouldAutoShowOnboarding(
   state: OnboardingState,
-  sessionDismissed: boolean,
+  sessionDismissed: boolean
 ): boolean {
   return (
     state.completed_version < state.current_version &&

--- a/src/util/package-import-url.ts
+++ b/src/util/package-import-url.ts
@@ -49,7 +49,7 @@ export interface PackageImportUrlPreview {
 }
 
 export function previewPackageImportUrl(
-  raw: string | null | undefined,
+  raw: string | null | undefined
 ): PackageImportUrlPreview {
   if (!raw) {
     return { raw: "", browseUrl: null, service: null };

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -76,7 +76,7 @@ export function dispatchShowLogsAfterInstall(
  */
 export function postInstallShowLogsHandler(
   getLogsDialog: () => ESPHomeLogsDialog,
-  getLocalize: () => LocalizeFunc,
+  getLocalize: () => LocalizeFunc
 ): (e: CustomEvent<PostInstallShowLogsDetail>) => Promise<void> {
   return (e) => handlePostInstallShowLogs(e, getLogsDialog(), getLocalize());
 }
@@ -98,7 +98,7 @@ export function postInstallShowLogsHandler(
 async function openSerialWithRetry(
   port: SerialPort,
   baudRate: number,
-  timeoutMs: number,
+  timeoutMs: number
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   let lastErr: unknown = null;
@@ -129,7 +129,7 @@ async function openSerialWithRetry(
 export async function handlePostInstallShowLogs(
   e: CustomEvent<PostInstallShowLogsDetail>,
   logsDialog: ESPHomeLogsDialog,
-  localize: LocalizeFunc,
+  localize: LocalizeFunc
 ) {
   e.preventDefault();
   const { configuration, name, port, webSerialPort, reopenInstall } = e.detail;

--- a/src/util/relative-time.ts
+++ b/src/util/relative-time.ts
@@ -40,7 +40,7 @@ function getFormatter(language?: string): Intl.RelativeTimeFormat {
 
 export function formatSecondsAgo(
   secondsAgo: number | null | undefined,
-  language?: string,
+  language?: string
 ): string {
   if (secondsAgo === null || secondsAgo === undefined) return "";
 
@@ -81,7 +81,7 @@ export function formatSecondsAgo(
 export function ageOf(
   baselineSecondsAgo: number | null | undefined,
   anchorMs: number,
-  nowMs: number,
+  nowMs: number
 ): number | null {
   if (baselineSecondsAgo === null || baselineSecondsAgo === undefined) {
     return null;
@@ -116,12 +116,9 @@ export function ageOf(
 export function remainingOf(
   baselineRemainingSeconds: number | null | undefined,
   anchorMs: number,
-  nowMs: number,
+  nowMs: number
 ): number | null {
-  if (
-    baselineRemainingSeconds === null ||
-    baselineRemainingSeconds === undefined
-  ) {
+  if (baselineRemainingSeconds === null || baselineRemainingSeconds === undefined) {
     return null;
   }
   const elapsedSeconds = Math.max(0, (nowMs - anchorMs) / 1000);
@@ -146,7 +143,7 @@ const numberFormatterCache = new Map<string, Intl.NumberFormat>();
 
 export function getNumberFormatter(
   language: string | undefined,
-  maximumFractionDigits: number,
+  maximumFractionDigits: number
 ): Intl.NumberFormat {
   const key = `${language ?? "default"}|${maximumFractionDigits}`;
   let formatter = numberFormatterCache.get(key);

--- a/src/util/section-entry-overrides.ts
+++ b/src/util/section-entry-overrides.ts
@@ -36,9 +36,7 @@ import { makeConfigEntry } from "./config-entry-defaults.js";
  *  YAML with ``{}`` on save (#361), so packages now goes through
  *  ``YAML_ONLY_SECTIONS`` instead — both shapes round-trip via
  *  the YAML pane. */
-export const MAP_SECTIONS: ReadonlySet<string> = new Set([
-  "substitutions",
-]);
+export const MAP_SECTIONS: ReadonlySet<string> = new Set(["substitutions"]);
 
 /** Sections that must persist explicit ``""`` values in YAML — i.e.
  *  the user typed a key + cleared the value, treat that as
@@ -46,9 +44,7 @@ export const MAP_SECTIONS: ReadonlySet<string> = new Set([
  *  ``substitutions`` is currently the only one: its values are
  *  user-supplied strings, and a cleared value means "this
  *  substitution is intentionally empty". */
-export const KEEP_EMPTY_STRING_SECTIONS: ReadonlySet<string> = new Set([
-  "substitutions",
-]);
+export const KEEP_EMPTY_STRING_SECTIONS: ReadonlySet<string> = new Set(["substitutions"]);
 
 /** Synthesised entries shared by every section in :data:`MAP_SECTIONS`
  *  — a single MAP whose value template is a string. The user names
@@ -95,7 +91,7 @@ const MAP_SECTION_ENTRIES: ConfigEntry[] = [
  */
 export function resolveSectionEntries(
   sectionKey: string,
-  catalogEntries: ConfigEntry[],
+  catalogEntries: ConfigEntry[]
 ): ConfigEntry[] {
   if (MAP_SECTIONS.has(sectionKey)) return MAP_SECTION_ENTRIES;
   return catalogEntries;

--- a/src/util/snapshot.ts
+++ b/src/util/snapshot.ts
@@ -29,7 +29,7 @@
  */
 export function seededMap<T, K>(
   rows: readonly T[] | undefined,
-  keyFn: (row: T) => K,
+  keyFn: (row: T) => K
 ): Map<K, T> | null {
   if (rows === undefined) return null;
   return new Map(rows.map((row) => [keyFn(row), row]));

--- a/src/util/template-split.ts
+++ b/src/util/template-split.ts
@@ -8,10 +8,7 @@
 // placeholder absent from the template yields an empty string in its slot
 // and the remainder stays trailing, matching the existing call sites'
 // pair-of-split-with-default-empty pattern.
-export function splitTemplate(
-  template: string,
-  ...placeholders: string[]
-): string[] {
+export function splitTemplate(template: string, ...placeholders: string[]): string[] {
   let rest = template;
   const parts: string[] = [];
   for (const placeholder of placeholders) {

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -39,7 +39,7 @@ export type VersionMismatchKind = "patch" | "release" | null;
  */
 export function classifyVersionMismatch(
   local: string,
-  peer: string,
+  peer: string
 ): VersionMismatchKind {
   // Either side unknown — handshake hasn't filled in the peer
   // value yet (PENDING / first-session) or the local probe
@@ -60,12 +60,8 @@ export function classifyVersionMismatch(
   // 2026.5b1 and 2026.5 still classify as the same release.
   const localParts = local.split(".");
   const peerParts = peer.split(".");
-  const localRelease = `${localParts[0] ?? ""}.${stripSuffix(
-    localParts[1] ?? "",
-  )}`;
-  const peerRelease = `${peerParts[0] ?? ""}.${stripSuffix(
-    peerParts[1] ?? "",
-  )}`;
+  const localRelease = `${localParts[0] ?? ""}.${stripSuffix(localParts[1] ?? "")}`;
+  const peerRelease = `${peerParts[0] ?? ""}.${stripSuffix(peerParts[1] ?? "")}`;
   return localRelease === peerRelease ? "patch" : "release";
 }
 

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -5,12 +5,7 @@
  * Web Serial API. No backend involvement — talks directly to the
  * USB-connected ESP device.
  */
-import {
-  ClassicReset,
-  ESPLoader,
-  Transport,
-  UsbJtagSerialReset,
-} from "esptool-js";
+import { ClassicReset, ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 const ESPRESSIF_USB_VID = 0x303a;
@@ -64,7 +59,7 @@ export function markSerialActivity(): void {
 }
 
 export function isRecentSerialActivity(
-  windowMs: number = SERIAL_ACTIVITY_WINDOW_MS,
+  windowMs: number = SERIAL_ACTIVITY_WINDOW_MS
 ): boolean {
   return Date.now() - _lastSerialActivityMs < windowMs;
 }
@@ -80,7 +75,10 @@ export function isRecentSerialActivity(
  * and falls back to ``port.close()`` so we never leak an open port —
  * a still-open port silently breaks the next ``port.open()`` call.
  */
-export async function connectToPort(port: SerialPort, onLog?: LogCallback): Promise<DetectedChip> {
+export async function connectToPort(
+  port: SerialPort,
+  onLog?: LogCallback
+): Promise<DetectedChip> {
   markSerialActivity();
   const transport = new Transport(port, false);
 
@@ -168,7 +166,9 @@ const APP_DESC_MAGIC = 0xabcd5432;
  * empty, or when the flash read fails — callers fall through to
  * chip-name-based board detection in that case.
  */
-export async function readDeviceManifest(loader: ESPLoader): Promise<DeviceManifest | null> {
+export async function readDeviceManifest(
+  loader: ESPLoader
+): Promise<DeviceManifest | null> {
   markSerialActivity();
   try {
     const bytes = await loader.readFlash(APP_DESC_OFFSET, APP_DESC_SIZE);
@@ -284,10 +284,7 @@ const RTC_CNTL_WDT_WKEY = 0x50d83aa1;
  * Returns ``false`` for chip types where this isn't safe (ESP32-C6
  * freezes; classic ESP32 / ESP8266 don't have the WDT at all).
  */
-async function watchdogReset(
-  loader: ESPLoader,
-  transport: Transport,
-): Promise<boolean> {
+async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<boolean> {
   const regs = loader.chip?.CHIP_NAME
     ? WDT_RESET_CHIPS[loader.chip.CHIP_NAME]
     : undefined;
@@ -312,10 +309,7 @@ async function watchdogReset(
   try {
     await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
     await loader.writeReg(regs.wdtConfig1, 2000);
-    await loader.writeReg(
-      regs.wdtConfig0,
-      (1 << 31) | (5 << 28) | (1 << 8) | 2,
-    );
+    await loader.writeReg(regs.wdtConfig0, (1 << 31) | (5 << 28) | (1 << 8) | 2);
     await loader.writeReg(regs.wdtWProtect, 0);
   } catch {
     /* A writeReg may race the actual reset firing — the chip is
@@ -356,7 +350,7 @@ async function watchdogReset(
 async function hardResetChip(
   loader: ESPLoader,
   transport: Transport,
-  port: SerialPort,
+  port: SerialPort
 ): Promise<void> {
   if (await watchdogReset(loader, transport)) return;
   const vendorId = port.getInfo().usbVendorId;
@@ -371,7 +365,7 @@ async function hardResetChip(
 export async function resetAndDisconnect(
   loader: ESPLoader,
   transport: Transport,
-  port: SerialPort,
+  port: SerialPort
 ): Promise<void> {
   markSerialActivity();
   try {

--- a/src/util/web-ui-url.ts
+++ b/src/util/web-ui-url.ts
@@ -54,6 +54,6 @@ export function buildWebUiUrl(device: ConfiguredDevice): string {
   const host = device.address || device.ip;
   if (!host) return "";
   return safeWebUiUrl(
-    `http://${_bracketIpv6(host)}${device.web_port === 80 ? "" : `:${device.web_port}`}`,
+    `http://${_bracketIpv6(host)}${device.web_port === 80 ? "" : `:${device.web_port}`}`
   );
 }

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -50,10 +50,7 @@ function readLiteralText(state: EditorState, node: SyntaxNode): string {
  *  quotes if it wraps a ``QuotedLiteral``. Returns ``null`` for
  *  non-scalar keys (block-mapping / sequence keys are valid YAML
  *  but never component-name keys we'd want to match here). */
-export function readKeyText(
-  state: EditorState,
-  key: SyntaxNode,
-): string | null {
+export function readKeyText(state: EditorState, key: SyntaxNode): string | null {
   // ``Key`` wraps an ``element`` — the literal we care about is
   // its first leaf-ish child (Literal / QuotedLiteral).
   let inner: SyntaxNode | null = key.firstChild;
@@ -74,19 +71,14 @@ export function readKeyText(
 }
 
 /** Walk up from any node to the nearest enclosing ``Pair``. */
-export function findEnclosingPair(
-  node: SyntaxNode | null,
-): SyntaxNode | null {
+export function findEnclosingPair(node: SyntaxNode | null): SyntaxNode | null {
   let cur = node;
   while (cur && cur.name !== "Pair") cur = cur.parent;
   return cur;
 }
 
 /** Read the ``Key`` text of a ``Pair`` directly. */
-export function getPairKey(
-  state: EditorState,
-  pair: SyntaxNode,
-): string | null {
+export function getPairKey(state: EditorState, pair: SyntaxNode): string | null {
   const key = pair.getChild("Key");
   if (!key) return null;
   return readKeyText(state, key);
@@ -99,9 +91,7 @@ export function getPairKey(
  * isn't nested under a top-level mapping (e.g. unparseable
  * single-line input).
  */
-export function findTopLevelPair(
-  node: SyntaxNode | null,
-): SyntaxNode | null {
+export function findTopLevelPair(node: SyntaxNode | null): SyntaxNode | null {
   let cur = findEnclosingPair(node);
   while (cur) {
     const map = cur.parent;
@@ -149,10 +139,7 @@ const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
  * list-item position via ``isListItem`` so this only triggers
  * the registry at the dash position.
  */
-export function isUnderAutomationItem(
-  state: EditorState,
-  pos: number,
-): boolean {
+export function isUnderAutomationItem(state: EditorState, pos: number): boolean {
   const node = syntaxTree(state).resolveInner(pos, -1);
   let cur: SyntaxNode | null = node;
   while (cur) {
@@ -177,10 +164,7 @@ export function isUnderAutomationItem(
  * cursor isn't nested under a top-level mapping pair (e.g.
  * cursor at the very top of an empty doc).
  */
-export function getTopLevelKey(
-  state: EditorState,
-  pos: number,
-): string | null {
+export function getTopLevelKey(state: EditorState, pos: number): string | null {
   const node = syntaxTree(state).resolveInner(pos, -1);
   const top = findTopLevelPair(node);
   if (!top) return null;
@@ -193,10 +177,7 @@ export function getTopLevelKey(
  * ``null`` when the cursor isn't inside a list-item that declares
  * a ``platform:`` sibling.
  */
-export function getPlatformValue(
-  state: EditorState,
-  pos: number,
-): string | null {
+export function getPlatformValue(state: EditorState, pos: number): string | null {
   // Walk up through every enclosing ``Item`` until one has a
   // ``platform:`` pair as a direct child of its mapping. Inner
   // list-of-mappings positions (cursor inside a ``filters:`` /
@@ -236,7 +217,7 @@ export function getPlatformValue(
  */
 export function resolveBundleContext(
   state: EditorState,
-  pos: number,
+  pos: number
 ): { topLevelKey: string; platformValue: string | null } | null {
   const topLevelKey = getTopLevelKey(state, pos);
   if (!topLevelKey) return null;

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -260,8 +260,7 @@ function entryToCompletion(entry: ConfigEntry): Completion {
   detailParts.push(entry.required ? "required" : entry.type);
   return {
     label: entry.key,
-    apply: (view, _completion, from, to) =>
-      applyKeyInsertion(view, from, to, entry.key),
+    apply: (view, _completion, from, to) => applyKeyInsertion(view, from, to, entry.key),
     type: iconType(entry.type),
     detail: detailParts.join(" · "),
     info: buildEntryInfo(entry),
@@ -344,9 +343,7 @@ export function buildTopLevelCompletions(catalog: CatalogIndex): Completion[] {
   return out;
 }
 
-export function platformValueCompletion(
-  c: ComponentCatalogEntry,
-): Completion {
+export function platformValueCompletion(c: ComponentCatalogEntry): Completion {
   // ``c.id`` is the dotted catalog id (``binary_sensor.gpio``);
   // YAML's ``platform:`` value is just the stem (``gpio``).
   // Strip the domain prefix so the inserted text is valid YAML —
@@ -379,7 +376,7 @@ function applyInsertion(
   view: EditorView,
   from: number,
   to: number,
-  insert: string,
+  insert: string
 ): void {
   view.dispatch({
     changes: { from, to, insert },
@@ -397,7 +394,7 @@ function applyKeyInsertion(
   view: EditorView,
   from: number,
   to: number,
-  key: string,
+  key: string
 ): void {
   applyInsertion(view, from, to, `${key}: `);
   startCompletion(view);
@@ -412,15 +409,10 @@ function applyListBlockInsertion(
   view: EditorView,
   from: number,
   to: number,
-  key: string,
+  key: string
 ): void {
   const lead = readLineLead(view, from);
-  applyInsertion(
-    view,
-    from,
-    to,
-    `${key}:\n${lead}${ESPHOME_YAML_INDENT}- `,
-  );
+  applyInsertion(view, from, to, `${key}:\n${lead}${ESPHOME_YAML_INDENT}- `);
   startCompletion(view);
 }
 
@@ -433,7 +425,7 @@ function applyListItemEntry(
   view: EditorView,
   from: number,
   to: number,
-  key: string,
+  key: string
 ): void {
   const line = view.state.doc.lineAt(from);
   const before = line.text.slice(0, from - line.from);
@@ -484,7 +476,7 @@ function triggerToCompletion(t: { key: string; docs?: string }): Completion {
         view,
         from,
         to,
-        `${t.key}:\n${inner}then:\n${inner}${ESPHOME_YAML_INDENT}- `,
+        `${t.key}:\n${inner}then:\n${inner}${ESPHOME_YAML_INDENT}- `
       );
     },
     type: "namespace",
@@ -505,8 +497,7 @@ function triggerToCompletion(t: { key: string; docs?: string }): Completion {
 function actionToCompletion(a: SchemaAction): Completion {
   return {
     label: a.key,
-    apply: (view, _completion, from, to) =>
-      applyListItemEntry(view, from, to, a.key),
+    apply: (view, _completion, from, to) => applyListItemEntry(view, from, to, a.key),
     type: "function",
     detail: "action",
     info: a.docs ?? undefined,
@@ -518,14 +509,10 @@ function actionToCompletion(a: SchemaAction): Completion {
  *  registry-key name itself (``filter`` / ``effects``) so the
  *  popup distinguishes filters from actions when both could
  *  apply. */
-function registryToCompletion(
-  e: SchemaRegistryEntry,
-  registryKey: string,
-): Completion {
+function registryToCompletion(e: SchemaRegistryEntry, registryKey: string): Completion {
   return {
     label: e.key,
-    apply: (view, _completion, from, to) =>
-      applyListItemEntry(view, from, to, e.key),
+    apply: (view, _completion, from, to) => applyListItemEntry(view, from, to, e.key),
     type: "function",
     detail: registryKey,
     info: e.docs ?? undefined,
@@ -553,7 +540,7 @@ function registryToCompletion(
  */
 function bundleFor(
   topLevelKey: string,
-  platformValue: string | null,
+  platformValue: string | null
 ): { bundle: string; componentKey: string } {
   return platformValue
     ? {
@@ -586,7 +573,7 @@ export async function resolveAvailableEntries(
   catalog: CatalogIndex,
   parentKey: string,
   platformValue: string | null,
-  topLevelKey: string | null,
+  topLevelKey: string | null
 ): Promise<ConfigEntry[]> {
   // Special case: cursor is nested under a list-item header
   // (``- platform: template`` → parentKey="platform"). The form
@@ -655,7 +642,7 @@ function resolveCompletionContext(
   pos: number,
   allLines: string[],
   lineIdx: number,
-  indent: number,
+  indent: number
 ): {
   platformValue: string | null;
   topLevelKey: string | null;
@@ -781,14 +768,14 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         pos,
         allLines,
         lineInfo.number - 1,
-        indent,
+        indent
       );
       const entries = await resolveAvailableEntries(
         api,
         catalog,
         parent.key,
         completionCtx.platformValue,
-        completionCtx.topLevelKey,
+        completionCtx.topLevelKey
       );
       const entry = entries.find((e) => e.key === key);
 
@@ -827,15 +814,12 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       // (``device_class:``), since Lezer hasn't seen the value
       // yet.
       if (completionCtx.topLevelKey) {
-        const target = bundleFor(
-          completionCtx.topLevelKey,
-          completionCtx.platformValue,
-        );
+        const target = bundleFor(completionCtx.topLevelKey, completionCtx.platformValue);
         const enumValues = await getConfigVarValueOptions(
           api,
           target.bundle,
           target.componentKey,
-          key,
+          key
         );
         if (enumValues.length > 0) {
           return {
@@ -888,7 +872,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       pos,
       allLines,
       lineInfo.number - 1,
-      indent,
+      indent
     );
     const keyCtx: KeyPositionCtx = {
       api,
@@ -914,9 +898,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         ctx.explicit || partial === "" || RE_TRIGGER_PREFIX.test(partial),
     };
 
-    const buckets = await Promise.all(
-      KEY_POSITION_PROVIDERS.map((p) => p.fetch(keyCtx)),
-    );
+    const buckets = await Promise.all(KEY_POSITION_PROVIDERS.map((p) => p.fetch(keyCtx)));
     const options = buckets.flat();
     if (options.length === 0) return null;
 
@@ -1009,7 +991,7 @@ async function resolveCatalogEntries(k: KeyPositionCtx): Promise<ConfigEntry[]> 
       k.catalog,
       k.parent.key,
       k.platformValue,
-      k.topLevelKey,
+      k.topLevelKey
     );
   }
   return k._cachedCatalogEntries;
@@ -1054,11 +1036,7 @@ const triggerKeysProvider: KeyPositionProvider = {
     if (!k.partialCouldBeTrigger) return [];
     if (!k.bundleCtx) return [];
     const target = bundleFor(k.bundleCtx.topLevelKey, k.bundleCtx.platformValue);
-    const triggers = await getTriggerKeys(
-      k.api,
-      target.bundle,
-      target.componentKey,
-    );
+    const triggers = await getTriggerKeys(k.api, target.bundle, target.componentKey);
     return triggers.map(triggerToCompletion);
   },
 };
@@ -1094,7 +1072,7 @@ const filterRegistryProvider: KeyPositionProvider = {
       k.api,
       target.bundle,
       target.componentKey,
-      k.parent.key,
+      k.parent.key
     );
     if (!ref) return [];
     const entries = await getRegistryEntries(k.api, ref);
@@ -1154,7 +1132,7 @@ const registryEntryArgsProvider: KeyPositionProvider = {
       k.api,
       ref.bundleName,
       ref.componentName,
-      ref.entryName,
+      ref.entryName
     );
     return keys.map(schemaKeyToCompletion);
   },
@@ -1192,4 +1170,3 @@ const KEY_POSITION_PROVIDERS: KeyPositionProvider[] = [
   platformKeyProvider,
   triggerBodyProvider,
 ];
-

--- a/src/util/yaml-editor-theme.ts
+++ b/src/util/yaml-editor-theme.ts
@@ -44,13 +44,20 @@ const darkHighlight = HighlightStyle.define([
   { tag: t.bool, color: "#569cd6" },
   { tag: t.null, color: "#569cd6" },
   { tag: t.atom, color: "#569cd6" },
-  { tag: [t.lineComment, t.blockComment, t.comment], color: "#6a9955", fontStyle: "italic" },
+  {
+    tag: [t.lineComment, t.blockComment, t.comment],
+    color: "#6a9955",
+    fontStyle: "italic",
+  },
   { tag: t.definition(t.propertyName), color: "#9cdcfe" },
   { tag: t.propertyName, color: "#9cdcfe" },
   { tag: t.labelName, color: "#dcdcaa" },
   { tag: t.typeName, color: "#4ec9b0" },
   { tag: t.meta, color: "#c586c0" },
-  { tag: [t.separator, t.punctuation, t.bracket, t.squareBracket, t.brace], color: DARK_FG },
+  {
+    tag: [t.separator, t.punctuation, t.bracket, t.squareBracket, t.brace],
+    color: DARK_FG,
+  },
   { tag: t.content, color: DARK_FG },
 ]);
 
@@ -63,13 +70,20 @@ const lightHighlight = HighlightStyle.define([
   { tag: t.bool, color: "#0550ae" },
   { tag: t.null, color: "#0550ae" },
   { tag: t.atom, color: "#0550ae" },
-  { tag: [t.lineComment, t.blockComment, t.comment], color: "#6e7781", fontStyle: "italic" },
+  {
+    tag: [t.lineComment, t.blockComment, t.comment],
+    color: "#6e7781",
+    fontStyle: "italic",
+  },
   { tag: t.definition(t.propertyName), color: "#0550ae" },
   { tag: t.propertyName, color: "#0550ae" },
   { tag: t.labelName, color: "#6f42c1" },
   { tag: t.typeName, color: "#953800" },
   { tag: t.meta, color: "#8250df" },
-  { tag: [t.separator, t.punctuation, t.bracket, t.squareBracket, t.brace], color: LIGHT_FG },
+  {
+    tag: [t.separator, t.punctuation, t.bracket, t.squareBracket, t.brace],
+    color: LIGHT_FG,
+  },
   { tag: t.content, color: LIGHT_FG },
 ]);
 
@@ -107,7 +121,7 @@ const darkBase = EditorView.theme(
       backgroundColor: "#9d550f",
     },
   },
-  { dark: true },
+  { dark: true }
 );
 
 const lightBase = EditorView.theme(
@@ -144,7 +158,7 @@ const lightBase = EditorView.theme(
       backgroundColor: "#ffd33d",
     },
   },
-  { dark: false },
+  { dark: false }
 );
 
 export const vscodeDark: Extension = [darkBase, syntaxHighlighting(darkHighlight)];

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -79,7 +79,7 @@ export interface ParentKey {
 export function findParentKey(
   lines: string[],
   lineIdx: number,
-  belowIndent: number,
+  belowIndent: number
 ): ParentKey | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
     const stripped = stripComment(lines[i]);
@@ -93,10 +93,7 @@ export function findParentKey(
 }
 
 /** Walk back from *lineIdx* to the first column-0 ``key:`` line. */
-export function findTopLevelBlock(
-  lines: string[],
-  lineIdx: number,
-): string | null {
+export function findTopLevelBlock(lines: string[], lineIdx: number): string | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
     const stripped = stripComment(lines[i]);
     if (!stripped.trim()) continue;
@@ -123,7 +120,7 @@ export function findTopLevelBlock(
 export function readPlatformSibling(
   lines: string[],
   lineIdx: number,
-  indent: number,
+  indent: number
 ): string | null {
   // First pass: scan back for *any* ``- platform: <value>`` at a
   // shallower indent than the cursor. This catches the

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -40,7 +40,7 @@ const _lastValidated = new Map<
 /** Return the linter's last result if it matches the current buffer and is fresh. */
 export function getLastValidatedResult(
   configuration: string,
-  content: string,
+  content: string
 ): EditorValidateResponse | null {
   const entry = _lastValidated.get(configuration);
   if (entry === undefined || entry.content !== content) return null;
@@ -52,7 +52,7 @@ export function getLastValidatedResult(
 export function __setLastValidatedForTesting(
   configuration: string,
   content: string,
-  result: EditorValidateResponse,
+  result: EditorValidateResponse
 ): void {
   _lastValidated.set(configuration, { content, result, at: performance.now() });
 }
@@ -68,7 +68,7 @@ const YAML_LINE_RE = /line\s+(\d+)/i;
  */
 function rangeToOffsets(
   view: EditorView,
-  range: { start_line: number; start_col: number; end_line: number; end_col: number },
+  range: { start_line: number; start_col: number; end_line: number; end_col: number }
 ): { from: number; to: number } {
   const doc = view.state.doc;
   const totalLines = doc.lines;
@@ -104,7 +104,7 @@ function rangeToOffsets(
 function lineToOffsets(
   view: EditorView,
   line1: number,
-  col1: number | null,
+  col1: number | null
 ): { from: number; to: number } {
   const doc = view.state.doc;
   const lineNum = Math.min(Math.max(line1, 1), doc.lines);
@@ -193,6 +193,6 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
       // Don't auto-open the panel — we only want the inline wavy underlines
       // and hover tooltip.
       autoPanel: false,
-    },
+    }
   );
 }

--- a/src/util/yaml-search-helpers.ts
+++ b/src/util/yaml-search-helpers.ts
@@ -73,9 +73,7 @@ function maskSensitiveLine(line: string): string {
   // ``# password: hunter2`` is just as much a leak as the live
   // form. The leading-``#`` group is captured into ``prefix`` so
   // the masked output preserves the comment marker.
-  const m = line.match(
-    /^(\s*(?:#+\s*)?-?\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$/
-  );
+  const m = line.match(/^(\s*(?:#+\s*)?-?\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$/);
   if (!m) return line;
   const [, prefix, key, valueRaw] = m;
   if (!isSensitiveKey(key)) return line;
@@ -134,9 +132,7 @@ function maskSnippetBlock(lines: readonly string[]): string[] {
     const value = line.slice(range.valueFrom, range.valueTo).trim();
     if (value.startsWith("${")) continue;
     out[idx] =
-      line.slice(0, range.valueFrom) +
-      MASK_PLACEHOLDER +
-      line.slice(range.valueTo);
+      line.slice(0, range.valueFrom) + MASK_PLACEHOLDER + line.slice(range.valueTo);
     scannerMaskedLines.add(idx);
   }
   for (let i = 0; i < out.length; i++) {
@@ -373,8 +369,6 @@ export function yamlSnippetBlockHref(
   // that somehow has no matched lines — defensive only;
   // ``buildYamlSnippetBlocks`` always populates it.
   const firstMatch =
-    block.matchedLines.size > 0
-      ? Math.min(...block.matchedLines)
-      : block.startLine;
+    block.matchedLines.size > 0 ? Math.min(...block.matchedLines) : block.startLine;
   return `/device/${encodeURIComponent(hit.configuration)}?line=${firstMatch}`;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -58,9 +58,7 @@ const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_]/;
  * "inline key" means; sharing the regex makes that a compile-time
  * fact.
  */
-const LIST_ITEM_INLINE_KEY_RE = new RegExp(
-  `^\\s+-\\s+(${KEY_PATTERN}):\\s*(.*)$`,
-);
+const LIST_ITEM_INLINE_KEY_RE = new RegExp(`^\\s+-\\s+(${KEY_PATTERN}):\\s*(.*)$`);
 
 /**
  * Detect a YAML list-item start. Accepts both the standard
@@ -145,8 +143,7 @@ const childRegexFor = (indent: string) =>
 // the dash (detected from the actual list content by the caller),
 // not the parent key's indent — a 4-space user file puts the
 // dash at ``parent + 4``, not the canonical ``parent + 2``.
-const listItemRegexFor = (dashIndent: string) =>
-  new RegExp(`^${dashIndent}-\\s+(.*)$`);
+const listItemRegexFor = (dashIndent: string) => new RegExp(`^${dashIndent}-\\s+(.*)$`);
 
 /**
  * True when *line* is structurally invisible to the key/value
@@ -172,10 +169,7 @@ const isBlankOrCommentLine = (line: string): boolean => {
  * lines. Returns the first index that holds real content, or
  * ``lines.length`` if none.
  */
-const _skipBlankAndCommentLines = (
-  lines: string[],
-  startIdx: number,
-): number => {
+const _skipBlankAndCommentLines = (lines: string[], startIdx: number): number => {
   let j = startIdx;
   while (j < lines.length && isBlankOrCommentLine(lines[j])) j++;
   return j;
@@ -190,8 +184,7 @@ const _skipBlankAndCommentLines = (
  * 2-space canonical form, and pasting one into the editor
  * shouldn't silently come back empty.
  */
-const _leadingIndent = (line: string): string =>
-  line.match(/^ */)![0];
+const _leadingIndent = (line: string): string => line.match(/^ */)![0];
 
 /**
  * Walk forward from *startIdx* and return the indent of the first
@@ -205,7 +198,7 @@ const _leadingIndent = (line: string): string =>
 const _detectSectionChildIndent = (
   lines: string[],
   startIdx: number,
-  isListItem: boolean,
+  isListItem: boolean
 ): string => {
   // The "floor" is the column a child line must strictly beat. For
   // map sections that's the section header's leading whitespace;
@@ -213,9 +206,7 @@ const _detectSectionChildIndent = (
   // child key (at ``dash + 2``) clears it while a sibling dash
   // (same column as ours) doesn't.
   const headLine = lines[startIdx];
-  const floor = isListItem
-    ? headLine.indexOf("-") + 1
-    : _leadingIndent(headLine).length;
+  const floor = isListItem ? headLine.indexOf("-") + 1 : _leadingIndent(headLine).length;
   const fallback = isListItem
     ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`
     : ESPHOME_YAML_INDENT;
@@ -244,7 +235,7 @@ const _detectSectionChildIndent = (
 const _detectListItemChildIndent = (
   lines: string[],
   startIdx: number,
-  dashIndent: string,
+  dashIndent: string
 ): string | null => {
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
@@ -285,10 +276,7 @@ const isListItemLine = (line: string, dashIndent: string): boolean => {
  * list of the current key, regardless of which indent step the
  * user picked". 4-space YAML pastes work as a result.
  */
-const isDeeperListItemLine = (
-  line: string,
-  parentIndent: string,
-): boolean => {
+const isDeeperListItemLine = (line: string, parentIndent: string): boolean => {
   const lead = _leadingIndent(line);
   if (lead.length <= parentIndent.length) return false;
   const tail = line.slice(lead.length);
@@ -296,10 +284,7 @@ const isDeeperListItemLine = (
 };
 
 const stripQuotes = (s: string): string => {
-  if (
-    (s.startsWith('"') && s.endsWith('"')) ||
-    (s.startsWith("'") && s.endsWith("'"))
-  ) {
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
     return s.slice(1, -1);
   }
   return s;
@@ -333,7 +318,7 @@ const collectBlockListItems = (
   lines: string[],
   startIdx: number,
   prefix: string,
-  itemRegex: RegExp,
+  itemRegex: RegExp
 ): { items: string[]; endIdx: number } => {
   const items: string[] = [];
   let j = startIdx;
@@ -357,20 +342,16 @@ const collectBlockListItems = (
 const _detectFirstDashIndent = (
   lines: string[],
   startIdx: number,
-  fallback: string,
+  fallback: string
 ): { dashIndent: string; firstDashIdx: number } => {
   let firstDashIdx = startIdx;
-  while (
-    firstDashIdx < lines.length &&
-    isBlankOrCommentLine(lines[firstDashIdx])
-  ) {
+  while (firstDashIdx < lines.length && isBlankOrCommentLine(lines[firstDashIdx])) {
     firstDashIdx++;
   }
   if (firstDashIdx >= lines.length) {
     return { dashIndent: fallback, firstDashIdx };
   }
-  const dashIndent =
-    lines[firstDashIdx].match(/^( *)-/)?.[1] ?? fallback;
+  const dashIndent = lines[firstDashIdx].match(/^( *)-/)?.[1] ?? fallback;
   return { dashIndent, firstDashIdx };
 };
 
@@ -397,7 +378,7 @@ const _detectFirstDashIndent = (
 const parseListBlock = (
   lines: string[],
   startIdx: number,
-  parentIndent: string,
+  parentIndent: string
 ): {
   value: YamlRawValue | Record<string, unknown>[] | string[];
   endIdx: number;
@@ -407,7 +388,7 @@ const parseListBlock = (
   const { dashIndent, firstDashIdx } = _detectFirstDashIndent(
     lines,
     startIdx,
-    canonicalDashIndent,
+    canonicalDashIndent
   );
   const childIndent =
     _detectListItemChildIndent(lines, firstDashIdx + 1, dashIndent) ??
@@ -420,12 +401,7 @@ const parseListBlock = (
   // ``esphome.areas``); fall through to ``YamlRawValue`` for
   // shapes the editor can't round-trip.
   if (isComplex) {
-    const mapping = collectBlockListMappings(
-      lines,
-      startIdx,
-      dashIndent,
-      childIndent,
-    );
+    const mapping = collectBlockListMappings(lines, startIdx, dashIndent, childIndent);
     if (mapping) {
       return {
         value: mapping.items,
@@ -449,7 +425,7 @@ const parseListBlock = (
     lines,
     startIdx,
     `${dashIndent}- `,
-    listItemRegexFor(dashIndent),
+    listItemRegexFor(dashIndent)
   );
   return {
     value: items,
@@ -470,7 +446,7 @@ const parseListBlock = (
  */
 const parseFlatMappingField = (
   key: string,
-  raw: string,
+  raw: string
 ): { key: string; value: unknown } | null => {
   // Dotted keys (``logger.log:``, ``switch.turn_on:``) are
   // automation-action shorthand — not flat-mapping fields. Bail
@@ -493,7 +469,7 @@ const parseFlatMappingField = (
  */
 const _matchFlatMappingField = (
   line: string,
-  re: RegExp,
+  re: RegExp
 ): { key: string; value: unknown } | null => {
   const m = line.match(re);
   return m ? parseFlatMappingField(m[1], m[2].trim()) : null;
@@ -514,7 +490,7 @@ const _parseItemSubKeys = (
   startIdx: number,
   childIndent: string,
   childRe: RegExp,
-  item: Record<string, unknown>,
+  item: Record<string, unknown>
 ): number | null => {
   let j = startIdx;
   while (j < lines.length) {
@@ -554,11 +530,9 @@ const collectBlockListMappings = (
   lines: string[],
   startIdx: number,
   dashIndent: string,
-  childIndent: string,
+  childIndent: string
 ): { items: Record<string, unknown>[]; endIdx: number } | null => {
-  const headerRe = new RegExp(
-    `^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`,
-  );
+  const headerRe = new RegExp(`^${dashIndent}-\\s+(${KEY_PATTERN}):\\s*(.*)$`);
   const childRe = new RegExp(`^${childIndent}(${KEY_PATTERN}):\\s*(.*)$`);
 
   /**
@@ -576,7 +550,7 @@ const collectBlockListMappings = (
    * predicates in lockstep.
    */
   const parseItem = (
-    at: number,
+    at: number
   ): { item: Record<string, unknown>; endIdx: number } | null => {
     // Same null-prototype defence as the surrounding parser — see
     // the comment in ``parseYamlSectionValues``.
@@ -642,7 +616,7 @@ const collectBlockListMappings = (
 const _scanValueBlock = (
   lines: string[],
   startIdx: number,
-  keyIndent: string,
+  keyIndent: string
 ): { endIdx: number; isComplex: boolean } => {
   let isComplex = false;
   for (let i = startIdx; i < lines.length; i++) {
@@ -671,7 +645,7 @@ const _scanValueBlock = (
 export function findSectionStart(
   lines: string[],
   sectionKey: string,
-  fromLine?: number,
+  fromLine?: number
 ): number {
   if (fromLine !== undefined) return fromLine - 1;
   for (let i = 0; i < lines.length; i++) {
@@ -694,7 +668,7 @@ export function findSectionStart(
 export function parseYamlSectionValues(
   yaml: string,
   sectionKey: string,
-  fromLine?: number,
+  fromLine?: number
 ): Record<string, unknown> {
   const lines = yaml.split("\n");
   // Null-prototype map so a YAML key like `__proto__` /
@@ -784,7 +758,7 @@ export function parseYamlSectionValues(
         const { value, endIdx, isEmptyScalarList } = parseListBlock(
           lines,
           i + 1,
-          childIndent,
+          childIndent
         );
         if (!isEmptyScalarList) {
           values[key] = value;
@@ -820,7 +794,7 @@ export function parseYamlSectionValues(
 function parseNestedBlock(
   lines: string[],
   startIdx: number,
-  indent: string,
+  indent: string
 ): { values: Record<string, unknown>; endIdx: number } {
   const childRegex = childRegexFor(indent);
   // Null-prototype — same prototype-pollution defense as the
@@ -857,10 +831,7 @@ function parseNestedBlock(
 
     if (raw === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
-      if (
-        peek < lines.length &&
-        isDeeperListItemLine(lines[peek], indent)
-      ) {
+      if (peek < lines.length && isDeeperListItemLine(lines[peek], indent)) {
         const { value, endIdx } = parseListBlock(lines, i + 1, indent);
         values[key] = value;
         i = endIdx;
@@ -907,7 +878,7 @@ function parseNestedBlock(
 export function findSectionRange(
   lines: string[],
   sectionKey: string,
-  fromLine?: number,
+  fromLine?: number
 ): { start: number; end: number } {
   const start = findSectionStart(lines, sectionKey, fromLine);
   if (start < 0) return { start: -1, end: -1 };
@@ -951,7 +922,7 @@ export function updateSectionInYaml(
   sectionKey: string,
   values: Record<string, unknown>,
   fromLine?: number,
-  options: SerializeYamlOptions = {},
+  options: SerializeYamlOptions = {}
 ): string {
   const lines = yaml.split("\n");
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
@@ -1027,9 +998,7 @@ export function updateSectionInYaml(
         const dashIndent = dashPrefixMatch[1];
         const dashPrefix = `${dashIndent}-${dashPrefixMatch[2]}`;
         if (_isInlinableScalar(values[inlineKey])) {
-          dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(
-            values[inlineKey],
-          )}`;
+          dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}`;
           const { [inlineKey]: _omit, ...rest } = values;
           toSerialize = rest;
         } else {
@@ -1052,8 +1021,7 @@ export function updateSectionInYaml(
   // Default to canonical 2-space; the round-trip stays
   // valid-and-readable even when the surrounding file uses a
   // different step elsewhere.
-  const detectedStep =
-    !isListItem && childIndent ? childIndent : ESPHOME_YAML_INDENT;
+  const detectedStep = !isListItem && childIndent ? childIndent : ESPHOME_YAML_INDENT;
   const newLines = [
     dashLine,
     ...serializeYamlValues(toSerialize, childIndent, {
@@ -1086,7 +1054,7 @@ function _isInlinableScalar(value: unknown): boolean {
 export function removeSectionFromYaml(
   yaml: string,
   sectionKey: string,
-  fromLine?: number,
+  fromLine?: number
 ): string {
   const lines = yaml.split("\n");
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -55,15 +55,38 @@ export interface CategorizedSections {
 // component and lives under "Components" in the navigator.
 export const CORE_KEYS = new Set([
   // Target platforms
-  "esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "ln882x", "nrf52", "host",
+  "esp32",
+  "esp8266",
+  "rp2040",
+  "bk72xx",
+  "rtl87xx",
+  "ln882x",
+  "nrf52",
+  "host",
   // ESPHome infrastructure
-  "esphome", "logger", "api", "ota", "wifi", "ethernet", "mqtt", "mdns",
-  "network", "web_server", "captive_portal", "improv_serial",
-  "safe_mode", "debug", "preferences", "update",
+  "esphome",
+  "logger",
+  "api",
+  "ota",
+  "wifi",
+  "ethernet",
+  "mqtt",
+  "mdns",
+  "network",
+  "web_server",
+  "captive_portal",
+  "improv_serial",
+  "safe_mode",
+  "debug",
+  "preferences",
+  "update",
   // Device-wide config keys (not strictly components — no C++
   // implementation — but they share the top-level YAML namespace
   // alongside real components).
-  "external_components", "packages", "substitutions", "dashboard_import",
+  "external_components",
+  "packages",
+  "substitutions",
+  "dashboard_import",
   // `globals:` is technically a list of typed variables, but in
   // practice it acts as device-wide config metadata (variable
   // declarations, similar to substitutions) — we want it living next
@@ -228,7 +251,7 @@ export function _clearYamlSectionsMemo(): void {
  */
 function _expandListItems(
   lines: string[],
-  section: { key: string; fromLine: number; toLine: number },
+  section: { key: string; fromLine: number; toLine: number }
 ): YamlSection[] {
   // Sections marked non-expandable keep their list items hidden from
   // the navigator — the user navigates to the whole block, not the
@@ -281,8 +304,7 @@ function _expandListItems(
   const items: YamlSection[] = [];
   for (let idx = 0; idx < listStarts.length; idx++) {
     const itemStart = listStarts[idx];
-    const itemEnd =
-      idx + 1 < listStarts.length ? listStarts[idx + 1] - 1 : endIdx;
+    const itemEnd = idx + 1 < listStarts.length ? listStarts[idx + 1] - 1 : endIdx;
 
     let name = "";
     let id = "";
@@ -293,7 +315,7 @@ function _expandListItems(
       const idMatch = lines[j].match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
       if (idMatch) id = idMatch[1];
       const platformMatch = lines[j].match(
-        /^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/,
+        /^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/
       );
       if (platformMatch) platform = platformMatch[1];
     }
@@ -400,8 +422,7 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
     if (!block) continue;
     const items = _enumerateListItems(lines, block.fromLine, block.toLine);
     items.forEach((item, idx) => {
-      const itemId =
-        top === "script" ? _readKeyOnLine(lines, item.fromLine, "id") : null;
+      const itemId = top === "script" ? _readKeyOnLine(lines, item.fromLine, "id") : null;
       const key =
         top === "script" && itemId
           ? `automation:script:${itemId}`
@@ -440,13 +461,13 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
       lines,
       apiBlock.fromLine,
       apiBlock.toLine,
-      "actions",
+      "actions"
     );
     if (actionsBlock) {
       const items = _enumerateListItems(
         lines,
         actionsBlock.fromLine,
-        actionsBlock.toLine,
+        actionsBlock.toLine
       );
       for (const item of items) {
         const actionName =
@@ -470,11 +491,7 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
 
 /** First non-empty line at indent ≤ ``indent`` after ``startIdx``,
  *  or end-of-file. */
-function _findBlockEnd(
-  lines: string[],
-  startIdx: number,
-  indent: number,
-): number {
+function _findBlockEnd(lines: string[], startIdx: number, indent: number): number {
   for (let j = startIdx + 1; j < lines.length; j++) {
     if (lines[j].trim() === "") continue;
     const lineIndent = (lines[j].match(/^(\s*)/) ?? ["", ""])[1].length;
@@ -501,11 +518,7 @@ interface Ancestry {
  * - ``componentId`` — the configured component's ``id:`` if found,
  *   used as the stable identifier.
  */
-function _walkAncestry(
-  lines: string[],
-  startIdx: number,
-  childIndent: number,
-): Ancestry {
+function _walkAncestry(lines: string[], startIdx: number, childIndent: number): Ancestry {
   let parentKey: string | null = null;
   let parentName: string | null = null;
   let componentId: string | null = null;
@@ -534,13 +547,9 @@ function _walkAncestry(
     // can't contribute id / name for our automation.
     if (lineIndent > childIndent) continue;
     if (crossedItemBoundary) continue;
-    const idMatch = line.match(
-      /^\s+(?:-\s+)?id:\s*["']?([^"'\s]+)["']?\s*$/,
-    );
+    const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?([^"'\s]+)["']?\s*$/);
     if (idMatch && !componentId) componentId = idMatch[1];
-    const nameMatch = line.match(
-      /^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/,
-    );
+    const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
     if (nameMatch && !parentName) parentName = nameMatch[1];
   }
   return { parentKey, parentName, componentId };
@@ -551,7 +560,7 @@ function _walkAncestry(
  *  absent. */
 function _findTopLevelBlock(
   lines: string[],
-  key: string,
+  key: string
 ): { fromLine: number; toLine: number } | null {
   for (let i = 0; i < lines.length; i++) {
     const m = lines[i].match(new RegExp(`^${key}\\s*:`));
@@ -568,7 +577,7 @@ function _findChildBlock(
   lines: string[],
   parentFromLine: number,
   parentToLine: number,
-  childKey: string,
+  childKey: string
 ): { fromLine: number; toLine: number } | null {
   // Locate the parent block's child indent by reading the first
   // non-blank child line and capturing its leading whitespace —
@@ -599,7 +608,7 @@ function _findChildBlock(
 function _enumerateListItems(
   lines: string[],
   blockFromLine: number,
-  blockToLine: number,
+  blockToLine: number
 ): Array<{ fromLine: number; toLine: number }> {
   const out: Array<{ fromLine: number; toLine: number }> = [];
   let topIndent: number | null = null;
@@ -624,11 +633,7 @@ function _enumerateListItems(
 
 /** Read a leading ``key: value`` line inside a list item — used to
  *  pull the script's ``id:`` for the stable section key. */
-function _readKeyOnLine(
-  lines: string[],
-  fromLine: number,
-  key: string,
-): string | null {
+function _readKeyOnLine(lines: string[], fromLine: number, key: string): string | null {
   const target = lines[fromLine - 1];
   // The script id can be on the same line as the leading dash:
   // ``- id: my_alarm`` — or on the next non-empty line.
@@ -664,24 +669,20 @@ function _readKeyOnLine(
 export function findAddedSection(
   yaml: string,
   componentId: string,
-  newId: string | undefined,
+  newId: string | undefined
 ): { sectionKey: string; fromLine: number } | null {
   const sections = parseYamlTopLevelSections(yaml);
 
   // Top-level (non-platform) component — match the bare key, e.g.
   // adding "wifi" navigates to the `wifi:` block.
   if (!componentId.includes(".")) {
-    const match = sections.find(
-      (s) => s.key === componentId && !s.platform,
-    );
+    const match = sections.find((s) => s.key === componentId && !s.platform);
     if (match) return { sectionKey: match.key, fromLine: match.fromLine };
   }
 
   // Platform-based component — find the list item(s) under the parent
   // block whose computed sectionKey matches componentId.
-  const candidates = sections.filter(
-    (s) => sectionKeyOf(s) === componentId,
-  );
+  const candidates = sections.filter((s) => sectionKeyOf(s) === componentId);
   if (candidates.length === 0) return null;
   if (candidates.length === 1) {
     return {
@@ -737,10 +738,7 @@ export function findAddedSection(
  * Tracked as a follow-up to extend `sectionAtLine` to consult
  * automations and prefer the most-specific (smallest) range.
  */
-export function sectionAtLine(
-  yaml: string,
-  line: number,
-): YamlSection | null {
+export function sectionAtLine(yaml: string, line: number): YamlSection | null {
   // Automations take precedence over top-level sections whenever a
   // click falls inside one: a click inside ``script: - id: proost``
   // routes to the script editor (not the enclosing ``script:``
@@ -761,7 +759,7 @@ export function sectionAtLine(
   // to fall through to the enclosing top-level section so the user
   // lands somewhere useful.
   const autos = parseYamlAutomations(yaml).filter(
-    (s) => !s.key.startsWith("automation:unscoped:"),
+    (s) => !s.key.startsWith("automation:unscoped:")
   );
   const autoHit = _smallestContaining(autos, line);
   if (autoHit) return autoHit;
@@ -769,10 +767,7 @@ export function sectionAtLine(
   return _smallestContaining(tops, line);
 }
 
-function _smallestContaining(
-  sections: YamlSection[],
-  line: number,
-): YamlSection | null {
+function _smallestContaining(sections: YamlSection[], line: number): YamlSection | null {
   let best: YamlSection | null = null;
   let bestSpan = Number.POSITIVE_INFINITY;
   for (const s of sections) {
@@ -836,20 +831,19 @@ export function sectionKeyOf(section: YamlSection): string {
 export function resolveCurrentFromLine(
   yaml: string,
   sectionKey: string,
-  staleFromLine?: number,
+  staleFromLine?: number
 ): number | undefined {
   if (!yaml || !sectionKey) return undefined;
   const matches = parseYamlTopLevelSections(yaml).filter(
-    (s) => sectionKeyOf(s) === sectionKey,
+    (s) => sectionKeyOf(s) === sectionKey
   );
   if (matches.length === 0) return undefined;
   if (matches.length === 1 || staleFromLine === undefined) {
     return matches[0].fromLine;
   }
   return matches.reduce((best, candidate) =>
-    Math.abs(candidate.fromLine - staleFromLine) <
-    Math.abs(best.fromLine - staleFromLine)
+    Math.abs(candidate.fromLine - staleFromLine) < Math.abs(best.fromLine - staleFromLine)
       ? candidate
-      : best,
+      : best
   ).fromLine;
 }

--- a/src/util/yaml-sensitive-mask.ts
+++ b/src/util/yaml-sensitive-mask.ts
@@ -25,7 +25,12 @@
  */
 
 import { type Range } from "@codemirror/state";
-import { StateEffect, StateField, type EditorState, type Extension } from "@codemirror/state";
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Extension,
+} from "@codemirror/state";
 import { Decoration, EditorView, type DecorationSet } from "@codemirror/view";
 import { findSensitiveValueRanges } from "./yaml-sensitive-scan.js";
 
@@ -36,7 +41,7 @@ const sensitiveMark = Decoration.mark({ class: "cm-esphome-sensitive-value" });
 function computeDecorations(
   state: EditorState,
   revealed: boolean,
-  maskAllValues: boolean,
+  maskAllValues: boolean
 ): DecorationSet {
   if (revealed) return Decoration.none;
   const doc = state.doc;
@@ -62,7 +67,7 @@ function computeDecorations(
 
 export function sensitiveValueMaskExtension(
   initialReveal = false,
-  maskAllValues = false,
+  maskAllValues = false
 ): Extension {
   // Holds the current reveal flag so the field can short-circuit
   // when the user has the toolbar reveal button on.
@@ -91,9 +96,7 @@ export function sensitiveValueMaskExtension(
       computeDecorations(state, state.field(revealedField), maskAllValues),
     update(decos, tr) {
       const revealed = tr.state.field(revealedField);
-      const revealedChanged = tr.effects.some((e) =>
-        e.is(setRevealSensitiveEffect),
-      );
+      const revealedChanged = tr.effects.some((e) => e.is(setRevealSensitiveEffect));
       if (!tr.docChanged && !revealedChanged) {
         return decos.map(tr.changes);
       }

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -134,7 +134,7 @@ function isLineSource(value: string | LineSource): value is LineSource {
 
 export function findSensitiveValueRanges(
   yaml: string | LineSource,
-  options: FindSensitiveValueRangesOptions = {},
+  options: FindSensitiveValueRangesOptions = {}
 ): SensitiveValueRange[] {
   const { maskAllValues = false } = options;
   const ranges: SensitiveValueRange[] = [];

--- a/src/util/yaml-validation-summary.ts
+++ b/src/util/yaml-validation-summary.ts
@@ -45,9 +45,7 @@ export interface ValidationSummary {
  * case anyway. When parse errors are absent, take the first
  * validation error's range.
  */
-export function summarizeValidation(
-  res: EditorValidateResponse,
-): ValidationSummary {
+export function summarizeValidation(res: EditorValidateResponse): ValidationSummary {
   const yamlErrors = res.yaml_errors ?? [];
   const validationErrors = res.validation_errors ?? [];
   const count = yamlErrors.length + validationErrors.length;

--- a/test/_lit-template-walker.ts
+++ b/test/_lit-template-walker.ts
@@ -44,10 +44,7 @@ export function isTemplateResult(value: unknown): value is TemplateResult {
  * non-arrays are skipped. Order matches Lit's render order:
  * parents before their interpolated children.
  */
-export function visitTemplates(
-  root: unknown,
-  visit: (t: TemplateResult) => void,
-): void {
+export function visitTemplates(root: unknown, visit: (t: TemplateResult) => void): void {
   if (!root) return;
   if (Array.isArray(root)) {
     for (const r of root) visitTemplates(r, visit);
@@ -69,10 +66,7 @@ export function visitTemplates(
  *  way to find the templates that emit the tag you care about,
  *  without parsing the lit-html grammar yourself.
  */
-export function findTemplatesByAnchor(
-  root: unknown,
-  anchor: string,
-): TemplateResult[] {
+export function findTemplatesByAnchor(root: unknown, anchor: string): TemplateResult[] {
   const matches: TemplateResult[] = [];
   visitTemplates(root, (t) => {
     if (t.strings.join("§").includes(anchor)) matches.push(t);
@@ -105,9 +99,7 @@ export function findTemplatesByAnchor(
  * ``b[".label"]``) without depending on the order the renderer
  * wrote the attributes in the template literal.
  */
-export function extractAttributeBindings(
-  t: TemplateResult,
-): Record<string, unknown> {
+export function extractAttributeBindings(t: TemplateResult): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (let i = 0; i < t.values.length; i++) {
     // The static string preceding `values[i]`. We only care about

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -52,7 +52,7 @@ const _BASE = {
  *  full ``ConfiguredDevice`` (not ``Partial``) so consumers can
  *  pass the result anywhere a real device object is expected. */
 export function makeConfiguredDevice(
-  overrides: Partial<ConfiguredDevice> = {},
+  overrides: Partial<ConfiguredDevice> = {}
 ): ConfiguredDevice {
   return { ..._BASE, ...overrides };
 }

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "../../src/api/api-error.js";
 import { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { JobType } from "../../src/api/types.js";
@@ -67,8 +60,11 @@ describe("ESPHomeAPI — connection", () => {
   });
 
   it("upgrades to wss:// when the page is https", async () => {
-    (globalThis as unknown as { window: { location: { protocol: string; host: string } } }).window =
-      { location: { protocol: "https:", host: "example.test" } };
+    (
+      globalThis as unknown as {
+        window: { location: { protocol: string; host: string } };
+      }
+    ).window = { location: { protocol: "https:", host: "example.test" } };
     const api = new ESPHomeAPI();
     const pending = api.connect();
     const ws = MockWebSocket.latest();
@@ -197,9 +193,7 @@ describe("ESPHomeAPI — sendCommand", () => {
 
   it("throws when the socket is not open", async () => {
     const api = new ESPHomeAPI();
-    await expect(api.sendCommand("ping")).rejects.toThrow(
-      /not connected/,
-    );
+    await expect(api.sendCommand("ping")).rejects.toThrow(/not connected/);
   });
 
   it("assigns sequential message_ids", async () => {
@@ -236,7 +230,7 @@ describe("ESPHomeAPI — cloneDevice", () => {
     const pending = api.cloneDevice(
       "kitchen.yaml",
       "bedroom-bulb",
-      "Bedroom Reading Lamp",
+      "Bedroom Reading Lamp"
     );
     const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
 
@@ -363,7 +357,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
     ws.receive({ message_id: messageId, event: "output", data: "line 1" });
     ws.receive({ message_id: messageId, event: "output", data: "line 2" });
@@ -380,7 +374,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
     ws.receive({
       message_id: messageId,
@@ -400,7 +394,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const messageId = api.sendStreamCommand(
       "devices/validate",
       { configuration: "foo.yaml" },
-      { onError },
+      { onError }
     );
     ws.receive({
       message_id: messageId,
@@ -427,7 +421,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput: vi.fn(), onResult: vi.fn() },
+      { onOutput: vi.fn(), onResult: vi.fn() }
     );
 
     const pending = api.stopStream(streamId);
@@ -452,7 +446,7 @@ describe("ESPHomeAPI — streaming commands", () => {
     const streamId = api.sendStreamCommand(
       "devices/logs",
       { configuration: "foo.yaml", port: "" },
-      { onOutput, onResult },
+      { onOutput, onResult }
     );
 
     // Pre-stop: events flow normally.
@@ -496,7 +490,7 @@ describe("ESPHomeAPI — event subscriptions", () => {
     const ws = await connect(api);
     const received: Array<{ event: string; data: unknown }> = [];
     const subscribed = api.subscribeEvents((event, data) =>
-      received.push({ event, data }),
+      received.push({ event, data })
     );
     const msgId = ws.sentAs<{ message_id: string }>(0).message_id;
     ws.receive({ message_id: msgId, result: { subscribed: true } });
@@ -540,7 +534,11 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       component_id: "dht",
       fields: { pin: "GPIO4" },
     });
-    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
     expect(sent.command).toBe("devices/add_component");
     expect(sent.args).toEqual({
       configuration: "foo.yaml",
@@ -656,7 +654,7 @@ describe("ESPHomeAPI — typed command wrappers", () => {
       details: "Could not detect a chip on /dev/cu.usbserial-10",
     });
     await expect(pending).rejects.toThrow(
-      /Could not detect a chip on \/dev\/cu\.usbserial-10/,
+      /Could not detect a chip on \/dev\/cu\.usbserial-10/
     );
   });
 
@@ -676,7 +674,11 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);
     const pending = api.setRemoteBuildSettings({ enabled: true });
-    const sent = ws.sentAs<{ command: string; message_id: string; args: Record<string, unknown> }>(0);
+    const sent = ws.sentAs<{
+      command: string;
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
     expect(sent.command).toBe("remote_build/set_settings");
     expect(sent.args).toEqual({ enabled: true });
     const result = { enabled: true, peers: [] };
@@ -1119,7 +1121,7 @@ describe("ESPHomeAPI — auth", () => {
 
     // Fresh token persisted for the next reconnect.
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 }),
+      JSON.stringify({ token: "fresh-tok", expires_at: 1_800_000_000 })
     );
   });
 
@@ -1182,7 +1184,7 @@ describe("ESPHomeAPI — auth", () => {
     });
     await expect(api.ready).resolves.toBeUndefined();
     expect(localStorage.getItem("esphome.auth-token")).toBe(
-      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 }),
+      JSON.stringify({ token: "new-tok", expires_at: 1_900_000_000 })
     );
   });
 
@@ -1525,7 +1527,9 @@ describe("ESPHomeAPI — automations catalog", () => {
       actions: [],
       conditions: [],
       scripts: [{ id: "morning_alarm", parameters: [{ name: "hour", type: "int" }] }],
-      devices: [{ component_id: "switch.gpio", id: "kitchen_relay", name: "Kitchen Relay" }],
+      devices: [
+        { component_id: "switch.gpio", id: "kitchen_relay", name: "Kitchen Relay" },
+      ],
     };
     ws.receive({
       message_id: ws.sentAs<{ message_id: string }>(0).message_id,
@@ -1560,9 +1564,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
         automation: {
           trigger_id: "on_boot",
           trigger_params: {},
-          actions: [
-            { action_id: "logger.log", params: { message: "hi" } },
-          ],
+          actions: [{ action_id: "logger.log", params: { message: "hi" } }],
         },
         from_line: 2,
         to_line: 5,
@@ -1588,9 +1590,7 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
     const automation = {
       trigger_id: "on_press",
       trigger_params: {},
-      actions: [
-        { action_id: "switch.toggle", params: { id: "my_switch" } },
-      ],
+      actions: [{ action_id: "switch.toggle", params: { id: "my_switch" } }],
     };
     const location = {
       kind: "component_on" as const,
@@ -1611,11 +1611,19 @@ describe("ESPHomeAPI — automations parse / upsert / delete", () => {
     ws.receive({
       message_id: ws.sentAs<{ message_id: string }>(0).message_id,
       result: {
-        yaml_diff: { fromLine: 12, toLine: 14, replacement: "on_press:\n  then:\n    - switch.toggle: my_switch\n" },
+        yaml_diff: {
+          fromLine: 12,
+          toLine: 14,
+          replacement: "on_press:\n  then:\n    - switch.toggle: my_switch\n",
+        },
       },
     });
     await expect(pending).resolves.toEqual({
-      yaml_diff: { fromLine: 12, toLine: 14, replacement: "on_press:\n  then:\n    - switch.toggle: my_switch\n" },
+      yaml_diff: {
+        fromLine: 12,
+        toLine: 14,
+        replacement: "on_press:\n  then:\n    - switch.toggle: my_switch\n",
+      },
     });
   });
 

--- a/test/api/subscribe-device-reachability.test.ts
+++ b/test/api/subscribe-device-reachability.test.ts
@@ -243,7 +243,7 @@ describe("ESPHomeAPI.subscribeDeviceReachability", () => {
           return 0 as unknown as ReturnType<typeof setTimeout>;
         }
         return realSetTimeout(fn, delay, ...args);
-      },
+      }
     );
 
     try {
@@ -270,9 +270,9 @@ describe("ESPHomeAPI.subscribeDeviceReachability", () => {
     const api = new ESPHomeAPI();
     // Don't connect — the call should reject immediately rather
     // than queuing forever or sending into a closed transport.
-    await expect(
-      api.subscribeDeviceReachability("kitchen", () => {}),
-    ).rejects.toThrow(/not connected/i);
+    await expect(api.subscribeDeviceReachability("kitchen", () => {})).rejects.toThrow(
+      /not connected/i
+    );
   });
 
   it("bumps connectionGeneration on every WS open", async () => {

--- a/test/build-scripts/rspack-config.test.ts
+++ b/test/build-scripts/rspack-config.test.ts
@@ -12,9 +12,7 @@ const loadPatterns = async (): Promise<CopyPattern[]> => {
     };
   };
   const cfg = mod.createRspackConfig();
-  const copyPlugin = cfg.plugins.find(
-    (p) => p?.constructor?.name === "CopyRspackPlugin",
-  );
+  const copyPlugin = cfg.plugins.find((p) => p?.constructor?.name === "CopyRspackPlugin");
   if (!copyPlugin) {
     throw new Error("CopyRspackPlugin not found in rspack plugins");
   }
@@ -29,23 +27,15 @@ describe("rspack config", () => {
     // index.html and the JS bundles but no logos/board images, so
     // the running dashboard 404s every static asset request.
     const patterns = await loadPatterns();
-    const assetsPattern = patterns.find((p) =>
-      p.from.endsWith("/public/assets"),
-    );
+    const assetsPattern = patterns.find((p) => p.from.endsWith("/public/assets"));
     expect(assetsPattern, "expected a copy pattern for public/assets").toBeDefined();
-    expect(assetsPattern!.to).toMatch(
-      /\/esphome_device_builder_frontend\/assets$/,
-    );
+    expect(assetsPattern!.to).toMatch(/\/esphome_device_builder_frontend\/assets$/);
   });
 
   it("copies the package __init__.py so pip install ships where()", async () => {
     const patterns = await loadPatterns();
-    const initPattern = patterns.find((p) =>
-      p.from.endsWith("/public/__init__.py"),
-    );
+    const initPattern = patterns.find((p) => p.from.endsWith("/public/__init__.py"));
     expect(initPattern, "expected a copy pattern for __init__.py").toBeDefined();
-    expect(initPattern!.to).toMatch(
-      /\/esphome_device_builder_frontend\/__init__\.py$/,
-    );
+    expect(initPattern!.to).toMatch(/\/esphome_device_builder_frontend\/__init__\.py$/);
   });
 });

--- a/test/common/localize.test.ts
+++ b/test/common/localize.test.ts
@@ -3,9 +3,7 @@ import { defaultLocalize } from "../../src/common/localize.js";
 
 describe("defaultLocalize", () => {
   it("resolves a top-level string key", () => {
-    expect(defaultLocalize("dashboard.title")).toBe(
-      "ESPHome - Device Builder",
-    );
+    expect(defaultLocalize("dashboard.title")).toBe("ESPHome - Device Builder");
   });
 
   it("resolves a deeply nested key", () => {

--- a/test/components/_reset-suggestion-helpers.ts
+++ b/test/components/_reset-suggestion-helpers.ts
@@ -21,7 +21,7 @@ const RESET_SUGGESTION_ANCHOR = 'class="reset-suggestion"';
  */
 export const localize = (
   key: string,
-  values?: Record<string, string | number>,
+  values?: Record<string, string | number>
 ): string => {
   const parts = key.split(".");
   let cur: unknown = enMessages as unknown;
@@ -35,10 +35,7 @@ export const localize = (
   }
   const text = typeof cur === "string" ? cur : key;
   if (!values) return text;
-  return text.replace(
-    /\{(\w+)\}/g,
-    (_, k) => String(values[k] ?? `{${k}}`),
-  );
+  return text.replace(/\{(\w+)\}/g, (_, k) => String(values[k] ?? `{${k}}`));
 };
 
 export type LocalizeFn = typeof localize;
@@ -51,7 +48,7 @@ interface SuggestionHandlers {
 /** Assert the LOCAL two-link variant rendered (clean + reset). */
 export function expectLocalSuggestion(
   tree: TemplateResult | typeof import("lit").nothing,
-  host: SuggestionHandlers,
+  host: SuggestionHandlers
 ): void {
   const matches = findTemplatesByAnchor(tree, RESET_SUGGESTION_ANCHOR);
   expect(matches.length).toBe(1);
@@ -68,7 +65,7 @@ export function expectLocalSuggestion(
 export function expectRemoteSuggestion(
   tree: TemplateResult | typeof import("lit").nothing,
   host: SuggestionHandlers,
-  receiver: string,
+  receiver: string
 ): void {
   const matches = findTemplatesByAnchor(tree, RESET_SUGGESTION_ANCHOR);
   expect(matches.length).toBe(1);
@@ -85,7 +82,7 @@ export function expectRemoteSuggestion(
  */
 export function expectFallbackToLocal(
   tree: TemplateResult | typeof import("lit").nothing,
-  host: SuggestionHandlers,
+  host: SuggestionHandlers
 ): void {
   const matches = findTemplatesByAnchor(tree, RESET_SUGGESTION_ANCHOR);
   expect(matches.length).toBe(1);
@@ -94,7 +91,7 @@ export function expectFallbackToLocal(
 
 /** Assert no build-failure hint rendered (user-stopped, peer-link lost, …). */
 export function expectNoSuggestion(
-  tree: TemplateResult | typeof import("lit").nothing,
+  tree: TemplateResult | typeof import("lit").nothing
 ): void {
   expect(findTemplatesByAnchor(tree, RESET_SUGGESTION_ANCHOR).length).toBe(0);
 }

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -11,12 +11,7 @@
  */
 import { describe, it } from "vitest";
 import { renderResetSuggestion } from "../../src/components/command-dialog/renderers.js";
-import {
-  JobSource,
-  JobStatus,
-  JobType,
-  type FirmwareJob,
-} from "../../src/api/types.js";
+import { JobSource, JobStatus, JobType, type FirmwareJob } from "../../src/api/types.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import {
   expectFallbackToLocal,
@@ -61,13 +56,11 @@ interface Host {
   _failedDuringValidate: boolean;
   _jobId: string;
   _jobs: Map<string, FirmwareJob>;
-  _primedSource:
-    | {
-        source: JobSource;
-        source_label: string;
-        source_esphome_version: string;
-      }
-    | null;
+  _primedSource: {
+    source: JobSource;
+    source_label: string;
+    source_esphome_version: string;
+  } | null;
   _tryCleanBuild: () => void;
   _tryResetBuildEnv: () => void;
   _tryOpenInEditor: () => void;
@@ -97,9 +90,7 @@ const render = (host: Host) =>
 describe("renderResetSuggestion — local build", () => {
   it("emits both clean and reset links when the live job is LOCAL", () => {
     const host = baseHost({
-      _jobs: new Map([
-        ["job-1", fakeJob({ source: JobSource.LOCAL, source_label: "" })],
-      ]),
+      _jobs: new Map([["job-1", fakeJob({ source: JobSource.LOCAL, source_label: "" })]]),
     });
     expectLocalSuggestion(render(host), host);
   });
@@ -148,10 +139,7 @@ describe("renderResetSuggestion — remote build", () => {
     // "ask the operator of  to ...".
     const host = baseHost({
       _jobs: new Map([
-        [
-          "job-1",
-          fakeJob({ source: JobSource.REMOTE, source_label: "" }),
-        ],
+        ["job-1", fakeJob({ source: JobSource.REMOTE, source_label: "" })],
       ]),
     });
     expectFallbackToLocal(render(host), host);

--- a/test/components/dashboard/render-ip-value.test.ts
+++ b/test/components/dashboard/render-ip-value.test.ts
@@ -53,11 +53,7 @@ describe("renderIpValue", () => {
   it("uses the localised visit-web label for aria-label and title", () => {
     const localize = (key: string): string =>
       key === "dashboard.action_visit_web_ui" ? "Visit web UI" : key;
-    const result = renderIpValue(
-      "192.168.1.42",
-      "http://kitchen.local",
-      localize,
-    );
+    const result = renderIpValue("192.168.1.42", "http://kitchen.local", localize);
     const [anchor] = findTemplatesByAnchor(result, "<a");
     const bindings = extractAttributeBindings(anchor);
     expect(bindings["aria-label"]).toBe("Visit web UI");

--- a/test/components/dashboard/render-mdns-txt-records.test.ts
+++ b/test/components/dashboard/render-mdns-txt-records.test.ts
@@ -60,10 +60,7 @@ describe("renderMdnsTxtRecords", () => {
     // device serialised its TXT entries.
     const rowTemplates = findTemplatesByAnchor(result, "<dt>");
     expect(rowTemplates.length).toBe(4);
-    const pairs = rowTemplates.map((t) => [
-      t.values[0] as string,
-      t.values[1] as string,
-    ]);
+    const pairs = rowTemplates.map((t) => [t.values[0] as string, t.values[1] as string]);
     expect(pairs).toEqual([
       ["api_encryption", "Noise_NNpsk0_25519_ChaChaPoly_SHA256"],
       ["config_hash", "5a94a12d"],
@@ -87,10 +84,7 @@ describe("renderMdnsTxtRecords", () => {
     const result = renderMdnsTxtRecords(records, _identityLocalize);
     const rowTemplates = findTemplatesByAnchor(result, "<dt>");
     expect(rowTemplates.length).toBe(2);
-    const pairs = rowTemplates.map((t) => [
-      t.values[0] as string,
-      t.values[1] as string,
-    ]);
+    const pairs = rowTemplates.map((t) => [t.values[0] as string, t.values[1] as string]);
     expect(pairs).toEqual([
       ["api_encryption", ""],
       ["version", "2025.4.0"],
@@ -178,7 +172,7 @@ describe("renderMdnsTxtRecords", () => {
     // user-supplied content).
     const dangerous = {
       version: "<script>alert('xss')</script>",
-      config_hash: "\" onclick=\"alert(1)",
+      config_hash: '" onclick="alert(1)',
       "<key>": "innocent",
     };
     const result = renderMdnsTxtRecords(dangerous, _identityLocalize);
@@ -204,7 +198,7 @@ describe("renderMdnsTxtRecords", () => {
     // Values reach the rendered output as plain strings — Lit
     // turns them into text nodes at render time.
     expect(allValues).toContain("<script>alert('xss')</script>");
-    expect(allValues).toContain("\" onclick=\"alert(1)");
+    expect(allValues).toContain('" onclick="alert(1)');
     expect(allValues).toContain("<key>");
   });
 

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -15,11 +15,7 @@
  * to ``components/device``).
  */
 import { vi } from "vitest";
-import type {
-  BoardCatalogEntry,
-  BoardPin,
-  ConfigEntry,
-} from "../../../src/api/types.js";
+import type { BoardCatalogEntry, BoardPin, ConfigEntry } from "../../../src/api/types.js";
 import { ConfigEntryType } from "../../../src/api/types.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import {
@@ -31,10 +27,7 @@ import {
  *  input+output GPIO with ``available=true`` so the pin-renderer's
  *  feature filter and disabled-pin filter both see it as eligible.
  */
-export function makeBoardPin(
-  gpio: number,
-  overrides: Partial<BoardPin> = {},
-): BoardPin {
+export function makeBoardPin(gpio: number, overrides: Partial<BoardPin> = {}): BoardPin {
   return {
     gpio,
     label: `GPIO${gpio}`,
@@ -52,7 +45,7 @@ export function makeBoardPin(
  *  override the default 3-pin set, or pass ``overrides`` to swap
  *  any other field. */
 export function makeTestBoard(
-  options: { pins?: BoardPin[]; overrides?: Partial<BoardCatalogEntry> } = {},
+  options: { pins?: BoardPin[]; overrides?: Partial<BoardCatalogEntry> } = {}
 ): BoardCatalogEntry {
   const pins = options.pins ?? [makeBoardPin(0), makeBoardPin(2), makeBoardPin(33)];
   return {
@@ -81,7 +74,7 @@ export function makeRenderCtx(
   options: {
     board?: BoardCatalogEntry | null;
     overrides?: Partial<RenderCtx>;
-  } = {},
+  } = {}
 ): RenderCtx {
   return {
     localize: ((k: string) => k) as never,
@@ -128,7 +121,7 @@ export function makeRenderCtx(
  *  ``required``, ``pin_features``, etc. */
 export function makeEntry(
   type: ConfigEntryType,
-  overrides: Partial<ConfigEntry> = {},
+  overrides: Partial<ConfigEntry> = {}
 ): ConfigEntry {
   return {
     key: "field",
@@ -158,9 +151,7 @@ export function makeEntry(
  */
 export function findElementBindings(
   template: unknown,
-  tag: string,
+  tag: string
 ): Record<string, unknown>[] {
-  return findTemplatesByAnchor(template, `<${tag}`).map(
-    extractAttributeBindings,
-  );
+  return findTemplatesByAnchor(template, `<${tag}`).map(extractAttributeBindings);
 }

--- a/test/components/device/add-component-dialog-dep-nav.test.ts
+++ b/test/components/device/add-component-dialog-dep-nav.test.ts
@@ -5,16 +5,13 @@ import {
   navigateToDep,
   type DepNavHost,
 } from "../../../src/components/device/add-component-dialog-dep-nav.js";
-import {
-  ComponentCategory,
-  type ComponentCatalogEntry,
-} from "../../../src/api/types.js";
+import { ComponentCategory, type ComponentCatalogEntry } from "../../../src/api/types.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 function makeHost(
   getComponent: (...args: unknown[]) => unknown,
-  catalog: NonNullable<DepNavHost["_catalog"]> | null = null,
+  catalog: NonNullable<DepNavHost["_catalog"]> | null = null
 ): DepNavHost {
   return {
     _api: { getComponent } as unknown as ESPHomeAPI,

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -18,9 +18,9 @@ async function readSource(): Promise<string> {
   return fs.readFileSync(
     path.resolve(
       here,
-      "../../../../src/components/device/automation-editor/automation-editor.ts",
+      "../../../../src/components/device/automation-editor/automation-editor.ts"
     ),
-    "utf-8",
+    "utf-8"
   );
 }
 

--- a/test/components/device/automation-editor/catalog-picker-dialog.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog.test.ts
@@ -25,9 +25,9 @@ async function readSource(): Promise<string> {
   return fs.readFileSync(
     path.resolve(
       here,
-      "../../../../src/components/device/automation-editor/catalog-picker-dialog.ts",
+      "../../../../src/components/device/automation-editor/catalog-picker-dialog.ts"
     ),
-    "utf-8",
+    "utf-8"
   );
 }
 
@@ -38,7 +38,9 @@ describe("catalog-picker-dialog filtering contract", () => {
    * ``(``) and slurps until the next ``private`` / ``}`` boundary.
    */
   function methodBody(src: string, name: string): string {
-    const re = new RegExp(`private\\s+${name}[\\s\\S]*?(?=\\n {2}(private|static|public|protected|@|\\}))`);
+    const re = new RegExp(
+      `private\\s+${name}[\\s\\S]*?(?=\\n {2}(private|static|public|protected|@|\\}))`
+    );
     const m = src.match(re);
     if (!m) throw new Error(`Method ${name} not found`);
     return m[0];

--- a/test/components/device/automation-editor/section-key.test.ts
+++ b/test/components/device/automation-editor/section-key.test.ts
@@ -13,34 +13,34 @@ import type { AutomationLocation } from "../../../../src/api/types.js";
 
 describe("sectionKeyFromLocation", () => {
   it("emits the same shape parseYamlAutomations uses", () => {
-    expect(
-      sectionKeyFromLocation({ kind: "device_on", trigger: "on_boot" }),
-    ).toBe("automation:device_on:on_boot");
+    expect(sectionKeyFromLocation({ kind: "device_on", trigger: "on_boot" })).toBe(
+      "automation:device_on:on_boot"
+    );
     expect(
       sectionKeyFromLocation({
         kind: "component_on",
         component_id: "my_button",
         trigger: "on_press",
-      }),
+      })
     ).toBe("automation:component_on:my_button:on_press");
     expect(sectionKeyFromLocation({ kind: "script", id: "my_alarm" })).toBe(
-      "automation:script:my_alarm",
+      "automation:script:my_alarm"
     );
     expect(sectionKeyFromLocation({ kind: "interval", index: 2 })).toBe(
-      "automation:interval:2",
+      "automation:interval:2"
     );
     expect(
       sectionKeyFromLocation({
         kind: "light_effect",
         component_id: "strip",
         index: 0,
-      }),
+      })
     ).toBe("automation:light_effect:strip:0");
     expect(
       sectionKeyFromLocation({
         kind: "api_action",
         action_name: "start_laundry",
-      }),
+      })
     ).toBe("automation:api_action:start_laundry");
   });
 });

--- a/test/components/device/config-entry-boolean-renderer.test.ts
+++ b/test/components/device/config-entry-boolean-renderer.test.ts
@@ -24,7 +24,7 @@ describe("renderBooleanField default-value fallback", () => {
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const sourcePath = path.resolve(
       here,
-      "../../../src/components/device/config-entry-renderers/primitives.ts",
+      "../../../src/components/device/config-entry-renderers/primitives.ts"
     );
     const src = fs.readFileSync(sourcePath, "utf-8");
 
@@ -42,10 +42,7 @@ describe("renderBooleanField default-value fallback", () => {
     // false failure when an assertion's anchor falls past the
     // truncation boundary.
     const nextExportIdx = src.indexOf("export function ", startIdx + 1);
-    const fnSrc = src.slice(
-      startIdx,
-      nextExportIdx > 0 ? nextExportIdx : src.length,
-    );
+    const fnSrc = src.slice(startIdx, nextExportIdx > 0 ? nextExportIdx : src.length);
 
     // The renderer must consult ``entry.default_value`` when
     // computing the value that drives ``checked`` — a bare reference
@@ -67,14 +64,13 @@ describe("renderBooleanField default-value fallback", () => {
     // this test.
     const fallbackShape =
       /=\s*raw\s*===\s*undefined\s*\|\|\s*raw\s*===\s*null\s*\?\s*entry\.default_value\s*:\s*raw/.test(
-        fnSrc,
-      ) ||
-      /=\s*raw\s*\?\?\s*entry\.default_value/.test(fnSrc);
+        fnSrc
+      ) || /=\s*raw\s*\?\?\s*entry\.default_value/.test(fnSrc);
     expect(
       fallbackShape,
       "renderBooleanField must compute an intermediate that falls " +
         "back from raw to entry.default_value — default-true fields " +
-        "otherwise render OFF when the YAML omits them",
+        "otherwise render OFF when the YAML omits them"
     ).toBe(true);
 
     // The ``checked`` computation must depend on whichever value
@@ -90,7 +86,7 @@ describe("renderBooleanField default-value fallback", () => {
       /parseYamlBoolean\(.*\)\s*===\s*true\b/.test(fnSrc),
       "checked must route the fallback value through parseYamlBoolean " +
         "so all ESPHome YAML boolean spellings (True / yes / on / enable) " +
-        "collapse to the boolean primitive — issue device-builder#923",
+        "collapse to the boolean primitive — issue device-builder#923"
     ).toBe(true);
 
     // ``checked`` must be derived from the same value that consulted
@@ -101,7 +97,7 @@ describe("renderBooleanField default-value fallback", () => {
     // ``=== true`` lines compare against ``raw`` directly.
     expect(
       /raw\s*===\s*true\b/.test(fnSrc),
-      "checked must be computed from the fallback intermediate, not raw directly",
+      "checked must be computed from the fallback intermediate, not raw directly"
     ).toBe(false);
   });
 });

--- a/test/components/device/config-entry-lambda-renderer.test.ts
+++ b/test/components/device/config-entry-lambda-renderer.test.ts
@@ -18,10 +18,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types.js";
 import { renderLambdaField } from "../../../src/components/device/config-entry-renderers/lambda.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
-import {
-  findTemplatesByAnchor,
-  isTemplateResult,
-} from "../../_lit-template-walker.js";
+import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-walker.js";
 import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 function getEditorBindings(template: unknown): Record<string, unknown> {
@@ -87,7 +84,7 @@ describe("renderLambdaField change handler", () => {
     const handler = b["@lambda-change"];
     expect(typeof handler).toBe("function");
     (handler as (e: CustomEvent<{ value: string }>) => void)(
-      new CustomEvent("lambda-change", { detail: { value: "return 7;" } }),
+      new CustomEvent("lambda-change", { detail: { value: "return 7;" } })
     );
     expect(emit).toHaveBeenCalledTimes(1);
     const [path, value] = emit.mock.calls[0];

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -27,11 +27,7 @@
 import { describe, expect, it } from "vitest";
 import { renderPinField } from "../../../src/components/device/config-entry-pin-renderer.js";
 import { ConfigEntryType } from "../../../src/api/types.js";
-import {
-  findElementBindings,
-  makeEntry,
-  makeRenderCtx,
-} from "./_renderer-fixtures.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 const pinEntry = () =>
   makeEntry(ConfigEntryType.PIN, {
@@ -59,7 +55,7 @@ describe("renderPinField — long-form pin block selection", () => {
       selected.length,
       `exactly one option should be selected; got ${selected.length} (${selected
         .map((s) => String(s.value))
-        .join(", ")})`,
+        .join(", ")})`
     ).toBe(1);
     expect(selected[0].value, "selected option value").toBe("GPIO33");
     expect(selected[0][".label"], "selected option label").toBe("GPIO33");
@@ -70,7 +66,7 @@ describe("renderPinField — long-form pin block selection", () => {
     const result = renderPinField(pinEntry(), ["pin"], ctx);
 
     const selected = findElementBindings(result, "wa-option").filter(
-      (o) => o["?selected"] === true,
+      (o) => o["?selected"] === true
     );
     expect(selected.length).toBe(1);
     expect(selected[0].value).toBe("GPIO33");
@@ -84,7 +80,7 @@ describe("renderPinField — long-form pin block selection", () => {
     const result = renderPinField(pinEntry(), ["pin"], ctx);
 
     const selected = findElementBindings(result, "wa-option").filter(
-      (o) => o["?selected"] === true,
+      (o) => o["?selected"] === true
     );
     expect(selected.length).toBe(0);
   });
@@ -103,7 +99,7 @@ describe("renderPinField — long-form pin block selection", () => {
 
     const result = renderPinField(pinEntry(), ["pin"], ctx);
     const selected = findElementBindings(result, "wa-option").filter(
-      (o) => o["?selected"] === true,
+      (o) => o["?selected"] === true
     );
     expect(selected.length).toBe(0);
   });

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -37,7 +37,7 @@ describe("parsePinGpio", () => {
         number: 0,
         mode: { input: true, pullup: true },
         inverted: true,
-      }),
+      })
     ).toBe(0);
     expect(parsePinGpio({ number: 13 })).toBe(13);
     expect(parsePinGpio({ number: "GPIO4" })).toBe(4);
@@ -75,7 +75,7 @@ describe("renderPinField wa-select binding", () => {
     const result = renderPinField(
       makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
       ["pin"],
-      ctx,
+      ctx
     );
 
     const selects = findTemplatesByAnchor(result, "<wa-select");
@@ -89,7 +89,7 @@ describe("renderPinField wa-select binding", () => {
     const staticParts = tag.strings.join("§");
     expect(
       /\bdata-no-value-sync\b/.test(staticParts),
-      "wa-select must carry data-no-value-sync to opt out of _syncSelectValues",
+      "wa-select must carry data-no-value-sync to opt out of _syncSelectValues"
     ).toBe(true);
 
     // Pin the inverse: don't bind ``.value=`` on the parent. The
@@ -100,7 +100,7 @@ describe("renderPinField wa-select binding", () => {
     const bindings = extractAttributeBindings(tag);
     expect(
       ".value" in bindings,
-      "wa-select must not have a property binding to .value alongside data-no-value-sync",
+      "wa-select must not have a property binding to .value alongside data-no-value-sync"
     ).toBe(false);
   });
 });
@@ -151,7 +151,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: null,
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     expect(findTemplatesByAnchor(result, "<button").length).toBe(0);
   });
@@ -165,7 +165,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const toggles = findTemplatesByAnchor(result, "<button");
     expect(toggles.length, "Advanced toggle button must render").toBe(1);
@@ -180,7 +180,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
     const openSet = new Set<string>(["pin:pin-advanced"]);
     const ctx = makeRenderCtx(
       { pin: { number: "GPIO5" } },
-      { overrides: { nestedOpenSections: openSet } },
+      { overrides: { nestedOpenSections: openSet } }
     );
     const children = makeLongFormChildren();
     renderPinField(
@@ -190,20 +190,14 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: children,
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     // ``mode`` and ``inverted`` both rendered, each at its nested
     // path under the pin field. Order-sensitive — ``mode`` first
     // matches the catalog's emission order, which the form's
     // tab-order convention follows.
-    expect(ctx.renderEntry).toHaveBeenNthCalledWith(1, children[0], [
-      "pin",
-      "mode",
-    ]);
-    expect(ctx.renderEntry).toHaveBeenNthCalledWith(2, children[1], [
-      "pin",
-      "inverted",
-    ]);
+    expect(ctx.renderEntry).toHaveBeenNthCalledWith(1, children[0], ["pin", "mode"]);
+    expect(ctx.renderEntry).toHaveBeenNthCalledWith(2, children[1], ["pin", "inverted"]);
   });
 
   it("promotes the pin value to long form when the user opens Advanced", () => {
@@ -220,7 +214,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const toggle = findTemplatesByAnchor(result, "<button")[0];
     const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
@@ -246,7 +240,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const toggle = findTemplatesByAnchor(result, "<button")[0];
     const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
@@ -274,12 +268,10 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const select = findTemplatesByAnchor(result, "<wa-select")[0];
-    const onChange = extractAttributeBindings(select)["@change"] as (
-      e: Event,
-    ) => void;
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
     // Synthesise the pick event the way wa-select dispatches it.
     onChange({ target: { value: "GPIO12" } } as never);
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "number"], "GPIO12");
@@ -299,12 +291,10 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const select = findTemplatesByAnchor(result, "<wa-select")[0];
-    const onChange = extractAttributeBindings(select)["@change"] as (
-      e: Event,
-    ) => void;
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
     onChange({ target: { value: "GPIO12" } } as never);
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "GPIO12");
   });
@@ -316,10 +306,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
     // open the disclosure on a locked field, and the click handler
     // would fire the promotion ``emitChange`` and rewrite the
     // locked value.
-    const ctx = makeRenderCtx(
-      { pin: 5 },
-      { overrides: { disabled: true } },
-    );
+    const ctx = makeRenderCtx({ pin: 5 }, { overrides: { disabled: true } });
     const result = renderPinField(
       makeEntry(ConfigEntryType.PIN, {
         key: "pin",
@@ -327,16 +314,16 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const toggle = findTemplatesByAnchor(result, "<button")[0];
     const bindings = extractAttributeBindings(toggle);
     expect(
       "?disabled" in bindings,
-      "Advanced toggle must carry a ?disabled binding",
+      "Advanced toggle must carry a ?disabled binding"
     ).toBe(true);
     expect(bindings["?disabled"], "binding must reflect the field-disabled state").toBe(
-      true,
+      true
     );
   });
 
@@ -345,10 +332,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
     // handler is still wired (the framework / accessibility tooling
     // / a synthetic event from a test could fire it). Confirm the
     // handler short-circuits before mutating state.
-    const ctx = makeRenderCtx(
-      { pin: "GPIO5" },
-      { overrides: { disabled: true } },
-    );
+    const ctx = makeRenderCtx({ pin: "GPIO5" }, { overrides: { disabled: true } });
     const result = renderPinField(
       makeEntry(ConfigEntryType.PIN, {
         key: "pin",
@@ -356,7 +340,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     const toggle = findTemplatesByAnchor(result, "<button")[0];
     const onClick = extractAttributeBindings(toggle)["@click"] as () => void;
@@ -372,9 +356,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
     // filter here would let the long-form disclosure leak fields
     // the catalog has marked advanced or gated by platform.
     const openSet = new Set<string>(["pin:pin-advanced"]);
-    const filterMock = vi.fn(
-      (entries: ConfigEntry[]) => entries.slice(0, 1),
-    );
+    const filterMock = vi.fn((entries: ConfigEntry[]) => entries.slice(0, 1));
     const ctx = makeRenderCtx(
       { pin: { number: "GPIO5" } },
       {
@@ -382,7 +364,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
           nestedOpenSections: openSet,
           filterRenderable: filterMock as never,
         },
-      },
+      }
     );
     const children = makeLongFormChildren();
     renderPinField(
@@ -392,7 +374,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: children,
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     // Filter received the full children list; only the survivor
     // (the first child) gets handed to renderEntry. A regression
@@ -412,7 +394,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
     const filterMock = vi.fn(() => [] as ConfigEntry[]);
     const ctx = makeRenderCtx(
       { pin: 0 },
-      { overrides: { filterRenderable: filterMock as never } },
+      { overrides: { filterRenderable: filterMock as never } }
     );
     const result = renderPinField(
       makeEntry(ConfigEntryType.PIN, {
@@ -421,7 +403,7 @@ describe("renderPinField long-form Advanced disclosure", () => {
         config_entries: makeLongFormChildren(),
       }),
       ["pin"],
-      ctx,
+      ctx
     );
     expect(findTemplatesByAnchor(result, "<button").length).toBe(0);
   });

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -29,10 +29,14 @@ describe("filterRenderable", () => {
       makeEntry({ key: "a", hidden: true }),
       makeEntry({ key: "b", required: true }),
     ];
-    const out = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const out = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect(out.map((e) => e.key)).toEqual(["b"]);
   });
 
@@ -41,15 +45,23 @@ describe("filterRenderable", () => {
       makeEntry({ key: "a", advanced: true, required: true }),
       makeEntry({ key: "b", required: true }),
     ];
-    const required = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const required = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect(required.map((e) => e.key)).toEqual(["b"]);
-    const withAdv = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: true,
-    });
+    const withAdv = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: true,
+      }
+    );
     expect(withAdv.map((e) => e.key)).toEqual(["a", "b"]);
   });
 
@@ -59,10 +71,14 @@ describe("filterRenderable", () => {
       makeEntry({ key: "fast_connect", advanced: true }),
       makeEntry({ key: "ssid", required: true }),
     ];
-    const out = filterRenderable(entries, { tx_power: "20dB", ssid: "x" }, {
-      requiredOnly: false,
-      showAdvanced: false,
-    });
+    const out = filterRenderable(
+      entries,
+      { tx_power: "20dB", ssid: "x" },
+      {
+        requiredOnly: false,
+        showAdvanced: false,
+      }
+    );
     // `tx_power` survives because YAML supplied a value;
     // `fast_connect` stays hidden because it isn't filled.
     expect(out.map((e) => e.key)).toEqual(["tx_power", "ssid"]);
@@ -77,13 +93,9 @@ describe("filterRenderable", () => {
     const out = filterRenderable(
       entries,
       { use_address: false, channel: 0, comment: "" },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
-    expect(out.map((e) => e.key)).toEqual([
-      "use_address",
-      "channel",
-      "comment",
-    ]);
+    expect(out.map((e) => e.key)).toEqual(["use_address", "channel", "comment"]);
   });
 
   it("keeps an advanced NESTED group when any descendant has a value", () => {
@@ -92,22 +104,23 @@ describe("filterRenderable", () => {
         key: "manual_ip",
         type: ConfigEntryType.NESTED,
         advanced: true,
-        config_entries: [
-          makeEntry({ key: "static_ip" }),
-          makeEntry({ key: "gateway" }),
-        ],
+        config_entries: [makeEntry({ key: "static_ip" }), makeEntry({ key: "gateway" })],
       }),
     ];
     const filled = filterRenderable(
       entries,
       { manual_ip: { static_ip: "10.0.0.5" } },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(filled.map((e) => e.key)).toEqual(["manual_ip"]);
-    const empty = filterRenderable(entries, {}, {
-      requiredOnly: false,
-      showAdvanced: false,
-    });
+    const empty = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: false,
+        showAdvanced: false,
+      }
+    );
     expect(empty.map((e) => e.key)).toEqual([]);
   });
 
@@ -125,19 +138,19 @@ describe("filterRenderable", () => {
     const filled = filterRenderable(
       entries,
       { ota: { platform: "esphome", password: "secret" } },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(filled.map((e) => e.key)).toEqual(["ota"]);
     const filledChildren = filterRenderable(
       entries[0].config_entries!,
       { platform: "esphome", password: "secret" },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(filledChildren.map((e) => e.key)).toEqual(["platform", "password"]);
     const emptyChildren = filterRenderable(
       entries[0].config_entries!,
       { platform: "esphome" },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(emptyChildren.map((e) => e.key)).toEqual(["platform"]);
   });
@@ -148,10 +161,14 @@ describe("filterRenderable", () => {
       makeEntry({ key: "name" }), // optional but always shown
       makeEntry({ key: "scl", required: true }),
     ];
-    const out = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const out = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect(out.map((e) => e.key)).toEqual(["name", "scl"]);
   });
 
@@ -160,10 +177,14 @@ describe("filterRenderable", () => {
       makeEntry({ key: "freq" }),
       makeEntry({ key: "scl", required: true }),
     ];
-    const out = filterRenderable(entries, {}, {
-      requiredOnly: false,
-      showAdvanced: true,
-    });
+    const out = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: false,
+        showAdvanced: true,
+      }
+    );
     expect(out.map((e) => e.key)).toEqual(["freq", "scl"]);
   });
 
@@ -180,10 +201,14 @@ describe("filterRenderable", () => {
         ],
       }),
     ];
-    const out = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const out = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect(out.map((e) => e.key)).toEqual([]);
   });
 
@@ -198,10 +223,14 @@ describe("filterRenderable", () => {
         ],
       }),
     ];
-    const out = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const out = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect(out.map((e) => e.key)).toEqual(["auth"]);
   });
 
@@ -226,13 +255,13 @@ describe("filterRenderable", () => {
     const empty = filterRenderable(
       entries,
       {},
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(empty.map((e) => e.key)).toEqual(["devices"]);
     const populated = filterRenderable(
       entries,
       { devices: [{ id: "front" }] },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(populated.map((e) => e.key)).toEqual(["devices"]);
   });
@@ -256,8 +285,14 @@ describe("filterRenderable", () => {
     ];
     const out = filterRenderable(
       entries,
-      { devices: new YamlRawValue(["    - id: kitchen", "      filters:", "        delta: 0.5"]) },
-      { requiredOnly: false, showAdvanced: false },
+      {
+        devices: new YamlRawValue([
+          "    - id: kitchen",
+          "      filters:",
+          "        delta: 0.5",
+        ]),
+      },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(out.map((e) => e.key)).toEqual(["devices"]);
   });
@@ -278,13 +313,13 @@ describe("filterRenderable", () => {
     const filled = filterRenderable(
       entries,
       { devices: [{ id: "front" }] },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect(filled.map((e) => e.key)).toEqual(["devices"]);
     const empty = filterRenderable(
       entries,
       { devices: [] },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     // Empty array → not material → advanced gate hides it.
     expect(empty.map((e) => e.key)).toEqual([]);
@@ -302,17 +337,25 @@ describe("filterRenderable", () => {
     ];
     // mode != "expert" → advanced_opt hidden.
     expect(
-      filterRenderable(entries, { mode: "basic" }, {
-        requiredOnly: true,
-        showAdvanced: false,
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        { mode: "basic" },
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+        }
+      ).map((e) => e.key)
     ).toEqual(["mode"]);
     // mode == "expert" → both visible.
     expect(
-      filterRenderable(entries, { mode: "expert" }, {
-        requiredOnly: true,
-        showAdvanced: false,
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        { mode: "expert" },
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+        }
+      ).map((e) => e.key)
     ).toEqual(["mode", "advanced_opt"]);
   });
 
@@ -326,18 +369,26 @@ describe("filterRenderable", () => {
       makeEntry({ key: "name", required: true }),
     ];
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        presentComponents: new Set(["esphome"]),
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          presentComponents: new Set(["esphome"]),
+        }
+      ).map((e) => e.key)
     ).toEqual(["name"]);
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        presentComponents: new Set(["esphome", "mqtt"]),
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          presentComponents: new Set(["esphome", "mqtt"]),
+        }
+      ).map((e) => e.key)
     ).toEqual(["mqtt_topic", "name"]);
   });
 
@@ -356,17 +407,25 @@ describe("filterRenderable", () => {
       }),
       makeEntry({ key: "free", required: true }),
     ];
-    const onEsp8266 = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-      targetPlatform: "esp8266",
-    });
+    const onEsp8266 = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp8266",
+      }
+    );
     expect(onEsp8266.map((e) => e.key)).toEqual(["free"]);
-    const onEsp32 = filterRenderable(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-      targetPlatform: "esp32",
-    });
+    const onEsp32 = filterRenderable(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+        targetPlatform: "esp32",
+      }
+    );
     expect(onEsp32.map((e) => e.key)).toEqual(["psram", "free"]);
   });
 
@@ -383,25 +442,37 @@ describe("filterRenderable", () => {
       }),
     ];
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: "esp32",
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: "esp32",
+        }
+      ).map((e) => e.key)
     ).toEqual(["fragmentation"]);
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: "esp8266",
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: "esp8266",
+        }
+      ).map((e) => e.key)
     ).toEqual(["fragmentation"]);
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: "rp2040",
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: "rp2040",
+        }
+      ).map((e) => e.key)
     ).toEqual([]);
   });
 
@@ -413,11 +484,15 @@ describe("filterRenderable", () => {
       makeEntry({ key: "free", required: true }),
     ];
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: "esp8266",
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: "esp8266",
+        }
+      ).map((e) => e.key)
     ).toEqual(["loop_time", "free"]);
   });
 
@@ -435,17 +510,25 @@ describe("filterRenderable", () => {
       }),
     ];
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: null,
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: null,
+        }
+      ).map((e) => e.key)
     ).toEqual(["psram"]);
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+        }
+      ).map((e) => e.key)
     ).toEqual(["psram"]);
   });
 
@@ -467,11 +550,15 @@ describe("filterRenderable", () => {
       }),
     ];
     expect(
-      filterRenderable(entries, {}, {
-        requiredOnly: true,
-        showAdvanced: false,
-        targetPlatform: "esp8266",
-      }).map((e) => e.key),
+      filterRenderable(
+        entries,
+        {},
+        {
+          requiredOnly: true,
+          showAdvanced: false,
+          targetPlatform: "esp8266",
+        }
+      ).map((e) => e.key)
     ).toEqual([]);
   });
 });
@@ -483,10 +570,14 @@ describe("collectRenderablePaths", () => {
       makeEntry({ key: "sda", required: true }),
       makeEntry({ key: "freq" }), // dropped in required-only
     ];
-    const paths = collectRenderablePaths(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const paths = collectRenderablePaths(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect([...paths].sort()).toEqual(["scl", "sda"]);
   });
 
@@ -501,15 +592,15 @@ describe("collectRenderablePaths", () => {
         ],
       }),
     ];
-    const paths = collectRenderablePaths(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
-    expect([...paths].sort()).toEqual([
-      "auth",
-      "auth.password",
-      "auth.username",
-    ]);
+    const paths = collectRenderablePaths(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
+    expect([...paths].sort()).toEqual(["auth", "auth.password", "auth.username"]);
   });
 
   it("omits NESTED groups whose children are all filtered out", () => {
@@ -523,10 +614,14 @@ describe("collectRenderablePaths", () => {
       }),
       makeEntry({ key: "name", required: true }),
     ];
-    const paths = collectRenderablePaths(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const paths = collectRenderablePaths(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect([...paths].sort()).toEqual(["name"]);
   });
 
@@ -536,10 +631,14 @@ describe("collectRenderablePaths", () => {
       makeEntry({ key: "adv", required: true, advanced: true }),
       makeEntry({ key: "vis", required: true }),
     ];
-    const paths = collectRenderablePaths(entries, {}, {
-      requiredOnly: true,
-      showAdvanced: false,
-    });
+    const paths = collectRenderablePaths(
+      entries,
+      {},
+      {
+        requiredOnly: true,
+        showAdvanced: false,
+      }
+    );
     expect([...paths]).toEqual(["vis"]);
   });
 
@@ -558,7 +657,7 @@ describe("collectRenderablePaths", () => {
     const paths = collectRenderablePaths(
       entries,
       { devices: [{ id: "front" }, { id: "kitchen", name: "Kitchen" }] },
-      { requiredOnly: false, showAdvanced: false },
+      { requiredOnly: false, showAdvanced: false }
     );
     expect([...paths].sort()).toEqual(
       [
@@ -567,7 +666,7 @@ describe("collectRenderablePaths", () => {
         "devices.0.name",
         "devices.1.id",
         "devices.1.name",
-      ].sort(),
+      ].sort()
     );
   });
 
@@ -583,10 +682,14 @@ describe("collectRenderablePaths", () => {
         config_entries: [makeEntry({ key: "id", required: true })],
       }),
     ];
-    const paths = collectRenderablePaths(entries, {}, {
-      requiredOnly: false,
-      showAdvanced: false,
-    });
+    const paths = collectRenderablePaths(
+      entries,
+      {},
+      {
+        requiredOnly: false,
+        showAdvanced: false,
+      }
+    );
     expect([...paths]).toEqual(["devices"]);
   });
 });

--- a/test/components/device/config-entry-templatable-renderer.test.ts
+++ b/test/components/device/config-entry-templatable-renderer.test.ts
@@ -42,7 +42,7 @@ function clickAt(template: unknown, label: "literal" | "lambda") {
   const handlers = clickHandlers(template);
   if (handlers.length < 2) {
     throw new Error(
-      `Expected two click handlers (literal + lambda); got ${handlers.length}`,
+      `Expected two click handlers (literal + lambda); got ${handlers.length}`
     );
   }
   const handler = label === "literal" ? handlers[0] : handlers[1];
@@ -74,20 +74,12 @@ describe("renderTemplatableField", () => {
 
   it("toggling literal → lambda emits a LambdaValue sentinel", () => {
     const emit = vi.fn();
-    const ctx = makeRenderCtx(
-      { field: "hello" },
-      { overrides: { emitChange: emit } },
-    );
+    const ctx = makeRenderCtx({ field: "hello" }, { overrides: { emitChange: emit } });
     const entry = makeEntry(ConfigEntryType.STRING, {
       key: "field",
       templatable: true,
     });
-    const template = renderTemplatableField(
-      entry,
-      ["field"],
-      ctx,
-      () => "<INNER>",
-    );
+    const template = renderTemplatableField(entry, ["field"], ctx, () => "<INNER>");
     clickAt(template, "lambda");
     expect(emit).toHaveBeenCalledTimes(1);
     const [path, value] = emit.mock.calls[0];
@@ -99,18 +91,13 @@ describe("renderTemplatableField", () => {
     const emit = vi.fn();
     const ctx = makeRenderCtx(
       { field: { _lambda: "return 1;" } },
-      { overrides: { emitChange: emit } },
+      { overrides: { emitChange: emit } }
     );
     const entry = makeEntry(ConfigEntryType.STRING, {
       key: "field",
       templatable: true,
     });
-    const template = renderTemplatableField(
-      entry,
-      ["field"],
-      ctx,
-      () => "<INNER>",
-    );
+    const template = renderTemplatableField(entry, ["field"], ctx, () => "<INNER>");
     clickAt(template, "literal");
     expect(emit).toHaveBeenCalledTimes(1);
     const [, value] = emit.mock.calls[0];
@@ -119,20 +106,12 @@ describe("renderTemplatableField", () => {
 
   it("re-clicking the active mode is a no-op (no double-emit)", () => {
     const emit = vi.fn();
-    const ctx = makeRenderCtx(
-      { field: "hello" },
-      { overrides: { emitChange: emit } },
-    );
+    const ctx = makeRenderCtx({ field: "hello" }, { overrides: { emitChange: emit } });
     const entry = makeEntry(ConfigEntryType.STRING, {
       key: "field",
       templatable: true,
     });
-    const template = renderTemplatableField(
-      entry,
-      ["field"],
-      ctx,
-      () => "<INNER>",
-    );
+    const template = renderTemplatableField(entry, ["field"], ctx, () => "<INNER>");
     clickAt(template, "literal");
     expect(emit).not.toHaveBeenCalled();
   });

--- a/test/components/device/device-board-info-helpers.test.ts
+++ b/test/components/device/device-board-info-helpers.test.ts
@@ -11,24 +11,21 @@ describe("isEmptyToPopulatedYamlChange", () => {
     expect(isEmptyToPopulatedYamlChange(undefined, "esphome:\n  name: x\n")).toBe(true);
   });
 
-  it("fires on user-cleared-then-pasted (\"\" → real)", () => {
+  it('fires on user-cleared-then-pasted ("" → real)', () => {
     expect(isEmptyToPopulatedYamlChange("", "esphome:\n  name: x\n")).toBe(true);
   });
 
   it("does not fire on typing (real → real)", () => {
     expect(
-      isEmptyToPopulatedYamlChange(
-        "esphome:\n  name: x\n",
-        "esphome:\n  name: xy\n",
-      ),
+      isEmptyToPopulatedYamlChange("esphome:\n  name: x\n", "esphome:\n  name: xy\n")
     ).toBe(false);
   });
 
-  it("does not fire on user-cleared-the-pane (real → \"\")", () => {
+  it('does not fire on user-cleared-the-pane (real → "")', () => {
     expect(isEmptyToPopulatedYamlChange("esphome:\n  name: x\n", "")).toBe(false);
   });
 
-  it("does not fire on noop-empty (\"\" → \"\")", () => {
+  it('does not fire on noop-empty ("" → "")', () => {
     expect(isEmptyToPopulatedYamlChange("", "")).toBe(false);
   });
 

--- a/test/components/device/password-input.test.ts
+++ b/test/components/device/password-input.test.ts
@@ -49,7 +49,7 @@ describe("password-input event contract", () => {
     const target = new EventTarget();
     const seen: Array<CustomEvent<PasswordInputValueChange>> = [];
     target.addEventListener(PASSWORD_INPUT_VALUE_CHANGE_EVENT, (e) =>
-      seen.push(e as CustomEvent<PasswordInputValueChange>),
+      seen.push(e as CustomEvent<PasswordInputValueChange>)
     );
     target.dispatchEvent(buildPasswordValueChangeEvent("secret"));
     expect(seen).toHaveLength(1);

--- a/test/components/device/render-map-field.test.ts
+++ b/test/components/device/render-map-field.test.ts
@@ -28,9 +28,7 @@ import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 function makeMapEntry(): ConfigEntry {
   return makeConfigEntry({
     type: ConfigEntryType.MAP,
-    config_entries: [
-      makeConfigEntry({ key: "value", required: true }),
-    ],
+    config_entries: [makeConfigEntry({ key: "value", required: true })],
   });
 }
 
@@ -44,9 +42,7 @@ interface CtxStub {
  *  collect every function (event handlers Lit binds to ``@click``
  *  / ``@change`` attributes). Used by the null-prototype test to
  *  invoke add / rename / delete handlers without a DOM. */
-function collectHandlers(
-  values: unknown[],
-): Array<(...args: unknown[]) => unknown> {
+function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unknown> {
   const out: Array<(...args: unknown[]) => unknown> = [];
   const walk = (v: unknown): void => {
     if (typeof v === "function") {
@@ -114,9 +110,7 @@ describe("renderMapField (substitutions / logger.logs / etc.)", () => {
     // value template at the per-row path.
     const calls = stub.renderEntry.mock.calls;
     const paths = calls.map((c) => c[1]);
-    expect(paths).toEqual(
-      expect.arrayContaining([["id_prefix"], ["timeout"]]),
-    );
+    expect(paths).toEqual(expect.arrayContaining([["id_prefix"], ["timeout"]]));
     expect(calls).toHaveLength(2);
   });
 
@@ -226,9 +220,10 @@ describe("renderMapField (substitutions / logger.logs / etc.)", () => {
     // Every dict ``ctx.emitChange`` received must be null-proto.
     const emittedDicts = stub.emitChange.mock.calls
       .map((c) => c[1])
-      .filter(
-        (v) => v !== null && typeof v === "object" && !Array.isArray(v),
-      ) as Record<string, unknown>[];
+      .filter((v) => v !== null && typeof v === "object" && !Array.isArray(v)) as Record<
+      string,
+      unknown
+    >[];
     expect(emittedDicts.length).toBeGreaterThanOrEqual(2);
     for (const d of emittedDicts) {
       expect(Object.getPrototypeOf(d)).toBeNull();

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -46,9 +46,7 @@ interface CtxStub {
   filterRenderable: ReturnType<typeof vi.fn>;
 }
 
-function collectHandlers(
-  values: unknown[],
-): Array<(...args: unknown[]) => unknown> {
+function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unknown> {
   const out: Array<(...args: unknown[]) => unknown> = [];
   const walk = (v: unknown): void => {
     if (typeof v === "function") {
@@ -137,10 +135,7 @@ describe("renderNestedListField", () => {
     // Last handler in render order is the add button (rendered after
     // the items + their per-item remove buttons).
     handlers[handlers.length - 1]();
-    expect(emitChange).toHaveBeenCalledWith(
-      ["devices"],
-      [{ id: "kitchen" }, {}],
-    );
+    expect(emitChange).toHaveBeenCalledWith(["devices"], [{ id: "kitchen" }, {}]);
   });
 
   it("removeAt drops the item at idx and emits the new array", () => {
@@ -154,10 +149,7 @@ describe("renderNestedListField", () => {
     const handlers = collectHandlers(tpl.values);
     expect(handlers).toHaveLength(4);
     handlers[1]();
-    expect(emitChange).toHaveBeenCalledWith(
-      ["devices"],
-      [{ id: "a" }, { id: "c" }],
-    );
+    expect(emitChange).toHaveBeenCalledWith(["devices"], [{ id: "a" }, { id: "c" }]);
     // Untouched siblings preserve identity.
     const next = emitChange.mock.calls[0][1] as Array<Record<string, unknown>>;
     expect(next[0]).toBe(before.devices[0]);
@@ -201,7 +193,7 @@ describe("renderNestedListField", () => {
     });
     // Pretend the filter drops ``area_id`` for this item.
     filterRenderable.mockImplementation((entries) =>
-      entries.filter((e) => e.key !== "area_id"),
+      entries.filter((e) => e.key !== "area_id")
     );
     renderNestedListField(entry, ["devices"], ctx);
     expect(renderEntry).toHaveBeenCalledTimes(2);

--- a/test/components/reauth-wizard-dialog-helpers.test.ts
+++ b/test/components/reauth-wizard-dialog-helpers.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { APIError } from "../../src/api/api-error.js";
-import {
-  ErrorCode,
-  type OffloaderPinMismatchAlert,
-} from "../../src/api/types.js";
+import { ErrorCode, type OffloaderPinMismatchAlert } from "../../src/api/types.js";
 import {
   buildReauthPairRequest,
   classifyReauthError,
@@ -28,7 +25,7 @@ import {
  */
 
 function fixtureAlert(
-  overrides: Partial<OffloaderPinMismatchAlert> = {},
+  overrides: Partial<OffloaderPinMismatchAlert> = {}
 ): OffloaderPinMismatchAlert {
   return {
     kind: "pin_mismatch",

--- a/test/components/wizard/wizard-step-board-platforms.test.ts
+++ b/test/components/wizard/wizard-step-board-platforms.test.ts
@@ -63,9 +63,7 @@ describe("wizard step-board platform chips", () => {
       // esptool-js returns names like "ESP32-C6 (QFN32) (revision v0.2)".
       // The function must strip everything from the first `(` onward
       // before matching, otherwise the variant lookup misses.
-      expect(chipNameToFilterLabel("ESP32-C6 (QFN32) (revision v0.2)")).toBe(
-        "ESP32-C6",
-      );
+      expect(chipNameToFilterLabel("ESP32-C6 (QFN32) (revision v0.2)")).toBe("ESP32-C6");
     });
 
     it("maps every ESP32 variant to its filter label", () => {

--- a/test/util/_make-component-entry.ts
+++ b/test/util/_make-component-entry.ts
@@ -7,14 +7,11 @@
  * under ``test/util/`` so the file isn't picked up by the
  * ``test/**\/*.test.ts`` vitest glob.
  */
-import {
-  ComponentCategory,
-  type ComponentCatalogEntry,
-} from "../../src/api/types.js";
+import { ComponentCategory, type ComponentCatalogEntry } from "../../src/api/types.js";
 
 export function makeComponentEntry(
   id: string,
-  overrides: Partial<ComponentCatalogEntry> = {},
+  overrides: Partial<ComponentCatalogEntry> = {}
 ): ComponentCatalogEntry {
   return {
     id,

--- a/test/util/auth-token.test.ts
+++ b/test/util/auth-token.test.ts
@@ -52,7 +52,7 @@ describe("auth-token", () => {
   it("treats an empty token string as no token", () => {
     localStorage.setItem(
       "esphome.auth-token",
-      JSON.stringify({ token: "", expires_at: 0 }),
+      JSON.stringify({ token: "", expires_at: 0 })
     );
     expect(getStoredToken()).toBeNull();
   });

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -67,30 +67,34 @@ type Stubbed = {
 };
 
 const stubApi = (impls?: {
-  triggers?: (platform?: string, boardId?: string) =>
-    | Promise<AutomationTrigger[]>
-    | AutomationTrigger[];
-  actions?: (platform?: string, boardId?: string) =>
-    | Promise<AutomationAction[]>
-    | AutomationAction[];
-  conditions?: (platform?: string, boardId?: string) =>
-    | Promise<AutomationCondition[]>
-    | AutomationCondition[];
-  effects?: (platform?: string, boardId?: string) =>
-    | Promise<LightEffect[]>
-    | LightEffect[];
+  triggers?: (
+    platform?: string,
+    boardId?: string
+  ) => Promise<AutomationTrigger[]> | AutomationTrigger[];
+  actions?: (
+    platform?: string,
+    boardId?: string
+  ) => Promise<AutomationAction[]> | AutomationAction[];
+  conditions?: (
+    platform?: string,
+    boardId?: string
+  ) => Promise<AutomationCondition[]> | AutomationCondition[];
+  effects?: (
+    platform?: string,
+    boardId?: string
+  ) => Promise<LightEffect[]> | LightEffect[];
 }): Stubbed => {
   const getAutomationTriggers = vi.fn((platform?: string, boardId?: string) =>
-    Promise.resolve(impls?.triggers?.(platform, boardId) ?? [trigger("on_boot")]),
+    Promise.resolve(impls?.triggers?.(platform, boardId) ?? [trigger("on_boot")])
   );
   const getAutomationActions = vi.fn((platform?: string, boardId?: string) =>
-    Promise.resolve(impls?.actions?.(platform, boardId) ?? [action("delay")]),
+    Promise.resolve(impls?.actions?.(platform, boardId) ?? [action("delay")])
   );
   const getAutomationConditions = vi.fn((platform?: string, boardId?: string) =>
-    Promise.resolve(impls?.conditions?.(platform, boardId) ?? [condition("and")]),
+    Promise.resolve(impls?.conditions?.(platform, boardId) ?? [condition("and")])
   );
   const getLightEffects = vi.fn((platform?: string, boardId?: string) =>
-    Promise.resolve(impls?.effects?.(platform, boardId) ?? [effect("pulse")]),
+    Promise.resolve(impls?.effects?.(platform, boardId) ?? [effect("pulse")])
   );
   return {
     api: {

--- a/test/util/base-path.test.ts
+++ b/test/util/base-path.test.ts
@@ -21,10 +21,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 type Globals = Record<string, unknown>;
 
-function setGlobals(opts: {
-  scriptSrc?: string;
-  pathname?: string;
-}): void {
+function setGlobals(opts: { scriptSrc?: string; pathname?: string }): void {
   const g = globalThis as Globals;
   // Fake HTMLScriptElement so the ``script instanceof HTMLScriptElement``
   // guard in ``base-path.ts`` doesn't throw on the missing constructor.
@@ -76,8 +73,7 @@ describe("BASE_PATH derivation", () => {
 
   it("derives the HA ingress prefix from the entry script URL", async () => {
     setGlobals({
-      scriptSrc:
-        "http://homeassistant.local:8123/api/hassio_ingress/TOKEN/app.abc123.js",
+      scriptSrc: "http://homeassistant.local:8123/api/hassio_ingress/TOKEN/app.abc123.js",
     });
     const { BASE_PATH } = await loadModule();
     expect(BASE_PATH).toBe("/api/hassio_ingress/TOKEN/");
@@ -123,7 +119,7 @@ describe("withBase", () => {
     expect(withBase("/")).toBe("/api/hassio_ingress/T/");
     expect(withBase("/dashboard")).toBe("/api/hassio_ingress/T/dashboard");
     expect(withBase("/assets/logo/esphome.svg")).toBe(
-      "/api/hassio_ingress/T/assets/logo/esphome.svg",
+      "/api/hassio_ingress/T/assets/logo/esphome.svg"
     );
   });
 

--- a/test/util/board-pin-defaults.test.ts
+++ b/test/util/board-pin-defaults.test.ts
@@ -72,12 +72,9 @@ describe("seedBoardPinDefaults", () => {
   ];
 
   it("seeds matching pins from board manifest features", () => {
-    const result = seedBoardPinDefaults(
-      "i2c",
-      i2cEntries,
-      makeBoard(c3Pins),
-      { id: "i2c_1" },
-    );
+    const result = seedBoardPinDefaults("i2c", i2cEntries, makeBoard(c3Pins), {
+      id: "i2c_1",
+    });
     // GPIO8 is tagged i2c_sda → sda entry gets 8.
     // GPIO9 is tagged i2c_scl → scl entry gets 9.
     expect(result).toEqual({ id: "i2c_1", scl: 9, sda: 8 });
@@ -89,7 +86,7 @@ describe("seedBoardPinDefaults", () => {
       i2cEntries,
       makeBoard(c3Pins),
       // User typed scl manually before clicking Add.
-      { id: "i2c_1", scl: 5 },
+      { id: "i2c_1", scl: 5 }
     );
     // sda still seeded; scl untouched.
     expect(result).toEqual({ id: "i2c_1", scl: 5, sda: 8 });
@@ -103,12 +100,9 @@ describe("seedBoardPinDefaults", () => {
   });
 
   it("returns input unchanged when board has no pins", () => {
-    const result = seedBoardPinDefaults(
-      "i2c",
-      i2cEntries,
-      makeBoard([]),
-      { id: "i2c_1" },
-    );
+    const result = seedBoardPinDefaults("i2c", i2cEntries, makeBoard([]), {
+      id: "i2c_1",
+    });
     expect(result).toEqual({ id: "i2c_1" });
   });
 
@@ -134,7 +128,7 @@ describe("seedBoardPinDefaults", () => {
       "audio_adc.es7210",
       [makeEntry({ key: "din", default_value: "GPIO4" })],
       makeBoard([makePin({ gpio: 4, features: ["adc"] })]),
-      {},
+      {}
     );
     expect(result).toEqual({});
   });
@@ -151,7 +145,7 @@ describe("seedBoardPinDefaults", () => {
       "featured.athom-smart-plug-v3.relay",
       [makeEntry({ key: "pin", default_value: "GPIO12" })],
       makeBoard([makePin({ gpio: 8, features: ["i2c_sda"] })]),
-      { pin: "GPIO12" }, // catalog preset already in values
+      { pin: "GPIO12" } // catalog preset already in values
     );
     // No change — preset stays put.
     expect(result).toEqual({ pin: "GPIO12" });
@@ -160,9 +154,7 @@ describe("seedBoardPinDefaults", () => {
   it("only seeds PIN-typed entries, not other types", () => {
     // A board pin tagged i2c_frequency wouldn't make sense, but if
     // the manifest had it, the seeder must NOT touch a FLOAT entry.
-    const board = makeBoard([
-      makePin({ gpio: 8, features: ["i2c_frequency"] }),
-    ]);
+    const board = makeBoard([makePin({ gpio: 8, features: ["i2c_frequency"] })]);
     const result = seedBoardPinDefaults(
       "i2c",
       [
@@ -173,7 +165,7 @@ describe("seedBoardPinDefaults", () => {
         }),
       ],
       board,
-      {},
+      {}
     );
     expect(result).toEqual({});
   });
@@ -194,7 +186,7 @@ describe("seedBoardPinDefaults", () => {
         makeEntry({ key: "tx", default_value: "GPIO1" }),
       ],
       board,
-      {},
+      {}
     );
     // Only entries whose key matches the suffix after ``uart_`` get
     // seeded — ``rx`` and ``tx``. Mismatched keys (``rx_pin``,
@@ -215,7 +207,7 @@ describe("seedBoardPinDefaults", () => {
       "i2c",
       [makeEntry({ key: "sda", default_value: "SDA" })],
       board,
-      {},
+      {}
     );
     expect(result).toEqual({ sda: 8 });
   });

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -23,13 +23,14 @@ const entry = (id: string, name: string): ComponentCatalogEntry =>
   }) as ComponentCatalogEntry;
 
 const mockApi = (
-  impl: (id: string, platform?: string, boardId?: string) =>
-    | Promise<ComponentCatalogEntry | null>
-    | ComponentCatalogEntry
-    | null,
+  impl: (
+    id: string,
+    platform?: string,
+    boardId?: string
+  ) => Promise<ComponentCatalogEntry | null> | ComponentCatalogEntry | null
 ): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
   const getComponent = vi.fn((id: string, platform?: string, boardId?: string) =>
-    Promise.resolve(impl(id, platform, boardId)),
+    Promise.resolve(impl(id, platform, boardId))
   );
   return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
 };
@@ -57,7 +58,7 @@ describe("component-name-cache", () => {
   it("dedupes concurrent in-flight calls for the same key", async () => {
     let resolve!: (v: ComponentCatalogEntry) => void;
     const { api, getComponent } = mockApi(
-      () => new Promise<ComponentCatalogEntry>((r) => (resolve = r)),
+      () => new Promise<ComponentCatalogEntry>((r) => (resolve = r))
     );
 
     const a = fetchComponent(api, "binary_sensor.gpio", "esp32");
@@ -75,7 +76,7 @@ describe("component-name-cache", () => {
 
   it("keys cache entries by component id, platform, and board id", async () => {
     const { api, getComponent } = mockApi((id, platform) =>
-      entry(id, `${id}|${platform ?? ""}`),
+      entry(id, `${id}|${platform ?? ""}`)
     );
 
     await fetchComponent(api, "sensor.dht", "esp32");
@@ -83,12 +84,8 @@ describe("component-name-cache", () => {
     await fetchComponent(api, "sensor.dht");
 
     expect(getComponent).toHaveBeenCalledTimes(3);
-    expect(getCachedComponent("sensor.dht", "esp32")?.name).toBe(
-      "sensor.dht|esp32",
-    );
-    expect(getCachedComponent("sensor.dht", "esp8266")?.name).toBe(
-      "sensor.dht|esp8266",
-    );
+    expect(getCachedComponent("sensor.dht", "esp32")?.name).toBe("sensor.dht|esp32");
+    expect(getCachedComponent("sensor.dht", "esp8266")?.name).toBe("sensor.dht|esp8266");
     expect(getCachedComponent("sensor.dht")?.name).toBe("sensor.dht|");
   });
 

--- a/test/util/component-name-resolver-controller.test.ts
+++ b/test/util/component-name-resolver-controller.test.ts
@@ -42,7 +42,7 @@ const stubHost = () => {
 };
 
 const mockApi = (
-  impl: (id: string) => ComponentCatalogEntry | null,
+  impl: (id: string) => ComponentCatalogEntry | null
 ): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
   const getComponent = vi.fn((id: string) => Promise.resolve(impl(id)));
   return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
@@ -58,7 +58,7 @@ describe("ComponentNameResolverController", () => {
     const ctl = new ComponentNameResolverController(
       host,
       () => api,
-      () => "esp32",
+      () => "esp32"
     );
 
     expect(ctl.resolve("i2c")).toBe("i2c"); // not yet fetched
@@ -71,7 +71,11 @@ describe("ComponentNameResolverController", () => {
   it("falls back to the raw id when the cache has no entry", () => {
     const { host } = stubHost();
     const { api } = mockApi(() => null);
-    const ctl = new ComponentNameResolverController(host, () => api, () => undefined);
+    const ctl = new ComponentNameResolverController(
+      host,
+      () => api,
+      () => undefined
+    );
 
     expect(ctl.resolve("uart")).toBe("uart");
   });
@@ -82,7 +86,7 @@ describe("ComponentNameResolverController", () => {
     const ctl = new ComponentNameResolverController(
       host,
       () => api,
-      () => undefined,
+      () => undefined
     );
 
     // No subscription before hostConnected — kickoff still fetches, but
@@ -106,7 +110,7 @@ describe("ComponentNameResolverController", () => {
     const ctl = new ComponentNameResolverController(
       host,
       () => undefined,
-      () => undefined,
+      () => undefined
     );
     // Should be a no-op rather than throwing.
     expect(() => ctl.kickoff(["i2c", "uart"])).not.toThrow();
@@ -118,7 +122,7 @@ describe("ComponentNameResolverController", () => {
     const ctl = new ComponentNameResolverController(
       host,
       () => api,
-      () => undefined,
+      () => undefined
     );
     connect();
 

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -11,13 +11,9 @@ describe("generateDefaultComponentId", () => {
     // namespace in ESPHome codegen. These components aren't referenced
     // by id from elsewhere, so we just don't seed one — power users
     // can type a value if they need it for `!extend` overrides.
-    expect(generateDefaultComponentId("web_server", false, new Set())).toBe(
-      null,
-    );
+    expect(generateDefaultComponentId("web_server", false, new Set())).toBe(null);
     expect(generateDefaultComponentId("mdns", false, new Set())).toBe(null);
-    expect(generateDefaultComponentId("captive_portal", false, new Set())).toBe(
-      null,
-    );
+    expect(generateDefaultComponentId("captive_portal", false, new Set())).toBe(null);
     expect(generateDefaultComponentId("logger", false, new Set())).toBe(null);
     expect(generateDefaultComponentId("api", false, new Set())).toBe(null);
     expect(generateDefaultComponentId("ota", false, new Set())).toBe(null);
@@ -28,18 +24,14 @@ describe("generateDefaultComponentId", () => {
     // Even an unrelated id collision shouldn't flip them back into
     // suffix-generation mode.
     const existing = new Set(["web_server", "web_server_1", "web_server_2"]);
-    expect(generateDefaultComponentId("web_server", false, existing)).toBe(
-      null,
-    );
+    expect(generateDefaultComponentId("web_server", false, existing)).toBe(null);
   });
 
   it("suffixes top-level multi_conf components", () => {
     // `script`, `i2c`, `spi`, etc. — users add several and reference
     // them by id from automations / bus consumers, so a prefilled
     // unique id earns its keep.
-    expect(generateDefaultComponentId("script", true, new Set())).toBe(
-      "script_1",
-    );
+    expect(generateDefaultComponentId("script", true, new Set())).toBe("script_1");
   });
 
   it("suffixes platform entries even when multi_conf is false", () => {
@@ -47,17 +39,17 @@ describe("generateDefaultComponentId", () => {
     // routinely add multiple entries of the same platform and reference
     // them by id (`id(my_switch).turn_on()`), so the suffix is useful.
     expect(generateDefaultComponentId("switch.gpio", false, new Set())).toBe(
-      "switch_gpio_1",
+      "switch_gpio_1"
     );
     expect(generateDefaultComponentId("sensor.dht", true, new Set())).toBe(
-      "sensor_dht_1",
+      "sensor_dht_1"
     );
   });
 
   it("walks the suffix counter on collision", () => {
     const existing = new Set(["switch_gpio_1", "switch_gpio_2"]);
     expect(generateDefaultComponentId("switch.gpio", true, existing)).toBe(
-      "switch_gpio_3",
+      "switch_gpio_3"
     );
   });
 
@@ -65,14 +57,12 @@ describe("generateDefaultComponentId", () => {
     // Counter-walk for a top-level (no `.`) multi_conf entry is a
     // distinct code path from the platform case above — pin it.
     const existing = new Set(["script_1"]);
-    expect(generateDefaultComponentId("script", true, existing)).toBe(
-      "script_2",
-    );
+    expect(generateDefaultComponentId("script", true, existing)).toBe("script_2");
   });
 
   it("lowercases mixed-case platform ids", () => {
     expect(generateDefaultComponentId("Switch.GPIO", true, new Set())).toBe(
-      "switch_gpio_1",
+      "switch_gpio_1"
     );
   });
 });
@@ -92,7 +82,7 @@ sensor:
     platform: dht
 `;
     expect(collectExistingIds(yaml)).toEqual(
-      new Set(["web_server", "temp_1", "humid_1"]),
+      new Set(["web_server", "temp_1", "humid_1"])
     );
   });
 

--- a/test/util/device-sort.test.ts
+++ b/test/util/device-sort.test.ts
@@ -4,10 +4,7 @@
  * order rows by what they display. #946.
  */
 import { describe, expect, it } from "vitest";
-import {
-  DEVICE_SORT_COLLATOR,
-  deviceSortKey,
-} from "../../src/util/device-sort.js";
+import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../src/util/device-sort.js";
 
 type SortInput = Parameters<typeof deviceSortKey>[0];
 

--- a/test/util/download-text.test.ts
+++ b/test/util/download-text.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  downloadAnsiText,
-  downloadBase64Binary,
-} from "../../src/util/download-text.js";
+import { downloadAnsiText, downloadBase64Binary } from "../../src/util/download-text.js";
 
 /* The runtime test environment is Node, so we stub the bits of the
    browser API the helper touches. The download mechanics (anchor +
@@ -15,7 +12,7 @@ class FakeBlob {
   static instances: FakeBlob[] = [];
   constructor(
     public parts: BlobPart[],
-    public options?: BlobPropertyBag,
+    public options?: BlobPropertyBag
   ) {
     FakeBlob.instances.push(this);
   }
@@ -58,10 +55,7 @@ function withBrowserStubs<T>(fn: () => T): { result: T; anchor: FakeAnchor } {
 describe("downloadAnsiText", () => {
   it("strips ANSI escape sequences before saving", () => {
     const { result, anchor } = withBrowserStubs(() =>
-      downloadAnsiText(
-        ["plain", "[31mred[0m", "[1;33mwarn[0m"],
-        "out.txt",
-      ),
+      downloadAnsiText(["plain", "[31mred[0m", "[1;33mwarn[0m"], "out.txt")
     );
     expect(result).toBe("plain\nred\nwarn");
     expect(anchor.download).toBe("out.txt");
@@ -69,9 +63,7 @@ describe("downloadAnsiText", () => {
   });
 
   it("joins lines with a single \\n (no trailing newline)", () => {
-    const { result } = withBrowserStubs(() =>
-      downloadAnsiText(["a", "b", "c"], "x.txt"),
-    );
+    const { result } = withBrowserStubs(() => downloadAnsiText(["a", "b", "c"], "x.txt"));
     expect(result).toBe("a\nb\nc");
   });
 
@@ -88,17 +80,14 @@ describe("downloadAnsiText", () => {
        that shape). All three terminators must collapse so the saved
        file reads cleanly. */
     const { result } = withBrowserStubs(() =>
-      downloadAnsiText(
-        ["one\n", "two\r\n", "three", "four\r", "five\r\r\n"],
-        "log.txt",
-      ),
+      downloadAnsiText(["one\n", "two\r\n", "three", "four\r", "five\r\r\n"], "log.txt")
     );
     expect(result).toBe("one\ntwo\nthree\nfour\nfive");
   });
 
   it("preserves bracketed text that isn't an ANSI escape (no ESC byte)", () => {
     const { result } = withBrowserStubs(() =>
-      downloadAnsiText(["[INFO] startup", "[1;31m not-an-escape"], "log.txt"),
+      downloadAnsiText(["[INFO] startup", "[1;31m not-an-escape"], "log.txt")
     );
     /* stripAnsi only matches when ESC () is present, so plain
        bracketed text — which shows up in real ESPHome logs as level
@@ -107,9 +96,7 @@ describe("downloadAnsiText", () => {
   });
 
   it("creates a text/plain Blob with the joined content", () => {
-    withBrowserStubs(() =>
-      downloadAnsiText(["hello", "[32mworld[0m"], "greeting.txt"),
-    );
+    withBrowserStubs(() => downloadAnsiText(["hello", "[32mworld[0m"], "greeting.txt"));
     expect(FakeBlob.instances).toHaveLength(1);
     const blob = FakeBlob.instances[0];
     expect(blob.options?.type).toBe("text/plain");
@@ -121,7 +108,7 @@ describe("downloadBase64Binary", () => {
   it("decodes the base64 payload and saves as application/octet-stream", () => {
     /* ``AAECAw==`` decodes to the four-byte sequence 0x00 0x01 0x02 0x03. */
     const { anchor } = withBrowserStubs(() =>
-      downloadBase64Binary("AAECAw==", "firmware.bin"),
+      downloadBase64Binary("AAECAw==", "firmware.bin")
     );
     expect(anchor.download).toBe("firmware.bin");
     expect(anchor.click).toHaveBeenCalledTimes(1);
@@ -162,9 +149,7 @@ describe("downloadBase64Binary", () => {
     /* An empty base64 string decodes to zero bytes. Helpful for
        defensive call sites that pass through whatever the backend
        returned without their own length gate. */
-    const { anchor } = withBrowserStubs(() =>
-      downloadBase64Binary("", "empty.bin"),
-    );
+    const { anchor } = withBrowserStubs(() => downloadBase64Binary("", "empty.bin"));
     expect(anchor.download).toBe("empty.bin");
     const blob = FakeBlob.instances[0];
     const part = blob.parts[0];

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -21,8 +21,12 @@ describe("getEncryptionState", () => {
     expect(getEncryptionState(inputs({ api_enabled: false }))).toBe("none");
     expect(
       getEncryptionState(
-        inputs({ api_enabled: false, api_encrypted: true, api_encryption_active: "Noise_..." }),
-      ),
+        inputs({
+          api_enabled: false,
+          api_encrypted: true,
+          api_encryption_active: "Noise_...",
+        })
+      )
     ).toBe("none");
   });
 
@@ -38,15 +42,18 @@ describe("getEncryptionState", () => {
     /* Cast through ``as unknown`` so we can simulate an older WS
        payload that omits the field entirely; ``EncryptionInputs``
        declares it required to keep call-site coverage tight. */
-    const stale = { ...inputs(), api_encryption_active: undefined } as unknown as EncryptionInputs;
+    const stale = {
+      ...inputs(),
+      api_encryption_active: undefined,
+    } as unknown as EncryptionInputs;
     expect(getEncryptionState(stale)).toBe("active");
   });
 
   it("returns 'active' when YAML encrypted and mDNS confirms encryption", () => {
     expect(
       getEncryptionState(
-        inputs({ api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256" }),
-      ),
+        inputs({ api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256" })
+      )
     ).toBe("active");
   });
 
@@ -62,8 +69,8 @@ describe("getEncryptionState", () => {
     for (const observed of [null, ""]) {
       expect(
         getEncryptionState(
-          inputs({ api_encryption_active: observed, has_pending_changes: true }),
-        ),
+          inputs({ api_encryption_active: observed, has_pending_changes: true })
+        )
       ).toBe("pending");
     }
   });
@@ -80,16 +87,16 @@ describe("getEncryptionState", () => {
         inputs({
           api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
           has_pending_changes: true,
-        }),
-      ),
+        })
+      )
     ).toBe("active");
   });
 
   it("returns 'mismatch' when YAML encrypted, mDNS reports plaintext, no pending changes", () => {
     expect(
       getEncryptionState(
-        inputs({ api_encryption_active: "", has_pending_changes: false }),
-      ),
+        inputs({ api_encryption_active: "", has_pending_changes: false })
+      )
     ).toBe("mismatch");
   });
 
@@ -124,8 +131,8 @@ describe("getEncryptionState", () => {
         inputs({
           api_encrypted: false,
           api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
-        }),
-      ),
+        })
+      )
     ).toBe("active");
   });
 
@@ -137,9 +144,7 @@ describe("getEncryptionState", () => {
        just because ``api_encryption_active`` is non-null —
        only truthy strings (the live cipher) flip the state. */
     expect(
-      getEncryptionState(
-        inputs({ api_encrypted: false, api_encryption_active: "" }),
-      ),
+      getEncryptionState(inputs({ api_encrypted: false, api_encryption_active: "" }))
     ).toBe("plaintext");
   });
 });
@@ -169,41 +174,35 @@ describe("getCompactEncryptionVisual", () => {
     // state, hidden in compact views.
     expect(
       getCompactEncryptionVisual(
-        inputs({ api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256" }),
-      ),
+        inputs({ api_encryption_active: "Noise_NNpsk0_25519_ChaChaPoly_SHA256" })
+      )
     ).toBeNull();
   });
 
   it("keeps the lock when YAML enables encryption but mDNS hasn't broadcast", () => {
     // active state with null api_encryption_active is the
     // "waiting / unknown" case the issue explicitly wants visible.
-    const v = getCompactEncryptionVisual(
-      inputs({ api_encryption_active: null }),
-    );
+    const v = getCompactEncryptionVisual(inputs({ api_encryption_active: null }));
     expect(v).not.toBeNull();
     expect(v!.cssClass).toBe("secure");
   });
 
   it("keeps showing the icon for plaintext / pending / mismatch states", () => {
     const plaintext = getCompactEncryptionVisual(
-      inputs({ api_encrypted: false, api_encryption_active: null }),
+      inputs({ api_encrypted: false, api_encryption_active: null })
     );
     expect(plaintext?.cssClass).toBe("insecure");
 
     const pending = getCompactEncryptionVisual(
-      inputs({ api_encryption_active: "", has_pending_changes: true }),
+      inputs({ api_encryption_active: "", has_pending_changes: true })
     );
     expect(pending?.cssClass).toBe("pending");
 
-    const mismatch = getCompactEncryptionVisual(
-      inputs({ api_encryption_active: "" }),
-    );
+    const mismatch = getCompactEncryptionVisual(inputs({ api_encryption_active: "" }));
     expect(mismatch?.cssClass).toBe("mismatch");
   });
 
   it("returns null when the API is disabled (no indicator at all)", () => {
-    expect(
-      getCompactEncryptionVisual(inputs({ api_enabled: false })),
-    ).toBeNull();
+    expect(getCompactEncryptionVisual(inputs({ api_enabled: false }))).toBeNull();
   });
 });

--- a/test/util/escape-controller.test.ts
+++ b/test/util/escape-controller.test.ts
@@ -111,7 +111,7 @@ describe("EscapeController", () => {
         received = e;
         e.preventDefault();
       },
-      { target },
+      { target }
     );
     ctrl.set(true);
 

--- a/test/util/esphome-id.test.ts
+++ b/test/util/esphome-id.test.ts
@@ -16,9 +16,7 @@ describe("normalizeEspHomeId", () => {
   it("collapses runs of invalid characters to a single underscore", () => {
     // The screenshot's regression case: spaces and slashes all
     // collapse into one underscore each, including the "is / a" run.
-    expect(normalizeEspHomeId("this is / a invalid id")).toBe(
-      "this_is_a_invalid_id",
-    );
+    expect(normalizeEspHomeId("this is / a invalid id")).toBe("this_is_a_invalid_id");
     expect(normalizeEspHomeId("my-script-name")).toBe("my_script_name");
     expect(normalizeEspHomeId("kitchen.sensor")).toBe("kitchen_sensor");
   });

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -88,7 +88,9 @@ describe("fetchBundle", () => {
     });
     const bundle = await fetchBundle(makeApi() as never, "esphome");
     expect(bundle).not.toBeNull();
-    expect(bundle?.esphome?.schemas?.CONFIG_SCHEMA?.schema.config_vars.on_boot).toBeDefined();
+    expect(
+      bundle?.esphome?.schemas?.CONFIG_SCHEMA?.schema.config_vars.on_boot
+    ).toBeDefined();
   });
 
   it("falls back to /dev/ when the version-specific bundle is missing", async () => {
@@ -132,7 +134,7 @@ describe("fetchBundle", () => {
     await Promise.all([fetchBundle(api, "esphome"), fetchBundle(api, "esphome")]);
     // One HEAD probe + one GET, regardless of how many in-flight callers.
     const gets = fetchSpy.mock.calls.filter(
-      (c) => (c[1] as RequestInit | undefined)?.method !== "HEAD",
+      (c) => (c[1] as RequestInit | undefined)?.method !== "HEAD"
     );
     expect(gets.length).toBe(1);
   });
@@ -151,9 +153,7 @@ describe("getTriggerKeys", () => {
       "on_shutdown",
     ]);
     // Docs flow through when present.
-    expect(triggers.find((t) => t.key === "on_boot")?.docs).toBe(
-      "Run when device boots",
-    );
+    expect(triggers.find((t) => t.key === "on_boot")?.docs).toBe("Run when device boots");
   });
 
   it("returns trigger keys from a platform-style component (binary_sensor.gpio)", async () => {
@@ -164,7 +164,7 @@ describe("getTriggerKeys", () => {
     const triggers = await getTriggerKeys(
       makeApi() as never,
       "binary_sensor",
-      "binary_sensor.gpio",
+      "binary_sensor.gpio"
     );
     expect(triggers.map((t) => t.key).sort()).toEqual(["on_press", "on_release"]);
   });
@@ -200,7 +200,7 @@ describe("getTriggerKeys", () => {
             },
           },
         }),
-        { status: 200 },
+        { status: 200 }
       );
     });
     const triggers = await getTriggerKeys(makeApi() as never, "plain", "plain");
@@ -255,12 +255,9 @@ describe("getTriggerKeys", () => {
     const triggers = await getTriggerKeys(
       makeApi() as never,
       "gpio",
-      "gpio.binary_sensor",
+      "gpio.binary_sensor"
     );
-    expect(triggers.map((t) => t.key).sort()).toEqual([
-      "on_press",
-      "on_release",
-    ]);
+    expect(triggers.map((t) => t.key).sort()).toEqual(["on_press", "on_release"]);
     expect(triggers.find((t) => t.key === "on_press")?.docs).toBe("Pressed");
   });
 
@@ -295,11 +292,7 @@ describe("getTriggerKeys", () => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
-    const triggers = await getTriggerKeys(
-      makeApi() as never,
-      "child",
-      "child",
-    );
+    const triggers = await getTriggerKeys(makeApi() as never, "child", "child");
     expect(triggers.map((t) => t.key).sort()).toEqual(["on_state", "on_value"]);
     expect(triggers.find((t) => t.key === "on_state")?.docs).toBe("child");
   });
@@ -355,7 +348,7 @@ describe("getActions", () => {
     const actions = await getActions(
       makeApi() as never,
       ["logger", "light"],
-      ["logger", "light"],
+      ["logger", "light"]
     );
     const keys = actions.map((a) => a.key).sort();
     expect(keys).toEqual([
@@ -364,9 +357,7 @@ describe("getActions", () => {
       "logger.log",
       "logger.set_level",
     ]);
-    expect(actions.find((a) => a.key === "logger.log")?.docs).toBe(
-      "Log a message",
-    );
+    expect(actions.find((a) => a.key === "logger.log")?.docs).toBe("Log a message");
   });
 
   it("emits core actions without a domain prefix", async () => {
@@ -384,7 +375,7 @@ describe("getActions", () => {
     const actions = await getActions(
       makeApi() as never,
       ["logger", "light"],
-      ["logger", "light"],
+      ["logger", "light"]
     );
     expect(actions).toEqual([]);
     debugSpy.mockRestore();
@@ -400,7 +391,7 @@ describe("getActions", () => {
     const actions = await getActions(
       makeApi() as never,
       ["logger", "logger"],
-      ["logger"],
+      ["logger"]
     );
     expect(actions.filter((a) => a.key === "logger.log").length).toBe(1);
   });
@@ -420,19 +411,12 @@ describe("getActions", () => {
             action: { foo: { type: "schema" } },
           },
         }),
-        { status: 200 },
+        { status: 200 }
       );
     });
-    const actions = await getActions(
-      makeApi() as never,
-      ["logger"],
-      ["logger"],
-    );
+    const actions = await getActions(makeApi() as never, ["logger"], ["logger"]);
     expect(actions.map((a) => a.key)).not.toContain("ignored.foo");
-    expect(actions.map((a) => a.key).sort()).toEqual([
-      "logger.log",
-      "logger.set_level",
-    ]);
+    expect(actions.map((a) => a.key).sort()).toEqual(["logger.log", "logger.set_level"]);
   });
 });
 
@@ -497,11 +481,7 @@ describe("getConfigVarKeys", () => {
         });
       throw new Error(`unexpected ${url}`);
     });
-    const keys = await getConfigVarKeys(
-      makeApi() as never,
-      "uptime",
-      "uptime.sensor",
-    );
+    const keys = await getConfigVarKeys(makeApi() as never, "uptime", "uptime.sensor");
     const labels = keys.map((k) => k.key);
     // Discriminator surfaces.
     expect(labels).toContain("type");
@@ -540,11 +520,7 @@ describe("getConfigVarKeys", () => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
       return new Response(JSON.stringify(CHILD_BUNDLE), { status: 200 });
     });
-    const keys = await getConfigVarKeys(
-      makeApi() as never,
-      "child",
-      "child",
-    );
+    const keys = await getConfigVarKeys(makeApi() as never, "child", "child");
     expect(keys.map((k) => k.key).sort()).toEqual(["inherited", "local"]);
   });
 
@@ -568,22 +544,14 @@ describe("getConfigVarKeys", () => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
-    const keys = await getConfigVarKeys(
-      makeApi() as never,
-      "thing",
-      "thing",
-    );
+    const keys = await getConfigVarKeys(makeApi() as never, "thing", "thing");
     expect(keys.map((k) => k.key)).toEqual(["name"]);
   });
 
   it("returns [] when the bundle fails to load", async () => {
     fetchSpy.mockRejectedValue(new TypeError("Failed to fetch"));
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const keys = await getConfigVarKeys(
-      makeApi() as never,
-      "uptime",
-      "uptime.sensor",
-    );
+    const keys = await getConfigVarKeys(makeApi() as never, "uptime", "uptime.sensor");
     expect(keys).toEqual([]);
     debugSpy.mockRestore();
   });
@@ -649,16 +617,14 @@ describe("getConfigVarValueOptions", () => {
       makeApi() as never,
       "uptime",
       "uptime.sensor",
-      "device_class",
+      "device_class"
     );
     expect(values.map((v) => v.value).sort()).toEqual([
       "duration",
       "humidity",
       "temperature",
     ]);
-    expect(values.find((v) => v.value === "duration")?.docs).toBe(
-      "Time elapsed",
-    );
+    expect(values.find((v) => v.value === "duration")?.docs).toBe("Time elapsed");
   });
 
   it("returns [] when the named config-var isn't an enum", async () => {
@@ -680,7 +646,7 @@ describe("getConfigVarValueOptions", () => {
       makeApi() as never,
       "thing",
       "thing",
-      "name",
+      "name"
     );
     expect(values).toEqual([]);
   });
@@ -692,7 +658,7 @@ describe("getConfigVarValueOptions", () => {
       makeApi() as never,
       "uptime",
       "uptime.sensor",
-      "device_class",
+      "device_class"
     );
     expect(values).toEqual([]);
     debugSpy.mockRestore();
@@ -759,20 +725,17 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       makeApi() as never,
       "uptime",
       "uptime.sensor",
-      "filters",
+      "filters"
     );
     expect(ref).toBe("sensor.filter");
-    const entries = await getRegistryEntries(
-      makeApi() as never,
-      ref!,
-    );
+    const entries = await getRegistryEntries(makeApi() as never, ref!);
     expect(entries.map((e) => e.key).sort()).toEqual([
       "calibrate_linear",
       "clamp",
       "multiply",
     ]);
     expect(entries.find((e) => e.key === "calibrate_linear")?.docs).toBe(
-      "Linear calibration",
+      "Linear calibration"
     );
   });
 
@@ -804,11 +767,7 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
-    const keys = await getConfigVarKeys(
-      makeApi() as never,
-      "thing",
-      "thing",
-    );
+    const keys = await getConfigVarKeys(makeApi() as never, "thing", "thing");
     expect(keys.find((k) => k.key === "filters")?.isList).toBe(true);
     expect(keys.find((k) => k.key === "name")?.isList).toBe(false);
   });
@@ -828,27 +787,16 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
-    const ref = await lookupRegistryRef(
-      makeApi() as never,
-      "thing",
-      "thing",
-      "name",
-    );
+    const ref = await lookupRegistryRef(makeApi() as never, "thing", "thing", "name");
     expect(ref).toBeNull();
   });
 
   it("returns [] when the registry ref points at a missing slot", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
       if (init?.method === "HEAD") return new Response(null, { status: 200 });
-      return new Response(
-        JSON.stringify({ thing: { schemas: {} } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ thing: { schemas: {} } }), { status: 200 });
     });
-    const entries = await getRegistryEntries(
-      makeApi() as never,
-      "thing.filter",
-    );
+    const entries = await getRegistryEntries(makeApi() as never, "thing.filter");
     expect(entries).toEqual([]);
   });
 
@@ -928,7 +876,7 @@ describe("getRegistryEntryKeys", () => {
       makeApi() as never,
       "globals",
       "globals",
-      "set",
+      "set"
     );
     expect(keys.map((k) => k.key).sort()).toEqual(["id", "value"]);
     expect(keys.find((k) => k.key === "id")?.required).toBe(true);
@@ -967,7 +915,7 @@ describe("getRegistryEntryKeys", () => {
       makeApi() as never,
       "light",
       "light",
-      "turn_on",
+      "turn_on"
     );
     expect(keys.map((k) => k.key).sort()).toEqual([
       "brightness",
@@ -986,7 +934,7 @@ describe("getRegistryEntryKeys", () => {
       makeApi() as never,
       "thing",
       "thing",
-      "missing",
+      "missing"
     );
     expect(keys).toEqual([]);
   });
@@ -1013,7 +961,7 @@ describe("getRegistryEntryKeys", () => {
       makeApi() as never,
       "esphome",
       "core",
-      "delay",
+      "delay"
     );
     expect(keys.map((k) => k.key)).toEqual(["time"]);
   });
@@ -1057,7 +1005,7 @@ describe("resolveVersion (probe failure handling)", () => {
     expect(bundle).not.toBeNull();
     await fetchBundle(makeApi() as never, "esphome");
     const heads = fetchSpy.mock.calls.filter(
-      (c) => (c[1] as RequestInit | undefined)?.method === "HEAD",
+      (c) => (c[1] as RequestInit | undefined)?.method === "HEAD"
     );
     expect(heads.length).toBe(1);
   });

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { getIndentation, indentUnit } from "@codemirror/language";
-import {
-  ESPHOME_YAML_INDENT,
-  esphomeYaml,
-} from "../../src/util/esphome-yaml-lang.js";
+import { ESPHOME_YAML_INDENT, esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 
 /**
  * The indent service mirrors the legacy esphome dashboard's Monaco
@@ -111,4 +108,3 @@ describe("esphome-yaml language extension shape", () => {
     expect(flat.length).toBeGreaterThan(0);
   });
 });
-

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { JobSource, JobStatus, JobType } from "../../src/api/types.js";
-import type {
-  ConfiguredDevice,
-  FirmwareJob,
-} from "../../src/api/types.js";
+import type { ConfiguredDevice, FirmwareJob } from "../../src/api/types.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { firmwareJobDisplayName } from "../../src/util/firmware-job-display.js";
 
@@ -58,22 +55,18 @@ describe("firmwareJobDisplayName (receiver-side remote-build jobs)", () => {
   it("prefers device_friendly_name when set", () => {
     const j = job({
       remote_peer: "alpha-dashboard",
-      configuration:
-        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      configuration: ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
       device_name: "kitchen",
       device_friendly_name: "AC Float Monitor 32",
     });
 
-    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe(
-      "AC Float Monitor 32",
-    );
+    expect(firmwareJobDisplayName(j, NO_DEVICES, localize)).toBe("AC Float Monitor 32");
   });
 
   it("falls back to device_name when friendly_name is empty", () => {
     const j = job({
       remote_peer: "alpha-dashboard",
-      configuration:
-        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      configuration: ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
       device_name: "kitchen",
       device_friendly_name: "",
     });
@@ -88,8 +81,7 @@ describe("firmwareJobDisplayName (receiver-side remote-build jobs)", () => {
        configuration path. */
     const j = job({
       remote_peer: "alpha-dashboard",
-      configuration:
-        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      configuration: ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
       device_name: "",
       device_friendly_name: "",
     });
@@ -104,8 +96,7 @@ describe("firmwareJobDisplayName (receiver-side remote-build jobs)", () => {
        must NOT shadow the offloader-sent name. */
     const j = job({
       remote_peer: "alpha-dashboard",
-      configuration:
-        ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
+      configuration: ".esphome/.remote_builds/alpha-dashboard/kitchen/kitchen.yaml",
       device_friendly_name: "AC Float Monitor 32",
     });
     const decoyDevices: ConfiguredDevice[] = [
@@ -116,9 +107,7 @@ describe("firmwareJobDisplayName (receiver-side remote-build jobs)", () => {
       } as ConfiguredDevice,
     ];
 
-    expect(firmwareJobDisplayName(j, decoyDevices, localize)).toBe(
-      "AC Float Monitor 32",
-    );
+    expect(firmwareJobDisplayName(j, decoyDevices, localize)).toBe("AC Float Monitor 32");
   });
 });
 

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -111,8 +111,7 @@ describe("parseFloatWithUnit", () => {
 
   it("round-trips through serialize for typical inputs", () => {
     for (const raw of ["50kHz", "0.5mHz", "1000Hz", "-2GHz"]) {
-      expect(serializeFloatWithUnit(parseFloatWithUnit(raw, FREQUENCY_UNITS)))
-        .toBe(raw);
+      expect(serializeFloatWithUnit(parseFloatWithUnit(raw, FREQUENCY_UNITS))).toBe(raw);
     }
   });
 
@@ -291,18 +290,14 @@ describe("defaultUnitForFloatWithUnit", () => {
 
 describe("chooseDisplayUnit", () => {
   it("uses the parsed unit when the value is non-empty", () => {
-    expect(
-      chooseDisplayUnit("50kHz", "10MHz", undefined, FREQUENCY_UNITS),
-    ).toBe("kHz");
+    expect(chooseDisplayUnit("50kHz", "10MHz", undefined, FREQUENCY_UNITS)).toBe("kHz");
   });
 
   it("ignores the pending unit when the value is non-empty", () => {
     // Once the user has typed a number, the picker reflects the
     // value's unit — pending state from before they typed is
     // superseded.
-    expect(
-      chooseDisplayUnit("50kHz", "10MHz", "GHz", FREQUENCY_UNITS),
-    ).toBe("kHz");
+    expect(chooseDisplayUnit("50kHz", "10MHz", "GHz", FREQUENCY_UNITS)).toBe("kHz");
   });
 
   it("uses the pending unit when the value is empty", () => {
@@ -315,15 +310,11 @@ describe("chooseDisplayUnit", () => {
   });
 
   it("falls back to the catalog default's unit when no pending pick", () => {
-    expect(
-      chooseDisplayUnit("", "50kHz", undefined, FREQUENCY_UNITS),
-    ).toBe("kHz");
+    expect(chooseDisplayUnit("", "50kHz", undefined, FREQUENCY_UNITS)).toBe("kHz");
   });
 
   it("falls back to the canonical option when nothing else is set", () => {
-    expect(
-      chooseDisplayUnit("", null, undefined, FREQUENCY_UNITS),
-    ).toBe("Hz");
+    expect(chooseDisplayUnit("", null, undefined, FREQUENCY_UNITS)).toBe("Hz");
   });
 
   it("returns empty when unit_options is empty", () => {
@@ -333,9 +324,7 @@ describe("chooseDisplayUnit", () => {
 
 describe("serializeFloatWithUnit", () => {
   it("concatenates value and unit without separator", () => {
-    expect(
-      serializeFloatWithUnit({ value: 50, unit: "kHz" }),
-    ).toBe("50kHz");
+    expect(serializeFloatWithUnit({ value: 50, unit: "kHz" })).toBe("50kHz");
   });
 
   it("returns empty string for null value", () => {

--- a/test/util/friendly-name-slugify.test.ts
+++ b/test/util/friendly-name-slugify.test.ts
@@ -12,7 +12,7 @@ describe("friendlyNameSlugify", () => {
     // entirely instead of mapping it to ``-`` like upstream's
     // ``friendly_name_slugify`` does. Pin the legacy parity.
     expect(friendlyNameSlugify("test_web_server_ota_esp32")).toBe(
-      "test-web-server-ota-esp32",
+      "test-web-server-ota-esp32"
     );
   });
 
@@ -31,9 +31,7 @@ describe("friendlyNameSlugify", () => {
     // ``.replace("__", "_")`` (which would leave ``my-cool--device``
     // for the same input). See the implementation comment for the
     // why.
-    expect(friendlyNameSlugify("  My  Cool - Device  ")).toBe(
-      "my-cool-device",
-    );
+    expect(friendlyNameSlugify("  My  Cool - Device  ")).toBe("my-cool-device");
   });
 
   it("drops characters outside [a-z0-9_-] before the underscore→hyphen pass", () => {

--- a/test/util/hostname.test.ts
+++ b/test/util/hostname.test.ts
@@ -34,20 +34,16 @@ describe("trimTrailingDot", () => {
 
 describe("normalizeHostnameForCompare", () => {
   it("lowercases per RFC 4343", () => {
-    expect(normalizeHostnameForCompare("MyDashboard.LOCAL")).toBe(
-      "mydashboard.local",
-    );
+    expect(normalizeHostnameForCompare("MyDashboard.LOCAL")).toBe("mydashboard.local");
   });
 
   it("strips trailing dot", () => {
-    expect(normalizeHostnameForCompare("mydashboard.local.")).toBe(
-      "mydashboard.local",
-    );
+    expect(normalizeHostnameForCompare("mydashboard.local.")).toBe("mydashboard.local");
   });
 
   it("trims surrounding whitespace", () => {
     expect(normalizeHostnameForCompare("  mydashboard.local  ")).toBe(
-      "mydashboard.local",
+      "mydashboard.local"
     );
   });
 
@@ -56,7 +52,7 @@ describe("normalizeHostnameForCompare", () => {
     // Freshly-discovered mDNS row: "MyDashboard.local."
     // The "already paired" check must consider these equal.
     expect(normalizeHostnameForCompare("mydashboard.local")).toBe(
-      normalizeHostnameForCompare("MyDashboard.local."),
+      normalizeHostnameForCompare("MyDashboard.local.")
     );
   });
 
@@ -88,9 +84,7 @@ describe("friendlyHostname", () => {
   });
 
   it("returns the input shape for non-mDNS FQDNs", () => {
-    expect(friendlyHostname("buildhost.example.com")).toBe(
-      "buildhost.example.com",
-    );
+    expect(friendlyHostname("buildhost.example.com")).toBe("buildhost.example.com");
   });
 
   it("returns the input shape for plain short names", () => {

--- a/test/util/label-usage.test.ts
+++ b/test/util/label-usage.test.ts
@@ -78,15 +78,9 @@ describe("deleteConfirmKey", () => {
 
 describe("isLabelNameDuplicate", () => {
   it("flags a name already in the catalog (case-insensitive)", () => {
-    expect(isLabelNameDuplicate("Kitchen", ["Bedroom", "Kitchen"], null)).toBe(
-      true,
-    );
-    expect(isLabelNameDuplicate("kitchen", ["Bedroom", "Kitchen"], null)).toBe(
-      true,
-    );
-    expect(isLabelNameDuplicate("KITCHEN", ["Bedroom", "Kitchen"], null)).toBe(
-      true,
-    );
+    expect(isLabelNameDuplicate("Kitchen", ["Bedroom", "Kitchen"], null)).toBe(true);
+    expect(isLabelNameDuplicate("kitchen", ["Bedroom", "Kitchen"], null)).toBe(true);
+    expect(isLabelNameDuplicate("KITCHEN", ["Bedroom", "Kitchen"], null)).toBe(true);
   });
 
   it("ignores leading/trailing whitespace", () => {
@@ -94,9 +88,7 @@ describe("isLabelNameDuplicate", () => {
   });
 
   it("does not flag a fresh name", () => {
-    expect(isLabelNameDuplicate("Garage", ["Bedroom", "Kitchen"], null)).toBe(
-      false,
-    );
+    expect(isLabelNameDuplicate("Garage", ["Bedroom", "Kitchen"], null)).toBe(false);
   });
 
   it("treats an empty / whitespace-only name as non-duplicate", () => {
@@ -110,21 +102,19 @@ describe("isLabelNameDuplicate", () => {
   it("excludes the editing label's own current name", () => {
     // User opened "Kitchen" for edit and types its name again —
     // shouldn't flag as duplicate.
-    expect(
-      isLabelNameDuplicate("Kitchen", ["Bedroom", "Kitchen"], "Kitchen"),
-    ).toBe(false);
+    expect(isLabelNameDuplicate("Kitchen", ["Bedroom", "Kitchen"], "Kitchen")).toBe(
+      false
+    );
     // Case-insensitive exclusion: typed casing differs from the
     // stored casing, but the editing-name match still applies.
-    expect(
-      isLabelNameDuplicate("kitchen", ["Bedroom", "Kitchen"], "Kitchen"),
-    ).toBe(false);
+    expect(isLabelNameDuplicate("kitchen", ["Bedroom", "Kitchen"], "Kitchen")).toBe(
+      false
+    );
   });
 
   it("still flags a name that collides with a different existing label in edit mode", () => {
     // User editing "Kitchen" tries to rename it to "Bedroom" —
     // that's a real collision.
-    expect(
-      isLabelNameDuplicate("Bedroom", ["Bedroom", "Kitchen"], "Kitchen"),
-    ).toBe(true);
+    expect(isLabelNameDuplicate("Bedroom", ["Bedroom", "Kitchen"], "Kitchen")).toBe(true);
   });
 });

--- a/test/util/markdown.test.ts
+++ b/test/util/markdown.test.ts
@@ -64,7 +64,7 @@ describe("isSafeLinkHref — rejected schemes", () => {
     // ``data:text/html;…`` would let an injected catalog
     // description carry a base64-encoded HTML payload.
     expect(
-      isSafeLinkHref("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="),
+      isSafeLinkHref("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")
     ).toBe(false);
   });
 

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -77,7 +77,7 @@ describe("navigate", () => {
     expect(pushStateSpy).toHaveBeenCalledTimes(1);
     expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
     const popstateCalls = dispatchSpy.mock.calls.filter(
-      (call) => (call[0] as Event).type === "popstate",
+      (call) => (call[0] as Event).type === "popstate"
     );
     expect(popstateCalls).toHaveLength(1);
   });
@@ -93,7 +93,7 @@ describe("navigate", () => {
     // refactor that fired pushState eagerly (and only consulted
     // the guard for cancellation) can't slip through.
     expect(guard.mock.invocationCallOrder[0]).toBeLessThan(
-      pushStateSpy.mock.invocationCallOrder[0],
+      pushStateSpy.mock.invocationCallOrder[0]
     );
   });
 
@@ -106,7 +106,7 @@ describe("navigate", () => {
     expect(guard).toHaveBeenCalledTimes(1);
     expect(pushStateSpy).not.toHaveBeenCalled();
     const popstateCalls = dispatchSpy.mock.calls.filter(
-      (call) => (call[0] as Event).type === "popstate",
+      (call) => (call[0] as Event).type === "popstate"
     );
     expect(popstateCalls).toHaveLength(0);
   });
@@ -126,7 +126,7 @@ describe("navigate", () => {
 
     expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/");
     const popstateCalls = dispatchSpy.mock.calls.filter(
-      (call) => (call[0] as Event).type === "popstate",
+      (call) => (call[0] as Event).type === "popstate"
     );
     expect(popstateCalls).toHaveLength(1);
   });
@@ -170,7 +170,7 @@ describe("navigate", () => {
       () =>
         new Promise<boolean>((resolve) => {
           resolveGuard = resolve;
-        }),
+        })
     );
     setLeaveGuard(guard);
 

--- a/test/util/nested-values.test.ts
+++ b/test/util/nested-values.test.ts
@@ -72,7 +72,7 @@ describe("setIn", () => {
 
   it("preserves array shape when replacing a slot", () => {
     expect(
-      setIn({ devices: [{ name: "old" }] }, ["devices", "0"], { name: "new" }),
+      setIn({ devices: [{ name: "old" }] }, ["devices", "0"], { name: "new" })
     ).toEqual({ devices: [{ name: "new" }] });
   });
 
@@ -106,8 +106,9 @@ describe("getIn", () => {
   it("descends into arrays via numeric path segments", () => {
     // Arrays are valid containers — the nested-list renderer needs
     // to read child fields out of items at ``devices[0]``.
-    expect(getIn({ devices: [{ name: "front" }] }, ["devices", "0", "name"]))
-      .toBe("front");
+    expect(getIn({ devices: [{ name: "front" }] }, ["devices", "0", "name"])).toBe(
+      "front"
+    );
     expect(getIn({ a: [1, 2, 3] }, ["a", "2"])).toBe(3);
   });
 
@@ -141,9 +142,7 @@ describe("isPrimitiveOrNullish", () => {
     // Pinning this is the whole reason the helper exists.
     const noProto = Object.create(null);
     expect(isPrimitiveOrNullish(noProto)).toBe(false);
-    expect(() => String(noProto)).toThrow(
-      /Cannot convert object to primitive value/,
-    );
+    expect(() => String(noProto)).toThrow(/Cannot convert object to primitive value/);
   });
 
   it("rejects arrays, dates, maps, and other built-ins", () => {

--- a/test/util/onboarding-gate.test.ts
+++ b/test/util/onboarding-gate.test.ts
@@ -27,7 +27,7 @@ const wifi = (status: OnboardingStepStatus) => ({
 const stateWith = (
   steps: ReturnType<typeof wifi>[],
   current_version = 1,
-  completed_version = 0,
+  completed_version = 0
 ): OnboardingState => ({
   current_version,
   completed_version,
@@ -36,15 +36,13 @@ const stateWith = (
 
 describe("isOnboardingPending", () => {
   it("returns true when any step is pending", () => {
-    expect(
-      isOnboardingPending(stateWith([wifi(OnboardingStepStatus.PENDING)])),
-    ).toBe(true);
+    expect(isOnboardingPending(stateWith([wifi(OnboardingStepStatus.PENDING)]))).toBe(
+      true
+    );
   });
 
   it("returns false when every step is done", () => {
-    expect(
-      isOnboardingPending(stateWith([wifi(OnboardingStepStatus.DONE)])),
-    ).toBe(false);
+    expect(isOnboardingPending(stateWith([wifi(OnboardingStepStatus.DONE)]))).toBe(false);
   });
 
   it("returns false on an empty step list", () => {
@@ -55,10 +53,7 @@ describe("isOnboardingPending", () => {
 describe("shouldAutoShowOnboarding", () => {
   it("pops for a fresh-install user behind current with pending step", () => {
     expect(
-      shouldAutoShowOnboarding(
-        stateWith([wifi(OnboardingStepStatus.PENDING)]),
-        false,
-      ),
+      shouldAutoShowOnboarding(stateWith([wifi(OnboardingStepStatus.PENDING)]), false)
     ).toBe(true);
   });
 
@@ -67,20 +62,17 @@ describe("shouldAutoShowOnboarding", () => {
       "(this is the bug fix — completed_version=0 + step DONE must not interrupt)",
     () => {
       expect(
-        shouldAutoShowOnboarding(
-          stateWith([wifi(OnboardingStepStatus.DONE)]),
-          false,
-        ),
+        shouldAutoShowOnboarding(stateWith([wifi(OnboardingStepStatus.DONE)]), false)
       ).toBe(false);
-    },
+    }
   );
 
   it("does NOT pop when user is up to date even with pending step", () => {
     expect(
       shouldAutoShowOnboarding(
         stateWith([wifi(OnboardingStepStatus.PENDING)], 1, 1),
-        false,
-      ),
+        false
+      )
     ).toBe(false);
   });
 
@@ -88,17 +80,14 @@ describe("shouldAutoShowOnboarding", () => {
     expect(
       shouldAutoShowOnboarding(
         stateWith([wifi(OnboardingStepStatus.PENDING)], 1, 2),
-        false,
-      ),
+        false
+      )
     ).toBe(false);
   });
 
   it("respects session-dismissal even with pending work", () => {
     expect(
-      shouldAutoShowOnboarding(
-        stateWith([wifi(OnboardingStepStatus.PENDING)]),
-        true,
-      ),
+      shouldAutoShowOnboarding(stateWith([wifi(OnboardingStepStatus.PENDING)]), true)
     ).toBe(false);
   });
 

--- a/test/util/package-import-url.test.ts
+++ b/test/util/package-import-url.test.ts
@@ -17,14 +17,14 @@ import { previewPackageImportUrl } from "../../src/util/package-import-url.js";
 describe("previewPackageImportUrl — github://", () => {
   it("resolves a basic shorthand with @ref", () => {
     const out = previewPackageImportUrl(
-      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0",
+      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0"
     );
     expect(out.browseUrl).toBe(
-      "https://github.com/athom-tech/athom-configs/blob/v1.0.0/athom-rgbct-light.yaml",
+      "https://github.com/athom-tech/athom-configs/blob/v1.0.0/athom-rgbct-light.yaml"
     );
     expect(out.service).toBe("github");
     expect(out.raw).toBe(
-      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0",
+      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0"
     );
   });
 
@@ -34,10 +34,10 @@ describe("previewPackageImportUrl — github://", () => {
     // somewhere — ``HEAD`` is what GitHub's blob view falls back to
     // for the default branch.
     const out = previewPackageImportUrl(
-      "github://athom-tech/athom-configs/athom-rgbct-light.yaml",
+      "github://athom-tech/athom-configs/athom-rgbct-light.yaml"
     );
     expect(out.browseUrl).toBe(
-      "https://github.com/athom-tech/athom-configs/blob/HEAD/athom-rgbct-light.yaml",
+      "https://github.com/athom-tech/athom-configs/blob/HEAD/athom-rgbct-light.yaml"
     );
     expect(out.service).toBe("github");
   });
@@ -47,10 +47,10 @@ describe("previewPackageImportUrl — github://", () => {
     // monorepo. Pinning this case so a regex-tightening that broke
     // ``/`` in the filename wouldn't slip through CI.
     const out = previewPackageImportUrl(
-      "github://ApolloAutomation/PUMP-1/Integrations/ESPHome/PUMP-1_Minimal.yaml@main",
+      "github://ApolloAutomation/PUMP-1/Integrations/ESPHome/PUMP-1_Minimal.yaml@main"
     );
     expect(out.browseUrl).toBe(
-      "https://github.com/ApolloAutomation/PUMP-1/blob/main/Integrations/ESPHome/PUMP-1_Minimal.yaml",
+      "https://github.com/ApolloAutomation/PUMP-1/blob/main/Integrations/ESPHome/PUMP-1_Minimal.yaml"
     );
     expect(out.service).toBe("github");
   });
@@ -62,10 +62,10 @@ describe("previewPackageImportUrl — github://", () => {
     // semantic to ESPHome only — for the browse URL we drop it,
     // since GitHub doesn't know what ``?full_config`` means.
     const out = previewPackageImportUrl(
-      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0?full_config",
+      "github://athom-tech/athom-configs/athom-rgbct-light.yaml@v1.0.0?full_config"
     );
     expect(out.browseUrl).toBe(
-      "https://github.com/athom-tech/athom-configs/blob/v1.0.0/athom-rgbct-light.yaml",
+      "https://github.com/athom-tech/athom-configs/blob/v1.0.0/athom-rgbct-light.yaml"
     );
   });
 });
@@ -75,20 +75,20 @@ describe("previewPackageImportUrl — gitlab://", () => {
     // GitLab's blob route is ``-/blob/<ref>/<path>`` — note the
     // ``-/`` segment that GitHub doesn't have.
     const out = previewPackageImportUrl(
-      "gitlab://example-group/example-repo/configs/device.yaml@v1.0.0",
+      "gitlab://example-group/example-repo/configs/device.yaml@v1.0.0"
     );
     expect(out.browseUrl).toBe(
-      "https://gitlab.com/example-group/example-repo/-/blob/v1.0.0/configs/device.yaml",
+      "https://gitlab.com/example-group/example-repo/-/blob/v1.0.0/configs/device.yaml"
     );
     expect(out.service).toBe("gitlab");
   });
 
   it("falls back to HEAD when @ref is omitted", () => {
     const out = previewPackageImportUrl(
-      "gitlab://example-group/example-repo/configs/device.yaml",
+      "gitlab://example-group/example-repo/configs/device.yaml"
     );
     expect(out.browseUrl).toBe(
-      "https://gitlab.com/example-group/example-repo/-/blob/HEAD/configs/device.yaml",
+      "https://gitlab.com/example-group/example-repo/-/blob/HEAD/configs/device.yaml"
     );
   });
 });
@@ -106,9 +106,7 @@ describe("previewPackageImportUrl — fall-through to plain text", () => {
     // a vendor starts shipping ``bitbucket://…`` URLs before we
     // update this util, we render them as plain text rather than
     // fabricating a wrong click target.
-    const out = previewPackageImportUrl(
-      "bitbucket://owner/repo/file.yaml@main",
-    );
+    const out = previewPackageImportUrl("bitbucket://owner/repo/file.yaml@main");
     expect(out.browseUrl).toBe(null);
     expect(out.service).toBe(null);
     expect(out.raw).toBe("bitbucket://owner/repo/file.yaml@main");
@@ -120,9 +118,9 @@ describe("previewPackageImportUrl — fall-through to plain text", () => {
     // render them as a clickable preview either; the user
     // sees the raw value and the missing link is the
     // signal that it won't import.
-    expect(previewPackageImportUrl("https://github.com/o/r/blob/main/x.yaml").browseUrl).toBe(
-      null,
-    );
+    expect(
+      previewPackageImportUrl("https://github.com/o/r/blob/main/x.yaml").browseUrl
+    ).toBe(null);
     expect(previewPackageImportUrl("http://example.com/foo.yaml").browseUrl).toBe(null);
   });
 
@@ -134,7 +132,7 @@ describe("previewPackageImportUrl — fall-through to plain text", () => {
     expect(previewPackageImportUrl("javascript:alert(1)").browseUrl).toBe(null);
     expect(previewPackageImportUrl("not a url at all").browseUrl).toBe(null);
     expect(
-      previewPackageImportUrl("github://owner/repo/file.yaml javascript:").browseUrl,
+      previewPackageImportUrl("github://owner/repo/file.yaml javascript:").browseUrl
     ).toBe(null);
   });
 

--- a/test/util/pin-emoji.test.ts
+++ b/test/util/pin-emoji.test.ts
@@ -44,9 +44,7 @@ describe("pinSha256ToEmojis", () => {
   it("yields different sequences for different pins", () => {
     const a = pinSha256ToEmojis("deadbeef".repeat(8));
     const b = pinSha256ToEmojis("cafebabe".repeat(8));
-    expect(a.map((s) => s.emoji).join("")).not.toBe(
-      b.map((s) => s.emoji).join(""),
-    );
+    expect(a.map((s) => s.emoji).join("")).not.toBe(b.map((s) => s.emoji).join(""));
   });
 
   it("truncates rather than padding when input is too short for count", () => {
@@ -88,9 +86,7 @@ describe("pinSha256ToEmojis", () => {
     // change, the security UX has changed and both
     // receiver-side and sender-side code paths need a
     // coordinated update — the test forces that conversation.
-    const pin =
-      "8b1a3f5e2c7d9061a4b8c5d2e3f47ab1" +
-      "0c5d6e7f8a9b1c2d3e4f5a6b7c8d9e0f";
+    const pin = "8b1a3f5e2c7d9061a4b8c5d2e3f47ab1" + "0c5d6e7f8a9b1c2d3e4f5a6b7c8d9e0f";
     const emojis = pinSha256ToEmojis(pin);
     expect(emojis.map((s) => s.name)).toEqual([
       "Wrench",

--- a/test/util/render-error.test.ts
+++ b/test/util/render-error.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { nothing } from "lit";
 
-import {
-  renderErrorBanner,
-  renderInlineError,
-} from "../../src/util/render-error.js";
+import { renderErrorBanner, renderInlineError } from "../../src/util/render-error.js";
 
 /**
  * Lit's TemplateResult exposes a ``strings`` array (the static
@@ -55,7 +52,7 @@ describe("renderErrorBanner", () => {
   it("renders a div.field-error[role=alert] wrapping the message", () => {
     const t = asTemplate(renderErrorBanner("connect refused"));
     expect(t.strings.join("")).toMatch(
-      /^<div class="field-error" role="alert">.*<\/div>$/,
+      /^<div class="field-error" role="alert">.*<\/div>$/
     );
     expect(t.values).toEqual(["connect refused"]);
   });

--- a/test/util/safe-upload-filename.test.ts
+++ b/test/util/safe-upload-filename.test.ts
@@ -8,7 +8,7 @@ describe("safeUploadFilename", () => {
     // intent is "import my working config", so the filename should
     // round-trip character-for-character.
     expect(safeUploadFilename("test_web_server_ota_esp32")).toBe(
-      "test_web_server_ota_esp32",
+      "test_web_server_ota_esp32"
     );
   });
 

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -121,7 +121,7 @@ describe("device-section-config wiring", () => {
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const sourcePath = path.resolve(
       here,
-      "../../src/components/device/device-section-config.ts",
+      "../../src/components/device/device-section-config.ts"
     );
     const src = fs.readFileSync(sourcePath, "utf-8");
 
@@ -134,14 +134,14 @@ describe("device-section-config wiring", () => {
     const expr = match![1].trim();
     expect(
       expr.includes("renderEntries") || expr.includes("resolveSectionEntries"),
-      `form's .entries binds to '${expr}', not to the resolver's output`,
+      `form's .entries binds to '${expr}', not to the resolver's output`
     ).toBe(true);
 
     // Pin the inverse too: the catalog source ``this._config.entries``
     // must NOT be the value bound to the form's ``.entries`` prop.
     expect(
       expr.includes("this._config.entries"),
-      "form's .entries binds to the raw catalog entries — substitutions override is bypassed",
+      "form's .entries binds to the raw catalog entries — substitutions override is bypassed"
     ).toBe(false);
   });
 
@@ -171,7 +171,7 @@ describe("device-section-config wiring", () => {
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const sourcePath = path.resolve(
       here,
-      "../../src/components/device/device-section-config/draft-and-delete.ts",
+      "../../src/components/device/device-section-config/draft-and-delete.ts"
     );
     const src = fs.readFileSync(sourcePath, "utf-8");
 
@@ -180,13 +180,12 @@ describe("device-section-config wiring", () => {
     expect(match, "validateEntries call not found").not.toBeNull();
     const firstArg = match![1].trim();
     expect(
-      firstArg.includes("renderEntries") ||
-        firstArg.includes("resolveSectionEntries"),
-      `validateEntries' first arg is '${firstArg}', not the resolver's output`,
+      firstArg.includes("renderEntries") || firstArg.includes("resolveSectionEntries"),
+      `validateEntries' first arg is '${firstArg}', not the resolver's output`
     ).toBe(true);
     expect(
       firstArg === "this._config.entries",
-      "validateEntries reads the raw catalog — MAP-section saves silently bail on the catalog's required fields",
+      "validateEntries reads the raw catalog — MAP-section saves silently bail on the catalog's required fields"
     ).toBe(false);
   });
 });
@@ -218,19 +217,13 @@ describe("save validation contract", () => {
 
     // Buggy path (validate against catalog): ``url`` reports
     // required, so ``_fieldErrors`` populates and the save bails.
-    const rawErrors = validateEntries(
-      packagesShapedCatalog,
-      userKeyedValues,
-    );
+    const rawErrors = validateEntries(packagesShapedCatalog, userKeyedValues);
     expect(rawErrors.has("url")).toBe(true);
 
     // Fixed path (validate against resolver output): the single
     // user-keyed MAP entry isn't required, so no errors and the
     // save proceeds.
-    const resolved = resolveSectionEntries(
-      "substitutions",
-      packagesShapedCatalog,
-    );
+    const resolved = resolveSectionEntries("substitutions", packagesShapedCatalog);
     const resolvedErrors = validateEntries(resolved, userKeyedValues);
     expect(resolvedErrors.size).toBe(0);
   });
@@ -247,10 +240,7 @@ describe("save validation contract", () => {
         required: true,
       }),
     ];
-    const errors = validateEntries(
-      resolveSectionEntries("wifi", wifiCatalog),
-      {},
-    );
+    const errors = validateEntries(resolveSectionEntries("wifi", wifiCatalog), {});
     expect(errors.has("ssid")).toBe(true);
   });
 });

--- a/test/util/strip-ansi.test.ts
+++ b/test/util/strip-ansi.test.ts
@@ -30,7 +30,7 @@ describe("stripAnsi", () => {
        was keeping those visible until the regex grew this branch. */
     expect(stripAnsi("\\033[32mINFO\\033[0m hello")).toBe("INFO hello");
     expect(stripAnsi("\\033[0;35m[C][i2c.idf:092]: I2C\\033[0m")).toBe(
-      "[C][i2c.idf:092]: I2C",
+      "[C][i2c.idf:092]: I2C"
     );
   });
 });

--- a/test/util/trailing-edge-dispatcher.test.ts
+++ b/test/util/trailing-edge-dispatcher.test.ts
@@ -111,7 +111,9 @@ describe("TrailingEdgeDispatcher", () => {
       throw new Error("sync boom");
     });
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const d = new TrailingEdgeDispatcher<string>(fn as unknown as (i: string) => Promise<void>);
+    const d = new TrailingEdgeDispatcher<string>(
+      fn as unknown as (i: string) => Promise<void>
+    );
 
     d.dispatch("a");
     await Promise.resolve();

--- a/test/util/url-line-resolver.test.ts
+++ b/test/util/url-line-resolver.test.ts
@@ -27,21 +27,17 @@ describe("resolveSectionForUrlLine", () => {
     expect(resolveSectionForUrlLine(SAMPLE_YAML, undefined, null)).toBeNull();
   });
 
-  it.each([
-    NaN,
-    0,
-    -1,
-    -100,
-    1.5,
-    7.5,
-  ])("returns null for invalid line value %s (URL param can be junk)", (badLine) => {
-    // ``line`` arrives via ``Number(raw)`` from ``URLSearchParams``,
-    // so a hand-crafted URL like ``?line=foo`` (NaN), ``?line=7.5``
-    // (fractional), or ``?line=-1`` would otherwise feed bad input
-    // to ``sectionAtLine`` / CodeMirror's ``doc.line(n)`` which
-    // throws. Validate at the boundary.
-    expect(resolveSectionForUrlLine(SAMPLE_YAML, badLine, null)).toBeNull();
-  });
+  it.each([NaN, 0, -1, -100, 1.5, 7.5])(
+    "returns null for invalid line value %s (URL param can be junk)",
+    (badLine) => {
+      // ``line`` arrives via ``Number(raw)`` from ``URLSearchParams``,
+      // so a hand-crafted URL like ``?line=foo`` (NaN), ``?line=7.5``
+      // (fractional), or ``?line=-1`` would otherwise feed bad input
+      // to ``sectionAtLine`` / CodeMirror's ``doc.line(n)`` which
+      // throws. Validate at the boundary.
+      expect(resolveSectionForUrlLine(SAMPLE_YAML, badLine, null)).toBeNull();
+    }
+  );
 
   it("returns null when YAML is empty (still loading)", () => {
     expect(resolveSectionForUrlLine("", 5, null)).toBeNull();

--- a/test/util/web-ui-url.test.ts
+++ b/test/util/web-ui-url.test.ts
@@ -5,9 +5,7 @@ import { makeConfiguredDevice as _device } from "../_make-configured-device.js";
 describe("safeWebUiUrl", () => {
   it("accepts http URLs", () => {
     expect(safeWebUiUrl("http://kitchen.local")).toBe("http://kitchen.local");
-    expect(safeWebUiUrl("http://kitchen.local:8080")).toBe(
-      "http://kitchen.local:8080",
-    );
+    expect(safeWebUiUrl("http://kitchen.local:8080")).toBe("http://kitchen.local:8080");
   });
 
   it("accepts https URLs", () => {
@@ -48,46 +46,44 @@ describe("buildWebUiUrl", () => {
   });
 
   it("returns empty string when neither address nor ip is set", () => {
-    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "" }))).toBe(
-      "",
-    );
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "" }))).toBe("");
   });
 
   it("uses the mDNS address when present", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local"
+    );
   });
 
   it("falls back to ip when address is empty", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "", ip: "10.0.0.5" })),
-    ).toBe("http://10.0.0.5");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "", ip: "10.0.0.5" }))).toBe(
+      "http://10.0.0.5"
+    );
   });
 
   it("omits the port when it's the default 80", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local");
+    expect(buildWebUiUrl(_device({ web_port: 80, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local"
+    );
   });
 
   it("includes a non-default port", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local:8080");
+    expect(buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local:8080"
+    );
   });
 
   it("includes ports below 80 verbatim", () => {
     expect(buildWebUiUrl(_device({ web_port: 22, address: "host" }))).toBe(
-      "http://host:22",
+      "http://host:22"
     );
   });
 
   it("brackets IPv6 hosts so the port suffix stays unambiguous", () => {
     expect(
       buildWebUiUrl(
-        _device({ web_port: 80, address: "", ip: "fe80::de54:75ff:fec7:cc0" }),
-      ),
+        _device({ web_port: 80, address: "", ip: "fe80::de54:75ff:fec7:cc0" })
+      )
     ).toBe("http://[fe80::de54:75ff:fec7:cc0]");
     expect(
       buildWebUiUrl(
@@ -95,17 +91,17 @@ describe("buildWebUiUrl", () => {
           web_port: 8080,
           address: "",
           ip: "2001:470:59ca:991:de54:75ff:fec7:cc0",
-        }),
-      ),
+        })
+      )
     ).toBe("http://[2001:470:59ca:991:de54:75ff:fec7:cc0]:8080");
   });
 
   it("leaves IPv4 and hostnames unbracketed", () => {
-    expect(
-      buildWebUiUrl(_device({ web_port: 8080, address: "", ip: "10.0.0.5" })),
-    ).toBe("http://10.0.0.5:8080");
-    expect(
-      buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" })),
-    ).toBe("http://kitchen.local:8080");
+    expect(buildWebUiUrl(_device({ web_port: 8080, address: "", ip: "10.0.0.5" }))).toBe(
+      "http://10.0.0.5:8080"
+    );
+    expect(buildWebUiUrl(_device({ web_port: 8080, address: "kitchen.local" }))).toBe(
+      "http://kitchen.local:8080"
+    );
   });
 });

--- a/test/util/yaml-ast.test.ts
+++ b/test/util/yaml-ast.test.ts
@@ -81,9 +81,7 @@ describe("resolveBundleContext", () => {
     // (``readPlatformSibling``) breaks at the dash column and
     // misses the ``platform:`` sibling — the AST is what makes
     // this work. Pin the resolution at exactly that position.
-    const yaml = ["binary_sensor:", "  - platform: gpio", "    pi"].join(
-      "\n",
-    );
+    const yaml = ["binary_sensor:", "  - platform: gpio", "    pi"].join("\n");
     const state = makeState(yaml);
     const ctx = resolveBundleContext(state, yaml.length);
     expect(ctx).toEqual({
@@ -98,11 +96,7 @@ describe("resolveBundleContext", () => {
     // keys at 6 spaces). YAML accepts any consistent indent; the
     // AST should resolve the same context regardless of whether
     // the user picked 2- or 4-space style.
-    const yaml = [
-      "sensor:",
-      "    - platform: uptime",
-      "      nam",
-    ].join("\n");
+    const yaml = ["sensor:", "    - platform: uptime", "      nam"].join("\n");
     const state = makeState(yaml);
     const ctx = resolveBundleContext(state, yaml.length);
     expect(ctx).toEqual({
@@ -134,7 +128,8 @@ describe("resolveBundleContext", () => {
 
 describe("getTopLevelKey", () => {
   it("returns the column-0 ancestor key", () => {
-    const yaml = "esphome:\n  name: test\nbinary_sensor:\n  - platform: gpio\n    pin: 5\n";
+    const yaml =
+      "esphome:\n  name: test\nbinary_sensor:\n  - platform: gpio\n    pin: 5\n";
     const state = makeState(yaml);
     expect(getTopLevelKey(state, posAt(yaml, 2, 5))).toBe("esphome");
     expect(getTopLevelKey(state, posAt(yaml, 5, 5))).toBe("binary_sensor");
@@ -194,8 +189,7 @@ describe("getPlatformValue", () => {
 
 describe("isUnderThenItem", () => {
   it("returns true at the list-item position inside a then: block", () => {
-    const yaml =
-      "esphome:\n  on_boot:\n    then:\n      - logger.log: hi\n";
+    const yaml = "esphome:\n  on_boot:\n    then:\n      - logger.log: hi\n";
     const state = makeState(yaml);
     // Cursor on the ``- logger.log`` line, inside the Item.
     expect(isUnderThenItem(state, posAt(yaml, 4, 9))).toBe(true);
@@ -254,21 +248,13 @@ describe("isUnderThenItem", () => {
 
 describe("collectTopLevelKeys", () => {
   it("returns each top-level key once, in document order", () => {
-    const yaml =
-      "esphome:\n  name: test\nwifi:\n  ssid: x\nlogger:\n  level: INFO\n";
-    expect(collectTopLevelKeys(makeState(yaml))).toEqual([
-      "esphome",
-      "wifi",
-      "logger",
-    ]);
+    const yaml = "esphome:\n  name: test\nwifi:\n  ssid: x\nlogger:\n  level: INFO\n";
+    expect(collectTopLevelKeys(makeState(yaml))).toEqual(["esphome", "wifi", "logger"]);
   });
 
   it("skips nested keys (only column-0 pairs)", () => {
     const yaml = "esphome:\n  name: test\n  on_boot:\nwifi:\n  ssid: x\n";
-    expect(collectTopLevelKeys(makeState(yaml))).toEqual([
-      "esphome",
-      "wifi",
-    ]);
+    expect(collectTopLevelKeys(makeState(yaml))).toEqual(["esphome", "wifi"]);
   });
 
   it("returns [] for empty / unparseable input", () => {

--- a/test/util/yaml-completion-top-level.test.ts
+++ b/test/util/yaml-completion-top-level.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompletionContext } from "@codemirror/autocomplete";
 import { EditorState } from "@codemirror/state";
-import {
-  ComponentCategory,
-  type ComponentCatalogEntry,
-} from "../../src/api/types.js";
+import { ComponentCategory, type ComponentCatalogEntry } from "../../src/api/types.js";
 import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import {
@@ -153,9 +150,7 @@ describe("resolveAvailableEntries (platform-merged)", () => {
     // walker pulls ``platform`` as ``parent.key``; the AST
     // supplies the real top-level block ``binary_sensor``. The
     // catalog keys this implementation as ``binary_sensor.template``.
-    const { resolveAvailableEntries } = await import(
-      "../../src/util/yaml-completion.js"
-    );
+    const { resolveAvailableEntries } = await import("../../src/util/yaml-completion.js");
     const platformEntry: ComponentCatalogEntry = {
       ...entry("binary_sensor.template", ComponentCategory.BINARY_SENSOR),
       config_entries: [
@@ -188,7 +183,7 @@ describe("resolveAvailableEntries (platform-merged)", () => {
       c,
       "platform", // parentKey from indent walker
       "template", // platformValue from sibling
-      "binary_sensor", // topLevelKey from AST
+      "binary_sensor" // topLevelKey from AST
     );
     expect(out.map((e: { key: string }) => e.key)).toContain("name");
   });
@@ -223,16 +218,14 @@ describe("platformValueCompletion", () => {
     // legacy ``getPlatformNames`` which yielded each entry as
     // the bare component name.
     const c = platformValueCompletion(
-      entry("binary_sensor.gpio", ComponentCategory.BINARY_SENSOR),
+      entry("binary_sensor.gpio", ComponentCategory.BINARY_SENSOR)
     );
     expect(c.label).toBe("gpio");
     expect(c.detail).toBe(ComponentCategory.BINARY_SENSOR);
   });
 
   it("leaves non-dotted ids alone (for safety)", () => {
-    const c = platformValueCompletion(
-      entry("plain", ComponentCategory.MISC),
-    );
+    const c = platformValueCompletion(entry("plain", ComponentCategory.MISC));
     expect(c.label).toBe("plain");
   });
 });
@@ -302,7 +295,7 @@ describe("createYamlCompletionSource (auto-fire at value position)", () => {
                 },
               },
             }),
-            { status: 200 },
+            { status: 200 }
           );
         }
         if (url.includes("sensor.json")) {
@@ -328,11 +321,11 @@ describe("createYamlCompletionSource (auto-fire at value position)", () => {
                 },
               },
             }),
-            { status: 200 },
+            { status: 200 }
           );
         }
         throw new Error(`unexpected fetch: ${url}`);
-      }),
+      })
     );
   });
 

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -107,11 +107,7 @@ describe("readPlatformSibling (regex fallback)", () => {
     // line as the enclosing list-item header and parses its
     // ``platform:`` value directly instead of breaking on
     // ``ind < cursorIndent``.
-    const lines = [
-      "binary_sensor:",
-      "  - platform: template",
-      "    name: hi",
-    ];
+    const lines = ["binary_sensor:", "  - platform: template", "    name: hi"];
     expect(readPlatformSibling(lines, 2, 4)).toBe("template");
   });
 

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -21,42 +21,36 @@ afterEach(() => {
 
 describe("getLastValidatedResult", () => {
   it("returns null when nothing has been validated for the configuration", async () => {
-    const { getLastValidatedResult } = await import(
-      "../../src/util/yaml-lint-backend.js"
-    );
+    const { getLastValidatedResult } =
+      await import("../../src/util/yaml-lint-backend.js");
     expect(getLastValidatedResult("kitchen.yaml", "esphome:\n")).toBeNull();
   });
 
   it("returns null for a configuration that has no entry yet", async () => {
-    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
-      "../../src/util/yaml-lint-backend.js"
-    );
+    const { getLastValidatedResult, __setLastValidatedForTesting } =
+      await import("../../src/util/yaml-lint-backend.js");
     const result = { yaml_errors: [], validation_errors: [] };
     __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: a\n", result);
-    expect(
-      getLastValidatedResult("bedroom.yaml", "esphome:\n  name: a\n"),
-    ).toBeNull();
+    expect(getLastValidatedResult("bedroom.yaml", "esphome:\n  name: a\n")).toBeNull();
   });
 
   it("returns the cached result when content matches exactly", async () => {
-    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
-      "../../src/util/yaml-lint-backend.js"
-    );
+    const { getLastValidatedResult, __setLastValidatedForTesting } =
+      await import("../../src/util/yaml-lint-backend.js");
     const result = { yaml_errors: [], validation_errors: [] };
     __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: kitchen\n", result);
-    expect(
-      getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen\n"),
-    ).toBe(result);
+    expect(getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen\n")).toBe(
+      result
+    );
   });
 
   it("returns null when content differs by even one byte", async () => {
-    const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
-      "../../src/util/yaml-lint-backend.js"
-    );
+    const { getLastValidatedResult, __setLastValidatedForTesting } =
+      await import("../../src/util/yaml-lint-backend.js");
     const result = { yaml_errors: [], validation_errors: [] };
     __setLastValidatedForTesting("kitchen.yaml", "esphome:\n  name: kitchen\n", result);
     expect(
-      getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen \n"),
+      getLastValidatedResult("kitchen.yaml", "esphome:\n  name: kitchen \n")
     ).toBeNull();
   });
 
@@ -66,9 +60,8 @@ describe("getLastValidatedResult", () => {
     let fakeNow = 1_000_000;
     vi.spyOn(performance, "now").mockImplementation(() => fakeNow);
     try {
-      const { getLastValidatedResult, __setLastValidatedForTesting } = await import(
-        "../../src/util/yaml-lint-backend.js"
-      );
+      const { getLastValidatedResult, __setLastValidatedForTesting } =
+        await import("../../src/util/yaml-lint-backend.js");
       const result = { yaml_errors: [], validation_errors: [] };
       __setLastValidatedForTesting("kitchen.yaml", "esphome:\n", result);
       fakeNow += 60_001;

--- a/test/util/yaml-raw-value.test.ts
+++ b/test/util/yaml-raw-value.test.ts
@@ -22,10 +22,7 @@ describe("YamlRawValue.toString", () => {
     //       lambda: |-
     //         return foo;
     //         return bar;
-    const raw = new YamlRawValue(
-      ["        return foo;", "        return bar;"],
-      "|-",
-    );
+    const raw = new YamlRawValue(["        return foo;", "        return bar;"], "|-");
     expect(String(raw)).toBe("return foo;\nreturn bar;");
   });
 
@@ -44,7 +41,7 @@ describe("YamlRawValue.indent", () => {
   it("picks the common leading whitespace of every non-blank line", () => {
     const raw = new YamlRawValue(
       ["    return foo;", "    if (bar) {", "      return baz;", "    }"],
-      "|-",
+      "|-"
     );
     expect(raw.indent).toBe("    ");
   });
@@ -52,10 +49,7 @@ describe("YamlRawValue.indent", () => {
   it("ignores blank lines when computing the common indent", () => {
     // A blank middle line shouldn't collapse the common indent
     // to "" — the body's indent comes from the non-blank lines.
-    const raw = new YamlRawValue(
-      ["    return foo;", "", "    return bar;"],
-      "|-",
-    );
+    const raw = new YamlRawValue(["    return foo;", "", "    return bar;"], "|-");
     expect(raw.indent).toBe("    ");
   });
 
@@ -77,10 +71,7 @@ describe("YamlRawValue.indent", () => {
 
 describe("YamlRawValue.body", () => {
   it("strips the common indent across all lines", () => {
-    const raw = new YamlRawValue(
-      ["    return foo;", "    return bar;"],
-      "|-",
-    );
+    const raw = new YamlRawValue(["    return foo;", "    return bar;"], "|-");
     expect(raw.body).toBe("return foo;\nreturn bar;");
   });
 
@@ -89,32 +80,20 @@ describe("YamlRawValue.body", () => {
     // their own indent — the common-prefix stripping must keep
     // those deeper indents intact, otherwise we'd corrupt the
     // user's formatting on display.
-    const raw = new YamlRawValue(
-      ["    if (x) {", "      return foo;", "    }"],
-      "|-",
-    );
+    const raw = new YamlRawValue(["    if (x) {", "      return foo;", "    }"], "|-");
     expect(raw.body).toBe("if (x) {\n  return foo;\n}");
   });
 
   it("preserves blank lines verbatim", () => {
-    const raw = new YamlRawValue(
-      ["    return foo;", "", "    return bar;"],
-      "|-",
-    );
+    const raw = new YamlRawValue(["    return foo;", "", "    return bar;"], "|-");
     expect(raw.body).toBe("return foo;\n\nreturn bar;");
   });
 });
 
 describe("YamlRawValue.fromBodyText", () => {
   it("re-applies the original common indent and preserves the inline header", () => {
-    const original = new YamlRawValue(
-      ["    return foo;", "    return bar;"],
-      "|-",
-    );
-    const edited = YamlRawValue.fromBodyText(
-      "return baz;\nreturn qux;",
-      original,
-    );
+    const original = new YamlRawValue(["    return foo;", "    return bar;"], "|-");
+    const edited = YamlRawValue.fromBodyText("return baz;\nreturn qux;", original);
     expect(edited.lines).toEqual(["    return baz;", "    return qux;"]);
     expect(edited.inlineHeader).toBe("|-");
   });
@@ -123,10 +102,7 @@ describe("YamlRawValue.fromBodyText", () => {
     // ``original.body → fromBodyText → .body`` must be identity for
     // the no-edit case, otherwise opening + saving without typing
     // would mutate the YAML.
-    const original = new YamlRawValue(
-      ["    return foo;", "      return bar;"],
-      "|-",
-    );
+    const original = new YamlRawValue(["    return foo;", "      return bar;"], "|-");
     const roundTripped = YamlRawValue.fromBodyText(original.body, original);
     expect(roundTripped.body).toBe(original.body);
   });
@@ -135,19 +111,9 @@ describe("YamlRawValue.fromBodyText", () => {
     // YAML block-scalar bodies can have blank lines; those should
     // round-trip as TRULY empty lines (no trailing whitespace) so
     // a subsequent re-parse doesn't see "this is a continuation."
-    const original = new YamlRawValue(
-      ["    return foo;", "    return bar;"],
-      "|-",
-    );
-    const edited = YamlRawValue.fromBodyText(
-      "return foo;\n\nreturn bar;",
-      original,
-    );
-    expect(edited.lines).toEqual([
-      "    return foo;",
-      "",
-      "    return bar;",
-    ]);
+    const original = new YamlRawValue(["    return foo;", "    return bar;"], "|-");
+    const edited = YamlRawValue.fromBodyText("return foo;\n\nreturn bar;", original);
+    expect(edited.lines).toEqual(["    return foo;", "", "    return bar;"]);
   });
 
   it("handles bodies with no original indent (zero-prefix lines)", () => {

--- a/test/util/yaml-search-helpers.test.ts
+++ b/test/util/yaml-search-helpers.test.ts
@@ -53,25 +53,25 @@ describe("yamlHitLabel", () => {
 
   it("falls back to device_name when friendly_name is empty", () => {
     expect(yamlHitLabel(mkHit({ friendly_name: "" }), MATCH)).toBe(
-      "kitchen — ssid: home",
+      "kitchen — ssid: home"
     );
   });
 
   it("falls back to configuration when neither name is set", () => {
-    expect(
-      yamlHitLabel(mkHit({ friendly_name: "", device_name: "" }), MATCH),
-    ).toBe("kitchen.yaml — ssid: home");
+    expect(yamlHitLabel(mkHit({ friendly_name: "", device_name: "" }), MATCH)).toBe(
+      "kitchen.yaml — ssid: home"
+    );
   });
 
   it("uses 'line N' fallback when the matched line is whitespace-only", () => {
-    expect(
-      yamlHitLabel(HIT, mkMatch({ line_number: 12, line_text: "    " })),
-    ).toBe("Kitchen Lamp — line 12");
+    expect(yamlHitLabel(HIT, mkMatch({ line_number: 12, line_text: "    " }))).toBe(
+      "Kitchen Lamp — line 12"
+    );
   });
 
   it("trims surrounding whitespace from the line text", () => {
     expect(
-      yamlHitLabel(HIT, mkMatch({ line_number: 3, line_text: "    wifi:    " })),
+      yamlHitLabel(HIT, mkMatch({ line_number: 3, line_text: "    wifi:    " }))
     ).toBe("Kitchen Lamp — wifi:");
   });
 
@@ -82,16 +82,13 @@ describe("yamlHitLabel", () => {
     ["psk: 0123456789abcdef", "psk: ••••••••"],
   ])("masks inline credential value in %s", (raw, expectedTrimmed) => {
     expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
-      `Kitchen Lamp — ${expectedTrimmed}`,
+      `Kitchen Lamp — ${expectedTrimmed}`
     );
   });
 
   it("does not mask !secret references — those are indirections, not credentials", () => {
     expect(
-      yamlHitLabel(
-        HIT,
-        mkMatch({ line_text: "  password: !secret wifi_password" }),
-      ),
+      yamlHitLabel(HIT, mkMatch({ line_text: "  password: !secret wifi_password" }))
     ).toBe("Kitchen Lamp — password: !secret wifi_password");
   });
 
@@ -103,13 +100,13 @@ describe("yamlHitLabel", () => {
     // the credential lives in the substitutions block (which
     // *is* masked, see the ``*_password`` suffix tests below).
     expect(
-      yamlHitLabel(HIT, mkMatch({ line_text: "  password: ${wifi_password}" })),
+      yamlHitLabel(HIT, mkMatch({ line_text: "  password: ${wifi_password}" }))
     ).toBe("Kitchen Lamp — password: ${wifi_password}");
   });
 
   it("does not mask non-sensitive keys", () => {
     expect(yamlHitLabel(HIT, mkMatch({ line_text: "  ssid: home_network" }))).toBe(
-      "Kitchen Lamp — ssid: home_network",
+      "Kitchen Lamp — ssid: home_network"
     );
   });
 
@@ -120,7 +117,7 @@ describe("yamlHitLabel", () => {
     // over-masks button codes (remote_receiver / remote_transmitter
     // commonly use ``key: <number>``) surfaces as a test failure.
     expect(yamlHitLabel(HIT, mkMatch({ line_text: "    key: 0xABCDEF12" }))).toBe(
-      "Kitchen Lamp — key: 0xABCDEF12",
+      "Kitchen Lamp — key: 0xABCDEF12"
     );
   });
 
@@ -136,7 +133,7 @@ describe("yamlHitLabel", () => {
     ["# - ap_password: 42dfadc0c2", "# - ap_password: ••••••••"],
   ])("masks credential value inside a YAML comment (%s)", (raw, expectedTrimmed) => {
     expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
-      `Kitchen Lamp — ${expectedTrimmed}`,
+      `Kitchen Lamp — ${expectedTrimmed}`
     );
   });
 
@@ -152,9 +149,9 @@ describe("yamlHitLabel", () => {
     "masks credential value for user-defined *_password / *_psk keys (%s)",
     (raw, expectedTrimmed) => {
       expect(yamlHitLabel(HIT, mkMatch({ line_text: raw }))).toBe(
-        `Kitchen Lamp — ${expectedTrimmed}`,
+        `Kitchen Lamp — ${expectedTrimmed}`
       );
-    },
+    }
   );
 
   it.each([
@@ -176,9 +173,9 @@ describe("yamlHitLabel", () => {
     // ``findSensitiveValueRanges`` — verify by checking that
     // the editor's scan-only path (``key`` under encryption) is
     // *not* masked here.
-    expect(
-      yamlHitLabel(HIT, mkMatch({ line_text: "    key: random-noise-here" })),
-    ).toBe("Kitchen Lamp — key: random-noise-here");
+    expect(yamlHitLabel(HIT, mkMatch({ line_text: "    key: random-noise-here" }))).toBe(
+      "Kitchen Lamp — key: random-noise-here"
+    );
   });
 });
 
@@ -188,9 +185,9 @@ describe("yamlHitHref", () => {
   });
 
   it("URL-encodes the configuration filename", () => {
-    expect(
-      yamlHitHref(mkHit({ configuration: "guest room (1).yaml" }), MATCH),
-    ).toBe("/device/guest%20room%20(1).yaml?line=7");
+    expect(yamlHitHref(mkHit({ configuration: "guest room (1).yaml" }), MATCH)).toBe(
+      "/device/guest%20room%20(1).yaml?line=7"
+    );
   });
 });
 
@@ -204,9 +201,9 @@ describe("yamlHitDeviceLabel", () => {
   });
 
   it("falls back to configuration when neither name is set", () => {
-    expect(
-      yamlHitDeviceLabel(mkHit({ friendly_name: "", device_name: "" })),
-    ).toBe("kitchen.yaml");
+    expect(yamlHitDeviceLabel(mkHit({ friendly_name: "", device_name: "" }))).toBe(
+      "kitchen.yaml"
+    );
   });
 });
 
@@ -422,11 +419,7 @@ describe("buildYamlSnippetBlocks", () => {
 
     const [block] = buildYamlSnippetBlocks([m]);
 
-    expect(block.lines).toEqual([
-      "wifi:",
-      "  ssid: home",
-      "  password: ••••••••",
-    ]);
+    expect(block.lines).toEqual(["wifi:", "  ssid: home", "  password: ••••••••"]);
   });
 
   it("masks the API encryption key when its parent is in the snippet window", () => {
@@ -495,10 +488,7 @@ describe("buildYamlSnippetBlocks", () => {
 
     const [block] = buildYamlSnippetBlocks([m]);
 
-    expect(block.lines).toEqual([
-      "wifi:",
-      "  password: ••••••••  # admin pwd",
-    ]);
+    expect(block.lines).toEqual(["wifi:", "  password: ••••••••  # admin pwd"]);
   });
 
   it("falls back to the single-line heuristic for commented credentials", () => {
@@ -563,10 +553,7 @@ describe("buildYamlSnippetBlocks", () => {
 
     const [block] = buildYamlSnippetBlocks([m]);
 
-    expect(block.lines).toEqual([
-      "substitutions:",
-      "  wifi_password: ••••••••",
-    ]);
+    expect(block.lines).toEqual(["substitutions:", "  wifi_password: ••••••••"]);
   });
 });
 
@@ -592,7 +579,7 @@ describe("yamlSnippetBlockHref", () => {
     const [block] = buildYamlSnippetBlocks([m]);
 
     expect(
-      yamlSnippetBlockHref(mkHit({ configuration: "guest room (1).yaml" }), block),
+      yamlSnippetBlockHref(mkHit({ configuration: "guest room (1).yaml" }), block)
     ).toBe("/device/guest%20room%20(1).yaml?line=5");
   });
 });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -95,12 +95,7 @@ wifi:
     // The same trim has to fire for the file's last section, not
     // just the inter-section seams — a banner at EOF would otherwise
     // extend the last section's highlight range past its content.
-    const yaml = [
-      "esphome:",
-      "  name: x",
-      "## --- end of file --- ##",
-      "",
-    ].join("\n");
+    const yaml = ["esphome:", "  name: x", "## --- end of file --- ##", ""].join("\n");
     const sections = parseYamlTopLevelSections(yaml);
     expect(sections).toHaveLength(1);
     expect(sections[0].toLine).toBe(2);
@@ -126,12 +121,7 @@ wifi:
   });
 
   it("keeps indented trailing comments as part of the final section", () => {
-    const yaml = [
-      "wifi:",
-      "  ssid: x",
-      "  # last note",
-      "",
-    ].join("\n");
+    const yaml = ["wifi:", "  ssid: x", "  # last note", ""].join("\n");
     const sections = parseYamlTopLevelSections(yaml);
     expect(sections).toHaveLength(1);
     expect(sections[0].toLine).toBe(3);
@@ -292,9 +282,7 @@ sensor:
 `;
     // ``on_press:`` itself is line 6; its body is lines 7-8.
     const m = sectionAtLine(yaml, 7);
-    expect(m?.key).toBe(
-      "automation:component_on:door_sensor:on_press",
-    );
+    expect(m?.key).toBe("automation:component_on:door_sensor:on_press");
   });
 
   // Click inside a top-level ``script:`` entry resolves to that
@@ -409,7 +397,7 @@ describe("parseYamlAutomations", () => {
       - logger.log: "cleanup"
 `;
     const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:script:"),
+      s.key.startsWith("automation:script:")
     );
     expect(items.map((s) => s.key)).toEqual([
       "automation:script:my_alarm",
@@ -428,7 +416,7 @@ describe("parseYamlAutomations", () => {
       - logger.log: "fast"
 `;
     const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:interval:"),
+      s.key.startsWith("automation:interval:")
     );
     expect(items.map((s) => s.key)).toEqual([
       "automation:interval:0",
@@ -448,7 +436,7 @@ describe("parseYamlAutomations", () => {
         - logger.log: "stopping"
 `;
     const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:api_action:"),
+      s.key.startsWith("automation:api_action:")
     );
     expect(items.map((s) => s.key)).toEqual([
       "automation:api_action:start_laundry",
@@ -466,11 +454,9 @@ describe("parseYamlAutomations", () => {
         - logger.log: "old"
 `;
     const items = parseYamlAutomations(yaml).filter((s) =>
-      s.key.startsWith("automation:api_action:"),
+      s.key.startsWith("automation:api_action:")
     );
-    expect(items.map((s) => s.key)).toEqual([
-      "automation:api_action:legacy_name",
-    ]);
+    expect(items.map((s) => s.key)).toEqual(["automation:api_action:legacy_name"]);
   });
 });
 
@@ -514,7 +500,7 @@ describe("resolveCurrentFromLine", () => {
       "logger:",
       "api:",
       "  encryption:",
-      "    key: \"...\"",
+      '    key: "..."',
       "wifi:",
       "  ssid: y",
       "",
@@ -551,12 +537,7 @@ describe("resolveCurrentFromLine", () => {
   });
 
   it("returns the first match when no stale line is provided", () => {
-    const dup = [
-      "ota:",
-      "  - platform: esphome",
-      "  - platform: esphome",
-      "",
-    ].join("\n");
+    const dup = ["ota:", "  - platform: esphome", "  - platform: esphome", ""].join("\n");
     expect(resolveCurrentFromLine(dup, "ota.esphome")).toBe(2);
   });
 
@@ -585,17 +566,9 @@ describe("resolveCurrentFromLine", () => {
     ].join("\n");
     // Cached fromLine from before the paste — the stale hint.
     const staleFromLine = 2;
-    const resolved = resolveCurrentFromLine(
-      yamlAfterPaste,
-      "ota.esphome",
-      staleFromLine,
-    );
+    const resolved = resolveCurrentFromLine(yamlAfterPaste, "ota.esphome", staleFromLine);
     expect(resolved).toBe(6);
-    const values = parseYamlSectionValues(
-      yamlAfterPaste,
-      "ota.esphome",
-      resolved!,
-    );
+    const values = parseYamlSectionValues(yamlAfterPaste, "ota.esphome", resolved!);
     expect(values).toEqual({ platform: "esphome", password: "secret" });
   });
 
@@ -610,11 +583,7 @@ describe("resolveCurrentFromLine", () => {
     const yaml = "esphome:\n  name: x\n";
     const resolved = resolveCurrentFromLine(yaml, "ota.esphome", 5);
     expect(resolved).toBeUndefined();
-    const values = parseYamlSectionValues(
-      yaml,
-      "ota.esphome",
-      resolved,
-    );
+    const values = parseYamlSectionValues(yaml, "ota.esphome", resolved);
     expect(values).toEqual({});
   });
 });

--- a/test/util/yaml-sensitive-scan.test.ts
+++ b/test/util/yaml-sensitive-scan.test.ts
@@ -33,11 +33,7 @@ mqtt:
   password: 'mq-secret'
 `;
     const ranges = findSensitiveValueRanges(yaml);
-    expect(valuesAt(yaml, ranges)).toEqual([
-      "hunter2",
-      `"ota-secret"`,
-      `'mq-secret'`,
-    ]);
+    expect(valuesAt(yaml, ranges)).toEqual(["hunter2", `"ota-secret"`, `'mq-secret'`]);
   });
 
   it("masks ap_password and ota_password", () => {
@@ -259,7 +255,7 @@ ota:
     expect(ranges.every((r) => r.line !== 6)).toBe(true);
   });
 
-  it("recognises closing `\"` after an even number of backslashes", () => {
+  it('recognises closing `"` after an even number of backslashes', () => {
     // `\\` is an escaped backslash; the `"` that follows is the real
     // close of the scalar. A naive "preceded by `\\`?" check would
     // run past it and lose the trailing comment-strip step.
@@ -269,16 +265,14 @@ ota:
     expect(valuesAt(yaml, ranges)).toEqual([`"ends with \\\\"`]);
   });
 
-  it("treats `\"` after an odd number of backslashes as escaped", () => {
+  it('treats `"` after an odd number of backslashes as escaped', () => {
     // `\"` is an escaped quote inside the scalar; the next real `"`
     // closes it.
     const yaml = `api:
   password: "with \\"escaped\\" inside" # comment
 `;
     const ranges = findSensitiveValueRanges(yaml);
-    expect(valuesAt(yaml, ranges)).toEqual([
-      `"with \\"escaped\\" inside"`,
-    ]);
+    expect(valuesAt(yaml, ranges)).toEqual([`"with \\"escaped\\" inside"`]);
   });
 
   describe("maskAllValues mode (secrets.yaml)", () => {
@@ -334,18 +328,14 @@ wifi_ssid: real-value
       // secrets.yaml itself, but if they do we still skip it.
       const yaml = `wifi_password: !secret real_password
 `;
-      expect(
-        findSensitiveValueRanges(yaml, { maskAllValues: true }),
-      ).toEqual([]);
+      expect(findSensitiveValueRanges(yaml, { maskAllValues: true })).toEqual([]);
     });
 
     it("ignores key-only lines with no inline value", () => {
       const yaml = `wifi_ssid:
 api_key:
 `;
-      expect(
-        findSensitiveValueRanges(yaml, { maskAllValues: true }),
-      ).toEqual([]);
+      expect(findSensitiveValueRanges(yaml, { maskAllValues: true })).toEqual([]);
     });
 
     it("default mode is unaffected (no maskAllValues option)", () => {

--- a/test/util/yaml-validation-summary.test.ts
+++ b/test/util/yaml-validation-summary.test.ts
@@ -23,7 +23,7 @@ import { summarizeValidation } from "../../src/util/yaml-validation-summary.js";
 
 function res(
   yaml_errors: EditorValidateResponse["yaml_errors"] = [],
-  validation_errors: EditorValidateResponse["validation_errors"] = [],
+  validation_errors: EditorValidateResponse["validation_errors"] = []
 ): EditorValidateResponse {
   return { yaml_errors, validation_errors };
 }
@@ -35,19 +35,19 @@ describe("summarizeValidation", () => {
 
   it("extracts line + column from a yaml-error message", () => {
     const summary = summarizeValidation(
-      res([{ message: "mapping values not allowed at line 7, column 12" }]),
+      res([{ message: "mapping values not allowed at line 7, column 12" }])
     );
     expect(summary.count).toBe(1);
     expect(summary.first?.line).toBe(7);
     expect(summary.first?.col).toBe(12);
     expect(summary.first?.message).toBe(
-      "mapping values not allowed at line 7, column 12",
+      "mapping values not allowed at line 7, column 12"
     );
   });
 
   it("falls back to bare 'line N' when the column is absent", () => {
     const summary = summarizeValidation(
-      res([{ message: "while parsing block mapping at line 4" }]),
+      res([{ message: "while parsing block mapping at line 4" }])
     );
     expect(summary.first?.line).toBe(4);
     expect(summary.first?.col).toBe(0);
@@ -58,9 +58,7 @@ describe("summarizeValidation", () => {
     // info; "Go to error" should disable rather than jump to a
     // bogus line. Dialog reads ``firstErrorLine === 0`` as
     // "no jump target".
-    const summary = summarizeValidation(
-      res([{ message: "Unknown YAML failure" }]),
-    );
+    const summary = summarizeValidation(res([{ message: "Unknown YAML failure" }]));
     expect(summary.first?.line).toBe(0);
     expect(summary.first?.col).toBe(0);
     expect(summary.first?.message).toBe("Unknown YAML failure");
@@ -75,15 +73,13 @@ describe("summarizeValidation", () => {
             message: "Invalid value for sensor.0.platform",
             range: { start_line: 9, start_col: 4, end_line: 9, end_col: 12 },
           },
-        ],
-      ),
+        ]
+      )
     );
     expect(summary.count).toBe(1);
     expect(summary.first?.line).toBe(10);
     expect(summary.first?.col).toBe(5);
-    expect(summary.first?.message).toBe(
-      "Invalid value for sensor.0.platform",
-    );
+    expect(summary.first?.message).toBe("Invalid value for sensor.0.platform");
   });
 
   it("yaml errors win precedence over validation errors", () => {
@@ -101,14 +97,14 @@ describe("summarizeValidation", () => {
             message: "Stale validation error",
             range: { start_line: 20, start_col: 0, end_line: 20, end_col: 1 },
           },
-        ],
-      ),
+        ]
+      )
     );
     expect(summary.count).toBe(2);
     expect(summary.first?.line).toBe(3);
     expect(summary.first?.col).toBe(5);
     expect(summary.first?.message).toBe(
-      "block sequence entries are not allowed at line 3, column 5",
+      "block sequence entries are not allowed at line 3, column 5"
     );
   });
 
@@ -125,8 +121,8 @@ describe("summarizeValidation", () => {
             message: "v2",
             range: { start_line: 1, start_col: 0, end_line: 1, end_col: 1 },
           },
-        ],
-      ),
+        ]
+      )
     );
     expect(summary.count).toBe(3);
   });


### PR DESCRIPTION
# What does this implement/fix?

Closes a tooling gap; `npm run format` exists but nothing runs it. CI (`test.yml`) and `.husky/pre-commit` both only ran `npm run lint` (which is just `tsc --noEmit`) and `npm test`, so prettier drift accumulated silently. As of this PR's base, `prettier --check` fails on 248 files across src and test.

Two commits:

1. **Format src and test with prettier.** One-shot `prettier --write "src/**/*.ts" "test/**/*.ts"` pass over 248 files; pure whitespace and trailing-comma changes, no logic touched. Tests and tsc unchanged.
2. **Run prettier --check in CI and pre-commit.** New `format:check` script; wired as the first step of both `test.yml` and `.husky/pre-commit`. The existing `format` script is widened to also cover `test/**/*.ts` so write target matches check target.

A `.git-blame-ignore-revs` file pins the reformat commit so `git blame` (and GitHub's blame view, which honours the file automatically) walks past it. Local enablement is a one-liner; the comment in the file documents it.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
