### PR TITLE
Align pairing Extend button left on narrow dialogs

### DIFF
--- a/src/components/settings-dialog/pairing-styles.ts
+++ b/src/components/settings-dialog/pairing-styles.ts
@@ -50,4 +50,15 @@ export const pairingWindowStyles = css`
   .pairing-window-extend:focus-visible {
     background: var(--wa-color-surface-border);
   }
+
+  /* On a narrow dialog the heading wraps and the auto margin pins the
+     Extend button alone against the far right edge, reading as
+     detached. Drop the auto margin at the mobile breakpoint (matching
+     the settings dialog's 700px layout switch) so the button packs
+     left with the status pill and countdown instead. */
+  @media (max-width: 700px) {
+    .pairing-window-extend {
+      margin-inline-start: 0;
+    }
+  }
 `;


### PR DESCRIPTION
# What does this implement/fix?

On a narrow dialog the pairing requests heading wraps, and the `margin-inline-start: auto` on the Extend button pinned it alone against the far right edge, so it read as detached from the status pill and countdown. This drops that auto margin at the 700px mobile breakpoint, matching the settings dialog's existing layout switch, so the button packs left with the rest of the heading.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
