### PR TITLE
Shrink the mobile banner-to-toolbar gap across all three views

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -146,6 +146,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
       .initialSorting=${host._tableSorting}
       .initialColumnVisibility=${host._tableColumnVisibility}
       ?select-mode=${host._selectMode}
+      ?has-discovered=${host._visibleImportableDevices.length > 0}
       .selectedDevices=${host._selectedDevices}
       .highlightConfiguration=${host._recentlyAdopted}
       @table-sort-change=${(e: CustomEvent<SortingState>) => host._saveTablePreference(e)}

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -953,6 +953,16 @@ export const dashboardStyles = css`
       padding-right: var(--wa-space-s);
     }
 
+    /* When the discovered banner is present, the host already
+       provides padding-top equal to the banner height; the
+       toolbar's own padding-top stacks on top of that and reads
+       as dead space between the banner bottom and the search
+       input. Shrink to one step so the two rows breathe without
+       the doubled gutter. #41 */
+    :host([has-discovered]) .toolbar {
+      padding-top: var(--wa-space-s);
+    }
+
     .yaml-hits {
       padding-left: var(--wa-space-s);
       padding-right: var(--wa-space-s);

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -84,6 +84,15 @@ export const tableLayoutStyles = css`
       padding-right: var(--wa-space-s);
     }
 
+    /* Mirrors the dashboard's :host([has-discovered]) .toolbar
+       trim: when the banner is present the dashboard already
+       provides padding-top equal to the banner's height, so the
+       controls' own padding-top stacks as dead space. Drop one
+       step so the table view matches the card / YAML views. #41 */
+    :host([has-discovered]) .controls {
+      padding-top: var(--wa-space-s);
+    }
+
     .table-wrap {
       margin-left: var(--wa-space-s);
       margin-right: var(--wa-space-s);


### PR DESCRIPTION
# What does this implement/fix?

On mobile, the dashboard host's padding-top is already tuned to the discovered banner's height, but each view's first row carries its own padding-top of var(--wa-space-l), so the gap between the banner bottom and the first row reads as roughly twice the intended gutter. Shrink the first-row padding-top to var(--wa-space-s) when the banner is present so cards, table, and YAML views all sit one step below the banner. Card and YAML views share .toolbar, so a single :host([has-discovered]) .toolbar rule covers both; the table view's .controls strip lives inside esphome-device-table's shadow DOM, so the dashboard passes ?has-discovered down to the device-table and table-styles applies the mirroring rule.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).