### PR TITLE
Bail to YAML-only notice when renderStringField gets a non-primitive value

### DIFF
--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -12,6 +12,7 @@ import {
   effectiveDisabled,
   renderFieldError,
   renderLabel,
+  renderYamlOnlyFallbackIfNonPrimitive,
   type RenderCtx,
 } from "./config-entry-renderers-shared.js";
 
@@ -24,7 +25,10 @@ export function renderIdReferenceField(
 ) {
   const domain = entry.references_component || "";
   const candidates = findReferencedComponents(ctx.yaml, domain);
-  const value = String(ctx.getAt(path) ?? "");
+  const raw = ctx.getAt(path);
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
+  const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const empty = candidates.length === 0;
 

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -13,6 +13,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import type { PasswordInputValueChange } from "./password-input.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
+import { isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { inputStyles } from "../../styles/inputs.js";
@@ -237,7 +238,26 @@ export function renderStringField(
   path: string[],
   ctx: RenderCtx
 ) {
-  const value = String(ctx.getAt(path) ?? "");
+  const raw = ctx.getAt(path);
+  // Defensive bail: when the value at *path* isn't a primitive
+  // (e.g. a YAML list that landed under a mapping-shaped catalog
+  // field because the upstream schema bundle missed ``is_list``,
+  // or an inline mapping under a scalar-shaped field), refuse to
+  // render an editable input. ``String([...])`` would silently
+  // coerce the list to a comma-joined string and a save would
+  // clobber the user's list with that string. Surface a YAML-only
+  // notice instead, same pattern ``renderNestedListField`` uses
+  // when the parser preserves a block as ``YamlRawValue``.
+  if (!isPrimitiveOrNullish(raw)) {
+    return html`
+      <div class="field" data-field-key=${path.join(".")}>
+        ${renderLabel(entry, ctx)}
+        <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
+        ${renderFieldError(path, ctx)}
+      </div>
+    `;
+  }
+  const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const placeholder = String(entry.default_value ?? "");
   const disabled = effectiveDisabled(entry, ctx);

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -232,6 +232,29 @@ export function renderFieldShell(
 // Re-exported by `config-entry-renderers.ts`; placed here so the pin
 // renderer can fall back to a string field without importing the
 // barrel and creating a cycle.
+/** Defensive bail for scalar field renderers: when the value at *path*
+ *  isn't a primitive (a YAML list or mapping that landed under a
+ *  scalar-shaped catalog field because the upstream schema bundle
+ *  missed ``is_list`` or a similar shape marker), refuse to render an
+ *  editable input. ``String([...])`` would silently coerce the list
+ *  to a comma-joined string and a save would clobber the user's value.
+ *  Returns the bail template, or ``null`` when *raw* is safe to coerce. */
+export function renderYamlOnlyFallbackIfNonPrimitive(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+  raw: unknown
+) {
+  if (isPrimitiveOrNullish(raw)) return null;
+  return html`
+    <div class="field" data-field-key=${path.join(".")}>
+      ${renderLabel(entry, ctx)}
+      <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
+      ${renderFieldError(path, ctx)}
+    </div>
+  `;
+}
+
 export function renderStringField(
   entry: ConfigEntry,
   inputType: string,
@@ -239,24 +262,8 @@ export function renderStringField(
   ctx: RenderCtx
 ) {
   const raw = ctx.getAt(path);
-  // Defensive bail: when the value at *path* isn't a primitive
-  // (e.g. a YAML list that landed under a mapping-shaped catalog
-  // field because the upstream schema bundle missed ``is_list``,
-  // or an inline mapping under a scalar-shaped field), refuse to
-  // render an editable input. ``String([...])`` would silently
-  // coerce the list to a comma-joined string and a save would
-  // clobber the user's list with that string. Surface a YAML-only
-  // notice instead, same pattern ``renderNestedListField`` uses
-  // when the parser preserves a block as ``YamlRawValue``.
-  if (!isPrimitiveOrNullish(raw)) {
-    return html`
-      <div class="field" data-field-key=${path.join(".")}>
-        ${renderLabel(entry, ctx)}
-        <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
-        ${renderFieldError(path, ctx)}
-      </div>
-    `;
-  }
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const placeholder = String(entry.default_value ?? "");

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -229,9 +229,6 @@ export function renderFieldShell(
   `;
 }
 
-// Re-exported by `config-entry-renderers.ts`; placed here so the pin
-// renderer can fall back to a string field without importing the
-// barrel and creating a cycle.
 /** Defensive bail for scalar field renderers: when the value at *path*
  *  isn't a primitive (a YAML list or mapping that landed under a
  *  scalar-shaped catalog field because the upstream schema bundle
@@ -255,6 +252,9 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
   `;
 }
 
+// Re-exported by `config-entry-renderers.ts`; placed here so the pin
+// renderer can fall back to a string field without importing the
+// barrel and creating a cycle.
 export function renderStringField(
   entry: ConfigEntry,
   inputType: string,

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -249,7 +249,7 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
   return html`
     <div class="field" data-field-key=${path.join(".")}>
       ${renderLabel(entry, ctx)}
-      <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
+      <p class="field-description">${ctx.localize("device.value_yaml_only")}</p>
       ${renderFieldError(path, ctx)}
     </div>
   `;

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -27,12 +27,14 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.suggestions && entry.suggestions.length > 0) {
     return renderStringField(entry, "number", path, ctx);
   }
+  const raw = ctx.getAt(path);
+  // Bail above the hex dispatch so the hex variant inherits the
+  // non-primitive guard without a second call.
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
   if (entry.display_format === "hex") {
     return renderHexIntField(entry, path, ctx);
   }
-  const raw = ctx.getAt(path);
-  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
-  if (bail) return bail;
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const min = entry.range ? String(entry.range[0]) : undefined;
@@ -450,6 +452,14 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
 export function renderTextareaField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
   const isRaw = raw instanceof YamlRawValue;
+  // YamlRawValue is an intentional textarea shape (block scalars
+  // like ``|-``); anything else non-primitive (a list / mapping
+  // that landed under a textarea-shaped field) should bail rather
+  // than coerce through ``String(...)``.
+  if (!isRaw) {
+    const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+    if (bail) return bail;
+  }
   const value = isRaw ? raw.body : String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -17,6 +17,7 @@ import {
   renderHelpLink,
   renderLabel,
   renderStringField,
+  renderYamlOnlyFallbackIfNonPrimitive,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -29,7 +30,10 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.display_format === "hex") {
     return renderHexIntField(entry, path, ctx);
   }
-  const value = String(ctx.getAt(path) ?? "");
+  const raw = ctx.getAt(path);
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
+  const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const min = entry.range ? String(entry.range[0]) : undefined;
   const max = entry.range ? String(entry.range[1]) : undefined;
@@ -352,7 +356,10 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
 }
 
 export function renderSelectField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
-  const value = String(ctx.getAt(path) ?? "");
+  const raw = ctx.getAt(path);
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
+  const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   // Featured suggestions override options — board author narrowed the choice.
@@ -465,7 +472,10 @@ export function renderTextareaField(entry: ConfigEntry, path: string[], ctx: Ren
 }
 
 export function renderIconField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
-  const value = String(ctx.getAt(path) ?? "");
+  const raw = ctx.getAt(path);
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
+  const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`
     <div class="field" data-field-key=${path.join(".")}>

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -29,7 +29,7 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   }
   const raw = ctx.getAt(path);
   // Bail above the hex dispatch so the hex variant inherits the
-  // non-primitive guard without a second call.
+  // guard without each renderer having to repeat the check.
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
   if (entry.display_format === "hex") {

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -179,6 +179,11 @@ export function renderTimePeriodField(
   ctx: RenderCtx
 ) {
   const raw = ctx.getAt(path);
+  // Bail above parseTimePeriod — its ``String(raw).trim()`` would
+  // turn a single-element list ``["5s"]`` into the parseable string
+  // ``"5s"`` and a save would clobber the original list.
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
   const parsed = parseTimePeriod(raw);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
@@ -254,6 +259,11 @@ export function renderFloatWithUnitField(
   const unitOptions = entry.unit_options ?? [];
   const canonicalUnit = unitOptions[0] ?? "";
   const rawValue = ctx.getAt(path);
+  // Bail above parseFloatWithUnit — same data-loss shape as
+  // renderTimePeriodField: a single-element list like ``["50Hz"]``
+  // stringifies to a parseable scalar and a save would clobber it.
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, rawValue);
+  if (bail) return bail;
   const parsed = parseFloatWithUnit(rawValue, unitOptions);
   // Edit buffer survives intermediate typing states ("-", "1e", "1.") that
   // the parser turns into null/"". Cleared on blur and on entries change.

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -348,6 +348,12 @@ export function renderFloatWithUnitField(
 // YAML editor reflects ON in the form view (issue device-builder#923).
 export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
+  // A list / mapping under a boolean-shaped catalog field renders
+  // unchecked (``parseYamlBoolean`` returns null), but the first
+  // user toggle emits ``true`` and clobbers the YAML structure.
+  // Bail to the YAML-only notice instead.
+  const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
+  if (bail) return bail;
   const effective = raw === undefined || raw === null ? entry.default_value : raw;
   const checked = parseYamlBoolean(effective) === true;
   return html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -620,6 +620,7 @@
     "multi_value_add": "Add",
     "multi_value_remove": "Remove",
     "multi_value_yaml_only": "This list contains YAML the visual editor can't model — edit it directly in the YAML pane on the right.",
+    "value_yaml_only": "This value can't be modeled by the visual editor — edit it directly in the YAML pane on the right.",
     "registry_list_loading": "Loading catalog…",
     "registry_list_select": "Select an option…",
     "registry_list_empty_catalog": "No options available for this registry.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -646,6 +646,7 @@
     "multi_value_add": "Ajouter",
     "multi_value_remove": "Supprimer",
     "multi_value_yaml_only": "Cette liste contient du YAML que l'éditeur visuel ne peut pas modéliser — modifiez-la directement dans le volet YAML à droite.",
+    "value_yaml_only": "Cette valeur ne peut pas être modélisée par l'éditeur visuel ; modifiez-la directement dans le volet YAML à droite.",
     "registry_list_loading": "Chargement du catalogue…",
     "registry_list_select": "Sélectionnez une option…",
     "registry_list_empty_catalog": "Aucune option disponible pour ce registre.",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -619,6 +619,7 @@
     "multi_value_add": "Hozzáadás",
     "multi_value_remove": "Eltávolítás",
     "multi_value_yaml_only": "Ez a lista olyan YAML-t tartalmaz, amelyet a vizuális szerkesztő nem tud kezelni – szerkessze közvetlenül a jobb oldali YAML-panelben.",
+    "value_yaml_only": "Ezt az értéket a vizuális szerkesztő nem tudja modellezni; szerkessze közvetlenül a jobb oldali YAML-panelben.",
     "registry_list_loading": "Katalógus betöltése…",
     "registry_list_select": "Válasszon egy lehetőséget…",
     "registry_list_empty_catalog": "Nincsenek elérhető lehetőségek ehhez a regiszterhez.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -646,6 +646,7 @@
     "multi_value_add": "Toevoegen",
     "multi_value_remove": "Verwijderen",
     "multi_value_yaml_only": "Deze lijst bevat YAML die de visuele editor niet kan modelleren — bewerk hem rechtstreeks in het YAML-paneel rechts.",
+    "value_yaml_only": "Deze waarde kan de visuele editor niet modelleren; bewerk hem rechtstreeks in het YAML-paneel rechts.",
     "registry_list_loading": "Catalogus laden…",
     "registry_list_select": "Selecteer een optie…",
     "registry_list_empty_catalog": "Geen opties beschikbaar voor dit register.",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -620,6 +620,7 @@
     "multi_value_add": "添加",
     "multi_value_remove": "移除",
     "multi_value_yaml_only": "此列表包含可视化编辑器无法建模的 YAML，请直接在右侧 YAML 面板中编辑。",
+    "value_yaml_only": "此值无法由可视化编辑器建模，请直接在右侧 YAML 面板中编辑。",
     "registry_list_loading": "正在加载目录…",
     "registry_list_select": "请选择一个选项…",
     "registry_list_empty_catalog": "此注册表暂无可用选项。",

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -269,27 +269,16 @@ const isListItemLine = (line: string, dashIndent: string): boolean => {
 };
 
 /**
- * True when *line* is a list-item dash deeper than *parentIndent*.
- * The exact dash column doesn't matter at peek time — that's
- * detected later by ``parseListBlock`` from the actual line —
- * so the peek check only needs to confirm "this is a child
- * list of the current key, regardless of which indent step the
- * user picked". 4-space YAML pastes work as a result.
+ * True when *line* is a list-item dash that belongs to *parentIndent*'s
+ * child list. Accepts both deeper-indent dashes (the standard YAML
+ * shape) and same-indent dashes (YAML 1.2's compact block-sequence
+ * form: ``calibration:\n- a\n- b`` parses to ``{calibration: [a, b]}``).
+ * The exact dash column doesn't matter at peek time — ``parseListBlock``
+ * picks it up from the actual line — so the peek only needs to
+ * confirm "this is a child list of the current key, regardless of
+ * which indent step the user picked". 4-space YAML pastes and ESPHome
+ * example snippets both work as a result.
  */
-const isDeeperListItemLine = (line: string, parentIndent: string): boolean => {
-  const lead = _leadingIndent(line);
-  if (lead.length <= parentIndent.length) return false;
-  const tail = line.slice(lead.length);
-  return tail === "-" || tail.startsWith("- ");
-};
-
-/** YAML's compact block-sequence form allows a dash-list under a
- *  mapping key at the SAME indent as the key (not strictly deeper).
- *  ``calibration:\n- a\n- b`` is valid YAML for
- *  ``{calibration: [a, b]}``. ``isDeeperListItemLine`` rejects that
- *  shape because the parent-block loop terminator requires strict-
- *  greater indent; this predicate covers the equal-indent case so the
- *  block-list under a key with no inline value loads correctly. */
 const isChildListItemLine = (line: string, parentIndent: string): boolean => {
   const lead = _leadingIndent(line);
   if (lead.length < parentIndent.length) return false;
@@ -817,7 +806,7 @@ export function parseYamlSectionValues(
       if (peek >= lines.length) continue;
       const peekLine = lines[peek];
 
-      if (isDeeperListItemLine(peekLine, childIndent)) {
+      if (isChildListItemLine(peekLine, childIndent)) {
         const { value, endIdx, isEmptyScalarList } = parseListBlock(
           lines,
           i + 1,

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -283,6 +283,20 @@ const isDeeperListItemLine = (line: string, parentIndent: string): boolean => {
   return tail === "-" || tail.startsWith("- ");
 };
 
+/** YAML's compact block-sequence form allows a dash-list under a
+ *  mapping key at the SAME indent as the key (not strictly deeper).
+ *  ``calibration:\n- a\n- b`` is valid YAML for
+ *  ``{calibration: [a, b]}``. ``isDeeperListItemLine`` rejects that
+ *  shape because the parent-block loop terminator requires strict-
+ *  greater indent; this predicate covers the equal-indent case so the
+ *  block-list under a key with no inline value loads correctly. */
+const isChildListItemLine = (line: string, parentIndent: string): boolean => {
+  const lead = _leadingIndent(line);
+  if (lead.length < parentIndent.length) return false;
+  const tail = line.slice(lead.length);
+  return tail === "-" || tail.startsWith("- ");
+};
+
 const stripQuotes = (s: string): string => {
   if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
     return s.slice(1, -1);
@@ -664,7 +678,15 @@ const _scanValueBlock = (
     const line = lines[i];
     if (isBlankOrCommentLine(line)) continue;
     const lead = line.match(/^ */)![0];
-    if (lead.length <= keyIndent.length) return { endIdx: i, isComplex };
+    if (lead.length < keyIndent.length) return { endIdx: i, isComplex };
+    if (lead.length === keyIndent.length) {
+      // YAML's compact block-sequence form allows a child list to
+      // share the parent key's indent (``calibration:\n- a\n- b``).
+      // Same-indent dash lines stay in the block; any other shape
+      // at this indent terminates as before.
+      const tail = line.slice(lead.length);
+      if (tail !== "-" && !tail.startsWith("- ")) return { endIdx: i, isComplex };
+    }
     if (!isComplex) {
       if (
         BLOCK_SCALAR_RE.test(line) ||
@@ -872,7 +894,11 @@ function parseNestedBlock(
 
     if (raw === "") {
       const peek = _skipBlankAndCommentLines(lines, i + 1);
-      if (peek < lines.length && isDeeperListItemLine(lines[peek], indent)) {
+      // ``key:`` followed by a block list. Accept both the standard
+      // (deeper-indent) and compact (same-indent) forms; the compact
+      // shape is what ESPHome examples produce for short
+      // ``calibration:`` / ``datapoints:`` lists.
+      if (peek < lines.length && isChildListItemLine(lines[peek], indent)) {
         const { value, endIdx } = parseListBlock(lines, i + 1, indent);
         values[key] = value;
         i = endIdx;

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Targeted tests for ``renderStringField``'s defensive bail when the
+ * value at *path* isn't a primitive (a list landed under a mapping-
+ * shaped catalog field because the upstream schema bundle missed
+ * ``is_list``, an inline mapping under a scalar-shaped field). The
+ * pre-fix renderer ran ``String(ctx.getAt(path) ?? "")`` which
+ * silently coerced the list to a comma-joined string; saving wrote
+ * that string back and clobbered the user's list.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
+import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+
+function makeStringEntry(): ConfigEntry {
+  return makeConfigEntry({
+    key: "calibration",
+    type: ConfigEntryType.STRING,
+    label: "Calibration",
+  });
+}
+
+function makeCtx(values: Record<string, unknown>): {
+  ctx: RenderCtx;
+  emitChange: ReturnType<typeof vi.fn>;
+} {
+  const emitChange = vi.fn();
+  const ctx: RenderCtx = {
+    localize: (key) => key,
+    disabled: false,
+    yaml: "",
+    fromLine: undefined,
+    sectionKey: "",
+    board: null,
+    requiredOnly: false,
+    nestedOpenSections: new Set(),
+    getAt: (path: string[]) => {
+      let cur: unknown = values;
+      for (const k of path) {
+        if (cur === null || typeof cur !== "object" || Array.isArray(cur)) {
+          if (path.indexOf(k) === path.length - 1 && Array.isArray(cur)) return cur;
+          return undefined;
+        }
+        cur = (cur as Record<string, unknown>)[k];
+      }
+      return cur;
+    },
+    errorAt: () => null,
+    emitChange,
+    toggleNested: () => {},
+    requestAddComponent: () => {},
+    scopeValues: () => ({}),
+    filterRenderable: (entries) => entries,
+    renderEntry: () => "<rendered>",
+    getPendingUnit: () => undefined,
+    setPendingUnit: () => {},
+    getEditingMagnitude: () => undefined,
+    setEditingMagnitude: () => {},
+    clearEditingMagnitude: () => {},
+    stashOwner: {},
+  };
+  return { ctx, emitChange };
+}
+
+describe("renderStringField — defensive bail on non-primitive values", () => {
+  it("renders a YAML-only notice when the value is a list", () => {
+    // to_ntc_resistance.calibration shape: the schema bundle drops
+    // is_list on the field because the upstream validator is a
+    // custom callable, so the catalog emits type=string and the
+    // YAML carries a list of strings. Bail rather than coerce.
+    const { ctx } = makeCtx({
+      calibration: ["10.0kOhm -> 25°C", "27.219kOhm -> 0°C"],
+    });
+    const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("device.multi_value_yaml_only");
+    // No editable <input type="text"> mounted.
+    expect(json).not.toContain('"text"');
+  });
+
+  it("renders a YAML-only notice when the value is a mapping", () => {
+    const { ctx } = makeCtx({
+      calibration: { b_constant: 3950, reference_temperature: 25 },
+    });
+    const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("device.multi_value_yaml_only");
+  });
+
+  it("renders the editable input for actual strings", () => {
+    const { ctx } = makeCtx({ calibration: "hello" });
+    const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).not.toContain("device.multi_value_yaml_only");
+    expect(json).toContain("hello");
+  });
+
+  it("renders the editable input for null / undefined (treated as empty)", () => {
+    const { ctx } = makeCtx({ calibration: null });
+    const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).not.toContain("device.multi_value_yaml_only");
+  });
+});

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -11,8 +11,10 @@ import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderTextareaField } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { getIn } from "../../../src/util/nested-values.js";
+import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
 
 function makeStringEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -108,5 +110,37 @@ describe("renderStringField — defensive bail on non-primitive values", () => {
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersEditableBranch(json)).toBe(true);
     expect(rendersBailBranch(json)).toBe(false);
+  });
+});
+
+function makeTextareaEntry(): ConfigEntry {
+  return makeConfigEntry({
+    key: "lambda",
+    type: ConfigEntryType.LAMBDA,
+    label: "Lambda",
+  });
+}
+
+// The textarea bail is conditional on ``!isRaw`` — a ``YamlRawValue``
+// is an intentional block-scalar (``|-`` / ``>-`` etc.) and must still
+// reach the textarea so the user can edit the body. The two cases
+// below pin that asymmetry so a future reorder of the bail / isRaw
+// check can't silently regress the lambda editor.
+describe("renderTextareaField — bail asymmetry with YamlRawValue", () => {
+  it("renders the textarea for a YamlRawValue (block scalar)", () => {
+    const raw = new YamlRawValue(["  return x;"], "|-");
+    const { ctx } = makeCtx({ lambda: raw });
+    const tpl = renderTextareaField(makeTextareaEntry(), ["lambda"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("textarea");
+  });
+
+  it("bails when the value is a list under a textarea field", () => {
+    const { ctx } = makeCtx({ lambda: ["a", "b"] });
+    const tpl = renderTextareaField(makeTextareaEntry(), ["lambda"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(json).not.toContain("textarea");
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -61,13 +61,11 @@ function makeCtx(values: Record<string, unknown>): {
  *  (different ``inputType``, restructured input element) doesn't silently
  *  false-pass. */
 function rendersBailBranch(json: string): boolean {
-  return (
-    json.includes("device.multi_value_yaml_only") && json.includes("field-description")
-  );
+  return json.includes("device.value_yaml_only") && json.includes("field-description");
 }
 
 function rendersEditableBranch(json: string): boolean {
-  return json.includes("placeholder") && !json.includes("device.multi_value_yaml_only");
+  return json.includes("placeholder") && !json.includes("device.value_yaml_only");
 }
 
 describe("renderStringField — defensive bail on non-primitive values", () => {

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -12,6 +12,7 @@ import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import {
+  renderBooleanField,
   renderFloatWithUnitField,
   renderTextareaField,
   renderTimePeriodField,
@@ -203,5 +204,30 @@ describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primi
     const tpl = renderFloatWithUnitField(entry, ["frequency"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(false);
+  });
+});
+
+// ``parseYamlBoolean`` returns null for non-boolean/non-string inputs,
+// so a list / mapping under a boolean field renders unchecked. The
+// first user toggle would then write ``true`` back and clobber the
+// YAML structure. Pin both halves.
+describe("renderBooleanField — bail on non-primitive", () => {
+  const entry = (): ConfigEntry =>
+    makeConfigEntry({ key: "enabled", type: ConfigEntryType.BOOLEAN, label: "Enabled" });
+
+  it("bails when the value is a list under a boolean field", () => {
+    const { ctx } = makeCtx({ enabled: [true] });
+    const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(json).not.toContain("wa-switch");
+  });
+
+  it("renders the switch for an actual boolean", () => {
+    const { ctx } = makeCtx({ enabled: true });
+    const tpl = renderBooleanField(entry(), ["enabled"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("wa-switch");
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -12,6 +12,7 @@ import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { getIn } from "../../../src/util/nested-values.js";
 
 function makeStringEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -35,17 +36,7 @@ function makeCtx(values: Record<string, unknown>): {
     board: null,
     requiredOnly: false,
     nestedOpenSections: new Set(),
-    getAt: (path: string[]) => {
-      let cur: unknown = values;
-      for (const k of path) {
-        if (cur === null || typeof cur !== "object" || Array.isArray(cur)) {
-          if (path.indexOf(k) === path.length - 1 && Array.isArray(cur)) return cur;
-          return undefined;
-        }
-        cur = (cur as Record<string, unknown>)[k];
-      }
-      return cur;
-    },
+    getAt: (path: string[]) => getIn(values, path),
     errorAt: () => null,
     emitChange,
     toggleNested: () => {},
@@ -63,6 +54,22 @@ function makeCtx(values: Record<string, unknown>): {
   return { ctx, emitChange };
 }
 
+/** The bail branch is the only one that emits a ``<p class="field-description">``
+ *  containing the YAML-only translation key; the editable branch emits an
+ *  ``<input>`` whose binding includes a ``placeholder`` attribute. Key the
+ *  branch checks off those bail-specific markers so a future renderer change
+ *  (different ``inputType``, restructured input element) doesn't silently
+ *  false-pass. */
+function rendersBailBranch(json: string): boolean {
+  return (
+    json.includes("device.multi_value_yaml_only") && json.includes("field-description")
+  );
+}
+
+function rendersEditableBranch(json: string): boolean {
+  return json.includes("placeholder") && !json.includes("device.multi_value_yaml_only");
+}
+
 describe("renderStringField — defensive bail on non-primitive values", () => {
   it("renders a YAML-only notice when the value is a list", () => {
     // to_ntc_resistance.calibration shape: the schema bundle drops
@@ -74,9 +81,8 @@ describe("renderStringField — defensive bail on non-primitive values", () => {
     });
     const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(json).toContain("device.multi_value_yaml_only");
-    // No editable <input type="text"> mounted.
-    expect(json).not.toContain('"text"');
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(rendersEditableBranch(json)).toBe(false);
   });
 
   it("renders a YAML-only notice when the value is a mapping", () => {
@@ -85,14 +91,16 @@ describe("renderStringField — defensive bail on non-primitive values", () => {
     });
     const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(json).toContain("device.multi_value_yaml_only");
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(rendersEditableBranch(json)).toBe(false);
   });
 
   it("renders the editable input for actual strings", () => {
     const { ctx } = makeCtx({ calibration: "hello" });
     const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(json).not.toContain("device.multi_value_yaml_only");
+    expect(rendersEditableBranch(json)).toBe(true);
+    expect(rendersBailBranch(json)).toBe(false);
     expect(json).toContain("hello");
   });
 
@@ -100,6 +108,7 @@ describe("renderStringField — defensive bail on non-primitive values", () => {
     const { ctx } = makeCtx({ calibration: null });
     const tpl = renderStringField(makeStringEntry(), "text", ["calibration"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-    expect(json).not.toContain("device.multi_value_yaml_only");
+    expect(rendersEditableBranch(json)).toBe(true);
+    expect(rendersBailBranch(json)).toBe(false);
   });
 });

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -11,7 +11,11 @@ import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
-import { renderTextareaField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import {
+  renderFloatWithUnitField,
+  renderTextareaField,
+  renderTimePeriodField,
+} from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { getIn } from "../../../src/util/nested-values.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
@@ -142,5 +146,62 @@ describe("renderTextareaField — bail asymmetry with YamlRawValue", () => {
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(true);
     expect(json).not.toContain("textarea");
+  });
+});
+
+// parseTimePeriod / parseFloatWithUnit both run ``String(raw).trim()``
+// internally — a single-element list like ``["5s"]`` or ``["50Hz"]``
+// would otherwise stringify to a parseable scalar, render an editable
+// UI, and clobber the original list on save. Pin both call-sites.
+describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primitive", () => {
+  it("bails on a list value for a time-period field", () => {
+    const entry = makeConfigEntry({
+      key: "delay",
+      type: ConfigEntryType.TIME_PERIOD,
+      label: "Delay",
+    });
+    const { ctx } = makeCtx({ delay: ["5s"] });
+    const tpl = renderTimePeriodField(entry, ["delay"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("renders the editable time-period UI for an actual scalar", () => {
+    const entry = makeConfigEntry({
+      key: "delay",
+      type: ConfigEntryType.TIME_PERIOD,
+      label: "Delay",
+    });
+    const { ctx } = makeCtx({ delay: "5s" });
+    const tpl = renderTimePeriodField(entry, ["delay"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("time-period");
+  });
+
+  it("bails on a list value for a float-with-unit field", () => {
+    const entry = makeConfigEntry({
+      key: "frequency",
+      type: ConfigEntryType.FLOAT_WITH_UNIT,
+      label: "Frequency",
+      unit_options: ["Hz", "kHz", "MHz"],
+    });
+    const { ctx } = makeCtx({ frequency: ["50Hz"] });
+    const tpl = renderFloatWithUnitField(entry, ["frequency"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+  });
+
+  it("renders the editable float-with-unit UI for an actual scalar", () => {
+    const entry = makeConfigEntry({
+      key: "frequency",
+      type: ConfigEntryType.FLOAT_WITH_UNIT,
+      label: "Frequency",
+      unit_options: ["Hz", "kHz", "MHz"],
+    });
+    const { ctx } = makeCtx({ frequency: "50Hz" });
+    const tpl = renderFloatWithUnitField(entry, ["frequency"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -936,6 +936,34 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
   // nested-list renderer would then show "No items yet" even when
   // the YAML had items.
 
+  it("parses a compact (same-indent) list under a nested key", () => {
+    // YAML 1.2 compact block-sequence form: ``key:`` followed by
+    // dash lines at the SAME indent as the key (not strictly
+    // deeper). ESPHome examples produce this for short
+    // ``calibration:`` / ``datapoints:`` lists. Pre-fix the parser
+    // required strictly-deeper dashes and silently dropped the
+    // list, so to_ntc_resistance loaded with an empty calibration
+    // field even when the YAML had values.
+    const yaml = `sensor:
+  - platform: template
+    name: Probe
+    filters:
+      - to_ntc_resistance:
+          calibration:
+          - 10.0kOhm -> 25°C
+          - 27.219kOhm -> 0°C
+          - 14.674kOhm -> 15°C
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.filters).toEqual([
+      {
+        to_ntc_resistance: {
+          calibration: ["10.0kOhm -> 25°C", "27.219kOhm -> 0°C", "14.674kOhm -> 15°C"],
+        },
+      },
+    ]);
+  });
+
   it("parses esphome.devices into an array of plain objects", () => {
     const yaml = `esphome:
   name: test

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -964,6 +964,74 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     ]);
   });
 
+  it("compact list followed by a sibling key at the same indent", () => {
+    // Sibling key after the dashes; the sibling must NOT get
+    // absorbed into the compact list. The terminator path in
+    // ``_scanValueBlock`` distinguishes same-indent dashes (stay
+    // in the block) from same-indent non-dash (end the block).
+    const yaml = `sensor:
+  - platform: template
+    filters:
+      - to_ntc_resistance:
+          calibration:
+          - "10.0kOhm -> 25°C"
+          - "27.219kOhm -> 0°C"
+          b_constant: 3950
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.filters).toEqual([
+      {
+        to_ntc_resistance: {
+          calibration: ["10.0kOhm -> 25°C", "27.219kOhm -> 0°C"],
+          b_constant: "3950",
+        },
+      },
+    ]);
+  });
+
+  it("two sibling compact lists under the same parent", () => {
+    const yaml = `sensor:
+  - platform: template
+    filters:
+      - to_ntc_resistance:
+          calibration:
+          - a
+          - b
+          other:
+          - c
+          - d
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.filters).toEqual([
+      {
+        to_ntc_resistance: {
+          calibration: ["a", "b"],
+          other: ["c", "d"],
+        },
+      },
+    ]);
+  });
+
+  it("compact list at the very end of input (no trailing newline)", () => {
+    // EOF terminates the list cleanly — no trailing key, no blank
+    // line. Pins that the dash-walk doesn't depend on a terminator.
+    const yaml = `sensor:
+  - platform: template
+    filters:
+      - to_ntc_resistance:
+          calibration:
+          - x
+          - y`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.filters).toEqual([
+      {
+        to_ntc_resistance: {
+          calibration: ["x", "y"],
+        },
+      },
+    ]);
+  });
+
   it("parses esphome.devices into an array of plain objects", () => {
     const yaml = `esphome:
   name: test


### PR DESCRIPTION
# What does this implement/fix?

The previous `renderStringField` ran `String(ctx.getAt(path) ?? "")`. When the value at *path* wasn't a primitive (a YAML list landed under a mapping-shaped catalog field because the upstream schema bundle missed `is_list`, an inline mapping under a scalar-shaped field), the list got silently coerced to a comma-joined string; the editable text input then showed that joined string and a save wrote the string back, clobbering the user's YAML list. The `to_ntc_resistance` filter is the canonical case (custom `ntc_process_calibration` validator hides the list shape), but the silent-coerce path could hit any future catalog/YAML drift. Bail to a `multi_value_yaml_only` notice when raw isn't a primitive, same pattern `renderNestedListField` already uses when the parser preserves a block as `YamlRawValue`. The companion catalog override in esphome/device-builder#996 fixes the specific `to_ntc_*` case; this PR is the defensive backstop so future mismatches surface as a YAML-only hint instead of silent data loss.

**Related issue or feature (if applicable):**

- follow-up to #941

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
