### PR TITLE
Drop dead 64px fallback on --select-bar-height

### DIFF
--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -24,7 +24,7 @@ export const tableLayoutStyles = css`
      --select-bar-height (with nowrap labels) so this reservation
      can't drift out of sync. */
   :host([select-mode]) {
-    padding-bottom: var(--select-bar-height, 64px);
+    padding-bottom: var(--select-bar-height);
     box-sizing: border-box;
   }
 

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -60,7 +60,7 @@ export class ESPHomeSelectBar extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: var(--wa-space-m) var(--wa-space-xl);
-        height: var(--select-bar-height, 64px);
+        height: var(--select-bar-height);
         box-sizing: border-box;
         /* Locked at exactly --select-bar-height so the table host's
            padding-bottom reservation can never be undershot by a


### PR DESCRIPTION
# What does this implement/fix?

Small follow-up to the shared-token cleanup. Both the floating multi-select bar and the device table reserved space for the bar using var(--select-bar-height, 64px); the 64px literal fallback duplicated the canonical --select-bar-height token defined on the dashboard host. Both components render inside the dashboard shadow and inherit that token, so the fallback was dead and just a second place for 64px to drift; a comment even promises the table reservation and the bar height can't drift out of sync, which the duplicated fallback quietly undermined.

This drops the fallback in both spots so the token is the single source. No visual change.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
