### PR TITLE
Render top-level list sections as a repeatable editor

### DIFF
--- a/src/util/section-entry-overrides.ts
+++ b/src/util/section-entry-overrides.ts
@@ -38,6 +38,17 @@ import { makeConfigEntry } from "./config-entry-defaults.js";
  *  the YAML pane. */
 export const MAP_SECTIONS: ReadonlySet<string> = new Set(["substitutions"]);
 
+/** Values-record key the list body is stashed under for a LIST_SECTIONS
+ *  section. Synthetic, not a real YAML key; parse and serialize strip
+ *  it so it never lands in YAML. */
+export const LIST_SECTION_VALUE_KEY = "__items__";
+
+/** Top-level sections whose body is a list of mappings (globals: one
+ *  variable per dash item). Single source of truth — a member is both
+ *  collapsed to one navigator entry (``_expandListItems``) and edited
+ *  as a whole-block ``multi_value`` list. Add a key to enable both. */
+export const LIST_SECTIONS: ReadonlySet<string> = new Set(["globals"]);
+
 /** Sections that must persist explicit ``""`` values in YAML — i.e.
  *  the user typed a key + cleared the value, treat that as
  *  intentional data instead of "user cleared the field, drop it".
@@ -94,5 +105,22 @@ export function resolveSectionEntries(
   catalogEntries: ConfigEntry[]
 ): ConfigEntry[] {
   if (MAP_SECTIONS.has(sectionKey)) return MAP_SECTION_ENTRIES;
+  if (LIST_SECTIONS.has(sectionKey)) {
+    return [
+      makeConfigEntry({
+        key: LIST_SECTION_VALUE_KEY,
+        type: ConfigEntryType.NESTED,
+        multi_value: true,
+        label: LIST_SECTION_ITEM_LABELS[sectionKey] ?? "Item",
+        config_entries: catalogEntries,
+      }),
+    ];
+  }
   return catalogEntries;
 }
+
+/** Singular noun for each item card's header; the nested-list renderer
+ *  shows '<label> <n>' (Global variable 1). */
+const LIST_SECTION_ITEM_LABELS: Readonly<Record<string, string>> = {
+  globals: "Global variable",
+};

--- a/src/util/section-entry-overrides.ts
+++ b/src/util/section-entry-overrides.ts
@@ -38,11 +38,6 @@ import { makeConfigEntry } from "./config-entry-defaults.js";
  *  the YAML pane. */
 export const MAP_SECTIONS: ReadonlySet<string> = new Set(["substitutions"]);
 
-/** Values-record key the list body is stashed under for a LIST_SECTIONS
- *  section. Synthetic, not a real YAML key; parse and serialize strip
- *  it so it never lands in YAML. */
-export const LIST_SECTION_VALUE_KEY = "__items__";
-
 /** Top-level sections whose body is a list of mappings (globals: one
  *  variable per dash item). Single source of truth — a member is both
  *  collapsed to one navigator entry (``_expandListItems``) and edited
@@ -106,9 +101,11 @@ export function resolveSectionEntries(
 ): ConfigEntry[] {
   if (MAP_SECTIONS.has(sectionKey)) return MAP_SECTION_ENTRIES;
   if (LIST_SECTIONS.has(sectionKey)) {
+    // Value lives at [sectionKey], like esphome.areas — the form's
+    // multi_value renderer reads the item array straight off it.
     return [
       makeConfigEntry({
-        key: LIST_SECTION_VALUE_KEY,
+        key: sectionKey,
         type: ConfigEntryType.NESTED,
         multi_value: true,
         label: LIST_SECTION_ITEM_LABELS[sectionKey] ?? "Item",

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -8,11 +8,10 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
-import { LIST_SECTION_VALUE_KEY, LIST_SECTIONS } from "./section-entry-overrides.js";
+import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import {
   formatYamlScalar,
   parseYamlBoolean,
-  serializeListSection,
   serializeYamlValues,
   YamlRawValue,
   type SerializeYamlOptions,
@@ -751,16 +750,12 @@ export function parseYamlSectionValues(
   const childIndent = _detectSectionChildIndent(lines, startIdx, isListItem);
   const childRegex = childRegexFor(childIndent);
 
-  // Top-level list-bodied section (globals): stash the list under the
-  // synthetic key the form renders as a multi_value NESTED entry.
+  // Top-level list-bodied section (globals): the item array lives at
+  // [sectionKey], where the wrapper's multi_value entry reads it.
   if (!isListItem && LIST_SECTIONS.has(sectionKey)) {
     const peek = _skipBlankAndCommentLines(lines, startIdx + 1);
     if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
-      values[LIST_SECTION_VALUE_KEY] = parseListBlock(
-        lines,
-        startIdx + 1,
-        childIndent
-      ).value;
+      values[sectionKey] = parseListBlock(lines, startIdx + 1, childIndent).value;
       return values;
     }
   }
@@ -1000,25 +995,24 @@ export function updateSectionInYaml(
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
 
-  // Top-level list-bodied section (globals): re-emit the stashed list
-  // as bare dash items under the preserved header; the synthetic key
-  // never reaches YAML.
+  // Top-level list-bodied section (globals): re-emit through the
+  // mapping serializer's array branch — { sectionKey: array } yields
+  // `sectionKey:` plus the dash items at the section's child indent.
   if (LIST_SECTIONS.has(sectionKey)) {
-    const raw = values[LIST_SECTION_VALUE_KEY];
+    const raw = values[sectionKey];
     // No array → leave the YAML untouched rather than collapse the
     // block to a bare header, which would wipe every item.
     if (!Array.isArray(raw)) return yaml;
-    const list = raw;
-    const headerIndent = _leadingIndent(lines[start]);
     const childIndent = _detectSectionChildIndent(lines, start, false);
-    const step = childIndent.startsWith(headerIndent)
-      ? childIndent.slice(headerIndent.length) || ESPHOME_YAML_INDENT
-      : ESPHOME_YAML_INDENT;
-    const body = serializeListSection(list, headerIndent, {
-      ...options,
-      indentStep: options.indentStep ?? step,
-    });
-    lines.splice(start, end - start, lines[start], ...body);
+    const block = serializeYamlValues(
+      { [sectionKey]: raw },
+      _leadingIndent(lines[start]),
+      {
+        ...options,
+        indentStep: options.indentStep ?? (childIndent || ESPHOME_YAML_INDENT),
+      }
+    );
+    lines.splice(start, end - start, ...block);
     return lines.join("\n");
   }
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -8,11 +8,13 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { LIST_SECTION_VALUE_KEY, LIST_SECTIONS } from "./section-entry-overrides.js";
 import {
-  YamlRawValue,
   formatYamlScalar,
   parseYamlBoolean,
+  serializeListSection,
   serializeYamlValues,
+  YamlRawValue,
   type SerializeYamlOptions,
 } from "./yaml-serialize.js";
 
@@ -749,6 +751,20 @@ export function parseYamlSectionValues(
   const childIndent = _detectSectionChildIndent(lines, startIdx, isListItem);
   const childRegex = childRegexFor(childIndent);
 
+  // Top-level list-bodied section (globals): stash the list under the
+  // synthetic key the form renders as a multi_value NESTED entry.
+  if (!isListItem && LIST_SECTIONS.has(sectionKey)) {
+    const peek = _skipBlankAndCommentLines(lines, startIdx + 1);
+    if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
+      values[LIST_SECTION_VALUE_KEY] = parseListBlock(
+        lines,
+        startIdx + 1,
+        childIndent
+      ).value;
+      return values;
+    }
+  }
+
   // List-item form: the first child key may sit on the same line as
   // the leading dash (e.g. `  - platform: gpio\n    pin: 4`).
   if (isListItem) {
@@ -983,6 +999,28 @@ export function updateSectionInYaml(
   const lines = yaml.split("\n");
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
+
+  // Top-level list-bodied section (globals): re-emit the stashed list
+  // as bare dash items under the preserved header; the synthetic key
+  // never reaches YAML.
+  if (LIST_SECTIONS.has(sectionKey)) {
+    const raw = values[LIST_SECTION_VALUE_KEY];
+    // No array → leave the YAML untouched rather than collapse the
+    // block to a bare header, which would wipe every item.
+    if (!Array.isArray(raw)) return yaml;
+    const list = raw;
+    const headerIndent = _leadingIndent(lines[start]);
+    const childIndent = _detectSectionChildIndent(lines, start, false);
+    const step = childIndent.startsWith(headerIndent)
+      ? childIndent.slice(headerIndent.length) || ESPHOME_YAML_INDENT
+      : ESPHOME_YAML_INDENT;
+    const body = serializeListSection(list, headerIndent, {
+      ...options,
+      indentStep: options.indentStep ?? step,
+    });
+    lines.splice(start, end - start, lines[start], ...body);
+    return lines.join("\n");
+  }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[start]);
   // Match the user's existing indent step on save so 4-space (or

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -1003,6 +1003,9 @@ export function updateSectionInYaml(
     // No array → leave the YAML untouched rather than collapse the
     // block to a bare header, which would wipe every item.
     if (!Array.isArray(raw)) return yaml;
+    // Emptied list (every item deleted) → drop the whole block instead
+    // of leaving an invalid bare `sectionKey:`. serializeYamlValues
+    // skips empty arrays, so the splice removes header + body.
     const childIndent = _detectSectionChildIndent(lines, start, false);
     const block = serializeYamlValues(
       { [sectionKey]: raw },

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,3 +1,5 @@
+import { LIST_SECTIONS } from "./section-entry-overrides.js";
+
 export interface YamlSection {
   key: string;
   fromLine: number; // 1-indexed (CodeMirror convention)
@@ -99,12 +101,6 @@ export const CORE_KEYS = new Set([
 // `script` and `interval` are the standalone automation-adjacent
 // top-level keys.
 const AUTOMATION_KEYS = new Set(["script", "interval"]);
-
-// Sections that contain list items but should still be navigated to
-// as a single unit — clicking them takes you to the whole block, not
-// to individual entries inside. Keeps the navigator from listing one
-// nav item per global variable.
-const NON_EXPANDABLE_KEYS = new Set(["globals"]);
 
 export function categorizeSections(sections: YamlSection[]): CategorizedSections {
   const core: YamlSection[] = [];
@@ -253,10 +249,10 @@ function _expandListItems(
   lines: string[],
   section: { key: string; fromLine: number; toLine: number }
 ): YamlSection[] {
-  // Sections marked non-expandable keep their list items hidden from
-  // the navigator — the user navigates to the whole block, not the
-  // individual entries (e.g. globals).
-  if (NON_EXPANDABLE_KEYS.has(section.key)) {
+  // LIST_SECTIONS members keep their list items hidden from the
+  // navigator — the user navigates to the whole block (edited as a
+  // repeatable list), not the individual entries (e.g. globals).
+  if (LIST_SECTIONS.has(section.key)) {
     return [
       {
         key: section.key,

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -281,6 +281,19 @@ function serializeListItem(
 }
 
 /**
+ * Serialize a bare list (no parent key header) at indent, one item per
+ * serializeListItem. For top-level list-bodied sections (globals)
+ * whose dash items sit directly under the header.
+ */
+export function serializeListSection(
+  items: readonly unknown[],
+  indent: string,
+  options: SerializeYamlOptions = {}
+): string[] {
+  return items.flatMap((item) => serializeListItem(item, indent, options));
+}
+
+/**
  * True when *value* would emit at least one line through
  * ``serializeYamlValues`` under its *default* options.
  *

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -281,19 +281,6 @@ function serializeListItem(
 }
 
 /**
- * Serialize a bare list (no parent key header) at indent, one item per
- * serializeListItem. For top-level list-bodied sections (globals)
- * whose dash items sit directly under the header.
- */
-export function serializeListSection(
-  items: readonly unknown[],
-  indent: string,
-  options: SerializeYamlOptions = {}
-): string[] {
-  return items.flatMap((item) => serializeListItem(item, indent, options));
-}
-
-/**
  * True when *value* would emit at least one line through
  * ``serializeYamlValues`` under its *default* options.
  *

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -17,7 +17,6 @@ import { YAML_ONLY_SECTIONS } from "../../src/components/device/yaml-only-sectio
 import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
 import { validateEntries } from "../../src/util/config-validation.js";
 import {
-  LIST_SECTION_VALUE_KEY,
   LIST_SECTIONS,
   MAP_SECTIONS,
   resolveSectionEntries,
@@ -57,7 +56,7 @@ describe("resolveSectionEntries (LIST section shape)", () => {
     ];
     const entries = resolveSectionEntries("globals", catalog);
     expect(entries).toHaveLength(1);
-    expect(entries[0].key).toBe(LIST_SECTION_VALUE_KEY);
+    expect(entries[0].key).toBe("globals");
     expect(entries[0].type).toBe(ConfigEntryType.NESTED);
     expect(entries[0].multi_value).toBe(true);
     expect(entries[0].config_entries).toBe(catalog);
@@ -80,7 +79,7 @@ describe("resolveSectionEntries (LIST section shape)", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0].type).toBe(ConfigEntryType.NESTED);
       expect(entries[0].multi_value).toBe(true);
-      expect(entries[0].key).toBe(LIST_SECTION_VALUE_KEY);
+      expect(entries[0].key).toBe("future_list_section");
       expect(entries[0].label).toBe("Item");
     } finally {
       mutable.delete("future_list_section");

--- a/test/util/section-entry-overrides.test.ts
+++ b/test/util/section-entry-overrides.test.ts
@@ -13,9 +13,12 @@
  */
 import { describe, expect, it } from "vitest";
 import { type ConfigEntry, ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { YAML_ONLY_SECTIONS } from "../../src/components/device/yaml-only-sections.js";
 import { makeConfigEntry } from "../../src/util/config-entry-defaults.js";
 import { validateEntries } from "../../src/util/config-validation.js";
 import {
+  LIST_SECTION_VALUE_KEY,
+  LIST_SECTIONS,
   MAP_SECTIONS,
   resolveSectionEntries,
 } from "../../src/util/section-entry-overrides.js";
@@ -32,6 +35,56 @@ describe("MAP_SECTIONS", () => {
     // Routed through ``YAML_ONLY_SECTIONS`` instead so both
     // shapes round-trip cleanly via the YAML pane.
     expect(MAP_SECTIONS.has("packages")).toBe(false);
+  });
+});
+
+describe("LIST_SECTIONS", () => {
+  it("contains 'globals' (top-level list of variable mappings)", () => {
+    expect(LIST_SECTIONS.has("globals")).toBe(true);
+  });
+
+  it("'globals' is NOT YAML-only and NOT a MAP section", () => {
+    expect(YAML_ONLY_SECTIONS.has("globals")).toBe(false);
+    expect(MAP_SECTIONS.has("globals")).toBe(false);
+  });
+});
+
+describe("resolveSectionEntries (LIST section shape)", () => {
+  it("globals resolves to one multi_value NESTED entry wrapping the catalog", () => {
+    const catalog: ConfigEntry[] = [
+      makeConfigEntry({ key: "id", type: ConfigEntryType.STRING }),
+      makeConfigEntry({ key: "type", type: ConfigEntryType.STRING }),
+    ];
+    const entries = resolveSectionEntries("globals", catalog);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe(LIST_SECTION_VALUE_KEY);
+    expect(entries[0].type).toBe(ConfigEntryType.NESTED);
+    expect(entries[0].multi_value).toBe(true);
+    expect(entries[0].config_entries).toBe(catalog);
+  });
+
+  it("each item card titles read 'Global variable <n>'", () => {
+    // labelFor reads entry.label directly, and the nested-list
+    // renderer shows ``<label> <n>``.
+    const entries = resolveSectionEntries("globals", []);
+    expect(entries[0].label).toBe("Global variable");
+  });
+
+  it("wraps any LIST_SECTIONS member, defaulting the item label to 'Item'", () => {
+    // Genericity pin: the wrap keys off membership, and a member with
+    // no LIST_SECTION_ITEM_LABELS entry falls back to "Item".
+    const mutable = LIST_SECTIONS as Set<string>;
+    mutable.add("future_list_section");
+    try {
+      const entries = resolveSectionEntries("future_list_section", []);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].type).toBe(ConfigEntryType.NESTED);
+      expect(entries[0].multi_value).toBe(true);
+      expect(entries[0].key).toBe(LIST_SECTION_VALUE_KEY);
+      expect(entries[0].label).toBe("Item");
+    } finally {
+      mutable.delete("future_list_section");
+    }
   });
 });
 
@@ -77,6 +130,11 @@ describe("resolveSectionEntries", () => {
       makeConfigEntry({ key: "name", required: true }),
       makeConfigEntry({ key: "ssid", required: true }),
     ];
+    expect(resolveSectionEntries("wifi", catalogEntries)).toBe(catalogEntries);
+  });
+
+  it("returns the catalog entries unchanged for a non-list section", () => {
+    const catalogEntries: ConfigEntry[] = [makeConfigEntry({ key: "ssid" })];
     expect(resolveSectionEntries("wifi", catalogEntries)).toBe(catalogEntries);
   });
 

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1820,6 +1820,19 @@ describe("globals list section (LIST_SECTIONS)", () => {
     expect(Array.isArray(parsed.globals)).toBe(false);
     expect(parsed.foo).toBe("bar");
   });
+
+  it("removes the whole block when every item is deleted, keeping siblings", () => {
+    const out = updateSectionInYaml(TWO_ENTRY + "wifi:\n  ssid: home\n", "globals", {
+      globals: [],
+    });
+    expect(out).not.toContain("globals:");
+    expect(out).toContain("wifi:");
+    expect(out).toContain("ssid: home");
+  });
+
+  it("emptying the only section yields an empty document", () => {
+    expect(updateSectionInYaml(TWO_ENTRY, "globals", { globals: [] })).toBe("");
+  });
 });
 
 describe("LIST_SECTIONS is membership-driven, not hardcoded to globals", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  LIST_SECTION_VALUE_KEY,
-  LIST_SECTIONS,
-} from "../../src/util/section-entry-overrides.js";
+import { LIST_SECTIONS } from "../../src/util/section-entry-overrides.js";
 import {
   findSectionStart,
   LIST_ITEM_START_RE,
@@ -1723,9 +1720,9 @@ describe("globals list section (LIST_SECTIONS)", () => {
     "    type: bool\n" +
     "    restore_value: true\n";
 
-  it("parses a 2-entry globals block into the synthetic list key", () => {
+  it("parses a 2-entry globals block into an item array at [sectionKey]", () => {
     const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
-    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const items = parsed.globals as Record<string, unknown>[];
     expect(Array.isArray(items)).toBe(true);
     expect(items).toHaveLength(2);
     expect(items[0].id).toBe("my_int");
@@ -1738,15 +1735,12 @@ describe("globals list section (LIST_SECTIONS)", () => {
 
   it("round-trips editing one item's initial_value, keeping every entry", () => {
     const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
-    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const items = parsed.globals as Record<string, unknown>[];
     items[0].initial_value = "42";
-    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
-      [LIST_SECTION_VALUE_KEY]: items,
-    });
-    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", { globals: items });
     expect(out.startsWith("globals:")).toBe(true);
     const reparsed = parseYamlSectionValues(out + "\n", "globals");
-    const ritems = reparsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const ritems = reparsed.globals as Record<string, unknown>[];
     expect(ritems).toHaveLength(2);
     expect(ritems[0].id).toBe("my_int");
     expect(ritems[0].initial_value).toBe("42");
@@ -1755,29 +1749,25 @@ describe("globals list section (LIST_SECTIONS)", () => {
 
   it("round-trips adding a third item", () => {
     const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
-    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const items = parsed.globals as Record<string, unknown>[];
     items.push({ id: "my_str", type: "std::string" });
-    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
-      [LIST_SECTION_VALUE_KEY]: items,
-    });
-    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
-    const ritems = parseYamlSectionValues(out + "\n", "globals")[
-      LIST_SECTION_VALUE_KEY
-    ] as Record<string, unknown>[];
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", { globals: items });
+    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
+      string,
+      unknown
+    >[];
     expect(ritems.map((i) => i.id)).toEqual(["my_int", "my_bool", "my_str"]);
   });
 
   it("round-trips removing the first item", () => {
     const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
-    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const items = parsed.globals as Record<string, unknown>[];
     items.splice(0, 1);
-    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
-      [LIST_SECTION_VALUE_KEY]: items,
-    });
-    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
-    const ritems = parseYamlSectionValues(out + "\n", "globals")[
-      LIST_SECTION_VALUE_KEY
-    ] as Record<string, unknown>[];
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", { globals: items });
+    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
+      string,
+      unknown
+    >[];
     expect(ritems).toHaveLength(1);
     expect(ritems[0].id).toBe("my_bool");
   });
@@ -1790,17 +1780,15 @@ describe("globals list section (LIST_SECTIONS)", () => {
       "    - id: my_bool\n" +
       "      type: bool\n";
     const parsed = parseYamlSectionValues(FOUR_SPACE, "globals");
-    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    const items = parsed.globals as Record<string, unknown>[];
     expect(items).toHaveLength(2);
     expect(items[0].id).toBe("my_int");
     items[0].type = "int64_t";
-    const out = updateSectionInYaml(FOUR_SPACE, "globals", {
-      [LIST_SECTION_VALUE_KEY]: items,
-    });
-    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
-    const ritems = parseYamlSectionValues(out + "\n", "globals")[
-      LIST_SECTION_VALUE_KEY
-    ] as Record<string, unknown>[];
+    const out = updateSectionInYaml(FOUR_SPACE, "globals", { globals: items });
+    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
+      string,
+      unknown
+    >[];
     expect(ritems).toHaveLength(2);
     expect(ritems[0].type).toBe("int64_t");
     expect(ritems[1].id).toBe("my_bool");
@@ -1808,24 +1796,29 @@ describe("globals list section (LIST_SECTIONS)", () => {
 
   it("preserves sibling sections after globals on round-trip", () => {
     const WITH_SIBLING = TWO_ENTRY + "wifi:\n  ssid: home\n";
-    const items = parseYamlSectionValues(WITH_SIBLING, "globals")[
-      LIST_SECTION_VALUE_KEY
-    ] as Record<string, unknown>[];
+    const items = parseYamlSectionValues(WITH_SIBLING, "globals").globals as Record<
+      string,
+      unknown
+    >[];
     items[0].initial_value = "7";
-    const out = updateSectionInYaml(WITH_SIBLING, "globals", {
-      [LIST_SECTION_VALUE_KEY]: items,
-    });
+    const out = updateSectionInYaml(WITH_SIBLING, "globals", { globals: items });
     expect(out).toContain("wifi:");
     expect(out).toContain("ssid: home");
   });
 
   it("leaves the YAML untouched when the list value is not an array (no wipe)", () => {
-    // The form never produces this, but a missing/garbled synthetic
-    // key must not collapse the block to an empty mapping.
-    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
-      [LIST_SECTION_VALUE_KEY]: undefined,
-    });
+    // A missing/garbled value must not collapse the block to an empty
+    // mapping.
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", { globals: undefined });
     expect(out).toBe(TWO_ENTRY);
+  });
+
+  it("falls through to mapping parse when the body is not a dash-list", () => {
+    // Guard branch: a member whose body isn't `- ` items must not
+    // stash an array — it degrades to the empty-list editor, not a wipe.
+    const parsed = parseYamlSectionValues("globals:\n  foo: bar\n", "globals");
+    expect(Array.isArray(parsed.globals)).toBe(false);
+    expect(parsed.foo).toBe("bar");
   });
 });
 
@@ -1839,31 +1832,28 @@ describe("LIST_SECTIONS is membership-driven, not hardcoded to globals", () => {
     const mutable = LIST_SECTIONS as Set<string>;
     mutable.add(KEY);
     try {
-      const items = parseYamlSectionValues(FIXTURE, KEY)[
-        LIST_SECTION_VALUE_KEY
-      ] as Record<string, unknown>[];
+      const items = parseYamlSectionValues(FIXTURE, KEY)[KEY] as Record<
+        string,
+        unknown
+      >[];
       expect(items).toHaveLength(2);
       expect(items[0].id).toBe("a");
 
       items.push({ id: "c", type: "float" });
-      const out = updateSectionInYaml(FIXTURE, KEY, {
-        [LIST_SECTION_VALUE_KEY]: items,
-      });
-      expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+      const out = updateSectionInYaml(FIXTURE, KEY, { [KEY]: items });
       expect(out.startsWith(`${KEY}:`)).toBe(true);
-      const ritems = parseYamlSectionValues(out + "\n", KEY)[
-        LIST_SECTION_VALUE_KEY
-      ] as Record<string, unknown>[];
+      const ritems = parseYamlSectionValues(out + "\n", KEY)[KEY] as Record<
+        string,
+        unknown
+      >[];
       expect(ritems.map((i) => i.id)).toEqual(["a", "b", "c"]);
     } finally {
       mutable.delete(KEY);
     }
   });
 
-  it("parses the same fixture as a flat mapping when NOT a member", () => {
-    // Without membership the header body isn't list-stashed; the
-    // synthetic key is absent.
+  it("parses as a flat mapping (no item array) when NOT a member", () => {
     const parsed = parseYamlSectionValues(FIXTURE, KEY);
-    expect(parsed[LIST_SECTION_VALUE_KEY]).toBeUndefined();
+    expect(parsed[KEY]).toBeUndefined();
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  LIST_SECTION_VALUE_KEY,
+  LIST_SECTIONS,
+} from "../../src/util/section-entry-overrides.js";
+import {
   findSectionStart,
   LIST_ITEM_START_RE,
   parseYamlSectionValues,
@@ -1706,5 +1710,160 @@ describe("parseYamlSectionValues — ESPHome YAML boolean spellings", () => {
     expect(values.state).toBe("yes");
     expect(values.fallback).toBe("True");
     expect(values.hint).toBe("enable");
+  });
+});
+
+describe("globals list section (LIST_SECTIONS)", () => {
+  const TWO_ENTRY =
+    "globals:\n" +
+    "  - id: my_int\n" +
+    "    type: int\n" +
+    "    initial_value: '0'\n" +
+    "  - id: my_bool\n" +
+    "    type: bool\n" +
+    "    restore_value: true\n";
+
+  it("parses a 2-entry globals block into the synthetic list key", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(Array.isArray(items)).toBe(true);
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    expect(items[0].type).toBe("int");
+    expect(items[0].initial_value).toBe("0");
+    expect(items[1].id).toBe("my_bool");
+    expect(items[1].type).toBe("bool");
+    expect(items[1].restore_value).toBe(true);
+  });
+
+  it("round-trips editing one item's initial_value, keeping every entry", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items[0].initial_value = "42";
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    expect(out.startsWith("globals:")).toBe(true);
+    const reparsed = parseYamlSectionValues(out + "\n", "globals");
+    const ritems = reparsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(2);
+    expect(ritems[0].id).toBe("my_int");
+    expect(ritems[0].initial_value).toBe("42");
+    expect(ritems[1].id).toBe("my_bool");
+  });
+
+  it("round-trips adding a third item", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items.push({ id: "my_str", type: "std::string" });
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems.map((i) => i.id)).toEqual(["my_int", "my_bool", "my_str"]);
+  });
+
+  it("round-trips removing the first item", () => {
+    const parsed = parseYamlSectionValues(TWO_ENTRY, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    items.splice(0, 1);
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(1);
+    expect(ritems[0].id).toBe("my_bool");
+  });
+
+  it("round-trips a 4-space-indented globals fixture", () => {
+    const FOUR_SPACE =
+      "globals:\n" +
+      "    - id: my_int\n" +
+      "      type: int\n" +
+      "    - id: my_bool\n" +
+      "      type: bool\n";
+    const parsed = parseYamlSectionValues(FOUR_SPACE, "globals");
+    const items = parsed[LIST_SECTION_VALUE_KEY] as Record<string, unknown>[];
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    items[0].type = "int64_t";
+    const out = updateSectionInYaml(FOUR_SPACE, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+    const ritems = parseYamlSectionValues(out + "\n", "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    expect(ritems).toHaveLength(2);
+    expect(ritems[0].type).toBe("int64_t");
+    expect(ritems[1].id).toBe("my_bool");
+  });
+
+  it("preserves sibling sections after globals on round-trip", () => {
+    const WITH_SIBLING = TWO_ENTRY + "wifi:\n  ssid: home\n";
+    const items = parseYamlSectionValues(WITH_SIBLING, "globals")[
+      LIST_SECTION_VALUE_KEY
+    ] as Record<string, unknown>[];
+    items[0].initial_value = "7";
+    const out = updateSectionInYaml(WITH_SIBLING, "globals", {
+      [LIST_SECTION_VALUE_KEY]: items,
+    });
+    expect(out).toContain("wifi:");
+    expect(out).toContain("ssid: home");
+  });
+
+  it("leaves the YAML untouched when the list value is not an array (no wipe)", () => {
+    // The form never produces this, but a missing/garbled synthetic
+    // key must not collapse the block to an empty mapping.
+    const out = updateSectionInYaml(TWO_ENTRY, "globals", {
+      [LIST_SECTION_VALUE_KEY]: undefined,
+    });
+    expect(out).toBe(TWO_ENTRY);
+  });
+});
+
+describe("LIST_SECTIONS is membership-driven, not hardcoded to globals", () => {
+  // Pins genericity: parse/serialize key off membership, so a future
+  // top-level list section is one allowlist edit.
+  const KEY = "future_list_section";
+  const FIXTURE = `${KEY}:\n  - id: a\n    type: int\n  - id: b\n    type: bool\n`;
+
+  it("parses and round-trips an arbitrary LIST_SECTIONS member", () => {
+    const mutable = LIST_SECTIONS as Set<string>;
+    mutable.add(KEY);
+    try {
+      const items = parseYamlSectionValues(FIXTURE, KEY)[
+        LIST_SECTION_VALUE_KEY
+      ] as Record<string, unknown>[];
+      expect(items).toHaveLength(2);
+      expect(items[0].id).toBe("a");
+
+      items.push({ id: "c", type: "float" });
+      const out = updateSectionInYaml(FIXTURE, KEY, {
+        [LIST_SECTION_VALUE_KEY]: items,
+      });
+      expect(out).not.toContain(LIST_SECTION_VALUE_KEY);
+      expect(out.startsWith(`${KEY}:`)).toBe(true);
+      const ritems = parseYamlSectionValues(out + "\n", KEY)[
+        LIST_SECTION_VALUE_KEY
+      ] as Record<string, unknown>[];
+      expect(ritems.map((i) => i.id)).toEqual(["a", "b", "c"]);
+    } finally {
+      mutable.delete(KEY);
+    }
+  });
+
+  it("parses the same fixture as a flat mapping when NOT a member", () => {
+    // Without membership the header body isn't list-stashed; the
+    // synthetic key is absent.
+    const parsed = parseYamlSectionValues(FIXTURE, KEY);
+    expect(parsed[LIST_SECTION_VALUE_KEY]).toBeUndefined();
   });
 });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -51,6 +51,23 @@ wifi:
     expect(sections[1].name).toBe("bedroom");
   });
 
+  it("keeps a LIST_SECTIONS member (globals) as one un-expanded section", () => {
+    // A plain list section (sensor above) expands per item; a
+    // LIST_SECTIONS member stays a single header entry so the nav
+    // shows one "Global Variables" row, not one per variable.
+    const yaml = `globals:
+  - id: my_int
+    type: int
+  - id: my_bool
+    type: bool
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe("globals");
+    expect(sections[0].fromLine).toBe(1);
+    expect(sections[0].parentKey).toBeUndefined();
+  });
+
   it("ignores nested sub-reading name:/id: when extracting the item label (#1015)", () => {
     // A platform with no top-level name: but nested temperature/humidity
     // sub-sensors must not adopt a child's name as its label.


### PR DESCRIPTION
# What does this implement/fix?

Top-level YAML sections whose body is a **list of mappings** — `globals:`
(one variable per dash item) being the canonical case — rendered an empty
structured-editor form and **wiped the block on save**. They sit in the
navigator as a single non-expandable entry, so the section's `fromLine`
points at the header; the flat-mapping parser then finds no `key: value`
children (they're `- ` items) and returns `{}`, and the serializer
re-emits a flat mapping over the whole range, destroying every variable.

This renders such sections through a **curated frontend allowlist**,
`LIST_SECTIONS`, instead of the reverted per-component `is_list` schema
flag (#489/#494) — which fired for *every* `cv.ensure_list` component
(uart, i2c, font…) and regressed their rich flat forms. A member is
parsed into / serialized from a synthesized `multi_value` `NESTED` entry
(the same machinery `esphome.areas` etc. already use), so every item
round-trips losslessly.

`LIST_SECTIONS` is the **single source of truth** for this editor style:
the duplicate `NON_EXPANDABLE_KEYS` set in `yaml-sections.ts` is collapsed
into it, so one membership drives both the single-nav-entry behaviour and
the whole-block list editor — they can no longer drift. **Adding a future
globals-like top-level key is a one-line allowlist edit**; no
parse/serialize/render change.

A non-array list value leaves the YAML untouched rather than collapsing
the block to a bare header (the exact wipe this editor exists to prevent).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1097 (follow-up to the `is_list` revert #494)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
