### PR TITLE
Tighten dashboard top gutter to match compact discovered pill

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -44,6 +44,17 @@ export const dashboardStyles = css`
     padding-top: var(--wa-space-2xl);
   }
 
+  /* Mobile: the pill itself compacted to ~30px (see
+     .discovered-section-header @media block below); the desktop
+     gutter-top sized for the full pill leaves ~40px of dead space
+     between the now-shrunk pill and the search bar. Tighten the
+     gutter to match the new pill height. #41 */
+  @media (max-width: 600px) {
+    :host([has-discovered]) {
+      padding-top: var(--wa-space-l);
+    }
+  }
+
   /* ─── Discovered Banner ─── */
 
   /* ─── Discovered section ─── */


### PR DESCRIPTION
# What does this implement/fix?

#402 shrunk the discovered-banner pill from ~70px to ~30px on mobile, but the host's `:host([has-discovered]) { padding-top: var(--wa-space-2xl); }` stayed sized for the desktop pill. That left ~40px of dead black space between the now-compact pill and the search bar. Drop the gutter to `--wa-space-l` below 600px so the search bar sits just under the pill at the same proportional offset the desktop layout has.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker; follow-up to #402)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
