### PR TITLE
Migrate input dialogs to the shared EnterController

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types.js";
@@ -8,6 +8,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
+import { EnterController } from "../util/enter-controller.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { renderInlineError } from "../util/render-error.js";
@@ -229,6 +230,13 @@ export class ESPHomeAdoptDialog extends LitElement {
     `,
   ];
 
+  // Enter submits; _submit self-guards on name validity and re-entry.
+  private _enter = new EnterController(this, () => this._submit());
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("_open")) this._enter.set(this._open);
+  }
+
   open(device: AdoptableDevice) {
     this._device = device;
     /* Default to the discovered hostname verbatim — including the
@@ -307,9 +315,6 @@ export class ESPHomeAdoptDialog extends LitElement {
                   @input=${(e: Event) => {
                     this._name = (e.target as HTMLInputElement).value;
                   }}
-                  @keydown=${(e: KeyboardEvent) => {
-                    if (e.key === "Enter" && canSubmit) this._submit();
-                  }}
                 />
                 ${renderInlineError(
                   nameErr ? this._localize(nameErr.code, nameErr.params) : undefined
@@ -327,9 +332,6 @@ export class ESPHomeAdoptDialog extends LitElement {
                   ?disabled=${this._busy}
                   @input=${(e: Event) => {
                     this._friendlyName = (e.target as HTMLInputElement).value;
-                  }}
-                  @keydown=${(e: KeyboardEvent) => {
-                    if (e.key === "Enter" && canSubmit) this._submit();
                   }}
                 />
               </div>
@@ -410,6 +412,7 @@ export class ESPHomeAdoptDialog extends LitElement {
   }
 
   private _submit = async () => {
+    if (this._busy) return; // Enter bypasses the disabled button; guard re-entry
     if (!this._device || !this._api) return;
     const name = this._name.trim();
     const friendlyName = this._friendlyName.trim();

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { EnterController } from "../util/enter-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -153,16 +154,24 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     `,
   ];
 
+  // Enter confirms; _confirm self-guards on empty / same / invalid.
+  private _enter = new EnterController(this, () => this._confirm());
+
   open(sourceName: string) {
     this.sourceName = sourceName;
     this._name = "";
     this._friendlyName = "";
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
     this._dialog.open = false;
   }
+
+  private _onAfterHide = (): void => {
+    this._enter.set(false);
+  };
 
   protected render() {
     const trimmedName = this._name.trim();
@@ -185,6 +194,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
       <wa-dialog
         label=${this._localize("dashboard.action_clone_title", { name: this.sourceName })}
         light-dismiss
+        @wa-after-hide=${this._onAfterHide}
       >
         <div class="field">
           <label for="clone-new-name"
@@ -198,9 +208,6 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
             placeholder=${this.sourceName}
             @input=${(e: Event) => {
               this._name = (e.target as HTMLInputElement).value;
-            }}
-            @keydown=${(e: KeyboardEvent) => {
-              if (e.key === "Enter" && canSubmit) this._confirm();
             }}
           />
           ${err
@@ -224,9 +231,6 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
             )}
             @input=${(e: Event) => {
               this._friendlyName = (e.target as HTMLInputElement).value;
-            }}
-            @keydown=${(e: KeyboardEvent) => {
-              if (e.key === "Enter" && canSubmit) this._confirm();
             }}
           />
           <span class="helper"

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -1,10 +1,11 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
@@ -158,6 +159,13 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     `,
   ];
 
+  // Enter confirms; _confirm self-guards on empty / unchanged.
+  private _enter = new EnterController(this, () => this._confirm());
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("_open")) this._enter.set(this._open);
+  }
+
   open(deviceName: string, currentFriendlyName: string) {
     this.deviceName = deviceName;
     this.currentFriendlyName = currentFriendlyName;
@@ -209,9 +217,6 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
             placeholder=${this.currentFriendlyName || this.deviceName}
             @input=${(e: Event) => {
               this._value = (e.target as HTMLInputElement).value;
-            }}
-            @keydown=${(e: KeyboardEvent) => {
-              if (e.key === "Enter" && canSubmit) this._confirm();
             }}
           />
           ${err

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -6,6 +6,7 @@ import { localizeContext } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { EnterController } from "../util/enter-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
@@ -129,15 +130,23 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     `,
   ];
 
+  // Enter confirms; _confirm self-guards on unchanged / invalid.
+  private _enter = new EnterController(this, () => this._confirm());
+
   open(name: string) {
     this.deviceName = name;
     this._value = name;
     this._dialog.open = true;
+    this._enter.set(true);
   }
 
   close() {
     this._dialog.open = false;
   }
+
+  private _onAfterHide = (): void => {
+    this._enter.set(false);
+  };
 
   protected render() {
     const trimmed = this._value.trim();
@@ -151,7 +160,11 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     const canSubmit = !unchanged && !err;
 
     return html`
-      <wa-dialog label=${this._localize("dashboard.action_rename_title")} light-dismiss>
+      <wa-dialog
+        label=${this._localize("dashboard.action_rename_title")}
+        light-dismiss
+        @wa-after-hide=${this._onAfterHide}
+      >
         <div class="field">
           <label>${this._localize("dashboard.action_rename_label")}</label>
           <input
@@ -160,9 +173,6 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
             .value=${this._value}
             @input=${(e: Event) => {
               this._value = (e.target as HTMLInputElement).value;
-            }}
-            @keydown=${(e: KeyboardEvent) => {
-              if (e.key === "Enter" && canSubmit) this._confirm();
             }}
           />
           ${err

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the adopt _submit guards re-entry, so the Enter path (which
+ * bypasses the disabled button via the shared EnterController) can't
+ * double-import on a held Enter. The Enter->action wiring itself mirrors
+ * friendly-name-dialog and is covered there.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { AdoptableDevice } from "../../src/api/types.js";
+import { ESPHomeAdoptDialog } from "../../src/components/adopt-dialog.js";
+
+const DEVICE = {
+  name: "foo-1234",
+  friendly_name: "Foo",
+  project_name: "acme.widget",
+  package_import_url: "github://acme/widget/widget.yaml@main",
+} as unknown as AdoptableDevice;
+
+describe("adopt-dialog re-entry guard", () => {
+  it("_submit ignores re-entry while an import is in flight", async () => {
+    const importDevice = vi.fn(() => new Promise<void>(() => {})); // stays in flight
+    const el = new ESPHomeAdoptDialog();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const priv = el as any;
+    priv._api = { importDevice };
+    priv._device = DEVICE;
+    priv._name = "foo-1234";
+
+    void priv._submit();
+    await priv._submit();
+
+    expect(importDevice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/clone-device-dialog.test.ts
+++ b/test/components/clone-device-dialog.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the clone dialog confirms a valid new name on Enter via the
+ * shared EnterController.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeCloneDeviceDialog } from "../../src/components/clone-device-dialog.js";
+import { pressEnter } from "../_press-enter.js";
+
+async function mount(): Promise<ESPHomeCloneDeviceDialog> {
+  const el = new ESPHomeCloneDeviceDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("clone-device-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("confirms a valid new name on Enter", async () => {
+    const el = await mount();
+    el.open("source");
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("clone-confirm", onConfirm as EventListener);
+    const input = el.shadowRoot!.querySelector<HTMLInputElement>("#clone-new-name")!;
+    input.value = "kitchen";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    pressEnter();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect((onConfirm.mock.calls[0][0] as CustomEvent).detail.newName).toBe("kitchen");
+  });
+
+  it("ignores Enter with an empty name", async () => {
+    const el = await mount();
+    el.open("source");
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("clone-confirm", onConfirm as EventListener);
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/friendly-name-dialog.test.ts
+++ b/test/components/friendly-name-dialog.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the friendly-name dialog confirms a changed value on Enter via
+ * the shared EnterController, and goes inert once closed.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/components/base-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/checkbox/checkbox.js", () => ({}));
+
+import { ESPHomeFriendlyNameDialog } from "../../src/components/friendly-name-dialog.js";
+import { pressEnter } from "../_press-enter.js";
+
+async function mount(): Promise<ESPHomeFriendlyNameDialog> {
+  const el = new ESPHomeFriendlyNameDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function setValue(el: ESPHomeFriendlyNameDialog, value: string): Promise<unknown> {
+  const input = el.shadowRoot!.querySelector<HTMLInputElement>("#friendly-name-input")!;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+  return el.updateComplete;
+}
+
+describe("friendly-name-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("confirms a changed friendly name on Enter", async () => {
+    const el = await mount();
+    el.open("kitchen", "Kitchen");
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("friendly-name-confirm", onConfirm as EventListener);
+    await setValue(el, "Living Room");
+    pressEnter();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect((onConfirm.mock.calls[0][0] as CustomEvent).detail.newFriendlyName).toBe(
+      "Living Room"
+    );
+  });
+
+  it("ignores Enter once closed (inactive)", async () => {
+    const el = await mount();
+    el.open("kitchen", "Kitchen");
+    await setValue(el, "Living Room");
+    el.close();
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("friendly-name-confirm", onConfirm as EventListener);
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/rename-device-dialog.test.ts
+++ b/test/components/rename-device-dialog.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the rename dialog confirms a valid new name on Enter (via the
+ * shared EnterController), and ignores Enter when unchanged or after close.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeRenameDeviceDialog } from "../../src/components/rename-device-dialog.js";
+import { pressEnter } from "../_press-enter.js";
+
+async function mount(): Promise<ESPHomeRenameDeviceDialog> {
+  const el = new ESPHomeRenameDeviceDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function setValue(el: ESPHomeRenameDeviceDialog, value: string): Promise<unknown> {
+  const input = el.shadowRoot!.querySelector("input")!;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+  return el.updateComplete;
+}
+
+describe("rename-device-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("confirms a valid new name on Enter", async () => {
+    const el = await mount();
+    el.open("oldname");
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("rename-confirm", onConfirm as EventListener);
+    await setValue(el, "kitchen");
+    pressEnter();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect((onConfirm.mock.calls[0][0] as CustomEvent).detail).toBe("kitchen");
+  });
+
+  it("ignores Enter when the name is unchanged", async () => {
+    const el = await mount();
+    el.open("kitchen");
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    el.addEventListener("rename-confirm", onConfirm as EventListener);
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("ignores Enter after the dialog hides", async () => {
+    const el = await mount();
+    el.open("oldname");
+    await setValue(el, "kitchen");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._onAfterHide(); // wa-dialog close path
+    const onConfirm = vi.fn();
+    el.addEventListener("rename-confirm", onConfirm as EventListener);
+    pressEnter();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Follow-up to #445. The rename, clone, friendly-name, and adopt dialogs each had their own per-input Enter handler (`if (e.key === "Enter" && canSubmit) ...`), which is the duplicated pattern the shared EnterController was meant to replace. This migrates all four onto EnterController, so they get the same modifier, IME, self-handling, and co-active guards the naive handler lacked, and the Enter logic lives in one place. Each gates the controller on its open state (willUpdate for the _open dialogs, open plus wa-after-hide for the wa-dialog ones); the actions self-guard, and adopt's _submit gains a _busy re-entry guard since the Enter path bypasses the disabled button. install-method's OTA field keeps its scoped keydown on purpose; it lives inside a multi-purpose dialog where a window-level Enter would misfire. Behavioral happy-dom tests added for each.

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder-frontend#445

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
