### PR TITLE
Fold table toolbar Filters, Columns, Create onto one row on mobile

### DIFF
--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -186,9 +186,10 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
     >
       <div slot="toolbar" class="toolbar-stack">
         <div class="toolbar-row">
-          ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
+          ${renderSearchInput(host)} ${renderViewToggle(host)}
         </div>
       </div>
+      <div slot="before-columns" class="table-facets">${renderFacets(host)}</div>
       <div slot="below-controls" class="table-device-count-row">
         ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}
       </div>
@@ -198,7 +199,7 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
         @click=${() => host._createDialog.open()}
       >
         <wa-icon library="mdi" name="plus"></wa-icon>
-        ${host._localize("dashboard.create_device")}
+        <span class="label">${host._localize("dashboard.create_device")}</span>
       </button>
       <div slot="no-results-extra" class="yaml-preview-banner">
         ${renderNoResultsExtras(host)}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -189,6 +189,12 @@ export function renderTable(host: ESPHomePageDashboard): TemplateResult {
           ${renderSearchInput(host)} ${renderViewToggle(host)}
         </div>
       </div>
+      <!-- Facets live in the controls-right cluster (with Columns +
+           Create) at every width, not just mobile. At <=1100px this is
+           the single collapsed Filters button; above 1100px it expands
+           to the full facet pills, which then sit in the right cluster
+           and let the search box absorb the horizontal squeeze. That
+           wide-screen expansion is intentional, not a regression. -->
       <div slot="before-columns" class="table-facets">${renderFacets(host)}</div>
       <div slot="below-controls" class="table-device-count-row">
         ${renderDeviceCountRow(host, filteredDevices.length, host._devices.length)}

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -373,6 +373,18 @@ export const dashboardStyles = css`
     flex: 1 1 220px;
     min-width: 140px;
   }
+
+  /* Table view only: the facets/Filters control no longer shares the
+     search row (it moved into the controls-right cluster), so the
+     search input can seed from a 0 flex-basis. Flex line-breaking uses
+     the basis, not min-width, so the 220px basis above would push the
+     view-toggle onto a second line at ~360px; a 0 basis keeps search +
+     view-toggle on one row (search still grows to fill, floored by the
+     140px min-width). Card / YAML toolbars keep the 220px basis since
+     their Filters control still shares this row. */
+  .toolbar-stack .search-wrap {
+    flex-basis: 0;
+  }
   /* Native <input class="search-input"> picks up the shared
      border / radius / focus-ring shape from inputStyles
      (src/styles/inputs.ts) — matches the .combobox-input shape
@@ -939,6 +951,11 @@ export const dashboardStyles = css`
     background: var(--esphome-primary);
     color: var(--esphome-on-primary);
     transition: background 0.12s;
+    /* Keeps its natural width; on mobile's single-row toolbar
+       (table-styles.ts) it may only shrink, never grow. min-width:0 +
+       the label ellipsis below let it ellipsize instead of wrapping
+       the row in a long locale. */
+    min-width: 0;
   }
 
   .table-create-btn:hover {
@@ -947,6 +964,21 @@ export const dashboardStyles = css`
 
   .table-create-btn wa-icon {
     font-size: 15px;
+    flex-shrink: 0;
+  }
+
+  .table-create-btn .label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Tighter horizontal padding on the mobile toolbar row so the three
+     controls sit more compactly (matches the Columns toggle). */
+  @media (max-width: 700px) {
+    .table-create-btn {
+      padding: 0 10px;
+    }
   }
 
   /* ─── FAB ─── */

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -971,6 +971,9 @@ export const dashboardStyles = css`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    /* Flex item must allow shrinking below its intrinsic width or the
+       ellipsis never triggers when the mobile row gets tight. */
+    min-width: 0;
   }
 
   /* Tighter horizontal padding on the mobile toolbar row so the three

--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -80,6 +80,9 @@ export class ESPHomeTableColumnToggle extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        /* Flex item must allow shrinking below its intrinsic width or
+           the ellipsis never triggers on a tight toolbar row. */
+        min-width: 0;
       }
 
       /* Tighter horizontal padding on the mobile toolbar row so the
@@ -204,7 +207,10 @@ export class ESPHomeTableColumnToggle extends LitElement {
     return html`
       <button
         class="toggle-btn"
+        type="button"
         aria-label=${this._localize("dashboard.table_columns")}
+        aria-haspopup="true"
+        aria-expanded=${this._open}
         @click=${this._toggle}
       >
         <wa-icon library="mdi" name="cog-outline"></wa-icon>

--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -35,6 +35,9 @@ export class ESPHomeTableColumnToggle extends LitElement {
       :host {
         display: block;
         position: relative;
+        /* Allow the toggle to shrink (and its label to ellipsize) when
+           it shares the mobile toolbar row with Filters + Create. */
+        min-width: 0;
       }
 
       .toggle-btn {
@@ -43,6 +46,8 @@ export class ESPHomeTableColumnToggle extends LitElement {
         gap: 6px;
         padding: 0 14px;
         height: 36px;
+        max-width: 100%;
+        min-width: 0;
         box-sizing: border-box;
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-xs);
@@ -64,6 +69,25 @@ export class ESPHomeTableColumnToggle extends LitElement {
 
       .toggle-btn wa-icon {
         font-size: 15px;
+        flex-shrink: 0;
+      }
+
+      /* On mobile the Columns toggle shares one row with Filters and
+         Create device (see table-styles.ts). The label ellipsizes
+         rather than wrapping the row when space is tight (e.g. a long
+         translated "Columns" string); the icon stays put. */
+      .toggle-btn .label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      /* Tighter horizontal padding on the mobile toolbar row so the
+         three controls sit more compactly (matches Create device). */
+      @media (max-width: 700px) {
+        .toggle-btn {
+          padding: 0 10px;
+        }
       }
 
       .backdrop {
@@ -84,6 +108,20 @@ export class ESPHomeTableColumnToggle extends LitElement {
         box-shadow: var(--wa-shadow-l);
         padding: var(--wa-space-xs) 0;
         animation: menu-in 0.15s ease-out;
+      }
+
+      /* At desktop widths the toggle sits at the right edge of the
+         controls row, so the menu (right:0) opens leftward and fits.
+         On mobile the toggle moves into the middle of the second
+         toolbar row (see table-styles.ts), where right:0 would push
+         the menu off the left edge of the viewport. Anchor it to the
+         toggle's left edge so it opens rightward into open space.
+         700px matches the breakpoint where the controls reflow. */
+      @media (max-width: 700px) {
+        .menu {
+          left: 0;
+          right: auto;
+        }
       }
 
       @keyframes menu-in {
@@ -164,9 +202,13 @@ export class ESPHomeTableColumnToggle extends LitElement {
 
   protected render() {
     return html`
-      <button class="toggle-btn" @click=${this._toggle}>
+      <button
+        class="toggle-btn"
+        aria-label=${this._localize("dashboard.table_columns")}
+        @click=${this._toggle}
+      >
         <wa-icon library="mdi" name="cog-outline"></wa-icon>
-        ${this._localize("dashboard.table_columns")}
+        <span class="label">${this._localize("dashboard.table_columns")}</span>
       </button>
       ${this._open
         ? html`

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -35,7 +35,12 @@ export const tableLayoutStyles = css`
        facets). The slotted toolbar's right edge sits at the same
        y as Columns / Create. */
     align-items: flex-start;
-    gap: var(--wa-space-s);
+    /* row-gap matches the card / YAML toolbars' .toolbar-row
+       (row-gap: --wa-space-xs) so the vertical distance between the
+       search row and the wrapped Filters/Columns/Create row is
+       identical across all three views; column-gap stays --wa-space-s
+       for the desktop single-row spacing. */
+    gap: var(--wa-space-xs) var(--wa-space-s);
     /* Shared with the card view's .toolbar via tokens inherited from
        the dashboard host, so the two views keep identical gutters at
        every breakpoint (incl. the mobile trim). */
@@ -66,12 +71,35 @@ export const tableLayoutStyles = css`
       flex-wrap: wrap;
     }
 
+    /* Row 1: search + view-toggle claim the full width. */
     .controls ::slotted([slot="toolbar"]) {
       flex: 1 1 100%;
     }
 
+    /* Row 2: Filters + Columns + Create device share one line, packed
+       at the left (margin-left was previously auto, which pinned the
+       cluster to the right and left the dead space on the left). The
+       buttons keep their natural width and the row never wraps; when
+       space is tight (a long locale) Columns and Create shrink and
+       ellipsize their labels rather than breaking to a second line.
+       Filters keeps its short label (does not shrink). */
     .controls-right {
-      margin-left: auto;
+      flex: 1 1 100%;
+      flex-wrap: nowrap;
+      margin-left: 0;
+      align-items: center;
+      /* Tighter inter-button gap on the mobile row than the desktop
+         cluster's --wa-space-s. */
+      gap: var(--wa-space-xs);
+    }
+
+    .controls-right ::slotted([slot="before-columns"]) {
+      flex: 0 0 auto;
+    }
+
+    .controls-right ::slotted([slot="actions"]) {
+      flex: 0 1 auto;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

On mobile the dashboard table/list toolbar wrapped its controls across three stacked rows; Filters sat alone, and Columns + Create device dropped to a third row pinned to the right with dead space on the left. This folds them onto a single row: row one keeps search + the view toggle, row two holds Filters, Columns, and Create device packed at the left. The row never wraps regardless of locale; Columns and Create device shrink and ellipsize their labels if space gets tight, while Filters keeps its short label.

Along the way it also fixes several related toolbar issues at narrow widths: the Columns dropdown now opens rightward so it no longer clips off the left edge of the viewport; the vertical gap between the search row and the controls row matches the card and YAML views; and the search box no longer shoves the view toggle onto its own line at 360px wide.

Filters now groups with Columns and Create device in the right cluster at all widths, not just mobile; on wide screens that moves the facet pills into that cluster.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
