### PR TITLE
Follow-up to #417: harden NO_COMPATIBLE_PEER toast against empty local-version race

### DIFF
--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -214,7 +214,15 @@ function formatForceLocalError(err: unknown): string {
 }
 
 function _installErrorMessage(host: ESPHomeCommandDialog, err: unknown): string {
-  if (err instanceof APIError && err.errorCode === ErrorCode.NO_COMPATIBLE_PEER) {
+  if (
+    err instanceof APIError &&
+    err.errorCode === ErrorCode.NO_COMPATIBLE_PEER &&
+    host._appVersion
+  ) {
+    // ``_appVersion`` empty during a reconnect race would leak ``""``
+    // into the ``{local}`` placeholder and misattribute the bucket;
+    // fall through to the raw backend message until the version
+    // snapshot lands.
     const reason = classifyNoCompatiblePeerReason(
       host._pairings?.values() ?? [],
       host._appVersion

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -378,7 +378,12 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
 
   private _onVersionMatchPolicyChange = (e: Event) => {
     if (this._versionMatchPolicy === null) return;
-    const raw = (e.target as HTMLSelectElement).value;
+    // wa-select isn't a native ``<select>`` — typing the cast as
+    // ``HTMLSelectElement`` reads correct but is misleading. WA's
+    // value property is string | number | null; narrow against
+    // the policy union before dispatching.
+    const raw = (e.target as HTMLElement & { value: string | number | null }).value;
+    if (typeof raw !== "string") return;
     if (!_VERSION_MATCH_POLICIES.includes(raw as VersionMatchPolicy)) return;
     const policy = raw as VersionMatchPolicy;
     if (policy === this._versionMatchPolicy) return;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -790,7 +790,14 @@ export class ESPHomePageDashboard extends LitElement {
     try {
       await this._api.firmwareInstallBulk(selected);
     } catch (err) {
-      if (err instanceof APIError && err.errorCode === ErrorCode.NO_COMPATIBLE_PEER) {
+      if (
+        err instanceof APIError &&
+        err.errorCode === ErrorCode.NO_COMPATIBLE_PEER &&
+        this._appVersion
+      ) {
+        // ``_appVersion`` empty during a reconnect race would leak
+        // into the ``{local}`` placeholder and misattribute the
+        // bucket; fall through to the generic toast.
         const reason = classifyNoCompatiblePeerReason(
           this._pairings?.values() ?? [],
           this._appVersion

--- a/src/util/version-mismatch.ts
+++ b/src/util/version-mismatch.ts
@@ -4,18 +4,13 @@ import type { PairingSummary, PeerStatus } from "../api/types.js";
  * Compare the local dashboard's bundled ESPHome version against
  * a paired build-server's reported version and classify the
  * result for the operator-facing mismatch sub-line in Settings →
- * Build server → paired build servers.
+ * Build server → paired build servers, and for the per-policy
+ * filter under ``VersionMatchPolicy.RELEASE`` (year + month
+ * match) and ``EXACT`` (full match).
  *
  * Versions are ESPHome's ``YYYY.M[.P][-suffix]`` shape (e.g.
- * ``2026.5.0``, ``2026.5.0b1``, ``2026.5.0-dev``). The first
- * two components (year + month) advance in lockstep with the
- * monthly ESPHome release and are what the scheduler's
- * allow-major-version-mismatch toggle keys on once 7a-3 +
- * 7b-toggle land: a YAML produced by the offloader against
- * ``2026.5`` is generally safe to compile on a receiver that
- * is also ``2026.5.*`` (patch differences are bugfix-only by
- * convention), but cross-month drift is the case the operator
- * wants to know about and explicitly accept.
+ * ``2026.5.0``, ``2026.5.0b1``, ``2026.5.0-dev``); year + month
+ * advance in lockstep with the monthly ESPHome release.
  *
  * Returned shape:
  *   * ``null`` — versions match, or either side is unknown
@@ -26,12 +21,6 @@ import type { PairingSummary, PeerStatus } from "../api/types.js";
  *   * ``"release"`` — year+month differs. Cautionary; the
  *     YAML may reference fields the receiver's schema does
  *     not recognise (or vice versa).
- *
- * The helper returns the classification kind only; it does
- * not echo back the version strings. The caller already
- * holds both values and renders them verbatim in the
- * translated sub-line (see settings-dialog's
- * ``_renderPairingVersionMismatch``).
  */
 export type VersionMismatchKind = "patch" | "release" | null;
 
@@ -97,14 +86,19 @@ export type NoCompatiblePeerReason = "offline" | "version" | "mixed";
  *
  * Only APPROVED + enabled rows count — PENDING and disabled
  * rows aren't operator-intentional, so the backend's hard-fail
- * doesn't fire on them. If there are no intentional pairings
+ * doesn't fire on them. If there are no intentional pairings,
  * the policy itself can't be the failure cause; return
  * ``"mixed"`` so the caller falls through to the generic toast.
+ * Same fallback when ``offloaderVersion`` is empty — without a
+ * local baseline ``classifyVersionMismatch`` short-circuits to
+ * ``null``, which would misattribute the bucket and leak an
+ * empty ``{local}`` placeholder into the toast string.
  */
 export function classifyNoCompatiblePeerReason(
   pairings: Iterable<PairingSummary>,
   offloaderVersion: string
 ): NoCompatiblePeerReason {
+  if (!offloaderVersion) return "mixed";
   let offline = 0;
   let version = 0;
   for (const p of pairings) {

--- a/test/util/version-mismatch.test.ts
+++ b/test/util/version-mismatch.test.ts
@@ -107,4 +107,18 @@ describe("classifyNoCompatiblePeerReason", () => {
     // of the error the classifier shouldn't pretend to know why.
     expect(classifyNoCompatiblePeerReason([pairing({})], LOCAL)).toBe("mixed");
   });
+
+  it("returns 'mixed' when offloaderVersion is empty (reconnect race)", () => {
+    // Without a local baseline classifyVersionMismatch short-
+    // circuits to null, which would mis-attribute the bucket
+    // and leak an empty {local} placeholder into the toast.
+    // Caller is expected to fall through to the generic toast,
+    // but the classifier itself should not pretend to know.
+    expect(classifyNoCompatiblePeerReason([pairing({ connected: false })], "")).toBe(
+      "mixed"
+    );
+    expect(
+      classifyNoCompatiblePeerReason([pairing({ esphome_version: "2026.4.0" })], "")
+    ).toBe("mixed");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Three follow-ups to the now-merged version-match policy picker (#417), all flagged by Kōan's post-merge review pass:

1. **`classifyNoCompatiblePeerReason` empty-version guard.** `_appVersion` is initialised to `""` and populated from `versionContext`; during a `subscribe_events` reconnect race a `NO_COMPATIBLE_PEER` error could arrive before the version snapshot has landed. Without a local baseline `classifyVersionMismatch` short-circuits to `null`, which would let every connected peer count as a version-match and mis-attribute the bucket. The classifier now returns `"mixed"` when `offloaderVersion` is empty. Both call-sites (`command-dialog/commands._installErrorMessage` + `pages/dashboard._installAll`) additionally guard on `_appVersion` before substituting the `{local}` placeholder, falling through to the generic install / bulk-update error toast otherwise — so the operator doesn't see `"No paired build server runs ESPHome  — …"` with an empty placeholder.

2. **`_onVersionMatchPolicyChange` cast.** The cast was `HTMLSelectElement`, which reads as a native `<select>` but the target is `<wa-select>`. Use `HTMLElement & { value: string | number | null }` (WA's actual value-property shape) + narrow against `string` before the policy-union check.

3. **Stale module docstring in `src/util/version-mismatch.ts`.** Referenced the pre-rework `allow-major-version-mismatch` toggle and the unmerged `7a-3 / 7b-toggle` work order. Drop the obsolete history; the helper now serves the live `VersionMatchPolicy.RELEASE` / `EXACT` filters.

**Related issue or feature (if applicable):**

- follow-up to #417
- refs companion backend rework esphome/device-builder#997

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
