### PR TITLE
Memoize firmware-jobs dialog render bucketing

### DIFF
--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -15,6 +15,7 @@ import {
 } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice, FirmwareJob } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -125,10 +126,22 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
   static styles = [espHomeStyles, firmwareJobsDialogStyles];
 
+  /** Bucket the live jobs Map into sorted / active / terminal lists.
+   *  Memoised on the upstream Map reference; the context provider
+   *  hands out a new Map identity on every job-lifecycle push, so
+   *  the cache invalidates exactly when the lists would change. One
+   *  sort + two filter passes per push, not per render. */
+  private _bucketJobs = memoizeOne((jobs: Map<string, FirmwareJob>) => {
+    const sorted = [...jobs.values()].sort(compareJobs);
+    return {
+      sorted,
+      active: sorted.filter((j) => !isTerminal(j)),
+      terminal: sorted.filter((j) => isTerminal(j)),
+    };
+  });
+
   protected render() {
-    const sorted = [...this._jobs.values()].sort(compareJobs);
-    const active = sorted.filter((j) => !isTerminal(j));
-    const terminal = sorted.filter((j) => isTerminal(j));
+    const { sorted, active, terminal } = this._bucketJobs(this._jobs);
     const hasJobs = sorted.length > 0;
 
     return html`


### PR DESCRIPTION
# What does this implement/fix?

`<esphome-firmware-jobs-dialog>`'s `render()` rebuilt three derived views of `this._jobs` (the firmware-jobs context Map) on every render: the sorted-jobs array (Map.values spread + sort), then two filter passes splitting into active vs terminal. The dialog stays open while the ticker fires, and any job-lifecycle push triggers a re-render. With many recent jobs that's three full O(n) passes per push.

Fold the bucketing into `_bucketJobs`, memoized on the `_jobs` Map identity. The `firmwareJobsContext` provider hands out a new Map on each lifecycle push, so the cache invalidates exactly when the buckets would actually change. Same `memoize-one` shape as #391 (dashboard caches) and #392 (`_applyFacetFilters`).

**Related issue or feature (if applicable):**

- Follow-up to #388 / #391 / #392 memoize-one rollout

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1339/1339).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, refactor; existing firmware-jobs dialog tests still pin the behaviour.
