### PR TITLE
Render per-row params sub-form for REGISTRY_LIST entries

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -28,8 +28,6 @@ import type { BoardCatalogEntry, ConfigEntry } from "../../api/types.js";
 import { ConfigEntryType } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
-import { inputStyles } from "../../styles/inputs.js";
-import { espHomeStyles } from "../../styles/shared.js";
 import { type ValidationError } from "../../util/config-validation.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
@@ -42,8 +40,8 @@ import "@home-assistant/webawesome/dist/components/select/select.js";
 import "@home-assistant/webawesome/dist/components/switch/switch.js";
 import "../mdi-icon-picker.js";
 import "./password-input.js";
-import { configEntryFormStyles } from "./config-entry-form.styles.js";
 import {
+  fieldRendererStyles,
   labelFor,
   renderBooleanField,
   renderFloatWithUnitField,
@@ -177,7 +175,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    */
   private _editingMagnitudes: Map<string, string> = new Map();
 
-  static styles = [espHomeStyles, inputStyles, configEntryFormStyles];
+  static styles = fieldRendererStyles;
 
   /**
    * Filter `entries` for rendering. Delegates to the shared

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -15,6 +15,15 @@ import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { inputStyles } from "../../styles/inputs.js";
+import { espHomeStyles } from "../../styles/shared.js";
+import { configEntryFormStyles } from "./config-entry-form.styles.js";
+
+/** Stylesheets every element that hosts ``ctx.renderEntry`` output
+ *  needs in its shadow root: field shell, input styling, and the
+ *  layout rules for compound widgets (``.time-period-inputs``,
+ *  ``.nested-fields``, …) the per-field renderers emit. */
+export const fieldRendererStyles = [espHomeStyles, inputStyles, configEntryFormStyles];
 
 registerMdiIcons({
   "key-variant": mdiKeyVariant,

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -4,6 +4,7 @@
 
 export {
   effectiveDisabled,
+  fieldRendererStyles,
   labelFor,
   renderLabel,
   renderStringField,

--- a/src/components/device/config-entry-renderers/lambda.ts
+++ b/src/components/device/config-entry-renderers/lambda.ts
@@ -28,7 +28,7 @@ import "./lambda-editor.js";
  *   byte-for-byte.
  * - plain string — fall back for hand-edited values.
  */
-function bodyOf(raw: unknown): string {
+export function lambdaBodyOf(raw: unknown): string {
   if (isLambdaValue(raw)) return raw._lambda;
   if (raw instanceof YamlRawValue) return raw.body;
   if (raw == null) return "";
@@ -37,7 +37,7 @@ function bodyOf(raw: unknown): string {
 
 export function renderLambdaField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
-  const value = bodyOf(raw);
+  const value = lambdaBodyOf(raw);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   return renderFieldShell(

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -17,6 +17,9 @@ import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
+import { inputStyles } from "../../../styles/inputs.js";
+import { espHomeStyles } from "../../../styles/shared.js";
+import { configEntryFormStyles } from "../config-entry-form.styles.js";
 import type { ConfigEntry, RegistryCatalogEntry } from "../../../api/types.js";
 import { isLambdaValue } from "../../../api/types.js";
 import { apiContext } from "../../../context/index.js";
@@ -284,35 +287,45 @@ export class ESPHomeRegistryList extends LitElement {
     this._kickedFetch = false;
   }
 
-  static styles = css`
-    :host {
-      display: block;
-    }
-    .registry-list-item {
-      margin-bottom: 1rem;
-    }
-    .registry-list-row {
-      display: flex;
-      gap: 0.5rem;
-      align-items: center;
-      margin-bottom: 0.5rem;
-    }
-    .registry-list-row wa-select {
-      flex: 1;
-    }
-    .registry-list-sub-form {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      margin-left: 1rem;
-      padding-left: 1rem;
-      border-left: 2px solid var(--wa-color-surface-border);
-    }
-    .registry-list-fallback {
-      color: var(--wa-color-neutral-fill-loud);
-      font-size: 0.9rem;
-    }
-  `;
+  static styles = [
+    // ctx.renderEntry renders ``.field`` / ``.time-period-inputs`` /
+    // ``.nested-fields`` etc. into the sub-form; those classes live
+    // in the form's stylesheet and don't cross the shadow DOM
+    // boundary into <esphome-registry-list>'s own root, so pull in
+    // the same three stylesheet modules the form mounts.
+    espHomeStyles,
+    inputStyles,
+    configEntryFormStyles,
+    css`
+      :host {
+        display: block;
+      }
+      .registry-list-item {
+        margin-bottom: 1rem;
+      }
+      .registry-list-row {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+      .registry-list-row wa-select {
+        flex: 1;
+      }
+      .registry-list-sub-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-left: 1rem;
+        padding-left: 1rem;
+        border-left: 2px solid var(--wa-color-surface-border);
+      }
+      .registry-list-fallback {
+        color: var(--wa-color-neutral-fill-loud);
+        font-size: 0.9rem;
+      }
+    `,
+  ];
 
   protected render() {
     const ops = this._ops();

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -17,9 +17,6 @@ import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
-import { inputStyles } from "../../../styles/inputs.js";
-import { espHomeStyles } from "../../../styles/shared.js";
-import { configEntryFormStyles } from "../config-entry-form.styles.js";
 import type { ConfigEntry, RegistryCatalogEntry } from "../../../api/types.js";
 import { isLambdaValue } from "../../../api/types.js";
 import { apiContext } from "../../../context/index.js";
@@ -35,6 +32,7 @@ import "./lambda-editor.js";
 import { lambdaBodyOf } from "./lambda.js";
 import {
   effectiveDisabled,
+  fieldRendererStyles,
   renderFieldError,
   renderLabel,
   type RenderCtx,
@@ -288,14 +286,10 @@ export class ESPHomeRegistryList extends LitElement {
   }
 
   static styles = [
-    // ctx.renderEntry renders ``.field`` / ``.time-period-inputs`` /
-    // ``.nested-fields`` etc. into the sub-form; those classes live
-    // in the form's stylesheet and don't cross the shadow DOM
-    // boundary into <esphome-registry-list>'s own root, so pull in
-    // the same three stylesheet modules the form mounts.
-    espHomeStyles,
-    inputStyles,
-    configEntryFormStyles,
+    // ctx.renderEntry output uses .field / .time-period-inputs etc.
+    // which live in the form's stylesheets; the shared bundle gives
+    // them to anything hosting renderEntry output across shadow roots.
+    ...fieldRendererStyles,
     css`
       :host {
         display: block;

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -446,18 +446,20 @@ export class ESPHomeRegistryList extends LitElement {
     const knownInCatalog = catalogEntry !== undefined;
     // Sort by id so 39 sensor filters in the picker stay scannable.
     const sortedCatalog = [...catalog].sort((a, b) => a.id.localeCompare(b.id));
-    // Per-row params sub-form: the catalog entry's ``config_entries``
-    // describe the parameter schema for the picked id (e.g.
-    // ``calibrate_polynomial`` needs ``degree`` and ``datapoints``).
-    // Render through ``ctx.renderEntry`` so each child dispatches to
-    // the right per-field renderer — same pattern renderNestedListField
-    // uses. Path is ``[...this.path, index, currentId, child.key]`` so
-    // setIn lands the value under the row's polymorphic single key.
-    const params = currentId ? (item[currentId] as Record<string, unknown> | null) : null;
+    // Skip the sub-form when params is a scalar: the catalog may encode
+    // a mapping schema for an id ESPHome also accepts as a scalar
+    // shorthand, and editing the mapping would clobber the scalar.
+    const params = currentId ? item[currentId] : null;
+    const paramsIsMapping =
+      params !== null && typeof params === "object" && !Array.isArray(params);
     const childEntries = catalogEntry?.config_entries ?? [];
-    const renderableChildren = childEntries.length
-      ? this.ctx.filterRenderable(childEntries, params ?? {})
-      : [];
+    const renderableChildren =
+      childEntries.length && (params === null || paramsIsMapping)
+        ? this.ctx.filterRenderable(
+            childEntries,
+            paramsIsMapping ? (params as Record<string, unknown>) : {}
+          )
+        : [];
     return html`
       <div class="registry-list-item" data-row-index=${index}>
         <div class="registry-list-row">

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -464,13 +464,16 @@ export class ESPHomeRegistryList extends LitElement {
     // an inline lambda editor bound to the row's polymorphic value
     // position so users can fill in the body visually.
     const isLambdaForm = currentId === "lambda";
-    const childEntries = catalogEntry?.config_entries ?? [];
-    const renderableChildren =
-      childEntries.length && (params === null || paramsIsMapping)
-        ? this.ctx.filterRenderable(
-            childEntries,
-            paramsIsMapping ? (params as Record<string, unknown>) : {}
-          )
+    // Render every child unconditionally — the user opted into this
+    // filter/effect by picking it from the dropdown, so the outer
+    // form's advanced / requiredOnly gates don't apply (many filters
+    // mark their tuning fields ``advanced: true`` and would render as
+    // an empty sub-form otherwise; exponential_moving_average is the
+    // canonical case). No catalog filter/effect carries depends_on on
+    // sub-fields today; revisit if that changes.
+    const childEntries =
+      (params === null || paramsIsMapping) && catalogEntry?.config_entries
+        ? catalogEntry.config_entries
         : [];
     return html`
       <div class="registry-list-item" data-row-index=${index}>
@@ -513,9 +516,9 @@ export class ESPHomeRegistryList extends LitElement {
                   this._setLambdaBody(index, currentId, e.detail.value)}
               ></esphome-lambda-editor>
             </div>`
-          : renderableChildren.length > 0
+          : childEntries.length > 0
             ? html`<div class="registry-list-sub-form">
-                ${renderableChildren.map((child) =>
+                ${childEntries.map((child) =>
                   this.ctx.renderEntry(child, [
                     ...this.path,
                     String(index),

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -285,6 +285,9 @@ export class ESPHomeRegistryList extends LitElement {
     :host {
       display: block;
     }
+    .registry-list-item {
+      margin-bottom: 1rem;
+    }
     .registry-list-row {
       display: flex;
       gap: 0.5rem;
@@ -293,6 +296,14 @@ export class ESPHomeRegistryList extends LitElement {
     }
     .registry-list-row wa-select {
       flex: 1;
+    }
+    .registry-list-sub-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-left: 1rem;
+      padding-left: 1rem;
+      border-left: 2px solid var(--wa-color-surface-border);
     }
     .registry-list-fallback {
       color: var(--wa-color-neutral-fill-loud);
@@ -431,39 +442,66 @@ export class ESPHomeRegistryList extends LitElement {
     // (older configs may carry an effect the schema dropped) so the
     // value round-trips on the next save instead of silently
     // disappearing from the picker.
-    const knownInCatalog = catalog.some((e) => e.id === currentId);
+    const catalogEntry = catalog.find((e) => e.id === currentId);
+    const knownInCatalog = catalogEntry !== undefined;
     // Sort by id so 39 sensor filters in the picker stay scannable.
     const sortedCatalog = [...catalog].sort((a, b) => a.id.localeCompare(b.id));
+    // Per-row params sub-form: the catalog entry's ``config_entries``
+    // describe the parameter schema for the picked id (e.g.
+    // ``calibrate_polynomial`` needs ``degree`` and ``datapoints``).
+    // Render through ``ctx.renderEntry`` so each child dispatches to
+    // the right per-field renderer — same pattern renderNestedListField
+    // uses. Path is ``[...this.path, index, currentId, child.key]`` so
+    // setIn lands the value under the row's polymorphic single key.
+    const params = currentId ? (item[currentId] as Record<string, unknown> | null) : null;
+    const childEntries = catalogEntry?.config_entries ?? [];
+    const renderableChildren = childEntries.length
+      ? this.ctx.filterRenderable(childEntries, params ?? {})
+      : [];
     return html`
-      <div class="registry-list-row" data-row-index=${index}>
-        <wa-select
-          .value=${currentId}
-          ?disabled=${disabled}
-          placeholder=${this.ctx.localize("device.registry_list_select")}
-          aria-label=${this.ctx.localize("device.registry_list_row_label", {
-            index: String(index + 1),
-          })}
-          @change=${(e: Event) => {
-            // wa-select isn't an HTMLSelectElement; cast to the read field.
-            const next = (e.target as unknown as { value: string }).value;
-            this._renameRow(index, next);
-          }}
-        >
-          ${!knownInCatalog && currentId
-            ? html`<wa-option value=${currentId} selected
-                >${formatRegistryId(currentId)}</wa-option
-              >`
-            : nothing}
-          ${sortedCatalog
-            .filter((effect) => effect.id === currentId || !takenIds.has(effect.id))
-            .map(
-              (effect) =>
-                html`<wa-option value=${effect.id} ?selected=${effect.id === currentId}
-                  >${formatRegistryId(effect.id)}</wa-option
+      <div class="registry-list-item" data-row-index=${index}>
+        <div class="registry-list-row">
+          <wa-select
+            .value=${currentId}
+            ?disabled=${disabled}
+            placeholder=${this.ctx.localize("device.registry_list_select")}
+            aria-label=${this.ctx.localize("device.registry_list_row_label", {
+              index: String(index + 1),
+            })}
+            @change=${(e: Event) => {
+              // wa-select isn't an HTMLSelectElement; cast to the read field.
+              const next = (e.target as unknown as { value: string }).value;
+              this._renameRow(index, next);
+            }}
+          >
+            ${!knownInCatalog && currentId
+              ? html`<wa-option value=${currentId} selected
+                  >${formatRegistryId(currentId)}</wa-option
                 >`
-            )}
-        </wa-select>
-        ${renderListRemoveButton(this.ctx, disabled, () => this._removeAt(index))}
+              : nothing}
+            ${sortedCatalog
+              .filter((effect) => effect.id === currentId || !takenIds.has(effect.id))
+              .map(
+                (effect) =>
+                  html`<wa-option value=${effect.id} ?selected=${effect.id === currentId}
+                    >${formatRegistryId(effect.id)}</wa-option
+                  >`
+              )}
+          </wa-select>
+          ${renderListRemoveButton(this.ctx, disabled, () => this._removeAt(index))}
+        </div>
+        ${renderableChildren.length > 0
+          ? html`<div class="registry-list-sub-form">
+              ${renderableChildren.map((child) =>
+                this.ctx.renderEntry(child, [
+                  ...this.path,
+                  String(index),
+                  currentId,
+                  child.key,
+                ])
+              )}
+            </div>`
+          : nothing}
       </div>
     `;
   }

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -18,6 +18,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
 import type { ConfigEntry, RegistryCatalogEntry } from "../../../api/types.js";
+import { isLambdaValue } from "../../../api/types.js";
 import { apiContext } from "../../../context/index.js";
 import {
   fetchFilters,
@@ -27,6 +28,8 @@ import {
   subscribeAutomationCatalogCache,
 } from "../../../util/automation-catalog-cache.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
+import "./lambda-editor.js";
+import { lambdaBodyOf } from "./lambda.js";
 import {
   effectiveDisabled,
   renderFieldError,
@@ -451,7 +454,16 @@ export class ESPHomeRegistryList extends LitElement {
     // shorthand, and editing the mapping would clobber the scalar.
     const params = currentId ? item[currentId] : null;
     const paramsIsMapping =
-      params !== null && typeof params === "object" && !Array.isArray(params);
+      params !== null &&
+      typeof params === "object" &&
+      !Array.isArray(params) &&
+      !isLambdaValue(params);
+    // ``lambda`` filter / effect takes a C++ body as the whole value
+    // (``- lambda: |- return x;``); the schema bundle exposes no
+    // config_vars for it, so the catalog has 0 config_entries. Render
+    // an inline lambda editor bound to the row's polymorphic value
+    // position so users can fill in the body visually.
+    const isLambdaForm = currentId === "lambda";
     const childEntries = catalogEntry?.config_entries ?? [];
     const renderableChildren =
       childEntries.length && (params === null || paramsIsMapping)
@@ -492,18 +504,27 @@ export class ESPHomeRegistryList extends LitElement {
           </wa-select>
           ${renderListRemoveButton(this.ctx, disabled, () => this._removeAt(index))}
         </div>
-        ${renderableChildren.length > 0
+        ${isLambdaForm
           ? html`<div class="registry-list-sub-form">
-              ${renderableChildren.map((child) =>
-                this.ctx.renderEntry(child, [
-                  ...this.path,
-                  String(index),
-                  currentId,
-                  child.key,
-                ])
-              )}
+              <esphome-lambda-editor
+                .value=${lambdaBodyOf(params)}
+                ?disabled=${disabled}
+                @lambda-change=${(e: CustomEvent<{ value: string }>) =>
+                  this._setLambdaBody(index, currentId, e.detail.value)}
+              ></esphome-lambda-editor>
             </div>`
-          : nothing}
+          : renderableChildren.length > 0
+            ? html`<div class="registry-list-sub-form">
+                ${renderableChildren.map((child) =>
+                  this.ctx.renderEntry(child, [
+                    ...this.path,
+                    String(index),
+                    currentId,
+                    child.key,
+                  ])
+                )}
+              </div>`
+            : nothing}
       </div>
     `;
   }
@@ -521,6 +542,12 @@ export class ESPHomeRegistryList extends LitElement {
     const { items, positions } = editableEntries(list);
     const next = transform(items);
     this.ctx.emitChange(this.path, spliceEditable(list, positions, next));
+  }
+
+  private _setLambdaBody(index: number, registryId: string, body: string) {
+    this._mutateEditable((items) =>
+      items.map((it, i) => (i === index ? { [registryId]: { _lambda: body } } : it))
+    );
   }
 
   private _addItem() {

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -335,6 +335,43 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
   });
 
+  it("renders no sub-form when the existing params is a scalar", async () => {
+    // ``delta: 0.5`` and ``throttle: 10s`` are scalar shorthands that
+    // ESPHome accepts even when the catalog encodes a mapping schema
+    // for the same id. Rendering the mapping inputs over a scalar
+    // would silently clobber the user's YAML on first edit.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "delta",
+        name: "Delta",
+        applies_to: [],
+        config_entries: [
+          makeEntry(ConfigEntryType.FLOAT, { key: "baseline" }),
+          makeEntry(ConfigEntryType.FLOAT, { key: "min_value" }),
+          makeEntry(ConfigEntryType.FLOAT, { key: "max_value" }),
+        ],
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ delta: "0.5" }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(renderEntry).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
+  });
+
   it("renders no sub-form on an empty / unselected row", async () => {
     const renderEntry = vi.fn();
     const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -372,6 +372,30 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
   });
 
+  it("renders the inline lambda editor when the picked id is 'lambda'", async () => {
+    // ``lambda`` filter takes a C++ body as the whole polymorphic value
+    // (``- lambda: |- return x;``). The catalog ships no config_entries
+    // for it (no schema), so the mapping sub-form path doesn't fire;
+    // the renderer instead mounts <esphome-lambda-editor> bound to the
+    // row's polymorphic value position.
+    const catalog = [
+      { id: "lambda", name: "Lambda", config_entries: [], applies_to: [] },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx({ filters: [{ lambda: null }] });
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector("esphome-lambda-editor")).toBeTruthy();
+  });
+
   it("renders no sub-form on an empty / unselected row", async () => {
     const renderEntry = vi.fn();
     const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -372,6 +372,57 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
   });
 
+  it("renders advanced sub-fields unconditionally for the picked filter", async () => {
+    // exponential_moving_average's three sub-fields are all marked
+    // advanced: true. The outer form's advanced gate filters those
+    // out unless the user toggles 'Show advanced'; picking the filter
+    // is itself an explicit opt-in, so the sub-form should render
+    // every field regardless of the outer setting.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "exponential_moving_average",
+        name: "EMA",
+        applies_to: [],
+        config_entries: [
+          makeEntry(ConfigEntryType.FLOAT, { key: "alpha", advanced: true }),
+          makeEntry(ConfigEntryType.INTEGER, { key: "send_every", advanced: true }),
+        ],
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ exponential_moving_average: null }] },
+      {
+        overrides: {
+          renderEntry,
+          // Simulate the outer form having advanced fields hidden;
+          // the sub-form ignores this.
+          filterRenderable: ((entries: (typeof catalog)[0]["config_entries"]) =>
+            entries.filter((e) => !e.advanced)) as never,
+        },
+      }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    const paths = renderEntry.mock.calls.map((c) => c[1]);
+    expect(paths).toContainEqual(["filters", "0", "exponential_moving_average", "alpha"]);
+    expect(paths).toContainEqual([
+      "filters",
+      "0",
+      "exponential_moving_average",
+      "send_every",
+    ]);
+  });
+
   it("renders the inline lambda editor when the picked id is 'lambda'", async () => {
     // ``lambda`` filter takes a C++ body as the whole polymorphic value
     // (``- lambda: |- return x;``). The catalog ships no config_entries

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -252,6 +252,108 @@ describe("renderRegistryListField — emitChange contract", () => {
   });
 });
 
+describe("renderRegistryListField — per-row params sub-form", () => {
+  it("renders a sub-form for the picked entry's config_entries", async () => {
+    // calibrate_polynomial requires ``degree`` + ``datapoints``;
+    // without a sub-form the user has to hand-edit YAML to set
+    // required params and the validator flags missing fields.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "calibrate_polynomial",
+        name: "Calibrate Polynomial",
+        applies_to: [],
+        config_entries: [
+          makeEntry(ConfigEntryType.INTEGER, { key: "degree", required: true }),
+          makeEntry(ConfigEntryType.STRING, { key: "datapoints", required: true }),
+        ],
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ calibrate_polynomial: { degree: 2, datapoints: ["0 -> 0"] } }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    const paths = renderEntry.mock.calls.map((c) => c[1]);
+    expect(paths).toContainEqual(["filters", "0", "calibrate_polynomial", "degree"]);
+    expect(paths).toContainEqual(["filters", "0", "calibrate_polynomial", "datapoints"]);
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeTruthy();
+  });
+
+  it("renders no sub-form when the picked entry has no config_entries", async () => {
+    const renderEntry = vi.fn();
+    const catalog = [{ id: "pulse", name: "Pulse", config_entries: [], applies_to: [] }];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "effects",
+      registry: "light_effects",
+      multi_value: true,
+    });
+    el.path = ["effects"];
+    el.ctx = makeRenderCtx(
+      { effects: [{ pulse: null }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(renderEntry).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
+  });
+
+  it("renders no sub-form when the picked id is missing from the catalog", async () => {
+    // Legacy id case: the picker still surfaces the value but we
+    // don't have the schema, so no fields to render.
+    const renderEntry = vi.fn();
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "effects",
+      registry: "light_effects",
+      multi_value: true,
+    });
+    el.path = ["effects"];
+    el.ctx = makeRenderCtx(
+      { effects: [{ unknown_effect: null }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: LightEffect[] })._catalog = STUB_CATALOG;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(renderEntry).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
+  });
+
+  it("renders no sub-form on an empty / unselected row", async () => {
+    const renderEntry = vi.fn();
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "effects",
+      registry: "light_effects",
+      multi_value: true,
+    });
+    el.path = ["effects"];
+    el.ctx = makeRenderCtx({ effects: [{}] }, { overrides: { renderEntry } });
+    document.body.append(el);
+    (el as unknown as { _catalog: LightEffect[] })._catalog = STUB_CATALOG;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(renderEntry).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
+  });
+});
+
 describe("renderRegistryListField — applies_to filtering", () => {
   it("scopes the light_effects catalog to the parent platform", async () => {
     // adalight is registered as ADDRESSABLE-only; on a


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to esphome/device-builder#941 adding per-row parameter editing for REGISTRY_LIST entries. V1 shipped the picker, but each row's params had to be filled in via the YAML pane; a filter like calibrate_polynomial that requires degree and datapoints couldn't be configured visually, so the validator rejected saves. The renderer now recurses ctx.renderEntry over the picked entry's config_entries, with the row's params at `[...path, index, currentId]`. Defensive bail-outs cover scalar params (`delta: 0.5`, `throttle: 10s`, `lambda: |- ...`), unknown ids the catalog dropped, freshly-added empty rows, and the unselected placeholder.

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder#941

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
