### PR TITLE
Fit the app-header title on mobile + rename badge to Beta

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -179,12 +179,12 @@ export class ESPHomeLayout extends LitElement {
 
         /* Tighten the chrome around the logo: the 44px button sized
            for a desktop touch target carries more whitespace than a
-           phone needs, and the app-header's --wa-space-m gap +
-           --wa-space-s padding together claim ~24px the title could
-           use to fit "Builder" before the PREVIEW badge. */
+           phone needs, and the app-header's --wa-space-m gap claims
+           extra room the title could use to fit "Builder" before
+           the PREVIEW badge. Keep the horizontal padding at the
+           desktop value so the logo doesn't hug the viewport edge. */
         .app-header {
           gap: var(--wa-space-s);
-          padding: 0 var(--wa-space-2xs);
         }
 
         .header-logo {

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -116,6 +116,18 @@ export class ESPHomeLayout extends LitElement {
         gap: var(--wa-space-xs);
       }
 
+      /* The title span is a flex item and needs its own min-width:0
+         + overflow handling for text-overflow:ellipsis to apply —
+         flex items default to min-width:auto, which keeps them at
+         intrinsic width and pushes later siblings (the
+         .preview-badge) past the h1's overflow:hidden. Without this
+         the badge clipped to just "P|" on phone-width viewports. */
+      .header-title-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
       .preview-badge {
         font-size: 9px;
         font-weight: var(--wa-font-weight-bold);
@@ -149,6 +161,20 @@ export class ESPHomeLayout extends LitElement {
       @media (max-width: 700px) {
         .header-text p {
           display: none;
+        }
+
+        /* The spacer's flex:1 was eating the slack between the title
+           and the kebab actions — desktop's intentional layout but on
+           a phone that's where the title needs room to fit "ESPHome
+           Device Builder" alongside the PREVIEW badge without
+           truncating. Drop the spacer and grow the header-text into
+           the freed space instead. */
+        .header-spacer {
+          display: none;
+        }
+
+        .header-text {
+          flex: 1;
         }
       }
 
@@ -213,7 +239,7 @@ export class ESPHomeLayout extends LitElement {
         </div>
         <div class="header-text">
           <h1>
-            <span>${this._localize("dashboard.title")}</span>
+            <span class="header-title-text">${this._localize("dashboard.title")}</span>
             <span class="preview-badge">${this._localize("layout.preview_badge")}</span>
           </h1>
           <p>${this._localize("dashboard.subtitle")}</p>

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -176,6 +176,21 @@ export class ESPHomeLayout extends LitElement {
         .header-text {
           flex: 1;
         }
+
+        /* Tighten the chrome around the logo: the 44px button sized
+           for a desktop touch target carries more whitespace than a
+           phone needs, and the app-header's --wa-space-m gap +
+           --wa-space-s padding together claim ~24px the title could
+           use to fit "Builder" before the PREVIEW badge. */
+        .app-header {
+          gap: var(--wa-space-s);
+          padding: 0 var(--wa-space-2xs);
+        }
+
+        .header-logo {
+          width: 36px;
+          height: 36px;
+        }
       }
 
       .app-footer {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -849,7 +849,7 @@
     "editor": "Editor",
     "yaml_diff_button": "YAML diff button",
     "more_options_with_count": "More options ({count} firmware task(s) active)",
-    "preview_badge": "Preview"
+    "preview_badge": "Beta"
   },
   "feedback": {
     "title": "Found a bug? Have an idea?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,6 +1,6 @@
 {
   "dashboard": {
-    "title": "ESPHome - Device Builder",
+    "title": "ESPHome Device Builder",
     "subtitle": "Create and make your smart devices and automations",
     "discovered_count_singular": "Discovered {count} device",
     "discovered_count_plural": "Discovered {count} devices",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,6 +1,6 @@
 {
   "dashboard": {
-    "title": "ESPHome - Device Builder",
+    "title": "ESPHome Device Builder",
     "subtitle": "Créez et fabriquez vos appareils intelligents et automatisations",
     "discovered_count_singular": "{count} appareil détecté",
     "discovered_count_plural": "{count} appareils détectés",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -728,7 +728,7 @@
     "editor": "Éditeur",
     "yaml_diff_button": "Bouton de diff YAML",
     "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))",
-    "preview_badge": "Aperçu"
+    "preview_badge": "Beta"
   },
   "feedback": {
     "title": "Un bug ? Une idée ?",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -841,7 +841,7 @@
     "editor": "Szerkesztő",
     "yaml_diff_button": "YAML-különbség gomb",
     "more_options_with_count": "További lehetőségek ({count} aktív firmware-feladat)",
-    "preview_badge": "Előnézet"
+    "preview_badge": "Beta"
   },
   "feedback": {
     "title": "Hibát talált? Van új ötlete?",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,6 +1,6 @@
 {
   "dashboard": {
-    "title": "ESPHome - Device Builder",
+    "title": "ESPHome Device Builder",
     "subtitle": "Maak en bouw uw slimme apparaten en automatiseringen",
     "discovered_count_singular": "{count} apparaat gevonden",
     "discovered_count_plural": "{count} apparaten gevonden",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -728,7 +728,7 @@
     "editor": "Editor",
     "yaml_diff_button": "YAML-diff-knop",
     "more_options_with_count": "Meer opties ({count} firmwaretaken actief)",
-    "preview_badge": "Preview"
+    "preview_badge": "Beta"
   },
   "feedback": {
     "title": "Probleem of idee?",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -849,7 +849,7 @@
     "editor": "编辑器",
     "yaml_diff_button": "YAML 差异按钮",
     "more_options_with_count": "更多选项（{count} 个固件任务正在运行）",
-    "preview_badge": "预览"
+    "preview_badge": "Beta"
   },
   "feedback": {
     "title": "发现 Bug？有新想法？",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "dashboard": {
-    "title": "ESPHome - Device Builder",
+    "title": "ESPHome Device Builder",
     "subtitle": "创建并构建你的智能设备和自动化",
     "discovered_count_singular": "发现了 {count} 台设备",
     "discovered_count_plural": "发现了 {count} 台设备",

--- a/test/common/localize.test.ts
+++ b/test/common/localize.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("defaultLocalize", () => {
   it("resolves a top-level string key", () => {
-    expect(defaultLocalize("dashboard.title")).toBe("ESPHome - Device Builder");
+    expect(defaultLocalize("dashboard.title")).toBe("ESPHome Device Builder");
   });
 
   it("resolves a deeply nested key", () => {


### PR DESCRIPTION
# What does this implement/fix?

The app-header title was clipping the badge to just "P|" on phone widths because the h1 (a flex container) had no min-width override on the title span — the title's intrinsic width pushed the trailing `.preview-badge` past the h1's `overflow: hidden`. Three composed changes get the full title + badge into the header at every viewport:

1. **Title span gets `min-width: 0` + `overflow: hidden` + `text-overflow: ellipsis`** — flex items default to `min-width: auto` which keeps them at intrinsic width; without this `text-overflow` on the h1 itself doesn't apply to the spans. Badge already has `flex-shrink: 0` so it stays at full size when the title truncates.
2. **Drop the stylistic dash from `dashboard.title`** across en/fr/nl/zh-CN — now reads "ESPHome Device Builder" matching README + pyproject.toml naming. Shorter title, less likely to truncate at all.
3. **Tighten header chrome below 700px** — drop the `.header-spacer` (its `flex: 1` was eating the slack between title and kebab actions; on mobile that's where the title needs room), grow `.header-text` to `flex: 1`, shrink the logo button from 44px to 36px, drop the app-header gap from `--wa-space-m` to `--wa-space-s`. Together that frees enough room for the full title to land alongside the badge.
4. **Rename the badge** from "Preview" to "Beta" across all five locales — matches the stage language the rest of the project uses (README: "Base functions are in late beta; remote / offload functions are in early beta").

Existing localize test updated to the new title text.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
