### PR TITLE
Share primary button elevation shadow through tokens

### DIFF
--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -124,11 +124,11 @@ export class ESPHomeAddApiActionDialog extends LitElement {
       .actions .primary {
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
-        box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
+        box-shadow: var(--esphome-primary-shadow);
       }
       .actions .primary:hover:not(:disabled) {
         background: var(--esphome-primary-hover);
-        box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
+        box-shadow: var(--esphome-primary-shadow-hover);
         transform: translateY(-1px);
       }
       .actions .primary:active:not(:disabled) {

--- a/src/components/device/add-automation-dialog.styles.ts
+++ b/src/components/device/add-automation-dialog.styles.ts
@@ -63,11 +63,11 @@ export const addAutomationDialogStyles = css`
   .actions .primary {
     background: var(--esphome-primary);
     color: var(--esphome-on-primary);
-    box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
+    box-shadow: var(--esphome-primary-shadow);
   }
   .actions .primary:hover:not(:disabled) {
     background: var(--esphome-primary-hover);
-    box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
+    box-shadow: var(--esphome-primary-shadow-hover);
     transform: translateY(-1px);
   }
   .actions .primary:active:not(:disabled) {

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -132,11 +132,11 @@ export class ESPHomeAddScriptDialog extends LitElement {
       .actions .primary {
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
-        box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
+        box-shadow: var(--esphome-primary-shadow);
       }
       .actions .primary:hover:not(:disabled) {
         background: var(--esphome-primary-hover);
-        box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
+        box-shadow: var(--esphome-primary-shadow-hover);
         transform: translateY(-1px);
       }
       .actions .primary:active:not(:disabled) {

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -97,12 +97,12 @@ export const deviceEditorStyles = css`
   .save-button {
     background: var(--esphome-primary);
     color: var(--esphome-on-primary);
-    box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
+    box-shadow: var(--esphome-primary-shadow);
   }
 
   .save-button:hover:not(:disabled) {
     background: var(--esphome-primary-hover);
-    box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
+    box-shadow: var(--esphome-primary-shadow-hover);
     transform: translateY(-1px);
   }
 

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -168,7 +168,7 @@ export class ESPHomePageSecrets extends LitElement {
         font-size: var(--wa-font-size-xs);
         font-weight: var(--wa-font-weight-bold);
         font-family: inherit;
-        box-shadow: 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%);
+        box-shadow: var(--esphome-primary-shadow);
         transition:
           background 0.12s,
           box-shadow 0.12s,
@@ -177,7 +177,7 @@ export class ESPHomePageSecrets extends LitElement {
 
       .save-button:hover:not(:disabled) {
         background: var(--esphome-primary-hover);
-        box-shadow: 0 4px 14px color-mix(in srgb, var(--esphome-primary), transparent 35%);
+        box-shadow: var(--esphome-primary-shadow-hover);
         transform: translateY(-1px);
       }
 

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -42,6 +42,16 @@ export const espHomeStyles = css`
     --esphome-focus-ring-tight: 0 0 0 2px
       color-mix(in srgb, var(--esphome-primary), transparent 70%);
 
+    /* Elevation glow for raised primary action buttons (save, add,
+       etc.); rest + hover pair so the lift on hover stays consistent.
+       Bigger floating surfaces (the FAB, the round add-device badge)
+       keep their own larger, multi-layer shadows. Used as the full
+       box-shadow value. */
+    --esphome-primary-shadow: 0 2px 8px
+      color-mix(in srgb, var(--esphome-primary), transparent 50%);
+    --esphome-primary-shadow-hover: 0 4px 14px
+      color-mix(in srgb, var(--esphome-primary), transparent 35%);
+
     /* ─── Layout ─── */
     --esphome-header-height: 56px;
     --esphome-footer-height: 20px;


### PR DESCRIPTION
# What does this implement/fix?

Continues the shared-token cleanup from #500, #501, #502 and #503. Raised primary action buttons (save, add, and friends) all carried the same elevation glow copy-pasted inline; a rest shadow of 0 2px 8px color-mix(in srgb, var(--esphome-primary), transparent 50%) and a hover shadow of 0 4px 14px ... transparent 35%, so the lift on hover had to be kept in sync by hand across five components.

This adds --esphome-primary-shadow and --esphome-primary-shadow-hover in espHomeStyles and points the ten sites at them. The bigger floating surfaces keep their own larger shadows on purpose; the dashboard FAB uses a two-layer shadow and the round add-device badge a larger blur, so those are left alone. No visual change is intended; the resolved shadows are identical.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
