### PR TITLE
Pair Select-multiple with the device-count row across both views

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -347,6 +347,7 @@ export class ESPHomeDeviceTable extends LitElement {
 
     return html`
       ${this._renderControls(table, toggleCols)}
+      <slot name="below-controls"></slot>
       <div class="table-wrap">
         <div class="table-scroll">
           <table role="grid">

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -4,10 +4,10 @@ import type { AdoptableDevice, ConfiguredDevice } from "../../api/types.js";
 import { downloadYaml, editDevice } from "./actions.js";
 import {
   renderAddDeviceCard,
+  renderDeviceCountRow,
   renderFacets,
   renderNoResultsExtras,
   renderSearchInput,
-  renderSelectToggle,
   renderViewToggle,
 } from "./render-toolbar.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
@@ -186,9 +186,9 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
     >
       <div slot="toolbar" class="toolbar-stack">
         <div class="toolbar-row">
-          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
-          ${renderFacets(host)}
+          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         </div>
+        ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}
       </div>
       <button
         slot="actions"

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -188,6 +188,8 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         <div class="toolbar-row">
           ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
         </div>
+      </div>
+      <div slot="below-controls" class="table-device-count-row">
         ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}
       </div>
       <button

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -212,21 +212,21 @@ export function renderToolbar(
       ? host._localize("dashboard.device_singular")
       : host._localize("dashboard.device_plural");
   const suffix = q ? " " + host._localize("dashboard.search_of", { total }) : "";
-  // Layout: [search] [view-toggle] [Select multiple] [facets…]
-  //         [X devices]
-  // Select-multiple sits between the view switcher and the facet
-  // chips so the row wraps cleanly at narrow widths (the trailing
-  // facets wrap to a new line first, keeping Select-multiple on
-  // the same row as the view switcher). Unified across card and
-  // table views so the toggle's position doesn't shift when the
-  // user flips the view.
+  // Layout: [search] [view-toggle] [facets…]
+  //         [X devices]                 [Select multiple]
+  // Select-multiple sits paired with the device-count on its own
+  // row — both reference the device list ("operate on these N
+  // devices") so semantically they belong together. Frees the
+  // toolbar-row above for filter-related controls only.
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderSelectToggle(host)}
-        ${renderFacets(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
       </div>
-      <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+      <div class="device-count-row">
+        <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+        ${renderSelectToggle(host)}
+      </div>
     </div>
   `;
 }

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -201,7 +201,10 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
   </div>`;
 }
 
-export function renderToolbar(
+/** Pairs the device-count with Select-multiple on one row. Used
+ *  by both the card-view toolbar and the table-view toolbar so the
+ *  toggle's position doesn't shift when the user flips the view. */
+export function renderDeviceCountRow(
   host: ESPHomePageDashboard,
   matchCount: number,
   total: number
@@ -212,6 +215,19 @@ export function renderToolbar(
       ? host._localize("dashboard.device_singular")
       : host._localize("dashboard.device_plural");
   const suffix = q ? " " + host._localize("dashboard.search_of", { total }) : "";
+  return html`
+    <div class="device-count-row">
+      <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
+      ${renderSelectToggle(host)}
+    </div>
+  `;
+}
+
+export function renderToolbar(
+  host: ESPHomePageDashboard,
+  matchCount: number,
+  total: number
+): TemplateResult {
   // Layout: [search] [view-toggle] [facets…]
   //         [X devices]                 [Select multiple]
   // Select-multiple sits paired with the device-count on its own
@@ -223,10 +239,7 @@ export function renderToolbar(
       <div class="toolbar-row">
         ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
       </div>
-      <div class="device-count-row">
-        <span class="device-count"><strong>${matchCount}</strong> ${unit}${suffix}</span>
-        ${renderSelectToggle(host)}
-      </div>
+      ${renderDeviceCountRow(host, matchCount, total)}
     </div>
   `;
 }

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -239,6 +239,19 @@ export const dashboardStyles = css`
     padding: var(--wa-space-l) var(--wa-space-l) 0;
     flex-shrink: 0;
   }
+
+  /* Table-view counterpart to .toolbar (sits inside the
+     device-table's named toolbar slot, where the slotted rule on
+     .controls handles the outer padding). Without this rule the
+     inner rows stacked at 0px gap while card view stacked at 2px,
+     so flipping the view-toggle made the X-devices row jump 2px
+     vertically. */
+  .toolbar-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
   .toolbar-row {
     display: flex;
     align-items: center;

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -523,9 +523,11 @@ export const dashboardStyles = css`
      width and Select-multiple right-aligns with Columns / Create
      device in the row above. Horizontal padding matches .controls
      and .table-wrap above/below so the count and toggle line up
-     with the column headers on the right. */
+     with the column headers on the right. Vertical padding pairs
+     the row with the .controls strip above (--wa-space-xs gap)
+     and the .table-wrap below (--wa-space-s breathing room). */
   .table-device-count-row {
-    padding: 0 var(--wa-space-l) var(--wa-space-s);
+    padding: var(--wa-space-xs) var(--wa-space-l) var(--wa-space-s);
   }
 
   /* Mobile: tighten the table-view count-row gutter to match the

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -523,20 +523,18 @@ export const dashboardStyles = css`
      width and Select-multiple right-aligns with Columns / Create
      device in the row above. Horizontal padding matches .controls
      and .table-wrap above/below so the count and toggle line up
-     with the column headers on the right. No vertical padding:
-     .controls sits directly above and .table-wrap directly below,
-     so the row butts against both — same shape as card view
-     where the count row hangs off the toolbar's bottom edge with
-     the .toolbar gap:2px providing the only inter-row spacing. */
+     with the column headers on the right. 2px top padding mirrors
+     card view's .toolbar gap:2px so the inter-row spacing reads
+     identically between views. */
   .table-device-count-row {
-    padding: 0 var(--wa-space-l);
+    padding: 2px var(--wa-space-l) 0;
   }
 
   /* Mobile: tighten the table-view count-row gutter to match the
      .controls / .table-wrap trim in PR-H (see table-styles.ts). */
   @media (max-width: 600px) {
     .table-device-count-row {
-      padding: 0 var(--wa-space-s);
+      padding: 2px var(--wa-space-s) 0;
     }
   }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -206,10 +206,16 @@ export const dashboardStyles = css`
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: var(--wa-space-l);
-    /* Tight 4px top so the count row above doesn't butt against
-       the first card; sides and bottom keep the full padding so
-       the grid doesn't hug the viewport edges or the FAB. */
-    padding: var(--wa-space-xs) var(--wa-space-l) var(--wa-space-l);
+    padding: var(--wa-space-l);
+  }
+
+  /* When the grid follows the toolbar's count row (whether directly
+     or with the empty-search pivot wedged between), the count row
+     already provides spacing above the first card. Tighten the
+     grid's top padding so the two rows don't double up. */
+  .toolbar + .devices-grid,
+  .toolbar + .empty-search + .devices-grid {
+    padding-top: var(--wa-space-xs);
   }
 
   /* Only the configured-device grid needs FAB clearance: it's the

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -494,6 +494,17 @@ export const dashboardStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
+  /* Pairs the count with the Select-multiple toggle on a row of
+     their own — both reference the device list, so they belong
+     side-by-side. justify-content:space-between puts the count on
+     the left and the toggle on the right at every width. */
+  .device-count-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--wa-space-m);
+  }
+
   /* ─── View Toggle ─── */
 
   .view-toggle {

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -518,6 +518,25 @@ export const dashboardStyles = css`
     gap: var(--wa-space-m);
   }
 
+  /* Table view slots the device-count-row through esphome-device-
+     table's below-controls slot so the row spans the full table
+     width and Select-multiple right-aligns with Columns / Create
+     device in the row above. Horizontal padding matches .controls
+     and .table-wrap above/below so the count and toggle line up
+     with the column headers on the right. */
+  .table-device-count-row {
+    padding: 0 var(--wa-space-l) var(--wa-space-s);
+  }
+
+  /* Mobile: tighten the table-view count-row gutter to match the
+     .controls / .table-wrap trim in PR-H (see table-styles.ts). */
+  @media (max-width: 600px) {
+    .table-device-count-row {
+      padding-left: var(--wa-space-s);
+      padding-right: var(--wa-space-s);
+    }
+  }
+
   /* ─── View Toggle ─── */
 
   .view-toggle {

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -523,19 +523,20 @@ export const dashboardStyles = css`
      width and Select-multiple right-aligns with Columns / Create
      device in the row above. Horizontal padding matches .controls
      and .table-wrap above/below so the count and toggle line up
-     with the column headers on the right. Vertical padding pairs
-     the row with the .controls strip above (--wa-space-xs gap)
-     and the .table-wrap below (--wa-space-s breathing room). */
+     with the column headers on the right. No vertical padding:
+     .controls sits directly above and .table-wrap directly below,
+     so the row butts against both — same shape as card view
+     where the count row hangs off the toolbar's bottom edge with
+     the .toolbar gap:2px providing the only inter-row spacing. */
   .table-device-count-row {
-    padding: var(--wa-space-xs) var(--wa-space-l) var(--wa-space-s);
+    padding: 0 var(--wa-space-l);
   }
 
   /* Mobile: tighten the table-view count-row gutter to match the
      .controls / .table-wrap trim in PR-H (see table-styles.ts). */
   @media (max-width: 600px) {
     .table-device-count-row {
-      padding-left: var(--wa-space-s);
-      padding-right: var(--wa-space-s);
+      padding: 0 var(--wa-space-s);
     }
   }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -208,7 +208,13 @@ export const dashboardStyles = css`
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: var(--wa-space-l);
-    padding: var(--wa-space-l);
+    /* No top padding: the .toolbar + device-count-row above
+       already provide the inter-row rhythm — keeping the
+       --wa-space-l top here stacked into a wide gap between the
+       count row and the first card. Sides and bottom keep the
+       full padding so the grid doesn't hug the viewport edges
+       or the FAB. */
+    padding: 0 var(--wa-space-l) var(--wa-space-l);
   }
 
   /* Only the configured-device grid needs FAB clearance: it's the

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -527,14 +527,14 @@ export const dashboardStyles = css`
      card view's .toolbar gap:2px so the inter-row spacing reads
      identically between views. */
   .table-device-count-row {
-    padding: 2px var(--wa-space-l) 0;
+    padding: 2px var(--wa-space-l);
   }
 
   /* Mobile: tighten the table-view count-row gutter to match the
      .controls / .table-wrap trim in PR-H (see table-styles.ts). */
   @media (max-width: 600px) {
     .table-device-count-row {
-      padding: 2px var(--wa-space-s) 0;
+      padding: 2px var(--wa-space-s);
     }
   }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -208,13 +208,10 @@ export const dashboardStyles = css`
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: var(--wa-space-l);
-    /* No top padding: the .toolbar + device-count-row above
-       already provide the inter-row rhythm — keeping the
-       --wa-space-l top here stacked into a wide gap between the
-       count row and the first card. Sides and bottom keep the
-       full padding so the grid doesn't hug the viewport edges
-       or the FAB. */
-    padding: 0 var(--wa-space-l) var(--wa-space-l);
+    /* Tight 4px top so the count row above doesn't butt against
+       the first card; sides and bottom keep the full padding so
+       the grid doesn't hug the viewport edges or the FAB. */
+    padding: var(--wa-space-xs) var(--wa-space-l) var(--wa-space-l);
   }
 
   /* Only the configured-device grid needs FAB clearance: it's the
@@ -533,14 +530,14 @@ export const dashboardStyles = css`
      card view's .toolbar gap:2px so the inter-row spacing reads
      identically between views. */
   .table-device-count-row {
-    padding: 2px var(--wa-space-l);
+    padding: 2px var(--wa-space-l) var(--wa-space-xs);
   }
 
   /* Mobile: tighten the table-view count-row gutter to match the
      .controls / .table-wrap trim in PR-H (see table-styles.ts). */
   @media (max-width: 600px) {
     .table-device-count-row {
-      padding: 2px var(--wa-space-s);
+      padding: 2px var(--wa-space-s) var(--wa-space-xs);
     }
   }
 

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -7,12 +7,6 @@ export const tableLayoutStyles = css`
     flex-direction: column;
     flex: 1;
     min-height: 0;
-    /* Clip any internal overflow so the pagination row doesn't
-       slide past the host's bottom edge — covers the case where
-       the .controls + below-controls slot push .table-wrap's
-       flex:1 share down enough that its pagination child can't
-       fit inside its remaining height. */
-    overflow: hidden;
   }
 
   /* Slotted content uses content-driven height — flex-shrink:0

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -21,7 +21,12 @@ export const tableLayoutStyles = css`
 
   .controls {
     display: flex;
-    align-items: center;
+    /* Top-align the right-cluster (Columns + Create device) with
+       the toolbar-stack's first row (search + view-toggle +
+       facets). The slotted toolbar now contains TWO stacked rows
+       (toolbar-row + device-count-row), and align-items:center
+       would float the right-cluster between them. */
+    align-items: flex-start;
     gap: var(--wa-space-s);
     padding: var(--wa-space-l) var(--wa-space-l) 0;
     margin-bottom: var(--wa-space-l);

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -23,13 +23,17 @@ export const tableLayoutStyles = css`
     display: flex;
     /* Top-align the right-cluster (Columns + Create device) with
        the toolbar-stack's first row (search + view-toggle +
-       facets). The slotted toolbar now contains TWO stacked rows
-       (toolbar-row + device-count-row), and align-items:center
-       would float the right-cluster between them. */
+       facets). The slotted toolbar's right edge sits at the same
+       y as Columns / Create. */
     align-items: flex-start;
     gap: var(--wa-space-s);
     padding: var(--wa-space-l) var(--wa-space-l) 0;
-    margin-bottom: var(--wa-space-l);
+    /* No bottom margin: the below-controls slot now carries the
+       device-count + Select-multiple row, and its own bottom
+       padding handles spacing to the .table-wrap. Keeping the
+       old --wa-space-l here would stack with the count row's
+       padding into ~32px of dead space. */
+    margin-bottom: 0;
     flex-shrink: 0;
   }
 

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -7,6 +7,21 @@ export const tableLayoutStyles = css`
     flex-direction: column;
     flex: 1;
     min-height: 0;
+    /* Clip any internal overflow so the pagination row doesn't
+       slide past the host's bottom edge — covers the case where
+       the .controls + below-controls slot push .table-wrap's
+       flex:1 share down enough that its pagination child can't
+       fit inside its remaining height. */
+    overflow: hidden;
+  }
+
+  /* Slotted content uses content-driven height — flex-shrink:0
+     prevents the .table-device-count-row from collapsing below
+     its intrinsic height when the column is tight, so the row's
+     count + toggle stay legible while .table-wrap absorbs the
+     remaining space. */
+  ::slotted([slot="below-controls"]) {
+    flex-shrink: 0;
   }
 
   /* When the dashboard's floating multi-select bar is visible, reserve


### PR DESCRIPTION
# What does this implement/fix?

Pairs Select-multiple with the device-count on its own row across both views, instead of leaving it inside the toolbar-row with the view-switcher and facet chips. Card view gets a new .device-count-row flex container with the count on the left and the toggle on the right via justify-content: space-between; table view mirrors the pairing through a below-controls slot on esphome-device-table so the count + toggle pair sits in the same place when switching views. The toolbar row above is now filter-only.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).