### PR TITLE
Hydrate automation bodies via batched cache

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -13,6 +13,7 @@ import type {
   AddComponentResponse,
   ArchivedDevice,
   AutomationAction,
+  AutomationCatalogBody,
   AutomationCondition,
   AutomationTree,
   AutomationTrigger,
@@ -1379,6 +1380,26 @@ export class ESPHomeAPI {
       ...(platform ? { platform } : {}),
       ...(boardId ? { board_id: boardId } : {}),
     });
+  }
+
+  /**
+   * Hydrate full automation bodies (config_entries trees) in one
+   * round trip. Each ref is ``{type, id}`` where ``type`` is one of
+   * ``triggers`` / ``actions`` / ``conditions`` / ``light_effects``
+   * / ``filters``. The response is keyed by ``"<type>/<id>"`` and
+   * carries the full body. Missing / unknown refs are absent.
+   * Callers should go through ``automation-body-cache.ts`` rather
+   * than calling this directly; it caches results and coalesces
+   * concurrent fetches into one batched call.
+   */
+  async getAutomationBodies(
+    refs: { type: string; id: string }[]
+  ): Promise<Record<string, AutomationCatalogBody>> {
+    if (refs.length === 0) return {};
+    return this.sendCommand<Record<string, AutomationCatalogBody>>(
+      "automations/get_bodies",
+      { refs }
+    );
   }
 
   /**

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -14,6 +14,7 @@ import type {
   ArchivedDevice,
   AutomationAction,
   AutomationCatalogBody,
+  AutomationCatalogBodyType,
   AutomationCondition,
   AutomationTree,
   AutomationTrigger,
@@ -1393,7 +1394,7 @@ export class ESPHomeAPI {
    * concurrent fetches into one batched call.
    */
   async getAutomationBodies(
-    refs: { type: string; id: string }[]
+    refs: { type: AutomationCatalogBodyType; id: string }[]
   ): Promise<Record<string, AutomationCatalogBody>> {
     if (refs.length === 0) return {};
     return this.sendCommand<Record<string, AutomationCatalogBody>>(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -931,6 +931,27 @@ export type LightEffect = RegistryCatalogEntry;
  *  entry whose `applies_to` spans every domain it lives in. */
 export type Filter = RegistryCatalogEntry;
 
+/** Discriminated union of every full body the
+ *  ``automations/get_bodies`` batch endpoint can return. The
+ *  endpoint keys the response by ``"<type>/<id>"`` and emits the
+ *  matching member; the wire shape is the full type (with
+ *  ``config_entries``) regardless of which type-list endpoint the
+ *  slim ``id`` was originally pulled from. */
+export type AutomationCatalogBody =
+  | AutomationTrigger
+  | AutomationAction
+  | AutomationCondition
+  | LightEffect
+  | Filter;
+
+/** Wire ``type`` field on an ``automations/get_bodies`` ref. */
+export type AutomationCatalogBodyType =
+  | "triggers"
+  | "actions"
+  | "conditions"
+  | "light_effects"
+  | "filters";
+
 /** Tagged-union locator for an automation inside a device YAML.
  *  Mirrors the backend's ``AutomationLocation`` Python dataclass.
  *  ``parse`` returns these and ``upsert`` / ``delete`` consume them

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -931,12 +931,11 @@ export type LightEffect = RegistryCatalogEntry;
  *  entry whose `applies_to` spans every domain it lives in. */
 export type Filter = RegistryCatalogEntry;
 
-/** Discriminated union of every full body the
- *  ``automations/get_bodies`` batch endpoint can return. The
- *  endpoint keys the response by ``"<type>/<id>"`` and emits the
- *  matching member; the wire shape is the full type (with
- *  ``config_entries``) regardless of which type-list endpoint the
- *  slim ``id`` was originally pulled from. */
+/** Union of every full body the ``automations/get_bodies`` batch
+ *  endpoint can return. There is no per-body discriminator field;
+ *  the discriminator is the ``"<type>/<id>"`` response key, so
+ *  narrowing happens at the call site against the type the caller
+ *  asked for, not via structural inspection. */
 export type AutomationCatalogBody =
   | AutomationTrigger
   | AutomationAction

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -388,12 +388,32 @@ export class ESPHomeAutomationEditor extends LitElement {
     if (!this._api || !this.configuration) return;
     try {
       const available = await this._api.getAvailableAutomations(this.configuration);
-      // Paint the picker with the slim list before awaiting body
-      // hydration; entries mutate in place and a ``requestUpdate``
-      // re-renders the forms once bodies arrive.
+      // Paint the picker with the slim list immediately.
       this._available = available;
-      await hydrateAvailableBodies(this._api, available);
-      this.requestUpdate();
+      const hydration = await hydrateAvailableBodies(this._api, available);
+      // Reassign ``_available`` with fresh array refs so child
+      // components (trigger picker, condition tree, action node)
+      // whose ``@property`` bindings default to identity-based
+      // ``hasChanged`` re-render with the hydrated entries.
+      this._available = {
+        ...available,
+        triggers: [...available.triggers],
+        actions: [...available.actions],
+        conditions: [...available.conditions],
+      };
+      const failures =
+        hydration.missingBody + hydration.missingField + hydration.rejected;
+      if (failures > 0) {
+        // Soft surface: log + non-blocking toast. Don't set
+        // ``_error`` since the picker is still usable for the
+        // entries that hydrated; ``cacheMisses: false`` lets a
+        // re-mount retry the missing ones.
+        toast.error(
+          this._localize("device.automation_partial_hydration", {
+            count: String(failures),
+          })
+        );
+      }
     } catch (err) {
       this._error = err instanceof Error ? err.message : String(err);
     }

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -399,14 +399,25 @@ export class ESPHomeAutomationEditor extends LitElement {
     if (!this._api) return;
     const api = this._api;
     type Entry = AutomationTrigger | AutomationAction | AutomationCondition;
-    const jobs: Promise<void>[] = [];
+    // ``allSettled`` so one body fetch failure (transport hiccup,
+    // mid-flight cache clear, server glitch on one ref) doesn't
+    // abort the whole editor load — the slim entry is enough to
+    // render the picker; the form re-fetches on focus.
+    const jobs: Promise<unknown>[] = [];
     const merge = (type: "triggers" | "actions" | "conditions", list: Entry[]): void => {
       for (const entry of list) {
         jobs.push(
           fetchAutomationBody(api, type, entry.id).then((body) => {
             if (body && "config_entries" in body) {
               entry.config_entries = body.config_entries;
+              return;
             }
+            // The list endpoint just advertised this id; a null or
+            // shapeless response from get_bodies is a contract
+            // violation worth surfacing in the console.
+            console.warn(
+              `automation-editor: ${type}/${entry.id} body missing config_entries; form will render empty`
+            );
           })
         );
       }
@@ -414,7 +425,12 @@ export class ESPHomeAutomationEditor extends LitElement {
     merge("triggers", available.triggers);
     merge("actions", available.actions);
     merge("conditions", available.conditions);
-    await Promise.all(jobs);
+    const results = await Promise.allSettled(jobs);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.warn("automation-editor: body fetch failed", r.reason);
+      }
+    }
   }
 
   protected render() {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -52,7 +52,7 @@ import {
   fetchComponent,
   getCachedComponent,
 } from "../../../util/component-name-cache.js";
-import { hydrateAvailableBodies } from "./hydrate-available-bodies.js";
+import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
 import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
@@ -385,29 +385,31 @@ export class ESPHomeAutomationEditor extends LitElement {
     this._loading = true;
     this._error = "";
     try {
-      const available = await this._api.getAvailableAutomations(this.configuration);
-      if (seq !== this._loadAvailableSeq) return;
-      // Paint the picker with the slim list immediately.
-      this._available = available;
-      const hydration = await hydrateAvailableBodies(this._api, available);
-      if (seq !== this._loadAvailableSeq) return;
-      // Reassign ``_available`` with fresh array refs so child
-      // components (trigger picker, condition tree, action node)
-      // whose ``@property`` bindings default to identity-based
-      // ``hasChanged`` re-render with the hydrated entries.
-      this._available = {
-        ...available,
-        triggers: [...available.triggers],
-        actions: [...available.actions],
-        conditions: [...available.conditions],
-      };
-      const failures =
-        hydration.missingBody + hydration.missingField + hydration.rejected;
+      const outcome = await loadAndHydrateAvailable(this._api, this.configuration, {
+        // Paint the picker with the slim list immediately so the
+        // dropdowns mount before bodies hydrate.
+        onSlim: (slim) => {
+          if (seq === this._loadAvailableSeq) this._available = slim;
+        },
+        isStale: () => seq !== this._loadAvailableSeq,
+      });
+      if (outcome.status === "stale") return;
+      if (outcome.status === "error") {
+        this._error =
+          outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+        return;
+      }
+      // Fresh array refs so identity-based ``hasChanged`` consumers
+      // (trigger picker, condition tree, action node) re-render
+      // with the hydrated entries.
+      this._available = outcome.available;
+      const { missingBody, missingField, rejected } = outcome.hydration;
+      const failures = missingBody + missingField + rejected;
       if (failures > 0) {
-        // Soft surface: log + non-blocking toast. Don't set
-        // ``_error`` since the picker is still usable for the
-        // entries that hydrated; ``cacheMisses: false`` lets a
-        // re-mount retry the missing ones.
+        // Soft surface: non-blocking toast. Don't set ``_error``
+        // since the picker is still usable for the entries that
+        // hydrated; ``cacheMisses: false`` lets a re-mount retry
+        // the missing ones.
         toast.error(
           this._localize("device.automation_partial_hydration", {
             count: String(failures),
@@ -415,9 +417,6 @@ export class ESPHomeAutomationEditor extends LitElement {
           { richColors: true }
         );
       }
-    } catch (err) {
-      if (seq !== this._loadAvailableSeq) return;
-      this._error = err instanceof Error ? err.message : String(err);
     } finally {
       if (seq === this._loadAvailableSeq) this._loading = false;
     }

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -411,7 +411,8 @@ export class ESPHomeAutomationEditor extends LitElement {
         toast.error(
           this._localize("device.automation_partial_hydration", {
             count: String(failures),
-          })
+          }),
+          { richColors: true }
         );
       }
     } catch (err) {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -34,8 +34,6 @@ import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
-  AutomationAction,
-  AutomationCondition,
   AutomationLocation,
   AutomationTree,
   AutomationTrigger,

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -129,6 +129,13 @@ export class ESPHomeAutomationEditor extends LitElement {
    *  device's YAML) so the dropdowns only show what's usable. */
   @state() private _available: AvailableAutomations | null = null;
 
+  /** Monotonic generation token for ``_loadAvailable``. Two
+   *  overlapping reconnect-driven loads can otherwise have the
+   *  earlier one's stale assignment land after the later one's
+   *  fresh assignment; this lets each invocation drop its results
+   *  if the seq has moved on while it awaited. */
+  private _loadAvailableSeq = 0;
+
   /** Component catalog entry for the ``interval`` component, lazily
    *  fetched the first time we render an interval automation. Drives
    *  the header (name / description / docs / image) and the inline
@@ -386,11 +393,14 @@ export class ESPHomeAutomationEditor extends LitElement {
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
+    const seq = ++this._loadAvailableSeq;
     try {
       const available = await this._api.getAvailableAutomations(this.configuration);
+      if (seq !== this._loadAvailableSeq) return;
       // Paint the picker with the slim list immediately.
       this._available = available;
       const hydration = await hydrateAvailableBodies(this._api, available);
+      if (seq !== this._loadAvailableSeq) return;
       // Reassign ``_available`` with fresh array refs so child
       // components (trigger picker, condition tree, action node)
       // whose ``@property`` bindings default to identity-based
@@ -416,6 +426,7 @@ export class ESPHomeAutomationEditor extends LitElement {
         );
       }
     } catch (err) {
+      if (seq !== this._loadAvailableSeq) return;
       this._error = err instanceof Error ? err.message : String(err);
     }
   }

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -50,11 +50,11 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { fetchAutomationBody } from "../../../util/automation-body-cache.js";
 import {
   fetchComponent,
   getCachedComponent,
 } from "../../../util/component-name-cache.js";
+import { hydrateAvailableBodies } from "./hydrate-available-bodies.js";
 import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
@@ -388,48 +388,14 @@ export class ESPHomeAutomationEditor extends LitElement {
     if (!this._api || !this.configuration) return;
     try {
       const available = await this._api.getAvailableAutomations(this.configuration);
-      await this._hydrateAvailableBodies(available);
+      // Paint the picker with the slim list before awaiting body
+      // hydration; entries mutate in place and a ``requestUpdate``
+      // re-renders the forms once bodies arrive.
       this._available = available;
+      await hydrateAvailableBodies(this._api, available);
+      this.requestUpdate();
     } catch (err) {
       this._error = err instanceof Error ? err.message : String(err);
-    }
-  }
-
-  private async _hydrateAvailableBodies(available: AvailableAutomations): Promise<void> {
-    if (!this._api) return;
-    const api = this._api;
-    type Entry = AutomationTrigger | AutomationAction | AutomationCondition;
-    // ``allSettled`` so one body fetch failure (transport hiccup,
-    // mid-flight cache clear, server glitch on one ref) doesn't
-    // abort the whole editor load — the slim entry is enough to
-    // render the picker; the form re-fetches on focus.
-    const jobs: Promise<unknown>[] = [];
-    const merge = (type: "triggers" | "actions" | "conditions", list: Entry[]): void => {
-      for (const entry of list) {
-        jobs.push(
-          fetchAutomationBody(api, type, entry.id).then((body) => {
-            if (body && "config_entries" in body) {
-              entry.config_entries = body.config_entries;
-              return;
-            }
-            // The list endpoint just advertised this id; a null or
-            // shapeless response from get_bodies is a contract
-            // violation worth surfacing in the console.
-            console.warn(
-              `automation-editor: ${type}/${entry.id} body missing config_entries; form will render empty`
-            );
-          })
-        );
-      }
-    };
-    merge("triggers", available.triggers);
-    merge("actions", available.actions);
-    merge("conditions", available.conditions);
-    const results = await Promise.allSettled(jobs);
-    for (const r of results) {
-      if (r.status === "rejected") {
-        console.warn("automation-editor: body fetch failed", r.reason);
-      }
     }
   }
 

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -34,6 +34,8 @@ import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
+  AutomationAction,
+  AutomationCondition,
   AutomationLocation,
   AutomationTree,
   AutomationTrigger,
@@ -48,6 +50,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { fetchAutomationBody } from "../../../util/automation-body-cache.js";
 import {
   fetchComponent,
   getCachedComponent,
@@ -384,10 +387,34 @@ export class ESPHomeAutomationEditor extends LitElement {
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
     try {
-      this._available = await this._api.getAvailableAutomations(this.configuration);
+      const available = await this._api.getAvailableAutomations(this.configuration);
+      await this._hydrateAvailableBodies(available);
+      this._available = available;
     } catch (err) {
       this._error = err instanceof Error ? err.message : String(err);
     }
+  }
+
+  private async _hydrateAvailableBodies(available: AvailableAutomations): Promise<void> {
+    if (!this._api) return;
+    const api = this._api;
+    type Entry = AutomationTrigger | AutomationAction | AutomationCondition;
+    const jobs: Promise<void>[] = [];
+    const merge = (type: "triggers" | "actions" | "conditions", list: Entry[]): void => {
+      for (const entry of list) {
+        jobs.push(
+          fetchAutomationBody(api, type, entry.id).then((body) => {
+            if (body && "config_entries" in body) {
+              entry.config_entries = body.config_entries;
+            }
+          })
+        );
+      }
+    };
+    merge("triggers", available.triggers);
+    merge("actions", available.actions);
+    merge("conditions", available.conditions);
+    await Promise.all(jobs);
   }
 
   protected render() {

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -386,10 +386,15 @@ export class ESPHomeAutomationEditor extends LitElement {
     this._error = "";
     try {
       const outcome = await loadAndHydrateAvailable(this._api, this.configuration, {
-        // Paint the picker with the slim list immediately so the
-        // dropdowns mount before bodies hydrate.
+        // Paint the picker with the slim list AND drop the loading
+        // spinner so the dropdowns mount while hydration runs in
+        // the background. The post-hydration ``_available``
+        // reassignment below carries fresh array refs to force a
+        // re-render with the hydrated ``config_entries``.
         onSlim: (slim) => {
-          if (seq === this._loadAvailableSeq) this._available = slim;
+          if (seq !== this._loadAvailableSeq) return;
+          this._available = slim;
+          this._loading = false;
         },
         isStale: () => seq !== this._loadAvailableSeq,
       });

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -219,7 +219,10 @@ export class ESPHomeAutomationEditor extends LitElement {
     // and re-pins location) don't accidentally unlock the picker
     // after it should stay locked.
     this._editMode = !this.addMode;
-    void this._loadCatalogs();
+    // ``_loadAvailable`` fires from ``updated()`` on the first
+    // render once ``configuration`` lands — no separate kickoff
+    // here, otherwise we'd send two ``automations/get_available``
+    // calls per mount.
     // Announce so the page-level save guard (device.ts) can hold a
     // direct ref and call flushPending() before its global save.
     // Mirrors device-section-config's section-mount event.
@@ -358,19 +361,6 @@ export class ESPHomeAutomationEditor extends LitElement {
     }
   }
 
-  private async _loadCatalogs() {
-    if (!this._api) return;
-    this._loading = true;
-    this._error = "";
-    try {
-      if (this.configuration) await this._loadAvailable();
-    } catch (err) {
-      this._error = err instanceof Error ? err.message : String(err);
-    } finally {
-      this._loading = false;
-    }
-  }
-
   /**
    * Re-hydrate from the live YAML. Called by the parent
    * (``device-board-info``) when the YAML pane changes the document
@@ -394,6 +384,8 @@ export class ESPHomeAutomationEditor extends LitElement {
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
     const seq = ++this._loadAvailableSeq;
+    this._loading = true;
+    this._error = "";
     try {
       const available = await this._api.getAvailableAutomations(this.configuration);
       if (seq !== this._loadAvailableSeq) return;
@@ -428,6 +420,8 @@ export class ESPHomeAutomationEditor extends LitElement {
     } catch (err) {
       if (seq !== this._loadAvailableSeq) return;
       this._error = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (seq === this._loadAvailableSeq) this._loading = false;
     }
   }
 

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -13,8 +13,6 @@ import {
   type HydrationResult,
 } from "../../../util/automation-body-hydration.js";
 
-export type { AutomationBodyFetcher, HydrationResult };
-
 type _AutomationListType = "triggers" | "actions" | "conditions";
 type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationCondition;
 
@@ -55,12 +53,7 @@ export async function hydrateAvailableBodies(
 
 /** Discriminated outcome of :func:`loadAndHydrateAvailable`. */
 export type LoadAndHydrateOutcome =
-  | {
-      status: "ok";
-      slim: AvailableAutomations;
-      available: AvailableAutomations;
-      hydration: HydrationResult;
-    }
+  | { status: "ok"; available: AvailableAutomations; hydration: HydrationResult }
   | { status: "stale" }
   | { status: "error"; error: unknown };
 
@@ -97,7 +90,7 @@ export async function loadAndHydrateAvailable(
       actions: [...slim.actions],
       conditions: [...slim.conditions],
     };
-    return { status: "ok", slim, available, hydration };
+    return { status: "ok", available, hydration };
   } catch (error) {
     if (options?.isStale?.()) return { status: "stale" };
     return { status: "error", error };

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -14,31 +14,58 @@ export type AutomationBodyFetcher = typeof fetchAutomationBody;
 type _AutomationListType = "triggers" | "actions" | "conditions";
 type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationCondition;
 
+/** Aggregate hydration outcome — caller can toast / set _error if
+ *  any entries failed. */
+export interface HydrationResult {
+  /** Entries whose ``config_entries`` was successfully replaced. */
+  succeeded: number;
+  /** Body fetches that returned null. */
+  missingBody: number;
+  /** Body shapes lacking ``config_entries``. */
+  missingField: number;
+  /** Body fetches that threw (transport error, cache cleared, …). */
+  rejected: number;
+}
+
 /**
  * Hydrate ``config_entries`` for every entry in *available* by
  * fetching its body through the batched body cache. Mutates the
- * passed lists in place (caller already holds the array refs).
- * ``allSettled`` so one fetch failure doesn't abort the rest;
- * missing-``config_entries`` shapes are logged but otherwise
- * skipped (the body cache's ``cacheMisses: false`` lets a re-mount
- * recover).
+ * passed lists in place. ``allSettled`` so one fetch failure
+ * doesn't abort the rest; the returned :class:`HydrationResult`
+ * lets the caller decide whether to surface a partial failure
+ * (the body cache's ``cacheMisses: false`` lets a re-mount
+ * recover from contract-violation misses; transport rejections
+ * are also retry-able).
  */
 export async function hydrateAvailableBodies(
   api: ESPHomeAPI,
   available: AvailableAutomations,
   fetchBody: AutomationBodyFetcher = fetchAutomationBody
-): Promise<void> {
+): Promise<HydrationResult> {
+  const result: HydrationResult = {
+    succeeded: 0,
+    missingBody: 0,
+    missingField: 0,
+    rejected: 0,
+  };
   const jobs: Promise<unknown>[] = [];
   const merge = (type: _AutomationListType, list: _AutomationEntry[]): void => {
     for (const entry of list) {
       jobs.push(
         fetchBody(api, type, entry.id).then((body) => {
           if (body && "config_entries" in body) {
-            // Shallow-clone so downstream form mutations can't
-            // poison the shared cache.
+            // Shallow-clone the array so add/remove/reorder on the
+            // entry's ``config_entries`` can't leak back into the
+            // shared cache. Individual ``ConfigEntry`` objects are
+            // still aliased; downstream forms must not mutate them
+            // in place (they don't today — the form returns a new
+            // value, never patches the schema).
             entry.config_entries = [...body.config_entries];
+            result.succeeded++;
             return;
           }
+          if (body === null) result.missingBody++;
+          else result.missingField++;
           const reason =
             body === null ? "no body returned" : "body shape missing config_entries";
           console.warn(
@@ -51,10 +78,12 @@ export async function hydrateAvailableBodies(
   merge("triggers", available.triggers);
   merge("actions", available.actions);
   merge("conditions", available.conditions);
-  const results = await Promise.allSettled(jobs);
-  for (const r of results) {
+  const settled = await Promise.allSettled(jobs);
+  for (const r of settled) {
     if (r.status === "rejected") {
+      result.rejected++;
       console.warn("automation-editor: body fetch failed", r.reason);
     }
   }
+  return result;
 }

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -54,13 +54,13 @@ export async function hydrateAvailableBodies(
       jobs.push(
         fetchBody(api, type, entry.id).then((body) => {
           if (body && "config_entries" in body) {
-            // Shallow-clone the array so add/remove/reorder on the
-            // entry's ``config_entries`` can't leak back into the
-            // shared cache. Individual ``ConfigEntry`` objects are
-            // still aliased; downstream forms must not mutate them
-            // in place (they don't today — the form returns a new
-            // value, never patches the schema).
-            entry.config_entries = [...body.config_entries];
+            // Deep-clone via ``structuredClone`` so the per-entry
+            // tree is structurally disjoint from the cached body —
+            // no add/remove/reorder OR entry-object mutation can
+            // leak back. JSON-shaped data only (primitives + arrays
+            // + plain objects from the wire), so structuredClone
+            // is faithful.
+            entry.config_entries = structuredClone(body.config_entries);
             result.succeeded++;
             return;
           }

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -52,3 +52,54 @@ export async function hydrateAvailableBodies(
   }
   return result;
 }
+
+/** Discriminated outcome of :func:`loadAndHydrateAvailable`. */
+export type LoadAndHydrateOutcome =
+  | {
+      status: "ok";
+      slim: AvailableAutomations;
+      available: AvailableAutomations;
+      hydration: HydrationResult;
+    }
+  | { status: "stale" }
+  | { status: "error"; error: unknown };
+
+/** Fetch the slim ``AvailableAutomations`` for *configuration* and
+ *  hydrate ``config_entries`` for every entry, returning fresh
+ *  array references so identity-based ``hasChanged`` consumers
+ *  re-render with the hydrated entries. The caller owns the
+ *  state-mutation policy (``_available`` / ``_loading`` /
+ *  ``_error`` on the editor element); this function is a thin
+ *  orchestration wrapper that the editor element wires into its
+ *  Lit lifecycle.
+ *
+ *  ``onSlim`` lets the caller paint the picker with the slim list
+ *  immediately, before awaiting hydration. ``isStale`` is checked
+ *  after each await so an overlapping load can bail out
+ *  cleanly. */
+export async function loadAndHydrateAvailable(
+  api: ESPHomeAPI,
+  configuration: string,
+  options?: {
+    onSlim?: (slim: AvailableAutomations) => void;
+    isStale?: () => boolean;
+  }
+): Promise<LoadAndHydrateOutcome> {
+  try {
+    const slim = await api.getAvailableAutomations(configuration);
+    if (options?.isStale?.()) return { status: "stale" };
+    options?.onSlim?.(slim);
+    const hydration = await hydrateAvailableBodies(api, slim);
+    if (options?.isStale?.()) return { status: "stale" };
+    const available: AvailableAutomations = {
+      ...slim,
+      triggers: [...slim.triggers],
+      actions: [...slim.actions],
+      conditions: [...slim.conditions],
+    };
+    return { status: "ok", slim, available, hydration };
+  } catch (error) {
+    if (options?.isStale?.()) return { status: "stale" };
+    return { status: "error", error };
+  }
+}

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -1,0 +1,58 @@
+import type { ESPHomeAPI } from "../../../api/index.js";
+import type {
+  AutomationAction,
+  AutomationCondition,
+  AutomationTrigger,
+  AvailableAutomations,
+} from "../../../api/types.js";
+import { fetchAutomationBody } from "../../../util/automation-body-cache.js";
+
+/** Per-entry body fetcher — defaults to the shared cache but is
+ *  swappable for unit tests. */
+export type AutomationBodyFetcher = typeof fetchAutomationBody;
+
+type _AutomationListType = "triggers" | "actions" | "conditions";
+type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationCondition;
+
+/**
+ * Hydrate ``config_entries`` for every entry in *available* by
+ * fetching its body through the batched body cache. Mutates the
+ * passed lists in place (caller already holds the array refs).
+ * ``allSettled`` so one fetch failure doesn't abort the rest;
+ * missing-``config_entries`` shapes are logged but otherwise
+ * skipped (the body cache's ``cacheMisses: false`` lets a re-mount
+ * recover).
+ */
+export async function hydrateAvailableBodies(
+  api: ESPHomeAPI,
+  available: AvailableAutomations,
+  fetchBody: AutomationBodyFetcher = fetchAutomationBody
+): Promise<void> {
+  const jobs: Promise<unknown>[] = [];
+  const merge = (type: _AutomationListType, list: _AutomationEntry[]): void => {
+    for (const entry of list) {
+      jobs.push(
+        fetchBody(api, type, entry.id).then((body) => {
+          if (body && "config_entries" in body) {
+            // Shallow-clone so downstream form mutations can't
+            // poison the shared cache.
+            entry.config_entries = [...body.config_entries];
+            return;
+          }
+          console.warn(
+            `automation-editor: ${type}/${entry.id} body missing config_entries; form will render empty`
+          );
+        })
+      );
+    }
+  };
+  merge("triggers", available.triggers);
+  merge("actions", available.actions);
+  merge("conditions", available.conditions);
+  const results = await Promise.allSettled(jobs);
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.warn("automation-editor: body fetch failed", r.reason);
+    }
+  }
+}

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -5,72 +5,37 @@ import type {
   AutomationTrigger,
   AvailableAutomations,
 } from "../../../api/types.js";
-import { fetchAutomationBody } from "../../../util/automation-body-cache.js";
+import {
+  emptyHydrationResult,
+  hydrateEntryConfigEntries,
+  tallyOutcome,
+  type AutomationBodyFetcher,
+  type HydrationResult,
+} from "../../../util/automation-body-hydration.js";
 
-/** Per-entry body fetcher — defaults to the shared cache but is
- *  swappable for unit tests. */
-export type AutomationBodyFetcher = typeof fetchAutomationBody;
+export type { AutomationBodyFetcher, HydrationResult };
 
 type _AutomationListType = "triggers" | "actions" | "conditions";
 type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationCondition;
 
-/** Aggregate hydration outcome — caller can toast / set _error if
- *  any entries failed. */
-export interface HydrationResult {
-  /** Entries whose ``config_entries`` was successfully replaced. */
-  succeeded: number;
-  /** Body fetches that returned null. */
-  missingBody: number;
-  /** Body shapes lacking ``config_entries``. */
-  missingField: number;
-  /** Body fetches that threw (transport error, cache cleared, …). */
-  rejected: number;
-}
-
-/**
- * Hydrate ``config_entries`` for every entry in *available* by
- * fetching its body through the batched body cache. Mutates the
- * passed lists in place. ``allSettled`` so one fetch failure
- * doesn't abort the rest; the returned :class:`HydrationResult`
- * lets the caller decide whether to surface a partial failure
- * (the body cache's ``cacheMisses: false`` lets a re-mount
- * recover from contract-violation misses; transport rejections
- * are also retry-able).
- */
+/** Hydrate ``config_entries`` for every entry in *available* via the
+ *  shared per-entry helper. ``allSettled`` so a single rejection
+ *  doesn't abort the rest; the returned aggregate lets the caller
+ *  surface partial-failure UI (the body cache's
+ *  ``cacheMisses: false`` lets a re-mount retry contract-violation
+ *  misses, and transport rejections are also retry-able). */
 export async function hydrateAvailableBodies(
   api: ESPHomeAPI,
   available: AvailableAutomations,
-  fetchBody: AutomationBodyFetcher = fetchAutomationBody
+  fetchBody?: AutomationBodyFetcher
 ): Promise<HydrationResult> {
-  const result: HydrationResult = {
-    succeeded: 0,
-    missingBody: 0,
-    missingField: 0,
-    rejected: 0,
-  };
+  const result = emptyHydrationResult();
   const jobs: Promise<unknown>[] = [];
   const merge = (type: _AutomationListType, list: _AutomationEntry[]): void => {
     for (const entry of list) {
       jobs.push(
-        fetchBody(api, type, entry.id).then((body) => {
-          if (body && "config_entries" in body) {
-            // Deep-clone via ``structuredClone`` so the per-entry
-            // tree is structurally disjoint from the cached body —
-            // no add/remove/reorder OR entry-object mutation can
-            // leak back. JSON-shaped data only (primitives + arrays
-            // + plain objects from the wire), so structuredClone
-            // is faithful.
-            entry.config_entries = structuredClone(body.config_entries);
-            result.succeeded++;
-            return;
-          }
-          if (body === null) result.missingBody++;
-          else result.missingField++;
-          const reason =
-            body === null ? "no body returned" : "body shape missing config_entries";
-          console.warn(
-            `automation-editor: ${type}/${entry.id} ${reason}; form will render empty`
-          );
+        hydrateEntryConfigEntries(api, type, entry, fetchBody).then((outcome) => {
+          tallyOutcome(result, outcome);
         })
       );
     }

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -39,8 +39,10 @@ export async function hydrateAvailableBodies(
             entry.config_entries = [...body.config_entries];
             return;
           }
+          const reason =
+            body === null ? "no body returned" : "body shape missing config_entries";
           console.warn(
-            `automation-editor: ${type}/${entry.id} body missing config_entries; form will render empty`
+            `automation-editor: ${type}/${entry.id} ${reason}; form will render empty`
           );
         })
       );

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -67,9 +67,12 @@ export type LoadAndHydrateOutcome =
  *  Lit lifecycle.
  *
  *  ``onSlim`` lets the caller paint the picker with the slim list
- *  immediately, before awaiting hydration. ``isStale`` is checked
- *  after each await so an overlapping load can bail out
- *  cleanly. */
+ *  immediately, before awaiting hydration. The slim snapshot is
+ *  guaranteed stable — hydration runs against a per-entry shallow
+ *  clone so ``config_entries`` mutations land on ``available`` and
+ *  never on the ``slim`` object the caller paints from. ``isStale``
+ *  is checked after each await so an overlapping load can bail
+ *  out cleanly. */
 export async function loadAndHydrateAvailable(
   api: ESPHomeAPI,
   configuration: string,
@@ -82,14 +85,19 @@ export async function loadAndHydrateAvailable(
     const slim = await api.getAvailableAutomations(configuration);
     if (options?.isStale?.()) return { status: "stale" };
     options?.onSlim?.(slim);
-    const hydration = await hydrateAvailableBodies(api, slim);
-    if (options?.isStale?.()) return { status: "stale" };
+    // Shallow-clone each entry so ``hydrateAvailableBodies``
+    // mutates ``available``'s copies, not the ``slim`` snapshot.
+    // Entry-level ``config_entries`` reassignment ends in a deep
+    // ``structuredClone`` inside the per-entry hydrator, so the
+    // cached body stays disjoint either way.
     const available: AvailableAutomations = {
       ...slim,
-      triggers: [...slim.triggers],
-      actions: [...slim.actions],
-      conditions: [...slim.conditions],
+      triggers: slim.triggers.map((e) => ({ ...e })),
+      actions: slim.actions.map((e) => ({ ...e })),
+      conditions: slim.conditions.map((e) => ({ ...e })),
     };
+    const hydration = await hydrateAvailableBodies(api, available);
+    if (options?.isStale?.()) return { status: "stale" };
     return { status: "ok", available, hydration };
   } catch (error) {
     if (options?.isStale?.()) return { status: "stale" };

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -382,17 +382,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (
       (changedProperties.has("yaml") || changedProperties.has("platform")) &&
-      this.yaml &&
-      this.platform
+      this.yaml
     ) {
-      // Gate on ``platform`` being set: the parent typically
-      // resolves ``yaml`` first and ``platform`` once the board
-      // manifest lands a beat later. Firing on the yaml-only edge
-      // sends ``get_component_bodies`` / ``get_triggers`` with
-      // ``platform=undefined``, which lands in a different
-      // ``BatchedCache`` bucket than the eventual platform-scoped
-      // fetch and gets discarded — two WS round trips for one
-      // navigator mount. Wait for the full context.
+      // Fire on both edges: the parent typically resolves ``yaml``
+      // first and ``platform`` once the board manifest lands a
+      // beat later. The yaml-edge fire goes into a
+      // ``platform=undefined`` ``BatchedCache`` bucket; the
+      // platform-edge fire refreshes labels with platform-scoped
+      // values. We intentionally pay the one-time double-fetch
+      // rather than gate on ``this.platform`` truthy, because a
+      // device without a resolvable board (``board_id`` missing,
+      // board fetch failed) would otherwise never get its labels
+      // resolved at all — see ``device.ts::_loadBoard``.
       this._kickoffNameResolves();
     }
 

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -382,8 +382,17 @@ export class ESPHomeDeviceNavigator extends LitElement {
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (
       (changedProperties.has("yaml") || changedProperties.has("platform")) &&
-      this.yaml
+      this.yaml &&
+      this.platform
     ) {
+      // Gate on ``platform`` being set: the parent typically
+      // resolves ``yaml`` first and ``platform`` once the board
+      // manifest lands a beat later. Firing on the yaml-only edge
+      // sends ``get_component_bodies`` / ``get_triggers`` with
+      // ``platform=undefined``, which lands in a different
+      // ``BatchedCache`` bucket than the eventual platform-scoped
+      // fetch and gets discarded — two WS round trips for one
+      // navigator mount. Wait for the full context.
       this._kickoffNameResolves();
     }
 

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -377,55 +377,14 @@ export class ESPHomeDeviceNavigator extends LitElement {
     super.disconnectedCallback();
     this._unsubscribeCache?.();
     this._unsubscribeCache = undefined;
-    if (this._pendingKickoff !== null) {
-      clearTimeout(this._pendingKickoff);
-      this._pendingKickoff = null;
-    }
   }
-
-  /** Window we wait on the yaml-edge for ``platform`` to land
-   *  before firing without it. Long enough for the typical
-   *  board-manifest fetch round trip (small JSON, sub-100ms LAN);
-   *  short enough that a platform-less device (board id missing
-   *  / manifest 404) feels responsive when labels do resolve. */
-  private static readonly _KICKOFF_DEFER_MS = 500;
-
-  /** Pending yaml-edge kickoff that's waiting for ``platform`` to
-   *  arrive. The platform-edge cancels it and fires with full
-   *  context; the disconnect cancels it cleanly. */
-  private _pendingKickoff: ReturnType<typeof setTimeout> | null = null;
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (
       (changedProperties.has("yaml") || changedProperties.has("platform")) &&
       this.yaml
     ) {
-      // Coalesce the yaml-then-platform mount sequence into one
-      // fetch: yaml typically lands first and ``platform``
-      // (derived from the board manifest fetch) a beat later. If
-      // we fire on both edges, the yaml-edge call hits a
-      // ``platform=undefined`` ``BatchedCache`` bucket and the
-      // platform-edge call hits a separate bucket — two WS round
-      // trips per mount, the first one's results orphaned.
-      //
-      // Instead, defer the yaml-edge fire by a short window so
-      // the platform-edge can cancel it and run once with full
-      // context. The fallback timer ensures devices without a
-      // resolvable board (board_id missing, manifest fetch
-      // failed — see ``device.ts::_loadBoard``) still get their
-      // labels resolved, just with platform-undefined values.
-      if (this._pendingKickoff !== null) {
-        clearTimeout(this._pendingKickoff);
-        this._pendingKickoff = null;
-      }
-      if (this.platform) {
-        this._kickoffNameResolves();
-      } else {
-        this._pendingKickoff = setTimeout(() => {
-          this._pendingKickoff = null;
-          if (this.yaml) this._kickoffNameResolves();
-        }, ESPHomeDeviceNavigator._KICKOFF_DEFER_MS);
-      }
+      this._kickoffNameResolves();
     }
 
     // Sync `_selectedLine`/`_selectedRange` whenever the externally-

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -377,24 +377,55 @@ export class ESPHomeDeviceNavigator extends LitElement {
     super.disconnectedCallback();
     this._unsubscribeCache?.();
     this._unsubscribeCache = undefined;
+    if (this._pendingKickoff !== null) {
+      clearTimeout(this._pendingKickoff);
+      this._pendingKickoff = null;
+    }
   }
+
+  /** Window we wait on the yaml-edge for ``platform`` to land
+   *  before firing without it. Long enough for the typical
+   *  board-manifest fetch round trip (small JSON, sub-100ms LAN);
+   *  short enough that a platform-less device (board id missing
+   *  / manifest 404) feels responsive when labels do resolve. */
+  private static readonly _KICKOFF_DEFER_MS = 500;
+
+  /** Pending yaml-edge kickoff that's waiting for ``platform`` to
+   *  arrive. The platform-edge cancels it and fires with full
+   *  context; the disconnect cancels it cleanly. */
+  private _pendingKickoff: ReturnType<typeof setTimeout> | null = null;
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (
       (changedProperties.has("yaml") || changedProperties.has("platform")) &&
       this.yaml
     ) {
-      // Fire on both edges: the parent typically resolves ``yaml``
-      // first and ``platform`` once the board manifest lands a
-      // beat later. The yaml-edge fire goes into a
-      // ``platform=undefined`` ``BatchedCache`` bucket; the
-      // platform-edge fire refreshes labels with platform-scoped
-      // values. We intentionally pay the one-time double-fetch
-      // rather than gate on ``this.platform`` truthy, because a
-      // device without a resolvable board (``board_id`` missing,
-      // board fetch failed) would otherwise never get its labels
-      // resolved at all — see ``device.ts::_loadBoard``.
-      this._kickoffNameResolves();
+      // Coalesce the yaml-then-platform mount sequence into one
+      // fetch: yaml typically lands first and ``platform``
+      // (derived from the board manifest fetch) a beat later. If
+      // we fire on both edges, the yaml-edge call hits a
+      // ``platform=undefined`` ``BatchedCache`` bucket and the
+      // platform-edge call hits a separate bucket — two WS round
+      // trips per mount, the first one's results orphaned.
+      //
+      // Instead, defer the yaml-edge fire by a short window so
+      // the platform-edge can cancel it and run once with full
+      // context. The fallback timer ensures devices without a
+      // resolvable board (board_id missing, manifest fetch
+      // failed — see ``device.ts::_loadBoard``) still get their
+      // labels resolved, just with platform-undefined values.
+      if (this._pendingKickoff !== null) {
+        clearTimeout(this._pendingKickoff);
+        this._pendingKickoff = null;
+      }
+      if (this.platform) {
+        this._kickoffNameResolves();
+      } else {
+        this._pendingKickoff = setTimeout(() => {
+          this._pendingKickoff = null;
+          if (this.yaml) this._kickoffNameResolves();
+        }, ESPHomeDeviceNavigator._KICKOFF_DEFER_MS);
+      }
     }
 
     // Sync `_selectedLine`/`_selectedRange` whenever the externally-

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -755,6 +755,7 @@
     "automation_action_delay_unit_d": "Days",
     "automation_light_effect": "Effect",
     "automation_parse_error": "Could not parse this automation. Edit the YAML directly to recover.",
+    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty.",
     "automation_save_error": "Failed to save automation",
     "automation_yaml_only_fallback": "This automation uses a value the editor doesn't recognise yet. Edit the YAML directly.",
     "add_action": "Add action",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -687,7 +687,8 @@
     "unsaved_message": "Vous avez des modifications non enregistrées sur cet appareil. Si vous quittez sans enregistrer, elles seront perdues.",
     "leave_anyway": "Quitter quand même",
     "discard_changes": "Annuler",
-    "save_and_leave": "Enregistrer"
+    "save_and_leave": "Enregistrer",
+    "automation_partial_hydration": "Impossible de charger {count} formulaire(s) d'automatisation. Certains formulaires peuvent s'afficher vides."
   },
   "onboarding": {
     "menu_item_setup_wifi": "Configurer le Wi-Fi",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -687,7 +687,8 @@
     "unsaved_message": "Vous avez des modifications non enregistrées sur cet appareil. Si vous quittez sans enregistrer, elles seront perdues.",
     "leave_anyway": "Quitter quand même",
     "discard_changes": "Annuler",
-    "save_and_leave": "Enregistrer"
+    "save_and_leave": "Enregistrer",
+    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
   },
   "onboarding": {
     "menu_item_setup_wifi": "Configurer le Wi-Fi",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -687,8 +687,7 @@
     "unsaved_message": "Vous avez des modifications non enregistrées sur cet appareil. Si vous quittez sans enregistrer, elles seront perdues.",
     "leave_anyway": "Quitter quand même",
     "discard_changes": "Annuler",
-    "save_and_leave": "Enregistrer",
-    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
+    "save_and_leave": "Enregistrer"
   },
   "onboarding": {
     "menu_item_setup_wifi": "Configurer le Wi-Fi",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -787,7 +787,8 @@
     "unsaved_message": "Nem mentett változtatások vannak ennél az eszköznél. Ha mentés nélkül lép ki innen, módosításai elvesznek.",
     "leave_anyway": "Elhagyás mindenképpen",
     "discard_changes": "Elvetés",
-    "save_and_leave": "Mentés"
+    "save_and_leave": "Mentés",
+    "automation_partial_hydration": "{count} automatizmus űrlap betöltése sikertelen. Néhány űrlap üresen jelenhet meg."
   },
   "validation": {
     "required": "Ez a mező kötelező",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -787,8 +787,7 @@
     "unsaved_message": "Nem mentett változtatások vannak ennél az eszköznél. Ha mentés nélkül lép ki innen, módosításai elvesznek.",
     "leave_anyway": "Elhagyás mindenképpen",
     "discard_changes": "Elvetés",
-    "save_and_leave": "Mentés",
-    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
+    "save_and_leave": "Mentés"
   },
   "validation": {
     "required": "Ez a mező kötelező",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -787,7 +787,8 @@
     "unsaved_message": "Nem mentett változtatások vannak ennél az eszköznél. Ha mentés nélkül lép ki innen, módosításai elvesznek.",
     "leave_anyway": "Elhagyás mindenképpen",
     "discard_changes": "Elvetés",
-    "save_and_leave": "Mentés"
+    "save_and_leave": "Mentés",
+    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
   },
   "validation": {
     "required": "Ez a mező kötelező",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -687,7 +687,8 @@
     "unsaved_message": "U heeft niet-opgeslagen wijzigingen op dit apparaat. Als u zonder opslaan vertrekt, gaan ze verloren.",
     "leave_anyway": "Toch verlaten",
     "discard_changes": "Negeren",
-    "save_and_leave": "Opslaan"
+    "save_and_leave": "Opslaan",
+    "automation_partial_hydration": "Kon {count} automatiseringsformulier(en) niet laden. Sommige formulieren worden mogelijk leeg weergegeven."
   },
   "onboarding": {
     "menu_item_setup_wifi": "Wi-Fi instellen",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -687,7 +687,8 @@
     "unsaved_message": "U heeft niet-opgeslagen wijzigingen op dit apparaat. Als u zonder opslaan vertrekt, gaan ze verloren.",
     "leave_anyway": "Toch verlaten",
     "discard_changes": "Negeren",
-    "save_and_leave": "Opslaan"
+    "save_and_leave": "Opslaan",
+    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
   },
   "onboarding": {
     "menu_item_setup_wifi": "Wi-Fi instellen",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -687,8 +687,7 @@
     "unsaved_message": "U heeft niet-opgeslagen wijzigingen op dit apparaat. Als u zonder opslaan vertrekt, gaan ze verloren.",
     "leave_anyway": "Toch verlaten",
     "discard_changes": "Negeren",
-    "save_and_leave": "Opslaan",
-    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
+    "save_and_leave": "Opslaan"
   },
   "onboarding": {
     "menu_item_setup_wifi": "Wi-Fi instellen",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -795,7 +795,8 @@
     "unsaved_message": "此设备有未保存的更改。如果离开且不保存，这些更改将丢失。",
     "leave_anyway": "仍然离开",
     "discard_changes": "放弃",
-    "save_and_leave": "保存"
+    "save_and_leave": "保存",
+    "automation_partial_hydration": "{count} 个自动化表单加载失败。部分表单可能显示为空。"
   },
   "validation": {
     "required": "此字段为必填项",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -795,8 +795,7 @@
     "unsaved_message": "此设备有未保存的更改。如果离开且不保存，这些更改将丢失。",
     "leave_anyway": "仍然离开",
     "discard_changes": "放弃",
-    "save_and_leave": "保存",
-    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
+    "save_and_leave": "保存"
   },
   "validation": {
     "required": "此字段为必填项",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -795,7 +795,8 @@
     "unsaved_message": "此设备有未保存的更改。如果离开且不保存，这些更改将丢失。",
     "leave_anyway": "仍然离开",
     "discard_changes": "放弃",
-    "save_and_leave": "保存"
+    "save_and_leave": "保存",
+    "automation_partial_hydration": "{count} automation form(s) could not be loaded. Some forms may render empty."
   },
   "validation": {
     "required": "此字段为必填项",

--- a/src/util/automation-body-cache.ts
+++ b/src/util/automation-body-cache.ts
@@ -1,0 +1,49 @@
+import type { ESPHomeAPI } from "../api/index.js";
+import type { AutomationCatalogBody, AutomationCatalogBodyType } from "../api/types.js";
+import { BatchedCache } from "./batched-cache.js";
+
+/** Session-scoped cache of full automation bodies, keyed by
+ *  ``"<type>/<id>"``. The list endpoints ship slim shapes; the
+ *  editor hydrates a body through here when it needs
+ *  ``config_entries`` to mount a form. Cross-type fetches in the
+ *  same microtask coalesce into one ``automations/get_bodies``
+ *  round trip. */
+
+const _cache = new BatchedCache<AutomationCatalogBody, void>({
+  name: "automation-body-cache",
+  bucketKey: () => "",
+  fetch: (api, keys) => {
+    const refs = keys.map((key) => {
+      const slash = key.indexOf("/");
+      return { type: key.slice(0, slash), id: key.slice(slash + 1) };
+    });
+    return api.getAutomationBodies(refs);
+  },
+});
+
+function _key(type: AutomationCatalogBodyType, id: string): string {
+  return `${type}/${id}`;
+}
+
+export function getCachedAutomationBody(
+  type: AutomationCatalogBodyType,
+  id: string
+): AutomationCatalogBody | null | undefined {
+  return _cache.getCached(_key(type, id), undefined);
+}
+
+export function fetchAutomationBody(
+  api: ESPHomeAPI,
+  type: AutomationCatalogBodyType,
+  id: string
+): Promise<AutomationCatalogBody | null> {
+  return _cache.fetch(api, _key(type, id), undefined);
+}
+
+export function subscribeAutomationBodyCache(listener: () => void): () => void {
+  return _cache.subscribe(listener);
+}
+
+export function _clearAutomationBodyCache(): void {
+  _cache.clear();
+}

--- a/src/util/automation-body-cache.ts
+++ b/src/util/automation-body-cache.ts
@@ -12,6 +12,11 @@ import { BatchedCache } from "./batched-cache.js";
 const _cache = new BatchedCache<AutomationCatalogBody, void>({
   name: "automation-body-cache",
   bucketKey: () => "",
+  // The list endpoint advertises every (type, id) the editor will
+  // ask for; a missing body is a backend contract violation, not a
+  // permanent catalog miss. Don't cache the null so a re-mount can
+  // recover.
+  cacheMisses: false,
   fetch: (api, keys) => {
     const refs = keys.map((key) => {
       const slash = key.indexOf("/");

--- a/src/util/automation-body-cache.ts
+++ b/src/util/automation-body-cache.ts
@@ -37,11 +37,15 @@ function _key(type: AutomationCatalogBodyType, id: string): string {
   return `${type}/${id}`;
 }
 
+/** Synchronous cache read. ``cacheMisses: false`` on the underlying
+ *  store means we never persist a null body, so the return is just
+ *  ``AutomationCatalogBody | undefined`` — the ``null`` half of
+ *  ``BatchedCache.getCached`` can't surface here. */
 export function getCachedAutomationBody(
   type: AutomationCatalogBodyType,
   id: string
-): AutomationCatalogBody | null | undefined {
-  return _cache.getCached(_key(type, id), undefined);
+): AutomationCatalogBody | undefined {
+  return _cache.getCached(_key(type, id), undefined) ?? undefined;
 }
 
 export function fetchAutomationBody(

--- a/src/util/automation-body-cache.ts
+++ b/src/util/automation-body-cache.ts
@@ -18,9 +18,16 @@ const _cache = new BatchedCache<AutomationCatalogBody, void>({
   // recover.
   cacheMisses: false,
   fetch: (api, keys) => {
+    // Keys are produced by ``_key`` below — by construction the
+    // prefix is a valid ``AutomationCatalogBodyType``. The cast
+    // keeps the public ``getAutomationBodies`` signature tight
+    // (literal union, no bare ``string``).
     const refs = keys.map((key) => {
       const slash = key.indexOf("/");
-      return { type: key.slice(0, slash), id: key.slice(slash + 1) };
+      return {
+        type: key.slice(0, slash) as AutomationCatalogBodyType,
+        id: key.slice(slash + 1),
+      };
     });
     return api.getAutomationBodies(refs);
   },

--- a/src/util/automation-body-hydration.ts
+++ b/src/util/automation-body-hydration.ts
@@ -1,0 +1,66 @@
+import type { ESPHomeAPI } from "../api/index.js";
+import type {
+  AutomationCatalogBody,
+  AutomationCatalogBodyType,
+  ConfigEntry,
+} from "../api/types.js";
+import { fetchAutomationBody } from "./automation-body-cache.js";
+
+/** Single source of truth for the per-entry hydration shape. Both
+ *  the editor (``hydrate-available-bodies.ts``) and the registry
+ *  cache (``automation-catalog-cache.ts``) go through here so the
+ *  warn messages, clone semantics, and outcome tags can't drift. */
+
+export type AutomationBodyFetcher = (
+  api: ESPHomeAPI,
+  type: AutomationCatalogBodyType,
+  id: string
+) => Promise<AutomationCatalogBody | null>;
+
+export type HydrationOutcome = "ok" | "missingBody" | "missingField";
+
+export interface HydrationResult {
+  succeeded: number;
+  missingBody: number;
+  missingField: number;
+  rejected: number;
+}
+
+interface _Hydratable {
+  id: string;
+  config_entries: ConfigEntry[];
+}
+
+/** Fetch one entry's body and replace ``entry.config_entries`` with
+ *  a structurally-disjoint deep copy. Returns an outcome tag so
+ *  callers can aggregate failure counts. A null body or missing
+ *  ``config_entries`` field is a backend contract violation; we log
+ *  it with the offending key + reason so the empty form has a
+ *  console breadcrumb. */
+export async function hydrateEntryConfigEntries(
+  api: ESPHomeAPI,
+  type: AutomationCatalogBodyType,
+  entry: _Hydratable,
+  fetchBody: AutomationBodyFetcher = fetchAutomationBody
+): Promise<HydrationOutcome> {
+  const body = await fetchBody(api, type, entry.id);
+  if (body && "config_entries" in body) {
+    // Deep-clone — the cached body and the entry's copy must be
+    // structurally disjoint so downstream form mutations can't
+    // poison the cache. Wire payload is JSON-shaped so
+    // structuredClone is faithful.
+    entry.config_entries = structuredClone(body.config_entries);
+    return "ok";
+  }
+  const reason = body === null ? "no body returned" : "body shape missing config_entries";
+  console.warn(`automation-body: ${type}/${entry.id} ${reason}; form will render empty`);
+  return body === null ? "missingBody" : "missingField";
+}
+
+export function emptyHydrationResult(): HydrationResult {
+  return { succeeded: 0, missingBody: 0, missingField: 0, rejected: 0 };
+}
+
+export function tallyOutcome(result: HydrationResult, outcome: HydrationOutcome): void {
+  result[outcome === "ok" ? "succeeded" : outcome]++;
+}

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -228,7 +228,16 @@ async function _hydrateRegistryConfigEntries(
       const body = await fetchAutomationBody(api, type, entry.id);
       if (body && "config_entries" in body) {
         entry.config_entries = [...body.config_entries];
+        return;
       }
+      // Same backend contract violation we surface from
+      // ``hydrateAvailableBodies``: the list endpoint just
+      // advertised this id, so a null or shapeless body is a
+      // server bug. Log it so the registry-list empty form has a
+      // breadcrumb in the console.
+      const reason =
+        body === null ? "no body returned" : "body shape missing config_entries";
+      console.warn(`${type}/${entry.id} ${reason}; form will render empty`);
     })
   );
   for (const r of results) {

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -1,11 +1,14 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import type {
   AutomationAction,
+  AutomationCatalogBodyType,
   AutomationCondition,
   AutomationTrigger,
   Filter,
   LightEffect,
+  RegistryCatalogEntry,
 } from "../api/types.js";
+import { fetchAutomationBody } from "./automation-body-cache.js";
 
 /**
  * Session-scoped cache of the four automation catalogues —
@@ -172,7 +175,16 @@ export function fetchLightEffects(
   platform?: string,
   boardId?: string
 ): Promise<LightEffect[]> {
-  return _fetch("light_effects", (p, b) => api.getLightEffects(p, b), platform, boardId);
+  return _fetch(
+    "light_effects",
+    async (p, b) => {
+      const list = await api.getLightEffects(p, b);
+      await _hydrateRegistryConfigEntries(api, "light_effects", list);
+      return list;
+    },
+    platform,
+    boardId
+  );
 }
 
 export function getCachedFilters(
@@ -187,7 +199,43 @@ export function fetchFilters(
   platform?: string,
   boardId?: string
 ): Promise<Filter[]> {
-  return _fetch("filters", (p, b) => api.getFilters(p, b), platform, boardId);
+  return _fetch(
+    "filters",
+    async (p, b) => {
+      const list = await api.getFilters(p, b);
+      await _hydrateRegistryConfigEntries(api, "filters", list);
+      return list;
+    },
+    platform,
+    boardId
+  );
+}
+
+/** Populate ``config_entries`` on each entry by routing through the
+ *  body cache. After backend #1016, ``automations/get_light_effects``
+ *  and ``automations/get_filters`` ship slim shapes (no
+ *  ``config_entries``); ``registry-list`` reads ``config_entries``
+ *  off cached entries, so the list has to land already hydrated. The
+ *  body cache coalesces the fan-out into one ``get_bodies`` round
+ *  trip. */
+async function _hydrateRegistryConfigEntries(
+  api: ESPHomeAPI,
+  type: AutomationCatalogBodyType,
+  list: RegistryCatalogEntry[]
+): Promise<void> {
+  const results = await Promise.allSettled(
+    list.map(async (entry) => {
+      const body = await fetchAutomationBody(api, type, entry.id);
+      if (body && "config_entries" in body) {
+        entry.config_entries = [...body.config_entries];
+      }
+    })
+  );
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.warn(`${type} hydration failed`, r.reason);
+    }
+  }
 }
 
 /** Subscribe to cache updates. Returns an unsubscribe function.

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -169,21 +169,23 @@ export function getCachedLightEffects(
   return _cache.light_effects.get(_key(platform, boardId));
 }
 
-export function fetchLightEffects(
+export async function fetchLightEffects(
   api: ESPHomeAPI,
   platform?: string,
   boardId?: string
 ): Promise<LightEffect[]> {
-  return _fetch(
+  const list = await _fetch(
     "light_effects",
-    async (p, b) => {
-      const list = await api.getLightEffects(p, b);
-      await _hydrateRegistryConfigEntries(api, "light_effects", list);
-      return list;
-    },
+    (p, b) => api.getLightEffects(p, b),
     platform,
     boardId
   );
+  // Hydration runs OUTSIDE ``_fetch`` so cache hits also retry
+  // any entries whose body fetch previously failed —
+  // ``_hydratedEntries`` short-circuits already-done ones, so the
+  // happy path pays a no-op filter.
+  await _hydrateRegistryConfigEntries(api, "light_effects", list);
+  return list;
 }
 
 export function getCachedFilters(
@@ -193,39 +195,44 @@ export function getCachedFilters(
   return _cache.filters.get(_key(platform, boardId));
 }
 
-export function fetchFilters(
+export async function fetchFilters(
   api: ESPHomeAPI,
   platform?: string,
   boardId?: string
 ): Promise<Filter[]> {
-  return _fetch(
-    "filters",
-    async (p, b) => {
-      const list = await api.getFilters(p, b);
-      await _hydrateRegistryConfigEntries(api, "filters", list);
-      return list;
-    },
-    platform,
-    boardId
-  );
+  const list = await _fetch("filters", (p, b) => api.getFilters(p, b), platform, boardId);
+  await _hydrateRegistryConfigEntries(api, "filters", list);
+  return list;
 }
 
-/** Populate ``config_entries`` on each entry by routing through the
- *  body cache. After backend #1016, ``automations/get_light_effects``
- *  and ``automations/get_filters`` ship slim shapes (no
- *  ``config_entries``); ``registry-list`` reads ``config_entries``
- *  off cached entries, so the list has to land already hydrated. The
- *  body cache coalesces the fan-out into one ``get_bodies`` round
- *  trip. */
+/** Per-entry hydration flag. Membership = body landed and
+ *  ``config_entries`` is the full schema; absence = either never
+ *  attempted or the previous attempt failed (null body / shapeless
+ *  body / rejection). Kept as a ``WeakSet`` so entries removed from
+ *  the catalog (e.g. via ``_clearAutomationCatalogCache``) GC
+ *  cleanly without us tracking removals separately. */
+const _hydratedEntries = new WeakSet<RegistryCatalogEntry>();
+
+/** Populate ``config_entries`` on un-hydrated entries via the body
+ *  cache. After backend #1016, the ``get_light_effects`` /
+ *  ``get_filters`` endpoints ship slim shapes; ``registry-list``
+ *  reads ``config_entries`` off cached entries. Filters to entries
+ *  not yet in ``_hydratedEntries`` so the happy-path retry is a
+ *  no-op walk — only entries whose previous attempt failed hit the
+ *  network, and the body cache coalesces those into one
+ *  ``get_bodies`` round trip. */
 async function _hydrateRegistryConfigEntries(
   api: ESPHomeAPI,
   type: AutomationCatalogBodyType,
   list: RegistryCatalogEntry[]
 ): Promise<void> {
+  const targets = list.filter((e) => !_hydratedEntries.has(e));
+  if (targets.length === 0) return;
   const result = emptyHydrationResult();
   const settled = await Promise.allSettled(
-    list.map(async (entry) => {
+    targets.map(async (entry) => {
       const outcome = await hydrateEntryConfigEntries(api, type, entry);
+      if (outcome === "ok") _hydratedEntries.add(entry);
       tallyOutcome(result, outcome);
     })
   );
@@ -240,7 +247,9 @@ async function _hydrateRegistryConfigEntries(
     // Aggregate breadcrumb — per-entry warns already landed via
     // ``hydrateEntryConfigEntries``. Registry-list callers don't
     // own a toast surface; this lets a maintainer triage from one
-    // log line without scrolling through per-id noise.
+    // log line without scrolling through per-id noise. Subsequent
+    // ``fetchLightEffects`` / ``fetchFilters`` calls (e.g. a
+    // form re-mount) retry the un-flagged entries.
     console.warn(
       `${type} hydration: ${result.succeeded} ok, ${failures} failed ` +
         `(missingBody=${result.missingBody}, missingField=${result.missingField}, rejected=${result.rejected})`

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -227,7 +227,8 @@ async function _hydrateRegistryConfigEntries(
     list.map(async (entry) => {
       const body = await fetchAutomationBody(api, type, entry.id);
       if (body && "config_entries" in body) {
-        entry.config_entries = [...body.config_entries];
+        // Deep-clone — see hydrate-available-bodies.ts.
+        entry.config_entries = structuredClone(body.config_entries);
         return;
       }
       // Same backend contract violation we surface from

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -8,30 +8,29 @@ import type {
   LightEffect,
   RegistryCatalogEntry,
 } from "../api/types.js";
-import { fetchAutomationBody } from "./automation-body-cache.js";
+import {
+  emptyHydrationResult,
+  hydrateEntryConfigEntries,
+  tallyOutcome,
+} from "./automation-body-hydration.js";
 
 /**
- * Session-scoped cache of the four automation catalogues —
- * triggers, actions, conditions, light effects — keyed by
- * ``platform|boardId``.
+ * Session-scoped cache of the five slim automation catalogues
+ * (triggers, actions, conditions, light effects, filters), keyed
+ * by ``platform|boardId``. After backend #1016 the list endpoints
+ * ship slim shapes only; ``light_effects`` and ``filters`` get
+ * their ``config_entries`` hydrated below via the shared body
+ * cache so ``registry-list`` consumers (which read
+ * ``config_entries`` synchronously) keep working. Triggers /
+ * actions / conditions don't need hydration here — the navigator
+ * only reads picker fields, and the editor hydrates separately
+ * via :func:`hydrateAvailableBodies`.
  *
- * Each catalogue is loaded from a static JSON file on the backend
- * (``definitions/automations.json``, baked at release time) and is
- * immutable for the lifetime of the process, so cached lists never
- * need invalidation. ``platform`` / ``boardId`` participate in the
- * key because the backend resolves per-platform
- * ``cv.SplitDefault`` fields on trigger/action parameter schemas
- * server-side — the same list filtered for a different platform
- * has different default values and must be cached separately.
- *
- * Concurrent fetches for the same key share a single in-flight
- * promise (the automation editor mount typically issues all four
- * commands in parallel; nothing prevents two mounts from racing).
- *
- * Mirrors ``component-name-cache.ts``; the duplication is
- * deliberate — each cache has its own value shape and fetcher, and
- * a generic helper would obscure the call sites without saving any
- * meaningful code.
+ * ``platform`` / ``boardId`` are part of the cache key because the
+ * backend resolves per-platform ``cv.SplitDefault`` fields
+ * server-side, so the same catalogue for different platforms has
+ * different default values and must cache separately. Concurrent
+ * fetches for the same key share one in-flight promise.
  */
 
 type CatalogKind = "triggers" | "actions" | "conditions" | "light_effects" | "filters";
@@ -223,28 +222,29 @@ async function _hydrateRegistryConfigEntries(
   type: AutomationCatalogBodyType,
   list: RegistryCatalogEntry[]
 ): Promise<void> {
-  const results = await Promise.allSettled(
+  const result = emptyHydrationResult();
+  const settled = await Promise.allSettled(
     list.map(async (entry) => {
-      const body = await fetchAutomationBody(api, type, entry.id);
-      if (body && "config_entries" in body) {
-        // Deep-clone — see hydrate-available-bodies.ts.
-        entry.config_entries = structuredClone(body.config_entries);
-        return;
-      }
-      // Same backend contract violation we surface from
-      // ``hydrateAvailableBodies``: the list endpoint just
-      // advertised this id, so a null or shapeless body is a
-      // server bug. Log it so the registry-list empty form has a
-      // breadcrumb in the console.
-      const reason =
-        body === null ? "no body returned" : "body shape missing config_entries";
-      console.warn(`${type}/${entry.id} ${reason}; form will render empty`);
+      const outcome = await hydrateEntryConfigEntries(api, type, entry);
+      tallyOutcome(result, outcome);
     })
   );
-  for (const r of results) {
+  for (const r of settled) {
     if (r.status === "rejected") {
+      result.rejected++;
       console.warn(`${type} hydration failed`, r.reason);
     }
+  }
+  const failures = result.missingBody + result.missingField + result.rejected;
+  if (failures > 0) {
+    // Aggregate breadcrumb — per-entry warns already landed via
+    // ``hydrateEntryConfigEntries``. Registry-list callers don't
+    // own a toast surface; this lets a maintainer triage from one
+    // log line without scrolling through per-id noise.
+    console.warn(
+      `${type} hydration: ${result.succeeded} ok, ${failures} failed ` +
+        `(missingBody=${result.missingBody}, missingField=${result.missingField}, rejected=${result.rejected})`
+    );
   }
 }
 

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -12,6 +12,7 @@ import {
   emptyHydrationResult,
   hydrateEntryConfigEntries,
   tallyOutcome,
+  type HydrationResult,
 } from "./automation-body-hydration.js";
 
 /**
@@ -184,8 +185,9 @@ export async function fetchLightEffects(
   // any entries whose body fetch previously failed —
   // ``_hydratedEntries`` short-circuits already-done ones, so the
   // happy path pays a no-op filter.
-  await _hydrateRegistryConfigEntries(api, "light_effects", list);
-  return list;
+  return _postHydrate("light_effects", platform, boardId, list, (l) =>
+    _hydrateRegistryConfigEntries(api, "light_effects", l)
+  );
 }
 
 export function getCachedFilters(
@@ -201,8 +203,33 @@ export async function fetchFilters(
   boardId?: string
 ): Promise<Filter[]> {
   const list = await _fetch("filters", (p, b) => api.getFilters(p, b), platform, boardId);
-  await _hydrateRegistryConfigEntries(api, "filters", list);
-  return list;
+  return _postHydrate("filters", platform, boardId, list, (l) =>
+    _hydrateRegistryConfigEntries(api, "filters", l)
+  );
+}
+
+/** After ``_fetch`` notifies subscribers with the slim list, hydrate
+ *  ``config_entries`` and — if any entry actually changed — replace
+ *  the cached array with a fresh identity and notify again so
+ *  identity-checking consumers (registry-list's
+ *  ``subscribeAutomationCatalogCache`` reread of ``cache()``) repaint
+ *  with the hydrated entries. Without the second notify + identity
+ *  swap, the slim entries the first ``_notify`` painted would never
+ *  refresh: in-place mutation of ``config_entries`` doesn't bump the
+ *  array reference Lit's ``hasChanged`` compares against. */
+async function _postHydrate<K extends "light_effects" | "filters">(
+  kind: K,
+  platform: string | undefined,
+  boardId: string | undefined,
+  list: CatalogValue[K],
+  hydrate: (list: CatalogValue[K]) => Promise<HydrationResult>
+): Promise<CatalogValue[K]> {
+  const result = await hydrate(list);
+  if (result.succeeded === 0) return list;
+  const fresh = [...list] as CatalogValue[K];
+  _cache[kind].set(_key(platform, boardId), fresh);
+  _notify();
+  return fresh;
 }
 
 /** Per-entry hydration flag. Membership = body landed and
@@ -233,10 +260,10 @@ async function _hydrateRegistryConfigEntries(
   api: ESPHomeAPI,
   type: AutomationCatalogBodyType,
   list: RegistryCatalogEntry[]
-): Promise<void> {
-  const targets = list.filter((e) => !_hydratedEntries.has(e));
-  if (targets.length === 0) return;
+): Promise<HydrationResult> {
   const result = emptyHydrationResult();
+  const targets = list.filter((e) => !_hydratedEntries.has(e));
+  if (targets.length === 0) return result;
   const settled = await Promise.allSettled(
     targets.map(async (entry) => {
       const outcome = await hydrateEntryConfigEntries(api, type, entry);
@@ -263,6 +290,7 @@ async function _hydrateRegistryConfigEntries(
         `(missingBody=${result.missingBody}, missingField=${result.missingField}, rejected=${result.rejected})`
     );
   }
+  return result;
 }
 
 /** Subscribe to cache updates. Returns an unsubscribe function.

--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -220,7 +220,15 @@ const _hydratedEntries = new WeakSet<RegistryCatalogEntry>();
  *  not yet in ``_hydratedEntries`` so the happy-path retry is a
  *  no-op walk — only entries whose previous attempt failed hit the
  *  network, and the body cache coalesces those into one
- *  ``get_bodies`` round trip. */
+ *  ``get_bodies`` round trip.
+ *
+ *  Concurrency: the ``_hydratedEntries`` filter is best-effort
+ *  dedup — two concurrent ``fetchLightEffects`` calls that race
+ *  past the filter will both walk the same entries and both run
+ *  ``structuredClone`` + reassign. The body cache's in-flight
+ *  promise dedup is the real network-concurrency guard; the
+ *  WeakSet just keeps subsequent calls fast. Idempotent: last
+ *  write wins with identical data. */
 async function _hydrateRegistryConfigEntries(
   api: ESPHomeAPI,
   type: AutomationCatalogBodyType,

--- a/src/util/batched-cache.ts
+++ b/src/util/batched-cache.ts
@@ -1,0 +1,124 @@
+import type { ESPHomeAPI } from "../api/index.js";
+
+/** Generic microtask-batched cache with context bucketing.
+ *  Shared by ``component-name-cache.ts`` (bucketed on
+ *  ``(platform, boardId)``) and ``automation-body-cache.ts``
+ *  (single bucket). ``null`` is cached for catalog misses;
+ *  transport errors are not. */
+
+interface _PendingResolver<V> {
+  resolve: (value: V | null) => void;
+  reject: (reason: unknown) => void;
+}
+
+interface _Bucket<V, Ctx> {
+  api: ESPHomeAPI;
+  ctx: Ctx;
+  pending: Map<string, _PendingResolver<V>>;
+}
+
+export interface BatchedCacheOptions<V, Ctx> {
+  name: string;
+  /** Same string = same fetcher round trip. */
+  bucketKey: (ctx: Ctx) => string;
+  fetch: (api: ESPHomeAPI, keys: string[], ctx: Ctx) => Promise<Record<string, V>>;
+}
+
+export class BatchedCache<V, Ctx> {
+  private _cache = new Map<string, V | null>();
+  private _inflight = new Map<string, Promise<V | null>>();
+  private _listeners = new Set<() => void>();
+  private _batches = new Map<string, _Bucket<V, Ctx>>();
+
+  constructor(private opts: BatchedCacheOptions<V, Ctx>) {}
+
+  getCached(key: string, ctx: Ctx): V | null | undefined {
+    return this._cache.get(this._cacheKey(key, ctx));
+  }
+
+  fetch(api: ESPHomeAPI, key: string, ctx: Ctx): Promise<V | null> {
+    const cacheKey = this._cacheKey(key, ctx);
+    if (this._cache.has(cacheKey)) {
+      return Promise.resolve(this._cache.get(cacheKey) ?? null);
+    }
+    const existing = this._inflight.get(cacheKey);
+    if (existing) return existing;
+
+    const promise = new Promise<V | null>((resolve, reject) => {
+      const bk = this.opts.bucketKey(ctx);
+      let bucket = this._batches.get(bk);
+      if (bucket === undefined) {
+        bucket = { api, ctx, pending: new Map() };
+        this._batches.set(bk, bucket);
+        queueMicrotask(() => this._flush(bk));
+      }
+      bucket.pending.set(key, { resolve, reject });
+    }).finally(() => {
+      this._inflight.delete(cacheKey);
+    });
+
+    this._inflight.set(cacheKey, promise);
+    return promise;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  clear(): void {
+    for (const promise of this._inflight.values()) promise.catch(() => {});
+    for (const bucket of this._batches.values()) {
+      for (const resolver of bucket.pending.values()) {
+        resolver.reject(new Error(`${this.opts.name} cleared`));
+      }
+    }
+    this._cache.clear();
+    this._inflight.clear();
+    this._listeners.clear();
+    this._batches.clear();
+  }
+
+  private async _flush(bucketKey: string): Promise<void> {
+    const bucket = this._batches.get(bucketKey);
+    if (bucket === undefined) return;
+    this._batches.delete(bucketKey);
+    const keys = Array.from(bucket.pending.keys());
+    let entries: Record<string, V>;
+    try {
+      entries = await this.opts.fetch(bucket.api, keys, bucket.ctx);
+    } catch (err) {
+      for (const resolver of bucket.pending.values()) resolver.reject(err);
+      return;
+    }
+    for (const [key, resolver] of bucket.pending) {
+      // Own-property check: the wire payload is a plain object so a
+      // bare lookup would resolve ``toString`` / ``constructor`` via
+      // the prototype chain and cache that garbage as a hit.
+      const value = Object.prototype.hasOwnProperty.call(entries, key)
+        ? entries[key]
+        : null;
+      // Cache write before resolve so a sync listener re-calling
+      // ``fetch`` for the same key hits the cache path.
+      this._cache.set(this._cacheKey(key, bucket.ctx), value);
+      resolver.resolve(value);
+    }
+    this._notify();
+  }
+
+  private _notify(): void {
+    for (const listener of this._listeners) {
+      try {
+        listener();
+      } catch (err) {
+        console.error(`${this.opts.name} listener threw`, err);
+      }
+    }
+  }
+
+  private _cacheKey(key: string, ctx: Ctx): string {
+    return `${key}|${this.opts.bucketKey(ctx)}`;
+  }
+}

--- a/src/util/batched-cache.ts
+++ b/src/util/batched-cache.ts
@@ -25,27 +25,30 @@ export interface BatchedCacheOptions<V, Ctx> {
 }
 
 export class BatchedCache<V, Ctx> {
-  private _cache = new Map<string, V | null>();
-  private _inflight = new Map<string, Promise<V | null>>();
+  // Nested by bucket key so neither ``key`` nor the bucket-key
+  // string can collide via a delimiter character.
+  private _cache = new Map<string, Map<string, V | null>>();
+  private _inflight = new Map<string, Map<string, Promise<V | null>>>();
   private _listeners = new Set<() => void>();
   private _batches = new Map<string, _Bucket<V, Ctx>>();
 
   constructor(private opts: BatchedCacheOptions<V, Ctx>) {}
 
   getCached(key: string, ctx: Ctx): V | null | undefined {
-    return this._cache.get(this._cacheKey(key, ctx));
+    return this._cache.get(this.opts.bucketKey(ctx))?.get(key);
   }
 
   fetch(api: ESPHomeAPI, key: string, ctx: Ctx): Promise<V | null> {
-    const cacheKey = this._cacheKey(key, ctx);
-    if (this._cache.has(cacheKey)) {
-      return Promise.resolve(this._cache.get(cacheKey) ?? null);
+    const bk = this.opts.bucketKey(ctx);
+    const cacheBucket = this._cache.get(bk);
+    if (cacheBucket?.has(key)) {
+      return Promise.resolve(cacheBucket.get(key) ?? null);
     }
-    const existing = this._inflight.get(cacheKey);
+    const inflightBucket = this._inflight.get(bk);
+    const existing = inflightBucket?.get(key);
     if (existing) return existing;
 
     const promise = new Promise<V | null>((resolve, reject) => {
-      const bk = this.opts.bucketKey(ctx);
       let bucket = this._batches.get(bk);
       if (bucket === undefined) {
         bucket = { api, ctx, pending: new Map() };
@@ -54,10 +57,12 @@ export class BatchedCache<V, Ctx> {
       }
       bucket.pending.set(key, { resolve, reject });
     }).finally(() => {
-      this._inflight.delete(cacheKey);
+      this._inflight.get(bk)?.delete(key);
     });
 
-    this._inflight.set(cacheKey, promise);
+    const inflight = inflightBucket ?? new Map<string, Promise<V | null>>();
+    inflight.set(key, promise);
+    if (!inflightBucket) this._inflight.set(bk, inflight);
     return promise;
   }
 
@@ -69,7 +74,9 @@ export class BatchedCache<V, Ctx> {
   }
 
   clear(): void {
-    for (const promise of this._inflight.values()) promise.catch(() => {});
+    for (const bucket of this._inflight.values()) {
+      for (const promise of bucket.values()) promise.catch(() => {});
+    }
     for (const bucket of this._batches.values()) {
       for (const resolver of bucket.pending.values()) {
         resolver.reject(new Error(`${this.opts.name} cleared`));
@@ -93,6 +100,11 @@ export class BatchedCache<V, Ctx> {
       for (const resolver of bucket.pending.values()) resolver.reject(err);
       return;
     }
+    let cacheBucket = this._cache.get(bucketKey);
+    if (cacheBucket === undefined) {
+      cacheBucket = new Map();
+      this._cache.set(bucketKey, cacheBucket);
+    }
     for (const [key, resolver] of bucket.pending) {
       // Own-property check: the wire payload is a plain object so a
       // bare lookup would resolve ``toString`` / ``constructor`` via
@@ -102,7 +114,7 @@ export class BatchedCache<V, Ctx> {
         : null;
       // Cache write before resolve so a sync listener re-calling
       // ``fetch`` for the same key hits the cache path.
-      this._cache.set(this._cacheKey(key, bucket.ctx), value);
+      cacheBucket.set(key, value);
       resolver.resolve(value);
     }
     this._notify();
@@ -116,9 +128,5 @@ export class BatchedCache<V, Ctx> {
         console.error(`${this.opts.name} listener threw`, err);
       }
     }
-  }
-
-  private _cacheKey(key: string, ctx: Ctx): string {
-    return `${key}|${this.opts.bucketKey(ctx)}`;
   }
 }

--- a/src/util/batched-cache.ts
+++ b/src/util/batched-cache.ts
@@ -22,6 +22,13 @@ export interface BatchedCacheOptions<V, Ctx> {
   /** Same string = same fetcher round trip. */
   bucketKey: (ctx: Ctx) => string;
   fetch: (api: ESPHomeAPI, keys: string[], ctx: Ctx) => Promise<Record<string, V>>;
+  /** Cache ``null`` for keys absent from the fetcher response.
+   *  Default ``true`` — right for an immutable catalog where a
+   *  miss is permanent. Set ``false`` when a missing key is a
+   *  server contract violation (the caller advertised the id) so
+   *  a re-mount can recover instead of seeing a sticky empty
+   *  result. */
+  cacheMisses?: boolean;
 }
 
 export class BatchedCache<V, Ctx> {
@@ -105,16 +112,16 @@ export class BatchedCache<V, Ctx> {
       cacheBucket = new Map();
       this._cache.set(bucketKey, cacheBucket);
     }
+    const cacheMisses = this.opts.cacheMisses ?? true;
     for (const [key, resolver] of bucket.pending) {
       // Own-property check: the wire payload is a plain object so a
       // bare lookup would resolve ``toString`` / ``constructor`` via
       // the prototype chain and cache that garbage as a hit.
-      const value = Object.prototype.hasOwnProperty.call(entries, key)
-        ? entries[key]
-        : null;
+      const present = Object.prototype.hasOwnProperty.call(entries, key);
+      const value = present ? entries[key] : null;
       // Cache write before resolve so a sync listener re-calling
       // ``fetch`` for the same key hits the cache path.
-      cacheBucket.set(key, value);
+      if (present || cacheMisses) cacheBucket.set(key, value);
       resolver.resolve(value);
     }
     this._notify();

--- a/src/util/batched-cache.ts
+++ b/src/util/batched-cache.ts
@@ -38,6 +38,13 @@ export class BatchedCache<V, Ctx> {
   private _inflight = new Map<string, Map<string, Promise<V | null>>>();
   private _listeners = new Set<() => void>();
   private _batches = new Map<string, _Bucket<V, Ctx>>();
+  // Bumped by ``clear()``; ``_flush`` snapshots it before the
+  // fetcher await and bails if it advanced during the network
+  // hop. Without this, a ``clear()`` overlapping an in-flight
+  // post-microtask fetch would neither reject the waiters nor
+  // stay cleared (the fetch would resolve, repopulate the cache,
+  // and silently outlive the clear).
+  private _clearGen = 0;
 
   constructor(private opts: BatchedCacheOptions<V, Ctx>) {}
 
@@ -81,6 +88,7 @@ export class BatchedCache<V, Ctx> {
   }
 
   clear(): void {
+    this._clearGen++;
     for (const bucket of this._inflight.values()) {
       for (const promise of bucket.values()) promise.catch(() => {});
     }
@@ -99,12 +107,23 @@ export class BatchedCache<V, Ctx> {
     const bucket = this._batches.get(bucketKey);
     if (bucket === undefined) return;
     this._batches.delete(bucketKey);
+    const gen = this._clearGen;
     const keys = Array.from(bucket.pending.keys());
     let entries: Record<string, V>;
     try {
       entries = await this.opts.fetch(bucket.api, keys, bucket.ctx);
     } catch (err) {
       for (const resolver of bucket.pending.values()) resolver.reject(err);
+      return;
+    }
+    if (gen !== this._clearGen) {
+      // ``clear()`` ran during the fetch. Reject the waiters (the
+      // bucket was already removed from ``_batches`` before
+      // ``clear`` ran, so it never saw them) and don't write the
+      // result into the freshly-cleared cache.
+      for (const resolver of bucket.pending.values()) {
+        resolver.reject(new Error(`${this.opts.name} cleared`));
+      }
       return;
     }
     let cacheBucket = this._cache.get(bucketKey);

--- a/src/util/component-name-cache.ts
+++ b/src/util/component-name-cache.ts
@@ -1,197 +1,49 @@
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ComponentCatalogEntry } from "../api/types.js";
+import { BatchedCache } from "./batched-cache.js";
 
-/**
- * Session-scoped cache of component catalog entries, keyed by
- * `componentId|platform|boardId`. Used by the device navigator to
- * resolve raw `domain.platform` ids (e.g. `binary_sensor.gpio`) into
- * friendly catalog names (e.g. "GPIO Binary Sensor") without
- * re-fetching across renders, devices, or navigations.
- *
- * The backend catalog is loaded from a static JSON file at startup
- * and is immutable for the lifetime of the process, so cache entries
- * never need invalidation. `null` is cached too (catalog miss) to
- * avoid re-fetching unknown ids; transport errors are not cached so
- * the next call retries.
- *
- * Concurrent fetches for the same key share a single in-flight
- * promise; in addition, every `fetchComponent` call enqueues onto a
- * microtask-flushed batch so a navigator that mounts N components in
- * one task triggers one `components/get_component_bodies` WS call
- * instead of N singletons. Different `(platform, boardId)` contexts
- * batch separately because the backend resolves platform_defaults
- * per call.
- */
+/** Session-scoped cache of component catalog entries, keyed by
+ *  ``componentId|platform|boardId``. The backend catalog is
+ *  immutable for the process lifetime so entries never need
+ *  invalidation; ``null`` is cached for catalog misses. Concurrent
+ *  fetches in one microtask coalesce into one
+ *  ``components/get_component_bodies`` round trip per bucket.
+ *  Different ``(platform, boardId)`` bucket separately because the
+ *  backend resolves ``platform_defaults`` per call. */
 
-type CacheValue = ComponentCatalogEntry | null;
-
-interface _PendingResolver {
-  resolve: (value: CacheValue) => void;
-  reject: (reason: unknown) => void;
-}
-
-interface _BatchBucket {
-  api: ESPHomeAPI;
+interface _ComponentContext {
   platform: string | undefined;
   boardId: string | undefined;
-  // One resolver per id. ``_inflight`` short-circuits same-id
-  // duplicates before they reach the bucket, so this never needs
-  // to fan out to a list.
-  pending: Map<string, _PendingResolver>;
 }
 
-const _cache = new Map<string, CacheValue>();
-const _inflight = new Map<string, Promise<CacheValue>>();
-const _listeners = new Set<() => void>();
-const _batches = new Map<string, _BatchBucket>();
+const _cache = new BatchedCache<ComponentCatalogEntry, _ComponentContext>({
+  name: "component-name-cache",
+  bucketKey: ({ platform, boardId }) => `${platform ?? ""}|${boardId ?? ""}`,
+  fetch: (api, ids, { platform, boardId }) =>
+    api.getComponentBodies(ids, platform, boardId),
+});
 
-function _key(componentId: string, platform?: string, boardId?: string): string {
-  return `${componentId}|${platform ?? ""}|${boardId ?? ""}`;
-}
-
-function _batchKey(platform?: string, boardId?: string): string {
-  return `${platform ?? ""}|${boardId ?? ""}`;
-}
-
-/**
- * Synchronous read. Returns the cached entry (or `null` for a known
- * catalog miss), or `undefined` when this key has never been fetched.
- * Callers typically use this from render and fall back to the raw id
- * when the result is `undefined` or `null`.
- */
 export function getCachedComponent(
   componentId: string,
   platform?: string,
   boardId?: string
-): CacheValue | undefined {
-  return _cache.get(_key(componentId, platform, boardId));
+): ComponentCatalogEntry | null | undefined {
+  return _cache.getCached(componentId, { platform, boardId });
 }
 
-/**
- * Fetch a component, populating the cache. Subsequent calls with the
- * same key return the cached value (or join the in-flight promise).
- * Notifies subscribers once after a fresh entry lands so reactive
- * consumers can re-render.
- *
- * Calls within the same microtask coalesce into one batched
- * `components/get_component_bodies` request, so a navigator that
- * fans out N parallel resolves pays one round trip.
- */
 export function fetchComponent(
   api: ESPHomeAPI,
   componentId: string,
   platform?: string,
   boardId?: string
-): Promise<CacheValue> {
-  const key = _key(componentId, platform, boardId);
-  if (_cache.has(key)) return Promise.resolve(_cache.get(key) ?? null);
-
-  const existing = _inflight.get(key);
-  if (existing) return existing;
-
-  const promise = new Promise<CacheValue>((resolve, reject) => {
-    const bucketKey = _batchKey(platform, boardId);
-    let bucket = _batches.get(bucketKey);
-    if (bucket === undefined) {
-      // Bucket captures the first caller's `api`. Assumes one
-      // live `ESPHomeAPI` per app (context-provided by app-shell);
-      // a future second instance would need `api` in the bucket key.
-      bucket = { api, platform, boardId, pending: new Map() };
-      _batches.set(bucketKey, bucket);
-      queueMicrotask(() => _flushBatch(bucketKey));
-    }
-    bucket.pending.set(componentId, { resolve, reject });
-  }).finally(() => {
-    _inflight.delete(key);
-  });
-
-  _inflight.set(key, promise);
-  return promise;
+): Promise<ComponentCatalogEntry | null> {
+  return _cache.fetch(api, componentId, { platform, boardId });
 }
 
-async function _flushBatch(bucketKey: string): Promise<void> {
-  const bucket = _batches.get(bucketKey);
-  if (bucket === undefined) return;
-  _batches.delete(bucketKey);
-  const ids = Array.from(bucket.pending.keys());
-  let entries: Record<string, ComponentCatalogEntry>;
-  try {
-    entries = await bucket.api.getComponentBodies(ids, bucket.platform, bucket.boardId);
-  } catch (err) {
-    // Surface the transport error to every waiter so callers can
-    // retry; do NOT populate the cache, mirroring the singleton
-    // path's "transport errors are not cached" contract.
-    for (const resolver of bucket.pending.values()) {
-      resolver.reject(err);
-    }
-    return;
-  }
-  for (const [componentId, resolver] of bucket.pending) {
-    // Own-property check rather than `entries[id] ?? null`: the
-    // wire payload is a plain object, so a bare index lookup would
-    // resolve `toString`, `constructor`, etc. via the prototype
-    // chain and cache that garbage as a "found" entry. Reachable
-    // from user-typed yaml-completion ids.
-    const entry = Object.prototype.hasOwnProperty.call(entries, componentId)
-      ? entries[componentId]
-      : null;
-    // Cache write MUST precede resolve. A sync `_notify` subscriber
-    // that re-calls `fetchComponent(api, id, ...)` hits the cache
-    // path; reordering would start a fresh round trip for an id
-    // we just resolved.
-    _cache.set(_key(componentId, bucket.platform, bucket.boardId), entry);
-    resolver.resolve(entry);
-  }
-  // Notify outside the response try so a throwing subscriber
-  // surfaces via `_notify`'s own try/catch instead of getting
-  // turned into a rejection of already-settled resolvers.
-  _notify();
-}
-
-/**
- * Subscribe to cache updates. Returns an unsubscribe function.
- * Listeners fire once per fresh entry; failed fetches do not fire.
- */
 export function subscribeComponentCache(listener: () => void): () => void {
-  _listeners.add(listener);
-  return () => {
-    _listeners.delete(listener);
-  };
+  return _cache.subscribe(listener);
 }
 
-function _notify(): void {
-  // Isolate each listener: a throwing subscriber would otherwise
-  // reject `fetchComponent`'s promise (the cache is already populated
-  // at this point, so the rejection is misleading) and skip later
-  // listeners that haven't been notified yet.
-  for (const listener of _listeners) {
-    try {
-      listener();
-    } catch (err) {
-      console.error("component-name-cache listener threw", err);
-    }
-  }
-}
-
-/** Test-only: drop all cached entries and pending promises.
- *  Bucket waiters waiting on a flush that will never happen are
- *  rejected so the dangling promises settle and dependent tests
- *  don't hang on an `await fetchComponent(...)`. Attach a noop
- *  catch to each in-flight promise first so a test that fired
- *  `fetchComponent` purely for cache side-effects (no await, no
- *  catch) doesn't surface the rejection as
- *  ``unhandledrejection`` under vitest strict mode. */
 export function _clearComponentCache(): void {
-  for (const promise of _inflight.values()) {
-    promise.catch(() => {});
-  }
-  for (const bucket of _batches.values()) {
-    for (const resolver of bucket.pending.values()) {
-      resolver.reject(new Error("component cache cleared"));
-    }
-  }
   _cache.clear();
-  _inflight.clear();
-  _listeners.clear();
-  _batches.clear();
 }

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -86,6 +86,56 @@ describe("automation-editor mount-time load (behavioral)", () => {
     expect(getAvailableAutomations).not.toHaveBeenCalled();
   });
 
+  it("drops the loading spinner once the slim list lands (paint before hydration)", async () => {
+    // Without ``onSlim`` flipping ``_loading=false``, ``render()``
+    // returns the spinner through both the slim and hydration
+    // awaits, so the "paint the picker immediately" intent never
+    // surfaces. Pin that the loading flag is cleared as soon as
+    // the slim list resolves, before bodies hydrate. Uses a
+    // non-empty trigger list so hydration actually needs to await
+    // ``getAutomationBodies``; an empty list resolves the inner
+    // ``Promise.allSettled`` synchronously and there's no "during
+    // hydration" state to observe.
+    const slim = {
+      triggers: [{ id: "on_boot", config_entries: [] }],
+      actions: [],
+      conditions: [],
+      scripts: [],
+      devices: [],
+    } as unknown as AvailableAutomations;
+    let resolveBodies!: (v: Record<string, unknown>) => void;
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slim);
+    const getAutomationBodies = vi.fn(
+      () =>
+        new Promise<Record<string, unknown>>((r) => {
+          resolveBodies = r;
+        })
+    );
+    const api = {
+      getAvailableAutomations,
+      getAutomationBodies,
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    // Let the slim list resolve; hydration is still blocked on
+    // ``getAutomationBodies``.
+    await flushPending();
+
+    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(getAutomationBodies).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any)._loading).toBe(false);
+
+    // Let hydration complete so the rest of the test cleans up.
+    resolveBodies({});
+    await flushPending();
+  });
+
   it("setting configuration after mount triggers the load", async () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
     const getAutomationBodies = vi.fn().mockResolvedValue({});

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral mount tests for ``automation-editor.ts``. The bulk of
+ * the editor's deps drag CodeMirror in through ``config-entry-form``
+ * → ``lambda-editor``, plus the action-list / target-picker /
+ * trigger-picker children, none of which we need to exercise the
+ * mount-time load path. ``vi.mock`` no-ops them so the editor itself
+ * can construct in a happy-dom window.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-target-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type { AvailableAutomations } from "../../../../src/api/types.js";
+import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
+
+const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+async function flushPending(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+describe("automation-editor mount-time load (behavioral)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("editor mounted with configuration preset issues exactly one getAvailableAutomations call", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAvailableAutomations,
+      getAutomationBodies,
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // ``_api`` lives behind a Lit context consumer; in tests we
+    // assign it directly because there's no provider in the tree.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushPending();
+
+    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml");
+  });
+
+  it("editor mounted without configuration does not call getAvailableAutomations", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushPending();
+
+    expect(getAvailableAutomations).not.toHaveBeenCalled();
+  });
+
+  it("setting configuration after mount triggers the load", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAvailableAutomations,
+      getAutomationBodies,
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    expect(getAvailableAutomations).not.toHaveBeenCalled();
+
+    editor.configuration = "device.yaml";
+    await editor.updateComplete;
+    await flushPending();
+
+    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -1,12 +1,11 @@
 /**
  * @vitest-environment happy-dom
  *
- * Behavioral mount tests for ``automation-editor.ts``. The bulk of
- * the editor's deps drag CodeMirror in through ``config-entry-form``
- * → ``lambda-editor``, plus the action-list / target-picker /
- * trigger-picker children, none of which we need to exercise the
- * mount-time load path. ``vi.mock`` no-ops them so the editor itself
- * can construct in a happy-dom window.
+ * Behavioral mount tests for ``automation-editor.ts``. The editor's
+ * deps drag CodeMirror in through ``config-entry-form`` →
+ * ``lambda-editor``, plus the action-list / target-picker /
+ * trigger-picker children. ``vi.mock`` no-ops them so the editor
+ * itself can construct in a happy-dom window.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -45,6 +44,24 @@ async function flushPending(times = 5): Promise<void> {
   for (let i = 0; i < times; i++) await Promise.resolve();
 }
 
+/** Construct an editor, plant the api on its consumer-private
+ *  ``_api`` slot (no Lit context provider in the test tree),
+ *  optionally set ``configuration``, then mount and settle the
+ *  lifecycle. */
+async function mountEditor(
+  api: ESPHomeAPI,
+  configuration?: string
+): Promise<ESPHomeAutomationEditor> {
+  const editor = new ESPHomeAutomationEditor();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any)._api = api;
+  if (configuration !== undefined) editor.configuration = configuration;
+  document.body.appendChild(editor);
+  await editor.updateComplete;
+  await flushPending();
+  return editor;
+}
+
 describe("automation-editor mount-time load (behavioral)", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -53,20 +70,9 @@ describe("automation-editor mount-time load (behavioral)", () => {
   it("editor mounted with configuration preset issues exactly one getAvailableAutomations call", async () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
     const getAutomationBodies = vi.fn().mockResolvedValue({});
-    const api = {
-      getAvailableAutomations,
-      getAutomationBodies,
-    } as unknown as ESPHomeAPI;
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeAutomationEditor();
-    // ``_api`` lives behind a Lit context consumer; in tests we
-    // assign it directly because there's no provider in the tree.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushPending();
+    await mountEditor(api, "device.yaml");
 
     expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
     expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml");
@@ -76,26 +82,16 @@ describe("automation-editor mount-time load (behavioral)", () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
     const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeAutomationEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    await flushPending();
+    await mountEditor(api);
 
     expect(getAvailableAutomations).not.toHaveBeenCalled();
   });
 
   it("drops the loading spinner once the slim list lands (paint before hydration)", async () => {
-    // Without ``onSlim`` flipping ``_loading=false``, ``render()``
-    // returns the spinner through both the slim and hydration
-    // awaits, so the "paint the picker immediately" intent never
-    // surfaces. Pin that the loading flag is cleared as soon as
-    // the slim list resolves, before bodies hydrate. Uses a
-    // non-empty trigger list so hydration actually needs to await
+    // Uses a non-empty trigger list so hydration actually awaits
     // ``getAutomationBodies``; an empty list resolves the inner
-    // ``Promise.allSettled`` synchronously and there's no "during
-    // hydration" state to observe.
+    // ``Promise.allSettled`` synchronously and there's no
+    // "during hydration" state to observe.
     const slim = {
       triggers: [{ id: "on_boot", config_entries: [] }],
       actions: [],
@@ -111,27 +107,15 @@ describe("automation-editor mount-time load (behavioral)", () => {
           resolveBodies = r;
         })
     );
-    const api = {
-      getAvailableAutomations,
-      getAutomationBodies,
-    } as unknown as ESPHomeAPI;
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeAutomationEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    editor.configuration = "device.yaml";
-    document.body.appendChild(editor);
-    await editor.updateComplete;
-    // Let the slim list resolve; hydration is still blocked on
-    // ``getAutomationBodies``.
-    await flushPending();
+    const editor = await mountEditor(api, "device.yaml");
 
     expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
     expect(getAutomationBodies).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((editor as any)._loading).toBe(false);
 
-    // Let hydration complete so the rest of the test cleans up.
     resolveBodies({});
     await flushPending();
   });
@@ -139,16 +123,9 @@ describe("automation-editor mount-time load (behavioral)", () => {
   it("setting configuration after mount triggers the load", async () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
     const getAutomationBodies = vi.fn().mockResolvedValue({});
-    const api = {
-      getAvailableAutomations,
-      getAutomationBodies,
-    } as unknown as ESPHomeAPI;
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
 
-    const editor = new ESPHomeAutomationEditor();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (editor as any)._api = api;
-    document.body.appendChild(editor);
-    await editor.updateComplete;
+    const editor = await mountEditor(api);
     expect(getAvailableAutomations).not.toHaveBeenCalled();
 
     editor.configuration = "device.yaml";

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -96,6 +96,34 @@ describe("automation-editor auto-apply / delete contract", () => {
     expect(slice).toMatch(/"yaml-updated"/);
   });
 
+  it("mount-time load: updated() fires _loadAvailable on configuration change", async () => {
+    const src = await readSource();
+    // ``_loadCatalogs`` was deleted in favor of the ``updated()``
+    // hook. Lit's first ``updated()`` fires with every initially-
+    // set property in ``_changedProperties``, so an editor mounted
+    // with ``configuration`` already populated still kicks off the
+    // load. Pin both halves: (1) connectedCallback no longer calls
+    // ``_loadAvailable`` / ``_loadCatalogs``, (2) ``updated()``
+    // does, gated on ``configuration`` having changed.
+    const ccIdx = src.indexOf("connectedCallback(): void");
+    expect(ccIdx).toBeGreaterThan(-1);
+    const ccAfter = src.slice(ccIdx);
+    const ccEnd = ccAfter.search(/\n\s\sdisconnectedCallback\(\)/);
+    const ccBody = ccEnd > 0 ? ccAfter.slice(0, ccEnd) : ccAfter;
+    expect(ccBody).not.toMatch(/_loadAvailable\s*\(/);
+    expect(ccBody).not.toMatch(/_loadCatalogs\s*\(/);
+
+    // ``updated()`` must fire ``_loadAvailable`` on
+    // ``changed.has("configuration")``. Without this, an editor
+    // mounted with ``configuration`` already present would render
+    // perpetually empty.
+    const updatedIdx = src.indexOf("protected updated(");
+    expect(updatedIdx).toBeGreaterThan(-1);
+    const updatedSlice = src.slice(updatedIdx, updatedIdx + 600);
+    expect(updatedSlice).toMatch(/changed\.has\("configuration"\)/);
+    expect(updatedSlice).toMatch(/this\._loadAvailable\(\)/);
+  });
+
   it("exposes an `inFlightWrite` getter for the parent's reconnect guard", async () => {
     const src = await readSource();
     expect(/get\s+inFlightWrite\s*\(\s*\)\s*:\s*boolean/.test(src)).toBe(true);

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -96,34 +96,6 @@ describe("automation-editor auto-apply / delete contract", () => {
     expect(slice).toMatch(/"yaml-updated"/);
   });
 
-  it("mount-time load: updated() fires _loadAvailable on configuration change", async () => {
-    const src = await readSource();
-    // ``_loadCatalogs`` was deleted in favor of the ``updated()``
-    // hook. Lit's first ``updated()`` fires with every initially-
-    // set property in ``_changedProperties``, so an editor mounted
-    // with ``configuration`` already populated still kicks off the
-    // load. Pin both halves: (1) connectedCallback no longer calls
-    // ``_loadAvailable`` / ``_loadCatalogs``, (2) ``updated()``
-    // does, gated on ``configuration`` having changed.
-    const ccIdx = src.indexOf("connectedCallback(): void");
-    expect(ccIdx).toBeGreaterThan(-1);
-    const ccAfter = src.slice(ccIdx);
-    const ccEnd = ccAfter.search(/\n\s\sdisconnectedCallback\(\)/);
-    const ccBody = ccEnd > 0 ? ccAfter.slice(0, ccEnd) : ccAfter;
-    expect(ccBody).not.toMatch(/_loadAvailable\s*\(/);
-    expect(ccBody).not.toMatch(/_loadCatalogs\s*\(/);
-
-    // ``updated()`` must fire ``_loadAvailable`` on
-    // ``changed.has("configuration")``. Without this, an editor
-    // mounted with ``configuration`` already present would render
-    // perpetually empty.
-    const updatedIdx = src.indexOf("protected updated(");
-    expect(updatedIdx).toBeGreaterThan(-1);
-    const updatedSlice = src.slice(updatedIdx, updatedIdx + 600);
-    expect(updatedSlice).toMatch(/changed\.has\("configuration"\)/);
-    expect(updatedSlice).toMatch(/this\._loadAvailable\(\)/);
-  });
-
   it("exposes an `inFlightWrite` getter for the parent's reconnect guard", async () => {
     const src = await readSource();
     expect(/get\s+inFlightWrite\s*\(\s*\)\s*:\s*boolean/.test(src)).toBe(true);

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
+  AutomationAction,
   AutomationCatalogBody,
   AutomationCatalogBodyType,
+  AutomationCondition,
+  AutomationTrigger,
   AvailableAutomations,
   ConfigEntry,
 } from "../../../../src/api/types.js";
@@ -181,6 +184,52 @@ describe("loadAndHydrateAvailable", () => {
     expect(outcome.available.triggers).not.toBe(slimPainted.triggers);
     expect(outcome.available.actions).not.toBe(slimPainted.actions);
     expect(outcome.available.conditions).not.toBe(slimPainted.conditions);
+  });
+
+  it("keeps the slim snapshot immutable during hydration", async () => {
+    // ``onSlim`` should hand the caller a stable view; the
+    // hydration mutations land on ``available`` (which is a
+    // per-entry shallow clone), never on the snapshot the picker
+    // paints from.
+    const slim = {
+      triggers: [
+        { id: "on_boot", config_entries: [] as ConfigEntry[] } as AutomationTrigger,
+      ],
+      actions: [] as AutomationAction[],
+      conditions: [] as AutomationCondition[],
+      scripts: [],
+      devices: [],
+    } as unknown as AvailableAutomations;
+    const body: AutomationCatalogBody = {
+      id: "on_boot",
+      name: "On Boot",
+      description: "",
+      docs_url: "",
+      applies_to: [],
+      is_device_level: true,
+      config_entries: [configEntry("interval")],
+    } as AutomationCatalogBody;
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+    let painted: AvailableAutomations | null = null;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
+      onSlim: (s) => {
+        painted = s;
+      },
+    });
+    // Force-hydrate ``available`` separately so the entry's
+    // ``config_entries`` is populated.
+    if (outcome.status !== "ok") throw new Error("expected ok");
+    await hydrateAvailableBodies(api, outcome.available, async () => body);
+
+    expect(painted).toBe(slim);
+    // The slim snapshot's entry still has its original empty
+    // ``config_entries``; only ``available``'s shallow-cloned
+    // entry got hydrated.
+    expect(slim.triggers[0].config_entries).toEqual([]);
+    expect(outcome.available.triggers[0]).not.toBe(slim.triggers[0]);
   });
 
   it("paints via onSlim before awaiting hydration", async () => {

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -6,7 +6,10 @@ import type {
   AvailableAutomations,
   ConfigEntry,
 } from "../../../../src/api/types.js";
-import { hydrateAvailableBodies } from "../../../../src/components/device/automation-editor/hydrate-available-bodies.js";
+import {
+  hydrateAvailableBodies,
+  loadAndHydrateAvailable,
+} from "../../../../src/components/device/automation-editor/hydrate-available-bodies.js";
 
 const configEntry = (key: string): ConfigEntry => ({ key }) as ConfigEntry;
 
@@ -131,5 +134,97 @@ describe("hydrateAvailableBodies", () => {
       warnSpy.mock.calls.some((args) => String(args[0]).includes("body fetch failed"))
     ).toBe(true);
     warnSpy.mockRestore();
+  });
+});
+
+describe("loadAndHydrateAvailable", () => {
+  const emptySlim = (): AvailableAutomations =>
+    ({
+      triggers: [],
+      actions: [],
+      conditions: [],
+      scripts: [],
+      devices: [],
+    }) as unknown as AvailableAutomations;
+
+  it("issues exactly one getAvailableAutomations call per invocation", async () => {
+    const slim = emptySlim();
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slim);
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
+
+    expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
+    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml");
+    expect(outcome.status).toBe("ok");
+  });
+
+  it("returns fresh array refs in the hydrated outcome", async () => {
+    const slim = emptySlim();
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
+    if (outcome.status !== "ok") throw new Error("expected ok");
+
+    expect(outcome.available).not.toBe(outcome.slim);
+    expect(outcome.available.triggers).not.toBe(outcome.slim.triggers);
+    expect(outcome.available.actions).not.toBe(outcome.slim.actions);
+    expect(outcome.available.conditions).not.toBe(outcome.slim.conditions);
+  });
+
+  it("paints via onSlim before awaiting hydration", async () => {
+    const slim = emptySlim();
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+    const onSlim = vi.fn();
+
+    await loadAndHydrateAvailable(api, "device.yaml", { onSlim });
+
+    expect(onSlim).toHaveBeenCalledTimes(1);
+    expect(onSlim).toHaveBeenCalledWith(slim);
+  });
+
+  it("returns 'stale' when isStale flips during the fetch", async () => {
+    const slim = emptySlim();
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+    const onSlim = vi.fn();
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
+      onSlim,
+      isStale: () => true,
+    });
+
+    expect(outcome.status).toBe("stale");
+    expect(onSlim).not.toHaveBeenCalled();
+  });
+
+  it("returns 'error' when the api call rejects", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn().mockRejectedValue(new Error("network down")),
+    } as unknown as ESPHomeAPI;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
+
+    expect(outcome.status).toBe("error");
+    if (outcome.status === "error") {
+      expect((outcome.error as Error).message).toBe("network down");
+    }
+  });
+
+  it("error path defers to 'stale' when the load was superseded", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn().mockRejectedValue(new Error("net")),
+    } as unknown as ESPHomeAPI;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
+      isStale: () => true,
+    });
+
+    expect(outcome.status).toBe("stale");
   });
 });

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -37,12 +37,11 @@ const slimAvailable = (): AvailableAutomations =>
 const makeApi = () => ({}) as ESPHomeAPI;
 
 describe("hydrateAvailableBodies", () => {
-  it("populates config_entries from the body cache and clones the array", async () => {
+  it("populates config_entries from the body cache and deep-clones the tree", async () => {
     const sharedEntries = [configEntry("foo"), configEntry("bar")];
+    const cachedBody = triggerBody("good", sharedEntries);
     const fetchBody = vi.fn(async (_api, type, id) => {
-      if (type === "triggers" && id === "good") {
-        return triggerBody("good", sharedEntries);
-      }
+      if (type === "triggers" && id === "good") return cachedBody;
       return null;
     });
     const available = slimAvailable();
@@ -51,9 +50,18 @@ describe("hydrateAvailableBodies", () => {
     const result = await hydrateAvailableBodies(makeApi(), available, fetchBody);
 
     expect(goodEntry.config_entries).toEqual(sharedEntries);
-    // Cloned, not aliased — mutating the entry's array can't leak
-    // back into the cached body.
+    // Array reference is distinct (add/remove/reorder safety).
     expect(goodEntry.config_entries).not.toBe(sharedEntries);
+    // Each entry object is also distinct (in-place mutation safety).
+    expect(goodEntry.config_entries[0]).not.toBe(sharedEntries[0]);
+
+    // Pin the invariant in code: mutate the hydrated copy and
+    // confirm the cached body's entries are untouched.
+    (goodEntry.config_entries[0] as unknown as { key: string }).key = "mutated";
+    expect(sharedEntries[0].key).toBe("foo");
+    if ("config_entries" in cachedBody) {
+      expect(cachedBody.config_entries[0].key).toBe("foo");
+    }
     expect(result.succeeded).toBe(1);
   });
 

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type {
+  AutomationCatalogBody,
+  AutomationCatalogBodyType,
+  AvailableAutomations,
+  ConfigEntry,
+} from "../../../../src/api/types.js";
+import { hydrateAvailableBodies } from "../../../../src/components/device/automation-editor/hydrate-available-bodies.js";
+
+const configEntry = (key: string): ConfigEntry => ({ key }) as ConfigEntry;
+
+const triggerBody = (id: string, entries: ConfigEntry[]): AutomationCatalogBody =>
+  ({
+    id,
+    name: id,
+    description: "",
+    docs_url: "",
+    applies_to: [],
+    is_device_level: false,
+    config_entries: entries,
+  }) as AutomationCatalogBody;
+
+const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [
+      { id: "good", config_entries: [] as ConfigEntry[] },
+      { id: "missing", config_entries: [] as ConfigEntry[] },
+      { id: "boom", config_entries: [] as ConfigEntry[] },
+    ],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+const makeApi = () => ({}) as ESPHomeAPI;
+
+describe("hydrateAvailableBodies", () => {
+  it("populates config_entries from the body cache and clones the array", async () => {
+    const sharedEntries = [configEntry("foo"), configEntry("bar")];
+    const fetchBody = vi.fn(async (_api, type, id) => {
+      if (type === "triggers" && id === "good") {
+        return triggerBody("good", sharedEntries);
+      }
+      return null;
+    });
+    const available = slimAvailable();
+    const goodEntry = available.triggers[0];
+
+    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+
+    expect(goodEntry.config_entries).toEqual(sharedEntries);
+    // Cloned, not aliased — mutating the entry's array can't leak
+    // back into the cached body.
+    expect(goodEntry.config_entries).not.toBe(sharedEntries);
+  });
+
+  it("logs and skips entries whose body is missing config_entries", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchBody: (
+      api: ESPHomeAPI,
+      type: AutomationCatalogBodyType,
+      id: string
+    ) => Promise<AutomationCatalogBody | null> = async (_api, _type, _id) => null;
+    const available = slimAvailable();
+
+    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+
+    expect(available.triggers[1].config_entries).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some((args) => String(args[0]).includes("triggers/missing"))
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("tolerates a rejected body fetch and keeps hydrating the rest", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchBody = vi.fn(async (_api, _type, id) => {
+      if (id === "boom") throw new Error("network down");
+      if (id === "good") return triggerBody("good", [configEntry("foo")]);
+      return null;
+    });
+    const available = slimAvailable();
+
+    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+
+    expect(available.triggers[0].config_entries).toEqual([configEntry("foo")]);
+    expect(
+      warnSpy.mock.calls.some((args) => String(args[0]).includes("body fetch failed"))
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+});

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -70,7 +70,11 @@ describe("hydrateAvailableBodies", () => {
     expect(available.triggers[1].config_entries).toEqual([]);
     expect(warnSpy).toHaveBeenCalled();
     expect(
-      warnSpy.mock.calls.some((args) => String(args[0]).includes("triggers/missing"))
+      warnSpy.mock.calls.some(
+        (args) =>
+          String(args[0]).includes("triggers/missing") &&
+          String(args[0]).includes("no body returned")
+      )
     ).toBe(true);
     warnSpy.mockRestore();
   });

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -164,14 +164,23 @@ describe("loadAndHydrateAvailable", () => {
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
     } as unknown as ESPHomeAPI;
+    // Capture the slim ref the orchestration paints through ``onSlim``
+    // so we can compare against the post-hydration arrays.
+    let painted: AvailableAutomations | null = null;
 
-    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
+      onSlim: (s) => {
+        painted = s;
+      },
+    });
     if (outcome.status !== "ok") throw new Error("expected ok");
+    if (painted === null) throw new Error("expected onSlim to fire");
+    const slimPainted: AvailableAutomations = painted;
 
-    expect(outcome.available).not.toBe(outcome.slim);
-    expect(outcome.available.triggers).not.toBe(outcome.slim.triggers);
-    expect(outcome.available.actions).not.toBe(outcome.slim.actions);
-    expect(outcome.available.conditions).not.toBe(outcome.slim.conditions);
+    expect(outcome.available).not.toBe(slimPainted);
+    expect(outcome.available.triggers).not.toBe(slimPainted.triggers);
+    expect(outcome.available.actions).not.toBe(slimPainted.actions);
+    expect(outcome.available.conditions).not.toBe(slimPainted.conditions);
   });
 
   it("paints via onSlim before awaiting hydration", async () => {

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -48,15 +48,16 @@ describe("hydrateAvailableBodies", () => {
     const available = slimAvailable();
     const goodEntry = available.triggers[0];
 
-    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+    const result = await hydrateAvailableBodies(makeApi(), available, fetchBody);
 
     expect(goodEntry.config_entries).toEqual(sharedEntries);
     // Cloned, not aliased — mutating the entry's array can't leak
     // back into the cached body.
     expect(goodEntry.config_entries).not.toBe(sharedEntries);
+    expect(result.succeeded).toBe(1);
   });
 
-  it("logs and skips entries whose body is missing config_entries", async () => {
+  it("counts and logs missing-body responses", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fetchBody: (
       api: ESPHomeAPI,
@@ -65,15 +66,39 @@ describe("hydrateAvailableBodies", () => {
     ) => Promise<AutomationCatalogBody | null> = async (_api, _type, _id) => null;
     const available = slimAvailable();
 
-    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+    const result = await hydrateAvailableBodies(makeApi(), available, fetchBody);
 
     expect(available.triggers[1].config_entries).toEqual([]);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(result.missingBody).toBe(3);
+    expect(result.succeeded).toBe(0);
     expect(
       warnSpy.mock.calls.some(
         (args) =>
           String(args[0]).includes("triggers/missing") &&
           String(args[0]).includes("no body returned")
+      )
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("counts body shapes missing config_entries separately from null bodies", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchBody = vi.fn(async (_api, _type, id) => {
+      if (id === "good") return triggerBody("good", []);
+      // Body present but no config_entries field — contract violation
+      // of a different flavor than null.
+      return { id, name: id } as unknown as AutomationCatalogBody;
+    });
+    const available = slimAvailable();
+
+    const result = await hydrateAvailableBodies(makeApi(), available, fetchBody);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.missingField).toBe(2);
+    expect(result.missingBody).toBe(0);
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes("body shape missing config_entries")
       )
     ).toBe(true);
     warnSpy.mockRestore();
@@ -88,9 +113,12 @@ describe("hydrateAvailableBodies", () => {
     });
     const available = slimAvailable();
 
-    await hydrateAvailableBodies(makeApi(), available, fetchBody);
+    const result = await hydrateAvailableBodies(makeApi(), available, fetchBody);
 
     expect(available.triggers[0].config_entries).toEqual([configEntry("foo")]);
+    expect(result.rejected).toBe(1);
+    expect(result.missingBody).toBe(1);
+    expect(result.succeeded).toBe(1);
     expect(
       warnSpy.mock.calls.some((args) => String(args[0]).includes("body fetch failed"))
     ).toBe(true);

--- a/test/util/automation-body-cache.test.ts
+++ b/test/util/automation-body-cache.test.ts
@@ -122,18 +122,33 @@ describe("automation-body-cache", () => {
 
     const result = await fetchAutomationBody(api, "triggers", "toString");
     expect(result).toBeNull();
-    expect(getCachedAutomationBody("triggers", "toString")).toBeNull();
   });
 
-  it("caches null (catalog miss) so unknown ids aren't re-fetched", async () => {
-    const { api, getAutomationBodies } = mockApi(() => null);
+  it("does not cache misses (advertised ids may recover on retry)", async () => {
+    // The list endpoint advertises every (type, id) the editor
+    // asks for; a null body is a server contract violation, not a
+    // permanent catalog miss. ``cacheMisses: false`` lets a second
+    // call re-attempt instead of pinning the null.
+    let attempts = 0;
+    const { api, getAutomationBodies } = mockApi(
+      () => null,
+      () => {
+        attempts++;
+        const out: Record<string, AutomationCatalogBody> =
+          attempts === 1
+            ? {}
+            : { "triggers/recovered": trigger("recovered", "Recovered") };
+        return Promise.resolve(out);
+      }
+    );
 
-    const first = await fetchAutomationBody(api, "triggers", "nope");
+    const first = await fetchAutomationBody(api, "triggers", "recovered");
     expect(first).toBeNull();
-    expect(getCachedAutomationBody("triggers", "nope")).toBeNull();
+    expect(getCachedAutomationBody("triggers", "recovered")).toBeUndefined();
 
-    await fetchAutomationBody(api, "triggers", "nope");
-    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+    const second = await fetchAutomationBody(api, "triggers", "recovered");
+    expect(second?.name).toBe("Recovered");
+    expect(getAutomationBodies).toHaveBeenCalledTimes(2);
   });
 
   it("does not cache transport errors (allows retry)", async () => {

--- a/test/util/automation-body-cache.test.ts
+++ b/test/util/automation-body-cache.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { AutomationCatalogBody } from "../../src/api/types.js";
+import {
+  _clearAutomationBodyCache,
+  fetchAutomationBody,
+  getCachedAutomationBody,
+  subscribeAutomationBodyCache,
+} from "../../src/util/automation-body-cache.js";
+
+const trigger = (id: string, name: string): AutomationCatalogBody =>
+  ({
+    id,
+    name,
+    description: "",
+    docs_url: "",
+    applies_to: [],
+    is_device_level: false,
+    config_entries: [],
+  }) as AutomationCatalogBody;
+
+interface MockApi {
+  api: ESPHomeAPI;
+  getAutomationBodies: ReturnType<typeof vi.fn>;
+}
+
+const mockApi = (
+  impl: (type: string, id: string) => AutomationCatalogBody | null,
+  overridePromise?: () => Promise<Record<string, AutomationCatalogBody>>
+): MockApi => {
+  const getAutomationBodies = vi.fn((refs: { type: string; id: string }[]) => {
+    if (overridePromise) return overridePromise();
+    const result: Record<string, AutomationCatalogBody> = {};
+    for (const ref of refs) {
+      const body = impl(ref.type, ref.id);
+      if (body !== null) result[`${ref.type}/${ref.id}`] = body;
+    }
+    return Promise.resolve(result);
+  });
+  return {
+    api: { getAutomationBodies } as unknown as ESPHomeAPI,
+    getAutomationBodies,
+  };
+};
+
+describe("automation-body-cache", () => {
+  afterEach(() => {
+    _clearAutomationBodyCache();
+  });
+
+  it("fetches an uncached body and caches the result", async () => {
+    const { api, getAutomationBodies } = mockApi(() => trigger("on_boot", "On Boot"));
+
+    expect(getCachedAutomationBody("triggers", "on_boot")).toBeUndefined();
+    const got = await fetchAutomationBody(api, "triggers", "on_boot");
+
+    expect(got?.name).toBe("On Boot");
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+    expect(getCachedAutomationBody("triggers", "on_boot")?.name).toBe("On Boot");
+
+    await fetchAutomationBody(api, "triggers", "on_boot");
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces cross-type parallel fetches into one batched call", async () => {
+    const { api, getAutomationBodies } = mockApi((type, id) =>
+      trigger(`${type}/${id}`, `name:${type}/${id}`)
+    );
+
+    const [t, a, c] = await Promise.all([
+      fetchAutomationBody(api, "triggers", "on_boot"),
+      fetchAutomationBody(api, "actions", "delay"),
+      fetchAutomationBody(api, "conditions", "lambda"),
+    ]);
+
+    expect(t?.name).toBe("name:triggers/on_boot");
+    expect(a?.name).toBe("name:actions/delay");
+    expect(c?.name).toBe("name:conditions/lambda");
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+    expect(getAutomationBodies).toHaveBeenCalledWith([
+      { type: "triggers", id: "on_boot" },
+      { type: "actions", id: "delay" },
+      { type: "conditions", id: "lambda" },
+    ]);
+  });
+
+  it("dedupes concurrent in-flight calls for the same key", async () => {
+    let resolve!: (v: Record<string, AutomationCatalogBody>) => void;
+    const { api, getAutomationBodies } = mockApi(
+      () => null,
+      () => new Promise<Record<string, AutomationCatalogBody>>((r) => (resolve = r))
+    );
+
+    const a = fetchAutomationBody(api, "triggers", "on_boot");
+    const b = fetchAutomationBody(api, "triggers", "on_boot");
+    const c = fetchAutomationBody(api, "triggers", "on_boot");
+
+    await Promise.resolve();
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+
+    resolve({ "triggers/on_boot": trigger("on_boot", "On Boot") });
+    await expect(a).resolves.toMatchObject({ name: "On Boot" });
+    await expect(b).resolves.toMatchObject({ name: "On Boot" });
+    await expect(c).resolves.toMatchObject({ name: "On Boot" });
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects pending waiters when the cache is cleared mid-flight", async () => {
+    const { api } = mockApi(
+      () => null,
+      () => new Promise<Record<string, AutomationCatalogBody>>(() => {})
+    );
+
+    const pending = fetchAutomationBody(api, "triggers", "on_boot");
+    _clearAutomationBodyCache();
+
+    await expect(pending).rejects.toThrow("automation-body-cache cleared");
+  });
+
+  it("does not resolve prototype keys as cache hits", async () => {
+    const { api } = mockApi(() => null);
+
+    const result = await fetchAutomationBody(api, "triggers", "toString");
+    expect(result).toBeNull();
+    expect(getCachedAutomationBody("triggers", "toString")).toBeNull();
+  });
+
+  it("caches null (catalog miss) so unknown ids aren't re-fetched", async () => {
+    const { api, getAutomationBodies } = mockApi(() => null);
+
+    const first = await fetchAutomationBody(api, "triggers", "nope");
+    expect(first).toBeNull();
+    expect(getCachedAutomationBody("triggers", "nope")).toBeNull();
+
+    await fetchAutomationBody(api, "triggers", "nope");
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache transport errors (allows retry)", async () => {
+    let attempts = 0;
+    const { api } = mockApi(
+      () => trigger("on_boot", "On Boot"),
+      () => {
+        attempts++;
+        if (attempts === 1) return Promise.reject(new Error("network down"));
+        return Promise.resolve({
+          "triggers/on_boot": trigger("on_boot", "On Boot"),
+        });
+      }
+    );
+
+    await expect(fetchAutomationBody(api, "triggers", "on_boot")).rejects.toThrow(
+      "network down"
+    );
+    expect(getCachedAutomationBody("triggers", "on_boot")).toBeUndefined();
+
+    const second = await fetchAutomationBody(api, "triggers", "on_boot");
+    expect(second?.name).toBe("On Boot");
+  });
+
+  it("notifies subscribers once per flushed batch", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeAutomationBodyCache(listener);
+
+    const { api } = mockApi((_t, id) => trigger(id, id));
+    await Promise.all([
+      fetchAutomationBody(api, "triggers", "on_boot"),
+      fetchAutomationBody(api, "actions", "delay"),
+    ]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    await fetchAutomationBody(api, "triggers", "on_boot");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    const { api: api2 } = mockApi(() => trigger("lambda", "lambda"));
+    await fetchAutomationBody(api2, "conditions", "lambda");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates listener exceptions from the fetch promise", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const goodA = vi.fn();
+    const goodB = vi.fn();
+    const bad = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    subscribeAutomationBodyCache(goodA);
+    subscribeAutomationBodyCache(bad);
+    subscribeAutomationBodyCache(goodB);
+
+    const { api } = mockApi(() => trigger("on_boot", "On Boot"));
+    const result = await fetchAutomationBody(api, "triggers", "on_boot");
+
+    expect(result?.name).toBe("On Boot");
+    expect(goodA).toHaveBeenCalledTimes(1);
+    expect(goodB).toHaveBeenCalledTimes(1);
+    expect(bad).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -21,6 +21,7 @@ import {
   getCachedLightEffects,
   subscribeAutomationCatalogCache,
 } from "../../src/util/automation-catalog-cache.js";
+import { _clearAutomationBodyCache } from "../../src/util/automation-body-cache.js";
 
 const trigger = (id: string): AutomationTrigger => ({
   id,
@@ -99,12 +100,14 @@ const stubApi = (impls?: {
   const getLightEffects = vi.fn((platform?: string, boardId?: string) =>
     Promise.resolve(impls?.effects?.(platform, boardId) ?? [effect("pulse")])
   );
+  const getAutomationBodies = vi.fn(() => Promise.resolve({}));
   return {
     api: {
       getAutomationTriggers,
       getAutomationActions,
       getAutomationConditions,
       getLightEffects,
+      getAutomationBodies,
     } as unknown as ESPHomeAPI,
     getAutomationTriggers,
     getAutomationActions,
@@ -116,6 +119,7 @@ const stubApi = (impls?: {
 describe("automation-catalog-cache", () => {
   afterEach(() => {
     _clearAutomationCatalogCache();
+    _clearAutomationBodyCache();
   });
 
   it("fetches each catalogue on first call and caches the result", async () => {
@@ -261,7 +265,8 @@ describe("automation-catalog-cache", () => {
       applies_to: [],
     };
     const getFilters = vi.fn(() => Promise.resolve([filter]));
-    const api = { getFilters } as unknown as ESPHomeAPI;
+    const getAutomationBodies = vi.fn(() => Promise.resolve({}));
+    const api = { getFilters, getAutomationBodies } as unknown as ESPHomeAPI;
 
     await fetchFilters(api);
     expect(getCachedFilters()?.map((f) => f.id)).toEqual(["delta"]);
@@ -273,5 +278,60 @@ describe("automation-catalog-cache", () => {
     // in-flight slot was also cleared.
     await fetchFilters(api);
     expect(getFilters).toHaveBeenCalledTimes(2);
+  });
+
+  it("hydrates config_entries on fetchLightEffects via the body cache", async () => {
+    // After backend #1016, the list endpoint ships slim shapes
+    // (no config_entries); fetchLightEffects must hydrate via
+    // automations/get_bodies before the entry lands in the cache,
+    // because registry-list.ts reads config_entries off it.
+    const getLightEffects = vi.fn(() =>
+      Promise.resolve([
+        { id: "pulse", name: "Pulse", config_entries: [], applies_to: [] } as LightEffect,
+      ])
+    );
+    const getAutomationBodies = vi.fn(() =>
+      Promise.resolve({
+        "light_effects/pulse": {
+          id: "pulse",
+          name: "Pulse",
+          config_entries: [{ key: "transition_length" }],
+          applies_to: [],
+        } as unknown as LightEffect,
+      })
+    );
+    const api = { getLightEffects, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const list = await fetchLightEffects(api);
+
+    expect(list[0].config_entries).toEqual([{ key: "transition_length" }]);
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+    expect(getAutomationBodies).toHaveBeenCalledWith([
+      { type: "light_effects", id: "pulse" },
+    ]);
+  });
+
+  it("hydrates config_entries on fetchFilters via the body cache", async () => {
+    const getFilters = vi.fn(() =>
+      Promise.resolve([
+        { id: "delta", name: "Delta", config_entries: [], applies_to: [] } as Filter,
+      ])
+    );
+    const getAutomationBodies = vi.fn(() =>
+      Promise.resolve({
+        "filters/delta": {
+          id: "delta",
+          name: "Delta",
+          config_entries: [{ key: "min_change" }],
+          applies_to: [],
+        } as unknown as Filter,
+      })
+    );
+    const api = { getFilters, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const list = await fetchFilters(api);
+
+    expect(list[0].config_entries).toEqual([{ key: "min_change" }]);
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -311,6 +311,74 @@ describe("automation-catalog-cache", () => {
     ]);
   });
 
+  it("retries hydration on a cached list when the previous attempt failed", async () => {
+    // Pre-merge bug: the list cache pinned a partially-hydrated
+    // list so a one-off body-fetch failure stayed empty for the
+    // session. Per-entry WeakSet flag now lets the next call's
+    // post-fetch hydration pick up only the still-empty entries.
+    const getLightEffects = vi.fn(() =>
+      Promise.resolve([
+        { id: "pulse", name: "Pulse", config_entries: [], applies_to: [] } as LightEffect,
+      ])
+    );
+    let attempts = 0;
+    const getAutomationBodies = vi.fn(() => {
+      attempts++;
+      const out: Record<string, LightEffect> =
+        attempts === 1
+          ? {} // contract violation: list advertised "pulse" but get_bodies returns nothing.
+          : {
+              "light_effects/pulse": {
+                id: "pulse",
+                name: "Pulse",
+                config_entries: [{ key: "transition_length" }],
+                applies_to: [],
+              } as unknown as LightEffect,
+            };
+      return Promise.resolve(out);
+    });
+    const api = { getLightEffects, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const first = await fetchLightEffects(api);
+    expect(first[0].config_entries).toEqual([]); // still slim after failure
+
+    const second = await fetchLightEffects(api);
+    // List cache returned cached array (same identity); retry
+    // hydration populated the entry in place.
+    expect(second).toBe(first);
+    expect(second[0].config_entries).toEqual([{ key: "transition_length" }]);
+    expect(getLightEffects).toHaveBeenCalledTimes(1); // list cache hit
+    expect(getAutomationBodies).toHaveBeenCalledTimes(2); // two body fetches (first failed, second recovered)
+  });
+
+  it("skips body fetches on a fully-hydrated cache hit", async () => {
+    const getLightEffects = vi.fn(() =>
+      Promise.resolve([
+        { id: "pulse", name: "Pulse", config_entries: [], applies_to: [] } as LightEffect,
+      ])
+    );
+    const getAutomationBodies = vi.fn(() =>
+      Promise.resolve({
+        "light_effects/pulse": {
+          id: "pulse",
+          name: "Pulse",
+          config_entries: [{ key: "transition_length" }],
+          applies_to: [],
+        } as unknown as LightEffect,
+      })
+    );
+    const api = { getLightEffects, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    await fetchLightEffects(api);
+    await fetchLightEffects(api);
+    await fetchLightEffects(api);
+
+    // First call fetched both list and body; second + third
+    // short-circuit both: list cache hit + WeakSet says hydrated.
+    expect(getLightEffects).toHaveBeenCalledTimes(1);
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+  });
+
   it("hydrates config_entries on fetchFilters via the body cache", async () => {
     const getFilters = vi.fn(() =>
       Promise.resolve([

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -4,6 +4,7 @@ import type {
   AutomationAction,
   AutomationCondition,
   AutomationTrigger,
+  ConfigEntry,
   Filter,
   LightEffect,
 } from "../../src/api/types.js";
@@ -343,9 +344,12 @@ describe("automation-catalog-cache", () => {
     expect(first[0].config_entries).toEqual([]); // still slim after failure
 
     const second = await fetchLightEffects(api);
-    // List cache returned cached array (same identity); retry
-    // hydration populated the entry in place.
-    expect(second).toBe(first);
+    // Same entry mutated in place — the entry object identity is
+    // preserved across calls. The wrapping array identity differs
+    // after the post-hydration swap (so identity-checking
+    // subscribers re-render), but the underlying entry object
+    // received its ``config_entries`` from the second body fetch.
+    expect(second[0]).toBe(first[0]);
     expect(second[0].config_entries).toEqual([{ key: "transition_length" }]);
     expect(getLightEffects).toHaveBeenCalledTimes(1); // list cache hit
     expect(getAutomationBodies).toHaveBeenCalledTimes(2); // two body fetches (first failed, second recovered)
@@ -377,6 +381,87 @@ describe("automation-catalog-cache", () => {
     // short-circuit both: list cache hit + WeakSet says hydrated.
     expect(getLightEffects).toHaveBeenCalledTimes(1);
     expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies subscribers with a fresh array reference after hydration", async () => {
+    // Without this, the slim list lands in the cache and ``_notify``
+    // fires; subscribers re-read ``cache()`` and store the slim
+    // array. Then hydration mutates ``config_entries`` in place but
+    // never re-notifies, so registry-list keeps showing empty forms
+    // because Lit's identity-based ``hasChanged`` says nothing
+    // changed on the array prop.
+    const slimEntry = {
+      id: "pulse",
+      name: "Pulse",
+      config_entries: [] as ConfigEntry[],
+      applies_to: [] as string[],
+    } as LightEffect;
+    const getLightEffects = vi.fn(() => Promise.resolve([slimEntry]));
+    const getAutomationBodies = vi.fn(() =>
+      Promise.resolve({
+        "light_effects/pulse": {
+          id: "pulse",
+          name: "Pulse",
+          config_entries: [{ key: "transition_length" }],
+          applies_to: [],
+        } as unknown as LightEffect,
+      })
+    );
+    const api = { getLightEffects, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const notifications: (LightEffect[] | undefined)[] = [];
+    const unsub = subscribeAutomationCatalogCache(() => {
+      notifications.push(getCachedLightEffects());
+    });
+
+    const returned = await fetchLightEffects(api);
+
+    // Two notifications: one when slim lands inside ``_fetch``, one
+    // after hydration replaces the cached array.
+    expect(notifications.length).toBe(2);
+    const slim = notifications[0]!;
+    const hydrated = notifications[1]!;
+    // Distinct array identity so Lit's hasChanged trips.
+    expect(hydrated).not.toBe(slim);
+    // Hydrated entries carry the populated ``config_entries``.
+    expect(hydrated[0].config_entries).toEqual([{ key: "transition_length" }]);
+    // The returned list matches what's now in the cache.
+    expect(returned).toBe(hydrated);
+    expect(returned).toBe(getCachedLightEffects());
+    unsub();
+  });
+
+  it("does not double-notify when hydration is a no-op (all entries already hydrated)", async () => {
+    const slimEntry = {
+      id: "pulse",
+      name: "Pulse",
+      config_entries: [] as ConfigEntry[],
+      applies_to: [] as string[],
+    } as LightEffect;
+    const getLightEffects = vi.fn(() => Promise.resolve([slimEntry]));
+    const getAutomationBodies = vi.fn(() =>
+      Promise.resolve({
+        "light_effects/pulse": {
+          id: "pulse",
+          name: "Pulse",
+          config_entries: [{ key: "transition_length" }],
+          applies_to: [],
+        } as unknown as LightEffect,
+      })
+    );
+    const api = { getLightEffects, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    await fetchLightEffects(api); // first call: slim + hydrate-notify
+
+    let extraNotifications = 0;
+    const unsub = subscribeAutomationCatalogCache(() => {
+      extraNotifications++;
+    });
+
+    await fetchLightEffects(api); // second call: cache hit, hydration no-op
+
+    expect(extraNotifications).toBe(0);
+    unsub();
   });
 
   it("hydrates config_entries on fetchFilters via the body cache", async () => {

--- a/test/util/batched-cache.test.ts
+++ b/test/util/batched-cache.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { BatchedCache } from "../../src/util/batched-cache.js";
+
+interface Ctx {
+  platform: string;
+}
+
+const makeApi = () => ({ getComponentBodies: vi.fn() }) as unknown as ESPHomeAPI;
+
+describe("BatchedCache", () => {
+  it("does not collide when keys or bucket-keys contain the | delimiter", async () => {
+    // Two callers whose flat ``${key}|${bucketKey}`` composition
+    // would collide (``a|b`` + ``c`` and ``a`` + ``b|c``) MUST stay
+    // distinct under the nested-map keying.
+    const fetcher = vi.fn(
+      (_api: ESPHomeAPI, keys: string[], ctx: Ctx): Promise<Record<string, string>> => {
+        const result: Record<string, string> = {};
+        for (const k of keys) result[k] = `${k}@${ctx.platform}`;
+        return Promise.resolve(result);
+      }
+    );
+    const cache = new BatchedCache<string, Ctx>({
+      name: "test",
+      bucketKey: (ctx) => ctx.platform,
+      fetch: fetcher,
+    });
+    const api = makeApi();
+
+    const [a, b] = await Promise.all([
+      cache.fetch(api, "a|b", { platform: "c" }),
+      cache.fetch(api, "a", { platform: "b|c" }),
+    ]);
+
+    expect(a).toBe("a|b@c");
+    expect(b).toBe("a@b|c");
+    expect(cache.getCached("a|b", { platform: "c" })).toBe("a|b@c");
+    expect(cache.getCached("a", { platform: "b|c" })).toBe("a@b|c");
+    // Different buckets → distinct fetcher invocations.
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/util/batched-cache.test.ts
+++ b/test/util/batched-cache.test.ts
@@ -9,6 +9,32 @@ interface Ctx {
 const makeApi = () => ({ getComponentBodies: vi.fn() }) as unknown as ESPHomeAPI;
 
 describe("BatchedCache", () => {
+  it("clear() during an in-flight fetch rejects waiters and doesn't repopulate the cache", async () => {
+    let resolveFetch!: (v: Record<string, string>) => void;
+    const fetcher = vi.fn(
+      (_api: ESPHomeAPI, _keys: string[]): Promise<Record<string, string>> =>
+        new Promise<Record<string, string>>((r) => (resolveFetch = r))
+    );
+    const cache = new BatchedCache<string, Ctx>({
+      name: "clear-race",
+      bucketKey: (ctx) => ctx.platform,
+      fetch: fetcher,
+    });
+    const api = makeApi();
+
+    const pending = cache.fetch(api, "wifi", { platform: "esp32" });
+    // Let the microtask flush so the fetcher is in-flight (past
+    // the await point, bucket already removed from ``_batches``).
+    await Promise.resolve();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    cache.clear();
+    resolveFetch({ wifi: "would-be-stale" });
+
+    await expect(pending).rejects.toThrow("clear-race cleared");
+    expect(cache.getCached("wifi", { platform: "esp32" })).toBeUndefined();
+  });
+
   it("caches misses by default so unknown keys aren't re-fetched", async () => {
     const fetcher = vi.fn(
       (_api: ESPHomeAPI, _keys: string[]): Promise<Record<string, string>> =>

--- a/test/util/batched-cache.test.ts
+++ b/test/util/batched-cache.test.ts
@@ -9,6 +9,50 @@ interface Ctx {
 const makeApi = () => ({ getComponentBodies: vi.fn() }) as unknown as ESPHomeAPI;
 
 describe("BatchedCache", () => {
+  it("caches misses by default so unknown keys aren't re-fetched", async () => {
+    const fetcher = vi.fn(
+      (_api: ESPHomeAPI, _keys: string[]): Promise<Record<string, string>> =>
+        Promise.resolve({})
+    );
+    const cache = new BatchedCache<string, Ctx>({
+      name: "default-misses",
+      bucketKey: (ctx) => ctx.platform,
+      fetch: fetcher,
+    });
+    const api = makeApi();
+
+    await cache.fetch(api, "ghost", { platform: "esp32" });
+    expect(cache.getCached("ghost", { platform: "esp32" })).toBeNull();
+    await cache.fetch(api, "ghost", { platform: "esp32" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("with cacheMisses: false re-fetches advertised keys whose body was absent", async () => {
+    let attempts = 0;
+    const fetcher = vi.fn(
+      (_api: ESPHomeAPI, _keys: string[]): Promise<Record<string, string>> => {
+        attempts++;
+        const out: Record<string, string> = attempts === 1 ? {} : { ghost: "recovered" };
+        return Promise.resolve(out);
+      }
+    );
+    const cache = new BatchedCache<string, Ctx>({
+      name: "no-miss-cache",
+      bucketKey: (ctx) => ctx.platform,
+      fetch: fetcher,
+      cacheMisses: false,
+    });
+    const api = makeApi();
+
+    const first = await cache.fetch(api, "ghost", { platform: "esp32" });
+    expect(first).toBeNull();
+    expect(cache.getCached("ghost", { platform: "esp32" })).toBeUndefined();
+
+    const second = await cache.fetch(api, "ghost", { platform: "esp32" });
+    expect(second).toBe("recovered");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it("does not collide when keys or bucket-keys contain the | delimiter", async () => {
     // Two callers whose flat ``${key}|${bucketKey}`` composition
     // would collide (``a|b`` + ``c`` and ``a`` + ``b|c``) MUST stay

--- a/test/util/component-name-cache.test.ts
+++ b/test/util/component-name-cache.test.ts
@@ -125,7 +125,7 @@ describe("component-name-cache", () => {
     const pending = fetchComponent(api, "wifi");
     _clearComponentCache();
 
-    await expect(pending).rejects.toThrow("component cache cleared");
+    await expect(pending).rejects.toThrow("component-name-cache cleared");
   });
 
   it("does not resolve prototype keys as cache hits", async () => {


### PR DESCRIPTION
## Summary

Companion to esphome/device-builder#1016. Backend's `automations/get_*` list endpoints now ship slim catalog index shapes (picker fields only, no `config_entries` tree). The editor fetches full bodies on demand through a new microtask-batched cache keyed by `"<type>/<id>"` that coalesces cross-type concurrent fetches into one `automations/get_bodies` round trip.

## Changes

- Add `ESPHomeAPI.getAutomationBodies(refs)` for the new backend batch endpoint.
- Add `AutomationCatalogBody` discriminated union + `AutomationCatalogBodyType` wire-type literal.
- Extract `BatchedCache<V, Ctx>` generic helper for the cold-path mechanics shared by `component-name-cache` and the new `automation-body-cache` (cache + inflight + microtask flush + own-property defense + listener notify). `component-name-cache` becomes a thin wrapper; behaviour-equivalent (existing tests pass unchanged except for the new tag in the cleared error).
- `automation-body-cache` is the new wrapper, single bucket (no platform context for body fetch), composes the body refs from `"<type>/<id>"` cache keys.
- `automation-editor` hydrates `config_entries` for every entry in the per-device scoped `AvailableAutomations` after the slim list lands, via a `Promise.all` over the body cache. Downstream form components (trigger picker, condition tree, action node) consume the already-hydrated shape unchanged.
- Tests: new `automation-body-cache.test.ts` mirrors the component-cache contracts (batched fetch, in-flight dedup, null caching for catalog misses, transport-error non-caching, listener subscribe/notify, prototype-pollution defense, mid-flight clear).

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 1420 tests pass (110 files).
- [ ] Pair with esphome/device-builder#1016 and walk through adding/editing an automation in the dev pair; the form should render identically to the pre-#1016 shape.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

This PR depends on esphome/device-builder#1016 merging first; without that the backend list endpoints still ship full bodies and the body-cache merge is a redundant no-op (still correct, just wasted work).