### PR TITLE
Compact discovered-banner pill on desktop

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -42,14 +42,12 @@ export const dashboardStyles = css`
      down so the collapsed pill doesn't sit on top of the view-toggle
      buttons.*/
   :host([has-discovered]) {
-    padding-top: var(--wa-space-2xl);
+    padding-top: var(--wa-space-xl);
   }
 
-  /* Mobile: the pill itself compacted to ~30px (see
-     .discovered-section-header @media block below); the desktop
-     gutter-top sized for the full pill leaves ~40px of dead space
-     between the now-shrunk pill and the search bar. Tighten the
-     gutter to match the new pill height. #41 */
+  /* Mobile compacts the pill further (see .discovered-section-header
+     @media block below), so the gutter tightens one more step to
+     match the smaller pill. #41 */
   @media (max-width: 600px) {
     :host([has-discovered]) {
       padding-top: var(--wa-space-l);
@@ -103,7 +101,7 @@ export const dashboardStyles = css`
     display: flex;
     align-items: center;
     gap: var(--wa-space-s);
-    padding: var(--wa-space-s) var(--wa-space-l);
+    padding: var(--wa-space-xs) var(--wa-space-m);
     background: var(--esphome-primary-light);
     color: var(--esphome-primary);
     border: var(--wa-border-width-s) solid var(--esphome-primary);
@@ -123,7 +121,7 @@ export const dashboardStyles = css`
   }
 
   .discovered-section-header wa-icon {
-    font-size: var(--wa-font-size-l);
+    font-size: var(--wa-font-size-m);
     color: var(--esphome-primary);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Mirrors #402 + #403 for desktop, at a less aggressive size. Pill padding drops from var(--wa-space-s) var(--wa-space-l) to var(--wa-space-xs) var(--wa-space-m); the icon font drops from var(--wa-font-size-l) to var(--wa-font-size-m); the host gutter when [has-discovered] drops from var(--wa-space-2xl) to var(--wa-space-xl). The mobile @media overrides still cascade on top, so phones keep their tighter sizes.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).