### PR TITLE
Show pretty trigger names in the component automations list

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -19,10 +19,6 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import {
-  fetchAutomationTriggers,
-  getCachedAutomationTriggers,
-} from "../../util/automation-catalog-cache.js";
-import {
   fetchComponent,
   getCachedComponent,
   subscribeComponentCache,
@@ -46,6 +42,7 @@ import "./add-config-dialog.js";
 import type { ESPHomeAddConfigDialog } from "./add-config-dialog.js";
 import "./add-script-dialog.js";
 import type { ESPHomeAddScriptDialog } from "./add-script-dialog.js";
+import { TriggerCatalogController } from "./trigger-catalog-controller.js";
 
 registerMdiIcons({
   "chevron-down": mdiChevronDown,
@@ -77,6 +74,14 @@ export class ESPHomeDeviceNavigator extends LitElement {
   private _cacheTick = 0;
 
   private _unsubscribeCache?: () => void;
+
+  // Resolves automation rows' pretty trigger names; shared with the
+  // component automations list in device-section-config.
+  private readonly _triggerCatalog = new TriggerCatalogController(this, () => ({
+    api: this._api,
+    platform: this.platform || undefined,
+    boardId: this.board?.id,
+  }));
 
   @property({ attribute: false })
   openSections: Set<number> = new Set();
@@ -660,7 +665,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
     const sections = parseYamlTopLevelSections(this.yaml);
     const { core, components } = categorizeSections(sections);
     const platform = this.platform || undefined;
-    const boardId = this.board?.id;
     for (const item of [...core, ...components]) {
       const id = sectionKeyOf(item);
       if (getCachedComponent(id, platform) !== undefined) continue;
@@ -670,24 +674,10 @@ export class ESPHomeDeviceNavigator extends LitElement {
         // shouldn't surface as an error here.
       });
     }
-    // Trigger catalog: needed so automation entries can render as
-    // "Switch → Turn on" (catalog-pretty domain + trigger name)
-    // instead of "warmtepomp → on_turn_on" (raw YAML key). The cache
-    // is process-wide and the subscription path re-renders when an
-    // entry lands.
-    if (getCachedAutomationTriggers(platform, boardId) === undefined) {
-      void fetchAutomationTriggers(this._api, platform, boardId).then(
-        () => {
-          // Manual nudge — the subscription handler only fires for
-          // ``component-name`` writes; the trigger cache has no
-          // observer surface, so we force a re-render directly.
-          this._cacheTick++;
-        },
-        () => {
-          /* swallow — same rationale as the component fetch above. */
-        }
-      );
-    }
+    // Trigger catalog: lets automation entries render as
+    // "Switch → On Turn On" instead of the raw YAML key. The
+    // controller re-renders the host when the fetch lands.
+    this._triggerCatalog.ensure();
   }
 
   /**
@@ -763,7 +753,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
     // line 2; keep line 2 empty since the trigger name already
     // identifies the automation uniquely.
     if (item.parentKey === "esphome" && item.eventKey) {
-      const primary = this._resolveTriggerName(
+      const primary = this._triggerCatalog.resolveName(
         "esphome",
         item.eventKey,
         `${this._prettyDomain("esphome")} → ${item.eventKey}`
@@ -774,34 +764,17 @@ export class ESPHomeDeviceNavigator extends LitElement {
     // catalog; "Warmtepomp" on line 2).
     if (item.parentKey && item.eventKey) {
       const fallback = `${this._prettyDomain(item.parentKey)} → ${item.eventKey}`;
-      const primary = this._resolveTriggerName(item.parentKey, item.eventKey, fallback);
+      const primary = this._triggerCatalog.resolveName(
+        item.parentKey,
+        item.eventKey,
+        fallback
+      );
       const named = item.name || item.id;
       const secondary = named && named !== primary ? named : undefined;
       return { primary, secondary };
     }
     // Unscoped / unrecognised — fall back to displayLabel.
     return { primary: item.displayLabel || raw };
-  }
-
-  /** Resolve the catalog's pretty name for ``<domain>.<event>`` or
-   *  return ``fallback`` (typically the raw event key) when the
-   *  catalog hasn't loaded yet. The catalog's ``name`` field is the
-   *  full display label including the domain prefix
-   *  (``"Switch → On Turn On"``), so callers use the resolved value
-   *  as-is — no separate domain prepend. */
-  private _resolveTriggerName(
-    domain: string,
-    eventKey: string,
-    fallback: string
-  ): string {
-    const triggers = getCachedAutomationTriggers(
-      this.platform || undefined,
-      this.board?.id
-    );
-    if (!triggers) return fallback;
-    const catalogId = domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
-    const hit = triggers.find((t) => t.id === catalogId);
-    return hit?.name || fallback;
   }
 
   /** Capitalize a YAML domain key for display (``binary_sensor`` →

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -26,9 +26,11 @@ import {
   parseYamlAutomations,
   parseYamlTopLevelSections,
   sectionKeyOf,
+  type YamlSection,
 } from "../../util/yaml-sections.js";
 import { renderAdvancedToggle } from "./advanced-toggle.js";
 import { applyYamlDiff } from "./automation-editor/serialise.js";
+import { TriggerCatalogController } from "./trigger-catalog-controller.js";
 import { isYamlOnlySection } from "./yaml-only-sections.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -151,6 +153,14 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   // the live yaml matches this snapshot.
   _lastSelfWrittenYaml: string | null = null;
 
+  // Resolves the automations-list rows' pretty trigger names; shared
+  // with the device navigator.
+  private readonly _triggerCatalog = new TriggerCatalogController(this, () => ({
+    api: this._api,
+    platform: this.board?.esphome.platform || undefined,
+    boardId: this.board?.id,
+  }));
+
   // 200ms is short enough that the YAML pane feels live as the user moves
   // between fields, long enough to coalesce typing into one splice.
   private static readonly DRAFT_DEBOUNCE_MS = 200;
@@ -178,6 +188,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     ) {
       void loadConfig(this);
     }
+    this._triggerCatalog.ensure();
   }
 
   connectedCallback() {
@@ -620,7 +631,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
             ${items.map(
               (item) =>
                 html`<li class="api-actions-row">
-                  <span class="api-actions-name">${item.eventKey}</span>
+                  <span class="api-actions-name">${this._triggerLabel(item)}</span>
                   <div class="api-actions-row-buttons">
                     <button
                       type="button"
@@ -648,6 +659,19 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
             )}
           </ul>`}
     </div>`;
+  }
+
+  /** Pretty trigger label for an automations-list row, resolved from
+   *  the trigger catalog ("Binary Sensor → On State"). Falls back to
+   *  ``displayLabel`` / the raw event key until the catalog loads. */
+  private _triggerLabel(item: YamlSection): string {
+    const fallback = item.displayLabel || item.eventKey || "";
+    if (!item.eventKey) return fallback;
+    return this._triggerCatalog.resolveName(
+      item.parentKey ?? "esphome",
+      item.eventKey,
+      fallback
+    );
   }
 
   private _renderAddAutomationDialog() {

--- a/src/components/device/trigger-catalog-controller.ts
+++ b/src/components/device/trigger-catalog-controller.ts
@@ -1,0 +1,69 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+import type { ESPHomeAPI } from "../../api/index.js";
+import {
+  fetchAutomationTriggers,
+  getCachedAutomationTriggers,
+  subscribeAutomationCatalogCache,
+} from "../../util/automation-catalog-cache.js";
+
+/** Host-supplied lookup keys, re-read per call since the host's
+ *  api / platform / board can change after construction. */
+export interface TriggerCatalogContext {
+  api?: ESPHomeAPI;
+  platform?: string;
+  boardId?: string;
+}
+
+/**
+ * Shared trigger-catalog access for the device navigator and the
+ * component automations list.
+ *
+ * Subscribes to the catalog cache (re-rendering the host when a fetch
+ * lands), kicks off the per-(platform, board) fetch on demand, and
+ * resolves a trigger key to its catalog pretty name
+ * (``"Binary Sensor → On State"``). The catalog ``name`` already
+ * carries the domain prefix, so callers render the resolved value
+ * as-is.
+ */
+export class TriggerCatalogController implements ReactiveController {
+  private _unsubscribe?: () => void;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost,
+    private readonly _context: () => TriggerCatalogContext
+  ) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {
+    this._unsubscribe = subscribeAutomationCatalogCache(() => this._host.requestUpdate());
+  }
+
+  hostDisconnected(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+  }
+
+  /** Fire-and-forget the catalog fetch so ``resolveName`` fills in once
+   *  it lands; no-op when already cached or when there's no API yet. */
+  ensure(): void {
+    const { api, platform, boardId } = this._context();
+    if (!api) return;
+    if (getCachedAutomationTriggers(platform, boardId) !== undefined) return;
+    void fetchAutomationTriggers(api, platform, boardId).catch(() => {
+      // Swallow — callers fall back to the raw key when the catalog
+      // can't load, so a transient backend hiccup isn't surfaced here.
+    });
+  }
+
+  /** Catalog pretty name for ``<domain>.<event>`` (or the bare event
+   *  key for device-level ``esphome``), or ``fallback`` until cached. */
+  resolveName(domain: string, eventKey: string, fallback: string): string {
+    const { platform, boardId } = this._context();
+    const triggers = getCachedAutomationTriggers(platform, boardId);
+    if (!triggers) return fallback;
+    const catalogId = domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
+    return triggers.find((t) => t.id === catalogId)?.name || fallback;
+  }
+}

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -1,0 +1,92 @@
+import type { ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { AutomationTrigger } from "../../../src/api/types/automations.js";
+import { TriggerCatalogController } from "../../../src/components/device/trigger-catalog-controller.js";
+import {
+  _clearAutomationCatalogCache,
+  fetchAutomationTriggers,
+  getCachedAutomationTriggers,
+} from "../../../src/util/automation-catalog-cache.js";
+
+const fakeHost = (): ReactiveControllerHost =>
+  ({
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  }) as unknown as ReactiveControllerHost;
+
+const trigger = (id: string, name: string): AutomationTrigger => ({
+  id,
+  name,
+  description: "",
+  docs_url: "",
+  applies_to: [],
+  is_device_level: true,
+  repeatable: false,
+  config_entries: [],
+});
+
+const fakeApi = (triggers: AutomationTrigger[]): ESPHomeAPI =>
+  ({ getAutomationTriggers: vi.fn(async () => triggers) }) as unknown as ESPHomeAPI;
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => _clearAutomationCatalogCache());
+
+describe("TriggerCatalogController", () => {
+  it("returns the fallback before the catalog is cached", () => {
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    expect(c.resolveName("binary_sensor", "on_state", "fallback")).toBe("fallback");
+  });
+
+  it("resolves a component trigger to its catalog name once cached", async () => {
+    await fetchAutomationTriggers(
+      fakeApi([trigger("binary_sensor.on_state", "Binary Sensor → On State")])
+    );
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    expect(c.resolveName("binary_sensor", "on_state", "raw")).toBe(
+      "Binary Sensor → On State"
+    );
+  });
+
+  it("resolves a device-level trigger by its bare event key", async () => {
+    await fetchAutomationTriggers(fakeApi([trigger("on_boot", "On Boot")]));
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    expect(c.resolveName("esphome", "on_boot", "raw")).toBe("On Boot");
+  });
+
+  it("falls back when the cached catalog has no matching id", async () => {
+    await fetchAutomationTriggers(
+      fakeApi([trigger("switch.on_turn_on", "Switch → On Turn On")])
+    );
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    expect(c.resolveName("binary_sensor", "on_state", "raw")).toBe("raw");
+  });
+
+  it("ensure() fetches once when uncached and is a no-op once cached", async () => {
+    const api = fakeApi([trigger("binary_sensor.on_state", "Binary Sensor → On State")]);
+    const c = new TriggerCatalogController(fakeHost(), () => ({ api }));
+    c.ensure();
+    await flush();
+    expect(getCachedAutomationTriggers()).toBeDefined();
+    c.ensure();
+    expect(api.getAutomationTriggers).toHaveBeenCalledTimes(1);
+  });
+
+  it("ensure() is a no-op without an api", () => {
+    const c = new TriggerCatalogController(fakeHost(), () => ({}));
+    expect(() => c.ensure()).not.toThrow();
+  });
+
+  it("re-renders the host when a catalog fetch lands while connected", async () => {
+    const host = fakeHost();
+    const c = new TriggerCatalogController(host, () => ({}));
+    c.hostConnected();
+    await fetchAutomationTriggers(fakeApi([trigger("on_boot", "On Boot")]));
+    expect(host.requestUpdate).toHaveBeenCalled();
+    c.hostDisconnected();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In a component's visual editor, the Automations list showed the raw YAML trigger key (for example `on_state_change`) instead of a friendly name. The device navigator already resolves these names from the trigger catalog; the inline list did not.

This extracts the resolution into a shared `TriggerCatalogController` (a Lit reactive controller that subscribes to the catalog cache, kicks off the fetch, and resolves a trigger key to its catalog name) and uses it from both the navigator and `device-section-config`. The row now reads "Binary Sensor → On State"; the duplicate `_resolveTriggerName` and the manual cache nudge in the navigator are gone.

**Related issue or feature (if applicable):**

- No separate issue filed; reported alongside the automation editor work for esphome/device-builder#1094

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
