### PR TITLE
Wrap the logs toolbar on mobile so Clear/Stop stay tappable

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -358,6 +358,20 @@ export class ESPHomeLogsDialog extends LitElement {
         .term-btn.expand-btn {
           display: none;
         }
+
+        /* The desktop toolbar is a single non-wrapping row that pushes the
+           controls right with a flex:1 spacer. On a phone the labelled
+           buttons (States / Clear / Stop) ran off the right edge, so the
+           Stop text was unreachable. Let the row wrap and drop the spacer
+           so the buttons flow left-to-right onto a second line, keeping
+           every label on-screen and tappable. */
+        .terminal-toolbar {
+          flex-wrap: wrap;
+        }
+
+        .terminal-toolbar .spacer {
+          display: none;
+        }
       }
     `,
   ];


### PR DESCRIPTION
# What does this implement/fix?

On a phone the logs dialog toolbar was a single non-wrapping row, so the labelled buttons (States, Clear, Stop) ran off the right edge and the Stop text was unreachable. This lets the toolbar wrap on narrow screens and drops the flex spacer there, so the buttons flow onto a second line with every label on-screen and tappable. CSS only; the mobile rules live in the existing `@media (max-width: 700px)` block, after the desktop defaults.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
