### PR TITLE
Fix wrong submit button label in logs-method dialog

### DIFF
--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -790,7 +790,11 @@ export class ESPHomeInstallMethodDialog extends LitElement {
                     ?disabled=${!canSubmit}
                     @click=${this._submitOtaAddress}
                   >
-                    ${this._localize("dashboard.install_method_network_address_submit")}
+                    ${this._localize(
+                      this.mode === "logs"
+                        ? "dashboard.logs_method_network_address_submit"
+                        : "dashboard.install_method_network_address_submit"
+                    )}
                   </button>
                 </div>
               </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -156,6 +156,7 @@
     "logs_method_usb_local_desc": "For devices connected via USB to this computer",
     "logs_method_usb_server": "Plug into computer running ESPHome Device Builder",
     "logs_method_usb_server_desc": "For devices connected via USB to the server",
+    "logs_method_network_address_submit": "View logs over network",
     "logs_web_serial_unsupported": "Web Serial is not supported in this browser",
     "install_method_title": "How do you want to install the firmware?",
     "install_method_network": "On the network",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -112,6 +112,7 @@
     "logs_method_usb_local_desc": "Pour les appareils connectés via USB à cet ordinateur",
     "logs_method_usb_server": "Brancher sur l'ordinateur exécutant ESPHome Device Builder",
     "logs_method_usb_server_desc": "Pour les appareils connectés via USB au serveur",
+    "logs_method_network_address_submit": "Voir les journaux via le réseau",
     "logs_web_serial_unsupported": "Web Serial n'est pas pris en charge dans ce navigateur",
     "table_columns": "Colonnes",
     "table_toggle_columns": "Afficher/masquer les colonnes",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -156,6 +156,7 @@
     "logs_method_usb_local_desc": "USB-n keresztül ehhez a géphez csatlakoztatott eszközökhöz",
     "logs_method_usb_server": "Csatlakoztatva az ESPHome Device Buildert futtató géphez",
     "logs_method_usb_server_desc": "USB-n keresztül a szerverhez csatlakoztatott eszközökhöz",
+    "logs_method_network_address_submit": "Naplók megtekintése a hálózaton",
     "logs_web_serial_unsupported": "A Web Serial nem támogatott ebben a böngészőben",
     "install_method_title": "Hogyan szeretné telepíteni a firmware-t?",
     "install_method_network": "A hálózaton",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -112,6 +112,7 @@
     "logs_method_usb_local_desc": "Voor apparaten via USB verbonden met deze computer",
     "logs_method_usb_server": "Aansluiten op computer met ESPHome Device Builder",
     "logs_method_usb_server_desc": "Voor apparaten via USB verbonden met de server",
+    "logs_method_network_address_submit": "Logboeken bekijken via netwerk",
     "logs_web_serial_unsupported": "Web Serial wordt niet ondersteund in deze browser",
     "table_columns": "Kolommen",
     "table_toggle_columns": "Kolommen in-/uitschakelen",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -156,6 +156,7 @@
     "logs_method_usb_local_desc": "适用于通过 USB 连接到此电脑的设备",
     "logs_method_usb_server": "插入运行 ESPHome Device Builder 的电脑",
     "logs_method_usb_server_desc": "适用于通过 USB 连接到服务器的设备",
+    "logs_method_network_address_submit": "通过网络查看日志",
     "logs_web_serial_unsupported": "此浏览器不支持 Web Serial",
     "install_method_title": "你想如何安装固件？",
     "install_method_network": "通过网络",

--- a/test/components/install-method-dialog-ota-submit-label.test.ts
+++ b/test/components/install-method-dialog-ota-submit-label.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the OTA address-override submit button label per dialog mode.
+ * The dialog is reused for ``install`` and ``logs``; the button used to
+ * read "Install over network" in both, so the logs-method dialog showed
+ * an install-labelled button that actually fetches logs (#1040).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { DeviceState } from "../../src/api/types.js";
+import { defaultLocalize } from "../../src/common/localize.js";
+import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
+
+async function flushPending(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountWithOtaCardOpen(
+  mode: "install" | "logs"
+): Promise<ESPHomeInstallMethodDialog> {
+  const dialog = new ESPHomeInstallMethodDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._localize = defaultLocalize;
+  // _environment reads api.serverInfo; a bare object is enough to
+  // resolve the deployment environment from window.location.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._api = {};
+  dialog.mode = mode;
+  dialog.deviceState = DeviceState.ONLINE;
+  // Expand the Advanced disclosure and the OTA address card so the
+  // submit button is in the rendered tree. Leave ``open`` unset — the
+  // method list renders regardless, and flipping ``open`` true would
+  // reset these flags in willUpdate.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._advancedExpanded = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (dialog as any)._otaAddressCardExpanded = true;
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  await flushPending();
+  return dialog;
+}
+
+const submitLabel = (d: ESPHomeInstallMethodDialog): string =>
+  d.shadowRoot?.querySelector("#ota-address-form .btn--primary")?.textContent?.trim() ??
+  "";
+
+describe("install-method-dialog OTA submit label", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("reads 'Install over network' in install mode", async () => {
+    const dialog = await mountWithOtaCardOpen("install");
+    expect(submitLabel(dialog)).toBe("Install over network");
+  });
+
+  it("reads 'View logs over network' in logs mode", async () => {
+    const dialog = await mountWithOtaCardOpen("logs");
+    expect(submitLabel(dialog)).toBe("View logs over network");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The install-method dialog is reused for installing and for getting logs from an offline device. Its OTA address override card showed up in both modes, but the submit button was always labeled "Install over network"; in the logs dialog that button actually fetches logs, so the label was a copy-paste leftover. The button now reads "View logs over network" in logs mode and keeps "Install over network" in install mode. Added the new key to all five locales.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1040

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
