### PR TITLE
Memoize label-id->name resolution in URL sync

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -224,6 +224,13 @@ export class ESPHomePageDashboard extends LitElement {
     )
   );
   private _computeLabelUsageMemo = memoizeOne(computeLabelUsage);
+  /** id → name map rebuilt once per labels-catalog reference change.
+   *  ``_syncUrl`` looks up the names for every selected label id; the
+   *  prior shape was a linear search per id, which is O(N×M) over the
+   *  full catalog on every search keystroke / facet click. */
+  private _labelNamesById = memoizeOne(
+    (catalog: Label[]) => new Map(catalog.map((l) => [l.id, l.name]))
+  );
 
   @query("esphome-api-key-dialog") _apiKeyDialog!: ESPHomeApiKeyDialog;
   @query("esphome-archived-devices-dialog")
@@ -369,12 +376,11 @@ export class ESPHomePageDashboard extends LitElement {
     // refresh during that window doesn't drop the param. Once the
     // catalog arrives and we resolve to ids, the catalog → name
     // mapping kicks in below.
+    const byId = this._labelNamesById(this._labelsCatalog);
     const labelNames =
       this._pendingLabelNames !== null
         ? this._pendingLabelNames
-        : this._selectedLabels
-            .map((id) => this._labelsCatalog.find((l) => l.id === id)?.name)
-            .filter((n): n is string => !!n);
+        : this._selectedLabels.map((id) => byId.get(id)).filter((n): n is string => !!n);
     writeDashboardUrl({
       search: this._search,
       labels: labelNames,


### PR DESCRIPTION
# What does this implement/fix?

`_syncUrl` resolved each selected label id to its name with `this._labelsCatalog.find((l) => l.id === id)`. That is a linear scan of the labels catalog per selected id, so an `O(N × M)` lookup over the catalog every time URL sync fires. URL sync runs on every search keystroke and every facet click, so on a dashboard with a deep catalog and several labels filtered, the linear scan repeats often.

Rebuild the id → name `Map` once per catalog reference change via `_labelNamesById` (`memoize-one`), then resolve each selected id with `Map.get`. Per-call work drops to `O(M)` Map lookups plus an `Object.is` cache check on the catalog reference.

Same `memoize-one` shape as #391 (dashboard caches), #392 (`_applyFacetFilters`), #393 (firmware-jobs render bucketing), #394 (wizard board split), and #395 (device-navigator bucket derivation).

**Related issue or feature (if applicable):**

- Final follow-up in the memoize-one rollout

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1339/1339).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, refactor; existing dashboard URL-sync tests still pin the behaviour.
