### PR TITLE
Show the OOB fingerprint on the offloader's Pair request sent dialog

### DIFF
--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -75,7 +75,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // This dashboard's own stable identity (dashboard_id + pin_sha256). Shown on
   // the sent step so the operator can match it against what the receiver's
   // "Pairing request" dialog displays for this offloader. Loaded on open();
-  // null until it lands (the emoji grid renders nothing for an empty pin).
+  // renderSentStep hides the whole identity card while this is null (load
+  // still in flight or failed).
   @state() _offloaderIdentity: IdentityView | null = null;
 
   static styles = [

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -3,7 +3,7 @@ import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { ESPHomeAPI } from "../api/index.js";
-import type { PairingSummary } from "../api/types.js";
+import type { IdentityView, PairingSummary } from "../api/types.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   apiContext,
@@ -72,6 +72,12 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // ${hostname}:${port} of the submitted request — null outside the sent step.
   @state() _sentKey: string | null = null;
 
+  // This dashboard's own stable identity (dashboard_id + pin_sha256). Shown on
+  // the sent step so the operator can match it against what the receiver's
+  // "Pairing request" dialog displays for this offloader. Loaded on open();
+  // null until it lands (the emoji grid renders nothing for an empty pin).
+  @state() _offloaderIdentity: IdentityView | null = null;
+
   static styles = [
     espHomeStyles,
     inputStyles,
@@ -95,7 +101,21 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     this._offloaderLabel = friendlyHostname(window.location.hostname);
     this._error = null;
     this._sentKey = null;
+    this._offloaderIdentity = null;
+    void this._loadOffloaderIdentity();
     this._open = true;
+  }
+
+  // Read this dashboard's own identity for the sent-step fingerprint. The
+  // call is idempotent and lazy-creates the peer-link keypair on first use;
+  // failures leave the card hidden rather than blocking the pair flow.
+  private async _loadOffloaderIdentity(): Promise<void> {
+    if (!this._api) return;
+    try {
+      this._offloaderIdentity = await this._api.getRemoteBuildIdentity();
+    } catch {
+      this._offloaderIdentity = null;
+    }
   }
 
   close = (): void => {

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -7,6 +7,22 @@ import {
 import { formatPinSha256 } from "../../util/pin-format.js";
 import type { ESPHomePairBuildServerDialog } from "../pair-build-server-dialog.js";
 
+// Emoji icon row + collapsible hex bytes for a SHA-256 pin. Shared by the
+// confirm step (the receiver's fingerprint) and the sent step (this
+// dashboard's own fingerprint) so the two render identically.
+function renderFingerprint(
+  host: ESPHomePairBuildServerDialog,
+  pin: string
+): TemplateResult {
+  return html`
+    <esphome-pin-emoji-grid .pin=${pin}></esphome-pin-emoji-grid>
+    <details class="pin-hex">
+      <summary>${host._localize("settings.pair_build_server_pin_hex_summary")}</summary>
+      <code>${formatPinSha256(pin)}</code>
+    </details>
+  `;
+}
+
 export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateResult {
   const portValid = parsePortInput(host._port) !== null;
   const canSubmit = !host._busy && host._hostname.trim().length > 0 && portValid;
@@ -92,11 +108,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
       <span class="pin-card-label">
         ${host._localize("settings.pair_build_server_pin_label")}
       </span>
-      <esphome-pin-emoji-grid .pin=${host._previewedPin}></esphome-pin-emoji-grid>
-      <details class="pin-hex">
-        <summary>${host._localize("settings.pair_build_server_pin_hex_summary")}</summary>
-        <code>${formatPinSha256(host._previewedPin)}</code>
-      </details>
+      ${renderFingerprint(host, host._previewedPin)}
       <span class="pin-card-target">
         ${host._localize("settings.pair_build_server_target", {
           hostname: trimTrailingDot(host._hostname),
@@ -177,6 +189,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
 }
 
 export function renderSentStep(host: ESPHomePairBuildServerDialog): TemplateResult {
+  const identity = host._offloaderIdentity;
   return html`
     <div class="sent-body">
       ${host._localize("settings.pair_build_server_sent_desc", {
@@ -184,6 +197,20 @@ export function renderSentStep(host: ESPHomePairBuildServerDialog): TemplateResu
         port: host._port,
       })}
     </div>
+    ${identity
+      ? html`
+          <div class="pin-card">
+            <span class="pin-card-label">
+              ${host._localize("settings.pair_build_server_sent_dashboard_id_label")}
+            </span>
+            <code>${identity.dashboard_id}</code>
+            <span class="pin-card-label">
+              ${host._localize("settings.pair_build_server_sent_pin_label")}
+            </span>
+            ${renderFingerprint(host, identity.pin_sha256)}
+          </div>
+        `
+      : nothing}
     <div class="actions">
       <button class="btn btn--primary" @click=${host.close}>
         ${host._localize("layout.close")}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -970,6 +970,8 @@
     "pair_build_server_invalid_args": "The receiver rejected the request: {details}",
     "pair_build_server_sent_title": "Pair request sent",
     "pair_build_server_sent_desc": "Open Settings → Pairing requests on the receiver dashboard at {hostname}:{port} and click Accept. The pair will complete once the admin there approves it.",
+    "pair_build_server_sent_dashboard_id_label": "Dashboard ID",
+    "pair_build_server_sent_pin_label": "Your fingerprint (the receiver shows this on its Pairing request screen)",
     "pair_build_server_sent_toast": "Pair request sent to {hostname}:{port}. Waiting for the receiver's admin to accept.",
     "pair_build_server_approved_toast": "Pairing with {hostname}:{port} accepted.",
     "pair_build_server_rejected_toast": "Pair request to {hostname}:{port} was declined or removed.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -910,6 +910,8 @@
     "pair_build_server_invalid_args": "Le destinataire a refusé la demande : {details}",
     "pair_build_server_sent_title": "Demande d'appairage envoyée",
     "pair_build_server_sent_desc": "Ouvrez Paramètres → Demandes d'appairage sur le tableau de bord destinataire à {hostname}:{port} et cliquez sur Accepter. L'appairage se terminera lorsque l'administrateur l'aura approuvé.",
+    "pair_build_server_sent_dashboard_id_label": "Identifiant du tableau de bord",
+    "pair_build_server_sent_pin_label": "Votre empreinte (le destinataire l'affiche sur son écran Demandes d'appairage)",
     "pair_build_server_sent_toast": "Demande d'appairage envoyée à {hostname}:{port}. En attente de l'acceptation par l'administrateur du destinataire.",
     "pair_build_server_approved_toast": "Appairage avec {hostname}:{port} accepté.",
     "pair_build_server_rejected_toast": "La demande d'appairage avec {hostname}:{port} a été refusée ou supprimée.",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -962,6 +962,8 @@
     "pair_build_server_invalid_args": "A fogadó elutasította a kérelmet: {details}",
     "pair_build_server_sent_title": "Párosítási kérelem elküldve",
     "pair_build_server_sent_desc": "Nyissa meg a Beállítások → Párosítási kérelmek oldalt a fogadó irányítópultján itt: {hostname}:{port}, és Kattintson az Elfogadás gombra. A párosítás az ottani admin jóváhagyása után fejeződik be.",
+    "pair_build_server_sent_dashboard_id_label": "Irányítópult azonosítója",
+    "pair_build_server_sent_pin_label": "Az Ön ujjlenyomata (a fogadó megjeleníti a Párosítási kérelmek képernyőn)",
     "pair_build_server_sent_toast": "Párosítási kérelem elküldve ide: {hostname}:{port}. Várakozás a fogadó adminisztrátorának elfogadására.",
     "pair_build_server_approved_toast": "Párosítás elfogadva: {hostname}:{port}.",
     "pair_build_server_rejected_toast": "A párosítási kérelem elutasítva vagy eltávolítva: {hostname}:{port}.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -910,6 +910,8 @@
     "pair_build_server_invalid_args": "De ontvanger heeft het verzoek geweigerd: {details}",
     "pair_build_server_sent_title": "Koppelingsverzoek verzonden",
     "pair_build_server_sent_desc": "Open Instellingen → Koppelingsverzoeken op het dashboard van de ontvanger op {hostname}:{port} en klik op Accepteren. De koppeling wordt voltooid zodra de beheerder daar het verzoek goedkeurt.",
+    "pair_build_server_sent_dashboard_id_label": "Dashboard-ID",
+    "pair_build_server_sent_pin_label": "Jouw vingerafdruk (de ontvanger toont deze op het scherm Koppelingsverzoeken)",
     "pair_build_server_sent_toast": "Koppelingsverzoek verzonden naar {hostname}:{port}. In afwachting van goedkeuring door de beheerder van de ontvanger.",
     "pair_build_server_approved_toast": "Koppeling met {hostname}:{port} geaccepteerd.",
     "pair_build_server_rejected_toast": "Het koppelingsverzoek aan {hostname}:{port} is geweigerd of verwijderd.",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -970,6 +970,8 @@
     "pair_build_server_invalid_args": "接收端拒绝了请求：{details}",
     "pair_build_server_sent_title": "配对请求已发送",
     "pair_build_server_sent_desc": "请在接收端仪表板 {hostname}:{port} 上打开“设置 → 配对请求”，然后点击“接受”。当那边的管理员批准后，配对才会完成。",
+    "pair_build_server_sent_dashboard_id_label": "仪表板 ID",
+    "pair_build_server_sent_pin_label": "您的指纹（接收端会在其“配对请求”界面中显示）",
     "pair_build_server_sent_toast": "配对请求已发送到 {hostname}:{port}。正在等待接收端管理员接受。",
     "pair_build_server_approved_toast": "与 {hostname}:{port} 的配对已被接受。",
     "pair_build_server_rejected_toast": "发送到 {hostname}:{port} 的配对请求已被拒绝或移除。",

--- a/test/components/pair-build-server-dialog/render-sent-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-sent-step.test.ts
@@ -8,15 +8,20 @@
  * graceful-degradation path when the identity load is in flight or
  * failed).
  *
- * Runs in vitest's default ``node`` environment, so we inspect the
- * returned ``TemplateResult`` tree rather than rendering to a DOM
- * (mirrors ``device/render-nested-list-field.test.ts``).
+ * Runs in vitest's default ``node`` environment, inspecting the
+ * returned ``TemplateResult`` tree via the shared
+ * ``test/_lit-template-walker.ts`` helpers rather than mounting a DOM.
  */
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import type { IdentityView } from "../../../src/api/types.js";
 import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
 import { renderSentStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+  visitTemplates,
+} from "../../_lit-template-walker.js";
 
 const IDENTITY: IdentityView = {
   dashboard_id: "7f3c1a9e-2b04-4d6a-9c17-8e5f0a2b3c4d",
@@ -36,52 +41,30 @@ function makeHost(identity: IdentityView | null): ESPHomePairBuildServerDialog {
   } as unknown as ESPHomePairBuildServerDialog;
 }
 
-interface TemplateResultLike {
-  strings: ReadonlyArray<string>;
-  values: ReadonlyArray<unknown>;
-}
-
-function isTemplateResult(v: unknown): v is TemplateResultLike {
-  return !!v && typeof v === "object" && "strings" in v && "values" in v;
-}
-
-// Flatten a (possibly nested) TemplateResult tree into its static markup
-// fragments and its interpolated values so we can assert against both.
-function flatten(node: unknown, markup: string[], values: unknown[]): void {
-  if (isTemplateResult(node)) {
-    markup.push(...node.strings);
-    node.values.forEach((v) => flatten(v, markup, values));
-  } else if (Array.isArray(node)) {
-    node.forEach((v) => flatten(v, markup, values));
-  } else {
-    values.push(node);
-  }
-}
-
-function flattenSentStep(identity: IdentityView | null) {
-  const markup: string[] = [];
-  const values: unknown[] = [];
-  flatten(renderSentStep(makeHost(identity)), markup, values);
-  return { markup: markup.join(""), values };
+/** Every interpolated value across the template tree, in render order. */
+function allValues(root: unknown): unknown[] {
+  const out: unknown[] = [];
+  visitTemplates(root, (t) => out.push(...t.values));
+  return out;
 }
 
 describe("renderSentStep", () => {
   it("renders the identity card once the offloader identity has loaded", () => {
-    const { markup, values } = flattenSentStep(IDENTITY);
+    const tree = renderSentStep(makeHost(IDENTITY));
 
-    expect(markup).toContain("esphome-pin-emoji-grid");
-    expect(markup).toContain("pin-hex");
-    // Dashboard ID and the raw pin are interpolated into the card; the
-    // emoji grid binds the raw pin via ``.pin``.
-    expect(values).toContain(IDENTITY.dashboard_id);
-    expect(values).toContain(IDENTITY.pin_sha256);
+    const grids = findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid");
+    expect(grids).toHaveLength(1);
+    // The emoji grid binds the raw pin via ``.pin``.
+    expect(extractAttributeBindings(grids[0])[".pin"]).toBe(IDENTITY.pin_sha256);
+    // The Dashboard ID is interpolated into the card body.
+    expect(allValues(tree)).toContain(IDENTITY.dashboard_id);
   });
 
-  it("renders no identity card while the identity is still null", () => {
-    const { markup, values } = flattenSentStep(null);
+  it("renders no identity card while the offloader identity is still null", () => {
+    const tree = renderSentStep(makeHost(null));
 
-    expect(values).toContain(nothing);
-    expect(markup).not.toContain("esphome-pin-emoji-grid");
-    expect(values).not.toContain(IDENTITY.dashboard_id);
+    expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(0);
+    expect(allValues(tree)).toContain(nothing);
+    expect(allValues(tree)).not.toContain(IDENTITY.dashboard_id);
   });
 });

--- a/test/components/pair-build-server-dialog/render-sent-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-sent-step.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Targeted tests for ``renderSentStep`` — the offloader "Pair request
+ * sent" step (#1047).
+ *
+ * Pins that the OOB identity card (Dashboard ID + emoji fingerprint +
+ * hex disclosure) renders once this dashboard's ``_offloaderIdentity``
+ * has loaded, and collapses to ``nothing`` while it is still null (the
+ * graceful-degradation path when the identity load is in flight or
+ * failed).
+ *
+ * Runs in vitest's default ``node`` environment, so we inspect the
+ * returned ``TemplateResult`` tree rather than rendering to a DOM
+ * (mirrors ``device/render-nested-list-field.test.ts``).
+ */
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import type { IdentityView } from "../../../src/api/types.js";
+import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import { renderSentStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
+
+const IDENTITY: IdentityView = {
+  dashboard_id: "7f3c1a9e-2b04-4d6a-9c17-8e5f0a2b3c4d",
+  pin_sha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  server_version: "0.1.0",
+  esphome_version: "2025.6.0",
+  listener_bound: true,
+};
+
+function makeHost(identity: IdentityView | null): ESPHomePairBuildServerDialog {
+  return {
+    _localize: (key: string) => key,
+    _hostname: "buildbox.local",
+    _port: "6055",
+    _offloaderIdentity: identity,
+    close: () => {},
+  } as unknown as ESPHomePairBuildServerDialog;
+}
+
+interface TemplateResultLike {
+  strings: ReadonlyArray<string>;
+  values: ReadonlyArray<unknown>;
+}
+
+function isTemplateResult(v: unknown): v is TemplateResultLike {
+  return !!v && typeof v === "object" && "strings" in v && "values" in v;
+}
+
+// Flatten a (possibly nested) TemplateResult tree into its static markup
+// fragments and its interpolated values so we can assert against both.
+function flatten(node: unknown, markup: string[], values: unknown[]): void {
+  if (isTemplateResult(node)) {
+    markup.push(...node.strings);
+    node.values.forEach((v) => flatten(v, markup, values));
+  } else if (Array.isArray(node)) {
+    node.forEach((v) => flatten(v, markup, values));
+  } else {
+    values.push(node);
+  }
+}
+
+function flattenSentStep(identity: IdentityView | null) {
+  const markup: string[] = [];
+  const values: unknown[] = [];
+  flatten(renderSentStep(makeHost(identity)), markup, values);
+  return { markup: markup.join(""), values };
+}
+
+describe("renderSentStep", () => {
+  it("renders the identity card once the offloader identity has loaded", () => {
+    const { markup, values } = flattenSentStep(IDENTITY);
+
+    expect(markup).toContain("esphome-pin-emoji-grid");
+    expect(markup).toContain("pin-hex");
+    // Dashboard ID and the raw pin are interpolated into the card; the
+    // emoji grid binds the raw pin via ``.pin``.
+    expect(values).toContain(IDENTITY.dashboard_id);
+    expect(values).toContain(IDENTITY.pin_sha256);
+  });
+
+  it("renders no identity card while the identity is still null", () => {
+    const { markup, values } = flattenSentStep(null);
+
+    expect(values).toContain(nothing);
+    expect(markup).not.toContain("esphome-pin-emoji-grid");
+    expect(values).not.toContain(IDENTITY.dashboard_id);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Show the OOB fingerprint on the offloader's "Pair request sent" dialog so it can be matched against the receiver's "Pairing request" dialog.

The receiver's dialog already renders the requesting offloader's fingerprint (emoji icon row, Dashboard ID, "Show hex bytes"), but the sender's "Pair request sent" dialog showed only text, so the operator had nothing to compare side by side. The sent step now renders this dashboard's own identity (dashboard_id and pin_sha256 from `remote_build/get_identity`); that is exactly the value the receiver displays for this offloader, so the two screens can sit next to each other and be verified. Note this is the offloader's own identity, not the receiver fingerprint the confirm step shows, so the two dialogs actually match. The emoji row plus hex disclosure was the same markup the confirm step used, so it is factored into a shared helper.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1047

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

