### PR TITLE
Add an "All" option to the list view pagination

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -49,8 +49,9 @@ import { tableLayoutStyles } from "./table-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import { ALL_PAGE_SIZE, effectiveTablePageSize } from "./pagination.js";
 import "./table-column-toggle.js";
-import { ALL_PAGE_SIZE } from "./table-pagination.js";
+import "./table-pagination.js";
 import "./table-row-menu.js";
 
 registerMdiIcons({
@@ -79,16 +80,6 @@ const coreRowModel = getCoreRowModel<DeviceRow>();
 const sortedRowModel = getSortedRowModel<DeviceRow>();
 const filteredRowModel = getFilteredRowModel<DeviceRow>();
 const paginatedRowModel = getPaginationRowModel<DeviceRow>();
-
-/**
- * Resolve the page-size sentinel for TanStack. ``ALL_PAGE_SIZE`` feeds
- * the row count (a safe upper bound even with a filter active) so every
- * row lands on page 0; the floor of 1 keeps 0 (Infinite page count /
- * empty slice) from ever reaching TanStack on an empty dataset.
- */
-export function effectiveTablePageSize(pageSize: number, rowCount: number): number {
-  return pageSize === ALL_PAGE_SIZE ? Math.max(rowCount, 1) : pageSize;
-}
 
 // Columns hidden by default unless the user explicitly enables them via preferences.
 const DEFAULT_HIDDEN_COLUMNS: VisibilityState = {

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -34,6 +34,7 @@ import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { repeat } from "lit/directives/repeat.js";
 import type { ConfiguredDevice, FirmwareJob, Label } from "../../api/types.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
@@ -537,7 +538,12 @@ export class ESPHomeDeviceTable extends LitElement {
     return html`
       <tbody>
         ${rows.length > 0
-          ? rows.map(
+          ? repeat(
+              rows,
+              // Key on the device config so Lit reuses each row's DOM
+              // across re-renders (job-progress ticks, selection) instead
+              // of re-diffing every row — matters most with "All" selected.
+              (row) => row.original.config,
               (row) => html`
                 <tr
                   role="row"

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -308,6 +308,12 @@ export class ESPHomeDeviceTable extends LitElement {
   // ─── Render ───
 
   protected render() {
+    // ``_pageSize === 0`` is the "All" sentinel — show every row on one page.
+    // TanStack can't take 0 (pageCount would be Infinity and the slice empty),
+    // so feed it the row count as the effective page size and pin page 0.
+    const effectivePageSize =
+      this._pageSize === 0 ? Math.max(this._rows.length, 1) : this._pageSize;
+    const effectivePageIndex = this._pageSize === 0 ? 0 : this._pageIndex;
     const table = this._tableController.table({
       data: this._rows,
       columns: this._columns,
@@ -315,7 +321,7 @@ export class ESPHomeDeviceTable extends LitElement {
         sorting: this._sorting,
         columnVisibility: this._columnVisibility,
         globalFilter: this.search,
-        pagination: { pageSize: this._pageSize, pageIndex: this._pageIndex },
+        pagination: { pageSize: effectivePageSize, pageIndex: effectivePageIndex },
       },
       onSortingChange: this._handleSortingChange as any,
       onColumnVisibilityChange: this._handleVisibilityChange as any,
@@ -351,7 +357,7 @@ export class ESPHomeDeviceTable extends LitElement {
         <esphome-table-pagination
           page-index=${pgState.pageIndex}
           page-count=${table.getPageCount()}
-          page-size=${pgState.pageSize}
+          page-size=${this._pageSize}
           total-rows=${table.getFilteredRowModel().rows.length}
           ?can-previous-page=${table.getCanPreviousPage()}
           ?can-next-page=${table.getCanNextPage()}
@@ -360,7 +366,19 @@ export class ESPHomeDeviceTable extends LitElement {
             this._scrollToTop();
           }}
           @page-size-change=${(e: CustomEvent<number>) => {
-            table.setPageSize(e.detail);
+            // Set our controlled state directly rather than
+            // ``table.setPageSize`` — the "All" sentinel (0) would make
+            // TanStack's setter divide by zero deriving the page index.
+            // The state we feed on the next render drives the slice.
+            this._pageSize = e.detail;
+            this._pageIndex = 0;
+            this.dispatchEvent(
+              new CustomEvent("table-page-size-change", {
+                detail: e.detail,
+                bubbles: true,
+                composed: true,
+              })
+            );
             this._scrollToTop();
           }}
         ></esphome-table-pagination>

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -50,7 +50,7 @@ import { tableLayoutStyles } from "./table-styles.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "./table-column-toggle.js";
-import "./table-pagination.js";
+import { ALL_PAGE_SIZE } from "./table-pagination.js";
 import "./table-row-menu.js";
 
 registerMdiIcons({
@@ -79,6 +79,16 @@ const coreRowModel = getCoreRowModel<DeviceRow>();
 const sortedRowModel = getSortedRowModel<DeviceRow>();
 const filteredRowModel = getFilteredRowModel<DeviceRow>();
 const paginatedRowModel = getPaginationRowModel<DeviceRow>();
+
+/**
+ * Resolve the page-size sentinel for TanStack. ``ALL_PAGE_SIZE`` feeds
+ * the row count (a safe upper bound even with a filter active) so every
+ * row lands on page 0; the floor of 1 keeps 0 (Infinite page count /
+ * empty slice) from ever reaching TanStack on an empty dataset.
+ */
+export function effectiveTablePageSize(pageSize: number, rowCount: number): number {
+  return pageSize === ALL_PAGE_SIZE ? Math.max(rowCount, 1) : pageSize;
+}
 
 // Columns hidden by default unless the user explicitly enables them via preferences.
 const DEFAULT_HIDDEN_COLUMNS: VisibilityState = {
@@ -309,12 +319,8 @@ export class ESPHomeDeviceTable extends LitElement {
   // ─── Render ───
 
   protected render() {
-    // ``_pageSize === 0`` is the "All" sentinel — show every row on one page.
-    // TanStack can't take 0 (pageCount would be Infinity and the slice empty),
-    // so feed it the row count as the effective page size and pin page 0.
-    const effectivePageSize =
-      this._pageSize === 0 ? Math.max(this._rows.length, 1) : this._pageSize;
-    const effectivePageIndex = this._pageSize === 0 ? 0 : this._pageIndex;
+    const effectivePageSize = effectiveTablePageSize(this._pageSize, this._rows.length);
+    const effectivePageIndex = this._pageSize === ALL_PAGE_SIZE ? 0 : this._pageIndex;
     const table = this._tableController.table({
       data: this._rows,
       columns: this._columns,

--- a/src/components/dashboard/pagination.ts
+++ b/src/components/dashboard/pagination.ts
@@ -1,0 +1,14 @@
+/** Shared page-size sentinel + translation for the device list view. */
+
+/** Page-size value for the "All" (no pagination) choice. */
+export const ALL_PAGE_SIZE = 0;
+
+/**
+ * Resolve the page-size sentinel for TanStack. ``ALL_PAGE_SIZE`` feeds
+ * the row count (a safe upper bound even with a filter active) so every
+ * row lands on page 0; the floor of 1 keeps 0 (Infinite page count /
+ * empty slice) from ever reaching TanStack on an empty dataset.
+ */
+export function effectiveTablePageSize(pageSize: number, rowCount: number): number {
+  return pageSize === ALL_PAGE_SIZE ? Math.max(rowCount, 1) : pageSize;
+}

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -16,6 +16,9 @@ registerMdiIcons({
   "page-last": mdiPageLast,
 });
 
+/** Page-size sentinel for the "All" (no pagination) choice. */
+export const ALL_PAGE_SIZE = 0;
+
 @customElement("esphome-table-pagination")
 export class ESPHomeTablePagination extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -147,15 +150,17 @@ export class ESPHomeTablePagination extends LitElement {
           <div class="page-size">
             <span>${this._localize("dashboard.pagination_rows_per_page")}</span>
             <select @change=${this._onPageSizeChange}>
-              ${[10, 20, 25, 50, 100, 0].map(
+              ${[10, 20, 25, 50, 100, ALL_PAGE_SIZE].map(
                 (size) =>
                   html`<option value=${size} ?selected=${this.pageSize === size}>
-                    ${size === 0 ? this._localize("dashboard.pagination_all") : size}
+                    ${size === ALL_PAGE_SIZE
+                      ? this._localize("dashboard.pagination_all")
+                      : size}
                   </option>`
               )}
             </select>
           </div>
-          ${this.pageSize === 0
+          ${this.pageSize === ALL_PAGE_SIZE
             ? nothing
             : html`
                 <span class="page-info">

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -7,6 +7,8 @@ import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
+import { ALL_PAGE_SIZE } from "./pagination.js";
+
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
@@ -15,9 +17,6 @@ registerMdiIcons({
   "page-first": mdiPageFirst,
   "page-last": mdiPageLast,
 });
-
-/** Page-size sentinel for the "All" (no pagination) choice. */
-export const ALL_PAGE_SIZE = 0;
 
 @customElement("esphome-table-pagination")
 export class ESPHomeTablePagination extends LitElement {

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { mdiChevronLeft, mdiChevronRight, mdiPageFirst, mdiPageLast } from "@mdi/js";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
@@ -147,54 +147,58 @@ export class ESPHomeTablePagination extends LitElement {
           <div class="page-size">
             <span>${this._localize("dashboard.pagination_rows_per_page")}</span>
             <select @change=${this._onPageSizeChange}>
-              ${[10, 20, 25, 50, 100].map(
+              ${[10, 20, 25, 50, 100, 0].map(
                 (size) =>
                   html`<option value=${size} ?selected=${this.pageSize === size}>
-                    ${size}
+                    ${size === 0 ? this._localize("dashboard.pagination_all") : size}
                   </option>`
               )}
             </select>
           </div>
-          <span class="page-info">
-            ${this._localize("dashboard.pagination_page_of", {
-              current: this.pageIndex + 1,
-              total: this.pageCount || 1,
-            })}
-          </span>
-          <div class="buttons">
-            <button
-              class="page-btn"
-              ?disabled=${!this.canPreviousPage}
-              @click=${() => this._emitPageChange(0)}
-              title=${this._localize("dashboard.pagination_first_page")}
-            >
-              <wa-icon library="mdi" name="page-first"></wa-icon>
-            </button>
-            <button
-              class="page-btn"
-              ?disabled=${!this.canPreviousPage}
-              @click=${() => this._emitPageChange(this.pageIndex - 1)}
-              title=${this._localize("dashboard.pagination_previous_page")}
-            >
-              <wa-icon library="mdi" name="chevron-left"></wa-icon>
-            </button>
-            <button
-              class="page-btn"
-              ?disabled=${!this.canNextPage}
-              @click=${() => this._emitPageChange(this.pageIndex + 1)}
-              title=${this._localize("dashboard.pagination_next_page")}
-            >
-              <wa-icon library="mdi" name="chevron-right"></wa-icon>
-            </button>
-            <button
-              class="page-btn"
-              ?disabled=${!this.canNextPage}
-              @click=${() => this._emitPageChange(this.pageCount - 1)}
-              title=${this._localize("dashboard.pagination_last_page")}
-            >
-              <wa-icon library="mdi" name="page-last"></wa-icon>
-            </button>
-          </div>
+          ${this.pageSize === 0
+            ? nothing
+            : html`
+                <span class="page-info">
+                  ${this._localize("dashboard.pagination_page_of", {
+                    current: this.pageIndex + 1,
+                    total: this.pageCount || 1,
+                  })}
+                </span>
+                <div class="buttons">
+                  <button
+                    class="page-btn"
+                    ?disabled=${!this.canPreviousPage}
+                    @click=${() => this._emitPageChange(0)}
+                    title=${this._localize("dashboard.pagination_first_page")}
+                  >
+                    <wa-icon library="mdi" name="page-first"></wa-icon>
+                  </button>
+                  <button
+                    class="page-btn"
+                    ?disabled=${!this.canPreviousPage}
+                    @click=${() => this._emitPageChange(this.pageIndex - 1)}
+                    title=${this._localize("dashboard.pagination_previous_page")}
+                  >
+                    <wa-icon library="mdi" name="chevron-left"></wa-icon>
+                  </button>
+                  <button
+                    class="page-btn"
+                    ?disabled=${!this.canNextPage}
+                    @click=${() => this._emitPageChange(this.pageIndex + 1)}
+                    title=${this._localize("dashboard.pagination_next_page")}
+                  >
+                    <wa-icon library="mdi" name="chevron-right"></wa-icon>
+                  </button>
+                  <button
+                    class="page-btn"
+                    ?disabled=${!this.canNextPage}
+                    @click=${() => this._emitPageChange(this.pageCount - 1)}
+                    title=${this._localize("dashboard.pagination_last_page")}
+                  >
+                    <wa-icon library="mdi" name="page-last"></wa-icon>
+                  </button>
+                </div>
+              `}
         </div>
       </div>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -223,6 +223,7 @@
     "table_no_results": "No results found.",
     "pagination_total": "{count} row(s) total",
     "pagination_rows_per_page": "Rows per page",
+    "pagination_all": "All",
     "pagination_page_of": "Page {current} of {total}",
     "pagination_first_page": "First page",
     "pagination_previous_page": "Previous page",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -134,6 +134,7 @@
     "table_no_results": "Aucun résultat trouvé.",
     "pagination_total": "{count} ligne(s) au total",
     "pagination_rows_per_page": "Lignes par page",
+    "pagination_all": "Tout",
     "pagination_page_of": "Page {current} sur {total}",
     "pagination_first_page": "Première page",
     "pagination_previous_page": "Page précédente",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -223,6 +223,7 @@
     "table_no_results": "Nem található eredmény.",
     "pagination_total": "{count} sor összesen",
     "pagination_rows_per_page": "Sorok oldalanként",
+    "pagination_all": "Összes",
     "pagination_page_of": "{current}. oldal / {total}",
     "pagination_first_page": "Első oldal",
     "pagination_previous_page": "Előző oldal",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -134,6 +134,7 @@
     "table_no_results": "Geen resultaten gevonden.",
     "pagination_total": "{count} rij(en) totaal",
     "pagination_rows_per_page": "Rijen per pagina",
+    "pagination_all": "Alle",
     "pagination_page_of": "Pagina {current} van {total}",
     "pagination_first_page": "Eerste pagina",
     "pagination_previous_page": "Vorige pagina",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -223,6 +223,7 @@
     "table_no_results": "未找到结果。",
     "pagination_total": "共 {count} 行",
     "pagination_rows_per_page": "每页行数",
+    "pagination_all": "全部",
     "pagination_page_of": "第 {current} 页，共 {total} 页",
     "pagination_first_page": "第一页",
     "pagination_previous_page": "上一页",

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -13,11 +13,11 @@ vi.mock("../../../src/components/dashboard/table-column-toggle.js", () => ({}));
 vi.mock("../../../src/components/dashboard/table-row-menu.js", () => ({}));
 
 import type { ConfiguredDevice } from "../../../src/api/types.js";
+import { ESPHomeDeviceTable } from "../../../src/components/dashboard/device-table.js";
 import {
-  ESPHomeDeviceTable,
+  ALL_PAGE_SIZE,
   effectiveTablePageSize,
-} from "../../../src/components/dashboard/device-table.js";
-import { ALL_PAGE_SIZE } from "../../../src/components/dashboard/table-pagination.js";
+} from "../../../src/components/dashboard/pagination.js";
 
 describe("effectiveTablePageSize", () => {
   it("passes a normal page size through unchanged", () => {

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "All" page size (sentinel 0): the translation feeds TanStack a
+ * real row-count size (floored at 1), and the mounted table renders
+ * every row on one page while a normal size paginates (discussion #3682).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../../src/components/dashboard/table-column-toggle.js", () => ({}));
+vi.mock("../../../src/components/dashboard/table-row-menu.js", () => ({}));
+
+import type { ConfiguredDevice } from "../../../src/api/types.js";
+import {
+  ESPHomeDeviceTable,
+  effectiveTablePageSize,
+} from "../../../src/components/dashboard/device-table.js";
+import { ALL_PAGE_SIZE } from "../../../src/components/dashboard/table-pagination.js";
+
+describe("effectiveTablePageSize", () => {
+  it("passes a normal page size through unchanged", () => {
+    expect(effectiveTablePageSize(25, 100)).toBe(25);
+  });
+
+  it("expands the All sentinel to the row count (fits every row on page 0)", () => {
+    expect(effectiveTablePageSize(ALL_PAGE_SIZE, 30)).toBe(30);
+  });
+
+  it("floors at 1 so 0 never reaches TanStack on an empty dataset", () => {
+    expect(effectiveTablePageSize(ALL_PAGE_SIZE, 0)).toBe(1);
+  });
+});
+
+function makeDevices(n: number): ConfiguredDevice[] {
+  return Array.from({ length: n }, (_, i) => ({
+    name: `demo-${i}`,
+    friendly_name: `Demo ${i}`,
+    configuration: `demo-${i}.yaml`,
+    state: "ONLINE",
+    address: `demo-${i}.local`,
+    ip: "",
+    ip_addresses: [],
+    mac_address: "",
+    target_platform: "ESP32",
+    deployed_version: "",
+    build_size_bytes: 0,
+    comment: "",
+    area: "",
+    labels: [],
+    has_pending_changes: false,
+    update_available: false,
+    api_enabled: true,
+    api_encrypted: false,
+    api_encryption_active: null,
+  })) as unknown as ConfiguredDevice[];
+}
+
+async function mount(
+  count: number,
+  initialPageSize: number
+): Promise<ESPHomeDeviceTable> {
+  const el = new ESPHomeDeviceTable();
+  el.devices = makeDevices(count);
+  el.initialPageSize = initialPageSize;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await el.updateComplete;
+  return el;
+}
+
+const rowCount = (el: ESPHomeDeviceTable) =>
+  el.shadowRoot!.querySelectorAll("tbody tr[data-configuration]").length;
+const pageSizeAttr = (el: ESPHomeDeviceTable) =>
+  el.shadowRoot!.querySelector("esphome-table-pagination")?.getAttribute("page-size");
+
+describe("device-table All rendering", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("paginates at a normal page size (25 of 30 rows)", async () => {
+    const el = await mount(30, 25);
+    expect(rowCount(el)).toBe(25);
+    expect(pageSizeAttr(el)).toBe("25");
+  });
+
+  it("renders every row on one page when All is selected", async () => {
+    const el = await mount(30, ALL_PAGE_SIZE);
+    expect(rowCount(el)).toBe(30);
+    expect(pageSizeAttr(el)).toBe("0");
+  });
+});

--- a/test/components/dashboard/table-pagination.test.ts
+++ b/test/components/dashboard/table-pagination.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The list view's "All" page-size option: it offers value 0, reports 0
+ * on change, and hides the page navigation while active (discussion #3682).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeTablePagination } from "../../../src/components/dashboard/table-pagination.js";
+
+async function mount(
+  props: Partial<ESPHomeTablePagination> = {}
+): Promise<ESPHomeTablePagination> {
+  const el = new ESPHomeTablePagination();
+  // No context provider in the test tree; map only the new key so the
+  // "All" label is meaningful and other keys stay identity.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._localize = (k: string) => (k === "dashboard.pagination_all" ? "All" : k);
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("table-pagination All option", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("offers an 'All' option (value 0) in the page-size selector", async () => {
+    const el = await mount({ pageSize: 25 });
+    const all = [...el.shadowRoot!.querySelectorAll("option")].find(
+      (o) => o.value === "0"
+    );
+    expect(all).toBeTruthy();
+    expect(all!.textContent?.trim()).toBe("All");
+  });
+
+  it("reports 0 on page-size-change when 'All' is selected", async () => {
+    const el = await mount({ pageSize: 25 });
+    const onChange = vi.fn();
+    el.addEventListener("page-size-change", (e) =>
+      onChange((e as CustomEvent<number>).detail)
+    );
+    const select = el.shadowRoot!.querySelector("select")!;
+    select.value = "0";
+    select.dispatchEvent(new Event("change"));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it("hides the page navigation while 'All' is active", async () => {
+    const el = await mount({ pageSize: 0 });
+    expect(el.shadowRoot!.querySelector(".buttons")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".page-info")).toBeNull();
+    // The rows-per-page selector and total-count stay.
+    expect(el.shadowRoot!.querySelector("select")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".info")).not.toBeNull();
+  });
+
+  it("shows the page navigation for a normal page size", async () => {
+    const el = await mount({ pageSize: 25, pageCount: 3, canNextPage: true });
+    expect(el.shadowRoot!.querySelector(".buttons")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".page-info")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds an "All" choice to the table list view's rows-per-page selector, so the device list can show every device on one page; the default stays 25, this is purely an added option. "All" is the sentinel page size 0, which persists like any other choice through the existing table_page_size preference. The table can't hand TanStack a page size of 0 (the page count would be infinite and the slice empty), so it translates 0 into an effective page size of the row count at the boundary and hides the page navigation while "All" is active. Adds the pagination_all key to every locale. No backend change; table_page_size already accepts any integer.

### Note on large fleets

"All" renders every row to the DOM; there is no virtualization. That's the explicit, opt-in request, the default stays 25, and rows are rendered with a keyed `repeat` so re-renders reuse row DOM. Windowing for very large fleets is a deliberate, separate follow-up.

**Related issue or feature (if applicable):**

- implements https://github.com/orgs/esphome/discussions/3682

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

