### PR TITLE
Constrain dashboard host padding to its fixed height

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -5,6 +5,7 @@ export const dashboardStyles = css`
     display: flex;
     flex-direction: column;
     position: relative;
+    box-sizing: border-box;
     height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
     overflow: hidden;
     /* Single source of truth for the floating Create-device button's


### PR DESCRIPTION
# What does this implement/fix?

The dashboard :host pins itself to height: calc(100vh - header - footer) with overflow: hidden, and :host([has-discovered]) layers padding-top: --wa-space-2xl on top of that. With the default box-sizing of content-box the padding grew the host past the viewport in table view, clipping the pagination row at the bottom. Adding box-sizing: border-box keeps the padding inside the fixed height so the table-wrap fits and pagination stays visible. Card view is unaffected because it already opts into height: auto, overflow: visible.

**Related issue or feature (if applicable):**

- related issue #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).