### PR TITLE
Add minimal .pre-commit-config.yaml for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Hygiene checks for pre-commit.ci. The repo's primary lint /
+# format / test pipeline runs through npm (``npm run format:check``,
+# ``npm run lint``, ``npm test``) in CI and the husky pre-commit
+# hook; pre-commit.ci's sandbox doesn't have Node installed, so
+# this config is intentionally narrow — Python-only hygiene that
+# complements rather than duplicates the npm flow. Without a
+# config file at all, pre-commit.ci fails every PR with
+# ``.pre-commit-config.yaml is not a file``.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-json
+      - id: mixed-line-ending
+        args: [--fix=lf]


### PR DESCRIPTION
# What does this implement/fix?

pre-commit.ci is enabled at the esphome org level (the backend repo uses it for ruff / yaml / json hygiene), so every open PR here was failing the `pre-commit.ci - pr` check with `.pre-commit-config.yaml is not a file`. Adding a minimal config silences the false-positive failures without changing the actual development flow.

The repo's primary lint / format / test pipeline runs through npm (`npm run format:check`, `npm run lint`, `npm test`) in `test.yml` and the husky pre-commit hook. pre-commit.ci's sandbox doesn't have Node available, so this config stays orthogonal to the npm flow rather than duplicating it; it covers Python-only hygiene that the npm flow doesn't:

- `trailing-whitespace`
- `end-of-file-fixer`
- `check-merge-conflict`
- `check-added-large-files`
- `check-yaml`
- `check-json`
- `mixed-line-ending` (force LF)

Verified `pre-commit run --all-files` passes against current main.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
