### PR TITLE
Render globals as a repeatable list in the section editor

### DIFF
--- a/src/util/section-entry-overrides.ts
+++ b/src/util/section-entry-overrides.ts
@@ -38,6 +38,17 @@ import { makeConfigEntry } from "./config-entry-defaults.js";
  *  the YAML pane. */
 export const MAP_SECTIONS: ReadonlySet<string> = new Set(["substitutions"]);
 
+/** Values-record key the list body is stashed under for a LIST_SECTIONS
+ *  section. Synthetic, not a real YAML key; parse and serialize strip
+ *  it so it never lands in YAML. */
+export const LIST_SECTION_VALUE_KEY = "__items__";
+
+/** Top-level sections whose body is a list of mappings (globals is one
+ *  variable per list item). Rendered through a synthesized keyed
+ *  NESTED + multi_value entry so every item round-trips, instead of the
+ *  flat catalog form that drops all but one on save. */
+export const LIST_SECTIONS: ReadonlySet<string> = new Set(["globals"]);
+
 /** Sections that must persist explicit ``""`` values in YAML — i.e.
  *  the user typed a key + cleared the value, treat that as
  *  intentional data instead of "user cleared the field, drop it".
@@ -94,5 +105,22 @@ export function resolveSectionEntries(
   catalogEntries: ConfigEntry[]
 ): ConfigEntry[] {
   if (MAP_SECTIONS.has(sectionKey)) return MAP_SECTION_ENTRIES;
+  if (LIST_SECTIONS.has(sectionKey)) {
+    return [
+      makeConfigEntry({
+        key: LIST_SECTION_VALUE_KEY,
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        label: LIST_SECTION_ITEM_LABELS[sectionKey] ?? "Item",
+        config_entries: catalogEntries,
+      }),
+    ];
+  }
   return catalogEntries;
 }
+
+/** Singular noun for each item card's header; the nested-list renderer
+ *  shows '<label> <n>' (Global variable 1). */
+const LIST_SECTION_ITEM_LABELS: Readonly<Record<string, string>> = {
+  globals: "Global variable",
+};

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -8,11 +8,13 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { LIST_SECTION_VALUE_KEY, LIST_SECTIONS } from "./section-entry-overrides.js";
 import {
-  YamlRawValue,
   formatYamlScalar,
   parseYamlBoolean,
+  serializeListSection,
   serializeYamlValues,
+  YamlRawValue,
   type SerializeYamlOptions,
 } from "./yaml-serialize.js";
 
@@ -749,6 +751,20 @@ export function parseYamlSectionValues(
   const childIndent = _detectSectionChildIndent(lines, startIdx, isListItem);
   const childRegex = childRegexFor(childIndent);
 
+  // Top-level list-bodied section (globals): stash the list under the
+  // synthetic key the form renders as a multi_value NESTED entry.
+  if (!isListItem && LIST_SECTIONS.has(sectionKey)) {
+    const peek = _skipBlankAndCommentLines(lines, startIdx + 1);
+    if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
+      values[LIST_SECTION_VALUE_KEY] = parseListBlock(
+        lines,
+        startIdx + 1,
+        childIndent
+      ).value;
+      return values;
+    }
+  }
+
   // List-item form: the first child key may sit on the same line as
   // the leading dash (e.g. `  - platform: gpio\n    pin: 4`).
   if (isListItem) {
@@ -983,6 +999,25 @@ export function updateSectionInYaml(
   const lines = yaml.split("\n");
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
+
+  // Top-level list-bodied section (globals): re-emit the stashed list
+  // as bare dash items under the preserved header; the synthetic key
+  // never reaches YAML.
+  if (LIST_SECTIONS.has(sectionKey)) {
+    const headerIndent = _leadingIndent(lines[start]);
+    const raw = values[LIST_SECTION_VALUE_KEY];
+    const list = Array.isArray(raw) ? raw : [];
+    const childIndent = _detectSectionChildIndent(lines, start, false);
+    const step = childIndent.startsWith(headerIndent)
+      ? childIndent.slice(headerIndent.length) || ESPHOME_YAML_INDENT
+      : ESPHOME_YAML_INDENT;
+    const body = serializeListSection(list, headerIndent, {
+      ...options,
+      indentStep: options.indentStep ?? step,
+    });
+    lines.splice(start, end - start, lines[start], ...body);
+    return lines.join("\n");
+  }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
   // Match the user's existing indent step on save so 4-space (or

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -281,6 +281,19 @@ function serializeListItem(
 }
 
 /**
+ * Serialize a bare list (no parent key header) at indent, one item per
+ * serializeListItem. For top-level list-bodied sections (globals)
+ * whose dash items sit directly under the header.
+ */
+export function serializeListSection(
+  items: readonly unknown[],
+  indent: string,
+  options: SerializeYamlOptions = {}
+): string[] {
+  return items.flatMap((item) => serializeListItem(item, indent, options));
+}
+
+/**
  * True when *value* would emit at least one line through
  * ``serializeYamlValues`` under its *default* options.
  *

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -13,9 +13,12 @@
  */
 import { describe, expect, it } from "vitest";
 import { type ConfigEntry, ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { YAML_ONLY_SECTIONS } from "../../src/components/device/yaml-only-sections.js";
 import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
 import { validateEntries } from "../../src/util/config-validation.js";
 import {
+  LIST_SECTION_VALUE_KEY,
+  LIST_SECTIONS,
   MAP_SECTIONS,
   resolveSectionEntries,
 } from "../../src/util/section-entry-overrides.js";
@@ -32,6 +35,39 @@ describe("MAP_SECTIONS", () => {
     // Routed through ``YAML_ONLY_SECTIONS`` instead so both
     // shapes round-trip cleanly via the YAML pane.
     expect(MAP_SECTIONS.has("packages")).toBe(false);
+  });
+});
+
+describe("LIST_SECTIONS", () => {
+  it("contains 'globals' (top-level list of variable mappings)", () => {
+    expect(LIST_SECTIONS.has("globals")).toBe(true);
+  });
+
+  it("'globals' is NOT YAML-only and NOT a MAP section", () => {
+    expect(YAML_ONLY_SECTIONS.has("globals")).toBe(false);
+    expect(MAP_SECTIONS.has("globals")).toBe(false);
+  });
+});
+
+describe("resolveSectionEntries (LIST section shape)", () => {
+  it("globals resolves to one multi_value NESTED entry wrapping the catalog", () => {
+    const catalog: ConfigEntry[] = [
+      makeConfigEntry({ key: "id", type: ConfigEntryType.STRING }),
+      makeConfigEntry({ key: "type", type: ConfigEntryType.STRING }),
+    ];
+    const entries = resolveSectionEntries("globals", catalog);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe(LIST_SECTION_VALUE_KEY);
+    expect(entries[0].type).toBe(ConfigEntryType.NESTED);
+    expect(entries[0].multi_value).toBe(true);
+    expect(entries[0].config_entries).toBe(catalog);
+  });
+
+  it("each item card titles read 'Global variable <n>'", () => {
+    // labelFor reads entry.label directly, and the nested-list
+    // renderer shows ``<label> <n>``.
+    const entries = resolveSectionEntries("globals", []);
+    expect(entries[0].label).toBe("Global variable");
   });
 });
 
@@ -77,6 +113,11 @@ describe("resolveSectionEntries", () => {
       makeConfigEntry({ key: "name", required: true }),
       makeConfigEntry({ key: "ssid", required: true }),
     ];
+    expect(resolveSectionEntries("wifi", catalogEntries)).toBe(catalogEntries);
+  });
+
+  it("returns the catalog entries unchanged for a non-list section", () => {
+    const catalogEntries: ConfigEntry[] = [makeConfigEntry({ key: "ssid" })];
     expect(resolveSectionEntries("wifi", catalogEntries)).toBe(catalogEntries);
   });
 

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LIST_SECTION_VALUE_KEY } from "../../src/util/section-entry-overrides.js";
 import {
   findSectionStart,
   LIST_ITEM_START_RE,
@@ -1706,5 +1707,112 @@ describe("parseYamlSectionValues — ESPHome YAML boolean spellings", () => {
     expect(values.state).toBe("yes");
     expect(values.fallback).toBe("True");
     expect(values.hint).toBe("enable");
+  });
+});
+
+describe("globals list section (LIST_SECTIONS)", () => {
+  const TWO_ENTRY =
+    "globals:\n" +
+    "  - id: my_int\n" +
+    "    type: int\n" +
+    "    initial_value: '0'\n" +
+    "  - id: my_bool\n" +
+    "    type: bool\n" +
+    "    restore_value: true\n";
+
+  it("parses a 2-entry globals block into the synthetic list key", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(Array.isArray(items)).toBe(true);
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    expect(items[0].type).toBe("int");
+    expect(items[0].initial_value).toBe("0");
+    expect(items[1].id).toBe("my_bool");
+    expect(items[1].type).toBe("bool");
+    expect(items[1].restore_value).toBe(true);
+  });
+
+  it("round-trips editing one item's initial_value, keeping every entry", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items[0].initial_value = "42";
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    expect(out.startsWith("globals:")).toBe(true);
+    const reparsed = parseYamlSectionValues(out + "\n", "globals");
+    const ritems = reparsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(2);
+    expect(ritems[0].id).toBe("my_int");
+    expect(ritems[0].initial_value).toBe("42");
+    expect(ritems[1].id).toBe("my_bool");
+  });
+
+  it("round-trips adding a third item", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items.push({ id: "my_str", type: "std::string" });
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems.map((i) => i.id)).toEqual(["my_int", "my_bool", "my_str"]);
+  });
+
+  it("round-trips removing the first item", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items.splice(0, 1);
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(1);
+    expect(ritems[0].id).toBe("my_bool");
+  });
+
+  it("round-trips a 4-space-indented globals fixture", () => {
+    const FOUR_SPACE =
+      "globals:\n" +
+      "    - id: my_int\n" +
+      "      type: int\n" +
+      "    - id: my_bool\n" +
+      "      type: bool\n";
+    const parsed = parseYamlSectionValues(FOUR_SPACE, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    items[0].type = "int64_t";
+    const out = updateSectionInYaml(FOUR_SPACE, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(2);
+    expect(ritems[0].type).toBe("int64_t");
+    expect(ritems[1].id).toBe("my_bool");
+  });
+
+  it("preserves sibling sections after globals on round-trip", () => {
+    const WITH_SIBLING = TWO_ENTRY + "wifi:\n  ssid: home\n";
+    const items = parseYamlSectionValues(WITH_SIBLING, "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    items[0].initial_value = "7";
+    const out = updateSectionInYaml(WITH_SIBLING, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).toContain("wifi:");
+    expect(out).toContain("ssid: home");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The Visual Editor lost all but one entry when a device had several globals. In ESPHome globals is a list of typed variables, but the section form treated it as a single mapping, so a multi entry block parsed back as empty and saving overwrote every variable.

This renders globals as a repeatable list, reusing the same nested list control that esphome.devices and esphome.areas already use; you can add, edit, and remove each variable in the form and every entry round trips to YAML. The change is gated to globals, so other sections behave exactly as before.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1097

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
