### PR TITLE
Render a consistent empty-cell placeholder in the device table

### DIFF
--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -69,6 +69,18 @@ const dispatchRowEvent = (e: Event, name: string, device: ConfiguredDevice) => {
   );
 };
 
+// One "no data" placeholder for every column. Rendered in the muted
+// proportional style rather than a column's value font so the em dash is
+// the same width everywhere — embedding it in cell-mono made it render as
+// a narrow monospace glyph that read as a hyphen next to the wide dashes
+// in the proportional columns (#1038).
+const EMPTY_CELL = html`<span class="cell-muted">—</span>`;
+
+// Populated cells keep their column's value font; empty cells fall back to
+// the shared placeholder so the "no data" dash is identical everywhere.
+const valueCell = (cls: string, val: string) =>
+  val ? html`<span class=${cls}>${val}</span>` : EMPTY_CELL;
+
 export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow>[] {
   return [
     {
@@ -179,59 +191,49 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
     {
       accessorKey: "address",
       header: localize("dashboard.table_col_address"),
-      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => valueCell("cell-mono", info.getValue() as string),
       size: 180,
       enableHiding: true,
     },
     {
       accessorKey: "ip",
       header: localize("dashboard.table_col_ip"),
-      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => valueCell("cell-mono", info.getValue() as string),
       size: 140,
       enableHiding: true,
     },
     {
       accessorKey: "mac_address",
       header: localize("dashboard.table_col_mac"),
-      cell: (info) => {
-        const raw = info.getValue() as string;
-        return raw
-          ? html`<span class="cell-mono">${raw}</span>`
-          : html`<span class="cell-muted">—</span>`;
-      },
+      cell: (info) => valueCell("cell-mono", info.getValue() as string),
       size: 160,
       enableHiding: true,
     },
     {
       accessorKey: "platform",
       header: localize("dashboard.table_col_platform"),
-      cell: (info) => {
-        const val = info.getValue() as string;
-        return val
-          ? html`<span class="cell-badge">${val}</span>`
-          : html`<span class="cell-muted">—</span>`;
-      },
+      cell: (info) => valueCell("cell-badge", info.getValue() as string),
       size: 120,
       enableHiding: true,
     },
     {
       accessorKey: "version",
       header: localize("dashboard.table_col_version"),
-      cell: (info) => html`<span class="cell-mono">${info.getValue() || "—"}</span>`,
+      cell: (info) => valueCell("cell-mono", info.getValue() as string),
       size: 150,
       enableHiding: true,
     },
     {
       accessorKey: "comment",
       header: localize("dashboard.table_col_comment"),
-      cell: (info) => html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
+      cell: (info) => valueCell("cell-comment", info.getValue() as string),
       size: 180,
       enableHiding: true,
     },
     {
       accessorKey: "area",
       header: localize("dashboard.table_col_area"),
-      cell: (info) => html`<span class="cell-comment">${info.getValue() || "—"}</span>`,
+      cell: (info) => valueCell("cell-comment", info.getValue() as string),
       size: 160,
       enableHiding: true,
     },
@@ -240,8 +242,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
       header: localize("dashboard.table_col_labels"),
       cell: (info) => {
         const labels = info.getValue() as Label[];
-        if (!labels || labels.length === 0)
-          return html`<span class="cell-muted">—</span>`;
+        if (!labels || labels.length === 0) return EMPTY_CELL;
         return renderLabelChips(labels, { max: 3 });
       },
       sortingFn: (rowA, rowB) => {
@@ -266,7 +267,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         const bytes = info.getValue() as number;
         return bytes
           ? html`<span class="cell-mono">${formatFileSize(bytes)}</span>`
-          : html`<span class="cell-muted">—</span>`;
+          : EMPTY_CELL;
       },
       // Compare the raw byte counts directly. ``"basic"`` /
       // ``"alphanumeric"`` would sort by the accessor value too

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the #1038 fix: every column renders the same "no data" placeholder
+ * (muted proportional em dash), instead of embedding the dash in a
+ * column's value font where monospace made it render as a narrow,
+ * hyphen-looking glyph. Populated cells keep their own font.
+ */
+import type { CellContext } from "@tanstack/lit-table";
+import type { TemplateResult } from "lit";
+import { describe, expect, it } from "vitest";
+import {
+  createDeviceColumns,
+  type DeviceRow,
+} from "../../../src/components/dashboard/table-columns.js";
+
+const columns = createDeviceColumns((key) => key);
+
+function columnByKey(key: string) {
+  const col = columns.find((c) => "accessorKey" in c && c.accessorKey === key);
+  if (!col?.cell || typeof col.cell !== "function") {
+    throw new Error(`no cell renderer for column ${key}`);
+  }
+  return col.cell;
+}
+
+function renderCell(key: string, value: unknown): TemplateResult {
+  const cell = columnByKey(key);
+  // The data columns only read info.getValue(); a minimal stub suffices.
+  const info = { getValue: () => value } as unknown as CellContext<DeviceRow, unknown>;
+  return cell(info) as TemplateResult;
+}
+
+// Flatten a TemplateResult's static strings AND interpolated values so the
+// assertions hold whether the class is a static literal or a binding.
+function rendered(t: TemplateResult): string {
+  const { strings, values } = t;
+  return strings.reduce(
+    (acc, s, i) => acc + s + (i < values.length ? String(values[i]) : ""),
+    ""
+  );
+}
+
+const DATA_COLUMNS = ["address", "ip", "version", "comment", "area", "mac_address"];
+
+describe("device table empty-cell placeholder (#1038)", () => {
+  for (const key of DATA_COLUMNS) {
+    it(`${key}: empty renders the shared muted placeholder, not the value font`, () => {
+      const html = rendered(renderCell(key, ""));
+      expect(html).toContain("cell-muted");
+      expect(html).toContain("—");
+      // The placeholder must not inherit the column's value font.
+      expect(html).not.toContain("cell-mono");
+      expect(html).not.toContain("cell-comment");
+    });
+  }
+
+  it("labels: empty renders the shared muted placeholder", () => {
+    const html = rendered(renderCell("labels", []));
+    expect(html).toContain("cell-muted");
+    expect(html).toContain("—");
+  });
+
+  it("keeps the monospace value font when a value is present", () => {
+    const html = rendered(renderCell("ip", "192.168.1.42"));
+    expect(html).toContain("cell-mono");
+    expect(html).toContain("192.168.1.42");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Empty cells in the device table used the same em dash everywhere, but it looked like a hyphen in some columns and a wide dash in others; IP Address and ESPHome Version render in a monospace font (`cell-mono`) where the em dash collapses to a narrow glyph, while Mac, Comment, Area and Labels use the proportional font where it renders full width. The placeholder now renders through one shared muted template regardless of the column's value font, so every "no data" cell shows the same em dash; populated cells keep their own font.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1038

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
