### PR TITLE
Stop the add-automation dialog from leaking wa-selects on every open

### DIFF
--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -260,7 +260,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         })
       : this._localize("device.add_automation");
     return html`<wa-dialog light-dismiss label=${title}>
-      ${this._loading
+      ${this._loading && !this._available
         ? html`<div style="text-align: center; padding: 32px;">
             <wa-spinner></wa-spinner>
           </div>`

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral guard for the add-automation dialog's render gate. Pins
+ * the memory-leak fix: every ``open()`` sets ``_loading=true``, and the
+ * old render swapped the whole form (its ``wa-select`` dropdowns
+ * included) out for a spinner and rebuilt it, leaking the discarded
+ * selects. The spinner must only show before the first load; once data
+ * has landed the form must stay mounted across reopens, so the same
+ * ``wa-select`` element survives instead of being recreated.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { AvailableAutomations } from "../../../src/api/types.js";
+import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
+
+async function flushPending(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [{ id: "on_boot", name: "On boot", config_entries: [] }],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [{ id: "relay", name: "Relay", component_id: "switch" }],
+  }) as unknown as AvailableAutomations;
+
+/** Mount a dialog with a stubbed api + localize, settle its lifecycle. */
+async function mountDialog(api: ESPHomeAPI): Promise<ESPHomeAddAutomationDialog> {
+  const dialog = new ESPHomeAddAutomationDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._api = api;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._localize = (key: string) => key; // no context provider in the test tree
+  dialog.configuration = "device.yaml";
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  await flushPending();
+  return dialog;
+}
+
+const kindSelect = (d: ESPHomeAddAutomationDialog) =>
+  d.shadowRoot?.querySelector('wa-select[aria-labelledby="kind-label"]') ?? null;
+
+describe("add-automation-dialog render gate (behavioral)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows only the spinner before the first load, then the form", async () => {
+    const first = deferred<AvailableAutomations>();
+    const getAvailableAutomations = vi.fn(() => first.promise);
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    const dialog = await mountDialog(api);
+    dialog.open();
+    await dialog.updateComplete;
+    await flushPending();
+
+    // First load in flight: spinner up, form (and its selects) absent.
+    expect(dialog.shadowRoot?.querySelector("wa-spinner")).not.toBeNull();
+    expect(kindSelect(dialog)).toBeNull();
+
+    first.resolve(slimAvailable());
+    await dialog.updateComplete;
+    await flushPending();
+
+    // Data landed: form rendered, spinner gone.
+    expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
+    expect(kindSelect(dialog)).not.toBeNull();
+  });
+
+  it("keeps the same wa-select mounted across a reopen (no teardown, no leak)", async () => {
+    const first = deferred<AvailableAutomations>();
+    const second = deferred<AvailableAutomations>();
+    const getAvailableAutomations = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    const dialog = await mountDialog(api);
+    dialog.open();
+    await dialog.updateComplete;
+    await flushPending();
+    first.resolve(slimAvailable());
+    await dialog.updateComplete;
+    await flushPending();
+
+    const selectBeforeReopen = kindSelect(dialog);
+    expect(selectBeforeReopen).not.toBeNull();
+
+    // Reopen: open() sets _loading=true again. The form must NOT be
+    // swapped out for the spinner (that is the leak), so the existing
+    // wa-select element must survive rather than be recreated.
+    dialog.open();
+    await dialog.updateComplete;
+    await flushPending();
+
+    expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
+    expect(kindSelect(dialog)).toBe(selectBeforeReopen);
+
+    second.resolve(slimAvailable());
+    await flushPending();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Opening the Add automation dialog leaked memory; each open rebuilt the whole form and recreated its wa-select dropdowns, and webawesome does not fully release those selects when they are removed, so the tab grew without bound. Now the spinner only shows before the first load; afterwards the form stays mounted across reopens, so the selects are created once and reused. Verified with a heap probe, opening the catalog dialogs repeatedly is now flat at zero added nodes and listeners.

**Related issue or feature (if applicable):**

- Reported on Discord, no issue filed.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
