### PR TITLE
Use only an item's top-level name/id for the navigator label

### DIFF
--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -309,14 +309,24 @@ function _expandListItems(
     let name = "";
     let id = "";
     let platform = "";
+    // Only the list item's own top-level keys count: the dash line's
+    // inline key, plus continuation keys at exactly the direct-child
+    // indent. Deeper lines belong to nested sub-mappings (a sensor
+    // platform's temperature:/humidity: blocks, the debug component's
+    // per-metric sensors) whose name:/id: must not override the item's.
+    const dashIndent = lines[itemStart].match(/^ */)?.[0].length ?? 0;
+    const childIndent = dashIndent + 2;
     for (let j = itemStart; j <= itemEnd; j++) {
-      const nameMatch = lines[j].match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
+      const line = lines[j];
+      if (j !== itemStart) {
+        const indent = line.match(/^ */)?.[0].length ?? 0;
+        if (indent !== childIndent) continue;
+      }
+      const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
       if (nameMatch) name = nameMatch[1];
-      const idMatch = lines[j].match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
+      const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
       if (idMatch) id = idMatch[1];
-      const platformMatch = lines[j].match(
-        /^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/
-      );
+      const platformMatch = line.match(/^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/);
       if (platformMatch) platform = platformMatch[1];
     }
 

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -51,6 +51,58 @@ wifi:
     expect(sections[1].name).toBe("bedroom");
   });
 
+  it("ignores nested sub-reading name:/id: when extracting the item label (#1015)", () => {
+    // A platform with no top-level name: but nested temperature/humidity
+    // sub-sensors must not adopt a child's name as its label.
+    const yaml = `sensor:
+  - platform: sht4x
+    id: sht4x_1
+    temperature:
+      id: sensor_sht4x_1_temperature
+      name: Temperature
+    humidity:
+      id: sensor_sht4x_1_humidity
+      filters:
+        - round:
+            accuracy_decimals: 2
+      name: Humidity
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].platform).toBe("sht4x");
+    expect(sections[0].id).toBe("sht4x_1");
+    expect(sections[0].name).toBeUndefined();
+  });
+
+  it("leaves name and id undefined when an item has neither at top level (#1015)", () => {
+    // id is optional: a debug-shaped platform with only nested
+    // sub-sensors has no own label, so the subtitle stays empty.
+    const yaml = `sensor:
+  - platform: debug
+    free:
+      name: Free
+    min_free:
+      name: Min Free
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].platform).toBe("debug");
+    expect(sections[0].name).toBeUndefined();
+    expect(sections[0].id).toBeUndefined();
+  });
+
+  it("extracts top-level name and id together", () => {
+    const yaml = `switch:
+  - platform: gpio
+    name: Relay
+    id: relay_1
+    pin: 4
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections[0].name).toBe("Relay");
+    expect(sections[0].id).toBe("relay_1");
+  });
+
   it("trims trailing blank lines from the final section", () => {
     const yaml = `esphome:
   name: test


### PR DESCRIPTION
# What does this implement/fix?

In the Device Navigator, a platform component that has no top-level name but does have nested sub-readings (an SHT4X sensor with temperature/humidity blocks, the Debug component, etc.) showed the last nested child's name as its subtitle, e.g. "Humidity" instead of the component id "sht4x_1". The list-item label extractor was scanning every line of the item, including nested sub-mappings, and taking the last name/id it found. It now reads only the item's own top-level keys (the dash line plus continuation keys at the direct-child indent), so nested sub-reading names are ignored; when an item has neither a top-level name nor id the subtitle is simply empty, since id is optional.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1015

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
