### PR TITLE
Render parse-errored automations read-only

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1019,6 +1019,10 @@ export interface ParsedAutomation {
    *  safety check and as a read-only fallback when the structured
    *  form is unrecoverable. */
   raw_yaml: string;
+  /** Set when this one automation failed to decompose (unknown
+   *  action / condition id). Siblings still parse; the editor renders
+   *  it read-only so its empty tree can't overwrite the real YAML. */
+  error?: string | null;
 }
 
 /** Splice instruction returned by ``automations/upsert`` and

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -44,11 +44,8 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import {
-  applyYamlDiff,
-  emptyAutomationTree,
-  sectionKeyFromLocation,
-} from "./serialise.js";
+import { ParseErrorController } from "./parse-error-controller.js";
+import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -105,6 +102,9 @@ export class ESPHomeApiActionEditor extends LitElement {
   @state() private _loading = true;
   @state() private _deleting = false;
   @state() private _error = "";
+  /** Renders read-only + blocks auto-apply for a parse-errored
+   *  action so its empty tree can't overwrite the real YAML. */
+  private readonly _parseError = new ParseErrorController(this);
 
   /** Debounce + in-flight machinery for the auto-apply path. Same
    *  shape as ``<esphome-script-editor>`` so the page-level save
@@ -204,6 +204,9 @@ export class ESPHomeApiActionEditor extends LitElement {
         <wa-spinner></wa-spinner>
         ${this._localize("device.loading_automation_catalog")}
       </div>`;
+    }
+    if (this._parseError.active) {
+      return this._parseError.renderPanel(this._localize);
     }
     const automation = this.value ?? emptyAutomationTree();
     const devices = this._available?.devices ?? [];
@@ -337,11 +340,10 @@ export class ESPHomeApiActionEditor extends LitElement {
         this.configuration,
         this.yaml
       );
-      const wantKey = sectionKeyFromLocation(this.location);
-      const match = parsed.find((p) => sectionKeyFromLocation(p.location) === wantKey);
-      if (match && match.location.kind === "api_action") {
-        this.value = match.automation;
-        this.location = match.location;
+      const m = this._parseError.resolve(parsed, this.location, "api_action");
+      if (m) {
+        this.location = m.location;
+        this.value = m.tree;
       }
     } catch (err) {
       this._error =
@@ -421,6 +423,7 @@ export class ESPHomeApiActionEditor extends LitElement {
 
   private _scheduleAutoApply() {
     if (this.addMode) return;
+    if (this._parseError.active) return;
     this._setDirty(true);
     if (this._applyTimer) clearTimeout(this._applyTimer);
     this._applyTimer = setTimeout(() => {
@@ -431,6 +434,12 @@ export class ESPHomeApiActionEditor extends LitElement {
 
   private async _autoApply(): Promise<void> {
     if (!this._api || !this.location || !this.value) return;
+    // Read-only: nothing to write, and drop any dirty a pre-error edit
+    // left so the section can't stay stuck dirty with an empty tree.
+    if (this._parseError.active) {
+      this._setDirty(false);
+      return;
+    }
     if (!this.location.action_name) return;
     if (this._applyInFlight) {
       this._applyDirty = true;

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -63,6 +63,7 @@ import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./automation-target-picker.js";
 import "./automation-trigger-picker.js";
 import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
+import { ParseErrorController } from "./parse-error-controller.js";
 import {
   applyYamlDiff,
   emptyAutomationTree,
@@ -144,6 +145,9 @@ export class ESPHomeAutomationEditor extends LitElement {
   @state() private _loading = true;
   @state() private _deleting = false;
   @state() private _error = "";
+  /** Renders read-only + blocks auto-apply for a parse-errored
+   *  automation so its empty tree can't overwrite the real YAML. */
+  private readonly _parseError = new ParseErrorController(this);
 
   /** "Show advanced settings" toggle state for the params form.
    *  Mirrors ``device-section-config``'s same-named state but
@@ -342,14 +346,13 @@ export class ESPHomeAutomationEditor extends LitElement {
         this.configuration,
         this.yaml
       );
-      const wantKey = sectionKeyFromLocation(this.location);
-      const match = parsed.find((p) => sectionKeyFromLocation(p.location) === wantKey);
-      if (match) {
-        this.value = match.automation;
-        // Re-pin location so the writer round-trips with the parser's
-        // canonical form (script id matched, light_effect index
-        // resolved against the actual YAML, …).
-        this.location = match.location;
+      // Re-pin location to the parser's canonical form (script id
+      // matched, light_effect index resolved against the actual YAML);
+      // the controller withholds a read-only automation's empty tree.
+      const m = this._parseError.resolve(parsed, this.location);
+      if (m) {
+        this.location = m.location;
+        this.value = m.tree;
       }
     } catch (err) {
       this._error =
@@ -433,6 +436,9 @@ export class ESPHomeAutomationEditor extends LitElement {
         <wa-spinner></wa-spinner>
         ${this._localize("device.loading_automation_catalog")}
       </div>`;
+    }
+    if (this._parseError.active) {
+      return this._parseError.renderPanel(this._localize);
     }
     const automation = this.value ?? emptyAutomationTree();
     const target = this.location;
@@ -827,6 +833,7 @@ export class ESPHomeAutomationEditor extends LitElement {
     // upserting partially-filled trees if someone instantiates
     // the editor in add-mode directly.
     if (this.addMode) return;
+    if (this._parseError.active) return;
     this._setDirty(true);
     if (this._applyTimer) clearTimeout(this._applyTimer);
     this._applyTimer = setTimeout(() => {
@@ -844,6 +851,12 @@ export class ESPHomeAutomationEditor extends LitElement {
    */
   private async _autoApply(): Promise<void> {
     if (!this._api || !this.location || !this.value) return;
+    // Read-only: nothing to write, and drop any dirty a pre-error edit
+    // left so the section can't stay stuck dirty with an empty tree.
+    if (this._parseError.active) {
+      this._setDirty(false);
+      return;
+    }
     if (this._applyInFlight) {
       this._applyDirty = true;
       return;

--- a/src/components/device/automation-editor/parse-error-controller.ts
+++ b/src/components/device/automation-editor/parse-error-controller.ts
@@ -1,0 +1,85 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { html, nothing } from "lit";
+
+import type {
+  AutomationLocation,
+  AutomationTree,
+  ParsedAutomation,
+} from "../../../api/types.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { sectionKeyFromLocation } from "./serialise.js";
+
+/**
+ * Shared read-only behaviour for the automation / script / api-action
+ * editors.
+ *
+ * When the backend flags one automation with a parse error (unknown
+ * action/condition id) its tree comes back empty; the editor must
+ * render read-only and never upsert, or that empty tree would
+ * overwrite the real YAML block (#1050). Each host:
+ *
+ *   1. Calls ``resolve(parsed, location[, kind])`` in its hydrate path
+ *      and adopts the returned tree (``null`` = leave ``value`` alone).
+ *   2. Early-returns ``renderPanel(localize)`` from ``render`` while
+ *      ``active``.
+ *   3. Bails out of its auto-apply path while ``active``.
+ */
+export class ParseErrorController implements ReactiveController {
+  private _active = false;
+  private _message = "";
+
+  constructor(private readonly _host: ReactiveControllerHost) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {}
+
+  /** True while the current automation is read-only (parse error). */
+  get active(): boolean {
+    return this._active;
+  }
+
+  /**
+   * Match *location* against *parsed*. On a clean match, return the
+   * editable tree plus the parser's resolved location (the editor
+   * re-pins ``this.location`` to it so the writer round-trips against
+   * the canonical form). Returns ``null`` — leave the editor's value
+   * and location alone — when the match is missing or read-only. A
+   * flagged automation (``error`` set, including an empty-string
+   * message) records the read-only state instead. ``kind`` filters the
+   * match for the single-kind editors (script / api).
+   */
+  resolve<L extends AutomationLocation>(
+    parsed: ParsedAutomation[],
+    location: L,
+    kind?: L["kind"]
+  ): { tree: AutomationTree; location: L } | null {
+    const key = sectionKeyFromLocation(location);
+    const match = parsed.find((p) => sectionKeyFromLocation(p.location) === key);
+    if (!match || (kind && match.location.kind !== kind)) {
+      this._set(null);
+      return null;
+    }
+    this._set(match.error ?? null);
+    if (match.error != null) return null;
+    // The section key encodes every location field, so a match shares
+    // the caller's location kind; ``as L`` re-narrows for the writer.
+    return { tree: match.automation, location: match.location as L };
+  }
+
+  /** The read-only panel rendered in place of the editable form. */
+  renderPanel(localize: LocalizeFunc) {
+    return html`<div class="ae-empty-block" role="alert">
+      <p class="ae-error">${localize("device.automation_parse_error")}</p>
+      ${this._message ? html`<p>${this._message}</p>` : nothing}
+    </div>`;
+  }
+
+  private _set(message: string | null): void {
+    const active = message != null;
+    if (this._active === active && this._message === (message ?? "")) return;
+    this._active = active;
+    this._message = message ?? "";
+    this._host.requestUpdate();
+  }
+}

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -53,11 +53,8 @@ import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import {
-  applyYamlDiff,
-  emptyAutomationTree,
-  sectionKeyFromLocation,
-} from "./serialise.js";
+import { ParseErrorController } from "./parse-error-controller.js";
+import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
 /** ``AutomationLocation`` variant for top-level ``script:`` blocks
  *  — pulled out as a separate type because the script editor only
@@ -114,6 +111,9 @@ export class ESPHomeScriptEditor extends LitElement {
   @state() private _loading = true;
   @state() private _deleting = false;
   @state() private _error = "";
+  /** Renders read-only + blocks auto-apply for a parse-errored
+   *  script so its empty tree can't overwrite the real YAML. */
+  private readonly _parseError = new ParseErrorController(this);
 
   /** Component catalog entry for the ``script`` component, lazily
    *  fetched on mount. Drives the header (name / description /
@@ -275,11 +275,10 @@ export class ESPHomeScriptEditor extends LitElement {
         this.configuration,
         this.yaml
       );
-      const wantKey = sectionKeyFromLocation(this.location);
-      const match = parsed.find((p) => sectionKeyFromLocation(p.location) === wantKey);
-      if (match && match.location.kind === "script") {
-        this.value = match.automation;
-        this.location = match.location;
+      const m = this._parseError.resolve(parsed, this.location, "script");
+      if (m) {
+        this.location = m.location;
+        this.value = m.tree;
       }
     } catch (err) {
       this._error =
@@ -309,6 +308,9 @@ export class ESPHomeScriptEditor extends LitElement {
         <wa-spinner></wa-spinner>
         ${this._localize("device.loading_automation_catalog")}
       </div>`;
+    }
+    if (this._parseError.active) {
+      return this._parseError.renderPanel(this._localize);
     }
     const automation = this.value ?? emptyAutomationTree();
     const devices = this._available?.devices ?? [];
@@ -583,6 +585,7 @@ export class ESPHomeScriptEditor extends LitElement {
    */
   private _scheduleAutoApply() {
     if (this.addMode) return;
+    if (this._parseError.active) return;
     this._setDirty(true);
     if (this._applyTimer) clearTimeout(this._applyTimer);
     this._applyTimer = setTimeout(() => {
@@ -593,6 +596,12 @@ export class ESPHomeScriptEditor extends LitElement {
 
   private async _autoApply(): Promise<void> {
     if (!this._api || !this.location || !this.value) return;
+    // Read-only: nothing to write, and drop any dirty a pre-error edit
+    // left so the section can't stay stuck dirty with an empty tree.
+    if (this._parseError.active) {
+      this._setDirty(false);
+      return;
+    }
     if (!this.location.id) return; // can't upsert a script with no id
     if (this._applyInFlight) {
       this._applyDirty = true;

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * When the parsed automation carries an ``error`` (the backend
+ * couldn't decompose it), the editor renders read-only and never
+ * upserts — its empty tree must not overwrite the real YAML (#1050).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-target-picker.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-trigger-picker.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type {
+  AutomationLocation,
+  AvailableAutomations,
+  ParsedAutomation,
+} from "../../../../src/api/types.js";
+import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
+
+const ON_BOOT: AutomationLocation = {
+  kind: "device_on",
+  trigger: "on_boot",
+} as unknown as AutomationLocation;
+
+const erroredParse = (): ParsedAutomation[] => [
+  {
+    location: ON_BOOT,
+    label: "On Boot",
+    automation: { trigger_id: "on_boot", trigger_params: {}, actions: [] },
+    from_line: 1,
+    to_line: 3,
+    raw_yaml: "on_boot:\n  then:\n    - made_up: 1\n",
+    error: "Unknown action id: 'made_up'",
+  } as unknown as ParsedAutomation,
+];
+
+const slimAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+async function flushPending(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+describe("automation-editor uneditable (errored parse)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders read-only and never upserts when the parsed automation has an error", async () => {
+    const upsertAutomation = vi.fn();
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+      parseDeviceAutomations: vi.fn().mockResolvedValue(erroredParse()),
+      upsertAutomation,
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = ON_BOOT;
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushPending();
+
+    // The errored automation is flagged read-only; its empty tree was
+    // not adopted, and the error surfaces in the rendered panel.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any)._parseError.active).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any).value).toBeNull();
+    expect(editor.shadowRoot?.textContent).toContain("made_up");
+    expect(upsertAutomation).not.toHaveBeenCalled();
+  });
+
+  it("_autoApply is a no-op while uneditable even with a value present", async () => {
+    const upsertAutomation = vi.fn();
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+      upsertAutomation,
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = ON_BOOT;
+    // A value is present (the auto-hydrate is skipped while value is
+    // non-null), modelling an editable automation that then turns
+    // read-only.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any).value = { trigger_id: "on_boot", trigger_params: {}, actions: [] };
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+
+    // Turn read-only through the controller's public resolve (an
+    // errored parse), not its private state.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._parseError.resolve(erroredParse(), ON_BOOT);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (editor as any)._autoApply();
+    expect(upsertAutomation).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/automation-editor/parse-error-controller.test.ts
+++ b/test/components/device/automation-editor/parse-error-controller.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for ``ParseErrorController.resolve`` — the classify step
+ * behind the editors' read-only-on-parse-error behaviour (#1050).
+ */
+import type { ReactiveControllerHost } from "lit";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AutomationLocation, ParsedAutomation } from "../../../../src/api/types.js";
+import { ParseErrorController } from "../../../../src/components/device/automation-editor/parse-error-controller.js";
+
+const fakeHost = (): ReactiveControllerHost =>
+  ({
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  }) as unknown as ReactiveControllerHost;
+
+const SCRIPT: AutomationLocation = {
+  kind: "script",
+  id: "s1",
+} as unknown as AutomationLocation;
+
+const parsed = (over: Partial<ParsedAutomation>): ParsedAutomation =>
+  ({
+    location: SCRIPT,
+    label: "Script: s1",
+    automation: { trigger_id: null, trigger_params: {}, actions: [] },
+    from_line: 1,
+    to_line: 2,
+    raw_yaml: "",
+    ...over,
+  }) as ParsedAutomation;
+
+describe("ParseErrorController.resolve", () => {
+  it("returns the editable tree and stays inactive for a clean match", () => {
+    const c = new ParseErrorController(fakeHost());
+    const tree = { trigger_id: null, trigger_params: {}, actions: [] };
+    const m = c.resolve([parsed({ automation: tree })], SCRIPT, "script");
+    expect(m?.tree).toBe(tree);
+    expect(c.active).toBe(false);
+  });
+
+  it("re-pins to the parser's matched location, not the caller's", () => {
+    // The editor adopts ``m.location`` so the writer round-trips
+    // against the parser's canonical form, not the navigator's input.
+    const c = new ParseErrorController(fakeHost());
+    const parserLoc = { kind: "script", id: "s1" } as unknown as AutomationLocation;
+    const m = c.resolve([parsed({ location: parserLoc })], SCRIPT, "script");
+    expect(m?.location).toBe(parserLoc);
+  });
+
+  it("goes read-only and withholds the tree on a parse error", () => {
+    const c = new ParseErrorController(fakeHost());
+    expect(
+      c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script")
+    ).toBeNull();
+    expect(c.active).toBe(true);
+  });
+
+  it("treats an empty-string error as read-only (wire type allows any string)", () => {
+    const c = new ParseErrorController(fakeHost());
+    expect(c.resolve([parsed({ error: "" })], SCRIPT, "script")).toBeNull();
+    expect(c.active).toBe(true);
+  });
+
+  it("returns null and stays inactive when nothing matches", () => {
+    const c = new ParseErrorController(fakeHost());
+    const other = { kind: "script", id: "other" } as unknown as AutomationLocation;
+    expect(c.resolve([parsed({})], other, "script")).toBeNull();
+    expect(c.active).toBe(false);
+  });
+
+  it("rejects a same-key entry of the wrong kind", () => {
+    const c = new ParseErrorController(fakeHost());
+    expect(c.resolve([parsed({})], SCRIPT, "api_action")).toBeNull();
+    expect(c.active).toBe(false);
+  });
+
+  it("clears read-only state when a later resolve matches cleanly", () => {
+    const c = new ParseErrorController(fakeHost());
+    c.resolve([parsed({ error: "boom" })], SCRIPT, "script");
+    expect(c.active).toBe(true);
+    c.resolve([parsed({})], SCRIPT, "script");
+    expect(c.active).toBe(false);
+  });
+
+  it("clears read-only state when a later resolve finds no match", () => {
+    // Navigating from an errored automation to a missing/unparsed one
+    // must not leave the editor latched read-only with a stale error.
+    const c = new ParseErrorController(fakeHost());
+    c.resolve([parsed({ error: "boom" })], SCRIPT, "script");
+    expect(c.active).toBe(true);
+    c.resolve([], SCRIPT, "script");
+    expect(c.active).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Companion to the backend fix esphome/device-builder#1065. The backend now isolates a single un-decodable automation (unknown action or condition id) instead of failing the whole `automations/parse`, returning that one entry with an `error` and an empty tree. This adds the `ParsedAutomation.error` field on the wire type and teaches the three editors (automation, script, api action) to render a flagged automation read only, surfacing the error rather than adopting the empty tree. Auto-apply is blocked while read only, so a parse-errored automation can never overwrite its real YAML block; valid automations are unaffected. A mount test pins the no write guarantee.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1050

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
