### PR TITLE
Remove experimental grouping from settings sections

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -106,8 +106,6 @@ export class ESPHomeSettingsDialog extends LitElement {
   }
 
   private _renderNav() {
-    const flat = SECTIONS.filter((s) => !s.group);
-    const experimental = SECTIONS.filter((s) => s.group === "experimental");
     // Pre-compute whether to render the alert dot on the
     // 'Send builds' (build_offload) entry. The dot's meaning is
     // 'something in this section needs your attention' -- driven
@@ -159,17 +157,7 @@ export class ESPHomeSettingsDialog extends LitElement {
         </button>
       `;
     };
-    return html`
-      ${flat.map(renderItem)}
-      ${experimental.length
-        ? html`
-            <div class="nav-group-header">
-              ${this._localize("settings.experimental_tag")}
-            </div>
-            ${experimental.map(renderItem)}
-          `
-        : nothing}
-    `;
+    return html`${SECTIONS.map(renderItem)}`;
   }
 
   private _renderSection() {

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -104,17 +104,6 @@ export const settingsSharedStyles = css`
     flex-shrink: 0;
   }
 
-  .nav-group-header {
-    font-size: var(--wa-font-size-2xs);
-    font-weight: var(--wa-font-weight-bold);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--wa-color-text-quiet);
-    padding: var(--wa-space-s) var(--wa-space-s) var(--wa-space-2xs);
-    margin-top: var(--wa-space-s);
-    border-top: 1px solid var(--wa-color-surface-border);
-  }
-
   .content {
     flex: 1;
     display: flex;

--- a/src/components/settings-dialog/types.ts
+++ b/src/components/settings-dialog/types.ts
@@ -19,7 +19,6 @@ export interface SectionDef {
    *  MDI). */
   iconActive?: string;
   labelKey: string;
-  group?: "experimental";
 }
 
 export const SECTIONS: SectionDef[] = [
@@ -36,20 +35,17 @@ export const SECTIONS: SectionDef[] = [
     icon: "server-network-outline",
     iconActive: "server-network",
     labelKey: "settings.build_server",
-    group: "experimental",
   },
   {
     id: "pairing_requests",
     icon: "handshake-outline",
     iconActive: "handshake",
     labelKey: "settings.pairing_requests",
-    group: "experimental",
   },
   {
     id: "build_offload",
     icon: "send-outline",
     iconActive: "send",
     labelKey: "settings.build_offload",
-    group: "experimental",
   },
 ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -936,7 +936,6 @@
     "build_server": "Build server",
     "pairing_requests": "Pairing requests",
     "build_offload": "Send builds",
-    "experimental_tag": "Experimental",
     "nav_item_attention_aria": "{label}, attention needed",
     "remote_build_enable": "Enable remote build",
     "remote_build_enable_desc": "Lets other dashboards on your network compile their YAML here. A paired peer can run arbitrary code on this machine; only pair with dashboards you'd give ssh access to.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -982,7 +982,6 @@
     "build_server": "Serveur de compilation",
     "pairing_requests": "Demandes d'appairage",
     "build_offload": "Envoyer les compilations",
-    "experimental_tag": "Expérimental",
     "nav_item_attention_aria": "{label}, attention requise",
     "remote_build_enable": "Activer la compilation à distance",
     "remote_build_enable_desc": "Permet à d'autres tableaux de bord de votre réseau de compiler leur YAML ici. Un pair appairé peut exécuter n'importe quel code sur cette machine ; n'appairez qu'avec des tableaux de bord à qui vous donneriez un accès ssh.",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -936,7 +936,6 @@
     "build_server": "Összeállítási szerver",
     "pairing_requests": "Párosítási kérelmek",
     "build_offload": "Összeállítások küldése",
-    "experimental_tag": "Kísérleti",
     "nav_item_attention_aria": "{label}, figyelmet igényel",
     "remote_build_enable": "Távoli összeállítás engedélyezése",
     "remote_build_enable_desc": "Lehetővé teszi a hálózaton lévő más irányítópultoknak, hogy itt fordítsák le a YAML-jeiket. A párosított társ tetszőleges kódot futtathat ezen a gépen; csak olyan irányítópultokkal párosítson, amelyeknek akár ssh-hozzáférést adna.",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -982,7 +982,6 @@
     "build_server": "Build-server",
     "pairing_requests": "Koppelingsverzoeken",
     "build_offload": "Builds verzenden",
-    "experimental_tag": "Experimenteel",
     "nav_item_attention_aria": "{label}, vereist aandacht",
     "remote_build_enable": "Bouwen op afstand inschakelen",
     "remote_build_enable_desc": "Laat andere dashboards in je netwerk hun YAML hier compileren. Een gekoppelde peer kan willekeurige code op deze machine uitvoeren; koppel alleen met dashboards waaraan je ssh-toegang zou geven.",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -936,7 +936,6 @@
     "build_server": "构建服务器",
     "pairing_requests": "配对请求",
     "build_offload": "发送构建任务",
-    "experimental_tag": "实验性",
     "nav_item_attention_aria": "{label}，需要注意",
     "remote_build_enable": "启用远程构建",
     "remote_build_enable_desc": "允许同一网络中的其他仪表板在此处编译其 YAML。已配对的对端可以在这台机器上运行任意代码；仅与愿意授予 ssh 访问权限的仪表板配对。",


### PR DESCRIPTION
# What does this implement/fix?

Drops the "Experimental" grouping in the settings dialog; build server, pairing requests, and send builds are now late beta, so they render as regular sections alongside the others. Also removes the now unused `experimental_tag` translation key and the `.nav-group-header` styles.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
