### PR TITLE
Fix Visual Editor dropping values for map keys containing a dot

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -30,6 +30,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { type ValidationError } from "../../util/config-validation.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
+import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
@@ -212,8 +213,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * the value/selected wiring through Lit's template doesn't always
    * land — especially on the first paint, when wa-select reads its
    * value before the slotted options are connected. Each field div
-   * carries a `data-field-key` (the dotted path) so we can look up
-   * the right value for its select.
+   * carries a `data-field-key` (the JSON-encoded path) so we can look
+   * up the right value for its select. Encoding the path as JSON
+   * rather than a dotted string keeps user-supplied map keys that
+   * contain a dot (a `logger.logs` row keyed `i2c.idf`) intact.
    *
    * We wait for each select's `updateComplete` (and one frame after
    * that) to make sure wa-select's own first-render bookkeeping —
@@ -271,7 +274,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       }
       const key = field.getAttribute("data-field-key");
       if (!key) continue;
-      const path = key.split(".");
+      const path = parseFieldKey(key);
       const value = getIn(this.values, path);
       // ``wa-select`` only carries primitive values; if the YAML
       // path resolves to an object (transient state from a partial
@@ -483,7 +486,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         // be edited via the automation editor tree, not as a form
         // field. Render a disabled placeholder so the user is told
         // why the field is inert.
-        return html`<div class="field" data-field-key=${path.join(".")}>
+        return html`<div class="field" data-field-key=${fieldKeyAttr(path)}>
           ${labelFor(entry, ctx)}
           <p class="trigger-placeholder" role="status">
             ${ctx.localize("device.automation_trigger_field_placeholder")}

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -10,6 +10,7 @@ import type { ConfigEntry } from "../../api/types.js";
 import { findReferencedComponents } from "../../util/config-entry-yaml-scan.js";
 import {
   effectiveDisabled,
+  fieldKeyAttr,
   renderFieldError,
   renderLabel,
   renderYamlOnlyFallbackIfNonPrimitive,
@@ -65,7 +66,7 @@ export function renderIdReferenceField(
 
   if (empty) {
     return html`
-      <div class="field" data-field-key=${path.join(".")}>
+      <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <wa-select
           class=${invalid ? "invalid" : ""}
@@ -81,7 +82,7 @@ export function renderIdReferenceField(
   }
 
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <wa-select
         class=${invalid ? "invalid" : ""}

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -12,6 +12,7 @@ import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import {
   effectiveDisabled,
+  fieldKeyAttr,
   renderFieldError,
   renderLabel,
   renderStringField,
@@ -186,7 +187,7 @@ export function renderPinField(
   };
 
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <wa-select
         data-no-value-sync

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -41,6 +41,24 @@ export function effectiveDisabled(entry: ConfigEntry, ctx: RenderCtx): boolean {
   return ctx.disabled || entry.locked;
 }
 
+/** Serialize a field path into the ``data-field-key`` attribute. JSON
+ *  (not ``path.join(".")``) so a user-supplied map key that itself
+ *  contains a dot (a ``logger.logs`` row keyed ``i2c.idf``) survives
+ *  the round-trip back to a path in ``parseFieldKey``. */
+export const fieldKeyAttr = (path: string[]): string => JSON.stringify(path);
+
+/** Recover a field path from a ``data-field-key`` attribute. Non-JSON
+ *  values (the pin-advanced toggle key) fall back to dot-splitting. */
+export const parseFieldKey = (attr: string): string[] => {
+  try {
+    const parsed: unknown = JSON.parse(attr);
+    if (Array.isArray(parsed)) return parsed.map(String);
+  } catch {
+    // not JSON — legacy / non-path attribute, fall through
+  }
+  return attr ? attr.split(".") : [];
+};
+
 /** ESPHome stores secret references as `!secret <key>` literal strings
  *  in the YAML — match that shape so any string-shaped field can flag
  *  values that point at the secrets store. */
@@ -223,7 +241,7 @@ export function renderFieldShell(
   trailing: unknown = nothing
 ) {
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${input} ${trailing} ${renderFieldError(path, ctx)}
     </div>
   `;
@@ -280,7 +298,7 @@ export function renderStringField(
   // means the form's re-renders don't blow it away.
   if (inputType === "password") {
     return html`
-      <div class="field" data-field-key=${path.join(".")}>
+      <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <esphome-password-input
           .value=${value}
@@ -295,7 +313,7 @@ export function renderStringField(
     `;
   }
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <input
         type=${inputType}
@@ -340,7 +358,7 @@ function renderSuggestionSelect(
     return Number.isFinite(n) ? n : raw;
   };
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <wa-select
         class=${invalid ? "invalid" : ""}

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -262,7 +262,7 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
 ) {
   if (isPrimitiveOrNullish(raw)) return null;
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <p class="field-description">${ctx.localize("device.value_yaml_only")}</p>
       ${renderFieldError(path, ctx)}

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -4,6 +4,7 @@ import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
+  fieldKeyAttr,
   labelFor,
   renderFieldError,
   renderLabel,
@@ -92,7 +93,7 @@ export function renderMultiValueField(
   };
 
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map(
         (item, i) => html`
@@ -211,7 +212,7 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
   };
 
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       ${keys.length === 0
         ? html`<p class="field-description">${ctx.localize("device.map_empty")}</p>`
@@ -248,7 +249,7 @@ export function renderNestedListField(
   const raw = ctx.getAt(path);
   if (raw instanceof YamlRawValue) {
     return html`
-      <div class="nested-list" data-field-key=${path.join(".")}>
+      <div class="nested-list" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <p class="field-description">${ctx.localize("device.multi_value_yaml_only")}</p>
         ${renderFieldError(path, ctx)}
@@ -263,13 +264,13 @@ export function renderNestedListField(
   const childrenSchema = entry.config_entries ?? [];
 
   return html`
-    <div class="nested-list" data-field-key=${path.join(".")}>
+    <div class="nested-list" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${renderListEmptyHint(items, ctx)}
       ${items.map((item, i) => {
         const itemPath = [...path, String(i)];
         const renderableChildren = ctx.filterRenderable(childrenSchema, item);
         return html`
-          <div class="nested-list-item" data-field-key=${itemPath.join(".")}>
+          <div class="nested-list-item" data-field-key=${fieldKeyAttr(itemPath)}>
             <div class="nested-list-item-header">
               <span class="nested-list-item-title"> ${itemTitle} ${i + 1} </span>
               ${renderListRemoveButton(ctx, disabled, () => removeAt(i))}

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import {
+  fieldKeyAttr,
   labelFor,
   renderHelpLink,
   type RenderCtx,
@@ -19,7 +20,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
     ctx.scopeValues(path)
   );
   return html`
-    <div class="nested-group" data-field-key=${path.join(".")}>
+    <div class="nested-group" data-field-key=${fieldKeyAttr(path)}>
       <div class="nested-header">
         <button
           type="button"

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -12,6 +12,7 @@ import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
+  fieldKeyAttr,
   renderFieldError,
   renderFieldShell,
   renderHelpLink,
@@ -211,7 +212,7 @@ export function renderTimePeriodField(
         ? defaultParsed.unit
         : parsed.unit;
   return html`
-    <div class="field time-period" data-field-key=${path.join(".")}>
+    <div class="field time-period" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <div class="time-period-inputs">
         <input
@@ -284,7 +285,7 @@ export function renderFloatWithUnitField(
   const emit = (next: { value: number | null; unit: string }) =>
     ctx.emitChange(path, serializeFloatWithUnit(next));
   return html`
-    <div class="field float-with-unit" data-field-key=${path.join(".")}>
+    <div class="field float-with-unit" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <div class="float-with-unit-inputs">
         <input
@@ -357,7 +358,7 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
   const effective = raw === undefined || raw === null ? entry.default_value : raw;
   const checked = parseYamlBoolean(effective) === true;
   return html`
-    <div class="switch-field" data-field-key=${path.join(".")}>
+    <div class="switch-field" data-field-key=${fieldKeyAttr(path)}>
       <div class="field-info">${renderLabel(entry, ctx, { includeHelpLink: false })}</div>
       ${renderHelpLink(entry, ctx)}
       <wa-switch
@@ -385,7 +386,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.suggestions && entry.suggestions.length > 0) {
     const valueLower = value.toLowerCase();
     return html`
-      <div class="field" data-field-key=${path.join(".")}>
+      <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <wa-select
           class=${invalid ? "invalid" : ""}
@@ -408,7 +409,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.allow_custom_value && entry.options && entry.options.length > 0) {
     const listId = `combobox-${path.join("-")}`;
     return html`
-      <div class="field" data-field-key=${path.join(".")}>
+      <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <input
           type="text"
@@ -439,7 +440,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   );
   const placeholder = defaultOption?.label ?? defaultStr;
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <wa-select
         class=${invalid ? "invalid" : ""}
@@ -479,7 +480,7 @@ export function renderTextareaField(entry: ConfigEntry, path: string[], ctx: Ren
   const value = isRaw ? raw.body : String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <textarea
         class="textarea-field ${invalid ? "invalid" : ""}"
@@ -504,7 +505,7 @@ export function renderIconField(entry: ConfigEntry, path: string[], ctx: RenderC
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   return html`
-    <div class="field" data-field-key=${path.join(".")}>
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <esphome-mdi-icon-picker
         .value=${value}

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -36,6 +36,7 @@ import {
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
+  fieldKeyAttr,
   fieldRendererStyles,
   renderFieldError,
   renderLabel,
@@ -346,7 +347,7 @@ export class ESPHomeRegistryList extends LitElement {
       // catalog values surface instead of silently substituting a
       // stand-in catalog.
       return html`
-        <div class="field" data-field-key=${this.path.join(".")}>
+        <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
           ${renderLabel(this.entry, this.ctx)}
           <p class="registry-list-fallback">
             ${this.ctx.localize("device.registry_list_unsupported")}
@@ -363,7 +364,7 @@ export class ESPHomeRegistryList extends LitElement {
     // YAML-only notice instead, same pattern as renderNestedListField.
     if (raw instanceof YamlRawValue || (raw !== undefined && !Array.isArray(raw))) {
       return html`
-        <div class="field" data-field-key=${this.path.join(".")}>
+        <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
           ${renderLabel(this.entry, this.ctx)}
           <p class="field-description">
             ${this.ctx.localize("device.multi_value_yaml_only")}
@@ -429,7 +430,7 @@ export class ESPHomeRegistryList extends LitElement {
     // leaving the row stuck.
     const addDisabled = disabled || catalog.length === 0;
     return html`
-      <div class="field" data-field-key=${this.path.join(".")}>
+      <div class="field" data-field-key=${fieldKeyAttr(this.path)}>
         ${renderLabel(this.entry, this.ctx)} ${renderListEmptyHint(items, this.ctx)}
         ${statusHint}
         ${items.map((item, i) =>

--- a/src/components/device/config-entry-renderers/templatable.ts
+++ b/src/components/device/config-entry-renderers/templatable.ts
@@ -22,7 +22,7 @@
 import { html } from "lit";
 import type { ConfigEntry } from "../../../api/types.js";
 import { isLambdaValue } from "../../../api/types.js";
-import type { RenderCtx } from "../config-entry-renderers-shared.js";
+import { fieldKeyAttr, type RenderCtx } from "../config-entry-renderers-shared.js";
 import { renderLambdaField } from "./lambda.js";
 
 interface StashEntry {
@@ -76,7 +76,7 @@ export function renderTemplatableField(
   const raw = ctx.getAt(path);
   const isLambda = isLambdaValue(raw);
   const stash = stashFor(ctx, path);
-  const fieldKey = path.join(".");
+  const fieldKey = fieldKeyAttr(path);
 
   const switchTo = (toLambda: boolean) => {
     if (toLambda === isLambda) return;

--- a/test/components/device/config-entry-form-map-sync.test.ts
+++ b/test/components/device/config-entry-form-map-sync.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression guard for the dotted-map-key bug (#1005) at the form's
+ * value-sync seam. ``_syncSelectValues`` recovers a field's path from
+ * its ``data-field-key`` with ``parseFieldKey``; this pins the other
+ * half — the MAP renderer emits a ``data-field-key`` for a row keyed
+ * ``i2c.idf`` that ``parseFieldKey`` decodes back to the dotted path,
+ * so the value lookup hits instead of over-segmenting into
+ * ``["logs","i2c","idf"]`` and blanking the select.
+ *
+ * Node env (no DOM): wa-select can't mount under happy-dom (its
+ * form-associated base reads ``ElementInternals.validity``), so we
+ * walk the ``TemplateResult`` the renderers produce rather than a
+ * shadow root.
+ */
+import { describe, expect, it } from "vitest";
+import { ConfigEntryType } from "../../../src/api/types.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import {
+  renderMapField,
+  renderSelectField,
+} from "../../../src/components/device/config-entry-renderers.js";
+import {
+  parseFieldKey,
+  type RenderCtx,
+} from "../../../src/components/device/config-entry-renderers-shared.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+
+const LOG_LEVELS = ["NONE", "ERROR", "WARN", "INFO", "DEBUG", "VERBOSE"].map((v) => ({
+  value: v,
+  label: v,
+}));
+
+const logsEntry = () =>
+  makeConfigEntry({
+    key: "logs",
+    type: ConfigEntryType.MAP,
+    config_entries: [
+      makeConfigEntry({
+        key: "value",
+        type: ConfigEntryType.STRING,
+        options: LOG_LEVELS,
+      }),
+    ],
+  });
+
+/** Render the logger ``logs`` map for *values* with the value template
+ *  routed through the real select renderer, and return every
+ *  ``data-field-key`` decoded back to a path. */
+function renderedFieldPaths(values: Record<string, unknown>): string[][] {
+  let ctx: RenderCtx;
+  ctx = makeRenderCtx(values, {
+    overrides: { renderEntry: (entry, path) => renderSelectField(entry, path, ctx) },
+  });
+  const result = renderMapField(logsEntry(), ["logs"], ctx);
+  return findElementBindings(result, "div")
+    .map((b) => b["data-field-key"])
+    .filter((k): k is string => typeof k === "string")
+    .map(parseFieldKey);
+}
+
+describe("logger.logs MAP renders a recoverable field path for dotted keys", () => {
+  it("emits a data-field-key that decodes back to the dotted path", () => {
+    expect(renderedFieldPaths({ logs: { "i2c.idf": "DEBUG" } })).toContainEqual([
+      "logs",
+      "i2c.idf",
+    ]);
+  });
+
+  it("does not over-segment the dotted key into separate path levels", () => {
+    expect(renderedFieldPaths({ logs: { "i2c.idf": "DEBUG" } })).not.toContainEqual([
+      "logs",
+      "i2c",
+      "idf",
+    ]);
+  });
+
+  it("still encodes a plain (dotless) key as its own path", () => {
+    expect(renderedFieldPaths({ logs: { wifi: "WARN" } })).toContainEqual([
+      "logs",
+      "wifi",
+    ]);
+  });
+});

--- a/test/components/device/field-key-codec.test.ts
+++ b/test/components/device/field-key-codec.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Pins the ``data-field-key`` round-trip used by the config form's
+ * post-render ``<wa-select>`` value sync. The path is JSON-encoded so a
+ * user-supplied map key that contains a dot (``logger.logs`` row
+ * ``i2c.idf``) survives back into a path; a dotted join+split would
+ * over-segment it and blank the select.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  fieldKeyAttr,
+  parseFieldKey,
+} from "../../../src/components/device/config-entry-renderers-shared.js";
+
+describe("fieldKeyAttr / parseFieldKey", () => {
+  it("round-trips a map key that contains a dot", () => {
+    expect(parseFieldKey(fieldKeyAttr(["logs", "i2c.idf"]))).toEqual(["logs", "i2c.idf"]);
+  });
+
+  it("round-trips a plain nested path", () => {
+    expect(parseFieldKey(fieldKeyAttr(["api", "encryption", "key"]))).toEqual([
+      "api",
+      "encryption",
+      "key",
+    ]);
+  });
+
+  it("returns list-index segments as strings", () => {
+    expect(parseFieldKey(fieldKeyAttr(["esphome", "devices", "0", "name"]))).toEqual([
+      "esphome",
+      "devices",
+      "0",
+      "name",
+    ]);
+  });
+
+  it("falls back to dot-splitting for a non-JSON attribute", () => {
+    expect(parseFieldKey("a.b.c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps a non-path UI-state key intact (pin-advanced toggle)", () => {
+    expect(parseFieldKey("pin:pin-advanced")).toEqual(["pin:pin-advanced"]);
+  });
+
+  it("returns an empty path for an empty attribute", () => {
+    expect(parseFieldKey("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In the Visual Editor, a logger `logs:` row keyed with a dot (for example `i2c.idf`) lost its level in the dropdown even though the value was written to YAML; a dotted key set in the YAML editor also did not show up in the Visual Editor.

The post-render `<wa-select>` value sync rebuilt a field's path from its `data-field-key` with `key.split(".")`, while the renderers built that attribute with `path.join(".")`. The round-trip over-segmented any path whose segment is a user-supplied map key that itself contains a dot, so the value lookup missed and the select was blanked. The fix encodes the path as JSON in `data-field-key` and decodes it back, with a dot-split fallback for the non-path pin-advanced toggle key.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1005

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
