### PR TITLE
Fix YAML search results clipping with no scroll

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -27,14 +27,13 @@ export const dashboardStyles = css`
     --select-bar-height: 64px;
   }
 
-  :host([view="cards"]) {
+  /* YAML mode renders over any underlying view, so it shares this
+     scroll override; without it, YAML search opened from table view
+     clips its hit list. Padding clears the fixed, opaque footer. */
+  :host([view="cards"]),
+  :host([yaml]) {
     height: auto;
     overflow: visible;
-    /* Body scrolls in cards view (incl. YAML mode), and the layout
-       footer is fixed and opaque — without this padding the trailing
-       row of yaml-hits / banner content can sit behind the version
-       line. The configured device grid has its own --fab-clearance,
-       so this only matters for the YAML / discovered content paths. */
     padding-bottom: var(--esphome-footer-height);
   }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -319,6 +319,7 @@ export class ESPHomePageDashboard extends LitElement {
     // state that would otherwise flash through on first paint.
     this._hydrateFromUrl();
     this.setAttribute("view", this._view);
+    this.toggleAttribute("yaml", this._yamlMode);
     this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
     window.addEventListener("esphome-serial-setup", this._onSerialSetup);
     window.addEventListener("esphome-show-ignored-changed", this._onShowIgnoredChanged);
@@ -432,6 +433,7 @@ export class ESPHomePageDashboard extends LitElement {
 
   protected willUpdate(changed: PropertyValues) {
     if (changed.has("_view")) this.setAttribute("view", this._view);
+    if (changed.has("_yamlMode")) this.toggleAttribute("yaml", this._yamlMode);
     // ``has-discovered`` is the hook that adds top padding for the
     // discovery banner. Track the same condition the banner renders
     // under so an all-ignored / hide-ignored state doesn't leave

--- a/test/pages/dashboard-yaml-attr.test.ts
+++ b/test/pages/dashboard-yaml-attr.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that ``ESPHomePageDashboard`` reflects a ``yaml`` host
+ * attribute whenever ``_yamlMode`` is active. The dashboard host
+ * clips at a fixed height unless a ``[view="cards"]`` / ``[yaml]``
+ * rule unlocks scrolling, so YAML search opened from table view
+ * relies on this attribute to scroll instead of clipping its hits.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+
+async function flushPending(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountDashboard(yamlMode: boolean): Promise<ESPHomePageDashboard> {
+  const page = new ESPHomePageDashboard();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._yamlMode = yamlMode;
+  document.body.appendChild(page);
+  await page.updateComplete;
+  await flushPending();
+  return page;
+}
+
+describe("dashboard yaml host attribute", () => {
+  // The dashboard syncs view/search state to the URL; happy-dom shares
+  // window.location across a file, so a prior mount's ``yaml`` param
+  // would leak back in through ``_hydrateFromUrl`` without this reset.
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState({}, "", "/");
+    vi.restoreAllMocks();
+  });
+
+  it("reflects the yaml attribute when mounted in YAML mode", async () => {
+    const page = await mountDashboard(true);
+    expect(page.hasAttribute("yaml")).toBe(true);
+  });
+
+  it("omits the yaml attribute when not in YAML mode", async () => {
+    const page = await mountDashboard(false);
+    expect(page.hasAttribute("yaml")).toBe(false);
+  });
+
+  it("toggles the attribute as _yamlMode flips", async () => {
+    const page = await mountDashboard(false);
+    expect(page.hasAttribute("yaml")).toBe(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._yamlMode = true;
+    await page.updateComplete;
+    await flushPending();
+    expect(page.hasAttribute("yaml")).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._yamlMode = false;
+    await page.updateComplete;
+    await flushPending();
+    expect(page.hasAttribute("yaml")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The YAML search view rendered inside the dashboard host, which is a fixed height flex column with overflow hidden; only the cards view unlocked scrolling. Entering YAML search from table view left the host on the table layout, so a long hit list got clipped with no way to scroll. YAML mode now reflects its own `yaml` host attribute and shares the cards-view scroll override, so the results scroll regardless of the underlying view.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1032

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
