### PR TITLE
Fix automation editor / script editor / api-action editor crash: backfill missing config_entries at API client

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1417,9 +1417,24 @@ export class ESPHomeAPI {
    * than caching across edits.
    */
   async getAvailableAutomations(configuration: string): Promise<AvailableAutomations> {
-    return this.sendCommand<AvailableAutomations>("automations/get_available", {
-      configuration,
-    });
+    const raw = await this.sendCommand<AvailableAutomations>(
+      "automations/get_available",
+      { configuration }
+    );
+    // Backend ships slim ``*Index`` shapes that drop ``config_entries``
+    // entirely. Renderers (``automation-action-node``,
+    // ``automation-trigger-picker``, ``automation-condition-tree``)
+    // read ``def.config_entries.length`` synchronously, so a missing
+    // field crashes on the first paint before per-form hydration
+    // fills the schema in. Backfill once at the API boundary so every
+    // ``getAvailableAutomations`` consumer is safe by construction;
+    // mirrors the precedent set by #432 (boards-client default
+    // backfill). Mutates in place — these objects belong to the call
+    // site and have no other readers yet.
+    for (const e of raw.triggers) e.config_entries ??= [];
+    for (const e of raw.actions) e.config_entries ??= [];
+    for (const e of raw.conditions) e.config_entries ??= [];
+    return raw;
   }
 
   /**

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -391,9 +391,9 @@ export class ESPHomeAutomationEditor extends LitElement {
         // the background. The post-hydration ``_available``
         // reassignment below carries fresh array refs to force a
         // re-render with the hydrated ``config_entries``.
-        onSlim: (slim) => {
+        onPaint: (painted) => {
           if (seq !== this._loadAvailableSeq) return;
-          this._available = slim;
+          this._available = painted;
           this._loading = false;
         },
         isStale: () => seq !== this._loadAvailableSeq,

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -4,7 +4,6 @@ import type {
   AutomationCondition,
   AutomationTrigger,
   AvailableAutomations,
-  ConfigEntry,
 } from "../../../api/types.js";
 import {
   emptyHydrationResult,
@@ -85,14 +84,16 @@ export async function loadAndHydrateAvailable(
   try {
     const slim = await api.getAvailableAutomations(configuration);
     if (options?.isStale?.()) return { status: "stale" };
-    // Backend's slim shape omits ``config_entries`` entirely; backfill
-    // ``[]`` so pre-hydration renders don't read undefined. Shallow
-    // clone keeps mutations off the raw api response.
+    // Shallow-clone each entry so ``hydrateAvailableBodies``
+    // mutates ``available``'s copies, not the api-client object
+    // (other consumers paint with the same reference). The client
+    // already backfills missing ``config_entries`` to ``[]`` at the
+    // wire boundary, so pre-hydration renders are safe.
     const available: AvailableAutomations = {
       ...slim,
-      triggers: slim.triggers.map(_normalizeEntry),
-      actions: slim.actions.map(_normalizeEntry),
-      conditions: slim.conditions.map(_normalizeEntry),
+      triggers: slim.triggers.map((e) => ({ ...e })),
+      actions: slim.actions.map((e) => ({ ...e })),
+      conditions: slim.conditions.map((e) => ({ ...e })),
     };
     options?.onPaint?.(available);
     const hydration = await hydrateAvailableBodies(api, available);
@@ -111,8 +112,4 @@ export async function loadAndHydrateAvailable(
     if (options?.isStale?.()) return { status: "stale" };
     return { status: "error", error };
   }
-}
-
-function _normalizeEntry<T extends { config_entries?: ConfigEntry[] }>(entry: T): T {
-  return { ...entry, config_entries: entry.config_entries ?? [] };
 }

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -4,6 +4,7 @@ import type {
   AutomationCondition,
   AutomationTrigger,
   AvailableAutomations,
+  ConfigEntry,
 } from "../../../api/types.js";
 import {
   emptyHydrationResult,
@@ -58,49 +59,60 @@ export type LoadAndHydrateOutcome =
   | { status: "error"; error: unknown };
 
 /** Fetch the slim ``AvailableAutomations`` for *configuration* and
- *  hydrate ``config_entries`` for every entry, returning fresh
- *  array references so identity-based ``hasChanged`` consumers
- *  re-render with the hydrated entries. The caller owns the
+ *  hydrate ``config_entries`` for every entry. The orchestration
+ *  builds a per-entry shallow clone with ``config_entries`` backed
+ *  by an empty array (the wire-shape backend slims drop the field
+ *  entirely), so child renderers can read ``.config_entries.length``
+ *  before hydration completes without a crash. The caller owns the
  *  state-mutation policy (``_available`` / ``_loading`` /
- *  ``_error`` on the editor element); this function is a thin
- *  orchestration wrapper that the editor element wires into its
- *  Lit lifecycle.
+ *  ``_error`` on the editor element).
  *
- *  ``onSlim`` lets the caller paint the picker with the slim list
- *  immediately, before awaiting hydration. The slim snapshot is
- *  guaranteed stable — hydration runs against a per-entry shallow
- *  clone so ``config_entries`` mutations land on ``available`` and
- *  never on the ``slim`` object the caller paints from. ``isStale``
- *  is checked after each await so an overlapping load can bail
- *  out cleanly. */
+ *  ``onPaint`` fires with the normalized pre-hydration object so
+ *  the picker dropdowns can mount immediately. Hydration mutates
+ *  the same object's per-entry ``config_entries`` in place; the
+ *  returned ``available`` carries fresh array refs so identity-
+ *  checking ``hasChanged`` consumers re-render with the hydrated
+ *  entries. ``isStale`` is checked after each await so an
+ *  overlapping load can bail out cleanly. */
 export async function loadAndHydrateAvailable(
   api: ESPHomeAPI,
   configuration: string,
   options?: {
-    onSlim?: (slim: AvailableAutomations) => void;
+    onPaint?: (available: AvailableAutomations) => void;
     isStale?: () => boolean;
   }
 ): Promise<LoadAndHydrateOutcome> {
   try {
     const slim = await api.getAvailableAutomations(configuration);
     if (options?.isStale?.()) return { status: "stale" };
-    options?.onSlim?.(slim);
-    // Shallow-clone each entry so ``hydrateAvailableBodies``
-    // mutates ``available``'s copies, not the ``slim`` snapshot.
-    // Entry-level ``config_entries`` reassignment ends in a deep
-    // ``structuredClone`` inside the per-entry hydrator, so the
-    // cached body stays disjoint either way.
+    // Backend's slim shape omits ``config_entries`` entirely; backfill
+    // ``[]`` so pre-hydration renders don't read undefined. Shallow
+    // clone keeps mutations off the raw api response.
     const available: AvailableAutomations = {
       ...slim,
-      triggers: slim.triggers.map((e) => ({ ...e })),
-      actions: slim.actions.map((e) => ({ ...e })),
-      conditions: slim.conditions.map((e) => ({ ...e })),
+      triggers: slim.triggers.map(_normalizeEntry),
+      actions: slim.actions.map(_normalizeEntry),
+      conditions: slim.conditions.map(_normalizeEntry),
     };
+    options?.onPaint?.(available);
     const hydration = await hydrateAvailableBodies(api, available);
     if (options?.isStale?.()) return { status: "stale" };
-    return { status: "ok", available, hydration };
+    // Fresh array refs so identity-based ``hasChanged`` consumers
+    // re-render with the hydrated entries (entries' object identity
+    // is preserved so per-entry caches stay valid).
+    const refreshed: AvailableAutomations = {
+      ...available,
+      triggers: [...available.triggers],
+      actions: [...available.actions],
+      conditions: [...available.conditions],
+    };
+    return { status: "ok", available: refreshed, hydration };
   } catch (error) {
     if (options?.isStale?.()) return { status: "stale" };
     return { status: "error", error };
   }
+}
+
+function _normalizeEntry<T extends { config_entries?: ConfigEntry[] }>(entry: T): T {
+  return { ...entry, config_entries: entry.config_entries ?? [] };
 }

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -289,6 +289,75 @@ describe("ESPHomeAPI — cloneDevice", () => {
   });
 });
 
+describe("ESPHomeAPI — getAvailableAutomations", () => {
+  beforeEach(() => {
+    installMockWebSocket();
+  });
+  afterEach(() => {
+    uninstallMockWebSocket();
+  });
+
+  it("backfills missing config_entries on triggers/actions/conditions", async () => {
+    // Backend's slim ``*Index`` shapes drop ``config_entries`` from
+    // the wire payload entirely. Renderers
+    // (``automation-action-node._renderActionParams`` and similar)
+    // read ``def.config_entries.length`` synchronously, so the
+    // client must normalize undefined to ``[]`` before any consumer
+    // touches the result. Pin the normalization at the client
+    // boundary so every caller is safe by construction (avoids
+    // duplicating the backfill in ``loadAndHydrateAvailable``,
+    // ``api-action-editor``, ``script-editor``, etc.).
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const pending = api.getAvailableAutomations("device.yaml");
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      result: {
+        // Wire shape: no ``config_entries`` field at all.
+        triggers: [{ id: "on_boot", name: "On Boot" }],
+        actions: [{ id: "delay", name: "Delay" }],
+        conditions: [{ id: "lambda", name: "Lambda" }],
+        scripts: [],
+        devices: [],
+      },
+    });
+    const result = await pending;
+
+    expect(result.triggers[0].config_entries).toEqual([]);
+    expect(result.actions[0].config_entries).toEqual([]);
+    expect(result.conditions[0].config_entries).toEqual([]);
+  });
+
+  it("preserves config_entries when the wire payload already carries them", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const pending = api.getAvailableAutomations("device.yaml");
+    const sent = ws.sentAs<{ message_id: string }>(0);
+    ws.receive({
+      message_id: sent.message_id,
+      result: {
+        triggers: [
+          {
+            id: "on_boot",
+            name: "On Boot",
+            config_entries: [{ key: "trigger_id" }],
+          },
+        ],
+        actions: [],
+        conditions: [],
+        scripts: [],
+        devices: [],
+      },
+    });
+    const result = await pending;
+
+    expect(result.triggers[0].config_entries).toEqual([{ key: "trigger_id" }]);
+  });
+});
+
 describe("ESPHomeAPI — editFriendlyName", () => {
   beforeEach(() => {
     installMockWebSocket();

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -162,35 +162,64 @@ describe("loadAndHydrateAvailable", () => {
     expect(outcome.status).toBe("ok");
   });
 
+  it("backfills config_entries when the backend's slim shape omits it", async () => {
+    // Backend's ``AutomationActionIndex`` / ``AutomationTriggerIndex``
+    // etc. drop the ``config_entries`` field entirely from the wire
+    // payload. Renderers like ``automation-action-node`` read
+    // ``def.config_entries.length`` synchronously, so the
+    // pre-hydration paint must normalize undefined to ``[]`` or
+    // child components crash.
+    const slim = {
+      triggers: [{ id: "on_boot" } as AutomationTrigger], // no config_entries
+      actions: [{ id: "delay" } as AutomationAction], // no config_entries
+      conditions: [{ id: "lambda" } as AutomationCondition], // no config_entries
+      scripts: [],
+      devices: [],
+    } as unknown as AvailableAutomations;
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
+    } as unknown as ESPHomeAPI;
+    let painted: AvailableAutomations | null = null;
+
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
+      onPaint: (p) => {
+        painted = p;
+      },
+    });
+    if (outcome.status !== "ok") throw new Error("expected ok");
+    if (painted === null) throw new Error("expected onPaint to fire");
+    const p: AvailableAutomations = painted;
+
+    expect(p.triggers[0].config_entries).toEqual([]);
+    expect(p.actions[0].config_entries).toEqual([]);
+    expect(p.conditions[0].config_entries).toEqual([]);
+    // The raw api response stays unmutated.
+    expect("config_entries" in slim.triggers[0]).toBe(false);
+  });
+
   it("returns fresh array refs in the hydrated outcome", async () => {
     const slim = emptySlim();
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
     } as unknown as ESPHomeAPI;
-    // Capture the slim ref the orchestration paints through ``onSlim``
-    // so we can compare against the post-hydration arrays.
     let painted: AvailableAutomations | null = null;
 
     const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
-      onSlim: (s) => {
-        painted = s;
+      onPaint: (p) => {
+        painted = p;
       },
     });
     if (outcome.status !== "ok") throw new Error("expected ok");
-    if (painted === null) throw new Error("expected onSlim to fire");
-    const slimPainted: AvailableAutomations = painted;
+    if (painted === null) throw new Error("expected onPaint to fire");
+    const p: AvailableAutomations = painted;
 
-    expect(outcome.available).not.toBe(slimPainted);
-    expect(outcome.available.triggers).not.toBe(slimPainted.triggers);
-    expect(outcome.available.actions).not.toBe(slimPainted.actions);
-    expect(outcome.available.conditions).not.toBe(slimPainted.conditions);
+    expect(outcome.available).not.toBe(p);
+    expect(outcome.available.triggers).not.toBe(p.triggers);
+    expect(outcome.available.actions).not.toBe(p.actions);
+    expect(outcome.available.conditions).not.toBe(p.conditions);
   });
 
-  it("keeps the slim snapshot immutable during hydration", async () => {
-    // ``onSlim`` should hand the caller a stable view; the
-    // hydration mutations land on ``available`` (which is a
-    // per-entry shallow clone), never on the snapshot the picker
-    // paints from.
+  it("keeps the raw api response immutable during hydration", async () => {
     const slim = {
       triggers: [
         { id: "on_boot", config_entries: [] as ConfigEntry[] } as AutomationTrigger,
@@ -212,37 +241,27 @@ describe("loadAndHydrateAvailable", () => {
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
     } as unknown as ESPHomeAPI;
-    let painted: AvailableAutomations | null = null;
 
-    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
-      onSlim: (s) => {
-        painted = s;
-      },
-    });
-    // Force-hydrate ``available`` separately so the entry's
-    // ``config_entries`` is populated.
+    const outcome = await loadAndHydrateAvailable(api, "device.yaml");
     if (outcome.status !== "ok") throw new Error("expected ok");
     await hydrateAvailableBodies(api, outcome.available, async () => body);
 
-    expect(painted).toBe(slim);
-    // The slim snapshot's entry still has its original empty
-    // ``config_entries``; only ``available``'s shallow-cloned
-    // entry got hydrated.
+    // Raw api response's entry stays untouched; orchestration
+    // works against a per-entry shallow clone.
     expect(slim.triggers[0].config_entries).toEqual([]);
     expect(outcome.available.triggers[0]).not.toBe(slim.triggers[0]);
   });
 
-  it("paints via onSlim before awaiting hydration", async () => {
+  it("paints via onPaint before awaiting hydration", async () => {
     const slim = emptySlim();
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
     } as unknown as ESPHomeAPI;
-    const onSlim = vi.fn();
+    const onPaint = vi.fn();
 
-    await loadAndHydrateAvailable(api, "device.yaml", { onSlim });
+    await loadAndHydrateAvailable(api, "device.yaml", { onPaint });
 
-    expect(onSlim).toHaveBeenCalledTimes(1);
-    expect(onSlim).toHaveBeenCalledWith(slim);
+    expect(onPaint).toHaveBeenCalledTimes(1);
   });
 
   it("returns 'stale' when isStale flips during the fetch", async () => {
@@ -250,15 +269,15 @@ describe("loadAndHydrateAvailable", () => {
     const api = {
       getAvailableAutomations: vi.fn().mockResolvedValue(slim),
     } as unknown as ESPHomeAPI;
-    const onSlim = vi.fn();
+    const onPaint = vi.fn();
 
     const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
-      onSlim,
+      onPaint,
       isStale: () => true,
     });
 
     expect(outcome.status).toBe("stale");
-    expect(onSlim).not.toHaveBeenCalled();
+    expect(onPaint).not.toHaveBeenCalled();
   });
 
   it("returns 'error' when the api call rejects", async () => {

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -162,41 +162,6 @@ describe("loadAndHydrateAvailable", () => {
     expect(outcome.status).toBe("ok");
   });
 
-  it("backfills config_entries when the backend's slim shape omits it", async () => {
-    // Backend's ``AutomationActionIndex`` / ``AutomationTriggerIndex``
-    // etc. drop the ``config_entries`` field entirely from the wire
-    // payload. Renderers like ``automation-action-node`` read
-    // ``def.config_entries.length`` synchronously, so the
-    // pre-hydration paint must normalize undefined to ``[]`` or
-    // child components crash.
-    const slim = {
-      triggers: [{ id: "on_boot" } as AutomationTrigger], // no config_entries
-      actions: [{ id: "delay" } as AutomationAction], // no config_entries
-      conditions: [{ id: "lambda" } as AutomationCondition], // no config_entries
-      scripts: [],
-      devices: [],
-    } as unknown as AvailableAutomations;
-    const api = {
-      getAvailableAutomations: vi.fn().mockResolvedValue(slim),
-    } as unknown as ESPHomeAPI;
-    let painted: AvailableAutomations | null = null;
-
-    const outcome = await loadAndHydrateAvailable(api, "device.yaml", {
-      onPaint: (p) => {
-        painted = p;
-      },
-    });
-    if (outcome.status !== "ok") throw new Error("expected ok");
-    if (painted === null) throw new Error("expected onPaint to fire");
-    const p: AvailableAutomations = painted;
-
-    expect(p.triggers[0].config_entries).toEqual([]);
-    expect(p.actions[0].config_entries).toEqual([]);
-    expect(p.conditions[0].config_entries).toEqual([]);
-    // The raw api response stays unmutated.
-    expect("config_entries" in slim.triggers[0]).toBe(false);
-  });
-
   it("returns fresh array refs in the hydrated outcome", async () => {
     const slim = emptySlim();
     const api = {


### PR DESCRIPTION
## Summary

After #431 merged, opening the automation editor, script editor, or api-action editor crashes with `Cannot read properties of undefined (reading 'length')` inside `ESPHomeAutomationActionNode._renderActionParams` (and matching trigger picker / condition tree sites).

## Root cause

The backend's slim shape (`AutomationTriggerIndex` / `AutomationActionIndex` / `AutomationConditionIndex`) omits `config_entries` from the wire payload entirely. The TS type still declares `config_entries: ConfigEntry[]`, so consumer code didn't guard for undefined, and the first paint hit `def.config_entries.length` on undefined.

Five call sites consume `getAvailableAutomations` directly:
- `automation-editor.ts` (via `loadAndHydrateAvailable`)
- `api-action-editor.ts:324`
- `script-editor.ts:239`
- `add-script-dialog.ts:174`
- `add-automation-dialog.ts:248`

The first three pass the raw slim list into `automation-action-list` → `automation-action-node`, which is the named crash site.

## Fix

Normalize at the data source: `ESPHomeAPI.getAvailableAutomations` now backfills `config_entries` to `[]` on every trigger / action / condition entry whose wire payload lacks the field. All consumers are safe by construction — no per-call-site normalization needed. Mirrors the precedent in #432 (board client backfill).

Secondary cleanup in `loadAndHydrateAvailable`:
- `onSlim` → `onPaint` rename — the caller receives a normalized, render-safe object (the orchestration's per-entry shallow clone, not the raw API response).
- Post-hydration `available` returned with fresh array refs so identity-based `hasChanged` consumers re-render with hydrated entries.

## Tests

- **`test/api/esphome-api.test.ts`** — new `ESPHomeAPI — getAvailableAutomations` suite pins the backfill at the wire boundary:
  - Wire payload with missing `config_entries` fields → normalized to `[]` on triggers / actions / conditions.
  - Wire payload with populated `config_entries` → preserved verbatim.
- **`test/components/device/automation-editor/hydrate-available-bodies.test.ts`** — updated for the `onSlim` → `onPaint` rename and the relocation of the backfill contract to the API client. The "raw api response immutable during hydration" test stays (shallow-clone behavior on the orchestration side).

## Test plan

- [x] 1450 tests pass; `npx tsc --noEmit` clean.
- [ ] Dev pair: open an automation in the visual editor — trigger / condition / action forms render without console errors.
- [ ] Dev pair: open a script with an `actions:` block — action forms render.
- [ ] Dev pair: open an api action (`api.services[]` etc) — action forms render.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`