### PR TITLE
Hide Filters control in YAML search view

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -163,7 +163,7 @@ export function renderYamlToolbar(host: ESPHomePageDashboard): TemplateResult {
   return html`
     <div class="toolbar">
       <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)} ${renderFacets(host)}
+        ${renderSearchInput(host)} ${renderViewToggle(host)}
         <span class="toolbar-spacer"></span>
       </div>
       ${matchCount !== null


### PR DESCRIPTION
# What does this implement/fix?

The YAML search view rendered the Filters control in its toolbar, but the facets filter the device list, not YAML file contents, so the button did nothing there and just added clutter. This drops `renderFacets` from the YAML toolbar, leaving the search box and the view toggle; the card and table views are unaffected since they render their own toolbars.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
