### PR TITLE
Pair Select-multiple with the device-count in card view

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -4,10 +4,10 @@ import type { AdoptableDevice, ConfiguredDevice } from "../../api/types.js";
 import { downloadYaml, editDevice } from "./actions.js";
 import {
   renderAddDeviceCard,
+  renderDeviceCountRow,
   renderFacets,
   renderNoResultsExtras,
   renderSearchInput,
-  renderSelectToggle,
   renderViewToggle,
 } from "./render-toolbar.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
@@ -186,9 +186,9 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
     >
       <div slot="toolbar" class="toolbar-stack">
         <div class="toolbar-row">
-          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
-          ${renderFacets(host)}
+          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         </div>
+        ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}
       </div>
       <button
         slot="actions"

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -212,21 +212,21 @@ export function renderToolbar(
       ? host._localize("dashboard.device_singular")
       : host._localize("dashboard.device_plural");
   const suffix = q ? " " + host._localize("dashboard.search_of", { total }) : "";
-  // Layout: [search] [view-toggle] [Select multiple] [facets…]
-  //         [X devices]
-  // Select-multiple sits between the view switcher and the facet
-  // chips so the row wraps cleanly at narrow widths (the trailing
-  // facets wrap to a new line first, keeping Select-multiple on
-  // the same row as the view switcher). Unified across card and
-  // table views so the toggle's position doesn't shift when the
-  // user flips the view.
+  // Layout: [search] [view-toggle] [facets…]
+  //         [X devices]                 [Select multiple]
+  // Select-multiple sits paired with the device-count on its own
+  // row — both reference the device list ("operate on these N
+  // devices") so semantically they belong together. Frees the
+  // toolbar-row above for filter-related controls only.
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
-        ${renderFacets(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
       </div>
-      <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+      <div class="device-count-row">
+        <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+        ${renderSelectToggle(host)}
+      </div>
     </div>
   `;
 }

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -201,7 +201,10 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
   </div>`;
 }
 
-export function renderToolbar(
+/** Pairs the device-count with Select-multiple on one row. Used
+ *  by both the card-view toolbar and the table-view toolbar so the
+ *  toggle's position doesn't shift when the user flips the view. */
+export function renderDeviceCountRow(
   host: ESPHomePageDashboard,
   matchCount: number,
   total: number
@@ -212,6 +215,19 @@ export function renderToolbar(
       ? host._localize("dashboard.device_singular")
       : host._localize("dashboard.device_plural");
   const suffix = q ? " " + host._localize("dashboard.search_of", { total }) : "";
+  return html`
+    <div class="device-count-row">
+      <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+      ${renderSelectToggle(host)}
+    </div>
+  `;
+}
+
+export function renderToolbar(
+  host: ESPHomePageDashboard,
+  matchCount: number,
+  total: number
+): TemplateResult {
   // Layout: [search] [view-toggle] [facets…]
   //         [X devices]                 [Select multiple]
   // Select-multiple sits paired with the device-count on its own
@@ -223,10 +239,7 @@ export function renderToolbar(
       <div class="toolbar-row">
         ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
       </div>
-      <div class="device-count-row">
-        <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
-        ${renderSelectToggle(host)}
-      </div>
+      ${renderDeviceCountRow(host, matchCount, total)}
     </div>
   `;
 }

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -493,6 +493,17 @@ export const dashboardStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
+  /* Pairs the count with the Select-multiple toggle on a row of
+     their own — both reference the device list, so they belong
+     side-by-side. justify-content:space-between puts the count on
+     the left and the toggle on the right at every width. */
+  .device-count-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--wa-space-m);
+  }
+
   /* ─── View Toggle ─── */
 
   .view-toggle {

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -238,6 +238,19 @@ export const dashboardStyles = css`
     padding: var(--wa-space-l) var(--wa-space-l) 0;
     flex-shrink: 0;
   }
+
+  /* Table-view counterpart to .toolbar (sits inside the
+     device-table's named toolbar slot, where the slotted rule on
+     .controls handles the outer padding). Without this rule the
+     inner rows stacked at 0px gap while card view stacked at 2px,
+     so flipping the view-toggle made the X-devices row jump 2px
+     vertically. */
+  .toolbar-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
   .toolbar-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
# What does this implement/fix?

Select-multiple was sitting in the toolbar-row between the view-switcher and the facet chips (PR-F). Better fit: pair it with the device-count on its own row — both reference the device list ("operate on these N devices"), and grouping them visually frees the toolbar-row above for filter-related controls only.

Adds a new `.device-count-row` flex container that puts the count on the left and the toggle on the right via `justify-content: space-between`. Table view (`render-content.ts`) keeps PR-F's placement because the table doesn't have an external device-count in its toolbar.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder-frontend/issues/41 (umbrella mobile-view tracker)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
