### PR TITLE
Quote string scalars a YAML loader would re-read as non-strings

### DIFF
--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -422,26 +422,75 @@ export function parseConfiguredPlatforms(yaml: string): Set<string> {
   return out;
 }
 
-/** Format a single scalar value, quoting when needed. */
-export function formatYamlScalar(v: unknown): string {
-  if (typeof v === "boolean") return String(v);
-  if (typeof v === "number") return String(v);
-  const s = String(v);
+// Scalar shapes a YAML 1.1 loader resolves to a non-string, so the bare
+// form would change type on reload. ESPHome loads configs with PyYAML
+// (yaml.safe_load); a typed-string field such as globals initial_value
+// emitted bare as 0 reloads as an int and fails ESPHome with an EInt
+// error, so any value the loader would re-type must be quoted to stay a
+// string. Mirrored from the YAML 1.1 type repository, narrowed to
+// PyYAML's resolver where it deviates from the spec (no single-letter
+// y/Y/n/N bool; float exponent must carry an explicit sign):
+//   bool      https://yaml.org/type/bool.html
+//   int       https://yaml.org/type/int.html
+//   float     https://yaml.org/type/float.html
+//   null      https://yaml.org/type/null.html
+//   timestamp https://yaml.org/type/timestamp.html
+//   resolver  https://github.com/yaml/pyyaml/blob/6.0.3/lib/yaml/resolver.py
+const YAML_BOOL =
+  /^(?:yes|Yes|YES|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)$/;
+// Base 16 (0x...) is intentionally omitted so i2c addresses and other
+// hand-written hex literals stay bare and readable; base 60 is omitted
+// because its colon is already caught by the structural check below.
+const YAML_INT = /^(?:[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?(?:0|[1-9][0-9_]*))$/;
+const YAML_FLOAT =
+  /^(?:[-+]?[0-9][0-9_]*\.[0-9_]*(?:[eE][-+][0-9]+)?|[-+]?\.[0-9_]+(?:[eE][-+][0-9]+)?|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN))$/;
+const YAML_NULL = /^(?:~|null|Null|NULL)$/;
+const YAML_TIMESTAMP =
+  /^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}(?:[Tt]|[ \t]+)[0-9]{1,2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]*)?(?:[ \t]*(?:Z|[-+][0-9]{1,2}(?::[0-9]{2})?))?)$/;
+
+/**
+ * True when *s* must be quoted to survive a YAML round-trip as a string.
+ * Beyond the structurally-unsafe characters (delimiters, leading
+ * indicators, surrounding whitespace), a value the loader would re-read
+ * as bool / int / float / null / timestamp also needs quoting.
+ */
+function yamlNeedsQuoting(s: string): boolean {
   // Empty string must be quoted: a bare ``key: `` round-trips as
   // YAML ``null``, not as the empty string we started with. Only
   // matters when the caller has opted into keep-empty-strings
   // (default is to drop the key entirely), but the formatter is
   // shared so we get it right at the source.
-  if (
+  return (
     s === "" ||
     /[:#]/.test(s) ||
     /^[-\s'"]/.test(s) ||
     /\s$/.test(s) ||
-    /[\n\r\t]/.test(s)
-  ) {
-    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`;
-  }
-  return s;
+    /[\n\r\t]/.test(s) ||
+    YAML_BOOL.test(s) ||
+    YAML_INT.test(s) ||
+    YAML_FLOAT.test(s) ||
+    YAML_NULL.test(s) ||
+    YAML_TIMESTAMP.test(s)
+  );
+}
+
+/** Wrap *s* in double quotes, escaping backslashes and control chars. */
+function yamlDoubleQuote(s: string): string {
+  const escaped = s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+/** Format a single scalar value, quoting when needed. */
+export function formatYamlScalar(v: unknown): string {
+  if (typeof v === "boolean") return String(v);
+  if (typeof v === "number") return String(v);
+  const s = String(v);
+  return yamlNeedsQuoting(s) ? yamlDoubleQuote(s) : s;
 }
 
 // ESPHome's YAML loader accepts the YAML 1.1 truthy/falsy spellings

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1748,6 +1748,17 @@ describe("parseYamlSectionValues - is_list section round-trip", () => {
     expect(reparsed[1].id).toBe("my_flag");
   });
 
+  it("quotes a numeric initial_value so it round-trips as a string", () => {
+    const values = parseYamlSectionValues(globalsYaml, "globals", undefined, true);
+    (values.globals as Record<string, unknown>[])[0].initial_value = "0";
+    const next = updateSectionInYaml(globalsYaml, "globals", values, undefined, {}, true);
+    expect(next).toContain('initial_value: "0"');
+    const reparsed = parseYamlSectionValues(next, "globals", undefined, true)
+      .globals as Record<string, unknown>[];
+    expect(typeof reparsed[0].initial_value).toBe("string");
+    expect(reparsed[0].initial_value).toBe("0");
+  });
+
   it("round-trips an added item, keeping the existing ones", () => {
     const values = parseYamlSectionValues(globalsYaml, "globals", undefined, true);
     (values.globals as Record<string, unknown>[]).push({ id: "added", type: "bool" });

--- a/test/util/yaml-serialize-escaping.test.ts
+++ b/test/util/yaml-serialize-escaping.test.ts
@@ -23,3 +23,55 @@ describe("formatYamlScalar escaping", () => {
     expect(formatYamlScalar("GPIO4")).toBe("GPIO4");
   });
 });
+
+// ESPHome loads via PyYAML (YAML 1.1). A typed-string field such as
+// globals initial_value emitted bare as 0 reloads as an int and is
+// rejected as EInt, so anything the loader would re-type must be quoted.
+// The bare cases mirror values PyYAML resolves as plain strings.
+describe("formatYamlScalar quotes values a YAML loader would re-type", () => {
+  it.each([
+    "0",
+    "42",
+    "-5",
+    "+5",
+    "1_000",
+    "0755",
+    "0b101",
+    "3.14",
+    ".5",
+    "1.5e+3",
+    ".inf",
+    "-.inf",
+    ".nan",
+    "true",
+    "True",
+    "TRUE",
+    "yes",
+    "on",
+    "off",
+    "no",
+    "null",
+    "Null",
+    "NULL",
+    "~",
+    "2024-01-01",
+  ])("quotes %j so it stays a string", (value) => {
+    expect(formatYamlScalar(value)).toBe(`"${value}"`);
+  });
+
+  it.each([
+    "0x3c", // hex i2c address — intentionally left bare and readable
+    "0xFF",
+    "1.5e3", // unsigned exponent is a string in PyYAML
+    "1e3",
+    "tRUe", // casing outside the resolver set
+    "y",
+    "Y",
+    "n",
+    "GPIO4",
+    "v1.2",
+    "0.0.0.0",
+  ])("leaves %j bare", (value) => {
+    expect(formatYamlScalar(value)).toBe(value);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A typed string field like globals' initial_value was written to YAML bare, so a value such as 0 came back from ESPHome's loader as an int and the config was rejected with an EInt error. formatYamlScalar now quotes any value the YAML 1.1 resolver would read back as a bool, int, float, null, or timestamp; hex stays bare so i2c addresses keep reading cleanly. The regexes mirror PyYAML, the loader ESPHome actually runs, and each one links its yaml.org spec page.

This re-lands the quoting fix that was reverted out of #489 as its own change.

**Related issue or feature (if applicable):**

- Re-lands the quoting fix reverted from #489

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
