### PR TITLE
Cascade table column hiding below 920/820/700px breakpoints

### DIFF
--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -253,9 +253,32 @@ export const tableCellStyles = css`
     .cell-action-btn--logs {
       display: none;
     }
+    /* Progressive column hiding for the table-view fallback on
+       narrow viewports (mobile users default to the card grid; this
+       only kicks in when they toggle to table view on a small
+       screen, or on tablet portraits). Same priority order as the
+       action-button ladder above: drop the lowest-signal columns
+       first, keep select / status / name / actions visible as the
+       four-column spine at every width.
+       Priority order (highest → lowest, last to drop):
+         select / status / name / actions  (always visible)
+         address (last to drop, useful for hostname-based access)
+         platform
+         config (file name — least useful when name is visible) */
+    .col-config {
+      display: none;
+    }
   }
   @media (max-width: 820px) {
     .cell-action-btn--install {
+      display: none;
+    }
+    .col-platform {
+      display: none;
+    }
+  }
+  @media (max-width: 700px) {
+    .col-address {
       display: none;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

The dashboard table shows 7 default-visible columns (select, status, name, address, platform, config, actions). The existing breakpoint ladder in `table-cell-styles.ts` only hid per-row action buttons; whole columns kept their slots and the table horizontal-scrolled on tablet portrait / phone-landscape widths. Extend the ladder so whole columns drop in the same priority order the action-button ladder uses: below 920px the `config` column hides, below 820px also `platform`, below 700px also `address`. `select / status / name / actions` stay as the four-column spine at every width. Mobile users still default to the card grid; this only affects users who toggle to table view on a narrow viewport.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker; this addresses @swoboda1337's "table view doesn't fit on mobile viewports" comment)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
