### PR TITLE
Memoize device-navigator bucket derivation

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -12,6 +12,7 @@ import {
 } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -82,6 +83,40 @@ export class ESPHomeDeviceNavigator extends LitElement {
 
   @property({ attribute: false })
   yaml = "";
+
+  /** Derive the three navigator buckets (core, components,
+   *  automations) from the YAML string. Memoised on the YAML
+   *  source so the parse + categorize + filter + sort pipeline
+   *  runs once per YAML edit, not per render. Two parser passes
+   *  and three list traversals collapse into a single cached
+   *  result. The render path destructures from this object. */
+  private _deriveBuckets = memoizeOne((yaml: string) => {
+    const {
+      core,
+      components,
+      automations: topLevelAutomations,
+    } = categorizeSections(parseYamlTopLevelSections(yaml));
+    // ``parseYamlAutomations`` enumerates individual ``script:`` /
+    // ``interval:`` list items as stable-keyed entries; drop the
+    // bare top-level blocks so each automation shows up exactly
+    // once.
+    const detailed = parseYamlAutomations(yaml);
+    const filteredTopLevel = topLevelAutomations.filter(
+      (s) => s.key !== "script" && s.key !== "interval"
+    );
+    // Drop ``light_effect`` (managed via the parent light's section
+    // editor) and ``unscoped`` entries (inline ``on_*:`` handlers
+    // on id-less components that the structured editor can't
+    // address).
+    const automations = [...filteredTopLevel, ...detailed]
+      .filter(
+        (s) =>
+          !s.key.startsWith("automation:light_effect:") &&
+          !s.key.startsWith("automation:unscoped:")
+      )
+      .sort((a, b) => a.fromLine - b.fromLine);
+    return { core, components, automations };
+  });
 
   /** Optional board metadata; forwarded to the add-component dialog so
    * the embedded form can render GPIO pin selectors. */
@@ -393,41 +428,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   protected render() {
-    const {
-      core,
-      components,
-      automations: topLevelAutomations,
-    } = categorizeSections(parseYamlTopLevelSections(this.yaml));
-    // ``parseYamlAutomations`` now enumerates individual ``script:``
-    // / ``interval:`` list items as stable-keyed entries
-    // (``automation:script:<id>``, ``automation:interval:<index>``),
-    // so the bare ``script:`` / ``interval:`` top-level blocks
-    // returned by the top-level parser would duplicate them. Drop
-    // those bare keys here so each automation shows up exactly once.
-    const detailed = parseYamlAutomations(this.yaml);
-    const filteredTopLevel = topLevelAutomations.filter(
-      (s) => s.key !== "script" && s.key !== "interval"
-    );
-    // Light effects belong to their parent light component now, not
-    // the automations surface — clicking one in the navigator
-    // routed to the automation editor in a confusing standalone
-    // mode. Effects are managed through the light's own section
-    // editor; drop them here so they don't appear orphaned in the
-    // automations group.
-    //
-    // ``automation:unscoped:*`` entries are inline ``on_*:`` handlers
-    // on components that have no ``id:`` set. The structured editor
-    // can't address them (locationFromSectionKey returns null), so
-    // routing one through the navigator would surface as a failing
-    // ``fetchComponent`` and a blank section editor. Drop them too;
-    // the user fixes by adding an ``id:`` to the host component.
-    const automations = [...filteredTopLevel, ...detailed]
-      .filter(
-        (s) =>
-          !s.key.startsWith("automation:light_effect:") &&
-          !s.key.startsWith("automation:unscoped:")
-      )
-      .sort((a, b) => a.fromLine - b.fromLine);
+    const { core, components, automations } = this._deriveBuckets(this.yaml);
 
     interface NavAction {
       label: string;


### PR DESCRIPTION
# What does this implement/fix?

`<esphome-device-navigator>`'s `render()` parsed `this.yaml` twice on every render (`parseYamlTopLevelSections` + `parseYamlAutomations`), categorised the first pass into three buckets, dropped duplicated `script:` / `interval:` entries from the top-level set, merged with the detailed pass, filtered out light effects + unscoped handlers, then sorted by source line. Five list traversals plus two parser passes per render, all driven from the same YAML string.

Move the whole derivation behind `_deriveBuckets`, memoized on the YAML source. The pipeline runs once per YAML edit and the render path destructures the cached `{ core, components, automations }` object.

Same `memoize-one` shape as #391 (dashboard caches), #392 (`_applyFacetFilters`), #393 (firmware-jobs render bucketing), and #394 (wizard board split).

**Related issue or feature (if applicable):**

- Follow-up to the memoize-one rollout

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1339/1339).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, refactor; existing device-navigator tests still pin the behaviour.
