### PR TITLE
Add enable toggle for optional entity sub-readings

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -112,6 +112,10 @@ export const configEntryFormStyles = css`
     gap: var(--wa-space-2xs);
   }
 
+  .nested-enable {
+    flex-shrink: 0;
+  }
+
   .nested-toggle {
     display: flex;
     flex: 1;

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -1,7 +1,9 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types.js";
 import { renderMarkdown } from "../../../util/markdown.js";
+import { hasSerializableValue } from "../../../util/yaml-serialize.js";
 import {
+  effectiveDisabled,
   labelFor,
   renderHelpLink,
   type RenderCtx,
@@ -18,9 +20,37 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
     entry.config_entries ?? [],
     ctx.scopeValues(path)
   );
+  // Optional entity sub-readings (a debug component's per-metric sensors,
+  // a DHT's temperature/humidity, …) are only written to YAML once their
+  // group holds a value, so an untouched one is silently "off". Give those
+  // an explicit enable switch; plain nested forms (platform_type === null)
+  // and required groups keep the bare collapsible header.
+  const isOptionalEntity = entry.platform_type != null && !entry.required;
+  const enabled = isOptionalEntity && hasSerializableValue(ctx.getAt(path));
+  const label = labelFor(entry, ctx);
+  const enableLabel = ctx.localize("device.enable_entity", { name: label });
   return html`
     <div class="nested-group" data-field-key=${path.join(".")}>
       <div class="nested-header">
+        ${isOptionalEntity
+          ? html`<wa-switch
+              class="nested-enable"
+              .checked=${enabled}
+              ?disabled=${effectiveDisabled(entry, ctx)}
+              aria-label=${enableLabel}
+              title=${enableLabel}
+              @click=${(e: Event) => e.stopPropagation()}
+              @change=${(e: Event) =>
+                _onEnableToggle(
+                  path,
+                  key,
+                  isOpen,
+                  (e.target as HTMLInputElement & { checked: boolean }).checked,
+                  label,
+                  ctx
+                )}
+            ></wa-switch>`
+          : nothing}
         <button
           type="button"
           class="nested-toggle"
@@ -28,7 +58,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
           @click=${() => ctx.toggleNested(key)}
         >
           <wa-icon library="mdi" name=${isOpen ? "chevron-up" : "chevron-down"}></wa-icon>
-          <span class="nested-title">${labelFor(entry, ctx)}</span>
+          <span class="nested-title">${label}</span>
           ${entry.platform_type
             ? html`<span class="nested-platform">${entry.platform_type}</span>`
             : nothing}
@@ -47,4 +77,25 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
         : nothing}
     </div>
   `;
+}
+
+// Enabling seeds the entity's name (its label, editable) so the group
+// becomes non-empty and serializes, then expands it for editing.
+// Disabling clears the whole group — the serializer prunes the empty
+// object so the block leaves the YAML — and collapses it.
+function _onEnableToggle(
+  path: string[],
+  key: string,
+  isOpen: boolean,
+  checked: boolean,
+  label: string,
+  ctx: RenderCtx
+): void {
+  if (checked) {
+    ctx.emitChange([...path, "name"], label);
+    if (!isOpen) ctx.toggleNested(key);
+  } else {
+    ctx.emitChange(path, undefined);
+    if (isOpen) ctx.toggleNested(key);
+  }
 }

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -113,11 +113,10 @@ export function onEnableToggle(
   ctx: RenderCtx
 ): void {
   const stash = _enableStash(ctx);
-  const stashKey = key;
   if (checked) {
-    const restored = stash.get(stashKey);
+    const restored = stash.get(key);
     if (restored && hasSerializableValue(restored)) {
-      stash.delete(stashKey);
+      stash.delete(key);
       ctx.emitChange(path, restored);
     } else {
       // Seed the *localized* label the user is looking at, so the
@@ -134,7 +133,7 @@ export function onEnableToggle(
     // scalars / arrays) so the stashed type is genuinely a Record.
     const current = ctx.getAt(path);
     if (isPlainObject(current) && hasSerializableValue(current)) {
-      stash.set(stashKey, current);
+      stash.set(key, current);
     }
     ctx.emitChange(path, undefined);
     if (isOpen) ctx.toggleNested(key);

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -57,9 +57,8 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
               ?disabled=${effectiveDisabled(entry, ctx)}
               aria-label=${enableLabel}
               title=${enableLabel}
-              @click=${(e: Event) => e.stopPropagation()}
               @change=${(e: Event) =>
-                _onEnableToggle(
+                onEnableToggle(
                   path,
                   key,
                   isOpen,
@@ -103,7 +102,8 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
 // becomes non-empty and serializes. Either way it expands for editing.
 // Disabling stashes the current group, then clears it — the serializer
 // prunes the empty object so the block leaves the YAML — and collapses.
-function _onEnableToggle(
+// Exported for direct unit testing (the render path only wires it up).
+export function onEnableToggle(
   path: string[],
   key: string,
   isOpen: boolean,

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types.js";
+import { asRecord } from "../../../util/nested-values.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { hasSerializableValue } from "../../../util/yaml-serialize.js";
 import {
@@ -8,6 +9,23 @@ import {
   renderHelpLink,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
+
+// Stash of the values a sub-reading held when its enable switch was
+// turned off, keyed by the form's ``stashOwner`` (the host element,
+// stable across re-renders) then the dotted path. Turning the switch
+// back on restores the stash so an accidental toggle doesn't wipe the
+// unit / accuracy / filters the user configured — only the next flip
+// back recovers it (mirrors the templatable literal/lambda stash).
+const _enableStashes = new WeakMap<object, Map<string, Record<string, unknown>>>();
+
+function _enableStash(ctx: RenderCtx): Map<string, Record<string, unknown>> {
+  let m = _enableStashes.get(ctx.stashOwner);
+  if (!m) {
+    m = new Map();
+    _enableStashes.set(ctx.stashOwner, m);
+  }
+  return m;
+}
 
 // In requiredOnly mode (add-component dialog) groups default open and the
 // set tracks groups the user explicitly *collapsed*. Otherwise groups default
@@ -79,10 +97,12 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
   `;
 }
 
-// Enabling seeds the entity's name (its label, editable) so the group
-// becomes non-empty and serializes, then expands it for editing.
-// Disabling clears the whole group — the serializer prunes the empty
-// object so the block leaves the YAML — and collapses it.
+// Enabling restores the values stashed by the last disable (so an
+// accidental off/on round-trip keeps the user's settings); with no
+// stash it seeds the entity's name (its label, editable) so the group
+// becomes non-empty and serializes. Either way it expands for editing.
+// Disabling stashes the current group, then clears it — the serializer
+// prunes the empty object so the block leaves the YAML — and collapses.
 function _onEnableToggle(
   path: string[],
   key: string,
@@ -91,10 +111,22 @@ function _onEnableToggle(
   label: string,
   ctx: RenderCtx
 ): void {
+  const stash = _enableStash(ctx);
+  const stashKey = key;
   if (checked) {
-    ctx.emitChange([...path, "name"], label);
+    const restored = stash.get(stashKey);
+    if (restored && hasSerializableValue(restored)) {
+      stash.delete(stashKey);
+      ctx.emitChange(path, restored);
+    } else {
+      ctx.emitChange([...path, "name"], label);
+    }
     if (!isOpen) ctx.toggleNested(key);
   } else {
+    const current = ctx.getAt(path);
+    if (hasSerializableValue(current)) {
+      stash.set(stashKey, asRecord(current));
+    }
     ctx.emitChange(path, undefined);
     if (isOpen) ctx.toggleNested(key);
   }

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -119,6 +119,11 @@ export function onEnableToggle(
       stash.delete(stashKey);
       ctx.emitChange(path, restored);
     } else {
+      // Seed the *localized* label the user is looking at, so the
+      // name they get matches the switch they clicked (WYSIWYG) and
+      // reads natively in their dashboard locale. It's a plain
+      // editable value, not locale-pinned state — don't "fix" this
+      // to the entry key.
       ctx.emitChange([...path, "name"], label);
     }
     if (!isOpen) ctx.toggleNested(key);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -619,6 +619,7 @@
     "docs": "Docs",
     "advanced_options": "Advanced options",
     "show_advanced": "Show advanced settings",
+    "enable_entity": "Enable {name}",
     "multi_value_empty": "No items yet — click + to add one.",
     "multi_value_add": "Add",
     "multi_value_remove": "Remove",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -645,6 +645,7 @@
     "docs": "Documentation",
     "advanced_options": "Options avancées",
     "show_advanced": "Afficher les paramètres avancés",
+    "enable_entity": "Activer {name}",
     "multi_value_empty": "Aucun élément — cliquez sur + pour en ajouter un.",
     "multi_value_add": "Ajouter",
     "multi_value_remove": "Supprimer",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -618,6 +618,7 @@
     "docs": "Dokumentáció",
     "advanced_options": "Speciális beállítások",
     "show_advanced": "Speciális beállítások megjelenítése",
+    "enable_entity": "{name} engedélyezése",
     "multi_value_empty": "Még nincsenek elemek – Kattintson a + gombra egy hozzáadásához.",
     "multi_value_add": "Hozzáadás",
     "multi_value_remove": "Eltávolítás",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -645,6 +645,7 @@
     "docs": "Documentatie",
     "advanced_options": "Geavanceerde opties",
     "show_advanced": "Geavanceerde instellingen tonen",
+    "enable_entity": "{name} inschakelen",
     "multi_value_empty": "Nog geen items — klik op + om er een toe te voegen.",
     "multi_value_add": "Toevoegen",
     "multi_value_remove": "Verwijderen",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -619,6 +619,7 @@
     "docs": "文档",
     "advanced_options": "高级选项",
     "show_advanced": "显示高级设置",
+    "enable_entity": "启用{name}",
     "multi_value_empty": "还没有项目，点击 + 添加一个。",
     "multi_value_add": "添加",
     "multi_value_remove": "移除",

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -281,6 +281,24 @@ function serializeListItem(
 }
 
 /**
+ * True when *value* would emit at least one line through
+ * ``serializeYamlValues`` — i.e. it survives the round-trip to YAML.
+ *
+ * Mirrors the per-value skip rules below so a caller asking "does
+ * this group hold anything?" agrees with what actually lands in the
+ * YAML. ``""`` / null / undefined / empty array / a mapping whose
+ * every descendant is itself empty all count as no value.
+ */
+export function hasSerializableValue(value: unknown): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (value instanceof YamlRawValue) return true;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isLambdaValue(value)) return true;
+  if (isPlainObject(value)) return Object.values(value).some(hasSerializableValue);
+  return true;
+}
+
+/**
  * Serialize a values dict as YAML lines at the given indent.
  * Returns an array of lines (not a joined string) so callers can
  * splice them into existing YAML when needed.

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -282,12 +282,15 @@ function serializeListItem(
 
 /**
  * True when *value* would emit at least one line through
- * ``serializeYamlValues`` — i.e. it survives the round-trip to YAML.
+ * ``serializeYamlValues`` under its *default* options.
  *
- * Mirrors the per-value skip rules below so a caller asking "does
- * this group hold anything?" agrees with what actually lands in the
+ * Mirrors the default per-value skip rules below so a caller asking
+ * "does this group hold anything?" agrees with what lands in the
  * YAML. ``""`` / null / undefined / empty array / a mapping whose
- * every descendant is itself empty all count as no value.
+ * every descendant is itself empty all count as no value. This
+ * disagrees with ``serializeYamlValues(..., {keepEmptyStrings:
+ * true})``, which keeps ``""`` — don't use this helper to predict
+ * output for that mode.
  */
 export function hasSerializableValue(value: unknown): boolean {
   if (value === undefined || value === null || value === "") return false;

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -295,6 +295,9 @@ function serializeListItem(
 export function hasSerializableValue(value: unknown): boolean {
   if (value === undefined || value === null || value === "") return false;
   if (value instanceof YamlRawValue) return true;
+  // A non-empty list always emits: ``serializeListItem`` renders a
+  // bare ``-`` dash even for ``{}`` / ``null`` items, so length alone
+  // decides (no per-item recursion needed to agree with the output).
   if (Array.isArray(value)) return value.length > 0;
   if (isLambdaValue(value)) return true;
   if (isPlainObject(value)) return Object.values(value).some(hasSerializableValue);

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -17,7 +17,7 @@ import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderNestedField } from "../../../src/components/device/config-entry-renderers.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { getIn } from "../../../src/util/nested-values.js";
+import { getIn, setIn } from "../../../src/util/nested-values.js";
 
 function makeSensorEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return makeConfigEntry({
@@ -132,5 +132,39 @@ describe("renderNestedField enable toggle", () => {
     const handlers = collectHandlers(tpl.values);
     handlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
     expect(toggleNested).not.toHaveBeenCalled();
+  });
+
+  it("restores the stashed config on off/on so no work is lost", () => {
+    // One ctx (one stashOwner) reused across both renders; emitChange
+    // applies to a live values object so the second render sees the
+    // cleared group, exactly as the form's reducer would.
+    const configured = {
+      name: "Custom",
+      unit_of_measurement: "%",
+      accuracy_decimals: 2,
+    };
+    let values: Record<string, unknown> = { min_free: { ...configured } };
+    const emitChange = vi.fn((path: string[], value: unknown) => {
+      values = setIn(values, path, value);
+    });
+    const ctx: RenderCtx = {
+      ...makeCtx({}, ["min_free"]).ctx,
+      getAt: (path: string[]) => getIn(values, path),
+      emitChange,
+    };
+
+    // Toggle OFF: clears the YAML block but stashes the config.
+    const offHandlers = collectHandlers(
+      renderNestedField(makeSensorEntry(), ["min_free"], ctx).values
+    );
+    offHandlers[SWITCH_CHANGE_IDX]({ target: { checked: false } });
+    expect(getIn(values, ["min_free"])).toBeUndefined();
+
+    // Toggle ON again: the full configuration comes back, not just the name.
+    const onHandlers = collectHandlers(
+      renderNestedField(makeSensorEntry(), ["min_free"], ctx).values
+    );
+    onHandlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
+    expect(emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
   });
 });

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the optional-entity enable toggle in ``renderNestedField``.
+ *
+ * Optional entity sub-readings (a debug component's per-metric
+ * sensors, a DHT's temperature/humidity) only land in YAML once
+ * their group holds a value, so an untouched one is silently "off".
+ * The renderer gives those a ``wa-switch``: on seeds the name +
+ * expands, off clears the group. Switch state is derived from the
+ * current values (loaded from YAML), so it round-trips.
+ *
+ * Runs in vitest's default ``node`` environment — no DOM — so we
+ * inspect the returned ``TemplateResult`` and invoke the collected
+ * event handlers directly rather than mounting a shadow root.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
+import { renderNestedField } from "../../../src/components/device/config-entry-renderers.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { getIn } from "../../../src/util/nested-values.js";
+
+function makeSensorEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return makeConfigEntry({
+    key: "min_free",
+    type: ConfigEntryType.NESTED,
+    platform_type: "sensor",
+    config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+    ...overrides,
+  });
+}
+
+interface CtxStub {
+  ctx: RenderCtx;
+  emitChange: ReturnType<typeof vi.fn>;
+  toggleNested: ReturnType<typeof vi.fn>;
+}
+
+function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unknown> {
+  const out: Array<(...args: unknown[]) => unknown> = [];
+  const walk = (v: unknown): void => {
+    if (typeof v === "function") {
+      out.push(v as (...args: unknown[]) => unknown);
+    } else if (Array.isArray(v)) {
+      v.forEach(walk);
+    } else if (v && typeof v === "object" && "values" in v) {
+      walk((v as { values: unknown[] }).values);
+    }
+  };
+  walk(values);
+  return out;
+}
+
+function makeCtx(values: Record<string, unknown>, openKeys: string[] = []): CtxStub {
+  const emitChange = vi.fn();
+  const toggleNested = vi.fn();
+  const ctx: RenderCtx = {
+    localize: (key, params) => (params ? `${key}:${JSON.stringify(params)}` : key),
+    disabled: false,
+    yaml: "",
+    fromLine: undefined,
+    sectionKey: "",
+    board: null,
+    requiredOnly: false,
+    nestedOpenSections: new Set(openKeys),
+    getAt: (path: string[]) => getIn(values, path),
+    errorAt: () => null,
+    emitChange,
+    toggleNested,
+    requestAddComponent: () => {},
+    scopeValues: () => ({}),
+    filterRenderable: (entries: ConfigEntry[]) => entries,
+    renderEntry: () => "<rendered>",
+    getPendingUnit: () => undefined,
+    setPendingUnit: () => {},
+    getEditingMagnitude: () => undefined,
+    setEditingMagnitude: () => {},
+    clearEditingMagnitude: () => {},
+    stashOwner: {},
+  };
+  return { ctx, emitChange, toggleNested };
+}
+
+const json = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+// Handler render order: switch @click (stopPropagation), switch
+// @change (the toggle), button @click (expand/collapse).
+const SWITCH_CHANGE_IDX = 1;
+
+describe("renderNestedField enable toggle", () => {
+  it("renders the switch for an optional entity sub-reading", () => {
+    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], makeCtx({}).ctx);
+    expect(json(tpl)).toContain("device.enable_entity");
+  });
+
+  it("omits the switch for a plain nested group (no platform_type)", () => {
+    const entry = makeSensorEntry({ platform_type: null });
+    const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
+    expect(json(tpl)).not.toContain("device.enable_entity");
+  });
+
+  it("omits the switch for a required entity group", () => {
+    const entry = makeSensorEntry({ required: true });
+    const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
+    expect(json(tpl)).not.toContain("device.enable_entity");
+  });
+
+  it("enabling seeds the name with the entity label and expands the group", () => {
+    const { ctx, emitChange, toggleNested } = makeCtx({});
+    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
+    const handlers = collectHandlers(tpl.values);
+    handlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
+    expect(emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
+    expect(toggleNested).toHaveBeenCalledWith("min_free");
+  });
+
+  it("disabling clears the whole group and collapses it", () => {
+    const { ctx, emitChange, toggleNested } = makeCtx(
+      { min_free: { name: "Min Free" } },
+      ["min_free"]
+    );
+    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
+    const handlers = collectHandlers(tpl.values);
+    handlers[SWITCH_CHANGE_IDX]({ target: { checked: false } });
+    expect(emitChange).toHaveBeenCalledWith(["min_free"], undefined);
+    expect(toggleNested).toHaveBeenCalledWith("min_free");
+  });
+
+  it("does not re-expand an already-open group on enable", () => {
+    const { ctx, toggleNested } = makeCtx({}, ["min_free"]);
+    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
+    const handlers = collectHandlers(tpl.values);
+    handlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
+    expect(toggleNested).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -79,6 +79,27 @@ function makeCtx(initial: Record<string, unknown>): CtxStub {
 const json = (tpl: unknown): string =>
   JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
 
+// Locate the wa-switch sub-template by its label binding (robust to
+// sibling render order) and return its bound values.
+function switchBindings(tpl: { values: unknown[] }): unknown[] | null {
+  let found: unknown[] | null = null;
+  const walk = (v: unknown): void => {
+    if (found) return;
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+    } else if (v && typeof v === "object" && "values" in v) {
+      const vals = (v as { values: unknown[] }).values;
+      if (vals.some((x) => typeof x === "string" && x.includes("device.enable_entity"))) {
+        found = vals;
+      } else {
+        walk(vals);
+      }
+    }
+  };
+  walk(tpl.values);
+  return found;
+}
+
 describe("renderNestedField enable switch", () => {
   it("renders the switch for an optional entity sub-reading", () => {
     const tpl = renderNestedField(makeSensorEntry(), ["min_free"], makeCtx({}).ctx);
@@ -95,6 +116,21 @@ describe("renderNestedField enable switch", () => {
     const entry = makeSensorEntry({ required: true });
     const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
     expect(json(tpl)).not.toContain("device.enable_entity");
+  });
+
+  it("renders the switch disabled for a board-locked entry", () => {
+    const tpl = renderNestedField(
+      makeSensorEntry({ locked: true }),
+      ["min_free"],
+      makeCtx({}).ctx
+    );
+    const vals = switchBindings(tpl);
+    expect(vals).not.toBeNull();
+    // Switch boolean bindings, template order: [.checked, ?disabled].
+    expect((vals as unknown[]).filter((v) => typeof v === "boolean")).toEqual([
+      false,
+      true,
+    ]);
   });
 });
 

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -1,20 +1,23 @@
 /**
- * Tests for the optional-entity enable toggle in ``renderNestedField``.
+ * Tests for the optional-entity enable toggle.
  *
  * Optional entity sub-readings (a debug component's per-metric
  * sensors, a DHT's temperature/humidity) only land in YAML once
  * their group holds a value, so an untouched one is silently "off".
- * The renderer gives those a ``wa-switch``: on seeds the name +
- * expands, off clears the group. Switch state is derived from the
- * current values (loaded from YAML), so it round-trips.
+ * ``renderNestedField`` gives those a ``wa-switch``; ``onEnableToggle``
+ * is the change handler: on restores the stashed config (or seeds the
+ * name) and expands, off stashes then clears the group so the block
+ * leaves the YAML. Switch state derives from the current values
+ * (loaded from YAML), so it round-trips.
  *
- * Runs in vitest's default ``node`` environment — no DOM — so we
- * inspect the returned ``TemplateResult`` and invoke the collected
- * event handlers directly rather than mounting a shadow root.
+ * The render smoke tests inspect the returned ``TemplateResult``; the
+ * behaviour tests drive ``onEnableToggle`` directly so they don't
+ * depend on the order Lit serialises template bindings.
  */
 import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderNestedField } from "../../../src/components/device/config-entry-renderers.js";
+import { onEnableToggle } from "../../../src/components/device/config-entry-renderers/nested.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { getIn, setIn } from "../../../src/util/nested-values.js";
@@ -33,25 +36,18 @@ interface CtxStub {
   ctx: RenderCtx;
   emitChange: ReturnType<typeof vi.fn>;
   toggleNested: ReturnType<typeof vi.fn>;
+  read: (path: string[]) => unknown;
 }
 
-function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unknown> {
-  const out: Array<(...args: unknown[]) => unknown> = [];
-  const walk = (v: unknown): void => {
-    if (typeof v === "function") {
-      out.push(v as (...args: unknown[]) => unknown);
-    } else if (Array.isArray(v)) {
-      v.forEach(walk);
-    } else if (v && typeof v === "object" && "values" in v) {
-      walk((v as { values: unknown[] }).values);
-    }
-  };
-  walk(values);
-  return out;
-}
-
-function makeCtx(values: Record<string, unknown>, openKeys: string[] = []): CtxStub {
-  const emitChange = vi.fn();
+// A ctx whose ``emitChange`` mutates a live values object (as the
+// form's reducer would) so a follow-up ``getAt`` sees the change —
+// needed for the off/on round-trip. ``stashOwner`` is stable per ctx
+// so the disable-time stash survives into the re-enable call.
+function makeCtx(initial: Record<string, unknown>): CtxStub {
+  let values = initial;
+  const emitChange = vi.fn((path: string[], value: unknown) => {
+    values = setIn(values, path, value);
+  });
   const toggleNested = vi.fn();
   const ctx: RenderCtx = {
     localize: (key, params) => (params ? `${key}:${JSON.stringify(params)}` : key),
@@ -61,7 +57,7 @@ function makeCtx(values: Record<string, unknown>, openKeys: string[] = []): CtxS
     sectionKey: "",
     board: null,
     requiredOnly: false,
-    nestedOpenSections: new Set(openKeys),
+    nestedOpenSections: new Set(),
     getAt: (path: string[]) => getIn(values, path),
     errorAt: () => null,
     emitChange,
@@ -77,17 +73,13 @@ function makeCtx(values: Record<string, unknown>, openKeys: string[] = []): CtxS
     clearEditingMagnitude: () => {},
     stashOwner: {},
   };
-  return { ctx, emitChange, toggleNested };
+  return { ctx, emitChange, toggleNested, read: (path) => getIn(values, path) };
 }
 
 const json = (tpl: unknown): string =>
   JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
 
-// Handler render order: switch @click (stopPropagation), switch
-// @change (the toggle), button @click (expand/collapse).
-const SWITCH_CHANGE_IDX = 1;
-
-describe("renderNestedField enable toggle", () => {
+describe("renderNestedField enable switch", () => {
   it("renders the switch for an optional entity sub-reading", () => {
     const tpl = renderNestedField(makeSensorEntry(), ["min_free"], makeCtx({}).ctx);
     expect(json(tpl)).toContain("device.enable_entity");
@@ -104,67 +96,37 @@ describe("renderNestedField enable toggle", () => {
     const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
     expect(json(tpl)).not.toContain("device.enable_entity");
   });
+});
 
-  it("enabling seeds the name with the entity label and expands the group", () => {
+describe("onEnableToggle", () => {
+  it("enabling with no stash seeds the name with the entity label and expands", () => {
     const { ctx, emitChange, toggleNested } = makeCtx({});
-    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
-    const handlers = collectHandlers(tpl.values);
-    handlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
+    onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
     expect(emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
     expect(toggleNested).toHaveBeenCalledWith("min_free");
   });
 
+  it("does not re-expand an already-open group on enable", () => {
+    const { ctx, toggleNested } = makeCtx({});
+    onEnableToggle(["min_free"], "min_free", true, true, "Min Free", ctx);
+    expect(toggleNested).not.toHaveBeenCalled();
+  });
+
   it("disabling clears the whole group and collapses it", () => {
-    const { ctx, emitChange, toggleNested } = makeCtx(
-      { min_free: { name: "Min Free" } },
-      ["min_free"]
-    );
-    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
-    const handlers = collectHandlers(tpl.values);
-    handlers[SWITCH_CHANGE_IDX]({ target: { checked: false } });
+    const { ctx, emitChange, toggleNested } = makeCtx({ min_free: { name: "Min Free" } });
+    onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
     expect(emitChange).toHaveBeenCalledWith(["min_free"], undefined);
     expect(toggleNested).toHaveBeenCalledWith("min_free");
   });
 
-  it("does not re-expand an already-open group on enable", () => {
-    const { ctx, toggleNested } = makeCtx({}, ["min_free"]);
-    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], ctx);
-    const handlers = collectHandlers(tpl.values);
-    handlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
-    expect(toggleNested).not.toHaveBeenCalled();
-  });
-
   it("restores the stashed config on off/on so no work is lost", () => {
-    // One ctx (one stashOwner) reused across both renders; emitChange
-    // applies to a live values object so the second render sees the
-    // cleared group, exactly as the form's reducer would.
-    const configured = {
-      name: "Custom",
-      unit_of_measurement: "%",
-      accuracy_decimals: 2,
-    };
-    let values: Record<string, unknown> = { min_free: { ...configured } };
-    const emitChange = vi.fn((path: string[], value: unknown) => {
-      values = setIn(values, path, value);
-    });
-    const ctx: RenderCtx = {
-      ...makeCtx({}, ["min_free"]).ctx,
-      getAt: (path: string[]) => getIn(values, path),
-      emitChange,
-    };
+    const configured = { name: "Custom", unit_of_measurement: "%", accuracy_decimals: 2 };
+    const { ctx, emitChange, read } = makeCtx({ min_free: { ...configured } });
 
-    // Toggle OFF: clears the YAML block but stashes the config.
-    const offHandlers = collectHandlers(
-      renderNestedField(makeSensorEntry(), ["min_free"], ctx).values
-    );
-    offHandlers[SWITCH_CHANGE_IDX]({ target: { checked: false } });
-    expect(getIn(values, ["min_free"])).toBeUndefined();
+    onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
+    expect(read(["min_free"])).toBeUndefined();
 
-    // Toggle ON again: the full configuration comes back, not just the name.
-    const onHandlers = collectHandlers(
-      renderNestedField(makeSensorEntry(), ["min_free"], ctx).values
-    );
-    onHandlers[SWITCH_CHANGE_IDX]({ target: { checked: true } });
+    onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
     expect(emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
   });
 });

--- a/test/components/device/render-nested-field-enable-toggle.test.ts
+++ b/test/components/device/render-nested-field-enable-toggle.test.ts
@@ -9,18 +9,14 @@
  * name) and expands, off stashes then clears the group so the block
  * leaves the YAML. Switch state derives from the current values
  * (loaded from YAML), so it round-trips.
- *
- * The render smoke tests inspect the returned ``TemplateResult``; the
- * behaviour tests drive ``onEnableToggle`` directly so they don't
- * depend on the order Lit serialises template bindings.
  */
 import { describe, expect, it, vi } from "vitest";
 import { ConfigEntryType, type ConfigEntry } from "../../../src/api/types.js";
 import { renderNestedField } from "../../../src/components/device/config-entry-renderers.js";
 import { onEnableToggle } from "../../../src/components/device/config-entry-renderers/nested.js";
-import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
 import { getIn, setIn } from "../../../src/util/nested-values.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeSensorEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return makeConfigEntry({
@@ -32,137 +28,95 @@ function makeSensorEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   });
 }
 
-interface CtxStub {
-  ctx: RenderCtx;
-  emitChange: ReturnType<typeof vi.fn>;
-  toggleNested: ReturnType<typeof vi.fn>;
-  read: (path: string[]) => unknown;
-}
-
-// A ctx whose ``emitChange`` mutates a live values object (as the
-// form's reducer would) so a follow-up ``getAt`` sees the change —
-// needed for the off/on round-trip. ``stashOwner`` is stable per ctx
-// so the disable-time stash survives into the re-enable call.
-function makeCtx(initial: Record<string, unknown>): CtxStub {
-  let values = initial;
-  const emitChange = vi.fn((path: string[], value: unknown) => {
-    values = setIn(values, path, value);
-  });
-  const toggleNested = vi.fn();
-  const ctx: RenderCtx = {
-    localize: (key, params) => (params ? `${key}:${JSON.stringify(params)}` : key),
-    disabled: false,
-    yaml: "",
-    fromLine: undefined,
-    sectionKey: "",
-    board: null,
-    requiredOnly: false,
-    nestedOpenSections: new Set(),
-    getAt: (path: string[]) => getIn(values, path),
-    errorAt: () => null,
-    emitChange,
-    toggleNested,
-    requestAddComponent: () => {},
-    scopeValues: () => ({}),
-    filterRenderable: (entries: ConfigEntry[]) => entries,
-    renderEntry: () => "<rendered>",
-    getPendingUnit: () => undefined,
-    setPendingUnit: () => {},
-    getEditingMagnitude: () => undefined,
-    setEditingMagnitude: () => {},
-    clearEditingMagnitude: () => {},
-    stashOwner: {},
-  };
-  return { ctx, emitChange, toggleNested, read: (path) => getIn(values, path) };
-}
-
-const json = (tpl: unknown): string =>
-  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
-
-// Locate the wa-switch sub-template by its label binding (robust to
-// sibling render order) and return its bound values.
-function switchBindings(tpl: { values: unknown[] }): unknown[] | null {
-  let found: unknown[] | null = null;
-  const walk = (v: unknown): void => {
-    if (found) return;
-    if (Array.isArray(v)) {
-      v.forEach(walk);
-    } else if (v && typeof v === "object" && "values" in v) {
-      const vals = (v as { values: unknown[] }).values;
-      if (vals.some((x) => typeof x === "string" && x.includes("device.enable_entity"))) {
-        found = vals;
-      } else {
-        walk(vals);
-      }
-    }
-  };
-  walk(tpl.values);
-  return found;
-}
+const switchesOf = (tpl: unknown) => findElementBindings(tpl, "wa-switch");
 
 describe("renderNestedField enable switch", () => {
   it("renders the switch for an optional entity sub-reading", () => {
-    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], makeCtx({}).ctx);
-    expect(json(tpl)).toContain("device.enable_entity");
+    const tpl = renderNestedField(makeSensorEntry(), ["min_free"], makeRenderCtx({}));
+    expect(switchesOf(tpl)).toHaveLength(1);
   });
 
   it("omits the switch for a plain nested group (no platform_type)", () => {
     const entry = makeSensorEntry({ platform_type: null });
-    const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
-    expect(json(tpl)).not.toContain("device.enable_entity");
+    expect(
+      switchesOf(renderNestedField(entry, ["min_free"], makeRenderCtx({})))
+    ).toHaveLength(0);
   });
 
   it("omits the switch for a required entity group", () => {
     const entry = makeSensorEntry({ required: true });
-    const tpl = renderNestedField(entry, ["min_free"], makeCtx({}).ctx);
-    expect(json(tpl)).not.toContain("device.enable_entity");
+    expect(
+      switchesOf(renderNestedField(entry, ["min_free"], makeRenderCtx({})))
+    ).toHaveLength(0);
+  });
+
+  it("reflects the group's current value as the switch checked state", () => {
+    const [sw] = switchesOf(
+      renderNestedField(
+        makeSensorEntry(),
+        ["min_free"],
+        makeRenderCtx({ min_free: { name: "x" } })
+      )
+    );
+    expect(sw[".checked"]).toBe(true);
   });
 
   it("renders the switch disabled for a board-locked entry", () => {
-    const tpl = renderNestedField(
-      makeSensorEntry({ locked: true }),
-      ["min_free"],
-      makeCtx({}).ctx
+    const [sw] = switchesOf(
+      renderNestedField(
+        makeSensorEntry({ locked: true }),
+        ["min_free"],
+        makeRenderCtx({})
+      )
     );
-    const vals = switchBindings(tpl);
-    expect(vals).not.toBeNull();
-    // Switch boolean bindings, template order: [.checked, ?disabled].
-    expect((vals as unknown[]).filter((v) => typeof v === "boolean")).toEqual([
-      false,
-      true,
-    ]);
+    expect(sw["?disabled"]).toBe(true);
+    expect(sw[".checked"]).toBe(false);
   });
 });
 
 describe("onEnableToggle", () => {
   it("enabling with no stash seeds the name with the entity label and expands", () => {
-    const { ctx, emitChange, toggleNested } = makeCtx({});
+    const ctx = makeRenderCtx({});
     onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
-    expect(emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
-    expect(toggleNested).toHaveBeenCalledWith("min_free");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["min_free", "name"], "Min Free");
+    expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
 
   it("does not re-expand an already-open group on enable", () => {
-    const { ctx, toggleNested } = makeCtx({});
+    const ctx = makeRenderCtx({});
     onEnableToggle(["min_free"], "min_free", true, true, "Min Free", ctx);
-    expect(toggleNested).not.toHaveBeenCalled();
+    expect(ctx.toggleNested).not.toHaveBeenCalled();
   });
 
   it("disabling clears the whole group and collapses it", () => {
-    const { ctx, emitChange, toggleNested } = makeCtx({ min_free: { name: "Min Free" } });
+    const ctx = makeRenderCtx({ min_free: { name: "Min Free" } });
     onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
-    expect(emitChange).toHaveBeenCalledWith(["min_free"], undefined);
-    expect(toggleNested).toHaveBeenCalledWith("min_free");
+    expect(ctx.emitChange).toHaveBeenCalledWith(["min_free"], undefined);
+    expect(ctx.toggleNested).toHaveBeenCalledWith("min_free");
   });
 
   it("restores the stashed config on off/on so no work is lost", () => {
     const configured = { name: "Custom", unit_of_measurement: "%", accuracy_decimals: 2 };
-    const { ctx, emitChange, read } = makeCtx({ min_free: { ...configured } });
+    // emitChange mutates a live values object so the re-enable's getAt
+    // sees the cleared group, as the form's reducer would. One ctx ⇒
+    // one stashOwner, so the disable-time stash survives to re-enable.
+    let values: Record<string, unknown> = { min_free: { ...configured } };
+    const ctx = makeRenderCtx(
+      {},
+      {
+        overrides: {
+          emitChange: vi.fn((path: string[], value: unknown) => {
+            values = setIn(values, path, value);
+          }),
+          getAt: (path: string[]) => getIn(values, path),
+        },
+      }
+    );
 
     onEnableToggle(["min_free"], "min_free", true, false, "Min Free", ctx);
-    expect(read(["min_free"])).toBeUndefined();
+    expect(getIn(values, ["min_free"])).toBeUndefined();
 
     onEnableToggle(["min_free"], "min_free", false, true, "Min Free", ctx);
-    expect(emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
+    expect(ctx.emitChange).toHaveBeenLastCalledWith(["min_free"], configured);
   });
 });

--- a/test/util/has-serializable-value.test.ts
+++ b/test/util/has-serializable-value.test.ts
@@ -1,0 +1,37 @@
+/**
+ * ``hasSerializableValue`` mirrors the per-value skip rules in
+ * ``serializeYamlValues`` so the optional-entity enable toggle's
+ * checked state agrees with whether the group actually lands in the
+ * YAML. These cases pin that agreement.
+ */
+import { describe, expect, it } from "vitest";
+import { YamlRawValue, hasSerializableValue } from "../../src/util/yaml-serialize.js";
+
+describe("hasSerializableValue", () => {
+  it("treats undefined / null / empty string as no value", () => {
+    expect(hasSerializableValue(undefined)).toBe(false);
+    expect(hasSerializableValue(null)).toBe(false);
+    expect(hasSerializableValue("")).toBe(false);
+  });
+
+  it("treats empty arrays and empty objects as no value", () => {
+    expect(hasSerializableValue([])).toBe(false);
+    expect(hasSerializableValue({})).toBe(false);
+  });
+
+  it("treats a mapping whose descendants are all empty as no value", () => {
+    expect(hasSerializableValue({ name: "", id: undefined, nested: {} })).toBe(false);
+  });
+
+  it("treats scalars and non-empty containers as a value", () => {
+    expect(hasSerializableValue("x")).toBe(true);
+    expect(hasSerializableValue(0)).toBe(true);
+    expect(hasSerializableValue(false)).toBe(true);
+    expect(hasSerializableValue(["a"])).toBe(true);
+    expect(hasSerializableValue({ name: "Min Free" })).toBe(true);
+  });
+
+  it("treats a YamlRawValue block as a value", () => {
+    expect(hasSerializableValue(new YamlRawValue(["  foo: bar"]))).toBe(true);
+  });
+});

--- a/test/util/has-serializable-value.test.ts
+++ b/test/util/has-serializable-value.test.ts
@@ -23,6 +23,13 @@ describe("hasSerializableValue", () => {
     expect(hasSerializableValue({ name: "", id: undefined, nested: {} })).toBe(false);
   });
 
+  it("treats a non-empty list as a value even when its items are empty", () => {
+    // serializeListItem emits a bare ``-`` dash for {} / null items,
+    // so any non-empty array produces output regardless of contents.
+    expect(hasSerializableValue([{}])).toBe(true);
+    expect(hasSerializableValue([null])).toBe(true);
+  });
+
   it("treats scalars and non-empty containers as a value", () => {
     expect(hasSerializableValue("x")).toBe(true);
     expect(hasSerializableValue(0)).toBe(true);


### PR DESCRIPTION
# What does this implement/fix?

Optional entity sub-readings (for example the Debug component's per-metric sensors) render as collapsed dropdowns, and nothing signals that they are off or how to turn them on; a sensor is only written to YAML once its group gets a name, so users are left staring at inert rows. This adds an explicit on/off switch to each optional sensor's header; turning it on prefills the name with the sensor's label and expands the group, turning it off clears the group so it leaves the YAML. The switch state is derived from the current values, so it reflects whatever is already in the YAML on load.

**Related issue or feature (if applicable):**

- fixes #426

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
