### PR TITLE
Fix memory leak when switching device sections

### DIFF
--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -30,5 +30,11 @@ import { withBase } from "./util/base-path.js";
 const favicon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
 if (favicon) favicon.href = withBase("/assets/logo/esphome.svg");
 
+import { installWaComboboxLeakFix } from "./util/wa-combobox-leak-fix.js";
+
+// Register the wa-combobox stub before any wa-select / wa-option renders
+// so webawesome's never-resolving whenDefined promise can't leak (#1031).
+installWaComboboxLeakFix();
+
 import "./components/app-shell.js";
 import "./styles/apply-theme.js";

--- a/src/util/wa-combobox-leak-fix.ts
+++ b/src/util/wa-combobox-leak-fix.ts
@@ -1,0 +1,21 @@
+/**
+ * Work around a webawesome 3.7.0 memory leak.
+ *
+ * ``wa-option``'s ``handleDefaultSlotChange`` runs on every slot change
+ * and calls ``customElements.whenDefined("wa-combobox").then(cb)``, where
+ * ``cb`` closes over the option element. No 3.7.0 build ships
+ * ``wa-combobox``, so that promise never resolves; the registry keeps the
+ * reaction (and its captured option) alive forever. Every form mount that
+ * renders a ``wa-select`` then leaks the option -> select -> form ->
+ * editor subtree, so repeatedly opening section editors grows memory
+ * without bound (#1031).
+ *
+ * Registering a stub resolves the promise so the pending reactions settle
+ * and release. ``cb`` does ``this.closest("wa-combobox")`` -> null (we
+ * never nest options under a real combobox), so it is a no-op.
+ */
+export function installWaComboboxLeakFix(): void {
+  if (typeof customElements === "undefined") return;
+  if (customElements.get("wa-combobox")) return;
+  customElements.define("wa-combobox", class extends HTMLElement {});
+}

--- a/test/util/wa-combobox-leak-fix.test.ts
+++ b/test/util/wa-combobox-leak-fix.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Guards the #1031 leak fix: webawesome 3.7.0's wa-option awaits
+ * ``customElements.whenDefined("wa-combobox")``, which never resolves
+ * because no build ships wa-combobox — so each form mount's reaction was
+ * retained forever, leaking the wa-select / editor subtree. The fix
+ * registers a stub so the promise settles.
+ */
+import { describe, expect, it } from "vitest";
+import { installWaComboboxLeakFix } from "../../src/util/wa-combobox-leak-fix.js";
+
+describe("wa-combobox leak fix", () => {
+  it("registers a wa-combobox stub so whenDefined resolves", async () => {
+    expect(customElements.get("wa-combobox")).toBeUndefined();
+    installWaComboboxLeakFix();
+    expect(customElements.get("wa-combobox")).toBeDefined();
+    // The leak was a never-settling whenDefined promise; awaiting it here
+    // must complete (a hang would fail the test by timeout).
+    await customElements.whenDefined("wa-combobox");
+  });
+
+  it("is idempotent", () => {
+    installWaComboboxLeakFix();
+    expect(() => installWaComboboxLeakFix()).not.toThrow();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Switching between device sections (Components and Automations) leaked memory without bound; every section editor that renders a `wa-select` (e.g. an automation with a `logger.log` action) left its whole subtree behind on teardown.

Root cause is in webawesome 3.7.0: `wa-option.handleDefaultSlotChange` calls `customElements.whenDefined("wa-combobox").then(cb)` on every slot change, but no 3.7.0 build ships `wa-combobox`, so that promise never resolves; the registry keeps each reaction (and the option it closes over) alive forever, pinning the option, its `wa-select`, the form, and the editor. The fix registers a stub `wa-combobox` at startup so the promise settles and the reactions release; `closest("wa-combobox")` stays null so the callback is a no-op.

Proven with a CDP heap harness, toggling Components and Automations and forcing GC each round:

| metric | before | after |
| --- | --- | --- |
| DOM nodes per toggle | +1363 | 0 (flat) |
| JS listeners per toggle | +90 | 0 (flat) |
| live automation-editor after 40 toggles | 25 | 1 |
| live wa-select | 25 | 1 |

Over 70 toggles after the fix, nodes and listeners stay flat; heap only oscillates with GC.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1031

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
