### PR TITLE
Collapse wizard boards-grid to single column on narrow viewports

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -99,12 +99,25 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       /* Mobile: drop both width variants to fullscreen so the
          wizard's board picker and per-step bodies have room to
          breathe instead of getting boxed into a 520px column
-         flanked by black gutters. #41 */
+         flanked by black gutters. Mirrors the same shape the
+         logs-dialog uses — the --width custom property alone
+         doesn't work because wa-dialog's internal dialog part
+         carries a max-width calc(100% - …) and a UA max-height
+         that keep the dialog at its desktop size unless we
+         override them on the part directly. The dvh fallback
+         after vh lets modern browsers shrink the dialog as iOS
+         Safari's URL bar collapses. #41 */
       @media (max-width: 600px) {
-        wa-dialog,
-        wa-dialog.wide {
-          --width: 100vw;
-          --height: 100vh;
+        wa-dialog::part(dialog) {
+          position: fixed;
+          inset: 0;
+          width: 100vw;
+          height: 100vh;
+          height: 100dvh;
+          max-width: none;
+          max-height: none;
+          margin: 0;
+          border-radius: 0;
         }
       }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -96,6 +96,18 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         --width: 750px;
       }
 
+      /* Mobile: drop both width variants to fullscreen so the
+         wizard's board picker and per-step bodies have room to
+         breathe instead of getting boxed into a 520px column
+         flanked by black gutters. #41 */
+      @media (max-width: 600px) {
+        wa-dialog,
+        wa-dialog.wide {
+          --width: 100vw;
+          --height: 100vh;
+        }
+      }
+
       wa-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the close button sits flush with the

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -301,39 +301,6 @@ export class ESPHomeWizardStepBoard extends LitElement {
         gap: var(--wa-space-s);
       }
 
-      @media (max-width: 480px) {
-        .boards-grid {
-          grid-template-columns: 1fr;
-        }
-
-        /* Featured (Apollo Starter Kit) card: image-left + text-right
-           wraps to one word per line at phone width. Stack vertically
-           so the description has the full card width. #41 */
-        .featured-card {
-          flex-direction: column;
-          gap: var(--wa-space-s);
-        }
-
-        .featured-image {
-          width: 100%;
-          height: 160px;
-        }
-
-        /* Regular board cards: header row was image-on-left + title-on-
-           the-right; at narrow widths the right column shrinks to
-           ~140px and titles wrap awkwardly. Stack image above title
-           so each row gets the full card width. #41 */
-        .board-card-header {
-          flex-direction: column;
-          align-items: stretch;
-        }
-
-        .board-image {
-          width: 100%;
-          height: 100px;
-        }
-      }
-
       .board-card {
         position: relative;
         border-radius: var(--wa-border-radius-l);
@@ -511,6 +478,47 @@ export class ESPHomeWizardStepBoard extends LitElement {
         font-size: var(--wa-font-size-s);
         text-align: center;
         padding: var(--wa-space-xl);
+      }
+
+      /* Mobile overrides — placed at the end of the stylesheet so
+         they win the same-specificity source-order fight against
+         the base .featured-card / .featured-image /
+         .board-card-header / .board-image rules above. Caught by
+         Copilot review on PR #400 — the prior placement inline
+         with the base rules left align-items / width / height
+         silently overridden. #41 */
+      @media (max-width: 480px) {
+        .boards-grid {
+          grid-template-columns: 1fr;
+        }
+
+        /* Featured (Apollo Starter Kit) card: image-left +
+           text-right wraps to one word per line at phone width.
+           Stack vertically so the description has the full card
+           width. */
+        .featured-card {
+          flex-direction: column;
+          gap: var(--wa-space-s);
+        }
+
+        .featured-image {
+          width: 100%;
+          height: 160px;
+        }
+
+        /* Regular board cards: header row was image-on-left +
+           title-on-the-right; at narrow widths the right column
+           shrinks to ~140px and titles wrap awkwardly. Stack
+           image above title so each row gets the full card width. */
+        .board-card-header {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .board-image {
+          width: 100%;
+          height: 100px;
+        }
       }
     `,
   ];

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -305,6 +305,33 @@ export class ESPHomeWizardStepBoard extends LitElement {
         .boards-grid {
           grid-template-columns: 1fr;
         }
+
+        /* Featured (Apollo Starter Kit) card: image-left + text-right
+           wraps to one word per line at phone width. Stack vertically
+           so the description has the full card width. #41 */
+        .featured-card {
+          flex-direction: column;
+          gap: var(--wa-space-s);
+        }
+
+        .featured-image {
+          width: 100%;
+          height: 160px;
+        }
+
+        /* Regular board cards: header row was image-on-left + title-on-
+           the-right; at narrow widths the right column shrinks to
+           ~140px and titles wrap awkwardly. Stack image above title
+           so each row gets the full card width. #41 */
+        .board-card-header {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .board-image {
+          width: 100%;
+          height: 100px;
+        }
       }
 
       .board-card {

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -301,6 +301,12 @@ export class ESPHomeWizardStepBoard extends LitElement {
         gap: var(--wa-space-s);
       }
 
+      @media (max-width: 480px) {
+        .boards-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+
       .board-card {
         position: relative;
         border-radius: var(--wa-border-radius-l);


### PR DESCRIPTION
# What does this implement/fix?

`.boards-grid` was hard-coded to `repeat(2, 1fr)` with no media query, so the New Device wizard's "Other boards" section rendered two unusably-narrow cards side by side on phone-width screens. Drop to one column below 480px so each board card gets the full width. Verified locally at 375px (iPhone SE width) in Chrome DevTools responsive mode.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker; this addresses @jesserockz's "two columns of other boards" comment)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
