### PR TITLE
Pad YAML editor pane so buttons don't overlay last lines

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -286,6 +286,23 @@ export const deviceEditorStyles = css`
     overflow-y: auto;
   }
 
+  /* The floating Install / Validate / Save row overlays the
+     bottom-right of the card body. Reserve room below the
+     content so the last lines sit a header-matching
+     var(--wa-space-m) above the buttons (button bottom inset +
+     button height + the same top-of-pane gap the editor already
+     has via .editor-pane's padding).
+     Applied to:
+     - .editor-pane--right always (the row sits over its bottom-right
+       in both-pane + right-only layouts).
+     - .editor-layout--left .editor-pane--left (board-info-only
+       layout, where the right pane is hidden and the buttons now
+       overlap the full-width left pane). */
+  .editor-pane--right,
+  .editor-layout--left .editor-pane--left {
+    padding-bottom: calc(var(--wa-space-m) * 2 + 2.25rem);
+  }
+
   .editor-pane-title {
     margin: 0;
     font-size: var(--wa-font-size-s);


### PR DESCRIPTION
# What does this implement/fix?

The Install / Validate / Save action row sits at the bottom-right of `.card-body` via `position: absolute; bottom: var(--wa-space-m)`, overlaying whichever pane is currently visible in that corner. With no compensating padding the YAML editor's last lines (or the board-info pane's bottom content) rendered behind the buttons, partially hidden.

Add `padding-bottom: calc(var(--wa-space-m) * 2 + 2.25rem)` to:

- `.editor-pane--right` — covers the both-pane layout and the right-only layout where the editor sits under the buttons
- `.editor-layout--left .editor-pane--left` — covers the board-info-only layout where the right pane is hidden and the buttons now overlay the full-width left pane

Sized to clear:

- `var(--wa-space-m)` — the buttons' own bottom inset
- `2.25rem` — the button row height
- `var(--wa-space-m)` — header-matching gap above the buttons, so the last visible line sits the same distance above the buttons that the first line sits below the card header

**Related issue or feature (if applicable):**

- Reported via screenshot; no issue filed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1342/1342).
- [x] Tests have been added to verify that the new code works (where applicable). N/A, CSS-only fix verified visually in all three editor layouts.
