### PR TITLE
Share primary button hover color through a token

### DIFF
--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -132,7 +132,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
       }
 
       .btn--primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--primary:disabled {

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -83,7 +83,7 @@ export class ESPHomeConfirmDialog extends LitElement {
       }
 
       .btn--confirm:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--confirm.destructive {

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -266,7 +266,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
         color: var(--esphome-on-primary);
       }
       .action--primary:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .action--accent {

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -644,7 +644,7 @@ export const dashboardStyles = css`
   }
 
   .view-toggle-btn.active:hover {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .view-toggle-btn wa-icon {
@@ -942,7 +942,7 @@ export const dashboardStyles = css`
   }
 
   .table-create-btn:hover {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .table-create-btn wa-icon {
@@ -980,7 +980,7 @@ export const dashboardStyles = css`
     letter-spacing: 0.01em;
   }
   .fab-btn:hover {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
     transform: translateY(-2px);
     box-shadow:
       0 8px 24px color-mix(in srgb, var(--esphome-primary), transparent 30%),

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -291,7 +291,7 @@ export const deviceCardStyles = [
     }
 
     .action-btn--primary:hover {
-      background: color-mix(in srgb, var(--esphome-primary), black 10%);
+      background: var(--esphome-primary-hover);
     }
 
     .action-btn--accent {

--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -127,7 +127,7 @@ export class ESPHomeAddApiActionDialog extends LitElement {
         box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
       }
       .actions .primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
         box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
         transform: translateY(-1px);
       }

--- a/src/components/device/add-automation-dialog.styles.ts
+++ b/src/components/device/add-automation-dialog.styles.ts
@@ -66,7 +66,7 @@ export const addAutomationDialogStyles = css`
     box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
   }
   .actions .primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
     box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
     transform: translateY(-1px);
   }

--- a/src/components/device/add-component-form.styles.ts
+++ b/src/components/device/add-component-form.styles.ts
@@ -166,7 +166,7 @@ export const addComponentFormStyles = css`
   }
 
   .btn-primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .error {

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -135,7 +135,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
         box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
       }
       .actions .primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
         box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
         transform: translateY(-1px);
       }

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -101,7 +101,7 @@ export const deviceEditorStyles = css`
   }
 
   .save-button:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
     box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
     transform: translateY(-1px);
   }

--- a/src/components/esphome-login.ts
+++ b/src/components/esphome-login.ts
@@ -161,7 +161,7 @@ export class ESPHomeLogin extends LitElement {
       }
 
       button[type="submit"]:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       button[type="submit"]:disabled {

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -177,8 +177,8 @@ export class ESPHomeFeedbackDialog extends LitElement {
       }
 
       .link.featured:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 12%);
-        border-color: color-mix(in srgb, var(--esphome-primary), black 12%);
+        background: var(--esphome-primary-hover);
+        border-color: var(--esphome-primary-hover);
       }
 
       .link.featured .link-icon,

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -143,7 +143,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
       }
 
       .btn--primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--primary:disabled {

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -227,7 +227,7 @@ export const installMethodDialogStyles = css`
   }
 
   .ota-form-actions .btn--primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .ota-form-actions .btn--primary:disabled {

--- a/src/components/labels/label-form.styles.ts
+++ b/src/components/labels/label-form.styles.ts
@@ -247,8 +247,8 @@ export const labelFormStyles = css`
   }
 
   .btn--primary:hover {
-    background: color-mix(in srgb, var(--esphome-primary), #000 10%);
-    border-color: color-mix(in srgb, var(--esphome-primary), #000 10%);
+    background: var(--esphome-primary-hover);
+    border-color: var(--esphome-primary-hover);
   }
 
   .btn:disabled,

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -105,7 +105,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
       }
 
       .btn--primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--primary:disabled {

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -151,7 +151,7 @@ export class ESPHomeSelectBar extends LitElement {
       }
 
       .btn--primary:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--danger {

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -74,7 +74,7 @@ export const pairingRowStyles = css`
   }
 
   .btn-pair-build-server:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .btn-pair-build-server:active:not(:disabled) {

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -146,7 +146,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
       }
 
       .btn--save:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn wa-icon {

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -91,7 +91,7 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
       }
 
       .btn-next:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn-next:disabled {

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -219,7 +219,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
       }
 
       .btn-primary:hover {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn-primary:disabled {

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -87,7 +87,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
       }
 
       .btn--goto:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
       }
 
       .btn--save-anyway {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -176,7 +176,7 @@ export class ESPHomePageSecrets extends LitElement {
       }
 
       .save-button:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), black 10%);
+        background: var(--esphome-primary-hover);
         box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
         transform: translateY(-1px);
       }

--- a/src/styles/dialog-action-buttons.ts
+++ b/src/styles/dialog-action-buttons.ts
@@ -58,7 +58,7 @@ export const dialogActionButtonStyles = css`
   }
 
   .btn--primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), black 10%);
+    background: var(--esphome-primary-hover);
   }
 
   .btn--primary:disabled {

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -13,6 +13,12 @@ export const espHomeStyles = css`
   :host {
     /* ─── Brand colors ─── */
     --esphome-primary: var(--primary-color, #009fee);
+    /* Hover / active background for hand-rolled primary <button>s
+       (the FAB, dialog confirm buttons, etc. that don't use
+       wa-button[variant="primary"]). Defined once so the brand
+       hover can't drift across the ~two dozen buttons that share
+       it. wa-button has its own hover in the variant rules below. */
+    --esphome-primary-hover: color-mix(in srgb, var(--esphome-primary), black 10%);
     --esphome-primary-light: color-mix(
       in srgb,
       var(--primary-color, #009fee) 12%,


### PR DESCRIPTION
# What does this implement/fix?

Continues the shared-token cleanup from #500 and #501. The primary button hover background, color-mix(in srgb, var(--esphome-primary), black 10%), was copy-pasted as the hover or active state of every hand-rolled primary button (the dashboard FAB, the table Create button, dialog confirm buttons, and so on), so darkening the brand hover meant editing two dozen files by hand.

This adds a single --esphome-primary-hover token in espHomeStyles and points all of them at it. Two buttons in label-form spelled the same value as #000 10% and one in feedback-dialog used black 12%; both were the same intent drifted slightly, so they now use the token too. The wa-button[variant="primary"] hover keeps its own rule since it darkens --esphome-secondary, not --esphome-primary. No visual change is intended; the resolved color is unchanged except feedback-dialog, which moves from 12% to the standard 10%.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
