### PR TITLE
Navigator: gate kickoff on parent's platform-resolution signal

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -134,6 +134,15 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property()
   platform = "";
 
+  /** ``true`` once the parent has settled the platform resolution
+   *  (board manifest fetched or definitively absent). Until this
+   *  flips true, ``_kickoffNameResolves`` holds off so we don't
+   *  fire one fetch with ``platform=""`` and another with the real
+   *  platform — both would hit different ``BatchedCache`` buckets
+   *  and the first would be orphaned. */
+  @property({ type: Boolean })
+  platformReady = false;
+
   @query("esphome-add-config-dialog")
   private _addConfigDialog!: ESPHomeAddConfigDialog;
 
@@ -380,9 +389,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
+    // Gate the name-resolve kickoff on ``platformReady`` so we fire
+    // exactly once with the final platform context. Re-fire when
+    // ``yaml``, ``platform``, or the readiness flag itself flips —
+    // typical mount order is ``yaml`` first, then ``platformReady``
+    // when the parent's board fetch settles, which lands here as
+    // the single edge we want.
     if (
-      (changedProperties.has("yaml") || changedProperties.has("platform")) &&
-      this.yaml
+      (changedProperties.has("yaml") ||
+        changedProperties.has("platform") ||
+        changedProperties.has("platformReady")) &&
+      this.yaml &&
+      this.platformReady
     ) {
       this._kickoffNameResolves();
     }

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -134,12 +134,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property()
   platform = "";
 
-  /** ``true`` once the parent has settled the platform resolution
-   *  (board manifest fetched or definitively absent). Until this
-   *  flips true, ``_kickoffNameResolves`` holds off so we don't
-   *  fire one fetch with ``platform=""`` and another with the real
-   *  platform — both would hit different ``BatchedCache`` buckets
-   *  and the first would be orphaned. */
+  /** ``true`` once the parent's platform resolution settles.
+   *  Without this gate the kickoff fires twice (yaml-edge with
+   *  ``platform=""``, then platform-edge with the real value);
+   *  the two land in different ``BatchedCache`` buckets so the
+   *  first round-trip is orphaned. */
   @property({ type: Boolean })
   platformReady = false;
 
@@ -389,12 +388,8 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
-    // Gate the name-resolve kickoff on ``platformReady`` so we fire
-    // exactly once with the final platform context. Re-fire when
-    // ``yaml``, ``platform``, or the readiness flag itself flips —
-    // typical mount order is ``yaml`` first, then ``platformReady``
-    // when the parent's board fetch settles, which lands here as
-    // the single edge we want.
+    // Fire on whichever of yaml / platform / platformReady arrives
+    // last; the conjunction ensures one kickoff per mount.
     if (
       (changedProperties.has("yaml") ||
         changedProperties.has("platform") ||

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -135,10 +135,10 @@ export class ESPHomeDeviceNavigator extends LitElement {
   platform = "";
 
   /** ``true`` once the parent's platform resolution settles.
-   *  Without this gate the kickoff fires twice (yaml-edge with
-   *  ``platform=""``, then platform-edge with the real value);
-   *  the two land in different ``BatchedCache`` buckets so the
-   *  first round-trip is orphaned. */
+   *  Without this gate the kickoff would routinely fire twice
+   *  (yaml-edge with ``platform=""``, then platform-edge with the
+   *  real value), landing in different ``BatchedCache`` buckets
+   *  so the first round-trip is orphaned. */
   @property({ type: Boolean })
   platformReady = false;
 
@@ -388,8 +388,9 @@ export class ESPHomeDeviceNavigator extends LitElement {
   }
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
-    // Fire on whichever of yaml / platform / platformReady arrives
-    // last; the conjunction ensures one kickoff per mount.
+    // Fire on the edge that satisfies the gate — typically just
+    // the last of (yaml, platformReady) to land. A subsequent
+    // ``platform`` change (post-mount reconnect, etc.) refires.
     if (
       (changedProperties.has("yaml") ||
         changedProperties.has("platform") ||

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -481,6 +481,22 @@ export class ESPHomePageDevice extends LitElement {
       // still needs the gate to flip, and a yaml-fallback would
       // reintroduce the double-fetch this PR removes when yaml
       // beats the context.
+      //
+      // Known narrow window: a wizard-just-created device fires
+      // the backend event that adds it to ``_devices`` a beat
+      // after navigation lands. In that gap ``_devicesLoaded``
+      // is already true (from the initial subscribe-events
+      // payload) but ``_device`` is still null, so the gate
+      // flips here with ``platform=""`` and the navigator
+      // kickoff fires once against the empty bucket. When the
+      // event arrives and ``_device`` resolves with a real
+      // ``board_id``, the board-fetch branch resets the gate
+      // and the navigator fires again with the resolved
+      // platform. Self-correcting (labels still come up) but
+      // does pay the one extra round trip the rest of this PR
+      // exists to avoid. The tightest fix would be a "context
+      // has settled for *this id*" signal; we don't have one
+      // today.
       if (this._loadedBoardId !== null) {
         this._loadedBoardId = null;
         this._board = null;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -451,16 +451,22 @@ export class ESPHomePageDevice extends LitElement {
       this._loadedBoardId = boardId;
       this._platformReady = false;
       this._loadBoard(boardId);
-    } else if (!boardId && this._device !== null) {
-      // Device context has resolved with no ``board_id`` (rare —
-      // wizard re-run cleared it, or device was created without a
-      // board pin). No manifest to fetch; platform is
-      // definitively unknown.
+    } else if (!boardId) {
+      // No board id to fetch: either the device context has
+      // resolved with no ``board_id`` (rare — wizard re-run
+      // cleared it / device created without a board pin), or the
+      // device isn't in the devices context at all (deleted /
+      // stale id / context not yet loaded). In both cases there's
+      // no manifest to fetch; release the gate once we have
+      // *some* signal the page is operable, so the navigator can
+      // resolve labels with ``platform=undefined``.
       if (this._loadedBoardId !== null) {
         this._loadedBoardId = null;
         this._board = null;
       }
-      this._platformReady = true;
+      if (this._device !== null || this._yaml) {
+        this._platformReady = true;
+      }
     }
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -23,6 +23,7 @@ import {
   activeJobsContext,
   apiContext,
   devicesContext,
+  devicesLoadedContext,
   localizeContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -62,6 +63,16 @@ export class ESPHomePageDevice extends LitElement {
   @consume({ context: devicesContext, subscribe: true })
   @state()
   private _devices: ConfiguredDevice[] = [];
+
+  /** Flips ``true`` after the initial devices-list fetch has
+   *  resolved, regardless of whether it returned any devices. The
+   *  ``_platformReady`` gate uses this to distinguish "context still
+   *  loading" from "context delivered, our id isn't here" — using
+   *  ``_devices.length > 0`` would miss the legitimate zero-device
+   *  state and strand the gate forever. */
+  @consume({ context: devicesLoadedContext, subscribe: true })
+  @state()
+  private _devicesLoaded = false;
 
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;
@@ -449,6 +460,11 @@ export class ESPHomePageDevice extends LitElement {
     const boardId = this._device?.board_id ?? null;
     if (boardId && boardId !== this._loadedBoardId) {
       this._loadedBoardId = boardId;
+      // Drop the previous board immediately so derived props
+      // (``.platform``, ``.boardName``) don't stay out of sync
+      // with the in-flight ``board_id``. Restored by the success
+      // branch of ``_loadBoard``; left null on failure.
+      this._board = null;
       this._platformReady = false;
       this._loadBoard(boardId);
     } else if (!boardId) {
@@ -458,20 +474,18 @@ export class ESPHomePageDevice extends LitElement {
       // (deleted / stale link). Both are signals that no manifest
       // fetch is coming; release the gate.
       //
-      // We gate on ``_devices.length > 0`` for the missing-id
-      // case rather than ``this._yaml`` — yaml can resolve
-      // independently of the devices context, and a yaml-fallback
-      // would prematurely flip the gate when the context is just
-      // late, then we'd refetch when the context arrives with a
-      // real board_id, reintroducing the double-fetch this PR
-      // removes. ``_devices.length > 0`` means the context has
-      // delivered at least once; if our id still isn't there,
-      // it's actually missing.
+      // We gate the missing-id branch on
+      // ``this._devicesLoaded`` (provided by ``app-shell`` via
+      // ``devicesLoadedContext``) rather than
+      // ``_devices.length > 0`` — the legitimate zero-device case
+      // still needs the gate to flip, and a yaml-fallback would
+      // reintroduce the double-fetch this PR removes when yaml
+      // beats the context.
       if (this._loadedBoardId !== null) {
         this._loadedBoardId = null;
         this._board = null;
       }
-      if (this._device !== null || this._devices.length > 0) {
+      if (this._device !== null || this._devicesLoaded) {
         this._platformReady = true;
       }
     }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -452,19 +452,26 @@ export class ESPHomePageDevice extends LitElement {
       this._platformReady = false;
       this._loadBoard(boardId);
     } else if (!boardId) {
-      // No board id to fetch: either the device context has
-      // resolved with no ``board_id`` (rare — wizard re-run
-      // cleared it / device created without a board pin), or the
-      // device isn't in the devices context at all (deleted /
-      // stale id / context not yet loaded). In both cases there's
-      // no manifest to fetch; release the gate once we have
-      // *some* signal the page is operable, so the navigator can
-      // resolve labels with ``platform=undefined``.
+      // No board id to fetch — either the device resolved with no
+      // ``board_id`` (wizard re-run / created without one), or
+      // the devices context has loaded and our id isn't in it
+      // (deleted / stale link). Both are signals that no manifest
+      // fetch is coming; release the gate.
+      //
+      // We gate on ``_devices.length > 0`` for the missing-id
+      // case rather than ``this._yaml`` — yaml can resolve
+      // independently of the devices context, and a yaml-fallback
+      // would prematurely flip the gate when the context is just
+      // late, then we'd refetch when the context arrives with a
+      // real board_id, reintroducing the double-fetch this PR
+      // removes. ``_devices.length > 0`` means the context has
+      // delivered at least once; if our id still isn't there,
+      // it's actually missing.
       if (this._loadedBoardId !== null) {
         this._loadedBoardId = null;
         this._board = null;
       }
-      if (this._device !== null || this._yaml) {
+      if (this._device !== null || this._devices.length > 0) {
         this._platformReady = true;
       }
     }
@@ -507,10 +514,15 @@ export class ESPHomePageDevice extends LitElement {
       }
     } catch (e) {
       console.error("Failed to load board:", e);
-      // Definitive failure — release the navigator from its
-      // platform-ready wait so labels still resolve (with
-      // platform=undefined).
-      if (this._loadedBoardId === boardId) this._platformReady = true;
+      // Definitive failure — drop any previously-cached board
+      // (stale from a prior board_id) so the navigator doesn't
+      // resolve labels against the wrong platform, then release
+      // the gate so labels still come up (with
+      // ``platform=undefined``).
+      if (this._loadedBoardId === boardId) {
+        this._board = null;
+        this._platformReady = true;
+      }
     }
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -106,9 +106,11 @@ export class ESPHomePageDevice extends LitElement {
 
   /** ``true`` once this device's platform is known (manifest
    *  fetched, fetch failed, or no ``board_id``). The navigator
-   *  gates its kickoff on this so it fires once with the final
-   *  platform instead of twice (yaml-edge + platform-edge).
-   *  Resets on device-id change. */
+   *  gates on this to avoid the typical mount-time double-fetch
+   *  (yaml-edge with ``platform=""``, then platform-edge with the
+   *  real value); the no-board branch below has a documented
+   *  narrow window where it can still flip early. Resets on
+   *  device-id change. */
   @state()
   private _platformReady = false;
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -95,6 +95,17 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _board: BoardCatalogEntry | null = null;
 
+  /** Flips ``true`` once we know the answer about this device's
+   *  ``platform``: either the board manifest resolved (success or
+   *  definitive failure), or the device has no ``board_id`` (no
+   *  manifest to fetch). The navigator gates its name-resolve
+   *  kickoff on this signal so it fires exactly once with the
+   *  final ``platform`` context instead of double-fetching on the
+   *  yaml-edge with ``platform=undefined`` and then again on the
+   *  platform-edge. Re-fetched per device-id change. */
+  @state()
+  private _platformReady = false;
+
   /** Last `board_id` we kicked off a fetch for. Used to dedupe so a
    *  re-render doesn't refetch the same board, and to detect board
    *  changes (rename / wizard re-run) and refetch when needed. */
@@ -429,6 +440,7 @@ export class ESPHomePageDevice extends LitElement {
       // next fetch can repopulate.
       this._loadedBoardId = null;
       this._board = null;
+      this._platformReady = false;
       this._loadYaml();
     }
     // Devices context arrives async after connect; kick off the board
@@ -437,11 +449,18 @@ export class ESPHomePageDevice extends LitElement {
     const boardId = this._device?.board_id ?? null;
     if (boardId && boardId !== this._loadedBoardId) {
       this._loadedBoardId = boardId;
+      this._platformReady = false;
       this._loadBoard(boardId);
-    } else if (!boardId && this._loadedBoardId !== null && this._board) {
-      // Device dropped its board_id (rare — wizard re-run cleared it).
-      this._loadedBoardId = null;
-      this._board = null;
+    } else if (!boardId && this._device !== null) {
+      // Device context has resolved with no ``board_id`` (rare —
+      // wizard re-run cleared it, or device was created without a
+      // board pin). No manifest to fetch; platform is
+      // definitively unknown.
+      if (this._loadedBoardId !== null) {
+        this._loadedBoardId = null;
+        this._board = null;
+      }
+      this._platformReady = true;
     }
   }
 
@@ -478,9 +497,14 @@ export class ESPHomePageDevice extends LitElement {
       // `_loadedBoardId` will already point at the new id.
       if (this._loadedBoardId === boardId) {
         this._board = board;
+        this._platformReady = true;
       }
     } catch (e) {
       console.error("Failed to load board:", e);
+      // Definitive failure — release the navigator from its
+      // platform-ready wait so labels still resolve (with
+      // platform=undefined).
+      if (this._loadedBoardId === boardId) this._platformReady = true;
     }
   }
 
@@ -994,6 +1018,7 @@ export class ESPHomePageDevice extends LitElement {
       .boardName=${this._board?.name ?? ""}
       .configuration=${this.id}
       .platform=${this._board?.esphome.platform ?? ""}
+      .platformReady=${this._platformReady}
       .selectedKey=${this._selectedSection}
       .selectedFromLine=${this._selectedFromLine}
     ></esphome-device-navigator>`;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -64,12 +64,10 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _devices: ConfiguredDevice[] = [];
 
-  /** Flips ``true`` after the initial devices-list fetch has
-   *  resolved, regardless of whether it returned any devices. The
-   *  ``_platformReady`` gate uses this to distinguish "context still
-   *  loading" from "context delivered, our id isn't here" — using
-   *  ``_devices.length > 0`` would miss the legitimate zero-device
-   *  state and strand the gate forever. */
+  /** ``true`` once the initial subscribe-events payload landed.
+   *  ``_platformReady`` uses this to tell "context still loading"
+   *  apart from "context delivered, our id isn't here" — a length
+   *  check would strand the gate on a zero-device dashboard. */
   @consume({ context: devicesLoadedContext, subscribe: true })
   @state()
   private _devicesLoaded = false;
@@ -106,14 +104,11 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _board: BoardCatalogEntry | null = null;
 
-  /** Flips ``true`` once we know the answer about this device's
-   *  ``platform``: either the board manifest resolved (success or
-   *  definitive failure), or the device has no ``board_id`` (no
-   *  manifest to fetch). The navigator gates its name-resolve
-   *  kickoff on this signal so it fires exactly once with the
-   *  final ``platform`` context instead of double-fetching on the
-   *  yaml-edge with ``platform=undefined`` and then again on the
-   *  platform-edge. Re-fetched per device-id change. */
+  /** ``true`` once this device's platform is known (manifest
+   *  fetched, fetch failed, or no ``board_id``). The navigator
+   *  gates its kickoff on this so it fires once with the final
+   *  platform instead of twice (yaml-edge + platform-edge).
+   *  Resets on device-id change. */
   @state()
   private _platformReady = false;
 
@@ -460,43 +455,21 @@ export class ESPHomePageDevice extends LitElement {
     const boardId = this._device?.board_id ?? null;
     if (boardId && boardId !== this._loadedBoardId) {
       this._loadedBoardId = boardId;
-      // Drop the previous board immediately so derived props
-      // (``.platform``, ``.boardName``) don't stay out of sync
-      // with the in-flight ``board_id``. Restored by the success
-      // branch of ``_loadBoard``; left null on failure.
+      // Drop the previous board now so derived props
+      // (``.platform``, ``.boardName``) don't lag the in-flight
+      // ``board_id``. Restored on success, left null on failure.
       this._board = null;
       this._platformReady = false;
       this._loadBoard(boardId);
     } else if (!boardId) {
-      // No board id to fetch — either the device resolved with no
-      // ``board_id`` (wizard re-run / created without one), or
-      // the devices context has loaded and our id isn't in it
-      // (deleted / stale link). Both are signals that no manifest
-      // fetch is coming; release the gate.
-      //
-      // We gate the missing-id branch on
-      // ``this._devicesLoaded`` (provided by ``app-shell`` via
-      // ``devicesLoadedContext``) rather than
-      // ``_devices.length > 0`` — the legitimate zero-device case
-      // still needs the gate to flip, and a yaml-fallback would
-      // reintroduce the double-fetch this PR removes when yaml
-      // beats the context.
-      //
-      // Known narrow window: a wizard-just-created device fires
-      // the backend event that adds it to ``_devices`` a beat
-      // after navigation lands. In that gap ``_devicesLoaded``
-      // is already true (from the initial subscribe-events
-      // payload) but ``_device`` is still null, so the gate
-      // flips here with ``platform=""`` and the navigator
-      // kickoff fires once against the empty bucket. When the
-      // event arrives and ``_device`` resolves with a real
-      // ``board_id``, the board-fetch branch resets the gate
-      // and the navigator fires again with the resolved
-      // platform. Self-correcting (labels still come up) but
-      // does pay the one extra round trip the rest of this PR
-      // exists to avoid. The tightest fix would be a "context
-      // has settled for *this id*" signal; we don't have one
-      // today.
+      // No manifest to fetch (device has no ``board_id`` or our
+      // id isn't in the loaded context — deleted / stale link).
+      // Gate on ``_devicesLoaded`` rather than ``_devices.length
+      // > 0`` so a zero-device dashboard still releases. Known
+      // transient: a wizard-just-created device flips the gate
+      // here once with ``platform=""``, then the device-add
+      // event refires it with the real platform — self-correcting
+      // one-extra-fetch in that narrow window.
       if (this._loadedBoardId !== null) {
         this._loadedBoardId = null;
         this._board = null;
@@ -544,11 +517,9 @@ export class ESPHomePageDevice extends LitElement {
       }
     } catch (e) {
       console.error("Failed to load board:", e);
-      // Definitive failure — drop any previously-cached board
-      // (stale from a prior board_id) so the navigator doesn't
+      // Drop any stale ``_board`` so the navigator doesn't
       // resolve labels against the wrong platform, then release
-      // the gate so labels still come up (with
-      // ``platform=undefined``).
+      // the gate (labels come up with ``platform=undefined``).
       if (this._loadedBoardId === boardId) {
         this._board = null;
         this._platformReady = true;

--- a/test/components/device/device-navigator-coalesce.test.ts
+++ b/test/components/device/device-navigator-coalesce.test.ts
@@ -15,14 +15,8 @@ vi.mock("../../../src/components/device/add-script-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import type { ESPHomeAPI } from "../../../src/api/index.js";
-import {
-  _clearAutomationCatalogCache,
-  fetchAutomationTriggers,
-} from "../../../src/util/automation-catalog-cache.js";
-import {
-  _clearComponentCache,
-  fetchComponent,
-} from "../../../src/util/component-name-cache.js";
+import { _clearAutomationCatalogCache } from "../../../src/util/automation-catalog-cache.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
 
 async function flushPending(times = 5): Promise<void> {
@@ -171,8 +165,3 @@ describe("device-navigator kickoff gating", () => {
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
   });
 });
-
-// Touch the cache-exporters so this file doesn't carry unused
-// imports if happy-dom strips them.
-void fetchAutomationTriggers;
-void fetchComponent;

--- a/test/components/device/device-navigator-coalesce.test.ts
+++ b/test/components/device/device-navigator-coalesce.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral tests for ``device-navigator``'s ``_kickoffNameResolves``
+ * gating. The navigator pulls in several dialog children that we
+ * don't need to render here; ``vi.mock`` no-ops them so the element
+ * can construct in happy-dom.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-config-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-script-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import {
+  _clearAutomationCatalogCache,
+  fetchAutomationTriggers,
+} from "../../../src/util/automation-catalog-cache.js";
+import {
+  _clearComponentCache,
+  fetchComponent,
+} from "../../../src/util/component-name-cache.js";
+import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
+
+async function flushPending(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountNavigator(
+  api: ESPHomeAPI,
+  props: Partial<{
+    yaml: string;
+    platform: string;
+    platformReady: boolean;
+  }> = {}
+): Promise<ESPHomeDeviceNavigator> {
+  const nav = new ESPHomeDeviceNavigator();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (nav as any)._api = api;
+  if (props.yaml !== undefined) nav.yaml = props.yaml;
+  if (props.platform !== undefined) nav.platform = props.platform;
+  if (props.platformReady !== undefined) nav.platformReady = props.platformReady;
+  document.body.appendChild(nav);
+  await nav.updateComplete;
+  await flushPending();
+  return nav;
+}
+
+const YAML = "wifi:\n  ssid: foo\n";
+
+describe("device-navigator kickoff gating", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    _clearAutomationCatalogCache();
+    _clearComponentCache();
+  });
+
+  beforeEach(() => {
+    // Clear any cache state from prior tests so fetch counters are
+    // accurate per test.
+    _clearAutomationCatalogCache();
+    _clearComponentCache();
+  });
+
+  it("does not kickoff when yaml is set but platformReady is false", async () => {
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const getComponentBodies = vi.fn().mockResolvedValue({});
+    const api = { getAutomationTriggers, getComponentBodies } as unknown as ESPHomeAPI;
+
+    await mountNavigator(api, { yaml: YAML, platformReady: false });
+
+    expect(getAutomationTriggers).not.toHaveBeenCalled();
+    expect(getComponentBodies).not.toHaveBeenCalled();
+  });
+
+  it("does not kickoff when platformReady flips true but yaml is empty", async () => {
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const getComponentBodies = vi.fn().mockResolvedValue({});
+    const api = { getAutomationTriggers, getComponentBodies } as unknown as ESPHomeAPI;
+
+    const nav = await mountNavigator(api, { yaml: "", platformReady: false });
+    nav.platformReady = true;
+    await nav.updateComplete;
+    await flushPending();
+
+    expect(getAutomationTriggers).not.toHaveBeenCalled();
+    expect(getComponentBodies).not.toHaveBeenCalled();
+  });
+
+  it("kickoffs exactly once when yaml lands first, then platformReady", async () => {
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const getComponentBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAutomationTriggers,
+      getComponentBodies,
+    } as unknown as ESPHomeAPI;
+
+    const nav = await mountNavigator(api, { yaml: YAML, platformReady: false });
+    expect(getAutomationTriggers).not.toHaveBeenCalled();
+
+    nav.platform = "esp32";
+    nav.platformReady = true;
+    await nav.updateComplete;
+    // Microtask-batched body cache; let queued fetches flush.
+    await flushPending(10);
+
+    expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
+    expect(getAutomationTriggers).toHaveBeenCalledWith("esp32", undefined);
+  });
+
+  it("kickoffs exactly once when platformReady lands first, then yaml", async () => {
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const getComponentBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAutomationTriggers,
+      getComponentBodies,
+    } as unknown as ESPHomeAPI;
+
+    const nav = await mountNavigator(api, {
+      yaml: "",
+      platform: "esp32",
+      platformReady: true,
+    });
+    expect(getAutomationTriggers).not.toHaveBeenCalled();
+
+    nav.yaml = YAML;
+    await nav.updateComplete;
+    await flushPending(10);
+
+    expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
+    expect(getAutomationTriggers).toHaveBeenCalledWith("esp32", undefined);
+  });
+
+  it("kickoffs once with platform=undefined when platformReady flips true with empty platform", async () => {
+    // Platform-less device path (board fetch failed / device has no
+    // board): parent flips ``platformReady`` true but leaves
+    // ``platform=""``. Labels still resolve via the empty bucket.
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const api = { getAutomationTriggers } as unknown as ESPHomeAPI;
+
+    const nav = await mountNavigator(api, { yaml: YAML, platformReady: false });
+    nav.platformReady = true;
+    await nav.updateComplete;
+    await flushPending(10);
+
+    expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
+    expect(getAutomationTriggers).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it("does not re-kickoff when both fields stay set and nothing else changes", async () => {
+    const getAutomationTriggers = vi.fn().mockResolvedValue([]);
+    const api = { getAutomationTriggers } as unknown as ESPHomeAPI;
+
+    const nav = await mountNavigator(api, {
+      yaml: YAML,
+      platform: "esp32",
+      platformReady: true,
+    });
+    await flushPending(10);
+    expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
+
+    // An unrelated prop change shouldn't refire (selection update
+    // doesn't touch yaml / platform / platformReady).
+    nav.selectedKey = "wifi";
+    await nav.updateComplete;
+    await flushPending(10);
+
+    expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Touch the cache-exporters so this file doesn't carry unused
+// imports if happy-dom strips them.
+void fetchAutomationTriggers;
+void fetchComponent;

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -64,18 +64,23 @@ const makeApi = (overrides: Partial<FakeApi> = {}): ESPHomeAPI =>
   }) as unknown as ESPHomeAPI;
 
 /** Construct a page element, plant the api + devices context, and
- *  let Lit settle the initial lifecycle. ``addedDevices`` populates
- *  the devices context as if it had landed. */
+ *  let Lit settle the initial lifecycle. ``devicesLoaded`` simulates
+ *  the parent ``devicesLoadedContext`` signal landing; pass
+ *  ``false`` to keep the page in the "context not yet delivered"
+ *  state. */
 async function mountPage(
   api: ESPHomeAPI,
   id: string,
-  devicesList: ConfiguredDevice[]
+  devicesList: ConfiguredDevice[],
+  devicesLoaded = true
 ): Promise<ESPHomePageDevice> {
   const page = new ESPHomePageDevice();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (page as any)._api = api;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (page as any)._devices = devicesList;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._devicesLoaded = devicesLoaded;
   page.id = id;
   document.body.appendChild(page);
   await page.updateComplete;
@@ -100,6 +105,7 @@ function readBoard(page: ESPHomePageDevice): BoardCatalogEntry | null {
 describe("device page _platformReady lifecycle", () => {
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
   });
 
   it("flips true after a successful board fetch", async () => {
@@ -166,24 +172,38 @@ describe("device page _platformReady lifecycle", () => {
     expect(readPlatformReady(page)).toBe(true);
   });
 
-  it("stays false until devices context has landed (no premature flip on yaml)", async () => {
+  it("stays false until devicesLoaded fires (no premature flip on yaml)", async () => {
     // Pin suggestion #1 from the koan review: yaml landing before
-    // the devices context must not trip the gate, or we
+    // ``devicesLoadedContext`` must not trip the gate, or we
     // reintroduce the double-fetch this PR removes.
     const api = makeApi();
-    const page = await mountPage(api, "kitchen.yaml", []);
+    const page = await mountPage(api, "kitchen.yaml", [], false);
 
     expect(readPlatformReady(page)).toBe(false);
 
-    // Now the devices context arrives carrying a real board_id.
+    // Now the devices context delivers with a real board_id.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (page as any)._devices = [device()];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devicesLoaded = true;
     page.requestUpdate();
     await page.updateComplete;
     await flushPending();
 
     expect(readPlatformReady(page)).toBe(true);
     expect(readBoard(page)?.id).toBe("esp32cam");
+  });
+
+  it("flips true on devicesLoaded with an empty list (zero-device dashboard)", async () => {
+    // ``_devices.length > 0`` would miss this: a legitimate
+    // zero-device dashboard, where the context delivered but
+    // there's nothing in it. Using ``_devicesLoaded`` correctly
+    // releases the gate; the navigator resolves with
+    // ``platform=undefined``.
+    const api = makeApi();
+    const page = await mountPage(api, "ghost.yaml", [], true);
+
+    expect(readPlatformReady(page)).toBe(true);
   });
 
   it("resets to false on device id change", async () => {

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Focused tests for ``ESPHomePageDevice``'s ``_platformReady``
+ * lifecycle. The page imports many heavy children (firmware-
+ * install-dialog, command-dialog, yaml-editor → CodeMirror, …);
+ * ``vi.mock`` no-ops them so the page element can construct
+ * without dragging the editor stack in.
+ *
+ * The tests drive the lifecycle by setting properties and calling
+ * Lit's ``updateComplete`` rather than mounting via the
+ * customElements registry — the page's own ``updated()`` hook is
+ * where the gate transitions live.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));
+
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { BoardCatalogEntry, ConfiguredDevice } from "../../src/api/types.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+
+const board = (overrides: Partial<BoardCatalogEntry> = {}): BoardCatalogEntry =>
+  ({
+    id: "esp32cam",
+    name: "AI Thinker ESP32-CAM",
+    esphome: { platform: "esp32" } as BoardCatalogEntry["esphome"],
+    ...overrides,
+  }) as BoardCatalogEntry;
+
+const device = (overrides: Partial<ConfiguredDevice> = {}): ConfiguredDevice =>
+  ({
+    configuration: "kitchen.yaml",
+    name: "kitchen",
+    board_id: "esp32cam",
+    ...overrides,
+  }) as ConfiguredDevice;
+
+interface FakeApi {
+  getConfig: ReturnType<typeof vi.fn>;
+  getBoard: ReturnType<typeof vi.fn>;
+  getPreferences: ReturnType<typeof vi.fn>;
+}
+
+const makeApi = (overrides: Partial<FakeApi> = {}): ESPHomeAPI =>
+  ({
+    getConfig: vi.fn().mockResolvedValue("wifi:\n  ssid: x\n"),
+    getBoard: vi.fn().mockResolvedValue(board()),
+    getPreferences: vi.fn().mockResolvedValue({ navigator_visible: true }),
+    ...overrides,
+  }) as unknown as ESPHomeAPI;
+
+/** Construct a page element, plant the api + devices context, and
+ *  let Lit settle the initial lifecycle. ``addedDevices`` populates
+ *  the devices context as if it had landed. */
+async function mountPage(
+  api: ESPHomeAPI,
+  id: string,
+  devicesList: ConfiguredDevice[]
+): Promise<ESPHomePageDevice> {
+  const page = new ESPHomePageDevice();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._api = api;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._devices = devicesList;
+  page.id = id;
+  document.body.appendChild(page);
+  await page.updateComplete;
+  await flushPending();
+  return page;
+}
+
+async function flushPending(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+function readPlatformReady(page: ESPHomePageDevice): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (page as any)._platformReady;
+}
+
+function readBoard(page: ESPHomePageDevice): BoardCatalogEntry | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (page as any)._board;
+}
+
+describe("device page _platformReady lifecycle", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("flips true after a successful board fetch", async () => {
+    const api = makeApi();
+    const page = await mountPage(api, "kitchen.yaml", [device()]);
+
+    expect(readPlatformReady(page)).toBe(true);
+    expect(readBoard(page)?.id).toBe("esp32cam");
+  });
+
+  it("flips true and clears _board when the board fetch fails", async () => {
+    // Pin warning #1 from the koan review: on a failed fetch the
+    // catch must clear the stale board so the navigator doesn't
+    // resolve labels against a wrong platform with no correcting
+    // edge to follow.
+    const api = makeApi({ getBoard: vi.fn().mockRejectedValue(new Error("nope")) });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const page = await mountPage(api, "kitchen.yaml", [device()]);
+
+    expect(readPlatformReady(page)).toBe(true);
+    expect(readBoard(page)).toBeNull();
+  });
+
+  it("clears stale _board on board-id change followed by a failed re-fetch", async () => {
+    // Same scenario applied to the board-id-change-on-same-device
+    // path: first fetch succeeds with board A, then board_id
+    // changes (wizard re-run) and the second fetch fails — the
+    // stale A must not leak through to the navigator.
+    const boardA = board({
+      id: "esp32cam",
+      esphome: { platform: "esp32" } as BoardCatalogEntry["esphome"],
+    });
+    const getBoard = vi
+      .fn()
+      .mockResolvedValueOnce(boardA)
+      .mockRejectedValueOnce(new Error("nope"));
+    const api = makeApi({ getBoard });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const page = await mountPage(api, "kitchen.yaml", [device({ board_id: "esp32cam" })]);
+    expect(readBoard(page)?.id).toBe("esp32cam");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devices = [device({ board_id: "rp2040-rpi-pico" })];
+    page.requestUpdate();
+    await page.updateComplete;
+    await flushPending();
+
+    expect(readPlatformReady(page)).toBe(true);
+    expect(readBoard(page)).toBeNull();
+  });
+
+  it("flips true when the device has no board_id", async () => {
+    const api = makeApi();
+    const page = await mountPage(api, "kitchen.yaml", [device({ board_id: "" })]);
+
+    expect(readPlatformReady(page)).toBe(true);
+    expect(readBoard(page)).toBeNull();
+  });
+
+  it("flips true when devices context is loaded but our id isn't in it (stale link)", async () => {
+    const api = makeApi();
+    const page = await mountPage(api, "ghost.yaml", [device()]);
+
+    expect(readPlatformReady(page)).toBe(true);
+  });
+
+  it("stays false until devices context has landed (no premature flip on yaml)", async () => {
+    // Pin suggestion #1 from the koan review: yaml landing before
+    // the devices context must not trip the gate, or we
+    // reintroduce the double-fetch this PR removes.
+    const api = makeApi();
+    const page = await mountPage(api, "kitchen.yaml", []);
+
+    expect(readPlatformReady(page)).toBe(false);
+
+    // Now the devices context arrives carrying a real board_id.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devices = [device()];
+    page.requestUpdate();
+    await page.updateComplete;
+    await flushPending();
+
+    expect(readPlatformReady(page)).toBe(true);
+    expect(readBoard(page)?.id).toBe("esp32cam");
+  });
+
+  it("resets to false on device id change", async () => {
+    const api = makeApi();
+    const page = await mountPage(api, "kitchen.yaml", [device()]);
+    expect(readPlatformReady(page)).toBe(true);
+
+    page.id = "bedroom.yaml";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._devices = [device({ configuration: "bedroom.yaml", name: "bedroom" })];
+    page.requestUpdate();
+    await page.updateComplete;
+    await flushPending();
+
+    // Eventually true again after the new board fetch resolves.
+    expect(readPlatformReady(page)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #431. The navigator's `_kickoffNameResolves` previously fired on every `yaml` or `platform` edge, which on the typical mount sequence meant **two WS round trips per device mount**:

1. `yaml` lands first → fire with `platform=""` → results pinned in the `BatchedCache`'s `""` bucket.
2. `platform` lands a beat later from the board-manifest fetch → fire again with `platform="esp32"` → different bucket.

The first bucket's results are orphaned (every other consumer already knows the platform), so the first round trip is pure waste. The slim-bodies migration in #431 made this visible because the cache properly partitions by `(platform, boardId)`; pre-#431 everything ended up in one bucket so the waste was hidden.

## Fix

`pages/device.ts` exposes a deterministic `_platformReady` signal that flips `true` once we know the answer about this device's platform:

- Board manifest fetch resolves successfully → `true`.
- Board manifest fetch fails → `true` (definitive failure; labels still resolve with `platform=undefined`).
- Device context resolves with no `board_id` → `true` (nothing to fetch).
- Devices context delivers (via `devicesLoadedContext` from `app-shell`) and our id isn't in it → `true` (stale link).
- Device-id change / new board_id → reset to `false`.

The navigator gates `_kickoffNameResolves` on this flag. On the **typical** mount sequence this collapses the double-fetch into a single round-trip with the final platform context. A known narrow window (a wizard-just-created device whose backend event hasn't reached the page yet) can still pay the one extra fetch — self-correcting, documented in the gate's comment.

No timer race (an earlier attempt at a 500ms `setTimeout` defer was abandoned because slow board fetches fell through the timer, defeating the coalescing AND adding 500ms latency on platform-less devices). No platform-less device regression — the flag flips true even when the board fetch fails or the device has no board.

## Changes

- `src/pages/device.ts` — new `_platformReady` + `_devicesLoaded` state. Set in `updated()` lifecycle and `_loadBoard` try/catch. Passed to navigator as `.platformReady`.
- `src/components/device/device-navigator.ts` — new `platformReady` `@property({ type: Boolean })`. `willUpdate` gates the kickoff on `this.yaml && this.platformReady`.

## Tests

- `test/components/device/device-navigator-coalesce.test.ts` (6 cases) — pins the navigator's gate: no-kickoff when half the signal is missing, single kickoff once both land, no re-kickoff on unrelated prop changes, both arrival orders.
- `test/pages/device-platform-ready.test.ts` (8 cases) — pins the device-page state transitions: successful / failed board fetch, board-id change with stale-board cleanup, no-board device, stale-link, premature-flip guard against late devices context, zero-device dashboard, device-id change reset.

## Test plan

- [x] 1473 frontend tests pass
- [x] `npx tsc --noEmit` clean
- [x] Dev pair walkthrough: opened a device with a known board → single `components/get_component_bodies` + single `automations/get_triggers` per navigator mount, both with the populated `platform` + `board_id` context. No orphan `platform=undefined` variants.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`