### PR TITLE
Batch component body lookups through components/get_component_bodies

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1252,6 +1252,29 @@ export class ESPHomeAPI {
   }
 
   /**
+   * Batch variant of `getComponent`. Fetches every requested id in a
+   * single round trip; missing ids are absent from the returned map.
+   * `platform` / `boardId` resolve per-platform defaults exactly as
+   * the singular call does, applied uniformly across the batch.
+   */
+  async getComponentBodies(
+    componentIds: string[],
+    platform?: string,
+    boardId?: string
+  ): Promise<Record<string, ComponentCatalogEntry>> {
+    if (componentIds.length === 0) return {};
+    const raw = await this.sendCommand<unknown>("components/get_component_bodies", {
+      component_ids: componentIds,
+      ...(platform ? { platform } : {}),
+      ...(boardId ? { board_id: boardId } : {}),
+    });
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      return {};
+    }
+    return raw as Record<string, ComponentCatalogEntry>;
+  }
+
+  /**
    * Get components with optional filtering, search, and pagination.
    *
    * `platform` works the same as in `getComponent` — pass the device's

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1231,31 +1231,17 @@ export class ESPHomeAPI {
   // ─── Component Commands ───────────────────────────────────
 
   /**
-   * Get a single component by ID.
+   * Fetch component bodies in one round trip.
    *
-   * Pass `platform` (the device's target platform, e.g. "esp32",
-   * "esp8266") to have the backend resolve any per-platform
-   * `cv.SplitDefault` fields into a single `default_value`. Pass
-   * `boardId` to additionally narrow board-level constraints. Omit
-   * both when querying the generic catalog.
-   */
-  async getComponent(
-    componentId: string,
-    platform?: string,
-    boardId?: string
-  ): Promise<ComponentCatalogEntry | null> {
-    return this.sendCommand("components/get_component", {
-      component_id: componentId,
-      ...(platform ? { platform } : {}),
-      ...(boardId ? { board_id: boardId } : {}),
-    });
-  }
-
-  /**
-   * Batch variant of `getComponent`. Fetches every requested id in a
-   * single round trip; missing ids are absent from the returned map.
-   * `platform` / `boardId` resolve per-platform defaults exactly as
-   * the singular call does, applied uniformly across the batch.
+   * Returns a map keyed by the requested id; missing ids are absent
+   * from the result. Pass `platform` (the device's target platform,
+   * e.g. "esp32", "esp8266") to have the backend resolve any
+   * per-platform `cv.SplitDefault` fields into a single
+   * `default_value`; `boardId` additionally narrows board-level
+   * constraints. Omit both when querying the generic catalog. Most
+   * callers go through `fetchComponent` in
+   * `component-name-cache.ts`, which caches results and
+   * microtask-coalesces concurrent fetches into one call.
    */
   async getComponentBodies(
     componentIds: string[],
@@ -1277,8 +1263,9 @@ export class ESPHomeAPI {
   /**
    * Get components with optional filtering, search, and pagination.
    *
-   * `platform` works the same as in `getComponent` — pass the device's
-   * target platform to have per-platform defaults pre-resolved.
+   * `platform` works the same as in `getComponentBodies`; pass the
+   * device's target platform to have per-platform defaults
+   * pre-resolved.
    */
   async getComponents(args?: {
     query?: string;

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1249,15 +1249,14 @@ export class ESPHomeAPI {
     boardId?: string
   ): Promise<Record<string, ComponentCatalogEntry>> {
     if (componentIds.length === 0) return {};
-    const raw = await this.sendCommand<unknown>("components/get_component_bodies", {
-      component_ids: componentIds,
-      ...(platform ? { platform } : {}),
-      ...(boardId ? { board_id: boardId } : {}),
-    });
-    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-      return {};
-    }
-    return raw as Record<string, ComponentCatalogEntry>;
+    return this.sendCommand<Record<string, ComponentCatalogEntry>>(
+      "components/get_component_bodies",
+      {
+        component_ids: componentIds,
+        ...(platform ? { platform } : {}),
+        ...(boardId ? { board_id: boardId } : {}),
+      }
+    );
   }
 
   /**

--- a/src/components/device/add-component-dialog-dep-nav.ts
+++ b/src/components/device/add-component-dialog-dep-nav.ts
@@ -1,5 +1,6 @@
 import type { ComponentCatalogEntry } from "../../api/types.js";
 import type { ESPHomeAPI } from "../../api/index.js";
+import { fetchComponent } from "../../util/component-name-cache.js";
 
 /** Slice of ``ESPHomeAddComponentDialog`` state ``navigateToDep`` reads / writes. */
 export interface DepNavHost {
@@ -33,7 +34,8 @@ export async function navigateToDep(host: DepNavHost, domain: string): Promise<v
   const seq = ++host._depNavSeq;
   let direct: ComponentCatalogEntry | null = null;
   try {
-    direct = await host._api.getComponent(
+    direct = await fetchComponent(
+      host._api,
       domain,
       host.platform || undefined,
       host.board?.id ?? undefined

--- a/src/components/device/add-component-dialog-selection.ts
+++ b/src/components/device/add-component-dialog-selection.ts
@@ -1,0 +1,82 @@
+import type { ESPHomeAPI } from "../../api/index.js";
+import type { ComponentCatalogEntry } from "../../api/types.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+import { fetchComponent } from "../../util/component-name-cache.js";
+
+/**
+ * Slice of ``ESPHomeAddComponentDialog`` state ``hydrateForSelection`` reads.
+ * Mirrors the host-narrowing shape used by ``navigateToDep`` so the
+ * dialog stays a small surface against this helper.
+ *
+ * ``_selectionSeq`` is the monotonic token guarding async
+ * hydrations against stale-response races. The helper bumps it
+ * before each await and checks it after, so a slower earlier
+ * click can't write back over a faster later one. The caller
+ * does NOT need to bump it; the helper owns the lifecycle.
+ */
+export interface SelectionHost {
+  readonly _api: ESPHomeAPI;
+  platform: string;
+  board: { id: string } | null;
+  _selectionSeq: number;
+  readonly _localize: LocalizeFunc;
+}
+
+/** Result of an attempted selection hydration. ``stale`` means the
+ *  caller should NOT mutate any state (a newer selection bumped
+ *  the seq while we were awaiting). ``ok`` carries the resolved
+ *  body. ``error`` carries the message the caller should surface
+ *  in the submit-error banner. */
+export type SelectionResult =
+  | { kind: "stale" }
+  | { kind: "ok"; entry: ComponentCatalogEntry }
+  | { kind: "error"; message: string };
+
+/**
+ * Hydrate a slim catalog id to its full body, guarded by the
+ * host's selection token.
+ *
+ * The catalog list endpoint returns slim ``ComponentCatalogIndexEntry``
+ * shapes (no ``config_entries``); the dialog's form needs the full
+ * body to render its fields. Hydrate goes through ``fetchComponent``
+ * so the cached + microtask-batched path applies. A ``boardId``
+ * override is honoured for the featured-bundle path which knows
+ * the bundle's board explicitly; otherwise the host's current
+ * board wins.
+ *
+ * Mutation of caller state (``_selected`` / ``_submitError`` /
+ * bundle progress) intentionally lives in the caller so the
+ * "stale -> noop" path is one place to read. This closes the
+ * race the prior shape had: it used to set ``_submitError``
+ * before the caller had a chance to check the token, so a stale
+ * rejected hydration could overwrite the error banner of a
+ * fresh selection.
+ */
+export async function hydrateForSelection(
+  host: SelectionHost,
+  componentId: string,
+  boardIdOverride?: string
+): Promise<SelectionResult> {
+  const seq = ++host._selectionSeq;
+  const boardId = boardIdOverride ?? host.board?.id ?? undefined;
+  try {
+    const entry = await fetchComponent(
+      host._api,
+      componentId,
+      host.platform || undefined,
+      boardId
+    );
+    if (seq !== host._selectionSeq) return { kind: "stale" };
+    if (!entry) {
+      return { kind: "error", message: host._localize("device.add_component_error") };
+    }
+    return { kind: "ok", entry };
+  } catch (err) {
+    if (seq !== host._selectionSeq) return { kind: "stale" };
+    return {
+      kind: "error",
+      message:
+        err instanceof Error ? err.message : host._localize("device.add_component_error"),
+    };
+  }
+}

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -8,7 +8,6 @@ import {
   type FeaturedBundle,
 } from "../../api/types.js";
 import type { ESPHomeAPI } from "../../api/index.js";
-import { fetchComponent } from "../../util/component-name-cache.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, apiContext } from "../../context/index.js";
@@ -20,6 +19,10 @@ import {
   navigateToDep,
   type DepNavHost,
 } from "./add-component-dialog-dep-nav.js";
+import {
+  hydrateForSelection,
+  type SelectionHost,
+} from "./add-component-dialog-selection.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -390,54 +393,25 @@ export class ESPHomeAddComponentDialog extends LitElement {
     `;
   }
 
-  /** Hydrate a slim catalog id to its full body, going through the
-   *  cached + batched fetch path. Returns `null` and sets
-   *  `_submitError` on either a transport failure or a catalog
-   *  miss, so callers can bail uniformly. The WS layer can throw
-   *  on a transient disconnect / timeout; surfacing that via the
-   *  same banner as a missing-id keeps the dialog from
-   *  half-transitioning. */
-  private async _hydrateBody(
-    componentId: string,
-    boardId: string | undefined
-  ): Promise<ComponentCatalogEntry | null> {
-    try {
-      const entry = await fetchComponent(
-        this._api,
-        componentId,
-        this.platform || undefined,
-        boardId
-      );
-      if (!entry) {
-        this._submitError = this._localize("device.add_component_error");
-        return null;
-      }
-      return entry;
-    } catch (err) {
-      this._submitError =
-        err instanceof Error ? err.message : this._localize("device.add_component_error");
-      return null;
-    }
-  }
-
   private async _onComponentSelected(
     e: CustomEvent<{ component: ComponentCatalogEntry }>
   ) {
     e.stopPropagation();
     // The catalog list endpoint returns slim index entries (no
-    // `config_entries`); the form needs the full body to render
-    // its fields. Hydrate through the cached + batched fetch path
-    // so a subsequent click on the same card is instant. Capture
-    // the selection token before the await so a slower earlier
-    // click can't overwrite a faster later one.
-    const seq = ++this._selectionSeq;
-    const full = await this._hydrateBody(
-      e.detail.component.id,
-      this.board?.id ?? undefined
+    // `config_entries`); the form needs the full body. Hydration
+    // goes through `hydrateForSelection` so the cached + batched
+    // fetch path runs and the helper's seq guard discards a
+    // slower earlier click that returns after a faster later one.
+    const result = await hydrateForSelection(
+      this as unknown as SelectionHost,
+      e.detail.component.id
     );
-    if (seq !== this._selectionSeq) return;
-    if (!full) return;
-    this._selected = full;
+    if (result.kind === "stale") return;
+    if (result.kind === "error") {
+      this._submitError = result.message;
+      return;
+    }
+    this._selected = result.entry;
     this._submitError = "";
   }
 
@@ -459,13 +433,20 @@ export class ESPHomeAddComponentDialog extends LitElement {
       (localId) => `featured.${boardId}.${localId}`
     );
     const [first, ...rest] = fullIds;
-    // Same stale-response guard as `_onComponentSelected`; a quick
+    // Same selection guard as `_onComponentSelected`; a quick
     // re-pick or a card click landing between this bundle's flush
     // and response must not let the bundle resurrect itself.
-    const seq = ++this._selectionSeq;
-    const component = await this._hydrateBody(first, boardId);
-    if (seq !== this._selectionSeq) return;
-    if (!component) return;
+    const result = await hydrateForSelection(
+      this as unknown as SelectionHost,
+      first,
+      boardId
+    );
+    if (result.kind === "stale") return;
+    if (result.kind === "error") {
+      this._submitError = result.message;
+      return;
+    }
+    const component = result.entry;
     // Picking a bundle is a fresh sequence — abandon any in-flight
     // dep-detour state from the previous component the user was filling.
     // Without this clear, the bundle's first submit would route through
@@ -585,17 +566,20 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // it on re-render.
         const nextId = this._bundleQueue[0];
         const remaining = this._bundleQueue.slice(1);
-        // Same stale-response guard as the catalog/bundle pick
-        // entry points; a quick bundle-abandon (back button,
-        // dialog close, fresh selection) between the flush and
-        // response must not let this step apply its prefill.
-        const seq = ++this._selectionSeq;
-        const nextComponent = await this._hydrateBody(
-          nextId,
-          this.board?.id ?? undefined
+        // Same selection guard as the catalog/bundle pick entry
+        // points; a quick bundle-abandon (back button, dialog
+        // close, fresh selection) between the flush and response
+        // must not let this step apply its prefill.
+        const nextResult = await hydrateForSelection(
+          this as unknown as SelectionHost,
+          nextId
         );
-        if (seq !== this._selectionSeq) return;
-        if (!nextComponent) return;
+        if (nextResult.kind === "stale") return;
+        if (nextResult.kind === "error") {
+          this._submitError = nextResult.message;
+          return;
+        }
+        const nextComponent = nextResult.entry;
         // Hand the just-added component's id to the next step's matching
         // `references_component` field. Bundles are designed to chain —
         // e.g. `Status LED (full setup)` adds an `output.gpio`, then a

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -8,6 +8,7 @@ import {
   type FeaturedBundle,
 } from "../../api/types.js";
 import type { ESPHomeAPI } from "../../api/index.js";
+import { fetchComponent } from "../../util/component-name-cache.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, apiContext } from "../../context/index.js";
@@ -406,9 +407,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // (still on the catalog view but with bundle state about to be set
     // by the rest of this handler). Catch and surface via the same
     // banner the form submit uses, then bail.
-    let component: Awaited<ReturnType<ESPHomeAPI["getComponent"]>>;
+    let component: ComponentCatalogEntry | null;
     try {
-      component = await this._api.getComponent(
+      component = await fetchComponent(
+        this._api,
         first,
         this.platform || undefined,
         boardId
@@ -538,7 +540,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // it on re-render.
         const nextId = this._bundleQueue[0];
         const remaining = this._bundleQueue.slice(1);
-        const nextComponent = await this._api.getComponent(
+        const nextComponent = await fetchComponent(
+          this._api,
           nextId,
           this.platform || undefined,
           this.board?.id ?? undefined

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -378,9 +378,50 @@ export class ESPHomeAddComponentDialog extends LitElement {
     `;
   }
 
-  private _onComponentSelected(e: CustomEvent<{ component: ComponentCatalogEntry }>) {
+  /** Hydrate a slim catalog id to its full body, going through the
+   *  cached + batched fetch path. Returns `null` and sets
+   *  `_submitError` on either a transport failure or a catalog
+   *  miss, so callers can bail uniformly. The WS layer can throw
+   *  on a transient disconnect / timeout; surfacing that via the
+   *  same banner as a missing-id keeps the dialog from
+   *  half-transitioning. */
+  private async _hydrateBody(
+    componentId: string,
+    boardId: string | undefined
+  ): Promise<ComponentCatalogEntry | null> {
+    try {
+      const entry = await fetchComponent(
+        this._api,
+        componentId,
+        this.platform || undefined,
+        boardId
+      );
+      if (!entry) {
+        this._submitError = this._localize("device.add_component_error");
+        return null;
+      }
+      return entry;
+    } catch (err) {
+      this._submitError =
+        err instanceof Error ? err.message : this._localize("device.add_component_error");
+      return null;
+    }
+  }
+
+  private async _onComponentSelected(
+    e: CustomEvent<{ component: ComponentCatalogEntry }>
+  ) {
     e.stopPropagation();
-    this._selected = e.detail.component;
+    // The catalog list endpoint returns slim index entries (no
+    // `config_entries`); the form needs the full body to render
+    // its fields. Hydrate through the cached + batched fetch path
+    // so a subsequent click on the same card is instant.
+    const full = await this._hydrateBody(
+      e.detail.component.id,
+      this.board?.id ?? undefined
+    );
+    if (!full) return;
+    this._selected = full;
     this._submitError = "";
   }
 
@@ -402,28 +443,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
       (localId) => `featured.${boardId}.${localId}`
     );
     const [first, ...rest] = fullIds;
-    // The WS layer can throw on a transient disconnect / timeout; an
-    // unhandled rejection here would leave the dialog half-transitioned
-    // (still on the catalog view but with bundle state about to be set
-    // by the rest of this handler). Catch and surface via the same
-    // banner the form submit uses, then bail.
-    let component: ComponentCatalogEntry | null;
-    try {
-      component = await fetchComponent(
-        this._api,
-        first,
-        this.platform || undefined,
-        boardId
-      );
-    } catch (err) {
-      this._submitError =
-        err instanceof Error ? err.message : this._localize("device.add_component_error");
-      return;
-    }
-    if (!component) {
-      this._submitError = this._localize("device.add_component_error");
-      return;
-    }
+    const component = await this._hydrateBody(first, boardId);
+    if (!component) return;
     // Picking a bundle is a fresh sequence — abandon any in-flight
     // dep-detour state from the previous component the user was filling.
     // Without this clear, the bundle's first submit would route through
@@ -540,16 +561,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // it on re-render.
         const nextId = this._bundleQueue[0];
         const remaining = this._bundleQueue.slice(1);
-        const nextComponent = await fetchComponent(
-          this._api,
+        const nextComponent = await this._hydrateBody(
           nextId,
-          this.platform || undefined,
           this.board?.id ?? undefined
         );
-        if (!nextComponent) {
-          this._submitError = this._localize("device.add_component_error");
-          return;
-        }
+        if (!nextComponent) return;
         // Hand the just-added component's id to the next step's matching
         // `references_component` field. Bundles are designed to chain —
         // e.g. `Status LED (full setup)` adds an `output.gpio`, then a

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -136,6 +136,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
     bundleName: string;
   } | null = null;
 
+  /**
+   * Monotonically increasing token guarding async selection
+   * mutations against stale-response races. Every code path that
+   * starts an async hydration captures the current value, then
+   * checks it after the await; if the user clicked something else
+   * in between (and we bumped the token), the late response is
+   * discarded. Same shape as `_depNavSeq` in navigateToDep.
+   */
+  private _selectionSeq = 0;
+
   static styles = [
     espHomeStyles,
     css`
@@ -257,6 +267,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   public open() {
     this._resetDetourState();
+    this._selectionSeq++;
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
@@ -273,6 +284,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   public openWithSearch(domain: string) {
     this._resetDetourState();
+    this._selectionSeq++;
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
@@ -415,11 +427,15 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // The catalog list endpoint returns slim index entries (no
     // `config_entries`); the form needs the full body to render
     // its fields. Hydrate through the cached + batched fetch path
-    // so a subsequent click on the same card is instant.
+    // so a subsequent click on the same card is instant. Capture
+    // the selection token before the await so a slower earlier
+    // click can't overwrite a faster later one.
+    const seq = ++this._selectionSeq;
     const full = await this._hydrateBody(
       e.detail.component.id,
       this.board?.id ?? undefined
     );
+    if (seq !== this._selectionSeq) return;
     if (!full) return;
     this._selected = full;
     this._submitError = "";
@@ -443,7 +459,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
       (localId) => `featured.${boardId}.${localId}`
     );
     const [first, ...rest] = fullIds;
+    // Same stale-response guard as `_onComponentSelected`; a quick
+    // re-pick or a card click landing between this bundle's flush
+    // and response must not let the bundle resurrect itself.
+    const seq = ++this._selectionSeq;
     const component = await this._hydrateBody(first, boardId);
+    if (seq !== this._selectionSeq) return;
     if (!component) return;
     // Picking a bundle is a fresh sequence — abandon any in-flight
     // dep-detour state from the previous component the user was filling.
@@ -466,6 +487,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   private _onBack() {
     if (this._submitting) return;
+    // Bump the selection token so any hydration still in flight
+    // can't write back over the restored / cleared `_selected`.
+    this._selectionSeq++;
     // If the user is in the middle of a "go add a dependency" detour
     // and they hit back, treat it as cancelling the detour: drop them
     // back at the original component they were filling in, instead of
@@ -561,10 +585,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // it on re-render.
         const nextId = this._bundleQueue[0];
         const remaining = this._bundleQueue.slice(1);
+        // Same stale-response guard as the catalog/bundle pick
+        // entry points; a quick bundle-abandon (back button,
+        // dialog close, fresh selection) between the flush and
+        // response must not let this step apply its prefill.
+        const seq = ++this._selectionSeq;
         const nextComponent = await this._hydrateBody(
           nextId,
           this.board?.id ?? undefined
         );
+        if (seq !== this._selectionSeq) return;
         if (!nextComponent) return;
         // Hand the just-added component's id to the next step's matching
         // `references_component` field. Bundles are designed to chain —

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -139,14 +139,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     bundleName: string;
   } | null = null;
 
-  /**
-   * Monotonically increasing token guarding async selection
-   * mutations against stale-response races. Every code path that
-   * starts an async hydration captures the current value, then
-   * checks it after the await; if the user clicked something else
-   * in between (and we bumped the token), the late response is
-   * discarded. Same shape as `_depNavSeq` in navigateToDep.
-   */
+  /** Monotonic token guarding async selection against stale responses.
+   *  Bumped by `_resetDetourState` and by `hydrateForSelection`; a
+   *  hydrate whose captured token doesn't match `_selectionSeq` at
+   *  resolve time discards its result. */
   private _selectionSeq = 0;
 
   static styles = [
@@ -270,7 +266,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   public open() {
     this._resetDetourState();
-    this._selectionSeq++;
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
@@ -287,7 +282,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   public openWithSearch(domain: string) {
     this._resetDetourState();
-    this._selectionSeq++;
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
@@ -305,6 +299,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._bundleQueue = [];
     this._bundleProgress = null;
     this._depNavSeq++;
+    // Bumping here couples bundle/detour teardown to the selection
+    // token so an in-flight hydrate can't resurrect cleared state.
+    this._selectionSeq++;
   }
 
   protected render() {
@@ -468,9 +465,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   private _onBack() {
     if (this._submitting) return;
-    // Bump the selection token so any hydration still in flight
-    // can't write back over the restored / cleared `_selected`.
-    this._selectionSeq++;
     // If the user is in the middle of a "go add a dependency" detour
     // and they hit back, treat it as cancelling the detour: drop them
     // back at the original component they were filling in, instead of
@@ -566,10 +560,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // it on re-render.
         const nextId = this._bundleQueue[0];
         const remaining = this._bundleQueue.slice(1);
-        // Same selection guard as the catalog/bundle pick entry
-        // points; a quick bundle-abandon (back button, dialog
-        // close, fresh selection) between the flush and response
-        // must not let this step apply its prefill.
+        // The stale-return path is safe to leave the local
+        // `remaining` snapshot dangling because
+        // `_resetDetourState` bumps the seq AND wipes the queue
+        // in one synchronous block.
         const nextResult = await hydrateForSelection(
           this as unknown as SelectionHost,
           nextId

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -261,6 +261,19 @@ export class ESPHomeAddComponentDialog extends LitElement {
         font-size: 14px;
         color: var(--esphome-primary);
       }
+
+      /* Surfaces a hydrate / WS-transport failure on the catalog
+         view; the form's own banner is unreachable when _selected
+         is still null. */
+      .catalog-error {
+        margin-bottom: var(--wa-space-m);
+        padding: var(--wa-space-xs) var(--wa-space-s);
+        background: color-mix(in srgb, var(--wa-color-danger-60), transparent 88%);
+        border-left: 3px solid var(--wa-color-danger-60);
+        border-radius: var(--wa-border-radius-s);
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-normal);
+      }
     `,
   ];
 
@@ -363,6 +376,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
                 })}</span
               >
             </div>`
+          : nothing}
+        ${!isForm && this._submitError
+          ? html`<div class="catalog-error" role="alert">${this._submitError}</div>`
           : nothing}
         <esphome-component-catalog
           ?hidden=${isForm}

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -93,6 +93,9 @@ export function fetchComponent(
     const bucketKey = _batchKey(platform, boardId);
     let bucket = _batches.get(bucketKey);
     if (bucket === undefined) {
+      // Bucket captures the first caller's `api`. Assumes one
+      // live `ESPHomeAPI` per app (context-provided by app-shell);
+      // a future second instance would need `api` in the bucket key.
       bucket = { api, platform, boardId, pending: new Map() };
       _batches.set(bucketKey, bucket);
       queueMicrotask(() => _flushBatch(bucketKey));

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -15,18 +15,42 @@ import type { ComponentCatalogEntry } from "../api/types.js";
  * the next call retries.
  *
  * Concurrent fetches for the same key share a single in-flight
- * promise, so a navigator that mounts and dispatches N parallel
- * resolves only triggers N unique backend calls.
+ * promise; in addition, every `fetchComponent` call enqueues onto a
+ * microtask-flushed batch so a navigator that mounts N components in
+ * one task triggers one `components/get_component_bodies` WS call
+ * instead of N singletons. Different `(platform, boardId)` contexts
+ * batch separately because the backend resolves platform_defaults
+ * per call.
  */
 
 type CacheValue = ComponentCatalogEntry | null;
 
+interface _PendingResolver {
+  resolve: (value: CacheValue) => void;
+  reject: (reason: unknown) => void;
+}
+
+interface _BatchBucket {
+  api: ESPHomeAPI;
+  platform: string | undefined;
+  boardId: string | undefined;
+  // One resolver per id. ``_inflight`` short-circuits same-id
+  // duplicates before they reach the bucket, so this never needs
+  // to fan out to a list.
+  pending: Map<string, _PendingResolver>;
+}
+
 const _cache = new Map<string, CacheValue>();
 const _inflight = new Map<string, Promise<CacheValue>>();
 const _listeners = new Set<() => void>();
+const _batches = new Map<string, _BatchBucket>();
 
 function _key(componentId: string, platform?: string, boardId?: string): string {
   return `${componentId}|${platform ?? ""}|${boardId ?? ""}`;
+}
+
+function _batchKey(platform?: string, boardId?: string): string {
+  return `${platform ?? ""}|${boardId ?? ""}`;
 }
 
 /**
@@ -48,6 +72,10 @@ export function getCachedComponent(
  * same key return the cached value (or join the in-flight promise).
  * Notifies subscribers once after a fresh entry lands so reactive
  * consumers can re-render.
+ *
+ * Calls within the same microtask coalesce into one batched
+ * `components/get_component_bodies` request, so a navigator that
+ * fans out N parallel resolves pays one round trip.
  */
 export function fetchComponent(
   api: ESPHomeAPI,
@@ -61,21 +89,48 @@ export function fetchComponent(
   const existing = _inflight.get(key);
   if (existing) return existing;
 
-  const promise = api
-    .getComponent(componentId, platform, boardId)
-    .then((entry) => {
-      _cache.set(key, entry ?? null);
-      _inflight.delete(key);
-      _notify();
-      return entry ?? null;
-    })
-    .catch((err) => {
-      _inflight.delete(key);
-      throw err;
-    });
+  const promise = new Promise<CacheValue>((resolve, reject) => {
+    const bucketKey = _batchKey(platform, boardId);
+    let bucket = _batches.get(bucketKey);
+    if (bucket === undefined) {
+      bucket = { api, platform, boardId, pending: new Map() };
+      _batches.set(bucketKey, bucket);
+      queueMicrotask(() => _flushBatch(bucketKey));
+    }
+    bucket.pending.set(componentId, { resolve, reject });
+  }).finally(() => {
+    _inflight.delete(key);
+  });
 
   _inflight.set(key, promise);
   return promise;
+}
+
+async function _flushBatch(bucketKey: string): Promise<void> {
+  const bucket = _batches.get(bucketKey);
+  if (bucket === undefined) return;
+  _batches.delete(bucketKey);
+  const ids = Array.from(bucket.pending.keys());
+  try {
+    const entries = await bucket.api.getComponentBodies(
+      ids,
+      bucket.platform,
+      bucket.boardId
+    );
+    for (const [componentId, resolver] of bucket.pending) {
+      const entry = entries[componentId] ?? null;
+      _cache.set(_key(componentId, bucket.platform, bucket.boardId), entry);
+      resolver.resolve(entry);
+    }
+    _notify();
+  } catch (err) {
+    // Surface the transport error to every waiter so callers can
+    // retry; do NOT populate the cache, mirroring the singleton
+    // path's "transport errors are not cached" contract.
+    for (const resolver of bucket.pending.values()) {
+      resolver.reject(err);
+    }
+  }
 }
 
 /**
@@ -108,4 +163,5 @@ export function _clearComponentCache(): void {
   _cache.clear();
   _inflight.clear();
   _listeners.clear();
+  _batches.clear();
 }

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -166,8 +166,16 @@ function _notify(): void {
   }
 }
 
-/** Test-only: drop all cached entries and pending promises. */
+/** Test-only: drop all cached entries and pending promises.
+ *  Bucket waiters waiting on a flush that will never happen are
+ *  rejected so the dangling promises settle and dependent tests
+ *  don't hang on an `await fetchComponent(...)`. */
 export function _clearComponentCache(): void {
+  for (const bucket of _batches.values()) {
+    for (const resolver of bucket.pending.values()) {
+      resolver.reject(new Error("component cache cleared"));
+    }
+  }
   _cache.clear();
   _inflight.clear();
   _listeners.clear();

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -135,6 +135,10 @@ async function _flushBatch(bucketKey: string): Promise<void> {
     const entry = Object.prototype.hasOwnProperty.call(entries, componentId)
       ? entries[componentId]
       : null;
+    // Cache write MUST precede resolve. A sync `_notify` subscriber
+    // that re-calls `fetchComponent(api, id, ...)` hits the cache
+    // path; reordering would start a fresh round trip for an id
+    // we just resolved.
     _cache.set(_key(componentId, bucket.platform, bucket.boardId), entry);
     resolver.resolve(entry);
   }
@@ -172,8 +176,15 @@ function _notify(): void {
 /** Test-only: drop all cached entries and pending promises.
  *  Bucket waiters waiting on a flush that will never happen are
  *  rejected so the dangling promises settle and dependent tests
- *  don't hang on an `await fetchComponent(...)`. */
+ *  don't hang on an `await fetchComponent(...)`. Attach a noop
+ *  catch to each in-flight promise first so a test that fired
+ *  `fetchComponent` purely for cache side-effects (no await, no
+ *  catch) doesn't surface the rejection as
+ *  ``unhandledrejection`` under vitest strict mode. */
 export function _clearComponentCache(): void {
+  for (const promise of _inflight.values()) {
+    promise.catch(() => {});
+  }
   for (const bucket of _batches.values()) {
     for (const resolver of bucket.pending.values()) {
       resolver.reject(new Error("component cache cleared"));

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -111,18 +111,9 @@ async function _flushBatch(bucketKey: string): Promise<void> {
   if (bucket === undefined) return;
   _batches.delete(bucketKey);
   const ids = Array.from(bucket.pending.keys());
+  let entries: Record<string, ComponentCatalogEntry>;
   try {
-    const entries = await bucket.api.getComponentBodies(
-      ids,
-      bucket.platform,
-      bucket.boardId
-    );
-    for (const [componentId, resolver] of bucket.pending) {
-      const entry = entries[componentId] ?? null;
-      _cache.set(_key(componentId, bucket.platform, bucket.boardId), entry);
-      resolver.resolve(entry);
-    }
-    _notify();
+    entries = await bucket.api.getComponentBodies(ids, bucket.platform, bucket.boardId);
   } catch (err) {
     // Surface the transport error to every waiter so callers can
     // retry; do NOT populate the cache, mirroring the singleton
@@ -130,7 +121,24 @@ async function _flushBatch(bucketKey: string): Promise<void> {
     for (const resolver of bucket.pending.values()) {
       resolver.reject(err);
     }
+    return;
   }
+  for (const [componentId, resolver] of bucket.pending) {
+    // Own-property check rather than `entries[id] ?? null`: the
+    // wire payload is a plain object, so a bare index lookup would
+    // resolve `toString`, `constructor`, etc. via the prototype
+    // chain and cache that garbage as a "found" entry. Reachable
+    // from user-typed yaml-completion ids.
+    const entry = Object.prototype.hasOwnProperty.call(entries, componentId)
+      ? entries[componentId]
+      : null;
+    _cache.set(_key(componentId, bucket.platform, bucket.boardId), entry);
+    resolver.resolve(entry);
+  }
+  // Notify outside the response try so a throwing subscriber
+  // surfaces via `_notify`'s own try/catch instead of getting
+  // turned into a rejection of already-settled resolvers.
+  _notify();
 }
 
 /**

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1561,6 +1561,69 @@ describe("ESPHomeAPI — automations catalog", () => {
   });
 });
 
+describe("ESPHomeAPI — getComponentBodies", () => {
+  beforeEach(() => {
+    installMockWebSocket();
+  });
+  afterEach(() => {
+    uninstallMockWebSocket();
+  });
+
+  it("sends ``components/get_component_bodies`` with the requested ids", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const pending = api.getComponentBodies(["wifi", "api"]);
+    const sent = ws.sentAs<{ command: string; args: Record<string, unknown> }>(0);
+
+    expect(sent.command).toBe("components/get_component_bodies");
+    expect(sent.args).toEqual({ component_ids: ["wifi", "api"] });
+
+    const payload = {
+      wifi: { id: "wifi", name: "Wi-Fi" },
+      api: { id: "api", name: "API" },
+    };
+    ws.receive({
+      message_id: ws.sentAs<{ message_id: string }>(0).message_id,
+      result: payload,
+    });
+    await expect(pending).resolves.toEqual(payload);
+  });
+
+  it("forwards platform / board_id as snake_case when provided", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    api.getComponentBodies(["wifi"], "esp32", "esp32-s3-devkitc-1");
+    const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
+    expect(sent.args).toEqual({
+      component_ids: ["wifi"],
+      platform: "esp32",
+      board_id: "esp32-s3-devkitc-1",
+    });
+  });
+
+  it("omits platform / board_id when not provided so the backend's default path runs", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    api.getComponentBodies(["wifi"]);
+    const sent = ws.sentAs<{ args: Record<string, unknown> }>(0);
+    expect(sent.args).toEqual({ component_ids: ["wifi"] });
+    expect("platform" in sent.args).toBe(false);
+    expect("board_id" in sent.args).toBe(false);
+  });
+
+  it("short-circuits on an empty id list without touching the socket", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const result = await api.getComponentBodies([]);
+    expect(result).toEqual({});
+    expect(ws.sent).toHaveLength(0);
+  });
+});
+
 describe("ESPHomeAPI — automations parse / upsert / delete", () => {
   beforeEach(() => {
     installMockWebSocket();

--- a/test/components/device/add-component-dialog-dep-nav.test.ts
+++ b/test/components/device/add-component-dialog-dep-nav.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   matchesDepDomain,
@@ -7,14 +7,15 @@ import {
 } from "../../../src/components/device/add-component-dialog-dep-nav.js";
 import { ComponentCategory, type ComponentCatalogEntry } from "../../../src/api/types.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 function makeHost(
-  getComponent: (...args: unknown[]) => unknown,
+  getComponentBodies: (...args: unknown[]) => unknown,
   catalog: NonNullable<DepNavHost["_catalog"]> | null = null
 ): DepNavHost {
   return {
-    _api: { getComponent } as unknown as ESPHomeAPI,
+    _api: { getComponentBodies } as unknown as ESPHomeAPI,
     platform: "esp32",
     board: { id: "apollo-esk-1" },
     _catalog: catalog,
@@ -36,20 +37,32 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   return { promise, resolve };
 }
 
+/** `fetchComponent` routes through `getComponentBodies` and returns
+ *  the entry under the requested id (or null when absent). Tests
+ *  pass the entry they want returned and this helper wraps it. */
+const respond = (entry: ComponentCatalogEntry | null) =>
+  vi
+    .fn()
+    .mockImplementation((ids: string[]) =>
+      Promise.resolve(entry ? { [ids[0]]: entry } : {})
+    );
+
 describe("navigateToDep", () => {
   const aht20 = makeComponentEntry("sensor.aht10");
   const i2c = makeComponentEntry("i2c");
   const uart = makeComponentEntry("uart");
 
+  afterEach(() => _clearComponentCache());
+
   test("exact-id dep retargets the form to the fetched component", async () => {
-    const getComponent = vi.fn().mockResolvedValue(i2c);
+    const getComponentBodies = respond(i2c);
     const filterByDomain = vi.fn();
-    const host = makeHost(getComponent, { filterByDomain });
+    const host = makeHost(getComponentBodies, { filterByDomain });
     host._selected = aht20;
 
     await navigateToDep(host, "i2c");
 
-    expect(getComponent).toHaveBeenCalledWith("i2c", "esp32", "apollo-esk-1");
+    expect(getComponentBodies).toHaveBeenCalledWith(["i2c"], "esp32", "apollo-esk-1");
     expect(host._selected).toBe(i2c);
     expect(host._returnTo).toBe(aht20);
     expect(host._depDomain).toBe("i2c");
@@ -57,24 +70,24 @@ describe("navigateToDep", () => {
   });
 
   test("domain-level dep with no matching id falls back to the catalog filter", async () => {
-    const getComponent = vi.fn().mockResolvedValue(null);
+    const getComponentBodies = respond(null);
     const filterByDomain = vi.fn();
-    const host = makeHost(getComponent, { filterByDomain });
+    const host = makeHost(getComponentBodies, { filterByDomain });
     host._selected = aht20;
 
     await navigateToDep(host, "output");
 
-    expect(getComponent).toHaveBeenCalledWith("output", "esp32", "apollo-esk-1");
+    expect(getComponentBodies).toHaveBeenCalledWith(["output"], "esp32", "apollo-esk-1");
     expect(host._selected).toBeNull();
     expect(host._returnTo).toBe(aht20);
     expect(host._depDomain).toBe("output");
     expect(filterByDomain).toHaveBeenCalledWith("output");
   });
 
-  test("a transient getComponent failure falls back to the catalog filter", async () => {
-    const getComponent = vi.fn().mockRejectedValue(new Error("boom"));
+  test("a transient backend failure falls back to the catalog filter", async () => {
+    const getComponentBodies = vi.fn().mockRejectedValue(new Error("boom"));
     const filterByDomain = vi.fn();
-    const host = makeHost(getComponent, { filterByDomain });
+    const host = makeHost(getComponentBodies, { filterByDomain });
     host._selected = aht20;
 
     await navigateToDep(host, "i2c");
@@ -83,16 +96,16 @@ describe("navigateToDep", () => {
     expect(filterByDomain).toHaveBeenCalledWith("i2c");
   });
 
-  test("a stale getComponent response is dropped after _depNavSeq bumps", async () => {
+  test("a stale response is dropped after _depNavSeq bumps", async () => {
     // Simulates _resetDetourState or _onFormSubmit bumping mid-flight.
-    const d = deferred<ComponentCatalogEntry>();
+    const d = deferred<Record<string, ComponentCatalogEntry>>();
     const filterByDomain = vi.fn();
     const host = makeHost(() => d.promise, { filterByDomain });
     host._selected = aht20;
 
     const navPromise = navigateToDep(host, "i2c");
     host._depNavSeq++;
-    d.resolve(i2c);
+    d.resolve({ i2c });
     await navPromise;
 
     expect(host._selected).toBe(aht20);
@@ -102,7 +115,7 @@ describe("navigateToDep", () => {
   test("_returnTo stays null while the exact-id lookup is in flight", async () => {
     // A submit during this window would otherwise be misclassified
     // as completing a dep detour by _onFormSubmit.
-    const d = deferred<ComponentCatalogEntry>();
+    const d = deferred<Record<string, ComponentCatalogEntry>>();
     const host = makeHost(() => d.promise);
     host._selected = aht20;
 
@@ -110,42 +123,40 @@ describe("navigateToDep", () => {
     expect(host._returnTo).toBeNull();
     expect(host._depDomain).toBeNull();
 
-    d.resolve(i2c);
+    d.resolve({ i2c });
     await navPromise;
     expect(host._returnTo).toBe(aht20);
     expect(host._depDomain).toBe("i2c");
   });
 
   test("a superseded navigation does not race against the latest one", async () => {
-    const first = deferred<ComponentCatalogEntry>();
-    const second = deferred<ComponentCatalogEntry>();
-    const getComponent = vi
-      .fn()
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    const host = makeHost(getComponent);
+    // Both navigations queue into one batched `getComponentBodies`
+    // call; the seq guard inside navigateToDep is what prevents
+    // the earlier (now superseded) call from applying its result.
+    const batch = deferred<Record<string, ComponentCatalogEntry>>();
+    const getComponentBodies = vi.fn().mockReturnValue(batch.promise);
+    const host = makeHost(getComponentBodies);
     host._selected = aht20;
 
     const firstNav = navigateToDep(host, "i2c");
     const secondNav = navigateToDep(host, "uart");
-    // First resolves AFTER second — late arrival must not stomp.
-    second.resolve(uart);
-    first.resolve(i2c);
+    batch.resolve({ i2c, uart });
     await Promise.all([firstNav, secondNav]);
 
     expect(host._selected).toBe(uart);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
   test("does nothing while a submit is in flight", async () => {
-    const getComponent = vi.fn();
+    const getComponentBodies = vi.fn();
     const filterByDomain = vi.fn();
-    const host = makeHost(getComponent, { filterByDomain });
+    const host = makeHost(getComponentBodies, { filterByDomain });
     host._submitting = true;
     const before = host._selected;
 
     await navigateToDep(host, "i2c");
 
-    expect(getComponent).not.toHaveBeenCalled();
+    expect(getComponentBodies).not.toHaveBeenCalled();
     expect(filterByDomain).not.toHaveBeenCalled();
     expect(host._selected).toBe(before);
   });

--- a/test/components/device/add-component-dialog-selection.test.ts
+++ b/test/components/device/add-component-dialog-selection.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  hydrateForSelection,
+  type SelectionHost,
+} from "../../../src/components/device/add-component-dialog-selection.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types.js";
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+
+function makeHost(
+  getComponentBodies: (...args: unknown[]) => unknown,
+  overrides: Partial<SelectionHost> = {}
+): SelectionHost {
+  return {
+    _api: { getComponentBodies } as unknown as ESPHomeAPI,
+    platform: "esp32",
+    board: { id: "apollo-esk-1" },
+    _selectionSeq: 0,
+    _localize: ((key: string) => key) as SelectionHost["_localize"],
+    ...overrides,
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("hydrateForSelection", () => {
+  const wifi = makeComponentEntry("wifi");
+
+  afterEach(() => _clearComponentCache());
+
+  test("returns ok with the full body on a successful fetch", async () => {
+    const getComponentBodies = vi.fn().mockResolvedValue({ wifi });
+    const host = makeHost(getComponentBodies);
+
+    const result = await hydrateForSelection(host, "wifi");
+
+    expect(result).toEqual({ kind: "ok", entry: wifi });
+  });
+
+  test("returns error when the catalog has no entry for the id", async () => {
+    const getComponentBodies = vi.fn().mockResolvedValue({});
+    const host = makeHost(getComponentBodies);
+
+    const result = await hydrateForSelection(host, "missing.id");
+
+    expect(result).toEqual({
+      kind: "error",
+      message: "device.add_component_error",
+    });
+  });
+
+  test("returns error with the thrown message on transport failure", async () => {
+    const getComponentBodies = vi.fn().mockRejectedValue(new Error("network down"));
+    const host = makeHost(getComponentBodies);
+
+    const result = await hydrateForSelection(host, "wifi");
+
+    expect(result).toEqual({ kind: "error", message: "network down" });
+  });
+
+  test("returns stale when the seq bumps before the response lands", async () => {
+    const d = deferred<Record<string, ComponentCatalogEntry>>();
+    const getComponentBodies = vi.fn().mockReturnValue(d.promise);
+    const host = makeHost(getComponentBodies);
+
+    const pending = hydrateForSelection(host, "wifi");
+    // Simulate the user clicking something else (or hitting back)
+    // before this response arrives.
+    host._selectionSeq++;
+    d.resolve({ wifi });
+
+    expect(await pending).toEqual({ kind: "stale" });
+  });
+
+  test("returns stale when the seq bumps before a transport failure surfaces", async () => {
+    // Pins the post-await race the prior `_hydrateBody` shape had:
+    // a rejected stale fetch must not surface as an error banner
+    // on the newer selection.
+    const d = deferred<Record<string, ComponentCatalogEntry>>();
+    const getComponentBodies = vi.fn().mockReturnValue(
+      d.promise.then(() => {
+        throw new Error("stale failure");
+      })
+    );
+    const host = makeHost(getComponentBodies);
+
+    const pending = hydrateForSelection(host, "wifi");
+    host._selectionSeq++;
+    d.resolve({});
+
+    expect(await pending).toEqual({ kind: "stale" });
+  });
+
+  test("honours an explicit boardId override over the host's current board", async () => {
+    const getComponentBodies = vi.fn().mockResolvedValue({ wifi });
+    const host = makeHost(getComponentBodies);
+
+    await hydrateForSelection(host, "wifi", "esp32-c3-devkitm-1");
+
+    expect(getComponentBodies).toHaveBeenCalledWith(
+      ["wifi"],
+      "esp32",
+      "esp32-c3-devkitm-1"
+    );
+  });
+});

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -22,17 +22,32 @@ const entry = (id: string, name: string): ComponentCatalogEntry =>
     config_entries: [],
   }) as ComponentCatalogEntry;
 
+interface MockApi {
+  api: ESPHomeAPI;
+  getComponentBodies: ReturnType<typeof vi.fn>;
+}
+
+/** Mock that mirrors the batched WS shape: `getComponentBodies(ids,
+ *  platform, boardId)` resolves a map of id → entry. `impl` returns
+ *  the entry for one id (or `null` for a miss); the mock plumbs that
+ *  across the requested ids and accepts an optional override promise
+ *  so tests can pin in-flight behaviour. */
 const mockApi = (
-  impl: (
-    id: string,
-    platform?: string,
-    boardId?: string
-  ) => Promise<ComponentCatalogEntry | null> | ComponentCatalogEntry | null
-): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
-  const getComponent = vi.fn((id: string, platform?: string, boardId?: string) =>
-    Promise.resolve(impl(id, platform, boardId))
+  impl: (id: string, platform?: string, boardId?: string) => ComponentCatalogEntry | null,
+  overridePromise?: () => Promise<Record<string, ComponentCatalogEntry>>
+): MockApi => {
+  const getComponentBodies = vi.fn(
+    (ids: string[], platform?: string, boardId?: string) => {
+      if (overridePromise) return overridePromise();
+      const result: Record<string, ComponentCatalogEntry> = {};
+      for (const id of ids) {
+        const e = impl(id, platform, boardId);
+        if (e !== null) result[id] = e;
+      }
+      return Promise.resolve(result);
+    }
   );
-  return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
+  return { api: { getComponentBodies } as unknown as ESPHomeAPI, getComponentBodies };
 };
 
 describe("component-name-cache", () => {
@@ -41,72 +56,101 @@ describe("component-name-cache", () => {
   });
 
   it("fetches uncached components and caches the result", async () => {
-    const { api, getComponent } = mockApi(() => entry("wifi", "WiFi"));
+    const { api, getComponentBodies } = mockApi(() => entry("wifi", "WiFi"));
 
     expect(getCachedComponent("wifi")).toBeUndefined();
     const got = await fetchComponent(api, "wifi");
 
     expect(got?.name).toBe("WiFi");
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
     expect(getCachedComponent("wifi")?.name).toBe("WiFi");
 
     // Second call hits the cache, no extra backend round-trip.
     await fetchComponent(api, "wifi");
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces parallel fetches into one batched call", async () => {
+    const { api, getComponentBodies } = mockApi((id) => entry(id, `name:${id}`));
+
+    const [a, b, c] = await Promise.all([
+      fetchComponent(api, "wifi"),
+      fetchComponent(api, "api"),
+      fetchComponent(api, "logger"),
+    ]);
+
+    expect(a?.name).toBe("name:wifi");
+    expect(b?.name).toBe("name:api");
+    expect(c?.name).toBe("name:logger");
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledWith(
+      ["wifi", "api", "logger"],
+      undefined,
+      undefined
+    );
   });
 
   it("dedupes concurrent in-flight calls for the same key", async () => {
-    let resolve!: (v: ComponentCatalogEntry) => void;
-    const { api, getComponent } = mockApi(
-      () => new Promise<ComponentCatalogEntry>((r) => (resolve = r))
+    let resolve!: (v: Record<string, ComponentCatalogEntry>) => void;
+    const { api, getComponentBodies } = mockApi(
+      () => null,
+      () => new Promise<Record<string, ComponentCatalogEntry>>((r) => (resolve = r))
     );
 
     const a = fetchComponent(api, "binary_sensor.gpio", "esp32");
     const b = fetchComponent(api, "binary_sensor.gpio", "esp32");
     const c = fetchComponent(api, "binary_sensor.gpio", "esp32");
 
-    expect(getComponent).toHaveBeenCalledTimes(1);
-    resolve(entry("binary_sensor.gpio", "GPIO Binary Sensor"));
+    // Give the microtask queue a chance to flush the batch.
+    await Promise.resolve();
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
+
+    resolve({ "binary_sensor.gpio": entry("binary_sensor.gpio", "GPIO Binary Sensor") });
 
     await expect(a).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
     await expect(b).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
     await expect(c).resolves.toMatchObject({ name: "GPIO Binary Sensor" });
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
-  it("keys cache entries by component id, platform, and board id", async () => {
-    const { api, getComponent } = mockApi((id, platform) =>
+  it("batches per (platform, boardId) context", async () => {
+    const { api, getComponentBodies } = mockApi((id, platform) =>
       entry(id, `${id}|${platform ?? ""}`)
     );
 
-    await fetchComponent(api, "sensor.dht", "esp32");
-    await fetchComponent(api, "sensor.dht", "esp8266");
-    await fetchComponent(api, "sensor.dht");
+    await Promise.all([
+      fetchComponent(api, "sensor.dht", "esp32"),
+      fetchComponent(api, "sensor.dht", "esp8266"),
+      fetchComponent(api, "sensor.dht"),
+    ]);
 
-    expect(getComponent).toHaveBeenCalledTimes(3);
+    expect(getComponentBodies).toHaveBeenCalledTimes(3);
     expect(getCachedComponent("sensor.dht", "esp32")?.name).toBe("sensor.dht|esp32");
     expect(getCachedComponent("sensor.dht", "esp8266")?.name).toBe("sensor.dht|esp8266");
     expect(getCachedComponent("sensor.dht")?.name).toBe("sensor.dht|");
   });
 
   it("caches null (catalog miss) so unknown ids aren't re-fetched", async () => {
-    const { api, getComponent } = mockApi(() => null);
+    const { api, getComponentBodies } = mockApi(() => null);
 
     const first = await fetchComponent(api, "nonsense.id");
     expect(first).toBeNull();
     expect(getCachedComponent("nonsense.id")).toBeNull();
 
     await fetchComponent(api, "nonsense.id");
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
   it("does not cache transport errors (allows retry)", async () => {
     let attempts = 0;
-    const { api } = mockApi(() => {
-      attempts++;
-      if (attempts === 1) return Promise.reject(new Error("network down"));
-      return entry("wifi", "WiFi");
-    });
+    const { api } = mockApi(
+      () => entry("wifi", "WiFi"),
+      () => {
+        attempts++;
+        if (attempts === 1) return Promise.reject(new Error("network down"));
+        return Promise.resolve({ wifi: entry("wifi", "WiFi") });
+      }
+    );
 
     await expect(fetchComponent(api, "wifi")).rejects.toThrow("network down");
     expect(getCachedComponent("wifi")).toBeUndefined();
@@ -137,13 +181,14 @@ describe("component-name-cache", () => {
     errSpy.mockRestore();
   });
 
-  it("notifies subscribers exactly once per fresh entry", async () => {
+  it("notifies subscribers once per flushed batch", async () => {
     const listener = vi.fn();
     const unsubscribe = subscribeComponentCache(listener);
 
-    const { api } = mockApi(() => entry("api", "API"));
-    await fetchComponent(api, "api");
+    const { api } = mockApi((id) => entry(id, id));
+    await Promise.all([fetchComponent(api, "api"), fetchComponent(api, "wifi")]);
 
+    // One batched flush → one notify, not one per id.
     expect(listener).toHaveBeenCalledTimes(1);
 
     // Cached read shouldn't notify again.

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -113,6 +113,21 @@ describe("component-name-cache", () => {
     expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects pending bucket waiters when the cache is cleared mid-flight", async () => {
+    // Tests that call _clearComponentCache while a fetch is still
+    // pending would otherwise hang on the dangling promise; the
+    // cleanup path must settle every waiter explicitly.
+    const { api } = mockApi(
+      () => null,
+      () => new Promise<Record<string, ComponentCatalogEntry>>(() => {})
+    );
+
+    const pending = fetchComponent(api, "wifi");
+    _clearComponentCache();
+
+    await expect(pending).rejects.toThrow("component cache cleared");
+  });
+
   it("does not resolve prototype keys as cache hits", async () => {
     // Reachable from yaml-completion when the user types a key
     // whose name shadows an Object.prototype member (`toString`,

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -113,6 +113,18 @@ describe("component-name-cache", () => {
     expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
+  it("does not resolve prototype keys as cache hits", async () => {
+    // Reachable from yaml-completion when the user types a key
+    // whose name shadows an Object.prototype member (`toString`,
+    // `constructor`, etc.). A bare `entries[id]` lookup would
+    // resolve to the inherited function and cache it forever.
+    const { api } = mockApi(() => null);
+
+    const result = await fetchComponent(api, "toString");
+    expect(result).toBeNull();
+    expect(getCachedComponent("toString")).toBeNull();
+  });
+
   it("dedupes a same-id fetch that arrives after the batch has flushed", async () => {
     // After the microtask flush, a same-id call must join the
     // pending in-flight promise instead of triggering a second

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -113,6 +113,29 @@ describe("component-name-cache", () => {
     expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 
+  it("dedupes a same-id fetch that arrives after the batch has flushed", async () => {
+    // After the microtask flush, a same-id call must join the
+    // pending in-flight promise instead of triggering a second
+    // batch. Closes the "between flush and response" race window.
+    let resolve!: (v: Record<string, ComponentCatalogEntry>) => void;
+    const { api, getComponentBodies } = mockApi(
+      () => null,
+      () => new Promise<Record<string, ComponentCatalogEntry>>((r) => (resolve = r))
+    );
+
+    const a = fetchComponent(api, "wifi");
+    // Drain the microtask queue so the batch has flushed (api call started).
+    await Promise.resolve();
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
+
+    const b = fetchComponent(api, "wifi");
+    resolve({ wifi: entry("wifi", "WiFi") });
+
+    await expect(a).resolves.toMatchObject({ name: "WiFi" });
+    await expect(b).resolves.toMatchObject({ name: "WiFi" });
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
+  });
+
   it("batches per (platform, boardId) context", async () => {
     const { api, getComponentBodies } = mockApi((id, platform) =>
       entry(id, `${id}|${platform ?? ""}`)

--- a/test/util/component-name-resolver-controller.test.ts
+++ b/test/util/component-name-resolver-controller.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../src/api/types.js";
-import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import {
+  _clearComponentCache,
+  fetchComponent,
+} from "../../src/util/component-name-cache.js";
 import { ComponentNameResolverController } from "../../src/util/component-name-resolver-controller.js";
 
 const entry = (id: string, name: string): ComponentCatalogEntry =>
@@ -107,8 +110,14 @@ describe("ComponentNameResolverController", () => {
     disconnect();
     requestUpdate.mockClear();
     // Unsubscribed; a new cache write should not bump the host.
+    // Routes through ``fetchComponent`` so the cache actually
+    // populates and ``_notify()`` fires — calling
+    // ``api.getComponentBodies`` directly bypasses the cache layer
+    // and the assertion passes trivially without exercising
+    // anything. Uses a fresh id so the new fetch doesn't
+    // short-circuit on an already-cached entry.
     const { api: api2 } = mockApi((id) => entry(id, "Logger"));
-    await api2.getComponentBodies(["logger"]);
+    await fetchComponent(api2, "logger");
     expect(requestUpdate).not.toHaveBeenCalled();
   });
 

--- a/test/util/component-name-resolver-controller.test.ts
+++ b/test/util/component-name-resolver-controller.test.ts
@@ -43,9 +43,16 @@ const stubHost = () => {
 
 const mockApi = (
   impl: (id: string) => ComponentCatalogEntry | null
-): { api: ESPHomeAPI; getComponent: ReturnType<typeof vi.fn> } => {
-  const getComponent = vi.fn((id: string) => Promise.resolve(impl(id)));
-  return { api: { getComponent } as unknown as ESPHomeAPI, getComponent };
+): { api: ESPHomeAPI; getComponentBodies: ReturnType<typeof vi.fn> } => {
+  const getComponentBodies = vi.fn((ids: string[]) => {
+    const result: Record<string, ComponentCatalogEntry> = {};
+    for (const id of ids) {
+      const e = impl(id);
+      if (e !== null) result[id] = e;
+    }
+    return Promise.resolve(result);
+  });
+  return { api: { getComponentBodies } as unknown as ESPHomeAPI, getComponentBodies };
 };
 
 describe("ComponentNameResolverController", () => {
@@ -99,9 +106,9 @@ describe("ComponentNameResolverController", () => {
 
     disconnect();
     requestUpdate.mockClear();
-    // Unsubscribed — a new cache write should not bump the host.
+    // Unsubscribed; a new cache write should not bump the host.
     const { api: api2 } = mockApi((id) => entry(id, "Logger"));
-    await api2.getComponent("logger");
+    await api2.getComponentBodies(["logger"]);
     expect(requestUpdate).not.toHaveBeenCalled();
   });
 
@@ -118,7 +125,7 @@ describe("ComponentNameResolverController", () => {
 
   it("does not re-fetch ids already present in the cache", async () => {
     const { host, connect } = stubHost();
-    const { api, getComponent } = mockApi((id) => entry(id, "Cached"));
+    const { api, getComponentBodies } = mockApi((id) => entry(id, "Cached"));
     const ctl = new ComponentNameResolverController(
       host,
       () => api,
@@ -129,10 +136,10 @@ describe("ComponentNameResolverController", () => {
     ctl.kickoff(["spi"]);
     await Promise.resolve();
     await Promise.resolve();
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
 
     ctl.kickoff(["spi"]);
     await Promise.resolve();
-    expect(getComponent).toHaveBeenCalledTimes(1);
+    expect(getComponentBodies).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Routes every component-body lookup through one cached, microtask-batched path.

The device navigator and yaml-completion previously fired one `components/get_component` WS call per id; an N-component device paid N round trips on mount. `component-name-cache` now queues every `fetchComponent` into a microtask-flushed bucket, keyed on `(platform, boardId)`, and dispatches them as one `components/get_component_bodies` request. Same-id concurrent calls coalesce: requests in the same microtask share one bucket entry; a request landing after the bucket has flushed but before the response arrives joins the in-flight promise instead of starting a second batch.

The legacy `ESPHomeAPI.getComponent` method and its two direct callers (`add-component-dialog.ts` featured-bundle pick and bundle-step prefetch; `add-component-dialog-dep-nav.ts` dep retarget) are gone; everything goes through `fetchComponent` now, picking up the cache + in-flight coalescing for free.

Listener notifications fire once per flushed batch instead of once per id; the cache contract (null cached, transport errors not cached) is unchanged.

Pairs with the backend rework on esphome/device-builder#939.

**Related issue or feature (if applicable):**

- pairs with esphome/device-builder#939

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (1370 tests).
- [x] Tests have been added to pin the batch + in-flight coalescing contract.