### PR TITLE
Bump @rspack/dev-server to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@rspack/core": "2.0.5",
-        "@rspack/dev-server": "2.0.2",
+        "@rspack/dev-server": "2.0.3",
         "@swc/helpers": "0.5.23",
         "@types/node": "25.9.1",
         "@types/w3c-web-serial": "^1.0.8",
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@rspack/dev-server": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.0.2.tgz",
-      "integrity": "sha512-gE1FdeXtTX92t/5TIzOUxKV90UuyNfMT3PlSqrkGz7E0I3SbvnmLB0ewIJUEBA/up22m55rRxEG6jK9yajYCAw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-2.0.3.tgz",
+      "integrity": "sha512-S29nOxXQS9o+0uGNe7SgND2dAKnte5ZTD5tiT3/B4lKbviqpXD4tbH7NZWA3hGwlSkmOIbFlysYPL1bVHuBcSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rspack/core": "2.0.5",
-    "@rspack/dev-server": "2.0.2",
+    "@rspack/dev-server": "2.0.3",
     "@swc/helpers": "0.5.23",
     "@types/node": "25.9.1",
     "@types/w3c-web-serial": "^1.0.8",


### PR DESCRIPTION
## What
Bumps `@rspack/dev-server` from 2.0.2 to 2.0.3.

## Why
The pinned 2.0.2 is a broken npm publish; its tarball ships only LICENSE, package.json, and README, with no `dist` directory. The package's main entry (`dist/index.js`) is therefore missing, so `npm run dev` crashes immediately with `MODULE_NOT_FOUND` for `@rspack/dev-server`. 2.0.3 is the next intact release (45 files), and it pairs with the `@rspack/core` 2.0.5 already in use.

## Testing
Reinstalled, then ran `npm run dev`; the dev server now boots and serves, compiling successfully against Rspack 2.0.5.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`
