### PR TITLE
Download firmware artifacts over HTTP with a capability token

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -104,10 +104,7 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
     new rspack.HtmlRspackPlugin({
       templateContent: fs
         .readFileSync(path.resolve(PUBLIC_DIR, "index.html"), "utf-8")
-        .replace(
-          /__ESPHOME_BASE_HREF__/g,
-          isProdBuild ? "__ESPHOME_BASE_HREF__" : "/",
-        ),
+        .replace(/__ESPHOME_BASE_HREF__/g, isProdBuild ? "__ESPHOME_BASE_HREF__" : "/"),
       inject: "body",
     }),
     new rspack.CopyRspackPlugin({
@@ -200,6 +197,13 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
       {
         // Backend-served static files (board images, etc.)
         context: ["/boards"],
+        target: "http://localhost:6052",
+        changeOrigin: true,
+      },
+      {
+        // REST endpoints, incl. the firmware artifact download
+        // (GET /api/firmware/download — too large for the WS).
+        context: ["/api"],
         target: "http://localhost:6052",
         changeOrigin: true,
       },

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1212,12 +1212,14 @@ export class ESPHomeAPI {
   }
 
   /** Mint a single-use token authorizing the HTTP download of one artifact. */
-  async firmwareDownloadToken(configuration: string, file: string): Promise<string> {
-    const result = await this.sendCommand<{ token: string }>("firmware/download_token", {
-      configuration,
-      file,
-    });
-    return result.token;
+  async firmwareDownloadToken(
+    configuration: string,
+    file: string
+  ): Promise<{ token: string; filename: string }> {
+    return this.sendCommand<{ token: string; filename: string }>(
+      "firmware/download_token",
+      { configuration, file }
+    );
   }
 
   /**
@@ -1227,14 +1229,21 @@ export class ESPHomeAPI {
    * the file straight to disk — no in-memory buffering, works on mobile. The
    * token is the route's auth, so the URL needs no ``Authorization`` header.
    */
-  async firmwareDownloadUrl(configuration: string, file: string): Promise<string> {
-    const token = await this.firmwareDownloadToken(configuration, file);
-    return `${BASE_PATH}api/firmware/download?token=${encodeURIComponent(token)}`;
+  async firmwareDownloadUrl(
+    configuration: string,
+    file: string
+  ): Promise<{ url: string; filename: string }> {
+    const { token, filename } = await this.firmwareDownloadToken(configuration, file);
+    return {
+      url: `${BASE_PATH}api/firmware/download?token=${encodeURIComponent(token)}`,
+      filename,
+    };
   }
 
   /** Fetch an artifact's bytes (for in-browser Web Serial flashing). */
   async firmwareDownloadBytes(configuration: string, file: string): Promise<ArrayBuffer> {
-    const response = await fetch(await this.firmwareDownloadUrl(configuration, file));
+    const { url } = await this.firmwareDownloadUrl(configuration, file);
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Firmware download failed: ${response.status}`);
     }

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1211,16 +1211,6 @@ export class ESPHomeAPI {
     return this.sendCommand<FirmwareBinary[]>("firmware/get_binaries", { configuration });
   }
 
-  /** Download a compiled firmware binary as base64. */
-  /**
-   * Fetch a build artifact over HTTP (not the WS) for saving to disk.
-   *
-   * The WS ``firmware/download`` returns the whole file as one base64
-   * message; a ~14 MB ``firmware.elf`` exceeds a proxy's WebSocket
-   * ``max_msg_size`` and is dropped. This streams it over HTTP instead
-   * (same-origin, base-path aware), authenticating with the same bearer
-   * token the WS uses. Returns the blob plus the server-suggested filename.
-   */
   /** Mint a single-use token authorizing the HTTP download of one artifact. */
   async firmwareDownloadToken(configuration: string, file: string): Promise<string> {
     const result = await this.sendCommand<{ token: string }>("firmware/download_token", {

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -45,7 +45,6 @@ import type {
 } from "./types/event-subscription.js";
 import type {
   FirmwareBinary,
-  FirmwareDownload,
   FirmwareJob,
   RemoteBuildSubmitTarget,
 } from "./types/firmware-jobs.js";
@@ -1213,16 +1212,43 @@ export class ESPHomeAPI {
   }
 
   /** Download a compiled firmware binary as base64. */
-  async firmwareDownload(
-    configuration: string,
-    file: string,
-    compressed = false
-  ): Promise<FirmwareDownload> {
-    return this.sendCommand<FirmwareDownload>("firmware/download", {
+  /**
+   * Fetch a build artifact over HTTP (not the WS) for saving to disk.
+   *
+   * The WS ``firmware/download`` returns the whole file as one base64
+   * message; a ~14 MB ``firmware.elf`` exceeds a proxy's WebSocket
+   * ``max_msg_size`` and is dropped. This streams it over HTTP instead
+   * (same-origin, base-path aware), authenticating with the same bearer
+   * token the WS uses. Returns the blob plus the server-suggested filename.
+   */
+  /** Mint a single-use token authorizing the HTTP download of one artifact. */
+  async firmwareDownloadToken(configuration: string, file: string): Promise<string> {
+    const result = await this.sendCommand<{ token: string }>("firmware/download_token", {
       configuration,
       file,
-      compressed,
     });
+    return result.token;
+  }
+
+  /**
+   * Build the HTTP download URL for an artifact (mints a token first).
+   *
+   * Save-to-disk callers point an ``<a href>`` at this so the browser streams
+   * the file straight to disk — no in-memory buffering, works on mobile. The
+   * token is the route's auth, so the URL needs no ``Authorization`` header.
+   */
+  async firmwareDownloadUrl(configuration: string, file: string): Promise<string> {
+    const token = await this.firmwareDownloadToken(configuration, file);
+    return `${BASE_PATH}api/firmware/download?token=${encodeURIComponent(token)}`;
+  }
+
+  /** Fetch an artifact's bytes (for in-browser Web Serial flashing). */
+  async firmwareDownloadBytes(configuration: string, file: string): Promise<ArrayBuffer> {
+    const response = await fetch(await this.firmwareDownloadUrl(configuration, file));
+    if (!response.ok) {
+      throw new Error(`Firmware download failed: ${response.status}`);
+    }
+    return response.arrayBuffer();
   }
 
   // ─── Board Commands ───────────────────────────────────────

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -301,9 +301,12 @@ export async function downloadSelectedBinary(
   // footer must not offer Stop (see renderFooter).
   host._step = "downloading";
   try {
-    const url = await host._api.firmwareDownloadUrl(device.configuration, file);
-    triggerDownload(url, file);
-    host._downloadedFilename = file;
+    const { url, filename } = await host._api.firmwareDownloadUrl(
+      device.configuration,
+      file
+    );
+    triggerDownload(url, filename);
+    host._downloadedFilename = filename;
   } catch {
     host._fail(host._localize("firmware.download_failed"));
     return;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -1,6 +1,6 @@
 import { JobStatus, type FirmwareBinary } from "../../api/types/firmware-jobs.js";
 import { chipNameToVariant } from "../../util/chip-variant.js";
-import { downloadBase64Binary } from "../../util/download-text.js";
+import { triggerDownload } from "../../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import {
   connectToPort,
@@ -113,8 +113,9 @@ export async function startWebSerialInstall(
       return;
     }
     if (factory) flashAddress = 0x0;
-    const result = await host._api.firmwareDownload(device.configuration, binary.file);
-    firmwareBytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
+    firmwareBytes = new Uint8Array(
+      await host._api.firmwareDownloadBytes(device.configuration, binary.file)
+    );
   } catch {
     host._fail(host._localize("firmware.download_failed"));
     return;
@@ -300,9 +301,9 @@ export async function downloadSelectedBinary(
   // footer must not offer Stop (see renderFooter).
   host._step = "downloading";
   try {
-    const result = await host._api.firmwareDownload(device.configuration, file);
-    downloadBase64Binary(result.data, result.filename);
-    host._downloadedFilename = result.filename;
+    const url = await host._api.firmwareDownloadUrl(device.configuration, file);
+    triggerDownload(url, file);
+    host._downloadedFilename = file;
   } catch {
     host._fail(host._localize("firmware.download_failed"));
     return;

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -21,9 +21,9 @@ import { stripAnsi } from "./strip-ansi.js";
  *   reads. Holding the URL around would leak the underlying
  *   ``Blob`` for the page's lifetime.
  *
- * Private helper — call sites use the typed wrappers below
- * (:func:`downloadAnsiText`, :func:`downloadBase64Binary`)
- * rather than touching this directly.
+ * Private helper — call sites use :func:`downloadAnsiText` rather than
+ * touching this directly. (Binary artifacts download natively via
+ * :func:`triggerDownload`, which streams from a URL and skips this.)
  */
 function _downloadBlob(bytes: BlobPart, filename: string, mimeType: string): void {
   const blob = new Blob([bytes], { type: mimeType });
@@ -36,27 +36,19 @@ function _downloadBlob(bytes: BlobPart, filename: string, mimeType: string): voi
 }
 
 /**
- * Save a base64-encoded binary payload to the user's disk.
+ * Trigger a native browser download of a (same-origin) URL.
  *
- * Used by every install-related save path that hands the user
- * a firmware binary to flash with their own tooling:
- *
- * - :class:`ESPHomeFirmwareInstallDialog`'s manual-download
- *   install flow (post-compile save of the local-build output);
- * - :class:`ESPHomeDashboard`'s per-device "Download firmware"
- *   button on configured-device rows.
- *
- * ``b64`` is standard (not URL-safe) base64 — decoded via
- * ``atob`` + ``Uint8Array.from`` in one pass. Saves as
- * ``application/octet-stream`` so browsers don't sniff the
- * bytes as an executable / text / image. ``filename`` is
- * offered to the save dialog as-is; callers own extension
- * shaping (``.bin`` for firmware images, ``.uf2`` for
- * mass-storage flashes, etc.).
+ * Unlike the blob helpers this doesn't buffer the file in memory — the browser
+ * streams the response straight to disk, so it scales to large artifacts (the
+ * ~14 MB firmware.elf) and works on mobile where programmatic blob downloads
+ * are unreliable. The server's ``Content-Disposition`` names the saved file;
+ * ``filename`` is only a same-origin hint.
  */
-export function downloadBase64Binary(b64: string, filename: string): void {
-  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
-  _downloadBlob(bytes, filename, "application/octet-stream");
+export function triggerDownload(url: string, filename: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
 }
 
 /**

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1886,3 +1886,71 @@ describe("ESPHomeAPI — setDeviceLabelsBulk", () => {
     ]);
   });
 });
+
+describe("ESPHomeAPI — firmware download (HTTP)", () => {
+  afterEach(() => {
+    uninstallMockWebSocket();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("mints a download token over the WebSocket", async () => {
+    installMockWebSocket();
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const pending = api.firmwareDownloadToken("kitchen.yaml", "firmware.elf");
+    const sent = ws.sentAs<{ command: string; message_id: string; args: unknown }>(0);
+    expect(sent.command).toBe("firmware/download_token");
+    expect(sent.args).toEqual({ configuration: "kitchen.yaml", file: "firmware.elf" });
+    ws.receive({ message_id: sent.message_id, result: { token: "tok-123" } });
+
+    await expect(pending).resolves.toBe("tok-123");
+  });
+
+  it("builds a base-path-aware, token-encoded download URL", async () => {
+    const api = new ESPHomeAPI();
+    vi.spyOn(api, "firmwareDownloadToken").mockResolvedValue("a b/c+d");
+
+    const url = await api.firmwareDownloadUrl("kitchen.yaml", "firmware.elf");
+
+    expect(api.firmwareDownloadToken).toHaveBeenCalledWith(
+      "kitchen.yaml",
+      "firmware.elf"
+    );
+    expect(url).toBe("/api/firmware/download?token=a%20b%2Fc%2Bd");
+  });
+
+  it("fetches the bytes for Web Serial flashing", async () => {
+    const api = new ESPHomeAPI();
+    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue(
+      "/api/firmware/download?token=t"
+    );
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    const fetchFn = vi.fn(async () => ({ ok: true, arrayBuffer: async () => bytes }));
+    vi.stubGlobal("fetch", fetchFn);
+
+    const result = await api.firmwareDownloadBytes(
+      "kitchen.yaml",
+      "firmware.factory.bin"
+    );
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/firmware/download?token=t");
+    expect(result).toBe(bytes);
+  });
+
+  it("throws when the byte fetch responds non-ok", async () => {
+    const api = new ESPHomeAPI();
+    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue(
+      "/api/firmware/download?token=t"
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404 }))
+    );
+
+    await expect(
+      api.firmwareDownloadBytes("kitchen.yaml", "missing.bin")
+    ).rejects.toThrow(/404/);
+  });
+});

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -1903,29 +1903,42 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
     const sent = ws.sentAs<{ command: string; message_id: string; args: unknown }>(0);
     expect(sent.command).toBe("firmware/download_token");
     expect(sent.args).toEqual({ configuration: "kitchen.yaml", file: "firmware.elf" });
-    ws.receive({ message_id: sent.message_id, result: { token: "tok-123" } });
+    ws.receive({
+      message_id: sent.message_id,
+      result: { token: "tok-123", filename: "kitchen-firmware.elf" },
+    });
 
-    await expect(pending).resolves.toBe("tok-123");
+    await expect(pending).resolves.toEqual({
+      token: "tok-123",
+      filename: "kitchen-firmware.elf",
+    });
   });
 
-  it("builds a base-path-aware, token-encoded download URL", async () => {
+  it("builds a base-path-aware, token-encoded URL and passes the filename through", async () => {
     const api = new ESPHomeAPI();
-    vi.spyOn(api, "firmwareDownloadToken").mockResolvedValue("a b/c+d");
+    vi.spyOn(api, "firmwareDownloadToken").mockResolvedValue({
+      token: "a b/c+d",
+      filename: "kitchen-firmware.elf",
+    });
 
-    const url = await api.firmwareDownloadUrl("kitchen.yaml", "firmware.elf");
+    const result = await api.firmwareDownloadUrl("kitchen.yaml", "firmware.elf");
 
     expect(api.firmwareDownloadToken).toHaveBeenCalledWith(
       "kitchen.yaml",
       "firmware.elf"
     );
-    expect(url).toBe("/api/firmware/download?token=a%20b%2Fc%2Bd");
+    expect(result).toEqual({
+      url: "/api/firmware/download?token=a%20b%2Fc%2Bd",
+      filename: "kitchen-firmware.elf",
+    });
   });
 
   it("fetches the bytes for Web Serial flashing", async () => {
     const api = new ESPHomeAPI();
-    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue(
-      "/api/firmware/download?token=t"
-    );
+    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue({
+      url: "/api/firmware/download?token=t",
+      filename: "kitchen-firmware.factory.bin",
+    });
     const bytes = new Uint8Array([1, 2, 3]).buffer;
     const fetchFn = vi.fn(async () => ({ ok: true, arrayBuffer: async () => bytes }));
     vi.stubGlobal("fetch", fetchFn);
@@ -1941,9 +1954,10 @@ describe("ESPHomeAPI — firmware download (HTTP)", () => {
 
   it("throws when the byte fetch responds non-ok", async () => {
     const api = new ESPHomeAPI();
-    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue(
-      "/api/firmware/download?token=t"
-    );
+    vi.spyOn(api, "firmwareDownloadUrl").mockResolvedValue({
+      url: "/api/firmware/download?token=t",
+      filename: "kitchen-missing.bin",
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({ ok: false, status: 404 }))

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -52,7 +52,10 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
       return "s1";
     }),
     firmwareGetBinaries,
-    firmwareDownloadUrl: vi.fn().mockResolvedValue("/api/firmware/download?token=tok"),
+    firmwareDownloadUrl: vi.fn().mockResolvedValue({
+      url: "/api/firmware/download?token=tok",
+      filename: "device-firmware.elf",
+    }),
   };
   const host = {
     _device: { configuration: "device.yaml" },
@@ -123,9 +126,10 @@ describe("download flow (startArtifactDownload)", () => {
       "firmware.elf"
     );
     expect(api.firmwareDownloadUrl).toHaveBeenCalledWith("device.yaml", "firmware.elf");
+    // Saved under the server-chosen filename (from firmware/download_token).
     expect(triggerDownload).toHaveBeenCalledWith(
       "/api/firmware/download?token=tok",
-      "firmware.elf"
+      "device-firmware.elf"
     );
     expect(host._step).toBe("download-ready");
   });

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -7,8 +7,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { downloadBase64Binary } = vi.hoisted(() => ({ downloadBase64Binary: vi.fn() }));
-vi.mock("../../src/util/download-text.js", () => ({ downloadBase64Binary }));
+const { triggerDownload } = vi.hoisted(() => ({ triggerDownload: vi.fn() }));
+vi.mock("../../src/util/download-text.js", () => ({ triggerDownload }));
 vi.mock("../../src/util/web-serial.js", () => ({
   connectToPort: vi.fn(),
   detectChip: vi.fn(),
@@ -52,12 +52,7 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
       return "s1";
     }),
     firmwareGetBinaries,
-    firmwareDownload: vi.fn().mockResolvedValue({
-      filename: "device-firmware.elf",
-      data: "RUxG",
-      size: 3,
-      compressed: false,
-    }),
+    firmwareDownloadUrl: vi.fn().mockResolvedValue("/api/firmware/download?token=tok"),
   };
   const host = {
     _device: { configuration: "device.yaml" },
@@ -96,14 +91,14 @@ describe("download flow (startArtifactDownload)", () => {
     expect(api.firmwareCompile).not.toHaveBeenCalled();
     expect(host._step).toBe("choose-binary");
     expect(host._binaries).toEqual([FACTORY, OTA, ELF]);
-    expect(api.firmwareDownload).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
   });
 
   it("downloads directly without compiling when one artefact exists", async () => {
     const { host, api } = makeHost([[FACTORY]]);
     await run(host);
     expect(api.firmwareCompile).not.toHaveBeenCalled();
-    expect(api.firmwareDownload).toHaveBeenCalledWith(
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
       "device.yaml",
       "firmware.factory.bin"
     );
@@ -127,8 +122,11 @@ describe("download flow (startArtifactDownload)", () => {
       host as unknown as ESPHomeFirmwareInstallDialog,
       "firmware.elf"
     );
-    expect(api.firmwareDownload).toHaveBeenCalledWith("device.yaml", "firmware.elf");
-    expect(downloadBase64Binary).toHaveBeenCalledWith("RUxG", "device-firmware.elf");
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith("device.yaml", "firmware.elf");
+    expect(triggerDownload).toHaveBeenCalledWith(
+      "/api/firmware/download?token=tok",
+      "firmware.elf"
+    );
     expect(host._step).toBe("download-ready");
   });
 
@@ -137,6 +135,6 @@ describe("download flow (startArtifactDownload)", () => {
     await run(host);
     expect(api.firmwareCompile).toHaveBeenCalledTimes(1);
     expect(host._step).toBe("error");
-    expect(api.firmwareDownload).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
   });
 });

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -4,11 +4,15 @@
  * route to the choose-binary picker (so the OTA image is reachable)
  * instead of silently auto-downloading the factory image; web-flasher
  * paths still auto-select the self-contained factory image.
+ *
+ * Downloads go over HTTP: api.firmwareDownloadUrl mints a tokenized URL and
+ * triggerDownload navigates to it (native, streamed, mobile-friendly) so a
+ * large firmware.elf isn't capped by a proxy's WebSocket max_msg_size.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { downloadBase64Binary } = vi.hoisted(() => ({ downloadBase64Binary: vi.fn() }));
-vi.mock("../../src/util/download-text.js", () => ({ downloadBase64Binary }));
+const { triggerDownload } = vi.hoisted(() => ({ triggerDownload: vi.fn() }));
+vi.mock("../../src/util/download-text.js", () => ({ triggerDownload }));
 vi.mock("../../src/util/web-serial.js", () => ({
   connectToPort: vi.fn(),
   detectChip: vi.fn(),
@@ -48,12 +52,7 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
       return "s1";
     }),
     firmwareGetBinaries: vi.fn().mockResolvedValue(binaries),
-    firmwareDownload: vi.fn().mockResolvedValue({
-      filename: "device-firmware.bin",
-      data: "QUJD",
-      size: 3,
-      compressed: false,
-    }),
+    firmwareDownloadUrl: vi.fn().mockResolvedValue("/api/firmware/download?token=tok"),
   };
   const host = {
     _device: { configuration: "device.yaml" },
@@ -92,21 +91,21 @@ describe("manual firmware-binary download flow", () => {
     await run(host);
     expect(host._step).toBe("choose-binary");
     expect(host._binaries).toEqual([FACTORY, OTA]);
-    expect(api.firmwareDownload).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
   });
 
   it("downloads directly when the device produces a single format", async () => {
     const single: FirmwareBinary = { title: "Standard format", file: "firmware.bin" };
     const { host, api } = makeHost("binary-download", [single]);
     await run(host);
-    expect(api.firmwareDownload).toHaveBeenCalledWith("device.yaml", "firmware.bin");
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith("device.yaml", "firmware.bin");
     expect(host._step).toBe("download-ready");
   });
 
   it("web flasher auto-selects the factory image even with multiple formats", async () => {
     const { host, api } = makeHost("web-download", [FACTORY, OTA]);
     await run(host);
-    expect(api.firmwareDownload).toHaveBeenCalledWith(
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
       "device.yaml",
       "firmware.factory.bin"
     );
@@ -120,8 +119,14 @@ describe("manual firmware-binary download flow", () => {
       host as unknown as ESPHomeFirmwareInstallDialog,
       "firmware.ota.bin"
     );
-    expect(api.firmwareDownload).toHaveBeenCalledWith("device.yaml", "firmware.ota.bin");
-    expect(downloadBase64Binary).toHaveBeenCalledWith("QUJD", "device-firmware.bin");
+    expect(api.firmwareDownloadUrl).toHaveBeenCalledWith(
+      "device.yaml",
+      "firmware.ota.bin"
+    );
+    expect(triggerDownload).toHaveBeenCalledWith(
+      "/api/firmware/download?token=tok",
+      "firmware.ota.bin"
+    );
     expect(host._step).toBe("download-ready");
     // Kept so the done screen can offer "download another format".
     expect(host._binaries).toHaveLength(2);
@@ -132,7 +137,7 @@ describe("manual firmware-binary download flow", () => {
     api.firmwareGetBinaries.mockRejectedValueOnce(new Error("boom"));
     await run(host);
     expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
-    expect(api.firmwareDownload).not.toHaveBeenCalled();
+    expect(api.firmwareDownloadUrl).not.toHaveBeenCalled();
   });
 
   it("re-picking after a download grabs the other format and keeps the list", async () => {
@@ -148,7 +153,7 @@ describe("manual firmware-binary download flow", () => {
       host as unknown as ESPHomeFirmwareInstallDialog,
       "firmware.factory.bin"
     );
-    expect(api.firmwareDownload).toHaveBeenLastCalledWith(
+    expect(api.firmwareDownloadUrl).toHaveBeenLastCalledWith(
       "device.yaml",
       "firmware.factory.bin"
     );

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -52,7 +52,10 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
       return "s1";
     }),
     firmwareGetBinaries: vi.fn().mockResolvedValue(binaries),
-    firmwareDownloadUrl: vi.fn().mockResolvedValue("/api/firmware/download?token=tok"),
+    firmwareDownloadUrl: vi.fn().mockResolvedValue({
+      url: "/api/firmware/download?token=tok",
+      filename: "device-firmware.bin",
+    }),
   };
   const host = {
     _device: { configuration: "device.yaml" },
@@ -123,9 +126,10 @@ describe("manual firmware-binary download flow", () => {
       "device.yaml",
       "firmware.ota.bin"
     );
+    // Saved under the server-chosen filename (from firmware/download_token).
     expect(triggerDownload).toHaveBeenCalledWith(
       "/api/firmware/download?token=tok",
-      "firmware.ota.bin"
+      "device-firmware.bin"
     );
     expect(host._step).toBe("download-ready");
     // Kept so the done screen can offer "download another format".

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pins the Web Serial flash path after the WS→HTTP download migration: it must
+ * fetch the firmware bytes over HTTP (api.firmwareDownloadBytes), bound to the
+ * factory image, and flash them — the removed WS firmware/download command is
+ * never touched. Also covers the byte-fetch failure path.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const wsSerial = vi.hoisted(() => ({
+  connectToPort: vi.fn(),
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  flashFirmware: vi.fn(),
+  resetAndDisconnect: vi.fn(),
+}));
+vi.mock("../../src/util/web-serial.js", () => wsSerial);
+vi.mock("../../src/util/download-text.js", () => ({ triggerDownload: vi.fn() }));
+vi.mock("../../src/util/post-install-logs.js", () => ({
+  dispatchShowLogsAfterInstall: vi.fn(() => false),
+}));
+
+import { JobSource, JobStatus } from "../../src/api/types/firmware-jobs.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { startWebSerialInstall } from "../../src/components/firmware-install-dialog/install-flow.js";
+
+function makeHost() {
+  const api = {
+    getBoard: vi.fn(),
+    firmwareCompile: vi
+      .fn()
+      .mockResolvedValue({ job_id: "j1", source: JobSource.LOCAL, source_label: "" }),
+    firmwareFollowJob: vi.fn((_id: string, cbs: { onResult: (d: unknown) => void }) => {
+      cbs.onResult({ status: JobStatus.COMPLETED });
+      return "s1";
+    }),
+    firmwareGetBinaries: vi
+      .fn()
+      .mockResolvedValue([{ title: "Factory", file: "firmware.factory.bin" }]),
+    firmwareDownloadBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer),
+  };
+  const host = {
+    // board_id empty + target_platform "esp32" → coarse-esp32 chip check passes.
+    _device: {
+      configuration: "device.yaml",
+      name: "dev",
+      friendly_name: "Dev",
+      target_platform: "esp32",
+      board_id: "",
+    },
+    _api: api,
+    _step: "connecting",
+    _statusMessage: "",
+    _flashPercent: 0,
+    _logLines: [] as string[],
+    _open: true,
+    _showLogsAfterInstall: false,
+    _detected: null as unknown,
+    _failedDuringCompile: false,
+    _failedDuringValidate: false,
+    _jobId: "",
+    _streamId: "",
+    _jobSource: JobSource.LOCAL,
+    _jobSourceLabel: "",
+    _compileReject: null as null | ((e: unknown) => void),
+    _localize: (key: string) => key,
+    _fail: vi.fn(),
+  };
+  host._fail = vi.fn((msg: string) => {
+    host._step = "error";
+    host._statusMessage = msg;
+  });
+  return { host, api };
+}
+
+const CHIP = { chipName: "ESP32", transport: {}, port: {}, loader: {} };
+
+afterEach(() => vi.clearAllMocks());
+
+describe("Web Serial install — HTTP byte download", () => {
+  it("fetches firmware bytes over HTTP and flashes them", async () => {
+    const { host, api } = makeHost();
+    wsSerial.detectChip.mockResolvedValue(CHIP);
+    wsSerial.connectToPort.mockResolvedValue(CHIP);
+    wsSerial.disconnect.mockResolvedValue(undefined);
+    wsSerial.flashFirmware.mockResolvedValue(undefined);
+    wsSerial.resetAndDisconnect.mockResolvedValue(undefined);
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(api.firmwareDownloadBytes).toHaveBeenCalledWith(
+      "device.yaml",
+      "firmware.factory.bin"
+    );
+    expect(wsSerial.flashFirmware).toHaveBeenCalledTimes(1);
+    const [, bytes, address] = wsSerial.flashFirmware.mock.calls[0];
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(bytes as Uint8Array)).toEqual([1, 2, 3, 4]);
+    expect(address).toBe(0x0); // factory image flashes at 0x0
+    expect(host._step).toBe("done");
+  });
+
+  it("fails cleanly when the HTTP byte fetch errors", async () => {
+    const { host, api } = makeHost();
+    wsSerial.detectChip.mockResolvedValue(CHIP);
+    wsSerial.disconnect.mockResolvedValue(undefined);
+    api.firmwareDownloadBytes.mockRejectedValueOnce(new Error("boom"));
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
+    expect(wsSerial.flashFirmware).not.toHaveBeenCalled();
+  });
+});

--- a/test/util/download-text.test.ts
+++ b/test/util/download-text.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { downloadAnsiText, downloadBase64Binary } from "../../src/util/download-text.js";
+import { downloadAnsiText, triggerDownload } from "../../src/util/download-text.js";
 
 /* The runtime test environment is Node, so we stub the bits of the
    browser API the helper touches. The download mechanics (anchor +
@@ -104,56 +104,15 @@ describe("downloadAnsiText", () => {
   });
 });
 
-describe("downloadBase64Binary", () => {
-  it("decodes the base64 payload and saves as application/octet-stream", () => {
-    /* ``AAECAw==`` decodes to the four-byte sequence 0x00 0x01 0x02 0x03. */
+describe("triggerDownload", () => {
+  it("navigates an anchor to the URL so the browser streams it to disk", () => {
     const { anchor } = withBrowserStubs(() =>
-      downloadBase64Binary("AAECAw==", "firmware.bin")
+      triggerDownload("/api/firmware/download?token=tok", "firmware.elf")
     );
-    expect(anchor.download).toBe("firmware.bin");
+    expect(anchor.href).toBe("/api/firmware/download?token=tok");
+    expect(anchor.download).toBe("firmware.elf");
     expect(anchor.click).toHaveBeenCalledTimes(1);
-    expect(FakeBlob.instances).toHaveLength(1);
-    const blob = FakeBlob.instances[0];
-    expect(blob.options?.type).toBe("application/octet-stream");
-    expect(blob.parts).toHaveLength(1);
-    const part = blob.parts[0];
-    expect(part).toBeInstanceOf(Uint8Array);
-    expect(Array.from(part as Uint8Array)).toEqual([0x00, 0x01, 0x02, 0x03]);
-  });
-
-  it("creates and revokes an object URL for the Blob", () => {
-    const createSpy = vi.fn(() => "blob:fake");
-    const revokeSpy = vi.fn();
-    const stubs = {
-      Blob: FakeBlob,
-      URL: { createObjectURL: createSpy, revokeObjectURL: revokeSpy },
-      document: { createElement: vi.fn(() => new FakeAnchor()) },
-    };
-    const g = globalThis as Record<string, unknown>;
-    const prev: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(stubs)) {
-      prev[key] = g[key];
-      g[key] = value;
-    }
-    try {
-      downloadBase64Binary("aGVsbG8=", "hello.bin");
-    } finally {
-      for (const [key, value] of Object.entries(prev)) g[key] = value;
-    }
-    expect(createSpy).toHaveBeenCalledTimes(1);
-    expect(revokeSpy).toHaveBeenCalledTimes(1);
-    expect(revokeSpy).toHaveBeenCalledWith("blob:fake");
-  });
-
-  it("accepts an empty payload (zero-byte download)", () => {
-    /* An empty base64 string decodes to zero bytes. Helpful for
-       defensive call sites that pass through whatever the backend
-       returned without their own length gate. */
-    const { anchor } = withBrowserStubs(() => downloadBase64Binary("", "empty.bin"));
-    expect(anchor.download).toBe("empty.bin");
-    const blob = FakeBlob.instances[0];
-    const part = blob.parts[0];
-    expect(part).toBeInstanceOf(Uint8Array);
-    expect((part as Uint8Array).length).toBe(0);
+    // No Blob is constructed — the file is never buffered in memory.
+    expect(FakeBlob.instances).toHaveLength(0);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Download firmware artifacts over HTTP instead of the WebSocket. The Download picker sent each artifact as a single base64 `firmware/download` WS message; a ~14 MB `firmware.elf` (~19.6 MB base64) exceeds the 4 MB `max_msg_size` of WS proxies (HA ingress, nginx), which silently drop it, so the user sees "Failed to download firmware" with nothing in the log. Factory/OTA (~1 MB) stay under the cap, which is why only the ELF failed.

Now `firmwareDownloadUrl` mints a single-use capability token over the WS (`firmware/download_token`) and the picker points an `<a href>` at `GET /api/firmware/download?token=...`. The browser streams the file straight to disk; nothing is buffered in JS memory, and a plain navigation downloads reliably on mobile (where programmatic blob downloads are flaky). Web Serial flashing, which needs the bytes in JS, fetches the same tokenized URL. The WS download command and the base64 path are gone.

The token is the route's auth (a navigation can't send a bearer header): minted only over the authenticated WS, unguessable, ~60 s TTL, single-use, bound to one artifact. Needs the companion backend.

**Related issue or feature (if applicable):**

- Companion backend PR: esphome/device-builder#1088

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
