### PR TITLE
Share keyboard focus ring through tokens

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -351,7 +351,7 @@ export const dashboardStyles = css`
 
   .filter-clear:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   /* The <form role="search"> wrapper is what suppresses Chrome's
@@ -685,7 +685,7 @@ export const dashboardStyles = css`
   .select-toggle-btn:focus-visible {
     outline: none;
     color: var(--wa-color-text-normal);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .select-toggle-btn.active {

--- a/src/components/device/add-component-form.styles.ts
+++ b/src/components/device/add-component-form.styles.ts
@@ -52,7 +52,7 @@ export const addComponentFormStyles = css`
 
   select:focus {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   select.invalid {

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -228,7 +228,7 @@ export const configEntryFormStyles = css`
 
   .multi-row .multi-input:focus {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   .multi-row .multi-input.invalid {
@@ -257,7 +257,7 @@ export const configEntryFormStyles = css`
 
   .combobox-input:focus {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   .combobox-input.invalid {

--- a/src/components/facets/facet-styles.ts
+++ b/src/components/facets/facet-styles.ts
@@ -65,7 +65,7 @@ export const facetStyles = css`
 
   .facet-trigger:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   /* Leading + icon — sits before the facet name in every state. */
@@ -154,7 +154,7 @@ export const facetStyles = css`
   .facet-trigger-badge-remove:focus-visible {
     outline: none;
     opacity: 1;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .facet-trigger-badge-remove wa-icon {

--- a/src/components/labels/label-form.styles.ts
+++ b/src/components/labels/label-form.styles.ts
@@ -91,7 +91,7 @@ export const labelFormStyles = css`
 
   .suggestion-chip:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .suggestion-chip wa-icon {
@@ -181,7 +181,7 @@ export const labelFormStyles = css`
     outline: none;
     box-shadow:
       inset 0 0 0 1px color-mix(in srgb, #000, transparent 88%),
-      0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+      var(--esphome-focus-ring);
   }
 
   .swatch--selected {
@@ -211,7 +211,7 @@ export const labelFormStyles = css`
     border-style: solid;
     border-color: var(--esphome-primary);
     color: var(--esphome-primary);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 75%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .create-actions {

--- a/src/components/labels/labels-filter.styles.ts
+++ b/src/components/labels/labels-filter.styles.ts
@@ -105,7 +105,7 @@ export const labelsFilterStyles = css`
   .row-action:focus-visible {
     outline: none;
     color: var(--wa-color-text-normal);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .row-action--danger:hover {
@@ -207,7 +207,7 @@ export const labelsFilterStyles = css`
 
   .create-trigger:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .create-trigger wa-icon {

--- a/src/components/labels/labels-list-styles.ts
+++ b/src/components/labels/labels-list-styles.ts
@@ -67,7 +67,7 @@ export const labelsListStyles = css`
   .option:focus-visible {
     outline: none;
     background: var(--wa-color-surface-lowered);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .option-check {

--- a/src/components/mdi-icon-picker.styles.ts
+++ b/src/components/mdi-icon-picker.styles.ts
@@ -33,7 +33,7 @@ export const mdiIconPickerStyles = css`
   .trigger:focus,
   :host([open]) .trigger {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   .trigger.invalid {

--- a/src/components/settings-dialog/build-server-styles.ts
+++ b/src/components/settings-dialog/build-server-styles.ts
@@ -139,7 +139,7 @@ export const cleanupTtlStyles = css`
   .cleanup-ttl-number:focus {
     outline: none;
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .cleanup-ttl-unit {

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -83,7 +83,7 @@ export const pairingRowStyles = css`
 
   .btn-pair-build-server:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   .btn-pair-build-server:disabled {

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -43,7 +43,7 @@ export const inputStyles = css`
 
   input:focus {
     border-color: var(--esphome-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   input:disabled {
@@ -82,7 +82,7 @@ export const inputStyles = css`
   wa-select:focus-within::part(combobox) {
     border-color: var(--esphome-primary);
     outline: none;
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    box-shadow: var(--esphome-focus-ring);
   }
 
   wa-select[disabled]::part(combobox) {

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -33,6 +33,15 @@ export const espHomeStyles = css`
     /* Text color for use on primary / dark / colored backgrounds — white in both light and dark modes */
     --esphome-on-primary: var(--text-primary-color, #ffffff);
 
+    /* Keyboard focus ring, defined once so every :focus-visible glow
+       stays consistent. Two sizes: the default 3px ring for inputs /
+       fields, and a 2px "tight" ring for compact controls (chips,
+       pills, icon buttons). Used as the full box-shadow value. */
+    --esphome-focus-ring: 0 0 0 3px
+      color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    --esphome-focus-ring-tight: 0 0 0 2px
+      color-mix(in srgb, var(--esphome-primary), transparent 70%);
+
     /* ─── Layout ─── */
     --esphome-header-height: 56px;
     --esphome-footer-height: 20px;


### PR DESCRIPTION
# What does this implement/fix?

Continues the shared-token cleanup from #500, #501 and #502. The keyboard focus ring, box-shadow: 0 0 0 Npx color-mix(in srgb, var(--esphome-primary), transparent NN%), was copy-pasted as the :focus-visible glow across ~18 controls, with the opacity drifting between 60 and 80 percent.

This adds two tokens in espHomeStyles; --esphome-focus-ring (3px, for inputs and fields) and --esphome-focus-ring-tight (2px, for compact controls like chips, pills and icon buttons), and points every focus ring at one of them. The handful of strays (2px at 60, 75 and 80 percent, and 3px at 70 percent) were treated as accidental drift and folded into the nearest standard ring, so a few rings shift opacity very slightly; everything else resolves to the same value. The device-card pulse animation and the raised-button drop shadows are a different family and are left alone.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
