### PR TITLE
Stack the paired build server row so the actions get full width

### DIFF
--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -63,7 +63,7 @@ export function renderPairingRow(
   } = ctx;
   const { pillClass, pillLabel } = pillFor(pairing, localize);
   return html`
-    <div class="row peer-row pairing-row">
+    <div class="row peer-row row--stacked">
       <div class="row-label">
         <span class="row-title">
           ${pairing.label}
@@ -85,73 +85,75 @@ export function renderPairingRow(
           : nothing}
         ${renderVersionMismatch(pairing, localize, appVersion)}
       </div>
-      ${pairing.status === "approved"
-        ? html`
-            <button
-              class="toggle"
-              role="switch"
-              aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
-                label: pairing.label,
-              })}
-              aria-checked=${pairing.enabled}
-              title=${localize("settings.build_offload_pairing_enabled_title")}
-              @click=${() => onToggleEnabled(pairing)}
-            ></button>
-          `
-        : nothing}
-      ${pairing.status === "approved" && pairing.connected
-        ? html`
-            <button
-              type="button"
-              class="btn-build-remote"
-              aria-label=${localize("settings.remote_build_submit_aria", {
-                label: pairing.label,
-              })}
-              @click=${() => onBuildRemote(pairing)}
-            >
-              ${localize("settings.remote_build_submit_action")}
-            </button>
-          `
-        : nothing}
-      ${latestJob !== undefined
-        ? html`
-            <button
-              type="button"
-              class="btn-view-remote-build"
-              aria-label=${localize("settings.remote_build_view_aria", {
-                label: pairing.label,
-              })}
-              @click=${() => onViewBuild(latestJob.job_id)}
-            >
-              ${localize("settings.remote_build_view_action")}
-            </button>
-          `
-        : nothing}
-      ${pairing.status === "approved"
-        ? html`
-            <button
-              type="button"
-              class="btn-edit-endpoint"
-              aria-label=${localize("settings.edit_pairing_endpoint_aria", {
-                label: pairing.label,
-              })}
-              title=${localize("settings.edit_pairing_endpoint_aria", {
-                label: pairing.label,
-              })}
-              @click=${() => onEditEndpoint(pairing)}
-            >
-              <wa-icon library="mdi" name="pencil"></wa-icon>
-            </button>
-          `
-        : nothing}
-      <button
-        type="button"
-        class="peer-remove btn-unpair"
-        aria-label=${localize("settings.unpair_aria", { label: pairing.label })}
-        @click=${() => onUnpair(pairing)}
-      >
-        ${localize("settings.unpair_action")}
-      </button>
+      <div class="pairing-actions">
+        ${pairing.status === "approved"
+          ? html`
+              <button
+                class="toggle"
+                role="switch"
+                aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
+                  label: pairing.label,
+                })}
+                aria-checked=${pairing.enabled}
+                title=${localize("settings.build_offload_pairing_enabled_title")}
+                @click=${() => onToggleEnabled(pairing)}
+              ></button>
+            `
+          : nothing}
+        ${pairing.status === "approved" && pairing.connected
+          ? html`
+              <button
+                type="button"
+                class="btn-build-remote"
+                aria-label=${localize("settings.remote_build_submit_aria", {
+                  label: pairing.label,
+                })}
+                @click=${() => onBuildRemote(pairing)}
+              >
+                ${localize("settings.remote_build_submit_action")}
+              </button>
+            `
+          : nothing}
+        ${latestJob !== undefined
+          ? html`
+              <button
+                type="button"
+                class="btn-view-remote-build"
+                aria-label=${localize("settings.remote_build_view_aria", {
+                  label: pairing.label,
+                })}
+                @click=${() => onViewBuild(latestJob.job_id)}
+              >
+                ${localize("settings.remote_build_view_action")}
+              </button>
+            `
+          : nothing}
+        ${pairing.status === "approved"
+          ? html`
+              <button
+                type="button"
+                class="btn-edit-endpoint"
+                aria-label=${localize("settings.edit_pairing_endpoint_aria", {
+                  label: pairing.label,
+                })}
+                title=${localize("settings.edit_pairing_endpoint_aria", {
+                  label: pairing.label,
+                })}
+                @click=${() => onEditEndpoint(pairing)}
+              >
+                <wa-icon library="mdi" name="pencil"></wa-icon>
+              </button>
+            `
+          : nothing}
+        <button
+          type="button"
+          class="peer-remove btn-unpair"
+          aria-label=${localize("settings.unpair_aria", { label: pairing.label })}
+          @click=${() => onUnpair(pairing)}
+        >
+          ${localize("settings.unpair_action")}
+        </button>
+      </div>
     </div>
   `;
 }

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -68,6 +68,20 @@ export function renderPairingRow(
         <span class="row-title">
           ${pairing.label}
           <span class=${pillClass}>${pillLabel}</span>
+          ${pairing.status === "approved"
+            ? html`
+                <button
+                  class="toggle pairing-toggle"
+                  role="switch"
+                  aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
+                    label: pairing.label,
+                  })}
+                  aria-checked=${pairing.enabled}
+                  title=${localize("settings.build_offload_pairing_enabled_title")}
+                  @click=${() => onToggleEnabled(pairing)}
+                ></button>
+              `
+            : nothing}
         </span>
         <span class="row-desc">
           ${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}
@@ -86,20 +100,6 @@ export function renderPairingRow(
         ${renderVersionMismatch(pairing, localize, appVersion)}
       </div>
       <div class="pairing-actions">
-        ${pairing.status === "approved"
-          ? html`
-              <button
-                class="toggle"
-                role="switch"
-                aria-label=${localize("settings.build_offload_pairing_enabled_aria", {
-                  label: pairing.label,
-                })}
-                aria-checked=${pairing.enabled}
-                title=${localize("settings.build_offload_pairing_enabled_title")}
-                @click=${() => onToggleEnabled(pairing)}
-              ></button>
-            `
-          : nothing}
         ${pairing.status === "approved" && pairing.connected
           ? html`
               <button
@@ -149,9 +149,10 @@ export function renderPairingRow(
           type="button"
           class="peer-remove btn-unpair"
           aria-label=${localize("settings.unpair_aria", { label: pairing.label })}
+          title=${localize("settings.unpair_action")}
           @click=${() => onUnpair(pairing)}
         >
-          ${localize("settings.unpair_action")}
+          <wa-icon library="mdi" name="delete"></wa-icon>
         </button>
       </div>
     </div>

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiLanConnect, mdiPencil } from "@mdi/js";
+import { mdiDelete, mdiLanConnect, mdiPencil } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
@@ -46,7 +46,11 @@ import "../reauth-wizard-dialog.js";
 import "../remote-build-job-dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
-registerMdiIcons({ "lan-connect": mdiLanConnect, pencil: mdiPencil });
+registerMdiIcons({
+  delete: mdiDelete,
+  "lan-connect": mdiLanConnect,
+  pencil: mdiPencil,
+});
 
 @customElement("esphome-settings-build-offload")
 export class ESPHomeSettingsBuildOffload extends LitElement {

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -151,8 +151,15 @@ export const pairingRowStyles = css`
     font-size: 16px;
   }
 
-  .pairing-row {
+  /* Lives at the bottom of a .row--stacked pairing row. Wraps so a
+     narrow dialog (HA-addon sidebar, mobile) doesn't clip the
+     rightmost button when toggle + Build + View + edit + Unpair
+     are all present. */
+  .pairing-actions {
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: flex-end;
     gap: var(--wa-space-s);
   }
 

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -109,14 +109,14 @@ export const pairingRowStyles = css`
 
   .btn-unpair {
     height: 32px;
-    padding: 0 var(--wa-space-m);
+    width: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     border-radius: var(--wa-border-radius-s);
     background: var(--wa-color-surface-default);
     color: var(--wa-color-text-quiet);
-    font: inherit;
-    font-size: var(--wa-font-size-xs);
-    font-weight: var(--wa-font-weight-semibold);
     cursor: pointer;
     flex-shrink: 0;
   }
@@ -125,6 +125,10 @@ export const pairingRowStyles = css`
     background: color-mix(in srgb, var(--esphome-error), white 90%);
     color: var(--esphome-error);
     border-color: var(--esphome-error);
+  }
+
+  .btn-unpair wa-icon {
+    font-size: 16px;
   }
 
   .btn-edit-endpoint {
@@ -151,10 +155,18 @@ export const pairingRowStyles = css`
     font-size: 16px;
   }
 
+  /* The per-pairing enable toggle stays on the title line beside
+     the status pill so it reads as part of the server identity,
+     not as an action; margin-left: auto pushes it to the right
+     edge of the title flex. */
+  .pairing-toggle {
+    margin-left: auto;
+  }
+
   /* Lives at the bottom of a .row--stacked pairing row. Wraps so a
      narrow dialog (HA-addon sidebar, mobile) doesn't clip the
-     rightmost button when toggle + Build + View + edit + Unpair
-     are all present. */
+     rightmost button when Build + View + edit + Unpair are all
+     present. */
   .pairing-actions {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
# What does this implement/fix?

The paired build server row crowded the toggle, edit, and Unpair controls into a tight right column even when the label above was 4 to 7 lines tall (status pill, hostname, multi line connection error, version skew note); narrow dialogs sometimes clipped the rightmost button. This stacks the row using the existing .row--stacked pattern, so the actions sit on their own bottom line with the full row width to lay out in. The only new style is a small .pairing-actions wrap container, and the dead .pairing-row class is dropped.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
