### PR TITLE
Restore the OTA-format firmware download

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1361,6 +1361,8 @@ export interface FirmwareJob {
 export interface FirmwareBinary {
   title: string;
   file: string;
+  // Optional subtext from ESPHome's get_download_types; not every platform supplies one.
+  description?: string;
 }
 
 export interface FirmwareDownload {

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -12,7 +12,7 @@ import {
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import { JobSource, type ConfiguredDevice } from "../api/types.js";
+import { JobSource, type ConfiguredDevice, type FirmwareBinary } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -27,6 +27,7 @@ import {
   renderStatus,
 } from "./firmware-install-dialog/renderers.js";
 import {
+  downloadSelectedBinary,
   flipToLogs,
   startDownload,
   startWebSerialInstall,
@@ -55,6 +56,8 @@ export type InstallStep =
   | "compiling"
   | "flashing"
   | "done"
+  | "choose-binary"
+  | "downloading"
   | "download-ready"
   | "error";
 
@@ -95,6 +98,10 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @state() _logsExpanded = false;
   @state() _flashPercent = 0;
   @state() _downloadedFilename = "";
+
+  // Formats offered by the manual download picker; populated only when a
+  // device produces more than one (e.g. ESP32 factory + OTA).
+  @state() _binaries: FirmwareBinary[] = [];
 
   // Reset per _init so an opt-out on one run doesn't persist. installWebDownload
   // doesn't connect to a device, so the toggle is install-only.
@@ -146,6 +153,11 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     void startDownload(this);
   }
 
+  // Picked a format in the choose-binary step.
+  _onChooseBinary(file: string) {
+    void downloadSelectedBinary(this, file);
+  }
+
   // Reopen without clearing state. Used by logs-dialog's "Back to install"
   // after the Web Serial post-install hand-off so users can review output.
   public reopen() {
@@ -170,6 +182,7 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     this._logsExpanded = false;
     this._flashPercent = 0;
     this._downloadedFilename = "";
+    this._binaries = [];
     this._showLogsAfterInstall = true;
     this._installer = null;
     this._failedDuringCompile = false;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -1,4 +1,4 @@
-import { JobStatus } from "../../api/types.js";
+import { JobStatus, type FirmwareBinary } from "../../api/types.js";
 import { chipNameToVariant } from "../../util/chip-variant.js";
 import { downloadBase64Binary } from "../../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
@@ -214,32 +214,62 @@ export async function startDownload(host: ESPHomeFirmwareInstallDialog): Promise
   }
 
   host._statusMessage = host._localize("firmware.status_downloading");
+  let binaries: FirmwareBinary[];
   try {
-    const binaries = await host._api.firmwareGetBinaries(device.configuration);
-    // ESP32 → firmware.factory.bin (bootloader + partitions + app)
-    // ESP8266 → firmware.bin (full image, no bootloader split)
-    // web flasher requires one of those; manual falls back to first available.
-    const flashable =
-      binaries.find((b) => b.file === "firmware.factory.bin") ??
-      binaries.find((b) => b.file === "firmware.bin") ??
-      (isWebFlasher ? undefined : binaries[0]);
-    if (!flashable) {
-      // Web-flasher path with no match almost always = UF2 platform.
-      host._fail(
-        host._localize(
-          isWebFlasher ? "firmware.no_flashable_binary" : "firmware.no_binaries"
-        )
-      );
-      return;
-    }
-    const result = await host._api.firmwareDownload(device.configuration, flashable.file);
+    binaries = await host._api.firmwareGetBinaries(device.configuration);
+  } catch {
+    host._fail(host._localize("firmware.download_failed"));
+    return;
+  }
+
+  // More than one format (e.g. ESP32 factory + OTA): let the user pick,
+  // since the OTA image is otherwise unreachable from the manual path.
+  if (!isWebFlasher && binaries.length > 1) {
+    host._binaries = binaries;
+    host._statusMessage = "";
+    host._step = "choose-binary";
+    return;
+  }
+
+  // ESP32 → firmware.factory.bin (bootloader + partitions + app)
+  // ESP8266 → firmware.bin (full image, no bootloader split)
+  // web flasher requires one of those; manual falls back to first available.
+  const flashable =
+    binaries.find((b) => b.file === "firmware.factory.bin") ??
+    binaries.find((b) => b.file === "firmware.bin") ??
+    (isWebFlasher ? undefined : binaries[0]);
+  if (!flashable) {
+    // Web-flasher path with no match almost always = UF2 platform.
+    host._fail(
+      host._localize(
+        isWebFlasher ? "firmware.no_flashable_binary" : "firmware.no_binaries"
+      )
+    );
+    return;
+  }
+  await downloadSelectedBinary(host, flashable.file);
+}
+
+// Fetch one binary and hand it to the browser. Shared by the auto-select
+// paths and the picker; leaves _binaries intact for "download another format".
+export async function downloadSelectedBinary(
+  host: ESPHomeFirmwareInstallDialog,
+  file: string
+): Promise<void> {
+  const device = host._device;
+  if (!device) return;
+  host._statusMessage = host._localize("firmware.status_downloading");
+  // Distinct from the compile steps: the byte fetch isn't cancelable, so the
+  // footer must not offer Stop (see renderFooter).
+  host._step = "downloading";
+  try {
+    const result = await host._api.firmwareDownload(device.configuration, file);
     downloadBase64Binary(result.data, result.filename);
     host._downloadedFilename = result.filename;
   } catch {
     host._fail(host._localize("firmware.download_failed"));
     return;
   }
-
   host._step = "download-ready";
   host._statusMessage = "";
 }

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -72,6 +72,32 @@ export function renderStatus(host: ESPHomeFirmwareInstallDialog): TemplateResult
       </div>
     `;
   }
+  if (host._step === "choose-binary") {
+    return html`
+      <div class="status">
+        <span class="status-text">${host._localize("firmware.choose_binary_title")}</span>
+        <span class="status-detail"
+          >${host._localize("firmware.choose_binary_desc")}</span
+        >
+      </div>
+      <div class="binary-list">
+        ${host._binaries.map(
+          (binary) => html`
+            <button
+              type="button"
+              class="binary-option"
+              @click=${() => host._onChooseBinary(binary.file)}
+            >
+              <span class="title">${binary.title}</span>
+              ${binary.description
+                ? html`<span class="desc">${binary.description}</span>`
+                : nothing}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
   if (host._step === "download-ready") {
     const filename = host._downloadedFilename;
     // Manual binary download: just acknowledge the file — no web.esphome.io checklist.
@@ -90,6 +116,15 @@ export function renderStatus(host: ESPHomeFirmwareInstallDialog): TemplateResult
             >${host._localize("firmware.binary_download_done_body", { filename })}</span
           >
         </div>
+        ${host._binaries.length > 1
+          ? html`<button
+              type="button"
+              class="reset-suggestion-link"
+              @click=${() => (host._step = "choose-binary")}
+            >
+              ${host._localize("firmware.choose_binary_again")}
+            </button>`
+          : nothing}
       `;
     }
     return html`
@@ -184,6 +219,17 @@ export function renderLogs(
 }
 
 export function renderFooter(host: ESPHomeFirmwareInstallDialog): TemplateResult {
+  if (host._step === "choose-binary" || host._step === "downloading") {
+    // Compile is done and the byte fetch can't be cancelled, so offer Close
+    // rather than a Stop that would target an already-finished job.
+    return html`
+      <div class="footer">
+        <button class="btn btn--ghost" @click=${host._close}>
+          ${host._localize("command.close")}
+        </button>
+      </div>
+    `;
+  }
   const isRunning =
     host._step !== "done" && host._step !== "error" && host._step !== "download-ready";
   if (isRunning) {

--- a/src/components/firmware-install-dialog/styles.ts
+++ b/src/components/firmware-install-dialog/styles.ts
@@ -133,6 +133,45 @@ export const firmwareInstallDialogStyles = css`
     text-decoration: none;
   }
 
+  /* Manual binary-download format picker (factory / OTA / ...). */
+  .binary-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-xs);
+    margin-top: var(--wa-space-m);
+    text-align: left;
+  }
+  .binary-option {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-l);
+    background: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background 0.12s,
+      border-color 0.12s;
+  }
+  .binary-option:hover,
+  .binary-option:focus-visible {
+    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    border-color: var(--esphome-primary);
+    outline: none;
+  }
+  .binary-option .title {
+    font-weight: var(--wa-font-weight-bold);
+    font-size: var(--wa-font-size-s);
+  }
+  .binary-option .desc {
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-quiet);
+  }
+
   .progress-bar {
     width: 100%;
     height: 6px;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -433,7 +433,10 @@
     "web_download_step_install": "Choose Install and select the downloaded {filename}",
     "web_download_open_button": "Open web.esphome.io",
     "binary_download_done_title": "Firmware binary downloaded",
-    "binary_download_done_body": "Saved as {filename}. Flash it to your device with your preferred tool."
+    "binary_download_done_body": "Saved as {filename}. Flash it to your device with your preferred tool.",
+    "choose_binary_title": "Choose a binary format",
+    "choose_binary_desc": "Pick the format you need; each option explains what it's for.",
+    "choose_binary_again": "Download another format"
   },
   "serial": {
     "title": "USB Device",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -810,7 +810,10 @@
     "web_download_step_install": "Choisissez Install et sélectionnez le fichier téléchargé {filename}",
     "web_download_open_button": "Ouvrir web.esphome.io",
     "binary_download_done_title": "Binaire du firmware téléchargé",
-    "binary_download_done_body": "Enregistré sous {filename}. Flashez-le sur votre appareil avec votre outil préféré."
+    "binary_download_done_body": "Enregistré sous {filename}. Flashez-le sur votre appareil avec votre outil préféré.",
+    "choose_binary_title": "Choisissez un format de binaire",
+    "choose_binary_desc": "Choisissez le format dont vous avez besoin ; chaque option explique son usage.",
+    "choose_binary_again": "Télécharger un autre format"
   },
   "validation": {
     "required": "Ce champ est requis",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -432,7 +432,10 @@
     "web_download_step_install": "Válassza a Telepítés lehetőséget, és jelölje ki a letöltött {filename} fájlt",
     "web_download_open_button": "web.esphome.io megnyitása",
     "binary_download_done_title": "Firmware-bináris letöltve",
-    "binary_download_done_body": "Mentve: {filename}. Telepítse az eszközre egyénileg."
+    "binary_download_done_body": "Mentve: {filename}. Telepítse az eszközre egyénileg.",
+    "choose_binary_title": "Válasszon bináris formátumot",
+    "choose_binary_desc": "Válassza ki a szükséges formátumot; minden lehetőség leírja, mire való.",
+    "choose_binary_again": "Másik formátum letöltése"
   },
   "serial": {
     "title": "USB-eszköz",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -810,7 +810,10 @@
     "web_download_step_install": "Kies Install en selecteer het gedownloade bestand {filename}",
     "web_download_open_button": "Open web.esphome.io",
     "binary_download_done_title": "Firmware-binary gedownload",
-    "binary_download_done_body": "Opgeslagen als {filename}. Flash hem naar je apparaat met je eigen tool."
+    "binary_download_done_body": "Opgeslagen als {filename}. Flash hem naar je apparaat met je eigen tool.",
+    "choose_binary_title": "Kies een binary-formaat",
+    "choose_binary_desc": "Kies het formaat dat je nodig hebt; elke optie legt uit waarvoor het is.",
+    "choose_binary_again": "Een ander formaat downloaden"
   },
   "validation": {
     "required": "Dit veld is verplicht",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -433,7 +433,10 @@
     "web_download_step_install": "选择 Install 并选择已下载的 {filename}",
     "web_download_open_button": "打开 web.esphome.io",
     "binary_download_done_title": "固件二进制文件已下载",
-    "binary_download_done_body": "已保存为 {filename}。请使用你喜欢的工具将其刷写到设备上。"
+    "binary_download_done_body": "已保存为 {filename}。请使用你喜欢的工具将其刷写到设备上。",
+    "choose_binary_title": "选择二进制格式",
+    "choose_binary_desc": "选择你需要的格式；每个选项都会说明其用途。",
+    "choose_binary_again": "下载其他格式"
   },
   "serial": {
     "title": "USB 设备",

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the manual firmware-binary download flow. Pins the #1033 fix:
+ * when a device produces more than one format the manual download must
+ * route to the choose-binary picker (so the OTA image is reachable)
+ * instead of silently auto-downloading the factory image; web-flasher
+ * paths still auto-select the self-contained factory image.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { downloadBase64Binary } = vi.hoisted(() => ({ downloadBase64Binary: vi.fn() }));
+vi.mock("../../src/util/download-text.js", () => ({ downloadBase64Binary }));
+vi.mock("../../src/util/web-serial.js", () => ({
+  connectToPort: vi.fn(),
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  flashFirmware: vi.fn(),
+  resetAndDisconnect: vi.fn(),
+}));
+
+import { JobSource, JobStatus, type FirmwareBinary } from "../../src/api/types.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import {
+  downloadSelectedBinary,
+  startDownload,
+} from "../../src/components/firmware-install-dialog/install-flow.js";
+
+const FACTORY: FirmwareBinary = { title: "Factory format", file: "firmware.factory.bin" };
+const OTA: FirmwareBinary = {
+  title: "OTA format",
+  file: "firmware.ota.bin",
+  description: "For OTA updating a device.",
+};
+
+type Installer = "web-serial" | "web-download" | "binary-download";
+
+function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
+  const api = {
+    firmwareCompile: vi
+      .fn()
+      .mockResolvedValue({ job_id: "j1", source: JobSource.LOCAL, source_label: "" }),
+    // Resolve the compile synchronously by firing the completion callback.
+    firmwareFollowJob: vi.fn((_id: string, cbs: { onResult: (d: unknown) => void }) => {
+      cbs.onResult({ status: JobStatus.COMPLETED });
+      return "s1";
+    }),
+    firmwareGetBinaries: vi.fn().mockResolvedValue(binaries),
+    firmwareDownload: vi.fn().mockResolvedValue({
+      filename: "device-firmware.bin",
+      data: "QUJD",
+      size: 3,
+      compressed: false,
+    }),
+  };
+  const host = {
+    _device: { configuration: "device.yaml" },
+    _installer: installer,
+    _api: api,
+    _step: "queued",
+    _statusMessage: "",
+    _binaries: [] as FirmwareBinary[],
+    _downloadedFilename: "",
+    _logLines: [] as string[],
+    _failedDuringCompile: false,
+    _failedDuringValidate: false,
+    _jobId: "",
+    _streamId: "",
+    _jobSource: JobSource.LOCAL,
+    _jobSourceLabel: "",
+    _compileReject: null as null | ((e: unknown) => void),
+    _localize: (key: string) => key,
+    _fail: vi.fn(),
+  };
+  host._fail = vi.fn((msg: string) => {
+    host._step = "error";
+    host._statusMessage = msg;
+  });
+  return { host, api };
+}
+
+const run = (host: ReturnType<typeof makeHost>["host"]) =>
+  startDownload(host as unknown as ESPHomeFirmwareInstallDialog);
+
+afterEach(() => vi.clearAllMocks());
+
+describe("manual firmware-binary download flow", () => {
+  it("routes to the choose-binary picker when more than one format exists", async () => {
+    const { host, api } = makeHost("binary-download", [FACTORY, OTA]);
+    await run(host);
+    expect(host._step).toBe("choose-binary");
+    expect(host._binaries).toEqual([FACTORY, OTA]);
+    expect(api.firmwareDownload).not.toHaveBeenCalled();
+  });
+
+  it("downloads directly when the device produces a single format", async () => {
+    const single: FirmwareBinary = { title: "Standard format", file: "firmware.bin" };
+    const { host, api } = makeHost("binary-download", [single]);
+    await run(host);
+    expect(api.firmwareDownload).toHaveBeenCalledWith("device.yaml", "firmware.bin");
+    expect(host._step).toBe("download-ready");
+  });
+
+  it("web flasher auto-selects the factory image even with multiple formats", async () => {
+    const { host, api } = makeHost("web-download", [FACTORY, OTA]);
+    await run(host);
+    expect(api.firmwareDownload).toHaveBeenCalledWith(
+      "device.yaml",
+      "firmware.factory.bin"
+    );
+    expect(host._step).toBe("download-ready");
+  });
+
+  it("picking the OTA format downloads that file and hands it to the browser", async () => {
+    const { host, api } = makeHost("binary-download", [FACTORY, OTA]);
+    await run(host); // lands on choose-binary
+    await downloadSelectedBinary(
+      host as unknown as ESPHomeFirmwareInstallDialog,
+      "firmware.ota.bin"
+    );
+    expect(api.firmwareDownload).toHaveBeenCalledWith("device.yaml", "firmware.ota.bin");
+    expect(downloadBase64Binary).toHaveBeenCalledWith("QUJD", "device-firmware.bin");
+    expect(host._step).toBe("download-ready");
+    // Kept so the done screen can offer "download another format".
+    expect(host._binaries).toHaveLength(2);
+  });
+
+  it("fails cleanly when listing the binaries errors", async () => {
+    const { host, api } = makeHost("binary-download", [FACTORY, OTA]);
+    api.firmwareGetBinaries.mockRejectedValueOnce(new Error("boom"));
+    await run(host);
+    expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
+    expect(api.firmwareDownload).not.toHaveBeenCalled();
+  });
+
+  it("re-picking after a download grabs the other format and keeps the list", async () => {
+    const { host, api } = makeHost("binary-download", [FACTORY, OTA]);
+    await run(host); // lands on choose-binary
+    await downloadSelectedBinary(
+      host as unknown as ESPHomeFirmwareInstallDialog,
+      "firmware.ota.bin"
+    );
+    // "Download another format" → the renderer sends us back to the picker,
+    // then a second pick downloads the factory image.
+    await downloadSelectedBinary(
+      host as unknown as ESPHomeFirmwareInstallDialog,
+      "firmware.factory.bin"
+    );
+    expect(api.firmwareDownload).toHaveBeenLastCalledWith(
+      "device.yaml",
+      "firmware.factory.bin"
+    );
+    expect(host._step).toBe("download-ready");
+    expect(host._binaries).toHaveLength(2);
+  });
+});

--- a/test/components/firmware-install-dialog-footer.test.ts
+++ b/test/components/firmware-install-dialog-footer.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Pins the footer affordance for the binary-download picker: the
+ * choose-binary and downloading steps must offer Close (the _close
+ * handler), never the Stop button (_cancel), which targets a
+ * compile/follow-job that is already finished. A regression that folds
+ * "downloading" back into the isRunning branch would resurface a dead
+ * Stop button mid-download.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { renderFooter } from "../../src/components/firmware-install-dialog/renderers.js";
+import { findTemplatesByAnchor } from "../_lit-template-walker.js";
+
+function footerHost(step: string) {
+  return {
+    _step: step,
+    _installer: "binary-download",
+    _localize: (key: string) => key,
+    _close: vi.fn(),
+    _cancel: vi.fn(),
+    _showLogsAfterInstall: false,
+    _toggleShowLogsAfterInstall: vi.fn(),
+  };
+}
+
+const footerValues = (host: ReturnType<typeof footerHost>) =>
+  findTemplatesByAnchor(
+    renderFooter(host as unknown as ESPHomeFirmwareInstallDialog),
+    'class="footer"'
+  ).flatMap((t) => t.values);
+
+describe("firmware-install-dialog footer", () => {
+  it.each(["choose-binary", "downloading"])(
+    "offers Close and not Stop on the %s step",
+    (step) => {
+      const host = footerHost(step);
+      const values = footerValues(host);
+      expect(values).toContain(host._close);
+      expect(values).not.toContain(host._cancel);
+    }
+  );
+
+  it("still offers Stop while a cancelable job runs (compiling)", () => {
+    const host = footerHost("compiling");
+    const values = footerValues(host);
+    expect(values).toContain(host._cancel);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The manual Download firmware binary flow always handed back the factory image and never offered the other formats, so the OTA binary that the legacy dashboard exposed (needed for HTTP method OTA updates) was unreachable. The backend already lists every format via firmware/get_binaries, the UI just wasn't surfacing them. Now, when a compiled device produces more than one format, the dialog shows a picker listing each one (factory, OTA, ...) with its title and description; single format devices and the Web Serial / web.esphome.io paths are unchanged. The picker downloads whatever the backend lists, so it works for ESP32, RP2040, LibreTiny, and nRF52.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1033

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
