### PR TITLE
Match mobile card-grid gap to the side padding

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -946,6 +946,7 @@ export const dashboardStyles = css`
     .devices-grid {
       padding-left: var(--wa-space-s);
       padding-right: var(--wa-space-s);
+      gap: var(--wa-space-s);
     }
 
     .toolbar {


### PR DESCRIPTION
# What does this implement/fix?

PR #406 trimmed the card grid's horizontal padding to var(--wa-space-s) on mobile but left the inter-card gap at var(--wa-space-l), so the vertical spacing between cards read as ~3x the side margin. Pull the gap down to var(--wa-space-s) under the same media query so the rhythm is uniform.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).