### PR TITLE
Swap hand-rolled dashboard caches for memoize-one

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -13,6 +13,7 @@ import {
 import type { SortingState, VisibilityState } from "@tanstack/lit-table";
 import { LitElement, html, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type {
@@ -217,14 +218,12 @@ export class ESPHomePageDashboard extends LitElement {
   _pendingAdoptScroll: string | null = null;
   _actionDevice: ConfiguredDevice | null = null;
 
-  private _sortedDevicesCache: {
-    source: ConfiguredDevice[];
-    sorted: ConfiguredDevice[];
-  } | null = null;
-  private _labelUsageCache: {
-    source: ConfiguredDevice[];
-    map: Record<string, number>;
-  } | null = null;
+  private _sortDevices = memoizeOne((source: ConfiguredDevice[]) =>
+    [...source].sort((a, b) =>
+      DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
+    )
+  );
+  private _computeLabelUsageMemo = memoizeOne(computeLabelUsage);
 
   @query("esphome-api-key-dialog") _apiKeyDialog!: ESPHomeApiKeyDialog;
   @query("esphome-archived-devices-dialog")
@@ -513,14 +512,7 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   get _sortedDevices(): ConfiguredDevice[] {
-    const source = this._devices;
-    if (this._sortedDevicesCache?.source === source)
-      return this._sortedDevicesCache.sorted;
-    const sorted = [...source].sort((a, b) =>
-      DEVICE_SORT_COLLATOR.compare(deviceSortKey(a), deviceSortKey(b))
-    );
-    this._sortedDevicesCache = { source, sorted };
-    return sorted;
+    return this._sortDevices(this._devices);
   }
 
   /** True when any facet or text search would currently narrow the
@@ -628,11 +620,7 @@ export class ESPHomePageDashboard extends LitElement {
   }
 
   _computeLabelUsage(): Record<string, number> {
-    const source = this._devices;
-    if (this._labelUsageCache?.source === source) return this._labelUsageCache.map;
-    const map = computeLabelUsage(source);
-    this._labelUsageCache = { source, map };
-    return map;
+    return this._computeLabelUsageMemo(this._devices);
   }
 
   _enterDeviceView = (view: DashboardView) => {


### PR DESCRIPTION
# What does this implement/fix?

Swap the two hand-rolled reference-identity caches on `<esphome-page-dashboard>` (`_sortedDevicesCache`, `_labelUsageCache`) for `memoize-one`-backed memoizers. Same reference-identity semantics (same input array, same cached output); the per-call cache management lives in the library rather than in two custom `{ source, value }` typed fields and three update sites.

Both cache shapes were identical: `if (cache.source === source) return cache.value; ... cache = { source, value }`. `memoize-one` is the project's adopted memoization library for exactly this pattern (Home Assistant frontend convention, landed in #388 for the bulk-labels dialog). Switching to it removes the two ad-hoc typed cache fields and the read sites that hand-update them.

No behaviour change: same input array, same cached output. The cache slot still flips on every new `_devices` context push, the way the hand-rolled version did.

**Related issue or feature (if applicable):**

- Follow-up cleanup surfaced while reviewing #388

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Out of scope

Further memoization candidates surfaced in the same survey (`_applyFacetFilters`, firmware-jobs render-time filters) land in separate follow-up PRs so each gets independent review.

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1301/1301).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, refactor; existing dashboard tests still pin the behaviour.
