### PR TITLE
Validate Wi-Fi password is at least 8 characters in onboarding

### DIFF
--- a/src/components/device/password-input.ts
+++ b/src/components/device/password-input.ts
@@ -76,6 +76,15 @@ export class ESPHomePasswordInput extends LitElement {
   @property()
   label = "";
 
+  /** Optional ``aria-describedby`` forwarded to the inner ``<input>``.
+   *  The error/help text it points at lives in the consumer's shadow
+   *  root, not this one, so the consumer owns the id; we only relay
+   *  it onto the real focusable control. Default empty (no
+   *  ``aria-describedby`` attribute) so existing call sites are
+   *  unchanged. */
+  @property()
+  describedby = "";
+
   @state()
   private _revealed = false;
 
@@ -150,6 +159,8 @@ export class ESPHomePasswordInput extends LitElement {
           autocomplete="off"
           maxlength=${this.maxlength > 0 ? this.maxlength : nothing}
           aria-label=${this.label || nothing}
+          aria-invalid=${this.invalid ? "true" : nothing}
+          aria-describedby=${this.describedby || nothing}
           @input=${this._onInput}
         />
         <button

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -64,6 +64,15 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
+  // WPA/WPA2 passphrases are 8-63 characters; the maxlength=64 cap
+  // covers the 64-hex-digit PSK form. An empty password is a valid
+  // open network (the placeholder invites it), so only a non-empty
+  // value shorter than 8 is rejected. Whitespace is significant in
+  // a passphrase, so the length is taken from the raw value.
+  private get _passwordTooShort(): boolean {
+    return this._password.length > 0 && this._password.length < 8;
+  }
+
   /** True after the user has explicitly saved or declined inside
    *  the current open() — suppresses the close-via-X session-
    *  dismiss path so we don't both ``mark_acknowledged`` AND fire
@@ -212,6 +221,11 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
                 this._password = e.detail.value;
               }}
             ></esphome-password-input>
+            ${this._passwordTooShort
+              ? html`<p class="error" role="alert">
+                  ${this._localize("onboarding.wifi.password_too_short")}
+                </p>`
+              : nothing}
           </div>
           ${this._error
             ? html`<p class="error" role="alert">${this._error}</p>`
@@ -238,7 +252,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
           <button
             type="button"
             class="btn btn--primary"
-            ?disabled=${this._saving || !this._ssid.trim()}
+            ?disabled=${this._saving || !this._ssid.trim() || this._passwordTooShort}
             @click=${this._save}
           >
             ${this._saving
@@ -257,7 +271,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     // the device would fail to associate. The Save button is
     // already disabled on all-whitespace input via the same
     // check below.
-    if (!this._ssid.trim()) return;
+    if (!this._ssid.trim() || this._passwordTooShort) return;
     this._saving = true;
     this._error = null;
     try {

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -216,13 +216,15 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               .placeholder=${this._localize("onboarding.wifi.password_placeholder")}
               .maxlength=${64}
               .label=${this._localize("onboarding.wifi.password_label")}
+              .invalid=${this._passwordTooShort}
+              .describedby=${this._passwordTooShort ? "onboarding-password-error" : ""}
               ?disabled=${this._saving}
               @password-input-change=${(e: CustomEvent<PasswordInputValueChange>) => {
                 this._password = e.detail.value;
               }}
             ></esphome-password-input>
             ${this._passwordTooShort
-              ? html`<p class="error" role="alert">
+              ? html`<p id="onboarding-password-error" class="error" role="alert">
                   ${this._localize("onboarding.wifi.password_too_short")}
                 </p>`
               : nothing}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -818,6 +818,7 @@
       "ssid_placeholder": "MyHomeWifi",
       "password_label": "Wi-Fi password",
       "password_placeholder": "Leave blank for an open network",
+      "password_too_short": "Wi-Fi password must be at least 8 characters",
       "save": "Save credentials",
       "saving": "Saving…",
       "save_success": "Wi-Fi credentials saved",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -697,6 +697,7 @@
       "ssid_placeholder": "MonWifiMaison",
       "password_label": "Mot de passe Wi-Fi",
       "password_placeholder": "Laisser vide pour un réseau ouvert",
+      "password_too_short": "Le mot de passe Wi-Fi doit comporter au moins 8 caractères",
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "save_success": "Identifiants Wi-Fi enregistrés",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -810,6 +810,7 @@
       "ssid_placeholder": "OtthoniWifi",
       "password_label": "Wi-Fi jelszó",
       "password_placeholder": "Hagyja üresen nyílt hálózat esetén",
+      "password_too_short": "A Wi-Fi jelszónak legalább 8 karakterből kell állnia",
       "save": "Hitelesítő adatok mentése",
       "saving": "Mentés…",
       "save_success": "Wi-Fi hitelesítő adatok mentve",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -697,6 +697,7 @@
       "ssid_placeholder": "MijnThuisWifi",
       "password_label": "Wi-Fi-wachtwoord",
       "password_placeholder": "Laat leeg voor een open netwerk",
+      "password_too_short": "Wi-Fi-wachtwoord moet minstens 8 tekens bevatten",
       "save": "Opslaan",
       "saving": "Bezig met opslaan…",
       "save_success": "Wi-Fi-inloggegevens opgeslagen",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -818,6 +818,7 @@
       "ssid_placeholder": "MyHomeWifi",
       "password_label": "Wi-Fi 密码",
       "password_placeholder": "开放网络请留空",
+      "password_too_short": "Wi-Fi 密码至少需要 8 个字符",
       "save": "保存凭据",
       "saving": "保存中…",
       "save_success": "Wi-Fi 凭据已保存",

--- a/test/components/onboarding-wifi-dialog.test.ts
+++ b/test/components/onboarding-wifi-dialog.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { describe, expect, test, vi } from "vitest";
+
+import { ESPHomeOnboardingWifiDialog } from "../../src/components/onboarding-wifi-dialog.js";
+
+/**
+ * Regression coverage for the WPA password-length gate (fixes #425).
+ *
+ * The bug was a boundary one: the dialog accepted passwords 1-7 chars
+ * long, which no WPA/WPA2 device can associate to, while an empty
+ * password is a legitimate open network. ``_passwordTooShort`` is the
+ * single predicate behind the Save button's ``disabled`` state, the
+ * inline error, and the ``_save`` guard, so pinning it across the
+ * boundary locks the behavior in all three places at once.
+ */
+
+interface DialogPrivateView extends EventTarget {
+  _ssid: string;
+  _password: string;
+  _api: { setOnboardingWifi: (ssid: string, password: string) => Promise<unknown> };
+  readonly _passwordTooShort: boolean;
+  _save(): Promise<void>;
+}
+
+function makeDialog(): DialogPrivateView {
+  return new ESPHomeOnboardingWifiDialog() as unknown as DialogPrivateView;
+}
+
+describe("onboarding-wifi-dialog password-length gate", () => {
+  test("empty password is allowed (open network)", () => {
+    const dialog = makeDialog();
+    dialog._password = "";
+    expect(dialog._passwordTooShort).toBe(false);
+  });
+
+  test("1-7 char passwords are rejected", () => {
+    const dialog = makeDialog();
+    for (const pw of ["a", "1234567"]) {
+      dialog._password = pw;
+      expect(dialog._passwordTooShort).toBe(true);
+    }
+  });
+
+  test("8-char password is the first accepted length", () => {
+    const dialog = makeDialog();
+    dialog._password = "1234567"; // 7 — rejected
+    expect(dialog._passwordTooShort).toBe(true);
+    dialog._password = "12345678"; // 8 — the WPA minimum, accepted
+    expect(dialog._passwordTooShort).toBe(false);
+  });
+
+  test("whitespace counts toward the length (passphrases keep it)", () => {
+    const dialog = makeDialog();
+    dialog._password = "       "; // 7 spaces — still too short
+    expect(dialog._passwordTooShort).toBe(true);
+    dialog._password = "        "; // 8 spaces — accepted
+    expect(dialog._passwordTooShort).toBe(false);
+  });
+
+  test("_save bails out before hitting the API on a too-short password", async () => {
+    const dialog = makeDialog();
+    const setOnboardingWifi = vi.fn().mockResolvedValue(undefined);
+    dialog._api = { setOnboardingWifi };
+    dialog._ssid = "MyNetwork";
+    dialog._password = "1234567"; // 7 chars
+
+    await dialog._save();
+
+    expect(setOnboardingWifi).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The Wi-Fi onboarding dialog accepted passwords shorter than the WPA minimum of 8 characters, so a user could save credentials that no device could associate with. The Save button is now disabled and an inline message is shown when the password is 1 to 7 characters long; an empty password is still allowed for open networks, and the message is localized across all shipped locales.

**Related issue or feature (if applicable):**

- fixes #425

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
