### PR TITLE
Round-trip a list entry index on component_on locations

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -958,7 +958,7 @@ export type AutomationCatalogBodyType =
 export type AutomationLocation =
   | { kind: "script"; id: string }
   | { kind: "interval"; index: number }
-  | { kind: "component_on"; component_id: string; trigger: string }
+  | { kind: "component_on"; component_id: string; trigger: string; index?: number }
   | { kind: "device_on"; trigger: string }
   | { kind: "light_effect"; component_id: string; index: number }
   | { kind: "api_action"; action_name: string };

--- a/src/components/device/automation-editor/serialise.ts
+++ b/src/components/device/automation-editor/serialise.ts
@@ -111,7 +111,9 @@ export function sectionKeyFromLocation(loc: AutomationLocation): string {
     case "device_on":
       return `automation:device_on:${loc.trigger}`;
     case "component_on":
-      return `automation:component_on:${loc.component_id}:${loc.trigger}`;
+      return loc.index === undefined
+        ? `automation:component_on:${loc.component_id}:${loc.trigger}`
+        : `automation:component_on:${loc.component_id}:${loc.trigger}:${loc.index}`;
     case "script":
       return `automation:script:${loc.id}`;
     case "interval":
@@ -176,10 +178,23 @@ export function locationFromSectionKey(key: string): AutomationLocation | null {
   switch (parts[1]) {
     case "device_on":
       return parts[2] ? { kind: "device_on", trigger: parts[2] } : null;
-    case "component_on":
-      return parts.length >= 4
-        ? { kind: "component_on", component_id: parts[2], trigger: parts[3] }
-        : null;
+    case "component_on": {
+      if (parts.length < 4) return null;
+      // A 5th part marks one entry of a list-shaped trigger (time.on_time).
+      // The index is a list position, so only a non-negative integer is valid.
+      if (parts.length >= 5) {
+        const idx = Number(parts[4]);
+        return Number.isInteger(idx) && idx >= 0
+          ? {
+              kind: "component_on",
+              component_id: parts[2],
+              trigger: parts[3],
+              index: idx,
+            }
+          : null;
+      }
+      return { kind: "component_on", component_id: parts[2], trigger: parts[3] };
+    }
     case "script":
       return parts[2] ? { kind: "script", id: parts[2] } : null;
     case "interval": {

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -399,17 +399,37 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
         eventKey: eventName,
       });
     } else if (ancestry.componentId) {
-      const labelHead = ancestry.parentName || ancestry.componentId;
-      automations.push({
-        key: `automation:component_on:${ancestry.componentId}:${eventName}`,
-        displayLabel: `${labelHead} → ${eventName}`,
-        fromLine,
-        toLine,
-        id: ancestry.componentId,
+      const componentId = ancestry.componentId;
+      const labelHead = ancestry.parentName || componentId;
+      const base = {
+        id: componentId,
         name: ancestry.parentName ?? undefined,
         parentKey: ancestry.parentKey ?? undefined,
         eventKey: eventName,
-      });
+      };
+      // List-shaped trigger (``time.on_time``): one row per cron entry,
+      // keyed with its index so each matches the backend's per-entry
+      // ``ParsedAutomation`` location. Anything else is one row.
+      const entries = _listTriggerEntries(lines, fromLine, toLine);
+      if (entries) {
+        entries.forEach((entry, idx) => {
+          automations.push({
+            ...base,
+            key: `automation:component_on:${componentId}:${eventName}:${idx}`,
+            displayLabel: `${labelHead} → ${eventName} #${idx + 1}`,
+            fromLine: entry.fromLine,
+            toLine: entry.toLine,
+          });
+        });
+      } else {
+        automations.push({
+          ...base,
+          key: `automation:component_on:${componentId}:${eventName}`,
+          displayLabel: `${labelHead} → ${eventName}`,
+          fromLine,
+          toLine,
+        });
+      }
     } else {
       // No clear ancestry — keep the event as the bare display
       // label and emit a non-namespaced key so it doesn't collide
@@ -641,22 +661,81 @@ function _enumerateListItems(
   return out;
 }
 
+/** Keys that mark a ``time.on_time`` list entry — ``then:`` plus the
+ *  cron fields. Used to tell a list-shaped trigger (split one row per
+ *  entry) from a bare action list (one row for the whole handler). */
+const _TRIGGER_ENTRY_KEYS =
+  "then|seconds|minutes|hours|days_of_week|days_of_month|months|at|cron";
+/** A trigger-entry key at the start of a line; group 1 captures its indent. */
+const _TRIGGER_ENTRY_KEY_RE = new RegExp(`^(\\s*)(?:${_TRIGGER_ENTRY_KEYS})\\s*:`);
+/** The same key sitting inline right after a list dash (``- seconds: 0``). */
+const _DASH_TRIGGER_ENTRY_KEY_RE = new RegExp(
+  `^\\s*-\\s+(?:${_TRIGGER_ENTRY_KEYS})\\s*:`
+);
+
+/**
+ * When an ``on_*:`` body is a YAML list of trigger entries (the
+ * ``time.on_time`` shape — each item carries its own cron params and a
+ * ``then:``), return one ``{fromLine, toLine}`` per entry; otherwise
+ * ``null``. A bare action list (``on_press: - switch.toggle: ...``) or
+ * the single-mapping form returns ``null`` so it stays one automation,
+ * matching the backend's list-form discriminator and its un-indexed
+ * ``component_on`` location.
+ */
+function _listTriggerEntries(
+  lines: string[],
+  keyFromLine: number,
+  blockToLine: number
+): Array<{ fromLine: number; toLine: number }> | null {
+  const items = _enumerateListItems(lines, keyFromLine, blockToLine);
+  if (items.length === 0) return null;
+  return items.every((item) => _isTriggerEntry(lines, item)) ? items : null;
+}
+
+/** True when a list item carries ``then:`` or a cron key at its own
+ *  content indent. Pinning to the item's indent keeps a nested
+ *  ``then:`` under an ``if`` action (a bare action list) from counting. */
+function _isTriggerEntry(
+  lines: string[],
+  item: { fromLine: number; toLine: number }
+): boolean {
+  const dashLine = lines[item.fromLine - 1] ?? "";
+  // The first key can sit inline on the dash: ``- seconds: 0``.
+  if (_DASH_TRIGGER_ENTRY_KEY_RE.test(dashLine)) return true;
+  // Otherwise a sibling key at the item's own content indent (``- `` is a
+  // dash plus one space, so two columns in). A deeper match — a ``then:``
+  // nested under an ``if`` action — is not the entry's own key.
+  const contentIndent = _dashIndent(dashLine) + 2;
+  for (let i = item.fromLine; i < item.toLine && i < lines.length; i++) {
+    const m = lines[i].match(_TRIGGER_ENTRY_KEY_RE);
+    if (m && m[1].length === contentIndent) return true;
+  }
+  return false;
+}
+
+/** Leading-whitespace width of a ``- `` list-item dash on *line*
+ *  (0 when the line isn't a dash item). */
+function _dashIndent(line: string): number {
+  return line.match(/^(\s*)-/)?.[1].length ?? 0;
+}
+
 /** Read a leading ``key: value`` line inside a list item — used to
  *  pull the script's ``id:`` for the stable section key. */
 function _readKeyOnLine(lines: string[], fromLine: number, key: string): string | null {
   const target = lines[fromLine - 1];
-  // The script id can be on the same line as the leading dash:
-  // ``- id: my_alarm`` — or on the next non-empty line.
-  const inlineRe = new RegExp(`^\\s*-\\s*${key}:\\s*["']?([^"'\\s]+)["']?`);
-  const m = target.match(inlineRe);
+  // ``<key>: value`` with the value's quotes peeled — shared between the
+  // dash-line form (``- id: my_alarm``) and the indented sibling form.
+  const value = `${key}:\\s*["']?([^"'\\s]+)["']?`;
+  const m = target.match(new RegExp(`^\\s*-\\s*${value}`));
   if (m) return m[1];
-  const dashIndent = target.match(/^(\s*)-/)?.[1].length ?? 0;
+  const dashIndent = _dashIndent(target);
+  const siblingRe = new RegExp(`^\\s+${value}`);
   for (let i = fromLine; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
     const lineIndent = (line.match(/^(\s*)/) ?? ["", ""])[1].length;
     if (lineIndent <= dashIndent) break;
-    const kv = line.match(new RegExp(`^\\s+${key}:\\s*["']?([^"'\\s]+)["']?`));
+    const kv = line.match(siblingRe);
     if (kv) return kv[1];
   }
   return null;

--- a/test/components/device/automation-editor/section-key.test.ts
+++ b/test/components/device/automation-editor/section-key.test.ts
@@ -23,6 +23,22 @@ describe("sectionKeyFromLocation", () => {
         trigger: "on_press",
       })
     ).toBe("automation:component_on:my_button:on_press");
+    expect(
+      sectionKeyFromLocation({
+        kind: "component_on",
+        component_id: "my_time",
+        trigger: "on_time",
+        index: 0,
+      })
+    ).toBe("automation:component_on:my_time:on_time:0");
+    expect(
+      sectionKeyFromLocation({
+        kind: "component_on",
+        component_id: "my_time",
+        trigger: "on_time",
+        index: 1,
+      })
+    ).toBe("automation:component_on:my_time:on_time:1");
     expect(sectionKeyFromLocation({ kind: "script", id: "my_alarm" })).toBe(
       "automation:script:my_alarm"
     );
@@ -63,11 +79,31 @@ describe("locationFromSectionKey", () => {
     expect(locationFromSectionKey("automation:api_action:")).toBeNull();
   });
 
+  it("rejects a component_on index that is not a non-negative integer", () => {
+    expect(
+      locationFromSectionKey("automation:component_on:my_time:on_time:-1")
+    ).toBeNull();
+    expect(
+      locationFromSectionKey("automation:component_on:my_time:on_time:1.5")
+    ).toBeNull();
+    expect(
+      locationFromSectionKey("automation:component_on:my_time:on_time:x")
+    ).toBeNull();
+  });
+
   const cases: [string, AutomationLocation][] = [
     ["automation:device_on:on_boot", { kind: "device_on", trigger: "on_boot" }],
     [
       "automation:component_on:my_button:on_press",
       { kind: "component_on", component_id: "my_button", trigger: "on_press" },
+    ],
+    [
+      "automation:component_on:my_time:on_time:0",
+      { kind: "component_on", component_id: "my_time", trigger: "on_time", index: 0 },
+    ],
+    [
+      "automation:component_on:my_time:on_time:1",
+      { kind: "component_on", component_id: "my_time", trigger: "on_time", index: 1 },
     ],
     ["automation:script:my_alarm", { kind: "script", id: "my_alarm" }],
     ["automation:interval:2", { kind: "interval", index: 2 }],

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -510,6 +510,64 @@ describe("parseYamlAutomations", () => {
     );
     expect(items.map((s) => s.key)).toEqual(["automation:api_action:legacy_name"]);
   });
+
+  it("splits a list-shaped time.on_time into one indexed row per entry", () => {
+    const yaml = `time:
+  - platform: sntp
+    id: my_time
+    on_time:
+      - seconds: 0
+        minutes: 30
+        hours: 8
+        then:
+          - logger.log: "morning"
+      - cron: "0 0 12 * * *"
+        then:
+          - logger.log: "noon"
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:my_time:")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:my_time:on_time:0",
+      "automation:component_on:my_time:on_time:1",
+    ]);
+    expect(items[0].displayLabel).toBe("my_time → on_time #1");
+    // Each row spans only its own entry, not the whole on_time block.
+    expect(items[0].fromLine).toBe(5); // ``- seconds: 0``
+    expect(items[1].fromLine).toBe(10); // ``- cron: ...``
+  });
+
+  it("keeps a single-mapping on_time as one un-indexed row", () => {
+    const yaml = `time:
+  - platform: sntp
+    id: my_time
+    on_time:
+      seconds: 0
+      then:
+        - logger.log: "tick"
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:my_time:")
+    );
+    expect(items.map((s) => s.key)).toEqual(["automation:component_on:my_time:on_time"]);
+  });
+
+  it("does not split a bare action list into per-action rows", () => {
+    const yaml = `binary_sensor:
+  - platform: gpio
+    id: my_button
+    on_press:
+      - switch.toggle: relay
+      - delay: 1s
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:my_button:")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:my_button:on_press",
+    ]);
+  });
 });
 
 describe("resolveCurrentFromLine", () => {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

`time.on_time` is a list of cron schedules; the backend now returns one `component_on` location per entry, each carrying an optional `index`. This carries that `index` through `AutomationLocation` and the section key round-trip, so multiple `on_time` entries on one component get distinct, stable keys instead of colliding on the same key, and a click decodes back to the right entry. Single handler triggers keep their index-free key, so nothing else changes. The cron fields render from the trigger's existing string `config_entries`, and parse-errored automations already render read only from #453, so no other UI work is needed here.

Pairs with the backend change esphome/device-builder#1076. A follow up can add an "add another schedule" affordance to the add dialog; for now a second entry is authored in the YAML editor and shows up correctly in the visual editor.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1049

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
