### PR TITLE
Escape backslashes and control characters in formatYamlScalar

### DIFF
--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -432,8 +432,14 @@ export function formatYamlScalar(v: unknown): string {
   // matters when the caller has opted into keep-empty-strings
   // (default is to drop the key entirely), but the formatter is
   // shared so we get it right at the source.
-  if (s === "" || /[:#]/.test(s) || /^[-\s'"]/.test(s) || /\s$/.test(s)) {
-    return `"${s.replace(/"/g, '\\"')}"`;
+  if (
+    s === "" ||
+    /[:#]/.test(s) ||
+    /^[-\s'"]/.test(s) ||
+    /\s$/.test(s) ||
+    /[\n\r\t]/.test(s)
+  ) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`;
   }
   return s;
 }

--- a/test/util/yaml-serialize-escaping.test.ts
+++ b/test/util/yaml-serialize-escaping.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatYamlScalar } from "../../src/util/yaml-serialize.js";
+
+// When formatYamlScalar quotes a value it must escape backslashes and
+// control characters the same way the backend _quote helper does, so a
+// value round-trips through YAML instead of a bare backslash forming an
+// invalid escape on reload.
+describe("formatYamlScalar escaping", () => {
+  it("escapes a backslash inside a quoted value", () => {
+    // leading quote forces quoting; the backslash must be escaped too
+    expect(formatYamlScalar('"a\\b')).toBe('"\\"a\\\\b"');
+  });
+
+  it("escapes a tab inside a value that needs quoting", () => {
+    expect(formatYamlScalar("a:\tb")).toBe('"a:\\tb"');
+  });
+
+  it("quotes and escapes a value containing a newline", () => {
+    expect(formatYamlScalar("line1\nline2")).toBe('"line1\\nline2"');
+  });
+
+  it("leaves a plain identifier unquoted", () => {
+    expect(formatYamlScalar("GPIO4")).toBe("GPIO4");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The Visual Editor's YAML serializer quoted values that contain a colon, hash, leading indicator, or trailing space, but when it quoted it only escaped the double quote character. A value carrying a backslash or a control character then produced an invalid double quoted scalar, so a leading quote string containing a backslash, or a value with a tab, did not round trip. formatYamlScalar now also escapes backslash, newline, carriage return, and tab, and quotes values that contain a newline, tab, or carriage return, matching the backend _quote helper. Plain identifiers stay unquoted.

**Related issue or feature (if applicable):**

- related to the YAML quoting fix in esphome/device-builder#1095

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
