### PR TITLE
Share toolbar padding between card and table views on mobile

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -25,6 +25,13 @@ export const dashboardStyles = css`
        enforce the bar's own height and to reserve clearance inside
        the device table so its pagination row doesn't sit beneath it. */
     --select-bar-height: 64px;
+    /* Outer padding for the search toolbar, shared between the card
+       view's .toolbar and the table view's .controls. .controls lives
+       in esphome-device-table's shadow but inherits these from the
+       dashboard host, so both toolbars resolve identical values and
+       can't drift on mobile. Mobile override is in the @media block. */
+    --toolbar-pad-top: var(--wa-space-l);
+    --toolbar-pad-x: var(--wa-space-l);
   }
 
   /* YAML mode renders over any underlying view, so it shares this
@@ -50,6 +57,14 @@ export const dashboardStyles = css`
   @media (max-width: 600px) {
     :host([has-discovered]) {
       padding-top: var(--wa-space-l);
+    }
+
+    /* Tighten the shared toolbar gutters on mobile. Both .toolbar
+       (card) and .controls (table) inherit these, so the two views
+       stay in lockstep at narrow widths. #41 */
+    :host {
+      --toolbar-pad-top: var(--wa-space-s);
+      --toolbar-pad-x: var(--wa-space-s);
     }
   }
 
@@ -242,7 +257,7 @@ export const dashboardStyles = css`
     display: flex;
     flex-direction: column;
     gap: 2px;
-    padding: var(--wa-space-l) var(--wa-space-l) 0;
+    padding: var(--toolbar-pad-top) var(--toolbar-pad-x) 0;
     flex-shrink: 0;
   }
 
@@ -971,32 +986,19 @@ export const dashboardStyles = css`
     font-size: 18px;
   }
 
-  /* Mobile content-padding trim. The card grid, toolbar, and YAML
-     hit list all sit at --wa-space-l (24px) horizontal padding;
-     on a 375px phone viewport that's ~13% of the width per side
-     gone to chrome. Tighten to --wa-space-s (8px) so device cards
-     and the toolbar row claim the available width. Placed last in
-     the stylesheet so source-order wins against the base
-     declarations above. #41 */
+  /* Mobile content-padding trim. The card grid and YAML hit list
+     sit at --wa-space-l (24px) horizontal padding; on a 375px phone
+     viewport that's ~13% of the width per side gone to chrome.
+     Tighten to --wa-space-s (8px) so device cards claim the available
+     width. The toolbar's own gutters trim via the shared
+     --toolbar-pad-* tokens (see the :host @media block above), which
+     the table view inherits too. Placed last in the stylesheet so
+     source-order wins against the base declarations above. #41 */
   @media (max-width: 600px) {
     .devices-grid {
       padding-left: var(--wa-space-s);
       padding-right: var(--wa-space-s);
       gap: var(--wa-space-s);
-    }
-
-    .toolbar {
-      padding: var(--wa-space-s) var(--wa-space-s) 0;
-    }
-
-    /* When the discovered banner is present, the host already
-       provides padding-top equal to the banner height; the
-       toolbar's own padding-top stacks on top of that and reads
-       as dead space between the banner bottom and the search
-       input. Shrink to one step so the two rows breathe without
-       the doubled gutter. #41 */
-    :host([has-discovered]) .toolbar {
-      padding-top: var(--wa-space-s);
     }
 
     .yaml-hits {

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -36,7 +36,10 @@ export const tableLayoutStyles = css`
        y as Columns / Create. */
     align-items: flex-start;
     gap: var(--wa-space-s);
-    padding: var(--wa-space-l) var(--wa-space-l) 0;
+    /* Shared with the card view's .toolbar via tokens inherited from
+       the dashboard host, so the two views keep identical gutters at
+       every breakpoint (incl. the mobile trim). */
+    padding: var(--toolbar-pad-top) var(--toolbar-pad-x) 0;
     /* No bottom margin: the below-controls slot now carries the
        device-count + Select-multiple row, and its own bottom
        padding handles spacing to the .table-wrap. Keeping the
@@ -72,27 +75,15 @@ export const tableLayoutStyles = css`
     }
   }
 
-  /* Mobile content-padding trim. The controls strip and the
-     table-wrap claim --wa-space-l (24px) of horizontal padding /
-     margin on each side; on a 375px phone viewport that's ~13% of
-     the width per side gone to chrome. Match the dashboard's
-     .toolbar / .devices-grid trim so all three views share the
-     same tight gutters at narrow widths. #41 */
+  /* Mobile content-padding trim. The table-wrap claims --wa-space-l
+     (24px) of horizontal margin on each side; on a 375px phone
+     viewport that's ~13% of the width per side gone to chrome. Match
+     the dashboard's .devices-grid trim so all three views share the
+     same tight gutters at narrow widths. The .controls strip trims
+     via the shared --toolbar-pad-* tokens (defined on the dashboard
+     host and inherited here), so it stays in lockstep with the card
+     view's .toolbar without a duplicate rule. #41 */
   @media (max-width: 600px) {
-    .controls {
-      padding-left: var(--wa-space-s);
-      padding-right: var(--wa-space-s);
-    }
-
-    /* Mirrors the dashboard's :host([has-discovered]) .toolbar
-       trim: when the banner is present the dashboard already
-       provides padding-top equal to the banner's height, so the
-       controls' own padding-top stacks as dead space. Drop one
-       step so the table view matches the card / YAML views. #41 */
-    :host([has-discovered]) .controls {
-      padding-top: var(--wa-space-s);
-    }
-
     .table-wrap {
       margin-left: var(--wa-space-s);
       margin-right: var(--wa-space-s);


### PR DESCRIPTION
# What does this implement/fix?

On mobile the table (list) view had too much vertical space between the page header and the search input compared to the card view. The two toolbars live in different components; the card view's `.toolbar` and the table view's `.controls` each owned their own padding, so the mobile top padding trim only landed on the card view and the table view kept the full 24px gap.

This introduces shared CSS custom properties (`--toolbar-pad-top`, `--toolbar-pad-x`) on the dashboard host, following the existing single source of truth token pattern there. Both toolbars now consume the same tokens; the device table inherits them through the shadow tree, so the two views resolve identical gutters at every breakpoint and cannot drift again. Four now redundant override rules were removed in the process.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
