### PR TITLE
Remove orphaned FirmwareDownload type

### DIFF
--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -130,10 +130,3 @@ export interface FirmwareBinary {
   // the UI maps to a localized label, falling back to ``title`` when absent.
   type?: string;
 }
-
-export interface FirmwareDownload {
-  filename: string;
-  data: string;
-  size: number;
-  compressed: boolean;
-}


### PR DESCRIPTION
# What does this implement/fix?

Removes the orphaned `FirmwareDownload` interface; it described the old WebSocket `firmware/download` result, which went away when downloads moved to HTTP in #471. Nothing imports it anymore, so it is dead code.

**Related issue or feature (if applicable):**

- follow-up to #471

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
