### PR TITLE
Share primary tint backgrounds and borders through a token scale

### DIFF
--- a/src/components/command-palette.styles.ts
+++ b/src/components/command-palette.styles.ts
@@ -123,9 +123,9 @@ export const commandPaletteStyles = css`
      (the icon already swaps to magnify as the "switch to"
      destination). */
   .mode-toggle--yaml {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 85%);
+    background: var(--esphome-tint-strong);
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    border-color: var(--esphome-tint-border);
   }
 
   .list {

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -73,7 +73,7 @@ export class ESPHomeConfirmDialog extends LitElement {
       }
 
       .icon-wrap:not(.destructive) {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+        background: var(--esphome-tint);
         color: var(--esphome-primary);
       }
 

--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -39,7 +39,7 @@ export const deviceDrawerContentStyles = css`
     width: 32px;
     height: 32px;
     border-radius: var(--wa-border-radius-m);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    background: var(--esphome-tint);
     flex-shrink: 0;
     margin-top: 2px;
   }
@@ -154,7 +154,7 @@ export const deviceDrawerContentStyles = css`
   }
   .build-size-clean:hover {
     color: var(--wa-color-text-normal);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
   }
   /* aria-disabled instead of disabled so the title tooltip stays discoverable;
      the click handler is gated separately on the busy property. */
@@ -198,8 +198,8 @@ export const deviceDrawerContentStyles = css`
 
   .tag--link:hover,
   .tag--link:focus-visible {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    background: var(--esphome-tint);
+    border-color: var(--esphome-tint-border);
   }
 
   .tag--link:focus-visible {
@@ -285,7 +285,7 @@ export const deviceDrawerContentStyles = css`
   }
 
   .status-badge--update {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 
@@ -300,7 +300,7 @@ export const deviceDrawerContentStyles = css`
   }
 
   .status-badge--encryption-pending {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -270,12 +270,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
       }
 
       .action--accent {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+        background: var(--esphome-tint);
         color: var(--esphome-primary);
-        border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+        border-color: var(--esphome-tint-border);
       }
       .action--accent:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 82%);
+        background: var(--esphome-tint-strong);
         border-color: var(--esphome-primary);
       }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -346,7 +346,7 @@ export const dashboardStyles = css`
 
   .filter-clear:hover {
     color: var(--esphome-primary);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    background: var(--esphome-tint);
   }
 
   .filter-clear:focus-visible {
@@ -480,7 +480,7 @@ export const dashboardStyles = css`
       border-color 0.12s;
   }
   .yaml-hits:not(:has(.yaml-snippet)) .yaml-hit-group:hover {
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 50%);
+    border-color: var(--esphome-tint-border-strong);
     background: var(--wa-color-surface-lowered);
   }
   .yaml-hit-group-header {
@@ -543,7 +543,7 @@ export const dashboardStyles = css`
     padding: 1px 0;
   }
   .yaml-snippet-line--match {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
   }
   .yaml-snippet-gutter {
     flex: 0 0 auto;
@@ -689,13 +689,13 @@ export const dashboardStyles = css`
   }
 
   .select-toggle-btn.active {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    border-color: var(--esphome-tint-border);
   }
 
   .select-toggle-btn.active:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    background: var(--esphome-tint-strong);
   }
 
   .select-toggle-btn wa-icon {
@@ -748,7 +748,7 @@ export const dashboardStyles = css`
     transition: background 0.12s;
   }
   .empty-search-clear:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    background: var(--esphome-tint);
   }
 
   /* ─── Skeleton ─── */
@@ -861,7 +861,7 @@ export const dashboardStyles = css`
     align-items: center;
     justify-content: center;
     gap: var(--wa-space-m);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 96%);
+    background: var(--esphome-tint-faint);
     min-height: 200px;
     cursor: pointer;
     transition:
@@ -871,7 +871,7 @@ export const dashboardStyles = css`
   }
   .add-device-card:hover {
     border-color: var(--esphome-primary);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     transform: translateY(-2px);
   }
   .add-device-icon-wrap {

--- a/src/components/dashboard/table-cell-styles.ts
+++ b/src/components/dashboard/table-cell-styles.ts
@@ -27,7 +27,7 @@ export const tableCellStyles = css`
   }
   .cell-status-busy:hover,
   .cell-status-busy:focus-visible {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     outline: none;
   }
 
@@ -155,7 +155,7 @@ export const tableCellStyles = css`
     border-radius: 999px;
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-bold);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
     letter-spacing: 0.02em;
   }
@@ -224,9 +224,9 @@ export const tableCellStyles = css`
   }
 
   .cell-action-btn--accent:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    border-color: var(--esphome-tint-border);
   }
 
   /* Progressive overflow into the row-end kebab: as the viewport

--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -125,7 +125,7 @@ export class ESPHomeTableColumnToggle extends LitElement {
       }
 
       .menu-item:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        background: var(--esphome-tint);
       }
 
       .checkbox {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -136,7 +136,7 @@ export class ESPHomeTableRowMenu extends LitElement {
       }
 
       .menu-item:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        background: var(--esphome-tint);
       }
 
       /* The Visit-web-UI item renders as an <a> so the browser

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -185,7 +185,7 @@ export const tableLayoutStyles = css`
     border-bottom: none;
   }
   tbody tr:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 95%);
+    background: var(--esphome-tint-faint);
   }
   tbody tr:focus-visible {
     outline: 2px solid var(--esphome-primary);
@@ -233,7 +233,7 @@ export const tableLayoutStyles = css`
   }
 
   tbody tr.selected {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    background: var(--esphome-tint);
   }
 
   tbody tr.selected .row-checkbox {
@@ -257,7 +257,7 @@ export const tableLayoutStyles = css`
   @media (prefers-reduced-motion: reduce) {
     tbody tr.highlight {
       animation: none;
-      background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+      background: var(--esphome-tint);
     }
   }
 

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -51,7 +51,7 @@ export const deviceCardStyles = [
 
     .device-card--selected {
       border-color: var(--esphome-primary);
-      background: color-mix(in srgb, var(--esphome-primary), transparent 95%);
+      background: var(--esphome-tint-faint);
     }
 
     /* Brief accent flash for a just-adopted card — dashboard sets the
@@ -192,7 +192,7 @@ export const deviceCardStyles = [
     }
 
     .device-status.busy {
-      background: color-mix(in srgb, var(--esphome-primary), transparent 85%);
+      background: var(--esphome-tint-strong);
       color: var(--esphome-primary);
       cursor: pointer;
     }
@@ -295,13 +295,13 @@ export const deviceCardStyles = [
     }
 
     .action-btn--accent {
-      background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+      background: var(--esphome-tint);
       color: var(--esphome-primary);
-      border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+      border-color: var(--esphome-tint-border);
     }
 
     .action-btn--accent:hover {
-      background: color-mix(in srgb, var(--esphome-primary), transparent 82%);
+      background: var(--esphome-tint-strong);
       border-color: var(--esphome-primary);
     }
 

--- a/src/components/device/add-component-dialog.styles.ts
+++ b/src/components/device/add-component-dialog.styles.ts
@@ -85,7 +85,7 @@ export const addComponentDialogStyles = css`
     gap: var(--wa-space-2xs);
     margin-bottom: var(--wa-space-m);
     padding: var(--wa-space-2xs) var(--wa-space-s);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border-left: 3px solid var(--esphome-primary);
     border-radius: var(--wa-border-radius-s);
     font-size: var(--wa-font-size-xs);
@@ -103,7 +103,7 @@ export const addComponentDialogStyles = css`
     gap: var(--wa-space-xs);
     margin-bottom: var(--wa-space-m);
     padding: var(--wa-space-xs) var(--wa-space-s);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border-left: 3px solid var(--esphome-primary);
     border-radius: var(--wa-border-radius-s);
     font-size: var(--wa-font-size-xs);

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -48,12 +48,12 @@ export const componentCatalogStyles = css`
   }
 
   .category-btn:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 
   .category-btn--active {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 
@@ -180,7 +180,7 @@ export const componentCatalogStyles = css`
 
   .component-card:hover {
     border-color: var(--esphome-primary);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 96%);
+    background: var(--esphome-tint-faint);
   }
 
   .component-card:focus-within {
@@ -364,7 +364,7 @@ export const componentCatalogStyles = css`
   /* Featured cards get a subtle primary border so they read as the
      curated set, distinct from the regular catalog. */
   .component-card--featured {
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    border-color: var(--esphome-tint-border);
   }
 
   .bundle-badge {
@@ -374,7 +374,7 @@ export const componentCatalogStyles = css`
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-bold);
     color: var(--esphome-primary);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     border-radius: var(--wa-border-radius-s);
     padding: 1px 6px;
   }

--- a/src/components/device/device-board-info.styles.ts
+++ b/src/components/device/device-board-info.styles.ts
@@ -121,7 +121,7 @@ export const deviceBoardInfoStyles = css`
   }
 
   .welcome-banner-close:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    background: var(--esphome-tint-strong);
     color: var(--wa-color-text-normal);
   }
 

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -151,7 +151,7 @@ export const deviceEditorStyles = css`
       var(--wa-color-surface-default)
     );
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    border-color: var(--esphome-tint-border);
   }
 
   .install-fab:hover:not(:disabled) {

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -302,12 +302,12 @@ export class ESPHomeDeviceNavigator extends LitElement {
 
       .nav-item:hover,
       .nav-item--hovered {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+        background: var(--esphome-tint);
         border-color: var(--esphome-primary);
       }
 
       .nav-item--selected {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+        background: var(--esphome-tint);
         border-color: var(--esphome-primary);
       }
 

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -191,7 +191,7 @@ export class ESPHomeHeaderActions extends LitElement {
       }
 
       .menu-item:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        background: var(--esphome-tint);
       }
 
       .menu-item wa-icon {

--- a/src/components/facets/facet-styles.ts
+++ b/src/components/facets/facet-styles.ts
@@ -110,7 +110,7 @@ export const facetStyles = css`
     max-width: 140px;
     padding: 2px 4px 2px 8px;
     border-radius: 6px;
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--wa-color-text-normal);
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-semibold, 600);
@@ -228,7 +228,7 @@ export const facetStyles = css`
 
   .facet-search-input:focus {
     outline: none;
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    border-color: var(--esphome-tint-border);
   }
 
   /* Scrollable list of rows. min-height: 0 lets it shrink inside

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -145,8 +145,8 @@ export class ESPHomeFeedbackDialog extends LitElement {
       }
 
       .link:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
-        border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+        background: var(--esphome-tint);
+        border-color: var(--esphome-tint-border);
       }
 
       .link:hover .link-icon {

--- a/src/components/firmware-install-dialog/styles.ts
+++ b/src/components/firmware-install-dialog/styles.ts
@@ -159,7 +159,7 @@ export const firmwareInstallDialogStyles = css`
   }
   .binary-option:hover,
   .binary-option:focus-visible {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border-color: var(--esphome-primary);
     outline: none;
   }
@@ -263,9 +263,9 @@ export const firmwareInstallDialogStyles = css`
   /* Active state for ghost toggle buttons — mirrors the command-dialog
      and logs-dialog "is-active" treatment so visual language stays consistent. */
   .btn--ghost.is-active {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 85%);
+    background: var(--esphome-tint-strong);
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 60%);
+    border-color: var(--esphome-tint-border);
   }
   .btn--ghost wa-icon {
     font-size: 14px;

--- a/src/components/firmware-jobs-dialog/styles.ts
+++ b/src/components/firmware-jobs-dialog/styles.ts
@@ -167,7 +167,7 @@ export const firmwareJobsDialogStyles = css`
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -59,7 +59,7 @@ export const installMethodDialogStyles = css`
   }
 
   .option:hover:not(.option--disabled) {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border-color: var(--esphome-primary);
   }
 
@@ -164,7 +164,7 @@ export const installMethodDialogStyles = css`
 
   .option-collapsible:hover {
     border-color: var(--esphome-primary);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
   }
 
   .option-collapsible__header {

--- a/src/components/labels/label-form.styles.ts
+++ b/src/components/labels/label-form.styles.ts
@@ -103,7 +103,7 @@ export const labelFormStyles = css`
     align-items: center;
     gap: 6px;
     padding: 8px 12px;
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border: var(--wa-border-width-s) dashed
       color-mix(in srgb, var(--esphome-primary), transparent 60%);
     border-radius: var(--wa-border-radius-m);
@@ -120,8 +120,8 @@ export const labelFormStyles = css`
   }
 
   .create-toggle:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 85%);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 40%);
+    background: var(--esphome-tint-strong);
+    border-color: var(--esphome-tint-border-strong);
   }
 
   .create-toggle wa-icon {

--- a/src/components/labels/labels-filter.styles.ts
+++ b/src/components/labels/labels-filter.styles.ts
@@ -189,7 +189,7 @@ export const labelsFilterStyles = css`
     border: var(--wa-border-width-s) solid
       color-mix(in srgb, var(--esphome-primary), transparent 70%);
     border-radius: var(--wa-border-radius-m);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
     font-family: inherit;
     font-size: var(--wa-font-size-s);
@@ -201,8 +201,8 @@ export const labelsFilterStyles = css`
   }
 
   .create-trigger:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 85%);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 50%);
+    background: var(--esphome-tint-strong);
+    border-color: var(--esphome-tint-border-strong);
   }
 
   .create-trigger:focus-visible {

--- a/src/components/logs-method-dialog.ts
+++ b/src/components/logs-method-dialog.ts
@@ -79,7 +79,7 @@ export class ESPHomeLogsMethodDialog extends LitElement {
       }
 
       .option:hover:not(.option--disabled) {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        background: var(--esphome-tint);
         border-color: var(--esphome-primary);
       }
 

--- a/src/components/mdi-icon-picker.styles.ts
+++ b/src/components/mdi-icon-picker.styles.ts
@@ -57,7 +57,7 @@ export const mdiIconPickerStyles = css`
     align-items: center;
     justify-content: center;
     border-radius: var(--wa-border-radius-s);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
   }
 
@@ -208,9 +208,9 @@ export const mdiIconPickerStyles = css`
   }
 
   .icon-cell:hover {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     color: var(--esphome-primary);
-    border-color: color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    border-color: var(--esphome-tint-border);
     transform: scale(1.06);
   }
 

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -105,7 +105,7 @@ export class ESPHomeSelectBar extends LitElement {
       }
 
       .toggle:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+        background: var(--esphome-tint);
       }
 
       .right {

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -109,7 +109,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
       }
 
       .option:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+        background: var(--esphome-tint);
         border-color: var(--esphome-primary);
       }
 

--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -276,7 +276,7 @@ export const wizardStepBoardStyles = css`
     gap: var(--wa-space-s);
     padding: var(--wa-space-s) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);
-    background: color-mix(in srgb, var(--esphome-primary), transparent 92%);
+    background: var(--esphome-tint);
     border: var(--wa-border-width-s) solid
       color-mix(in srgb, var(--esphome-primary), transparent 70%);
     color: var(--wa-color-text);
@@ -304,7 +304,7 @@ export const wizardStepBoardStyles = css`
   }
 
   .platform-chip--active {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background: var(--esphome-tint);
     border-color: var(--esphome-primary);
     color: var(--esphome-primary);
   }

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -85,7 +85,7 @@ export class ESPHomeWizardStepMethod extends LitElement {
 
       .option-card:hover {
         border-color: var(--esphome-primary);
-        background: color-mix(in srgb, var(--esphome-primary), transparent 95%);
+        background: var(--esphome-tint-faint);
       }
 
       .option-card-text h3 {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -197,7 +197,7 @@ export class ESPHomePageSecrets extends LitElement {
 
       .reveal-toggle {
         border: var(--wa-border-width-s) solid var(--esphome-primary);
-        background: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+        background: var(--esphome-tint);
         color: var(--esphome-primary);
         padding: 6px 12px;
         border-radius: var(--wa-border-radius-m);
@@ -212,7 +212,7 @@ export class ESPHomePageSecrets extends LitElement {
       }
 
       .reveal-toggle:hover {
-        background: color-mix(in srgb, var(--esphome-primary), transparent 80%);
+        background: var(--esphome-tint-strong);
       }
 
       .reveal-toggle wa-icon {

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -114,7 +114,7 @@ export const inputStyles = css`
 
   wa-option:state(current),
   wa-option[disabled]:state(current) {
-    background-color: color-mix(in srgb, var(--esphome-primary), transparent 88%);
+    background-color: var(--esphome-tint);
     color: var(--wa-color-text-normal);
   }
 `;

--- a/src/styles/job-status-pill.ts
+++ b/src/styles/job-status-pill.ts
@@ -25,7 +25,7 @@ export const jobStatusPillStyles = css`
 
   .status-pill.status-queued,
   .status-pill.status-running {
-    background: color-mix(in srgb, var(--esphome-primary), transparent 80%);
+    background: var(--esphome-tint-strong);
     color: var(--esphome-primary);
   }
 

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -52,6 +52,24 @@ export const espHomeStyles = css`
     --esphome-primary-shadow-hover: 0 4px 14px
       color-mix(in srgb, var(--esphome-primary), transparent 35%);
 
+    /* Translucent primary tints for hover / selected / active state
+       backgrounds and borders, defined once so the dozens of these
+       across the app stop drifting between 80–96% opacity. Three fill
+       intensities (faint hover wash → standard hover/selected → strong
+       hover-on-active) and two border weights. Specials that aren't
+       generic state tints (the table highlight-glow, the yaml mark,
+       the mixed-checkbox fill, muted primary text) keep their own
+       inline values. */
+    --esphome-tint-faint: color-mix(in srgb, var(--esphome-primary), transparent 95%);
+    --esphome-tint: color-mix(in srgb, var(--esphome-primary), transparent 90%);
+    --esphome-tint-strong: color-mix(in srgb, var(--esphome-primary), transparent 82%);
+    --esphome-tint-border: color-mix(in srgb, var(--esphome-primary), transparent 65%);
+    --esphome-tint-border-strong: color-mix(
+      in srgb,
+      var(--esphome-primary),
+      transparent 45%
+    );
+
     /* ─── Layout ─── */
     --esphome-header-height: 56px;
     --esphome-footer-height: 20px;


### PR DESCRIPTION
# What does this implement/fix?

Continues the shared-token cleanup from #500 through #504. The translucent primary tints used for hover, selected and active states, color-mix(in srgb, var(--esphome-primary), transparent NN%), had drifted across the app; backgrounds ranged over 80 to 96 percent and borders over 40 to 70 percent, with no consistent rule, so the same state looked slightly different from one component to the next.

This defines a small role-based scale in espHomeStyles and points the 76 background and border declarations at it; three fill intensities (--esphome-tint-faint for a light hover wash, --esphome-tint for the standard hover/selected tint, --esphome-tint-strong for hover on an already-active control) and two border weights (--esphome-tint-border, --esphome-tint-border-strong). Each token's value is the median of the cluster it replaces, so every affected spot shifts by at most 5 percent transparency, which is imperceptible per spot but finally consistent. A few values that are not generic state tints keep their own inline values; the table row-highlight glow, the yaml match highlight, the mixed-checkbox fill and the two muted primary text colors.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
