### PR TITLE
Clear the automation editor parse-error banner once the YAML parses again

### DIFF
--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -346,6 +346,9 @@ export class ESPHomeAutomationEditor extends LitElement {
         this.configuration,
         this.yaml
       );
+      // A successful parse clears any prior parse error, so the banner
+      // doesn't stick after the user fixes invalid YAML in the pane.
+      this._error = "";
       // Re-pin location to the parser's canonical form (script id
       // matched, light_effect index resolved against the actual YAML);
       // the controller withholds a read-only automation's empty tree.

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -50,6 +50,17 @@ const erroredParse = (): ParsedAutomation[] => [
   } as unknown as ParsedAutomation,
 ];
 
+const validParse = (): ParsedAutomation[] => [
+  {
+    location: ON_BOOT,
+    label: "On Boot",
+    automation: { trigger_id: "on_boot", trigger_params: {}, actions: [] },
+    from_line: 1,
+    to_line: 2,
+    raw_yaml: "on_boot:\n  then: []\n",
+  } as unknown as ParsedAutomation,
+];
+
 const slimAvailable = (): AvailableAutomations =>
   ({
     triggers: [],
@@ -124,5 +135,46 @@ describe("automation-editor uneditable (errored parse)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (editor as any)._autoApply();
     expect(upsertAutomation).not.toHaveBeenCalled();
+  });
+});
+
+describe("automation-editor parse-error banner", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("clears a stale parse error once the YAML parses again", async () => {
+    const parseDeviceAutomations = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("invalid_args: Failed to parse device YAML"))
+      .mockResolvedValue(validParse());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimAvailable()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+      parseDeviceAutomations,
+      upsertAutomation: vi.fn(),
+    } as unknown as ESPHomeAPI;
+
+    const editor = new ESPHomeAutomationEditor();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any)._api = api;
+    editor.configuration = "device.yaml";
+    editor.location = ON_BOOT;
+    editor.yaml = "broken: [";
+    document.body.appendChild(editor);
+    await editor.updateComplete;
+    await flushPending();
+    // The failed parse surfaced an error banner.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any)._error).toContain("Failed to parse");
+
+    // The user fixes the YAML in the pane; the parent re-hydrates.
+    editor.yaml = "on_boot:\n  then: []\n";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor as any).reload();
+    await flushPending();
+    // A successful parse clears the stale error.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editor as any)._error).toBe("");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A parse-error banner in the automation editor never cleared. Hand-edit the device YAML in the pane into something invalid (e.g. drop a `-`) and the editor shows `Failed to parse device YAML: ...`; fix the YAML and the error stays on screen even though it now parses cleanly.

`_hydrateFromBackend` sets `_error` in its `catch` when `parseDeviceAutomations` rejects, but the success path never reset it (unlike `_loadAvailable`, which clears `_error` before each load). So a stale error from a transient invalid-YAML state stuck around.

Fix: clear `_error` on a successful parse. Added a behavioral test that mounts the editor, rejects then resolves `parseDeviceAutomations`, and asserts the banner is dismissed once the YAML parses again.

**Related issue or feature (if applicable):**

- Found while testing the add-automation / on_time wizard work

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
