### PR TITLE
Trim content horizontal padding across all three views on mobile

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -882,4 +882,28 @@ export const dashboardStyles = css`
   .fab-btn wa-icon {
     font-size: 18px;
   }
+
+  /* Mobile content-padding trim. The card grid, toolbar, and YAML
+     hit list all sit at --wa-space-l (24px) horizontal padding;
+     on a 375px phone viewport that's ~13% of the width per side
+     gone to chrome. Tighten to --wa-space-s (8px) so device cards
+     and the toolbar row claim the available width. Placed last in
+     the stylesheet so source-order wins against the base
+     declarations above. #41 */
+  @media (max-width: 600px) {
+    .devices-grid {
+      padding-left: var(--wa-space-s);
+      padding-right: var(--wa-space-s);
+    }
+
+    .toolbar {
+      padding-left: var(--wa-space-s);
+      padding-right: var(--wa-space-s);
+    }
+
+    .yaml-hits {
+      padding-left: var(--wa-space-s);
+      padding-right: var(--wa-space-s);
+    }
+  }
 `;

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -54,6 +54,24 @@ export const tableLayoutStyles = css`
     }
   }
 
+  /* Mobile content-padding trim. The controls strip and the
+     table-wrap claim --wa-space-l (24px) of horizontal padding /
+     margin on each side; on a 375px phone viewport that's ~13% of
+     the width per side gone to chrome. Match the dashboard's
+     .toolbar / .devices-grid trim so all three views share the
+     same tight gutters at narrow widths. #41 */
+  @media (max-width: 600px) {
+    .controls {
+      padding-left: var(--wa-space-s);
+      padding-right: var(--wa-space-s);
+    }
+
+    .table-wrap {
+      margin-left: var(--wa-space-s);
+      margin-right: var(--wa-space-s);
+    }
+  }
+
   /* ─── Table ─── */
 
   .table-wrap {


### PR DESCRIPTION
# What does this implement/fix?

The dashboard's three content surfaces (card grid, table view, YAML hits) all sit at `--wa-space-l` (24px) horizontal padding / margin — on a 375px phone viewport that's ~13% of the available width per side eaten by chrome before the actual content starts. Drop to `--wa-space-s` (8px) below 600px so the content uses the room phones have to offer. Covered across all three views in lockstep:

- `src/components/dashboard/styles.ts` — `.devices-grid`, `.toolbar`, `.yaml-hits`.
- `src/components/dashboard/table-styles.ts` — `.controls` (table toolbar strip) and `.table-wrap` (outer margin).

Desktop layout (≥600px) is unchanged.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
