### PR TITLE
Route content gutter and toolbar row gap through shared tokens

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -31,7 +31,18 @@ export const dashboardStyles = css`
        dashboard host, so both toolbars resolve identical values and
        can't drift on mobile. Mobile override is in the @media block. */
     --toolbar-pad-top: var(--wa-space-l);
-    --toolbar-pad-x: var(--wa-space-l);
+    /* Horizontal content gutter shared by every full-width region in
+       both views: the toolbar (.toolbar / .controls), the card grid,
+       the YAML hit list, the table outline (.table-wrap), and the
+       table count row. Full on desktop, tightened on mobile in the
+       @media block below. Defined on the host so the device-table
+       shadow inherits it, keeping card and table views aligned. #41 */
+    --content-gutter: var(--wa-space-l);
+    /* Inter-row gap inside the toolbar. Card view's .toolbar and the
+       table view's .toolbar-stack both use it, and the table count
+       row mirrors it as padding-top, so the rows line up identically
+       when toggling between views. */
+    --toolbar-row-gap: 2px;
   }
 
   /* YAML mode renders over any underlying view, so it shares this
@@ -59,12 +70,12 @@ export const dashboardStyles = css`
       padding-top: var(--wa-space-l);
     }
 
-    /* Tighten the shared toolbar gutters on mobile. Both .toolbar
-       (card) and .controls (table) inherit these, so the two views
+    /* Tighten the shared gutters on mobile. Every full-width region
+       in both views inherits these, so the card and table layouts
        stay in lockstep at narrow widths. #41 */
     :host {
       --toolbar-pad-top: var(--wa-space-s);
-      --toolbar-pad-x: var(--wa-space-s);
+      --content-gutter: var(--wa-space-s);
     }
   }
 
@@ -219,8 +230,8 @@ export const dashboardStyles = css`
   .devices-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: var(--wa-space-l);
-    padding: var(--wa-space-l);
+    gap: var(--content-gutter);
+    padding: var(--wa-space-l) var(--content-gutter);
   }
 
   /* When the grid follows the toolbar's count row (whether directly
@@ -256,8 +267,8 @@ export const dashboardStyles = css`
   .toolbar {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: var(--toolbar-pad-top) var(--toolbar-pad-x) 0;
+    gap: var(--toolbar-row-gap);
+    padding: var(--toolbar-pad-top) var(--content-gutter) 0;
     flex-shrink: 0;
   }
 
@@ -266,11 +277,12 @@ export const dashboardStyles = css`
      .controls handles the outer padding). Without this rule the
      inner rows stacked at 0px gap while card view stacked at 2px,
      so flipping the view-toggle made the X-devices row jump 2px
-     vertically. */
+     vertically. Both gaps draw from --toolbar-row-gap so they
+     can't drift apart. */
   .toolbar-stack {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--toolbar-row-gap);
   }
 
   .toolbar-row {
@@ -436,7 +448,7 @@ export const dashboardStyles = css`
   .yaml-hits {
     display: flex;
     flex-direction: column;
-    padding: var(--wa-space-m) var(--wa-space-l) var(--wa-space-l);
+    padding: var(--wa-space-m) var(--content-gutter) var(--wa-space-l);
     gap: var(--wa-space-l);
   }
   /* Title-only list (no search query): pack rows tightly so the
@@ -582,18 +594,13 @@ export const dashboardStyles = css`
      device in the row above. Horizontal padding matches .controls
      and .table-wrap above/below so the count and toggle line up
      with the column headers on the right. 2px top padding mirrors
-     card view's .toolbar gap:2px so the inter-row spacing reads
-     identically between views. */
+     card view's .toolbar gap so the inter-row spacing reads
+     identically between views. Horizontal padding and top gap draw
+     from the shared --content-gutter / --toolbar-row-gap tokens, so
+     the count row trims on mobile and lines up with the toolbar
+     above it without a separate @media rule. */
   .table-device-count-row {
-    padding: 2px var(--wa-space-l) var(--wa-space-xs);
-  }
-
-  /* Mobile: tighten the table-view count-row gutter to match the
-     .controls / .table-wrap trim in PR-H (see table-styles.ts). */
-  @media (max-width: 600px) {
-    .table-device-count-row {
-      padding: 2px var(--wa-space-s) var(--wa-space-xs);
-    }
+    padding: var(--toolbar-row-gap) var(--content-gutter) var(--wa-space-xs);
   }
 
   /* ─── View Toggle ─── */
@@ -984,26 +991,5 @@ export const dashboardStyles = css`
   }
   .fab-btn wa-icon {
     font-size: 18px;
-  }
-
-  /* Mobile content-padding trim. The card grid and YAML hit list
-     sit at --wa-space-l (24px) horizontal padding; on a 375px phone
-     viewport that's ~13% of the width per side gone to chrome.
-     Tighten to --wa-space-s (8px) so device cards claim the available
-     width. The toolbar's own gutters trim via the shared
-     --toolbar-pad-* tokens (see the :host @media block above), which
-     the table view inherits too. Placed last in the stylesheet so
-     source-order wins against the base declarations above. #41 */
-  @media (max-width: 600px) {
-    .devices-grid {
-      padding-left: var(--wa-space-s);
-      padding-right: var(--wa-space-s);
-      gap: var(--wa-space-s);
-    }
-
-    .yaml-hits {
-      padding-left: var(--wa-space-s);
-      padding-right: var(--wa-space-s);
-    }
   }
 `;

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -39,7 +39,7 @@ export const tableLayoutStyles = css`
     /* Shared with the card view's .toolbar via tokens inherited from
        the dashboard host, so the two views keep identical gutters at
        every breakpoint (incl. the mobile trim). */
-    padding: var(--toolbar-pad-top) var(--toolbar-pad-x) 0;
+    padding: var(--toolbar-pad-top) var(--content-gutter) 0;
     /* No bottom margin: the below-controls slot now carries the
        device-count + Select-multiple row, and its own bottom
        padding handles spacing to the .table-wrap. Keeping the
@@ -75,25 +75,15 @@ export const tableLayoutStyles = css`
     }
   }
 
-  /* Mobile content-padding trim. The table-wrap claims --wa-space-l
-     (24px) of horizontal margin on each side; on a 375px phone
-     viewport that's ~13% of the width per side gone to chrome. Match
-     the dashboard's .devices-grid trim so all three views share the
-     same tight gutters at narrow widths. The .controls strip trims
-     via the shared --toolbar-pad-* tokens (defined on the dashboard
-     host and inherited here), so it stays in lockstep with the card
-     view's .toolbar without a duplicate rule. #41 */
-  @media (max-width: 600px) {
-    .table-wrap {
-      margin-left: var(--wa-space-s);
-      margin-right: var(--wa-space-s);
-    }
-  }
-
   /* ─── Table ─── */
 
   .table-wrap {
-    margin: 0 var(--wa-space-l) var(--wa-space-l);
+    /* Horizontal margin draws from the shared --content-gutter token
+       (defined on the dashboard host, inherited here), so the table
+       outline trims on mobile in lockstep with the .controls strip
+       and the card view's grid. The bottom margin is a separate
+       vertical step, trimmed in the @media block below. #41 */
+    margin: 0 var(--content-gutter) var(--wa-space-l);
     border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     border-radius: var(--wa-border-radius-l);
     overflow: hidden;
@@ -320,14 +310,12 @@ export const tableLayoutStyles = css`
     font-size: var(--wa-font-size-s);
   }
 
-  /* Mobile margin trim for the table outline. Placed at the end
-     of the stylesheet so source-order beats the default
-     .table-wrap shorthand above (which would otherwise reset
-     margin-left / margin-right when the @media block fires).
-     Matches the card grid's mobile side padding. #41 */
+  /* Mobile bottom-margin trim for the table outline. The horizontal
+     margins already tighten via --content-gutter; only the bottom
+     gap (a separate vertical step) needs trimming here. #41 */
   @media (max-width: 600px) {
     .table-wrap {
-      margin: 0 var(--wa-space-s) var(--wa-space-s);
+      margin-bottom: var(--wa-space-s);
     }
   }
 `;


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #500, which shared the toolbar padding between the card and table views. The same drift risk applied to a few more values that both views restated independently, so this routes them through shared tokens too.

`--content-gutter` is the horizontal content gutter (full on desktop, tightened on mobile); it now feeds the toolbar, the card grid, the YAML hit list, the table outline, and the table count row, which previously each carried their own `@media` trim. `--toolbar-row-gap` is the 2px inter-row gap that the card toolbar, the table toolbar stack, and the count row must keep in sync to avoid a vertical jump when toggling views; a comment used to enforce that by hand, now the token does. Both tokens are defined once on the dashboard host and inherited into the device table shadow, so the two views resolve identical values and cannot drift again. No visual change is intended; the resolved values match what shipped before.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
