### PR TITLE
Compact the header on narrow viewports and slim it in the HA panel

### DIFF
--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -39,6 +39,10 @@ export interface ServerInfoMessage {
   esphome_version: string;
   port: number;
   ha_addon: boolean;
+  /** True only when served through HA Supervisor ingress (the panel
+   * iframe). Distinct from ha_addon, which is also true when the add-on
+   * is reached directly on its exposed port. Drives the slim header. */
+  ha_ingress: boolean;
   requires_auth: boolean;
 }
 

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -49,7 +49,6 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { BASE_PATH } from "../util/base-path.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
@@ -368,7 +367,7 @@ export class ESPHomeApp extends LitElement {
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
       this._serverVersion = info.server_version;
-      this._isHaIngress = info.ha_addon && BASE_PATH.includes("/ingress");
+      this._isHaIngress = info.ha_ingress;
       this._apiConnected = true;
       void this._api.ready.then(() => this._afterAuthenticated());
     };

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowCollapseRight, mdiArrowLeft } from "@mdi/js";
+import { mdiArrowLeft } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -19,7 +19,6 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./esphome-header-actions.js";
 
 registerMdiIcons({
-  "arrow-collapse-right": mdiArrowCollapseRight,
   "arrow-left": mdiArrowLeft,
 });
 
@@ -62,6 +61,12 @@ export class ESPHomeLayout extends LitElement {
     return this._path !== "/" && this._path !== "";
   }
 
+  protected updated() {
+    // Reflect the consumed context to a host attribute so the slim-header
+    // CSS (`:host([ingress])`) can key off it.
+    this.toggleAttribute("ingress", this._isHaIngress);
+  }
+
   static styles = [
     espHomeStyles,
     css`
@@ -84,25 +89,11 @@ export class ESPHomeLayout extends LitElement {
       .header-logos {
         display: flex;
         align-items: center;
-        gap: var(--wa-space-m);
-      }
-
-      .ha-btn::part(base) {
-        padding: 6px 6px;
-        gap: 6px;
-      }
-
-      .ha-btn::part(label) {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-      }
-
-      .header-separator {
-        width: 1px;
-        align-self: stretch;
-        background: var(--esphome-primary-light);
-        flex-shrink: 0;
+        /* Smaller than the logo→title gap (--wa-space-m on .app-header)
+           because the back button carries ~8px of its own padding on
+           the logo side; this makes the arrow sit the same visual
+           distance from the logo as the title does on the other side. */
+        gap: var(--wa-space-xs);
       }
 
       .header-back {
@@ -204,19 +195,19 @@ export class ESPHomeLayout extends LitElement {
         flex: 1;
       }
 
-      /* Mobile: drop the subtitle so the title isn't squashed against
-         the top of the viewport, and keep header height compact. */
-      @media (max-width: 700px) {
+      /* Compact header on narrow viewports. 870px is HA's
+         sidebar-collapse breakpoint, so this fires exactly when HA
+         shows its own 40px top bar; we apply it everywhere (HA or not)
+         so the standalone phone layout is compact too. The 40px height
+         comes from the --esphome-header-height token (espHomeStyles).
+         Shrink the logo to fit the shorter bar and drop the subtitle. */
+      @media (max-width: 870px) {
         .header-text p {
           display: none;
         }
 
-        /* The spacer's flex:1 was eating the slack between the title
-           and the kebab actions — desktop's intentional layout but on
-           a phone that's where the title needs room to fit "ESPHome
-           Device Builder" alongside the PREVIEW badge without
-           truncating. Drop the spacer and grow the header-text into
-           the freed space instead. */
+        /* Drop the spacer and let the title grow into the freed width
+           so "ESPHome Device Builder" + PREVIEW fit without truncating. */
         .header-spacer {
           display: none;
         }
@@ -225,19 +216,43 @@ export class ESPHomeLayout extends LitElement {
           flex: 1;
         }
 
-        /* Tighten the chrome around the logo: the 44px button sized
-           for a desktop touch target carries more whitespace than a
-           phone needs, and the app-header's --wa-space-m gap claims
-           extra room the title could use to fit "Builder" before
-           the PREVIEW badge. Keep the horizontal padding at the
-           desktop value so the logo doesn't hug the viewport edge. */
         .app-header {
           gap: var(--wa-space-s);
         }
 
+        /* Pull the back arrow and logo close together — the desktop
+           --wa-space-m gap reads as a big void next to the small logo
+           in the 40px bar. */
+        .header-logos {
+          gap: var(--wa-space-2xs);
+        }
+
+        /* Shrink the logo and give it a 3px top/bottom inset so it
+           doesn't crowd the 40px bar's edges. box-sizing keeps the
+           padding inside the 32px box; the img fills what's left. */
         .header-logo {
-          width: 36px;
-          height: 36px;
+          width: 32px;
+          height: 32px;
+          padding: 3px 0;
+          box-sizing: border-box;
+        }
+
+        .header-logo img {
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
+
+        /* Embedded in HA, its narrow bar already shows the title, so
+           hide our (duplicated) title text. The smaller logo and the
+           actions menu stay. */
+        :host([ingress]) .header-text {
+          display: none;
+        }
+
+        /* Title hidden, so bring the spacer back to pin the menu right. */
+        :host([ingress]) .header-spacer {
+          display: block;
         }
       }
 
@@ -282,20 +297,6 @@ export class ESPHomeLayout extends LitElement {
     return html`
       <div class="app-header">
         <div class="header-logos">
-          ${this._isHaIngress
-            ? html`
-                <wa-button
-                  class="ha-btn"
-                  variant="light"
-                  size="small"
-                  title=${this._localize("layout.home_assistant")}
-                >
-                  <wa-icon library="mdi" name="arrow-collapse-right"></wa-icon>
-                  <img src=${withBase("/assets/logo/ha.svg")} alt="Home Assistant" />
-                </wa-button>
-                <div class="header-separator"></div>
-              `
-            : nothing}
           ${this._showBack
             ? html`
                 <button

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -77,6 +77,18 @@ export const espHomeStyles = css`
     font-family: var(--wa-font-family-body);
   }
 
+  /* Compact the header on narrow viewports. 870px is HA's
+     sidebar-collapse breakpoint, so embedded in the HA panel this
+     fires exactly when HA swaps to its own 40px top bar — matching
+     its height avoids a chunky doubled-up bar. Defined on the shared
+     token so the header element, the content-area height calcs, and
+     the actions-menu top offset all shrink together. */
+  @media (max-width: 870px) {
+    :host {
+      --esphome-header-height: 40px;
+    }
+  }
+
   /* ─── Custom wa-button variants ─── */
 
   /* variant="primary": solid --esphome-secondary background, white text */

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -874,7 +874,6 @@
     "feedback_menu": "Found a bug? Have an idea?",
     "back": "Back",
     "close": "Close",
-    "home_assistant": "Home Assistant",
     "editor": "Editor",
     "yaml_diff_button": "YAML diff button",
     "more_options_with_count": "More options ({count} firmware task(s) active)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -811,7 +811,6 @@
     "feedback_menu": "Un bug ? Une idée ?",
     "back": "Retour",
     "close": "Fermer",
-    "home_assistant": "Home Assistant",
     "editor": "Éditeur",
     "yaml_diff_button": "Bouton de diff YAML",
     "more_options_with_count": "Plus d'options ({count} tâche(s) active(s))",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -874,7 +874,6 @@
     "feedback_menu": "Hibát talált? Van új ötlete?",
     "back": "Vissza",
     "close": "Bezárás",
-    "home_assistant": "Home Assistant",
     "editor": "Szerkesztő",
     "yaml_diff_button": "YAML-különbség gomb",
     "more_options_with_count": "További lehetőségek ({count} aktív firmware-feladat)",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -811,7 +811,6 @@
     "feedback_menu": "Probleem of idee?",
     "back": "Terug",
     "close": "Sluiten",
-    "home_assistant": "Home Assistant",
     "editor": "Editor",
     "yaml_diff_button": "YAML-diff-knop",
     "more_options_with_count": "Meer opties ({count} firmwaretaken actief)",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -874,7 +874,6 @@
     "feedback_menu": "发现 Bug？有新想法？",
     "back": "返回",
     "close": "关闭",
-    "home_assistant": "Home Assistant",
     "editor": "编辑器",
     "yaml_diff_button": "YAML 差异按钮",
     "more_options_with_count": "更多选项（{count} 个固件任务正在运行）",


### PR DESCRIPTION
# What does this implement/fix?

Two related header problems. First, our header was a fixed 56px even on phones. Second, when the dashboard is embedded in the Home Assistant panel and HA goes narrow, HA shows its own 40px top bar with the panel title, so our full blue header stacked a second, duplicated title bar right under it.

This makes the header compact on narrow viewports and slims it further in the HA panel:

- `--esphome-header-height` is now responsive, 56px normally and 40px at 870px and below. 870px is HA's sidebar-collapse breakpoint, so embedded in the panel this kicks in exactly when HA swaps to its 40px bar; matching that height avoids a chunky doubled-up bar. It is defined on the shared token so the header element, the content-area height calcs, and the actions-menu offset all shrink together.
- On narrow viewports (HA or standalone) the logo shrinks and gets a small inset, the subtitle drops, and the back arrow sits closer to the logo.
- Embedded in HA, the now-duplicated title text is also hidden; detection uses the backend ServerInfoMessage.ha_ingress flag (companion PR) rather than the old ha_addon plus base-path-string heuristic, which missed the iframe case.
- Removed the non-functional Home Assistant collapse button from the header and cleaned up its icon and the orphaned localization key in every locale.

Desktop is unchanged above 870px. HA's theme variables already cascade into the iframe, so colors adapt on their own.

Needs the companion backend PR for the ha_ingress field; until it lands the flag is undefined and the header renders as before.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder-frontend/issues/41
- companion backend PR: esphome/device-builder#1118

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
