### PR TITLE
Actually trim the .table-wrap side margin on mobile

### DIFF
--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -328,4 +328,15 @@ export const tableLayoutStyles = css`
     color: var(--wa-color-text-quiet);
     font-size: var(--wa-font-size-s);
   }
+
+  /* Mobile margin trim for the table outline. Placed at the end
+     of the stylesheet so source-order beats the default
+     .table-wrap shorthand above (which would otherwise reset
+     margin-left / margin-right when the @media block fires).
+     Matches the card grid's mobile side padding. #41 */
+  @media (max-width: 600px) {
+    .table-wrap {
+      margin: 0 var(--wa-space-s) var(--wa-space-s);
+    }
+  }
 `;


### PR DESCRIPTION
# What does this implement/fix?

The existing @media (max-width: 600px) block sets .table-wrap margin-left / margin-right to var(--wa-space-s), but the default .table-wrap { margin: 0 var(--wa-space-l) var(--wa-space-l) } shorthand sits below it in the stylesheet and resets those longhands when the media query matches; same specificity, later source order wins. Add a same-breakpoint override at the bottom of the file (matching --wa-space-s, which is 12px in the WebAwesome scale and matches the card grid's mobile side padding) so the trim actually takes effect on mobile.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).