### PR TITLE
Render scalar-valued registry entries through ctx.renderEntry

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -886,6 +886,12 @@ export interface AutomationCondition {
   accepts_condition_list: boolean;
 }
 
+/** Scalar primitives a polymorphic registry entry can take at the
+ *  key position (``- throttle: 10s``, ``- lambda: |- ...``). Union
+ *  rather than plain string so a misspelled tag is a compile-time
+ *  error against the renderer's dispatch table. */
+export type RegistryValueType = "time_period" | "float" | "integer" | "string" | "lambda";
+
 /** Common shape for the polymorphic-list registry catalogs
  *  (`light_effects`, `filter`, future additions). One entry per
  *  registered id; `config_entries` is the per-id parameter schema;
@@ -899,11 +905,11 @@ export interface RegistryCatalogEntry {
   config_entries: ConfigEntry[];
   applies_to: string[];
   /** Set when the entry takes a single scalar at the polymorphic
-   *  key position (`- throttle: 10s`, `- delayed_on: 50ms`) rather
-   *  than a nested mapping. The renderer mounts the matching inline
-   *  input (time-period widget, number, lambda body) at the row's
-   *  polymorphic value position instead of an empty sub-form. */
-  value_type?: string | null;
+   *  key position (``- throttle: 10s``, ``- delayed_on: 50ms``)
+   *  rather than a nested mapping. The renderer mounts the matching
+   *  inline input at the polymorphic value position instead of an
+   *  empty sub-form. */
+  value_type?: RegistryValueType | null;
 }
 
 /** A light effect (``pulse``, ``flicker``, ``addressable_lambda``…).

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -898,6 +898,12 @@ export interface RegistryCatalogEntry {
   name: string;
   config_entries: ConfigEntry[];
   applies_to: string[];
+  /** Set when the entry takes a single scalar at the polymorphic
+   *  key position (`- throttle: 10s`, `- delayed_on: 50ms`) rather
+   *  than a nested mapping. The renderer mounts the matching inline
+   *  input (time-period widget, number, lambda body) at the row's
+   *  polymorphic value position instead of an empty sub-form. */
+  value_type?: string | null;
 }
 
 /** A light effect (``pulse``, ``flicker``, ``addressable_lambda``…).

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -123,12 +123,14 @@ const TIME_PERIOD_UNITS = ["us", "ms", "s", "min", "h", "d"] as const;
 type TimePeriodUnit = (typeof TIME_PERIOD_UNITS)[number];
 
 /** Detect a polymorphic time-period scalar shorthand (``50ms``,
- *  ``2.5s``). Requires an explicit unit suffix so unitless numbers
- *  like ``delta: 0.5`` don't false-positive. Shared by callers that
- *  need to classify a raw YAML value without going through the full
- *  ``parseTimePeriod`` parse / unit pair. */
+ *  ``2.5s``); requires an explicit unit suffix so unitless numbers
+ *  like ``delta: 0.5`` don't false-positive. Units are escaped when
+ *  building the regex so a future entry with regex metacharacters
+ *  doesn't quietly malform the pattern. */
 const TIME_PERIOD_SCALAR_RE = new RegExp(
-  `^\\d+(?:\\.\\d+)?(?:${TIME_PERIOD_UNITS.join("|")})$`
+  `^\\d+(?:\\.\\d+)?(?:${TIME_PERIOD_UNITS.map((u) =>
+    u.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  ).join("|")})$`
 );
 export function looksLikeTimePeriodScalar(raw: unknown): boolean {
   return typeof raw === "string" && TIME_PERIOD_SCALAR_RE.test(raw.trim());

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -122,6 +122,18 @@ function hexDisplayOrFallback(rawValue: unknown): string {
 const TIME_PERIOD_UNITS = ["us", "ms", "s", "min", "h", "d"] as const;
 type TimePeriodUnit = (typeof TIME_PERIOD_UNITS)[number];
 
+/** Detect a polymorphic time-period scalar shorthand (``50ms``,
+ *  ``2.5s``). Requires an explicit unit suffix so unitless numbers
+ *  like ``delta: 0.5`` don't false-positive. Shared by callers that
+ *  need to classify a raw YAML value without going through the full
+ *  ``parseTimePeriod`` parse / unit pair. */
+const TIME_PERIOD_SCALAR_RE = new RegExp(
+  `^\\d+(?:\\.\\d+)?(?:${TIME_PERIOD_UNITS.join("|")})$`
+);
+export function looksLikeTimePeriodScalar(raw: unknown): boolean {
+  return typeof raw === "string" && TIME_PERIOD_SCALAR_RE.test(raw.trim());
+}
+
 function parseTimePeriod(raw: unknown): {
   value: string;
   unit: TimePeriodUnit;

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -18,8 +18,10 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
 import type { ConfigEntry, RegistryCatalogEntry } from "../../../api/types.js";
-import { isLambdaValue } from "../../../api/types.js";
+import { ConfigEntryType, isLambdaValue } from "../../../api/types.js";
 import { apiContext } from "../../../context/index.js";
+import { makeConfigEntry } from "../../../util/config-entry-defaults.js";
+import { looksLikeTimePeriodScalar } from "./primitives.js";
 import {
   fetchFilters,
   fetchLightEffects,
@@ -28,8 +30,6 @@ import {
   subscribeAutomationCatalogCache,
 } from "../../../util/automation-catalog-cache.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
-import "./lambda-editor.js";
-import { LAMBDA_REGISTRY_ID, lambdaBodyOf } from "./lambda.js";
 import {
   effectiveDisabled,
   fieldRendererStyles,
@@ -103,6 +103,20 @@ interface RegistryOps {
    *  YAML expressiveness. */
   dedupByTypeId: boolean;
 }
+
+/** Map a registry entry's ``value_type`` (backend's scalar-extends
+ *  classification: time_period / float / integer / string) to the
+ *  ConfigEntryType the per-field renderer dispatch knows. The
+ *  registry-list sub-form constructs a synthetic ConfigEntry of the
+ *  matching type and routes through ``ctx.renderEntry`` so each
+ *  scalar shape reuses the same input widget the regular form does. */
+const VALUE_TYPE_TO_CONFIG_TYPE: Record<string, ConfigEntryType> = {
+  time_period: ConfigEntryType.TIME_PERIOD,
+  float: ConfigEntryType.FLOAT,
+  integer: ConfigEntryType.INTEGER,
+  string: ConfigEntryType.STRING,
+  lambda: ConfigEntryType.LAMBDA,
+};
 
 const REGISTRY_OPS: Record<string, RegistryOps> = {
   light_effects: {
@@ -466,12 +480,14 @@ export class ESPHomeRegistryList extends LitElement {
       !Array.isArray(params) &&
       !isLambdaValue(params) &&
       !(params instanceof YamlRawValue);
-    // ``lambda`` filter / effect takes a C++ body as the whole value
-    // (``- lambda: |- return x;``); the schema bundle exposes no
-    // config_vars for it, so the catalog has 0 config_entries. Render
-    // an inline lambda editor bound to the row's polymorphic value
-    // position so users can fill in the body visually.
-    const isLambdaForm = currentId === LAMBDA_REGISTRY_ID;
+    // Scalar-valued entries (``throttle: 10s``, ``delayed_on: 50ms``,
+    // ``- lambda: |- ...``): dispatch the matching per-type renderer
+    // through ctx.renderEntry via a synthetic ConfigEntry so the row
+    // reuses the same widgets the regular form does. Falls back to a
+    // runtime check on the params value for polymorphic shorthands
+    // (``delayed_on_off: 50ms`` shorthand for the mapping form) the
+    // catalog doesn't classify.
+    const scalarConfigType = this._scalarDispatchType(catalogEntry, params);
     // Render every child unconditionally — the user opted into this
     // filter/effect by picking it from the dropdown, so the outer
     // form's advanced / requiredOnly gates don't apply (many filters
@@ -515,27 +531,7 @@ export class ESPHomeRegistryList extends LitElement {
           </wa-select>
           ${renderListRemoveButton(this.ctx, disabled, () => this._removeAt(index))}
         </div>
-        ${isLambdaForm
-          ? html`<div class="registry-list-sub-form">
-              <esphome-lambda-editor
-                .value=${lambdaBodyOf(params)}
-                ?disabled=${disabled}
-                @lambda-change=${(e: CustomEvent<{ value: string }>) =>
-                  this._setLambdaBody(index, currentId, e.detail.value)}
-              ></esphome-lambda-editor>
-            </div>`
-          : childEntries.length > 0
-            ? html`<div class="registry-list-sub-form">
-                ${childEntries.map((child) =>
-                  this.ctx.renderEntry(child, [
-                    ...this.path,
-                    String(index),
-                    currentId,
-                    child.key,
-                  ])
-                )}
-              </div>`
-            : nothing}
+        ${this._renderSubForm(index, currentId, scalarConfigType, childEntries)}
       </div>
     `;
   }
@@ -555,10 +551,51 @@ export class ESPHomeRegistryList extends LitElement {
     this.ctx.emitChange(this.path, spliceEditable(list, positions, next));
   }
 
-  private _setLambdaBody(index: number, registryId: string, body: string) {
-    this._mutateEditable((items) =>
-      items.map((it, i) => (i === index ? { [registryId]: { _lambda: body } } : it))
-    );
+  /** Decide which scalar input type to dispatch to, if any.
+   *  Backend ``value_type`` wins; otherwise sniff polymorphic
+   *  shorthands at runtime (a time-period string under a
+   *  mapping-shaped catalog entry is the common case). */
+  private _scalarDispatchType(
+    catalogEntry: RegistryCatalogEntry | undefined,
+    params: unknown
+  ): ConfigEntryType | null {
+    const tagged = catalogEntry?.value_type;
+    if (tagged && tagged in VALUE_TYPE_TO_CONFIG_TYPE) {
+      return VALUE_TYPE_TO_CONFIG_TYPE[tagged];
+    }
+    if (looksLikeTimePeriodScalar(params)) {
+      return ConfigEntryType.TIME_PERIOD;
+    }
+    return null;
+  }
+
+  /** Render the per-row sub-form: a synthetic scalar field when the
+   *  catalog entry takes a scalar value (``- throttle: 10s``,
+   *  ``- lambda: |- ...``), the mapping sub-form when it carries
+   *  config_entries, or nothing for ids with no params. */
+  private _renderSubForm(
+    index: number,
+    currentId: string,
+    scalarConfigType: ConfigEntryType | null,
+    childEntries: ConfigEntry[]
+  ) {
+    if (scalarConfigType !== null) {
+      return html`<div class="registry-list-sub-form">
+        ${this.ctx.renderEntry(makeConfigEntry({ type: scalarConfigType }), [
+          ...this.path,
+          String(index),
+          currentId,
+        ])}
+      </div>`;
+    }
+    if (childEntries.length > 0) {
+      return html`<div class="registry-list-sub-form">
+        ${childEntries.map((child) =>
+          this.ctx.renderEntry(child, [...this.path, String(index), currentId, child.key])
+        )}
+      </div>`;
+    }
+    return nothing;
   }
 
   private _addItem() {

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -108,12 +108,12 @@ interface RegistryOps {
   dedupByTypeId: boolean;
 }
 
-/** Map a registry entry's ``value_type`` (backend's scalar-extends
- *  classification: time_period / float / integer / string) to the
- *  ConfigEntryType the per-field renderer dispatch knows. The
- *  registry-list sub-form constructs a synthetic ConfigEntry of the
- *  matching type and routes through ``ctx.renderEntry`` so each
- *  scalar shape reuses the same input widget the regular form does. */
+/** Map a registry entry's ``value_type`` (time_period / float /
+ *  integer / string / lambda) to the ConfigEntryType the per-field
+ *  renderer dispatch knows. The registry-list sub-form constructs a
+ *  synthetic ConfigEntry of the matching type and routes through
+ *  ``ctx.renderEntry`` so each scalar shape reuses the same input
+ *  widget the regular form does. */
 const VALUE_TYPE_TO_CONFIG_TYPE: Record<RegistryValueType, ConfigEntryType> = {
   time_period: ConfigEntryType.TIME_PERIOD,
   float: ConfigEntryType.FLOAT,
@@ -490,8 +490,12 @@ export class ESPHomeRegistryList extends LitElement {
     // reuses the same widgets the regular form does. Falls back to a
     // runtime check on the params value for polymorphic shorthands
     // (``delayed_on_off: 50ms`` shorthand for the mapping form) the
-    // catalog doesn't classify.
-    const scalarConfigType = this._scalarDispatchType(catalogEntry, params);
+    // catalog doesn't classify. Suppressed when params is already a
+    // mapping so a hypothetical catalog miscategorisation can't
+    // clobber an existing nested config.
+    const scalarConfigType = paramsIsMapping
+      ? null
+      : this._scalarDispatchType(catalogEntry, params);
     // Render every child unconditionally — the user opted into this
     // filter/effect by picking it from the dropdown, so the outer
     // form's advanced / requiredOnly gates don't apply (many filters

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -17,7 +17,11 @@ import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../../api/esphome-api.js";
-import type { ConfigEntry, RegistryCatalogEntry } from "../../../api/types.js";
+import type {
+  ConfigEntry,
+  RegistryCatalogEntry,
+  RegistryValueType,
+} from "../../../api/types.js";
 import { ConfigEntryType, isLambdaValue } from "../../../api/types.js";
 import { apiContext } from "../../../context/index.js";
 import { makeConfigEntry } from "../../../util/config-entry-defaults.js";
@@ -110,7 +114,7 @@ interface RegistryOps {
  *  registry-list sub-form constructs a synthetic ConfigEntry of the
  *  matching type and routes through ``ctx.renderEntry`` so each
  *  scalar shape reuses the same input widget the regular form does. */
-const VALUE_TYPE_TO_CONFIG_TYPE: Record<string, ConfigEntryType> = {
+const VALUE_TYPE_TO_CONFIG_TYPE: Record<RegistryValueType, ConfigEntryType> = {
   time_period: ConfigEntryType.TIME_PERIOD,
   float: ConfigEntryType.FLOAT,
   integer: ConfigEntryType.INTEGER,
@@ -560,7 +564,13 @@ export class ESPHomeRegistryList extends LitElement {
     params: unknown
   ): ConfigEntryType | null {
     const tagged = catalogEntry?.value_type;
-    if (tagged && tagged in VALUE_TYPE_TO_CONFIG_TYPE) {
+    // hasOwnProperty rather than ``in`` so prototype-chain keys
+    // (``toString`` etc.) coming through a non-typed payload don't
+    // accidentally resolve to a non-ConfigEntryType value.
+    if (
+      tagged &&
+      Object.prototype.hasOwnProperty.call(VALUE_TYPE_TO_CONFIG_TYPE, tagged)
+    ) {
       return VALUE_TYPE_TO_CONFIG_TYPE[tagged];
     }
     if (looksLikeTimePeriodScalar(params)) {

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -335,11 +335,53 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     expect(el.shadowRoot!.querySelector(".registry-list-sub-form")).toBeNull();
   });
 
-  it("renders no sub-form when the existing params is a scalar", async () => {
-    // ``delta: 0.5`` and ``throttle: 10s`` are scalar shorthands that
-    // ESPHome accepts even when the catalog encodes a mapping schema
-    // for the same id. Rendering the mapping inputs over a scalar
-    // would silently clobber the user's YAML on first edit.
+  it("dispatches a time-period scalar shorthand under a mapping-shaped catalog entry", async () => {
+    // ``delayed_on_off: 50ms`` is a polymorphic shorthand for the
+    // ``{time_on, time_off}`` mapping form. The catalog has the
+    // mapping config_entries, but the YAML carries a string; the
+    // runtime sniff routes it through TIME_PERIOD so the user can
+    // see and edit the 50ms value.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "delayed_on_off",
+        name: "Delayed On Off",
+        applies_to: [],
+        config_entries: [
+          makeEntry(ConfigEntryType.TIME_PERIOD, { key: "time_on" }),
+          makeEntry(ConfigEntryType.TIME_PERIOD, { key: "time_off" }),
+        ],
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ delayed_on_off: "50ms" }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    const calls = renderEntry.mock.calls.map((c) => ({
+      type: (c[0] as { type: string }).type,
+      path: c[1],
+    }));
+    expect(calls).toContainEqual({
+      type: ConfigEntryType.TIME_PERIOD,
+      path: ["filters", "0", "delayed_on_off"],
+    });
+  });
+
+  it("renders no sub-form when the existing params is a non-time-period scalar", async () => {
+    // ``delta: 0.5`` is a unitless float; the runtime sniff requires
+    // an explicit time-period unit suffix so this stays picker-only
+    // rather than misrouting through TIME_PERIOD.
     const renderEntry = vi.fn();
     const catalog = [
       {
@@ -456,14 +498,28 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     ]);
   });
 
-  it("renders the inline lambda editor when the picked id is 'lambda'", async () => {
-    // ``lambda`` filter takes a C++ body as the whole polymorphic value
-    // (``- lambda: |- return x;``). The catalog ships no config_entries
-    // for it (no schema), so the mapping sub-form path doesn't fire;
-    // the renderer instead mounts <esphome-lambda-editor> bound to the
-    // row's polymorphic value position.
+  it("dispatches scalar value_types (time_period, lambda, ...) through ctx.renderEntry", async () => {
+    // The polymorphic value for ``- throttle: 10s`` / ``- lambda: |- ...``
+    // sits at the row's polymorphic key position rather than under a
+    // mapping. The renderer constructs a synthetic ConfigEntry of the
+    // matching type and routes through ctx.renderEntry so the row
+    // reuses the same per-type widgets the regular form does.
+    const renderEntry = vi.fn();
     const catalog = [
-      { id: "lambda", name: "Lambda", config_entries: [], applies_to: [] },
+      {
+        id: "throttle",
+        name: "Throttle",
+        config_entries: [],
+        applies_to: [],
+        value_type: "time_period",
+      },
+      {
+        id: "lambda",
+        name: "Lambda",
+        config_entries: [],
+        applies_to: [],
+        value_type: "lambda",
+      },
     ];
     const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
     el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
@@ -472,12 +528,26 @@ describe("renderRegistryListField — per-row params sub-form", () => {
       multi_value: true,
     });
     el.path = ["filters"];
-    el.ctx = makeRenderCtx({ filters: [{ lambda: null }] });
+    el.ctx = makeRenderCtx(
+      { filters: [{ throttle: "10s" }, { lambda: null }] },
+      { overrides: { renderEntry } }
+    );
     document.body.append(el);
     (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
     el.requestUpdate();
     await el.updateComplete;
-    expect(el.shadowRoot!.querySelector("esphome-lambda-editor")).toBeTruthy();
+    const calls = renderEntry.mock.calls.map((c) => ({
+      type: (c[0] as { type: string }).type,
+      path: c[1],
+    }));
+    expect(calls).toContainEqual({
+      type: ConfigEntryType.TIME_PERIOD,
+      path: ["filters", "0", "throttle"],
+    });
+    expect(calls).toContainEqual({
+      type: ConfigEntryType.LAMBDA,
+      path: ["filters", "1", "lambda"],
+    });
   });
 
   it("renders no sub-form on an empty / unselected row", async () => {

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -498,6 +498,54 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     ]);
   });
 
+  it("LAMBDA dispatch round-trips through emitChange as the {_lambda} sentinel", async () => {
+    // The previous implementation wrote ``{lambda: {_lambda: body}}``
+    // explicitly via ``_setLambdaBody``. After the refactor the LAMBDA
+    // renderer (``renderLambdaField``) emits the same ``{_lambda: body}``
+    // sentinel at the row's polymorphic value position; the serializer's
+    // existing list-item lambda branch turns that into ``- lambda: |- body``.
+    // Wire a stub renderEntry that fires renderLambdaField's @lambda-change
+    // shape so a future LAMBDA-renderer change can't silently drift the
+    // contract between this dispatch and the YAML round-trip.
+    const emit = vi.fn();
+    const renderEntry = vi.fn((_entry: unknown, path: string[]) => {
+      // Simulate the LAMBDA renderer's emit shape: a single
+      // ``{ _lambda: body }`` write to the field's path.
+      emit(path, { _lambda: "return x;" });
+      return null;
+    });
+    const catalog = [
+      {
+        id: "lambda",
+        name: "Lambda",
+        config_entries: [],
+        applies_to: [],
+        value_type: "lambda",
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ lambda: null }] },
+      { overrides: { renderEntry: renderEntry as never } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    // emit was called with the polymorphic value-position path, not
+    // a nested child path. setIn at that path lands the sentinel
+    // under the row's single key (``{lambda: {_lambda: body}}``).
+    expect(emit).toHaveBeenCalledWith(["filters", "0", "lambda"], {
+      _lambda: "return x;",
+    });
+  });
+
   it("dispatches scalar value_types (time_period, lambda, ...) through ctx.renderEntry", async () => {
     // The polymorphic value for ``- throttle: 10s`` / ``- lambda: |- ...``
     // sits at the row's polymorphic key position rather than under a

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -498,29 +498,24 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     ]);
   });
 
-  it("LAMBDA dispatch round-trips through emitChange as the {_lambda} sentinel", async () => {
-    // The previous implementation wrote ``{lambda: {_lambda: body}}``
-    // explicitly via ``_setLambdaBody``. After the refactor the LAMBDA
-    // renderer (``renderLambdaField``) emits the same ``{_lambda: body}``
-    // sentinel at the row's polymorphic value position; the serializer's
-    // existing list-item lambda branch turns that into ``- lambda: |- body``.
-    // Wire a stub renderEntry that fires renderLambdaField's @lambda-change
-    // shape so a future LAMBDA-renderer change can't silently drift the
-    // contract between this dispatch and the YAML round-trip.
-    const emit = vi.fn();
-    const renderEntry = vi.fn((_entry: unknown, path: string[]) => {
-      // Simulate the LAMBDA renderer's emit shape: a single
-      // ``{ _lambda: body }`` write to the field's path.
-      emit(path, { _lambda: "return x;" });
-      return null;
-    });
+  it("suppresses scalar dispatch when params is already a mapping (defensive)", async () => {
+    // Belt-and-braces: if the backend ever mistags a mapping-valued
+    // id with value_type: 'time_period' (catalog miscategorisation),
+    // the runtime params shape wins so an existing mapping doesn't
+    // get clobbered by a scalar input.
+    const renderEntry = vi.fn();
     const catalog = [
       {
-        id: "lambda",
-        name: "Lambda",
-        config_entries: [],
+        id: "delayed_on_off",
+        name: "Delayed On Off",
         applies_to: [],
-        value_type: "lambda",
+        config_entries: [
+          makeEntry(ConfigEntryType.TIME_PERIOD, { key: "time_on" }),
+          makeEntry(ConfigEntryType.TIME_PERIOD, { key: "time_off" }),
+        ],
+        // Hypothetical miscategorisation: catalog says scalar, YAML
+        // has a mapping.
+        value_type: "time_period",
       },
     ];
     const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
@@ -531,18 +526,26 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     });
     el.path = ["filters"];
     el.ctx = makeRenderCtx(
-      { filters: [{ lambda: null }] },
-      { overrides: { renderEntry: renderEntry as never } }
+      { filters: [{ delayed_on_off: { time_on: "50ms", time_off: "100ms" } }] },
+      { overrides: { renderEntry } }
     );
     document.body.append(el);
     (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
     el.requestUpdate();
     await el.updateComplete;
-    // emit was called with the polymorphic value-position path, not
-    // a nested child path. setIn at that path lands the sentinel
-    // under the row's single key (``{lambda: {_lambda: body}}``).
-    expect(emit).toHaveBeenCalledWith(["filters", "0", "lambda"], {
-      _lambda: "return x;",
+    const calls = renderEntry.mock.calls.map((c) => ({
+      type: (c[0] as { type: string }).type,
+      path: c[1],
+    }));
+    // Mapping dispatch fires (per-key children), scalar dispatch
+    // doesn't (no TIME_PERIOD bound to the polymorphic value path).
+    expect(calls).toContainEqual({
+      type: ConfigEntryType.TIME_PERIOD,
+      path: ["filters", "0", "delayed_on_off", "time_on"],
+    });
+    expect(calls).not.toContainEqual({
+      type: ConfigEntryType.TIME_PERIOD,
+      path: ["filters", "0", "delayed_on_off"],
     });
   });
 


### PR DESCRIPTION
# What does this implement/fix?

Render scalar-valued registry entries through the existing per-field dispatch so `- throttle: 10s`, `- delayed_on: 50ms`, `- lambda: |- ...` show the matching inline editor instead of the empty sub-form left over from V2. The catalog now carries a `value_type` marker for entries whose validator is a core scalar primitive; the renderer maps `time_period` / `float` / `integer` / `string` / `lambda` to the matching `ConfigEntryType` and routes through `ctx.renderEntry` with a synthetic ConfigEntry, so each scalar shape reuses the same widget the regular form uses. The lambda-by-id hardcode goes away; LAMBDA falls into the same dispatch table.

Runtime fallback for polymorphic shorthands the catalog can't classify (`delayed_on_off: 50ms`, where ESPHome accepts either the scalar or the mapping form but the bundle only emits the mapping schema): when params is a string with an explicit time-period unit suffix, dispatch through TIME_PERIOD. Unitless numbers like `delta: 0.5` don't match so the picker-only path stays.

**Related issue or feature (if applicable):**

- follow-up to #941

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
