### PR TITLE
Match YAML search box width to the device search

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -162,10 +162,7 @@ export function renderYamlToolbar(host: ESPHomePageDashboard): TemplateResult {
       : host._localize("yaml_search.match_count_plural");
   return html`
     <div class="toolbar">
-      <div class="toolbar-row">
-        ${renderSearchInput(host)} ${renderViewToggle(host)}
-        <span class="toolbar-spacer"></span>
-      </div>
+      <div class="toolbar-row">${renderSearchInput(host)} ${renderViewToggle(host)}</div>
       ${matchCount !== null
         ? html`<span class="device-count"><strong>${matchCount}</strong> ${unit}</span>`
         : ""}

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -293,17 +293,6 @@ export const dashboardStyles = css`
     row-gap: var(--wa-space-xs);
   }
 
-  /* Pushes the select-toggle to the right edge of the toolbar.
-     The facet pills sit in the middle of the row (between the
-     view-toggle and the spacer) so they read as part of the
-     "view / filter" cluster; on narrow viewports the row wraps
-     so the facets flow onto a second line without crowding the
-     search input. */
-  .toolbar-spacer {
-    flex: 1 1 auto;
-    min-width: var(--wa-space-s);
-  }
-
   /* Facet pills cluster inline with the view-toggle. flex-wrap
      lets pills flow onto a second row of their own if too many
      accumulate (large fleets with several areas / platforms). */
@@ -374,15 +363,17 @@ export const dashboardStyles = css`
     min-width: 140px;
   }
 
-  /* Table view only: the facets/Filters control no longer shares the
-     search row (it moved into the controls-right cluster), so the
-     search input can seed from a 0 flex-basis. Flex line-breaking uses
+  /* Table view (.toolbar-stack) and YAML view (:host([yaml])) no
+     longer carry a Filters control in the search row, so the search
+     input seeds from a 0 flex-basis and fills the row the same way in
+     both, matching the device-search width. Flex line-breaking uses
      the basis, not min-width, so the 220px basis above would push the
      view-toggle onto a second line at ~360px; a 0 basis keeps search +
      view-toggle on one row (search still grows to fill, floored by the
-     140px min-width). Card / YAML toolbars keep the 220px basis since
-     their Filters control still shares this row. */
-  .toolbar-stack .search-wrap {
+     140px min-width). The card toolbar keeps the 220px basis since its
+     Filters control still shares this row. */
+  .toolbar-stack .search-wrap,
+  :host([yaml]) .search-wrap {
     flex-basis: 0;
   }
   /* Native <input class="search-input"> picks up the shared


### PR DESCRIPTION
# What does this implement/fix?

In the YAML search view the search box rendered narrower than the search box in the card and table views, with a gap before the view toggle. The YAML toolbar carried a `.toolbar-spacer` (`flex: 1 1 auto`) that competed with the search input for the row's free space, so the input never grew to fill the row the way the device search does. This removes that spacer, and since the Filters control no longer shares the YAML search row, the YAML search input now seeds from a 0 flex-basis like the table view; both fill the row to the same width and the view toggle stays on one line at narrow widths. The now unused `.toolbar-spacer` style is removed.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
