### PR TITLE
Exclude YamlRawValue from params mapping; name the lambda registry id

### DIFF
--- a/src/components/device/config-entry-renderers/lambda.ts
+++ b/src/components/device/config-entry-renderers/lambda.ts
@@ -28,6 +28,13 @@ import "./lambda-editor.js";
  *   byte-for-byte.
  * - plain string — fall back for hand-edited values.
  */
+/** Registry id used for the ``lambda`` filter / effect across the
+ *  light_effects and filter registries. Co-located with the other
+ *  lambda helpers so the coupling between the registry-list
+ *  renderer's special-case and the lambda editor is searchable in
+ *  one grep. */
+export const LAMBDA_REGISTRY_ID = "lambda";
+
 export function lambdaBodyOf(raw: unknown): string {
   if (isLambdaValue(raw)) return raw._lambda;
   if (raw instanceof YamlRawValue) return raw.body;

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -29,7 +29,7 @@ import {
 } from "../../../util/automation-catalog-cache.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import "./lambda-editor.js";
-import { lambdaBodyOf } from "./lambda.js";
+import { LAMBDA_REGISTRY_ID, lambdaBodyOf } from "./lambda.js";
 import {
   effectiveDisabled,
   fieldRendererStyles,
@@ -464,13 +464,14 @@ export class ESPHomeRegistryList extends LitElement {
       params !== null &&
       typeof params === "object" &&
       !Array.isArray(params) &&
-      !isLambdaValue(params);
+      !isLambdaValue(params) &&
+      !(params instanceof YamlRawValue);
     // ``lambda`` filter / effect takes a C++ body as the whole value
     // (``- lambda: |- return x;``); the schema bundle exposes no
     // config_vars for it, so the catalog has 0 config_entries. Render
     // an inline lambda editor bound to the row's polymorphic value
     // position so users can fill in the body visually.
-    const isLambdaForm = currentId === "lambda";
+    const isLambdaForm = currentId === LAMBDA_REGISTRY_ID;
     // Render every child unconditionally — the user opted into this
     // filter/effect by picking it from the dropdown, so the outer
     // form's advanced / requiredOnly gates don't apply (many filters

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -372,6 +372,39 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
   });
 
+  it("renders no sub-form when the existing params is a YamlRawValue", async () => {
+    // A YamlRawValue at the params position means the parser preserved
+    // a block the loader couldn't normalize. Rendering the mapping
+    // sub-form over the opaque raw text would clobber it on the first
+    // child edit; same class of bug as the scalar bail.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "calibrate_polynomial",
+        name: "Calibrate Polynomial",
+        applies_to: [],
+        config_entries: [makeEntry(ConfigEntryType.INTEGER, { key: "degree" })],
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ calibrate_polynomial: new YamlRawValue(["  - 1 -> 1"]) }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(renderEntry).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
+  });
+
   it("renders advanced sub-fields unconditionally for the picked filter", async () => {
     // exponential_moving_average's three sub-fields are all marked
     // advanced: true. The outer form's advanced gate filters those


### PR DESCRIPTION
# What does this implement/fix?

Two follow-ups to #397 from the post-merge Koan review. `YamlRawValue` at the row's params position wasn't excluded from `paramsIsMapping`; the parser preserves an opaque block there when the loader can't normalize the YAML, and rendering the mapping sub-form over it would clobber the raw text on the first child edit, same class of bug as the scalar bail-out the previous PR already handled. The `"lambda"` special-case id is also extracted to a `LAMBDA_REGISTRY_ID` constant in `lambda.ts` alongside the other lambda helpers, so the coupling between the registry-list special-case and the lambda editor is searchable in one grep.

**Related issue or feature (if applicable):**

- follow-up to #941

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
