### PR TITLE
Compact discovered-banner pill on mobile

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -170,6 +170,26 @@ export const dashboardStyles = css`
     display: none;
   }
 
+  /* Mobile: shrink the floating pill so it stops eating ~70px of
+     viewport above the first device card. Same horizontal shape
+     (icon + count + Show), just denser padding and smaller text /
+     icon. The expandable grid below keeps its existing sizing —
+     this only compacts the collapsed-state header. #41 */
+  @media (max-width: 600px) {
+    .discovered-section-header {
+      padding: var(--wa-space-2xs) var(--wa-space-s);
+      gap: var(--wa-space-xs);
+    }
+
+    .discovered-section-header wa-icon {
+      font-size: var(--wa-font-size-s);
+    }
+
+    .discovered-section-count {
+      font-size: var(--wa-font-size-xs);
+    }
+  }
+
   /* ─── Card Grid ─── */
 
   .devices-grid {


### PR DESCRIPTION
# What does this implement/fix?

The floating "Discovered N devices" pill was eating ~70px of viewport at the top of the dashboard on phone viewports — between the app header and the search/filter chip rows, the user had to scroll past ~300px of chrome before seeing the first device card. Tighten the pill's padding to `--wa-space-2xs / --wa-space-s`, drop the clipboard icon from `font-size-l` to `font-size-s`, and shrink the count text to `font-size-xs` below 600px. Same horizontal shape (icon + count + Show / Show ignored), just compact enough to land at ~30-35px tall. The expandable grid below keeps its existing sizing.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
