### PR TITLE
Move Select-multiple between view-switcher and facets

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -186,10 +186,10 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
     >
       <div slot="toolbar" class="toolbar-stack">
         <div class="toolbar-row">
-          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
+          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
+          ${renderFacets(host)}
         </div>
       </div>
-      <div slot="before-columns">${renderSelectToggle(host)}</div>
       <button
         slot="actions"
         class="table-create-btn"

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -212,17 +212,19 @@ export function renderToolbar(
       ? host._localize("dashboard.device_singular")
       : host._localize("dashboard.device_plural");
   const suffix = q ? " " + host._localize("dashboard.search_of", { total }) : "";
-  // Layout: [search] [view-toggle] [facets…] <spacer> [Select multiple]
+  // Layout: [search] [view-toggle] [Select multiple] [facets…]
   //         [X devices]
-  // The spacer between the facet cluster and the select-mode
-  // toggle visually separates "filter the list" from "operate on
-  // the list" so the toggle no longer reads as another facet.
+  // Select-multiple sits between the view switcher and the facet
+  // chips so the row wraps cleanly at narrow widths (the trailing
+  // facets wrap to a new line first, keeping Select-multiple on
+  // the same row as the view switcher). Unified across card and
+  // table views so the toggle's position doesn't shift when the
+  // user flips the view.
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
-        <span class="toolbar-spacer"></span>
-        ${renderSelectToggle(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
+        ${renderFacets(host)}
       </div>
       <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
     </div>


### PR DESCRIPTION
# What does this implement/fix?

The Select-multiple toggle's position differed by view: card view had it at the right edge of the toolbar row (after a spacer that pushed it past the facets), table view had it in the device-table's `before-columns` slot beside Columns / Create device. On phone widths the table-view shape overflowed — Columns + Create device + Select-multiple don't fit in one row, and "Create device" got clipped off the right edge. Unify the placement across both views: Select-multiple slots between the view-switcher and the facet chips on the toolbar row, so the trailing facet chips wrap to a new line first when the row runs out of room and Select-multiple stays on the same row as the view-switcher at every viewport.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
