### PR TITLE
Hydrate the boards API client so omitted-default fields paint as their defaults

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1216,10 +1216,6 @@ export class ESPHomeAPI {
 
   /** Get a single board by ID. */
   async getBoard(boardId: string): Promise<BoardCatalogEntry | null> {
-    // ``hydrateBoard`` re-defaults the fields the backend omits via
-    // mashumaro's omit_default (see util/board-hydrate.ts) so
-    // downstream consumers can read board.pins / .hardware etc
-    // without an ``?? []`` at every site.
     const board = await this.sendCommand<BoardCatalogEntry | null>("boards/get_board", {
       board_id: boardId,
     });

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -9,6 +9,7 @@
 import { APIError } from "./api-error.js";
 import { BASE_PATH } from "../util/base-path.js";
 import { clearStoredToken, getStoredToken, setStoredToken } from "../util/auth-token.js";
+import { hydrateBoard, hydratePagedBoardsResponse } from "../util/board-hydrate.js";
 import type {
   AddComponentResponse,
   ArchivedDevice,
@@ -1213,7 +1214,14 @@ export class ESPHomeAPI {
 
   /** Get a single board by ID. */
   async getBoard(boardId: string): Promise<BoardCatalogEntry | null> {
-    return this.sendCommand("boards/get_board", { board_id: boardId });
+    // ``hydrateBoard`` re-defaults the fields the backend omits via
+    // mashumaro's omit_default (see util/board-hydrate.ts) so
+    // downstream consumers can read board.pins / .hardware etc
+    // without an ``?? []`` at every site.
+    const board = await this.sendCommand<BoardCatalogEntry | null>("boards/get_board", {
+      board_id: boardId,
+    });
+    return board === null ? null : hydrateBoard(board);
   }
 
   /** Get boards with optional filtering, search, and pagination. */
@@ -1225,7 +1233,11 @@ export class ESPHomeAPI {
     offset?: number;
     limit?: number;
   }): Promise<PagedBoardsResponse> {
-    return this.sendCommand<PagedBoardsResponse>("boards/get_boards", args);
+    const response = await this.sendCommand<PagedBoardsResponse>(
+      "boards/get_boards",
+      args
+    );
+    return hydratePagedBoardsResponse(response);
   }
 
   // ─── Component Commands ───────────────────────────────────

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -20,12 +20,16 @@ import type {
  * `models/boards.py` and `models/common.py` exactly — diverging
  * means a fresh fetch silently disagrees with what `from_dict`
  * round-trips on the backend.
+ *
+ * Each helper spreads the input before overriding defaults, so
+ * a forward-compat field added to the wire shape carries through
+ * the hydrator instead of being silently dropped.
  */
 export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
   return {
     ...entry,
     esphome: _hydrateEsphome(entry.esphome),
-    hardware: _hydrateHardware(entry.hardware ?? ({} as BoardHardware)),
+    hardware: _hydrateHardware(entry.hardware),
     images: entry.images ?? [],
     tags: entry.tags ?? [],
     pins: (entry.pins ?? []).map(_hydratePin),
@@ -52,12 +56,13 @@ function _hydrateEsphome(esphome: BoardEsphomeConfig): BoardEsphomeConfig {
   };
 }
 
-function _hydrateHardware(hardware: BoardHardware): BoardHardware {
+function _hydrateHardware(hardware: BoardHardware | null | undefined): BoardHardware {
   return {
-    flash_size: hardware.flash_size ?? null,
-    ram_size: hardware.ram_size ?? null,
-    cpu_frequency: hardware.cpu_frequency ?? null,
-    connectivity: hardware.connectivity ?? [],
+    ...hardware,
+    flash_size: hardware?.flash_size ?? null,
+    ram_size: hardware?.ram_size ?? null,
+    cpu_frequency: hardware?.cpu_frequency ?? null,
+    connectivity: hardware?.connectivity ?? [],
   };
 }
 
@@ -96,6 +101,7 @@ function _hydrateFeaturedBundle(fb: FeaturedBundle): FeaturedBundle {
 
 function _hydrateFieldPreset(preset: FieldPreset): FieldPreset {
   return {
+    ...preset,
     value: preset.value ?? null,
     locked: preset.locked ?? false,
     suggestions: preset.suggestions ?? null,

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -88,16 +88,13 @@ function _hydratePin(pin: BoardPin): BoardPin {
 }
 
 function _hydrateFeaturedComponent(fc: FeaturedComponent): FeaturedComponent {
-  const fields = fc.fields ?? {};
-  const hydratedFields: Record<string, FieldPreset> = {};
-  for (const [key, preset] of Object.entries(fields)) {
-    hydratedFields[key] = _hydrateFieldPreset(preset);
-  }
   return {
     ...fc,
     name: fc.name ?? null,
     description: fc.description ?? null,
-    fields: hydratedFields,
+    fields: Object.fromEntries(
+      Object.entries(fc.fields ?? {}).map(([k, v]) => [k, _hydrateFieldPreset(v)])
+    ),
   };
 }
 

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -1,0 +1,103 @@
+import type {
+  BoardCatalogEntry,
+  BoardEsphomeConfig,
+  BoardHardware,
+  BoardPin,
+  FeaturedBundle,
+  FeaturedComponent,
+  FieldPreset,
+  PagedBoardsResponse,
+} from "../api/types.js";
+
+/**
+ * Re-default fields the backend stripped from the wire payload.
+ *
+ * The board-catalog dataclasses on the backend use mashumaro's
+ * `omit_default = True` + `omit_none = True` config; ~40k empty
+ * `suggestions: null` / `locked: false` rows per response stop
+ * arriving (~36% off the catalog bytes, more once JS parses).
+ * Default values mirror the Python dataclass declarations in
+ * `models/boards.py` and `models/common.py` exactly — diverging
+ * means a fresh fetch silently disagrees with what `from_dict`
+ * round-trips on the backend.
+ */
+export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
+  return {
+    ...entry,
+    esphome: _hydrateEsphome(entry.esphome),
+    hardware: _hydrateHardware(entry.hardware ?? ({} as BoardHardware)),
+    images: entry.images ?? [],
+    tags: entry.tags ?? [],
+    pins: (entry.pins ?? []).map(_hydratePin),
+    docs_url: entry.docs_url ?? "",
+    product_url: entry.product_url ?? "",
+    featured: entry.featured ?? false,
+    is_generic: entry.is_generic ?? false,
+    featured_components: (entry.featured_components ?? []).map(_hydrateFeaturedComponent),
+    featured_bundles: (entry.featured_bundles ?? []).map(_hydrateFeaturedBundle),
+  };
+}
+
+export function hydratePagedBoardsResponse(
+  response: PagedBoardsResponse
+): PagedBoardsResponse {
+  return { ...response, boards: response.boards.map(hydrateBoard) };
+}
+
+function _hydrateEsphome(esphome: BoardEsphomeConfig): BoardEsphomeConfig {
+  return {
+    ...esphome,
+    variant: esphome.variant ?? null,
+    framework: esphome.framework ?? null,
+  };
+}
+
+function _hydrateHardware(hardware: BoardHardware): BoardHardware {
+  return {
+    flash_size: hardware.flash_size ?? null,
+    ram_size: hardware.ram_size ?? null,
+    cpu_frequency: hardware.cpu_frequency ?? null,
+    connectivity: hardware.connectivity ?? [],
+  };
+}
+
+function _hydratePin(pin: BoardPin): BoardPin {
+  return {
+    ...pin,
+    label: pin.label ?? "",
+    features: pin.features ?? [],
+    available: pin.available ?? null,
+    occupied_by: pin.occupied_by ?? null,
+    notes: pin.notes ?? null,
+  };
+}
+
+function _hydrateFeaturedComponent(fc: FeaturedComponent): FeaturedComponent {
+  const fields = fc.fields ?? {};
+  const hydratedFields: Record<string, FieldPreset> = {};
+  for (const [key, preset] of Object.entries(fields)) {
+    hydratedFields[key] = _hydrateFieldPreset(preset);
+  }
+  return {
+    ...fc,
+    name: fc.name ?? null,
+    description: fc.description ?? null,
+    fields: hydratedFields,
+  };
+}
+
+function _hydrateFeaturedBundle(fb: FeaturedBundle): FeaturedBundle {
+  return {
+    ...fb,
+    description: fb.description ?? "",
+    component_ids: fb.component_ids ?? [],
+  };
+}
+
+function _hydrateFieldPreset(preset: FieldPreset): FieldPreset {
+  return {
+    value: preset.value ?? null,
+    locked: preset.locked ?? false,
+    suggestions: preset.suggestions ?? null,
+  };
+}

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -45,7 +45,17 @@ export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
 export function hydratePagedBoardsResponse(
   response: PagedBoardsResponse
 ): PagedBoardsResponse {
-  return { ...response, boards: response.boards.map(hydrateBoard) };
+  // Defensive: PagedResponse on the backend doesn't strip today,
+  // but adding omit_default later would strip an empty page's
+  // boards: [] outright and crash the .map. Re-default symmetric
+  // with the nested hydration so the contract is robust.
+  return {
+    ...response,
+    total: response.total ?? 0,
+    offset: response.offset ?? 0,
+    limit: response.limit ?? 50,
+    boards: (response.boards ?? []).map(hydrateBoard),
+  };
 }
 
 function _hydrateEsphome(esphome: BoardEsphomeConfig): BoardEsphomeConfig {

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -115,14 +115,9 @@ describe("hydrateBoard", () => {
   });
 
   it("preserves unknown fields the backend may add later (forward-compat)", () => {
-    // Every helper spreads its input before applying defaults, so
-    // a wire payload that carries an additional field a future
-    // backend version introduced flows through the hydrator
-    // instead of being silently dropped. Pin the additive
-    // contract on the helpers Copilot specifically called out —
-    // _hydrateHardware and _hydrateFieldPreset both used to
-    // rebuild without spreading — plus a representative top-level
-    // pass-through.
+    // Each helper spreads its input before applying defaults, so
+    // wire fields the hydrator doesn't know about pass through
+    // instead of being silently dropped.
     const entry = {
       ...strippedEntry(),
       future_top_level: "kept",

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -21,8 +21,8 @@ function strippedEntry(): Record<string, unknown> {
     esphome: { platform: "esp32", board: "esp32dev" },
     // hardware / images / tags / pins / docs_url / product_url
     // / featured / is_generic / featured_components /
-    // featured_bundles / default_components all OMITTED by the
-    // strip — hydrator must fill them.
+    // featured_bundles all OMITTED by the strip — hydrator must
+    // fill them.
   };
 }
 
@@ -112,6 +112,53 @@ describe("hydrateBoard", () => {
     const [fb] = hydrateBoard(entry).featured_bundles;
     expect(fb.description).toBe("");
     expect(fb.component_ids).toEqual([]);
+  });
+
+  it("preserves unknown fields the backend may add later (forward-compat)", () => {
+    // Every helper spreads its input before applying defaults, so
+    // a wire payload that carries an additional field a future
+    // backend version introduced flows through the hydrator
+    // instead of being silently dropped. Pin the additive
+    // contract on the helpers Copilot specifically called out —
+    // _hydrateHardware and _hydrateFieldPreset both used to
+    // rebuild without spreading — plus a representative top-level
+    // pass-through.
+    const entry = {
+      ...strippedEntry(),
+      future_top_level: "kept",
+      hardware: { flash_size: "4 MB", future_hw_field: 42 },
+      featured_components: [
+        {
+          id: "led",
+          component_id: "output.gpio",
+          future_fc_field: "kept",
+          fields: {
+            pin: { value: 5, future_preset_field: ["kept"] },
+          },
+        },
+      ],
+      featured_bundles: [{ id: "sl", name: "Status LED", future_bundle_field: true }],
+      pins: [{ gpio: 13, future_pin_field: "kept" }],
+      esphome: {
+        platform: "esp32",
+        board: "esp32dev",
+        future_esphome_field: "kept",
+      },
+    } as unknown as BoardCatalogEntry;
+    const hydrated = hydrateBoard(entry) as unknown as Record<string, unknown>;
+    expect(hydrated.future_top_level).toBe("kept");
+    expect((hydrated.hardware as Record<string, unknown>).future_hw_field).toBe(42);
+    expect((hydrated.esphome as Record<string, unknown>).future_esphome_field).toBe(
+      "kept"
+    );
+    const [pin] = hydrated.pins as Record<string, unknown>[];
+    expect(pin.future_pin_field).toBe("kept");
+    const [fc] = hydrated.featured_components as Record<string, unknown>[];
+    expect(fc.future_fc_field).toBe("kept");
+    const preset = (fc.fields as Record<string, Record<string, unknown>>).pin;
+    expect(preset.future_preset_field).toEqual(["kept"]);
+    const [fb] = hydrated.featured_bundles as Record<string, unknown>[];
+    expect(fb.future_bundle_field).toBe(true);
   });
 
   it("preserves populated fields", () => {

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import type { BoardCatalogEntry, PagedBoardsResponse } from "../../src/api/types.js";
+import {
+  hydrateBoard,
+  hydratePagedBoardsResponse,
+} from "../../src/util/board-hydrate.js";
+
+/**
+ * Stripped wire shape: the keys the backend's omit_default
+ * config drops on serialise. Each call-site verifies hydrateBoard
+ * fills the matching default exactly the way Python's from_dict
+ * would, so consumers can read non-null fields without `?? []`
+ * defensive accesses on every site.
+ */
+function strippedEntry(): Record<string, unknown> {
+  return {
+    id: "esp32_devkit_v1",
+    name: "ESP32 DevKit v1",
+    description: "Generic ESP32 development kit",
+    manufacturer: "Espressif",
+    esphome: { platform: "esp32", board: "esp32dev" },
+    // hardware / images / tags / pins / docs_url / product_url
+    // / featured / is_generic / featured_components /
+    // featured_bundles / default_components all OMITTED by the
+    // strip — hydrator must fill them.
+  };
+}
+
+describe("hydrateBoard", () => {
+  it("re-defaults every omitted top-level field", () => {
+    const entry = strippedEntry() as unknown as BoardCatalogEntry;
+    const hydrated = hydrateBoard(entry);
+    expect(hydrated.hardware).toEqual({
+      flash_size: null,
+      ram_size: null,
+      cpu_frequency: null,
+      connectivity: [],
+    });
+    expect(hydrated.images).toEqual([]);
+    expect(hydrated.tags).toEqual([]);
+    expect(hydrated.pins).toEqual([]);
+    expect(hydrated.docs_url).toBe("");
+    expect(hydrated.product_url).toBe("");
+    expect(hydrated.featured).toBe(false);
+    expect(hydrated.is_generic).toBe(false);
+    expect(hydrated.featured_components).toEqual([]);
+    expect(hydrated.featured_bundles).toEqual([]);
+  });
+
+  it("re-defaults variant + framework on a stripped esphome block", () => {
+    const entry = strippedEntry() as unknown as BoardCatalogEntry;
+    const hydrated = hydrateBoard(entry);
+    expect(hydrated.esphome.variant).toBeNull();
+    expect(hydrated.esphome.framework).toBeNull();
+  });
+
+  it("re-defaults nested FieldPreset values (locked/false, suggestions/null)", () => {
+    // Mirrors the highest-frequency strip surface: ~40k empty
+    // suggestions + locked false rows live inside FeaturedComponent.fields
+    // on a fully-populated catalog.
+    const entry = {
+      ...strippedEntry(),
+      featured_components: [
+        {
+          id: "led",
+          component_id: "output.gpio",
+          // name, description omitted (would be null)
+          fields: {
+            pin: { value: 5 },
+            inverted: { value: true, locked: true },
+            // suggestions / locked default-fields all omitted
+          },
+        },
+      ],
+    } as unknown as BoardCatalogEntry;
+    const hydrated = hydrateBoard(entry);
+    const fc = hydrated.featured_components[0];
+    expect(fc.name).toBeNull();
+    expect(fc.description).toBeNull();
+    expect(fc.fields.pin).toEqual({ value: 5, locked: false, suggestions: null });
+    expect(fc.fields.inverted).toEqual({
+      value: true,
+      locked: true,
+      suggestions: null,
+    });
+  });
+
+  it("re-defaults BoardPin fields when the pin row is partially stripped", () => {
+    const entry = {
+      ...strippedEntry(),
+      pins: [
+        // Only gpio supplied — everything else stripped.
+        { gpio: 13 },
+      ],
+    } as unknown as BoardCatalogEntry;
+    const [pin] = hydrateBoard(entry).pins;
+    expect(pin).toEqual({
+      gpio: 13,
+      label: "",
+      features: [],
+      available: null,
+      occupied_by: null,
+      notes: null,
+    });
+  });
+
+  it("re-defaults a stripped FeaturedBundle's description + component_ids", () => {
+    const entry = {
+      ...strippedEntry(),
+      featured_bundles: [{ id: "status_led", name: "Status LED" }],
+    } as unknown as BoardCatalogEntry;
+    const [fb] = hydrateBoard(entry).featured_bundles;
+    expect(fb.description).toBe("");
+    expect(fb.component_ids).toEqual([]);
+  });
+
+  it("preserves populated fields", () => {
+    // A non-stripped board (every default explicitly set on the wire)
+    // round-trips unchanged.
+    const entry: BoardCatalogEntry = {
+      id: "esp32_devkit_v1",
+      name: "ESP32 DevKit v1",
+      description: "Generic ESP32 development kit",
+      manufacturer: "Espressif",
+      esphome: {
+        platform: "esp32",
+        board: "esp32dev",
+        variant: "esp32",
+        framework: "arduino",
+      },
+      hardware: {
+        flash_size: "4 MB",
+        ram_size: 320,
+        cpu_frequency: "240 MHz",
+        connectivity: ["wifi", "bluetooth"],
+      },
+      images: ["image.png"],
+      tags: ["development"],
+      pins: [
+        {
+          gpio: 13,
+          label: "LED",
+          features: ["digital"],
+          available: true,
+          occupied_by: null,
+          notes: "Built-in",
+        },
+      ],
+      docs_url: "https://example.com",
+      product_url: "https://shop.example.com",
+      featured: true,
+      is_generic: false,
+      featured_components: [],
+      featured_bundles: [],
+    };
+    expect(hydrateBoard(entry)).toEqual(entry);
+  });
+});
+
+describe("hydratePagedBoardsResponse", () => {
+  it("hydrates every board in the response", () => {
+    const response = {
+      total: 1,
+      offset: 0,
+      limit: 50,
+      boards: [strippedEntry()],
+    } as unknown as PagedBoardsResponse;
+    const hydrated = hydratePagedBoardsResponse(response);
+    expect(hydrated.boards).toHaveLength(1);
+    expect(hydrated.boards[0].pins).toEqual([]);
+    expect(hydrated.boards[0].docs_url).toBe("");
+    // Top-level paging fields pass through.
+    expect(hydrated.total).toBe(1);
+    expect(hydrated.offset).toBe(0);
+    expect(hydrated.limit).toBe(50);
+  });
+});

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -221,4 +221,17 @@ describe("hydratePagedBoardsResponse", () => {
     expect(hydrated.offset).toBe(0);
     expect(hydrated.limit).toBe(50);
   });
+
+  it("re-defaults a wholly-stripped wrapper (forward-compat against omit_default on PagedResponse)", () => {
+    // If the backend ever applies omit_default to PagedResponse,
+    // a zero-result query strips boards/total/offset/limit — the
+    // .map would throw and pagination would surface as undefined.
+    // Pin the defensive defaults.
+    const response = {} as unknown as PagedBoardsResponse;
+    const hydrated = hydratePagedBoardsResponse(response);
+    expect(hydrated.boards).toEqual([]);
+    expect(hydrated.total).toBe(0);
+    expect(hydrated.offset).toBe(0);
+    expect(hydrated.limit).toBe(50);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1018 (board catalog `omit_default` strip). With the backend now omitting empty defaults on `boards/get_board` + `boards/get_boards`, downstream TypeScript interfaces still type these fields as non-nullable lists or null-or-T scalars — so without a hydration step a fresh fetch would surface them as `undefined` at every read in the wizard step-board, the board picker, the pin-defaults helper, and `device-board-info`.

Add `src/util/board-hydrate.ts` with `hydrateBoard` / `hydratePagedBoardsResponse`: walks the wire shape and fills each missing field with the same default the Python dataclass declares. Wired into `src/api/esphome-api.ts::getBoard / getBoards` as the single chokepoint so downstream consumers don't need an `?? []` at every read.

Tests pin every omitted-field bucket:

- top-level (hardware / pins / images / tags / featured_*),
- nested esphome variant + framework,
- nested FieldPreset locked + suggestions (the highest-frequency strip surface, ~40 k rows across the catalog),
- BoardPin row defaults,
- FeaturedBundle description + component_ids,
- round-trip through a non-stripped entry to confirm populated fields pass through unchanged.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#1018

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
