### PR TITLE
Memoize wizard board featured/regular split

### DIFF
--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -9,6 +9,7 @@ import {
 } from "@mdi/js";
 import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, SerialPort } from "../../api/types.js";
@@ -64,6 +65,16 @@ export class ESPHomeWizardStepBoard extends LitElement {
 
   @state()
   private _boards: BoardCatalogEntry[] = [];
+
+  /** Split the live board catalog into the single featured tile +
+   *  the rest. Memoised on the ``_boards`` reference so the find +
+   *  filter pair shares one walk per catalog change (each search
+   *  keystroke replaces ``_boards`` with a freshly-filtered list,
+   *  so the cache invalidates exactly when the split needs to). */
+  private _splitBoards = memoizeOne((boards: BoardCatalogEntry[]) => ({
+    featured: boards.find((b) => b.featured),
+    regular: boards.filter((b) => !b.featured),
+  }));
 
   @state()
   private _loading = true;
@@ -490,8 +501,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
       return html`<p class="loading">${this._localize("wizard.loading_boards")}</p>`;
     }
 
-    const featured = this._boards.find((b) => b.featured);
-    const regular = this._boards.filter((b) => !b.featured);
+    const { featured, regular } = this._splitBoards(this._boards);
 
     return html`
       <input


### PR DESCRIPTION
# What does this implement/fix?

`<esphome-wizard-step-board>`'s `render()` did `_boards.find(b => b.featured)` then `_boards.filter(b => !b.featured)` on every call. The board step is the search-as-you-type board picker, so each keystroke re-renders and runs both passes over the freshly-filtered catalog. Two O(n) walks per keystroke is fine in absolute terms on the typical ~80-board catalog, but it's two distinct traversals where one cached split would do.

Fold both into `_splitBoards`, memoized on the `_boards` reference. The list is replaced wholesale on every search-filter update (and on the initial catalog load), so the memo cache invalidates exactly when the split needs to change.

Same `memoize-one` shape as #391 (dashboard caches), #392 (`_applyFacetFilters`), and #393 (firmware-jobs render bucketing).

**Related issue or feature (if applicable):**

- Follow-up to the memoize-one rollout (#388 / #391 / #392 / #393)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1339/1339).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, refactor; existing wizard-step-board tests still pin the behaviour.
