### PR TITLE
Gate secrets editor on load + refuse empty Save (#951)

### DIFF
--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -223,6 +223,15 @@ export class ESPHomePageSecrets extends LitElement {
       .reveal-toggle wa-icon {
         font-size: 16px;
       }
+
+      .loading {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 32px;
+        color: var(--wa-color-text-quiet);
+      }
     `,
   ];
 
@@ -252,25 +261,31 @@ export class ESPHomePageSecrets extends LitElement {
         </div>
         <wa-divider></wa-divider>
         <div class="editor-card">
-          <button
-            type="button"
-            class="save-button"
-            ?disabled=${this._saving || !this._loaded || this._yaml === this._savedYaml}
-            @click=${this._save}
-          >
-            <wa-icon library="mdi" name="content-save"></wa-icon>
-            ${this._saving
-              ? this._localize("secrets.saving")
-              : this._localize("secrets.save")}
-          </button>
-          <esphome-yaml-editor
-            .value=${this._yaml}
-            .maskAllValues=${true}
-            .revealSensitive=${this._revealSensitive}
-            @yaml-change=${(e: CustomEvent) => {
-              this._yaml = e.detail.value;
-            }}
-          ></esphome-yaml-editor>
+          ${this._loaded
+            ? html`
+                <button
+                  type="button"
+                  class="save-button"
+                  ?disabled=${this._saving ||
+                  this._yaml === this._savedYaml ||
+                  this._yaml.trim() === ""}
+                  @click=${this._save}
+                >
+                  <wa-icon library="mdi" name="content-save"></wa-icon>
+                  ${this._saving
+                    ? this._localize("secrets.saving")
+                    : this._localize("secrets.save")}
+                </button>
+                <esphome-yaml-editor
+                  .value=${this._yaml}
+                  .maskAllValues=${true}
+                  .revealSensitive=${this._revealSensitive}
+                  @yaml-change=${(e: CustomEvent) => {
+                    this._yaml = e.detail.value;
+                  }}
+                ></esphome-yaml-editor>
+              `
+            : html`<div class="loading"><wa-spinner></wa-spinner></div>`}
         </div>
       </div>
     `;

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -290,40 +290,46 @@ export class ESPHomePageSecrets extends LitElement {
     this._revealSensitive = !this._revealSensitive;
   }
 
-  private _save() {
+  private async _save() {
     // Optimistic update: dirty-state UI flips back to "saved"
     // immediately so the Save button disables. Snapshot the
     // previous saved buffer first so a real (non-timeout)
     // failure can revert and let the user retry.
     const previousSaved = this._savedYaml;
     this._savedYaml = this._yaml;
+    // ``_saving`` covers the in-flight window so a rapid second
+    // click can't queue a duplicate write; the dirty-check would
+    // also disable on the success path (savedYaml === yaml), but
+    // _saving stays true through both branches so the "Saving…"
+    // label and disabled state hold until the API call returns.
+    this._saving = true;
     toast.success(this._localize("secrets.saved"), { richColors: true });
-    this._api
-      .updateConfig(SECRETS_FILE, this._yaml)
-      .then(() => {
-        // Window-level so other mounted components (app-shell's
-        // onboarding-state refresh, peer secrets-page instances)
-        // can react regardless of where they live in the tree.
-        // ``detail.source`` lets self-listeners short-circuit.
-        window.dispatchEvent(
-          new CustomEvent("secrets-saved", { detail: { source: this } })
-        );
-      })
-      .catch((e) => {
-        const msg = e instanceof Error ? e.message : "";
-        // WS commands may time out client-side while the server
-        // still completes the write — keep the optimistic buffer
-        // so the user isn't told their save failed when it
-        // probably succeeded. Any other error is a real failure:
-        // restore the previous saved buffer so the dirty state
-        // returns and the user can retry.
-        if (!msg.includes("timed out")) {
-          this._savedYaml = previousSaved;
-          toast.error(this._localize("secrets.save_error"), {
-            richColors: true,
-          });
-        }
-      });
+    try {
+      await this._api.updateConfig(SECRETS_FILE, this._yaml);
+      // Window-level so other mounted components (app-shell's
+      // onboarding-state refresh, peer secrets-page instances)
+      // can react regardless of where they live in the tree.
+      // ``detail.source`` lets self-listeners short-circuit.
+      window.dispatchEvent(
+        new CustomEvent("secrets-saved", { detail: { source: this } })
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      // WS commands may time out client-side while the server
+      // still completes the write — keep the optimistic buffer
+      // so the user isn't told their save failed when it
+      // probably succeeded. Any other error is a real failure:
+      // restore the previous saved buffer so the dirty state
+      // returns and the user can retry.
+      if (!msg.includes("timed out")) {
+        this._savedYaml = previousSaved;
+        toast.error(this._localize("secrets.save_error"), {
+          richColors: true,
+        });
+      }
+    } finally {
+      this._saving = false;
+    }
   }
 }
 

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
+import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageSecrets } from "../../src/pages/secrets.js";
 import {
   extractAttributeBindings,
@@ -18,6 +19,8 @@ interface PageView {
   _yaml: string;
   _savedYaml: string;
   _saving: boolean;
+  _api: ESPHomeAPI;
+  _save(): Promise<void>;
   render(): unknown;
 }
 
@@ -104,16 +107,31 @@ describe("esphome-page-secrets save-button disabled state", () => {
     ).toBe(true);
   });
 
-  test("disabled while saving is in flight", () => {
-    expect(
-      saveDisabled(
-        makePage({
-          _loaded: true,
-          _yaml: "wifi_password: new\n",
-          _savedYaml: "wifi_password: old\n",
-          _saving: true,
-        })
-      )
-    ).toBe(true);
+  test("_save() flips _saving true during the in-flight call and false after", async () => {
+    let resolveUpdate!: () => void;
+    const updateConfigPromise = new Promise<void>((r) => {
+      resolveUpdate = r;
+    });
+    const page = makePage({
+      _loaded: true,
+      _yaml: "wifi_password: new\n",
+      _savedYaml: "wifi_password: old\n",
+    });
+    page._api = {
+      updateConfig: vi.fn().mockReturnValue(updateConfigPromise),
+    } as unknown as ESPHomeAPI;
+
+    expect(page._saving).toBe(false);
+    const savePromise = page._save();
+    // In-flight: _saving is true and the rendered button reflects that.
+    expect(page._saving).toBe(true);
+    expect(saveDisabled(page)).toBe(true);
+
+    resolveUpdate();
+    await savePromise;
+
+    expect(page._saving).toBe(false);
+    // Post-success: dirty-check disables (yaml === savedYaml now).
+    expect(saveDisabled(page)).toBe(true);
   });
 });

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from "vitest";
+
+import { ESPHomePageSecrets } from "../../src/pages/secrets.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+} from "../_lit-template-walker.js";
+
+/**
+ * Pin the secrets-page data-loss guards: don't render an editor
+ * with empty content while loading, and keep Save disabled when
+ * the buffer is empty.
+ */
+
+interface PageView {
+  _loaded: boolean;
+  _yaml: string;
+  _savedYaml: string;
+  _saving: boolean;
+  render(): unknown;
+}
+
+function makePage(overrides: Partial<PageView> = {}): PageView {
+  const page = new ESPHomePageSecrets() as unknown as PageView;
+  page._loaded = false;
+  page._yaml = "";
+  page._savedYaml = "";
+  page._saving = false;
+  Object.assign(page, overrides);
+  return page;
+}
+
+describe("esphome-page-secrets editor gating", () => {
+  test("while loading: spinner is rendered, no editor, no save button", () => {
+    const tree = makePage({ _loaded: false }).render();
+    expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(1);
+    expect(findTemplatesByAnchor(tree, "<esphome-yaml-editor")).toHaveLength(0);
+    expect(findTemplatesByAnchor(tree, 'class="save-button"')).toHaveLength(0);
+  });
+
+  test("after load: editor is rendered with the loaded buffer, spinner gone", () => {
+    const tree = makePage({
+      _loaded: true,
+      _yaml: "wifi_password: hunter2\n",
+      _savedYaml: "wifi_password: hunter2\n",
+    }).render();
+    expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(0);
+    const editors = findTemplatesByAnchor(tree, "<esphome-yaml-editor");
+    expect(editors).toHaveLength(1);
+    expect(extractAttributeBindings(editors[0])[".value"]).toBe(
+      "wifi_password: hunter2\n"
+    );
+  });
+});
+
+describe("esphome-page-secrets save-button disabled state", () => {
+  function saveDisabled(page: PageView): unknown {
+    const buttons = findTemplatesByAnchor(page.render(), 'class="save-button"');
+    expect(buttons).toHaveLength(1);
+    return extractAttributeBindings(buttons[0])["?disabled"];
+  }
+
+  test("disabled when buffer equals saved (no dirty state)", () => {
+    const yaml = "wifi_password: hunter2\n";
+    expect(saveDisabled(makePage({ _loaded: true, _yaml: yaml, _savedYaml: yaml }))).toBe(
+      true
+    );
+  });
+
+  test("enabled when buffer differs from saved AND is non-empty", () => {
+    expect(
+      saveDisabled(
+        makePage({
+          _loaded: true,
+          _yaml: "wifi_password: new\n",
+          _savedYaml: "wifi_password: old\n",
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("disabled when buffer is empty even though it differs from saved", () => {
+    expect(
+      saveDisabled(
+        makePage({
+          _loaded: true,
+          _yaml: "",
+          _savedYaml: "wifi_password: hunter2\n",
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("disabled when buffer is whitespace-only even though it differs from saved", () => {
+    expect(
+      saveDisabled(
+        makePage({
+          _loaded: true,
+          _yaml: "   \n\t\n",
+          _savedYaml: "wifi_password: hunter2\n",
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("disabled while saving is in flight", () => {
+    expect(
+      saveDisabled(
+        makePage({
+          _loaded: true,
+          _yaml: "wifi_password: new\n",
+          _savedYaml: "wifi_password: old\n",
+          _saving: true,
+        })
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The secrets page (`src/pages/secrets.ts`) can land in a state where
the user sees the editor "wiped" to just the line-1 gutter (#951
reports it after a mouse-back navigation; the precise frontend
state-clear path is hard to pin down by reading alone). Hitting Save
in that state previously persisted the empty buffer over the real
`secrets.yaml` on disk.

Two defensive layers on the frontend:

- **Don't mount the yaml-editor until `_loaded` is true.** The page
  shows a `<wa-spinner>` during the async load; the editor never
  paints with empty content as a transient state.
- **Keep Save disabled when `_yaml.trim() === ""`** (in addition to
  the existing dirty-check). The empty-buffer case has no legitimate
  "save" interpretation; refuse to fire the destructive write.

Pairs with the backend's `devices/update_config` empty-content
refusal (esphome/device-builder#977) as defense in depth. Either
layer alone closes the bug; both close it from different angles.

Seven new test cases in `test/pages/secrets.test.ts` pin:

1. Loading state renders a spinner, no editor, no save button.
2. Loaded state renders the editor with the loaded buffer.
3. Save disabled when buffer equals saved (clean state).
4. Save enabled when buffer is dirty AND non-empty.
5. Save disabled when buffer is empty even though dirty.
6. Save disabled when buffer is whitespace-only even though dirty.
7. Save disabled while a save is in flight.

The pattern follows existing renderer tests (template-walker over
the `render()` output rather than full DOM mount, since `wa-*` form
components don't play well with happy-dom).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#951

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1263 tests, including the seven new ones).
- [x] Tests have been added to verify that the new code works (where applicable).
