### PR TITLE
Confirm dialogs with Enter consistently

### DIFF
--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -112,8 +112,7 @@ export class ESPHomeConfirmDialog extends LitElement {
 
   private _decided = false;
 
-  // Enter confirms, but never a destructive prompt — a stray Enter must
-  // not delete. Cancel stays on Escape / the Cancel button.
+  // Enter confirms, but never a destructive prompt (a stray Enter must not delete).
   private _enter = new EnterController(this, () => {
     if (!this.destructive) this._confirm();
   });

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -7,6 +7,7 @@ import { localizeContext } from "../context/index.js";
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -111,9 +112,16 @@ export class ESPHomeConfirmDialog extends LitElement {
 
   private _decided = false;
 
+  // Enter confirms, but never a destructive prompt — a stray Enter must
+  // not delete. Cancel stays on Escape / the Cancel button.
+  private _enter = new EnterController(this, () => {
+    if (!this.destructive) this._confirm();
+  });
+
   open() {
     this._decided = false;
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
@@ -174,6 +182,7 @@ export class ESPHomeConfirmDialog extends LitElement {
   }
 
   private _onAfterHide() {
+    this._enter.set(false);
     if (!this._decided) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));
     }

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -163,6 +163,7 @@ export class ESPHomeConfirmDialog extends LitElement {
   }
 
   private _confirm() {
+    if (this._decided) return; // a repeated Enter must not dispatch twice
     this._decided = true;
     this.close();
     // composed:false (omitted) so wrappers like

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 
 import { APIError } from "../api/api-error.js";
@@ -9,6 +9,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import {
   normalizeHostnameForCompare,
   parsePortInput,
@@ -69,6 +70,15 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
   @state() private _errorMessage = "";
 
   @query("input[name='hostname']") private _hostInput?: HTMLInputElement;
+
+  // Enter saves while the dialog is open; mirrors the Save button's guard.
+  private _enter = new EnterController(this, () => {
+    if (!this._saveDisabled()) void this._onSave();
+  });
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("_open")) this._enter.set(this._open);
+  }
 
   /** Open the dialog targeting *pairing*. Hostname / port
    *  inputs pre-fill with the row's current coords; the user

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -65,6 +65,9 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   @query("wa-dialog")
   private _dialog!: HTMLElement & { open: boolean };
 
+  @query("#onboarding-ssid")
+  private _ssidInput?: HTMLInputElement;
+
   // WPA/WPA2 passphrases are 8-63 characters; the maxlength=64 cap
   // covers the 64-hex-digit PSK form. An empty password is a valid
   // open network (the placeholder invites it), so only a non-empty
@@ -91,6 +94,11 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._exitedExplicitly = false;
     this._dialog.open = true;
     this._enter.set(true);
+    // Focus the SSID field once the dialog has rendered. The attribute-based
+    // autofocus isn't reliable for a shadow-DOM input revealed by toggling
+    // ``open`` after first paint, so focus explicitly (matching
+    // edit-pairing-endpoint-dialog).
+    void this.updateComplete.then(() => this._ssidInput?.focus());
   }
 
   close() {
@@ -202,7 +210,6 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
             <input
               id="onboarding-ssid"
               type="text"
-              autofocus
               .value=${this._ssid}
               maxlength="32"
               placeholder=${this._localize("onboarding.wifi.ssid_placeholder")}

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -277,6 +277,9 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   }
 
   private async _save() {
+    // The Enter path bypasses the disabled Save button, so guard re-entry
+    // here too or a held Enter double-submits during the await below.
+    if (this._saving) return;
     // IEEE 802.11 SSIDs may legally contain leading/trailing
     // whitespace, so don't ``trim()`` the value being sent —
     // mutating it would silently change the network name and

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -94,10 +94,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._exitedExplicitly = false;
     this._dialog.open = true;
     this._enter.set(true);
-    // Focus the SSID field once the dialog has rendered. The attribute-based
-    // autofocus isn't reliable for a shadow-DOM input revealed by toggling
-    // ``open`` after first paint, so focus explicitly (matching
-    // edit-pairing-endpoint-dialog).
+    // autofocus is unreliable for a shadow-DOM input shown after first paint.
     void this.updateComplete.then(() => this._ssidInput?.focus());
   }
 

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -10,6 +10,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { type PasswordInputValueChange } from "./device/password-input-event.js";
 
@@ -79,6 +80,9 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
    *  ``onboarding-dismissed-session`` for the same close. */
   private _exitedExplicitly = false;
 
+  // Enter submits; _save() self-guards on a blank SSID / too-short password.
+  private _enter = new EnterController(this, () => this._save());
+
   open() {
     this._ssid = "";
     this._password = "";
@@ -86,6 +90,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._error = null;
     this._exitedExplicitly = false;
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
@@ -197,6 +202,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
             <input
               id="onboarding-ssid"
               type="text"
+              autofocus
               .value=${this._ssid}
               maxlength="32"
               placeholder=${this._localize("onboarding.wifi.ssid_placeholder")}
@@ -343,6 +349,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
    * mid-session.
    */
   private _onAfterHide() {
+    this._enter.set(false);
     if (!this._exitedExplicitly) {
       this._dismissForSession();
     }

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -190,6 +190,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   }
 
   private _onSave() {
+    if (this._resolved) return; // a repeated Enter must not dispatch twice
     this._resolved = true;
     this.close();
     this.dispatchEvent(new CustomEvent("save", { bubbles: true, composed: true }));

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -5,6 +5,7 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -26,9 +27,13 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
 
   private _resolved = false;
 
+  // Enter saves and leaves (the primary action); never Discard.
+  private _enter = new EnterController(this, () => this._onSave());
+
   open() {
     this._resolved = false;
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
@@ -191,6 +196,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   }
 
   private _onAfterHide() {
+    this._enter.set(false);
     if (!this._resolved) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
     }

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -47,6 +47,12 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   @state()
   private _step: WizardStep = "method";
 
+  // Drives the step components' Enter listeners: the steps stay mounted in
+  // the wa-dialog while it's merely hidden (light-dismiss / Escape / close),
+  // so they must deactivate on hide, not just on unmount.
+  @state()
+  private _open = false;
+
   @state()
   private _selectedBoard: BoardCatalogEntry | null = null;
 
@@ -235,6 +241,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     this._submitting = false;
     this._resetCreateErrors();
     this._dialog.open = true;
+    this._open = true;
   }
 
   /** Clear both error slots so a stale message from a prior
@@ -251,6 +258,13 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   public close() {
     this._dialog.open = false;
   }
+
+  // wa-dialog only hides on light-dismiss / Escape / close; the step
+  // components stay mounted, so flip _open to drop their Enter listeners.
+  private _onHide = (e: Event) => {
+    if (e.target !== this._dialog) return; // ignore bubbled child wa-* hides
+    this._open = false;
+  };
 
   private get _title(): string {
     switch (this._step) {
@@ -270,6 +284,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       <wa-dialog
         class=${this._step === "board" ? "wide" : ""}
         light-dismiss
+        @wa-after-hide=${this._onHide}
         @next-step=${this._onNextStep}
         @finish-setup=${this._onFinishSetup}
         @create-empty-config=${this._onCreateEmptyConfig}
@@ -310,9 +325,12 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       case "setup":
         return html`<esphome-wizard-step-setup
           .board=${this._selectedBoard}
+          ?active=${this._open}
         ></esphome-wizard-step-setup>`;
       case "empty-config":
-        return html`<esphome-wizard-step-empty-config></esphome-wizard-step-empty-config>`;
+        return html`<esphome-wizard-step-empty-config
+          ?active=${this._open}
+        ></esphome-wizard-step-empty-config>`;
     }
   }
 

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -20,8 +20,6 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   @state()
   private _name = "";
 
-  private _done = false;
-
   // Enter finishes setup once a name is entered.
   private _enter = new EnterController(this, () => {
     if (this._name.trim()) this._next();
@@ -136,8 +134,6 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   }
 
   private _next() {
-    if (this._done) return; // a repeated Enter must not create twice
-    this._done = true;
     this.dispatchEvent(
       new CustomEvent("create-empty-config", {
         detail: { name: this._name },

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -5,6 +5,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { EnterController } from "../../util/enter-controller.js";
 
 @customElement("esphome-wizard-step-empty-config")
 export class ESPHomeWizardStepEmptyConfig extends LitElement {
@@ -14,6 +15,16 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
 
   @state()
   private _name = "";
+
+  // Enter finishes setup once a name is entered.
+  private _enter = new EnterController(this, () => {
+    if (this._name.trim()) this._next();
+  });
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._enter.set(true);
+  }
 
   static styles = [
     espHomeStyles,

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { LitElement, css, html, type PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
@@ -13,6 +13,10 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   @state()
   private _localize: LocalizeFunc = (key) => key;
 
+  // Set by the parent dialog; the step stays mounted while the dialog is
+  // hidden, so the Enter listener follows this rather than connectedCallback.
+  @property({ type: Boolean }) active = false;
+
   @state()
   private _name = "";
 
@@ -23,9 +27,8 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
     if (this._name.trim()) this._next();
   });
 
-  connectedCallback() {
-    super.connectedCallback();
-    this._enter.set(true);
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("active")) this._enter.set(this.active);
   }
 
   static styles = [

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -16,6 +16,8 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   @state()
   private _name = "";
 
+  private _done = false;
+
   // Enter finishes setup once a name is entered.
   private _enter = new EnterController(this, () => {
     if (this._name.trim()) this._next();
@@ -131,6 +133,8 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
   }
 
   private _next() {
+    if (this._done) return; // a repeated Enter must not create twice
+    this._done = true;
     this.dispatchEvent(
       new CustomEvent("create-empty-config", {
         detail: { name: this._name },

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -8,6 +8,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
+import { EnterController } from "../../util/enter-controller.js";
 
 @customElement("esphome-wizard-step-setup")
 export class ESPHomeWizardStepSetup extends LitElement {
@@ -43,8 +44,18 @@ export class ESPHomeWizardStepSetup extends LitElement {
   @state()
   private _wifiPassword = "";
 
+  // Enter advances / finishes the current stage, mirroring the primary button.
+  private _enter = new EnterController(this, () => {
+    if (this._canAdvance()) this._onNext();
+  });
+
+  private _canAdvance(): boolean {
+    return this._stage === "name" ? !!this._deviceName.trim() : !!this._wifiSsid.trim();
+  }
+
   async connectedCallback() {
     super.connectedCallback();
+    this._enter.set(true);
     try {
       const yaml = await this._api.getConfig("secrets.yaml");
       const ssid = yaml.match(/^wifi_ssid\s*:\s*["']?(.+?)["']?\s*$/m);
@@ -253,9 +264,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
           <button
             class="btn btn-primary"
             type="button"
-            ?disabled=${this._stage === "name"
-              ? !this._deviceName.trim()
-              : !this._wifiSsid.trim()}
+            ?disabled=${!this._canAdvance()}
             @click=${this._onNext}
           >
             ${this._stage === "name" && !this._hasSecretWifi

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types.js";
@@ -21,6 +21,10 @@ export class ESPHomeWizardStepSetup extends LitElement {
 
   @property({ attribute: false })
   public board: BoardCatalogEntry | null = null;
+
+  // Set by the parent dialog; the step stays mounted while the dialog is
+  // hidden, so the Enter listener follows this rather than connectedCallback.
+  @property({ type: Boolean }) active = false;
 
   @state()
   private _stage: "name" | "wifi" = "name";
@@ -55,9 +59,12 @@ export class ESPHomeWizardStepSetup extends LitElement {
     return this._stage === "name" ? !!this._deviceName.trim() : !!this._wifiSsid.trim();
   }
 
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("active")) this._enter.set(this.active);
+  }
+
   async connectedCallback() {
     super.connectedCallback();
-    this._enter.set(true);
     try {
       const yaml = await this._api.getConfig("secrets.yaml");
       const ssid = yaml.match(/^wifi_ssid\s*:\s*["']?(.+?)["']?\s*$/m);

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -44,6 +44,8 @@ export class ESPHomeWizardStepSetup extends LitElement {
   @state()
   private _wifiPassword = "";
 
+  private _finished = false;
+
   // Enter advances / finishes the current stage, mirroring the primary button.
   private _enter = new EnterController(this, () => {
     if (this._canAdvance()) this._onNext();
@@ -384,6 +386,8 @@ export class ESPHomeWizardStepSetup extends LitElement {
   }
 
   private _finish(wifiSsid: string, wifiPassword: string) {
+    if (this._finished) return; // a repeated Enter must not finish twice
+    this._finished = true;
     this.dispatchEvent(
       new CustomEvent("finish-setup", {
         detail: {

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -48,8 +48,6 @@ export class ESPHomeWizardStepSetup extends LitElement {
   @state()
   private _wifiPassword = "";
 
-  private _finished = false;
-
   // Enter advances / finishes the current stage, mirroring the primary button.
   private _enter = new EnterController(this, () => {
     if (this._canAdvance()) this._onNext();
@@ -393,8 +391,6 @@ export class ESPHomeWizardStepSetup extends LitElement {
   }
 
   private _finish(wifiSsid: string, wifiPassword: string) {
-    if (this._finished) return; // a repeated Enter must not finish twice
-    this._finished = true;
     this.dispatchEvent(
       new CustomEvent("finish-setup", {
         detail: {

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -160,6 +160,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   }
 
   private _goto() {
+    if (this._resolvedExit !== null) return; // a repeated Enter must not dispatch twice
     this._resolvedExit = "goto";
     this.close();
     this.dispatchEvent(

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -103,8 +103,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
 
   private _resolvedExit: "goto" | "save-anyway" | null = null;
 
-  // Enter jumps to the first error (the recommended fix), never the
-  // force-save path; no-op when there's no located error line.
+  // Enter goes to the first error (the safe path), never force-save.
   private _enter = new EnterController(this, () => {
     if (this.firstErrorLine > 0) this._goto();
   });

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -7,6 +7,7 @@ import { localizeContext } from "../context/index.js";
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -102,9 +103,16 @@ export class ESPHomeYamlValidationDialog extends LitElement {
 
   private _resolvedExit: "goto" | "save-anyway" | null = null;
 
+  // Enter jumps to the first error (the recommended fix), never the
+  // force-save path; no-op when there's no located error line.
+  private _enter = new EnterController(this, () => {
+    if (this.firstErrorLine > 0) this._goto();
+  });
+
   open() {
     this._resolvedExit = null;
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
@@ -171,6 +179,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   }
 
   private _onAfterHide() {
+    this._enter.set(false);
     if (this._resolvedExit === null) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
     }

--- a/src/util/enter-controller.ts
+++ b/src/util/enter-controller.ts
@@ -49,8 +49,8 @@ export class EnterController implements ReactiveController {
     if (ke.key !== "Enter") return;
     if (ke.isComposing || ke.keyCode === 229) return; // mid-IME composition
     if (ke.ctrlKey || ke.metaKey || ke.altKey || ke.shiftKey) return;
-    // Assumes one active modal (like EscapeController); an onEnter may
-    // preventDefault to stop a co-active controller.
+    // First active controller to act claims the event (preventDefault below);
+    // a co-active one (stacked modal) then bails here. Mirrors EscapeController.
     if (ke.defaultPrevented) return;
     // composedPath()[0] is the real focused element across shadow roots.
     const el = ke.composedPath()[0] as HTMLElement | undefined;
@@ -58,6 +58,7 @@ export class EnterController implements ReactiveController {
       if (SELF_HANDLING.has(el.tagName)) return;
       if (el.isContentEditable) return;
     }
+    ke.preventDefault(); // claim it so a co-active controller bails (see above)
     this.onEnter(ke);
   };
 }

--- a/src/util/enter-controller.ts
+++ b/src/util/enter-controller.ts
@@ -1,0 +1,71 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+export interface EnterControllerOptions {
+  /** Where to bind the keydown listener. Defaults to ``window``. Accepts
+   *  any ``EventTarget`` so tests can inject a stub. */
+  target?: EventTarget;
+}
+
+// Elements that act on Enter themselves. When focus sits on one of these
+// we leave Enter alone: a focused button/link activates natively (so the
+// controller mustn't also fire the primary action and double-act), and a
+// textarea / select / editable region needs Enter for its own input.
+const SELF_HANDLING = new Set(["BUTTON", "A", "TEXTAREA", "SELECT"]);
+
+/**
+ * Reactive controller that runs ``onEnter`` when the user presses Enter
+ * while the controller is "active". Dialogs call ``set(open)`` so the
+ * listener attaches on open and detaches on close — the shared
+ * counterpart to :class:`EscapeController` for confirming a dialog from
+ * the keyboard instead of duplicating a keydown handler per dialog.
+ *
+ * Enter is ignored when a modifier is held, while an IME composition is
+ * in flight, when a deeper handler already claimed it (``defaultPrevented``),
+ * or when focus is on an element that handles Enter itself (button, link,
+ * textarea, select, contenteditable). The callback receives the raw event.
+ */
+export class EnterController implements ReactiveController {
+  private _bound = false;
+  private readonly _target: EventTarget;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly onEnter: (e: KeyboardEvent) => void,
+    options: EnterControllerOptions = {}
+  ) {
+    this._target = options.target ?? window;
+    host.addController(this);
+  }
+
+  hostDisconnected() {
+    this.set(false);
+  }
+
+  set(active: boolean) {
+    if (active === this._bound) return;
+    if (active) {
+      this._target.addEventListener("keydown", this._handler);
+    } else {
+      this._target.removeEventListener("keydown", this._handler);
+    }
+    this._bound = active;
+  }
+
+  /* Typed as EventListener so Window | Document accepts the registration;
+     the cast is local and callers get a real KeyboardEvent. */
+  private _handler: EventListener = (e) => {
+    const ke = e as KeyboardEvent;
+    if (ke.key !== "Enter") return;
+    if (ke.isComposing || ke.keyCode === 229) return; // mid-IME composition
+    if (ke.ctrlKey || ke.metaKey || ke.altKey) return;
+    if (ke.defaultPrevented) return;
+    // composedPath()[0] pierces shadow DOM to the real focused element,
+    // which document.activeElement can't see across roots.
+    const el = ke.composedPath()[0] as HTMLElement | undefined;
+    if (el) {
+      if (SELF_HANDLING.has(el.tagName)) return;
+      if (el.isContentEditable) return;
+    }
+    this.onEnter(ke);
+  };
+}

--- a/src/util/enter-controller.ts
+++ b/src/util/enter-controller.ts
@@ -50,7 +50,9 @@ export class EnterController implements ReactiveController {
     if (ke.isComposing || ke.keyCode === 229) return; // mid-IME composition
     if (ke.ctrlKey || ke.metaKey || ke.altKey || ke.shiftKey) return;
     // First active controller to act claims the event (preventDefault below);
-    // a co-active one (stacked modal) then bails here. Mirrors EscapeController.
+    // a co-active one then bails here. Mirrors EscapeController. Single active
+    // modal is load-bearing: "first" is window listener registration order
+    // (open order), not z-order, so Enter routing is undefined if two stack.
     if (ke.defaultPrevented) return;
     // composedPath()[0] is the real focused element across shadow roots.
     const el = ke.composedPath()[0] as HTMLElement | undefined;

--- a/src/util/enter-controller.ts
+++ b/src/util/enter-controller.ts
@@ -57,7 +57,13 @@ export class EnterController implements ReactiveController {
     const ke = e as KeyboardEvent;
     if (ke.key !== "Enter") return;
     if (ke.isComposing || ke.keyCode === 229) return; // mid-IME composition
-    if (ke.ctrlKey || ke.metaKey || ke.altKey) return;
+    if (ke.ctrlKey || ke.metaKey || ke.altKey || ke.shiftKey) return;
+    // Like EscapeController, this assumes a single active modal: each open
+    // dialog binds its own window listener, so two simultaneously-open
+    // dialogs would both fire. The defaultPrevented guard lets an onEnter
+    // callback stop a co-active controller by preventing the event; today
+    // only one of these dialogs is ever open at a time (accept-peer wraps
+    // confirm-dialog, so only the inner controller is active).
     if (ke.defaultPrevented) return;
     // composedPath()[0] pierces shadow DOM to the real focused element,
     // which document.activeElement can't see across roots.

--- a/src/util/enter-controller.ts
+++ b/src/util/enter-controller.ts
@@ -6,23 +6,14 @@ export interface EnterControllerOptions {
   target?: EventTarget;
 }
 
-// Elements that act on Enter themselves. When focus sits on one of these
-// we leave Enter alone: a focused button/link activates natively (so the
-// controller mustn't also fire the primary action and double-act), and a
-// textarea / select / editable region needs Enter for its own input.
+// Focus on one of these means Enter is already spoken for: a button/link
+// activates natively, a textarea/select needs Enter for its own input.
 const SELF_HANDLING = new Set(["BUTTON", "A", "TEXTAREA", "SELECT"]);
 
 /**
- * Reactive controller that runs ``onEnter`` when the user presses Enter
- * while the controller is "active". Dialogs call ``set(open)`` so the
- * listener attaches on open and detaches on close — the shared
- * counterpart to :class:`EscapeController` for confirming a dialog from
- * the keyboard instead of duplicating a keydown handler per dialog.
- *
- * Enter is ignored when a modifier is held, while an IME composition is
- * in flight, when a deeper handler already claimed it (``defaultPrevented``),
- * or when focus is on an element that handles Enter itself (button, link,
- * textarea, select, contenteditable). The callback receives the raw event.
+ * Runs ``onEnter`` on a plain Enter while active — the keyboard counterpart
+ * to :class:`EscapeController`, so dialogs confirm without duplicating a
+ * keydown handler. Toggle with ``set(open)``.
  */
 export class EnterController implements ReactiveController {
   private _bound = false;
@@ -58,15 +49,10 @@ export class EnterController implements ReactiveController {
     if (ke.key !== "Enter") return;
     if (ke.isComposing || ke.keyCode === 229) return; // mid-IME composition
     if (ke.ctrlKey || ke.metaKey || ke.altKey || ke.shiftKey) return;
-    // Like EscapeController, this assumes a single active modal: each open
-    // dialog binds its own window listener, so two simultaneously-open
-    // dialogs would both fire. The defaultPrevented guard lets an onEnter
-    // callback stop a co-active controller by preventing the event; today
-    // only one of these dialogs is ever open at a time (accept-peer wraps
-    // confirm-dialog, so only the inner controller is active).
+    // Assumes one active modal (like EscapeController); an onEnter may
+    // preventDefault to stop a co-active controller.
     if (ke.defaultPrevented) return;
-    // composedPath()[0] pierces shadow DOM to the real focused element,
-    // which document.activeElement can't see across roots.
+    // composedPath()[0] is the real focused element across shadow roots.
     const el = ke.composedPath()[0] as HTMLElement | undefined;
     if (el) {
       if (SELF_HANDLING.has(el.tagName)) return;

--- a/test/_press-enter.ts
+++ b/test/_press-enter.ts
@@ -1,0 +1,13 @@
+/** Dispatch a plain Enter keydown on the window, the event shape the
+ *  dialogs' EnterController listens for. Shared so the spec line lives in
+ *  one place across the dialog/wizard tests. */
+export function pressEnter(): void {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
+  );
+}

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -9,23 +9,13 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeConfirmDialog } from "../../src/components/confirm-dialog.js";
+import { pressEnter } from "../_press-enter.js";
 
 async function mount(): Promise<ESPHomeConfirmDialog> {
   const el = new ESPHomeConfirmDialog();
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
-}
-
-function pressEnter(): void {
-  window.dispatchEvent(
-    new KeyboardEvent("keydown", {
-      key: "Enter",
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-    })
-  );
 }
 
 describe("confirm-dialog ENTER", () => {

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral proof for issue #1035 on the most-used dialog: ENTER confirms
+ * a non-destructive confirm-dialog, but never a destructive one (a stray
+ * ENTER must not delete).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeConfirmDialog } from "../../src/components/confirm-dialog.js";
+
+async function mount(): Promise<ESPHomeConfirmDialog> {
+  const el = new ESPHomeConfirmDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function pressEnter(): void {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
+  );
+}
+
+describe("confirm-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("confirms a non-destructive dialog on Enter", async () => {
+    const el = await mount();
+    const onConfirm = vi.fn();
+    el.addEventListener("confirm", onConfirm);
+    el.open();
+    pressEnter();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not confirm a destructive dialog on Enter", async () => {
+    const el = await mount();
+    el.destructive = true;
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("confirm", onConfirm);
+    el.open();
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not confirm before the dialog is opened", async () => {
+    const el = await mount();
+    const onConfirm = vi.fn();
+    el.addEventListener("confirm", onConfirm);
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -1,9 +1,7 @@
 /**
  * @vitest-environment happy-dom
  *
- * Behavioral proof for issue #1035 on the most-used dialog: ENTER confirms
- * a non-destructive confirm-dialog, but never a destructive one (a stray
- * ENTER must not delete).
+ * Pins that Enter confirms a non-destructive confirm-dialog, never a destructive one.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -53,6 +53,16 @@ describe("confirm-dialog ENTER", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
+  it("fires confirm only once on a repeated Enter", async () => {
+    const el = await mount();
+    const onConfirm = vi.fn();
+    el.addEventListener("confirm", onConfirm);
+    el.open();
+    pressEnter();
+    pressEnter();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
   it("does not confirm before the dialog is opened", async () => {
     const el = await mount();
     const onConfirm = vi.fn();

--- a/test/components/onboarding-wifi-dialog.test.ts
+++ b/test/components/onboarding-wifi-dialog.test.ts
@@ -68,4 +68,20 @@ describe("onboarding-wifi-dialog password-length gate", () => {
 
     expect(setOnboardingWifi).not.toHaveBeenCalled();
   });
+
+  test("a second _save while one is in flight does not double-submit", async () => {
+    const dialog = makeDialog();
+    // Never resolves, so the first call stays in flight (``_saving`` true)
+    // while the second runs — exactly the held-Enter window the EnterController
+    // path opens by bypassing the disabled Save button.
+    const setOnboardingWifi = vi.fn(() => new Promise<void>(() => {}));
+    dialog._api = { setOnboardingWifi };
+    dialog._ssid = "MyNetwork";
+    dialog._password = "12345678";
+
+    void dialog._save();
+    await dialog._save();
+
+    expect(setOnboardingWifi).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the create de-dupe that the wizard steps rely on instead of a
+ * per-step latch: a second create event while one is in flight is dropped
+ * (the _submitting guard), but a create after a failed attempt is allowed
+ * so the user can retry — no permanent lockout.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../../src/components/wizard/wizard-step-board.js", () => ({}));
+vi.mock("../../../src/components/wizard/wizard-step-empty-config.js", () => ({}));
+vi.mock("../../../src/components/wizard/wizard-step-method.js", () => ({}));
+vi.mock("../../../src/components/wizard/wizard-step-setup.js", () => ({}));
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { ESPHomeCreateConfigDialog } from "../../../src/components/wizard/create-config-dialog.js";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+};
+
+async function mount(api: Partial<ESPHomeAPI>): Promise<ESPHomeCreateConfigDialog> {
+  const el = new ESPHomeCreateConfigDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = api as ESPHomeAPI;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.open();
+  await el.updateComplete;
+  return el;
+}
+
+// The parent listens for create-empty-config on its wa-dialog; emit it the
+// way a wizard step would (bubbling, composed).
+function emitCreate(el: ESPHomeCreateConfigDialog, name: string): void {
+  const wd = el.shadowRoot!.querySelector("wa-dialog")!;
+  wd.dispatchEvent(
+    new CustomEvent("create-empty-config", {
+      detail: { name },
+      bubbles: true,
+      composed: true,
+    })
+  );
+}
+
+describe("create-config-dialog create de-dupe + retry", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("drops a second create while the first is in flight", async () => {
+    const inflight = deferred<{ configuration: string }>();
+    const createDevice = vi.fn(() => inflight.promise);
+    const el = await mount({ createDevice });
+
+    emitCreate(el, "kitchen");
+    emitCreate(el, "kitchen");
+
+    expect(createDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a retry after a failed create (no permanent lockout)", async () => {
+    const createDevice = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ configuration: "kitchen.yaml" });
+    const el = await mount({ createDevice });
+
+    emitCreate(el, "kitchen"); // first attempt — fails
+    await flush();
+    emitCreate(el, "kitchen"); // retry — must not be blocked
+    await flush();
+
+    expect(createDevice).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -33,7 +33,7 @@ describe("wizard-step-empty-config ENTER", () => {
     expect((onCreate.mock.calls[0][0] as CustomEvent).detail.name).toBe("kitchen");
   });
 
-  it("emits create-empty-config only once on a repeated Enter", async () => {
+  it("re-dispatches on a second Enter (no permanent latch — parent de-dupes / allows retry)", async () => {
     const el = await mount();
     const onCreate = vi.fn();
     el.addEventListener("create-empty-config", onCreate as EventListener);
@@ -43,7 +43,8 @@ describe("wizard-step-empty-config ENTER", () => {
     await el.updateComplete;
     pressEnter();
     pressEnter();
-    expect(onCreate).toHaveBeenCalledTimes(1);
+    // The step must not latch; create de-dupe / retry lives in the parent.
+    expect(onCreate).toHaveBeenCalledTimes(2);
   });
 
   it("ignores Enter once the dialog is no longer active (hidden but still mounted)", async () => {

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that Enter finishes the empty-config wizard step once a name is set.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ESPHomeWizardStepEmptyConfig } from "../../../src/components/wizard/wizard-step-empty-config.js";
+
+async function mount(): Promise<ESPHomeWizardStepEmptyConfig> {
+  const el = new ESPHomeWizardStepEmptyConfig();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function pressEnter(): void {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
+  );
+}
+
+describe("wizard-step-empty-config ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("emits create-empty-config on Enter once a name is set", async () => {
+    const el = await mount();
+    const onCreate = vi.fn();
+    el.addEventListener("create-empty-config", onCreate as EventListener);
+    const input = el.shadowRoot!.querySelector("input")!;
+    input.value = "kitchen";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    pressEnter();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect((onCreate.mock.calls[0][0] as CustomEvent).detail.name).toBe("kitchen");
+  });
+
+  it("does nothing on Enter with an empty name", async () => {
+    const el = await mount();
+    const onCreate = vi.fn();
+    el.addEventListener("create-empty-config", onCreate as EventListener);
+    pressEnter();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -42,6 +42,19 @@ describe("wizard-step-empty-config ENTER", () => {
     expect((onCreate.mock.calls[0][0] as CustomEvent).detail.name).toBe("kitchen");
   });
 
+  it("emits create-empty-config only once on a repeated Enter", async () => {
+    const el = await mount();
+    const onCreate = vi.fn();
+    el.addEventListener("create-empty-config", onCreate as EventListener);
+    const input = el.shadowRoot!.querySelector("input")!;
+    input.value = "kitchen";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    pressEnter();
+    pressEnter();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
   it("does nothing on Enter with an empty name", async () => {
     const el = await mount();
     const onCreate = vi.fn();

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -5,23 +5,13 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepEmptyConfig } from "../../../src/components/wizard/wizard-step-empty-config.js";
+import { pressEnter } from "../../_press-enter.js";
 
 async function mount(): Promise<ESPHomeWizardStepEmptyConfig> {
   const el = new ESPHomeWizardStepEmptyConfig();
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
-}
-
-function pressEnter(): void {
-  window.dispatchEvent(
-    new KeyboardEvent("keydown", {
-      key: "Enter",
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-    })
-  );
 }
 
 describe("wizard-step-empty-config ENTER", () => {

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -9,6 +9,7 @@ import { pressEnter } from "../../_press-enter.js";
 
 async function mount(): Promise<ESPHomeWizardStepEmptyConfig> {
   const el = new ESPHomeWizardStepEmptyConfig();
+  el.active = true; // the parent dialog is open
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -43,6 +44,19 @@ describe("wizard-step-empty-config ENTER", () => {
     pressEnter();
     pressEnter();
     expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Enter once the dialog is no longer active (hidden but still mounted)", async () => {
+    const el = await mount();
+    const input = el.shadowRoot!.querySelector("input")!;
+    input.value = "kitchen";
+    input.dispatchEvent(new Event("input"));
+    el.active = false; // dialog hidden via light-dismiss / Escape / close
+    await el.updateComplete;
+    const onCreate = vi.fn();
+    el.addEventListener("create-empty-config", onCreate as EventListener);
+    pressEnter();
+    expect(onCreate).not.toHaveBeenCalled();
   });
 
   it("does nothing on Enter with an empty name", async () => {

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -6,6 +6,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepSetup } from "../../../src/components/wizard/wizard-step-setup.js";
+import { pressEnter } from "../../_press-enter.js";
 
 async function mount(): Promise<ESPHomeWizardStepSetup> {
   const el = new ESPHomeWizardStepSetup();
@@ -23,17 +24,6 @@ function setName(el: ESPHomeWizardStepSetup, value: string): Promise<unknown> {
   input.value = value;
   input.dispatchEvent(new Event("input"));
   return el.updateComplete;
-}
-
-function pressEnter(): void {
-  window.dispatchEvent(
-    new KeyboardEvent("keydown", {
-      key: "Enter",
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-    })
-  );
 }
 
 describe("wizard-step-setup ENTER", () => {

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins Enter handling on the board setup step: it advances / finishes the
+ * current stage, mirroring the primary button, and never acts on a blank name.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ESPHomeWizardStepSetup } from "../../../src/components/wizard/wizard-step-setup.js";
+
+async function mount(): Promise<ESPHomeWizardStepSetup> {
+  const el = new ESPHomeWizardStepSetup();
+  // No secrets file in the test; connectedCallback swallows the rejection.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = { getConfig: vi.fn().mockRejectedValue(new Error("none")) };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await Promise.resolve();
+  return el;
+}
+
+function setName(el: ESPHomeWizardStepSetup, value: string): Promise<unknown> {
+  const input = el.shadowRoot!.querySelector<HTMLInputElement>("#device-name")!;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+  return el.updateComplete;
+}
+
+function pressEnter(): void {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
+  );
+}
+
+describe("wizard-step-setup ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("finishes on Enter when wifi comes from secrets", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._secretWifiSsid = "ssid";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._secretWifiPassword = "pw";
+    await setName(el, "kitchen");
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.name).toBe("kitchen");
+  });
+
+  it("advances to the wifi stage on Enter when there is no secret wifi", async () => {
+    const el = await mount();
+    await setName(el, "kitchen");
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect(onFinish).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._stage).toBe("wifi");
+  });
+
+  it("does nothing on Enter with a blank name", async () => {
+    const el = await mount();
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect(onFinish).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._stage).toBe("name");
+  });
+});

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -13,6 +13,7 @@ async function mount(): Promise<ESPHomeWizardStepSetup> {
   // No secrets file in the test; connectedCallback swallows the rejection.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any)._api = { getConfig: vi.fn().mockRejectedValue(new Error("none")) };
+  el.active = true; // the parent dialog is open
   document.body.appendChild(el);
   await el.updateComplete;
   await Promise.resolve();

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -1,10 +1,8 @@
 /**
  * @vitest-environment happy-dom
  *
- * Behavioral tests for EnterController: it fires onEnter on a plain Enter
- * press while active, and stays out of the way for modifiers, IME
- * composition, already-handled events, and focus on elements that act on
- * Enter themselves (button/link/textarea/select/contenteditable).
+ * Pins EnterController: fires on a plain Enter, stays out of the way for
+ * modifiers, IME, already-handled events, and self-handling focus targets.
  */
 import type { ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -108,4 +108,17 @@ describe("EnterController", () => {
     press(target);
     expect(onEnter).not.toHaveBeenCalled();
   });
+
+  it("only the first active controller acts on a shared Enter (stacked modals)", () => {
+    target = document.createElement("div");
+    document.body.appendChild(target);
+    const first = vi.fn();
+    const second = vi.fn();
+    new EnterController(stubHost, first, { target }).set(true);
+    new EnterController(stubHost, second, { target }).set(true);
+    press(target);
+    // The first to act calls preventDefault; the second bails on its guard.
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral tests for EnterController: it fires onEnter on a plain Enter
+ * press while active, and stays out of the way for modifiers, IME
+ * composition, already-handled events, and focus on elements that act on
+ * Enter themselves (button/link/textarea/select/contenteditable).
+ */
+import type { ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EnterController } from "../../src/util/enter-controller.js";
+
+const stubHost = { addController() {} } as unknown as ReactiveControllerHost;
+
+let target: HTMLElement;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function setup(onEnter = vi.fn()) {
+  target = document.createElement("div");
+  document.body.appendChild(target);
+  const controller = new EnterController(stubHost, onEnter, { target });
+  controller.set(true);
+  return { controller, onEnter };
+}
+
+// Dispatch a keydown that bubbles up to `target`'s listener; `from` becomes
+// composedPath()[0], i.e. the element the controller treats as focused.
+function press(
+  from: Element,
+  init: KeyboardEventInit = {},
+  prevent = false
+): KeyboardEvent {
+  const ev = new KeyboardEvent("keydown", {
+    key: "Enter",
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  if (prevent) ev.preventDefault();
+  from.dispatchEvent(ev);
+  return ev;
+}
+
+describe("EnterController", () => {
+  it("fires on a plain Enter from a neutral element", () => {
+    const { onEnter } = setup();
+    press(target);
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires on Enter from a text input", () => {
+    const { onEnter } = setup();
+    const input = document.createElement("input");
+    target.appendChild(input);
+    press(input);
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["button", "a", "textarea", "select"])(
+    "ignores Enter when focus is on a <%s>",
+    (tag) => {
+      const { onEnter } = setup();
+      const el = document.createElement(tag);
+      target.appendChild(el);
+      press(el);
+      expect(onEnter).not.toHaveBeenCalled();
+    }
+  );
+
+  it("ignores Enter in a contenteditable region", () => {
+    const { onEnter } = setup();
+    const el = document.createElement("div");
+    el.contentEditable = "true";
+    target.appendChild(el);
+    press(el);
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ctrlKey", { ctrlKey: true }],
+    ["metaKey", { metaKey: true }],
+    ["altKey", { altKey: true }],
+    ["isComposing", { isComposing: true }],
+  ])("ignores Enter with %s", (_label, init) => {
+    const { onEnter } = setup();
+    press(target, init as KeyboardEventInit);
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it("ignores a non-Enter key", () => {
+    const { onEnter } = setup();
+    press(target, { key: "a" });
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it("ignores an already-defaultPrevented Enter", () => {
+    const { onEnter } = setup();
+    press(target, {}, true);
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it("stops firing after set(false)", () => {
+    const { controller, onEnter } = setup();
+    controller.set(false);
+    press(target);
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+});

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -84,6 +84,7 @@ describe("EnterController", () => {
     ["ctrlKey", { ctrlKey: true }],
     ["metaKey", { metaKey: true }],
     ["altKey", { altKey: true }],
+    ["shiftKey", { shiftKey: true }],
     ["isComposing", { isComposing: true }],
   ])("ignores Enter with %s", (_label, init) => {
     const { onEnter } = setup();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Several dialogs could not be confirmed with Enter; wa-dialog only handles Escape, and these dialogs use plain click buttons rather than forms, so Enter did nothing. Adds a shared EnterController (mirrors the existing EscapeController) that fires the dialog's primary action on a plain Enter, while ignoring modifiers, IME composition, already-handled events, and focus on elements that act on Enter themselves (button, link, textarea, select, contenteditable). It is wired into confirm-dialog, unsaved-changes-dialog, yaml-validation-dialog, onboarding-wifi-dialog, and edit-pairing-endpoint-dialog; accept-peer-dialog is fixed transitively since it wraps confirm-dialog. A destructive confirm does nothing on Enter so a stray keypress can't delete, and the yaml-invalid dialog jumps to the first error instead of force-saving. The two input dialogs also autofocus their first field so Enter works the moment they open. Tests are behavioral happy-dom mounts, not source scans.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1035

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
