### PR TITLE
Restore the global header back button on non-root routes

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowCollapseRight } from "@mdi/js";
+import { mdiArrowCollapseRight, mdiArrowLeft } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -10,7 +10,7 @@ import {
   versionContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { withBase } from "../util/base-path.js";
+import { stripBase, withBase } from "../util/base-path.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -20,6 +20,7 @@ import "./esphome-header-actions.js";
 
 registerMdiIcons({
   "arrow-collapse-right": mdiArrowCollapseRight,
+  "arrow-left": mdiArrowLeft,
 });
 
 @customElement("esphome-layout")
@@ -39,6 +40,27 @@ export class ESPHomeLayout extends LitElement {
   @consume({ context: serverVersionContext, subscribe: true })
   @state()
   private _serverVersion = "";
+
+  @state()
+  private _path = stripBase(window.location.pathname);
+
+  private _onPopState = () => {
+    this._path = stripBase(window.location.pathname);
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("popstate", this._onPopState);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener("popstate", this._onPopState);
+  }
+
+  private get _showBack(): boolean {
+    return this._path !== "/" && this._path !== "";
+  }
 
   static styles = [
     espHomeStyles,
@@ -81,6 +103,32 @@ export class ESPHomeLayout extends LitElement {
         align-self: stretch;
         background: var(--esphome-primary-light);
         flex-shrink: 0;
+      }
+
+      .header-back {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: none;
+        color: var(--esphome-on-primary);
+        padding: 6px;
+        border-radius: var(--wa-border-radius-m);
+        opacity: 0.85;
+        cursor: pointer;
+        flex-shrink: 0;
+        transition:
+          opacity 0.12s,
+          background 0.12s;
+      }
+
+      .header-back:hover {
+        opacity: 1;
+        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+      }
+
+      .header-back wa-icon {
+        font-size: 20px;
       }
 
       .header-logo {
@@ -246,6 +294,18 @@ export class ESPHomeLayout extends LitElement {
                   <img src=${withBase("/assets/logo/ha.svg")} alt="Home Assistant" />
                 </wa-button>
                 <div class="header-separator"></div>
+              `
+            : nothing}
+          ${this._showBack
+            ? html`
+                <button
+                  class="header-back"
+                  @click=${this._goHome}
+                  title=${this._localize("layout.back")}
+                  aria-label=${this._localize("layout.back")}
+                >
+                  <wa-icon library="mdi" name="arrow-left"></wa-icon>
+                </button>
               `
             : nothing}
           <button class="header-logo" @click=${this._goHome}>

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1197,7 +1197,12 @@ export class ESPHomePageDevice extends LitElement {
 
     const qs = params.toString();
     const newUrl = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
-    window.history.replaceState(null, "", newUrl);
+    // Preserve the existing state object rather than nulling it: the
+    // header back button's _goHome() reads history.state to tell an
+    // in-app arrival ({} -> pop back to the filtered dashboard) from a
+    // deep-link / fresh load (null -> navigate("/")). Replacing only the
+    // URL keeps that distinction across section navigation.
+    window.history.replaceState(window.history.state, "", newUrl);
   }
 }
 

--- a/test/components/esphome-layout-back-button.test.ts
+++ b/test/components/esphome-layout-back-button.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from "vitest";
+
+import { ESPHomeLayout } from "../../src/components/esphome-layout.js";
+
+interface LayoutPrivateView {
+  _path: string;
+  readonly _showBack: boolean;
+}
+
+function makeLayout(path: string): LayoutPrivateView {
+  const layout = new ESPHomeLayout() as unknown as LayoutPrivateView;
+  layout._path = path;
+  return layout;
+}
+
+describe("esphome-layout header back button visibility", () => {
+  test("hidden on the device-list root", () => {
+    expect(makeLayout("/")._showBack).toBe(false);
+    expect(makeLayout("")._showBack).toBe(false);
+  });
+
+  test("shown inside a device editor and other non-root routes", () => {
+    expect(makeLayout("/device/living-room")._showBack).toBe(true);
+    expect(makeLayout("/secrets")._showBack).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Restores the back button in the global app-shell header that lets the user exit the device editor and return to the device list.

PR #376 ("Rethink the nav for device page") removed the `.header-back` arrow from `esphome-layout.ts`. It was replaced by a back arrow inside the editor pane, but that one only walks the section-visit history (components → automations → board-info) and never leaves the device. The only remaining exits became the ESPHome logo (which doesn't read as a back/exit control) and the browser back button — so users felt stranded in the editor.

This reinstates the route-aware back arrow next to the ESPHome logo (shown on every non-root route), wired to the still-present `_goHome()` handler, which pops history to return to the device list while preserving the dashboard's filter/search state. The editor's in-pane section back arrow is unchanged.

Reuses the existing `layout.back` translation — no new copy, no locale changes.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1020

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
