### PR TITLE
Halve the dashboard toolbar's mobile top padding

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -950,8 +950,7 @@ export const dashboardStyles = css`
     }
 
     .toolbar {
-      padding-left: var(--wa-space-s);
-      padding-right: var(--wa-space-s);
+      padding: var(--wa-space-s) var(--wa-space-s) 0;
     }
 
     /* When the discovered banner is present, the host already


### PR DESCRIPTION
# What does this implement/fix?

On viewports <= 600px the dashboard `.toolbar` inherited the desktop `--wa-space-l` (24px) top padding from the base shorthand, leaving wasted space between the page header and the search input on phone-width screens. The mobile override only trimmed `padding-left` / `padding-right`, so the top stayed at 24px. Replace those longhands with `padding: var(--wa-space-s) var(--wa-space-s) 0` to drop the top to 12px (about half) while keeping the same horizontal trim and the base's `padding-bottom: 0` — the count row still owns the gap to the cards below.

**Related issue or feature (if applicable):**

- refs #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).