### PR TITLE
Center and cap dialogs on mobile, full-screen the build log

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,7 @@
 <html lang="en" class="wa-brand-cyan">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#038fc7" />
     <!--
       Content-Security-Policy - defense in depth against any future

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,10 @@
 <html lang="en" class="wa-brand-cyan">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#038fc7" />
     <!--
       Content-Security-Policy - defense in depth against any future

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -179,10 +179,10 @@ export class ESPHomeBaseDialog extends LitElement {
   static styles = [
     dialogCloseButtonStyles,
     // Default mobile behavior for every base-dialog: stay centered with a
-    // capped, safe-area-aware height. Content-heavy consumers (logs, build
-    // output, install, ...) override this with fullscreenMobileDialog via
-    // their own esphome-base-dialog::part(dialog) rule, which wins the
-    // parts cascade as the outer tree.
+    // dvh-capped height. Content-heavy consumers (logs, build output,
+    // install, ...) override this with fullscreenMobileDialog via their own
+    // esphome-base-dialog::part(dialog) rule, which wins the parts cascade
+    // as the outer tree.
     centeredMobileDialog("wa-dialog"),
     css`
       :host {

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
+import { centeredMobileDialog } from "../styles/dialog-mobile.js";
 
 /**
  * Thin shared wrapper around ``<wa-dialog>``.
@@ -177,6 +178,12 @@ export class ESPHomeBaseDialog extends LitElement {
 
   static styles = [
     dialogCloseButtonStyles,
+    // Default mobile behavior for every base-dialog: stay centered with a
+    // capped, safe-area-aware height. Content-heavy consumers (logs, build
+    // output, install, ...) override this with fullscreenMobileDialog via
+    // their own esphome-base-dialog::part(dialog) rule, which wins the
+    // parts cascade as the outer tree.
+    centeredMobileDialog("wa-dialog"),
     css`
       :host {
         display: contents;

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -178,11 +178,8 @@ export class ESPHomeBaseDialog extends LitElement {
 
   static styles = [
     dialogCloseButtonStyles,
-    // Default mobile behavior for every base-dialog: stay centered with a
-    // dvh-capped height. Content-heavy consumers (logs, build output,
-    // install, ...) override this with fullscreenMobileDialog via their own
-    // esphome-base-dialog::part(dialog) rule, which wins the parts cascade
-    // as the outer tree.
+    // Mobile default: centered, dvh-capped. Heavy dialogs override with
+    // fullscreenMobileDialog (their outer-tree ::part rule wins).
     centeredMobileDialog("wa-dialog"),
     css`
       :host {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -198,8 +198,7 @@ export class ESPHomeCommandDialog extends LitElement {
     dialogCloseButtonStyles,
     commandDialogStyles,
     remoteBuildHintStyles,
-    // Build/clean log output is content-heavy: go full-screen on mobile
-    // instead of a centered box that overflows the viewport. #41
+    // Log output is content-heavy: full-screen on mobile. #41
     fullscreenMobileDialog("wa-dialog"),
   ];
 

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -33,6 +33,7 @@ import {
   versionContext,
 } from "../context/index.js";
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
+import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
@@ -197,6 +198,9 @@ export class ESPHomeCommandDialog extends LitElement {
     dialogCloseButtonStyles,
     commandDialogStyles,
     remoteBuildHintStyles,
+    // Build/clean log output is content-heavy: go full-screen on mobile
+    // instead of a centered box that overflows the viewport. #41
+    fullscreenMobileDialog("wa-dialog"),
   ];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {

--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -62,12 +62,8 @@ export const commandDialogStyles = css`
     overflow: hidden;
   }
 
-  /* On the mobile full-screen sheet (fullscreenMobileDialog) the dialog
-     fills the viewport, so the log fills it too instead of staying at a
-     fixed 60vh with dead space below. The 600px here must track
-     fullscreenMobileDialog's default breakpoint in dialog-mobile.ts; if
-     the command-dialog call site ever passes a custom breakpoint, change
-     both. #41 */
+  /* Fill the mobile full-screen sheet (fullscreenMobileDialog); keep this
+     600px in sync with that fragment's breakpoint. #41 */
   @media (max-width: 600px) {
     .content {
       height: 100%;

--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -64,7 +64,10 @@ export const commandDialogStyles = css`
 
   /* On the mobile full-screen sheet (fullscreenMobileDialog) the dialog
      fills the viewport, so the log fills it too instead of staying at a
-     fixed 60vh with dead space below. #41 */
+     fixed 60vh with dead space below. The 600px here must track
+     fullscreenMobileDialog's default breakpoint in dialog-mobile.ts; if
+     the command-dialog call site ever passes a custom breakpoint, change
+     both. #41 */
   @media (max-width: 600px) {
     .content {
       height: 100%;

--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+
 export const commandDialogStyles = css`
   :host {
     --term-bg: #1e1e1e;
@@ -62,9 +64,8 @@ export const commandDialogStyles = css`
     overflow: hidden;
   }
 
-  /* Fill the mobile full-screen sheet (fullscreenMobileDialog); keep this
-     600px in sync with that fragment's breakpoint. #41 */
-  @media (max-width: 600px) {
+  /* Fill the mobile full-screen sheet (fullscreenMobileDialog). #41 */
+  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
     .content {
       height: 100%;
       min-height: 0;

--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -61,6 +61,17 @@ export const commandDialogStyles = css`
     max-height: 70vh;
     overflow: hidden;
   }
+
+  /* On the mobile full-screen sheet (fullscreenMobileDialog) the dialog
+     fills the viewport, so the log fills it too instead of staying at a
+     fixed 60vh with dead space below. #41 */
+  @media (max-width: 600px) {
+    .content {
+      height: 100%;
+      min-height: 0;
+      max-height: none;
+    }
+  }
   /* Anchor the queued overlay's positioning context on .log-area (not
      .content) so the overlay covers only the log — toolbar/banner stay
      interactive regardless of viewport height. */

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -232,9 +232,8 @@ export const logsDialogStyles = css`
   }
 
   @media (max-width: 700px) {
-    /* The full-screen ::part(dialog) rule comes from
-       fullscreenMobileDialog("esphome-base-dialog", 700) in the
-       component's static styles; these are the logs-specific companions. */
+    /* Full-screen ::part(dialog) comes from fullscreenMobileDialog in the
+       static styles; these are the logs-specific companions. */
     .logs-content {
       height: 100%;
       max-height: none;

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_DIALOG_BREAKPOINT } from "../styles/dialog-mobile.js";
+
 /**
  * Styles for <esphome-logs-dialog>. Extracted from the component
  * file to keep it under the repo's file-size cap (see README →
@@ -231,7 +233,7 @@ export const logsDialogStyles = css`
     border-radius: 0;
   }
 
-  @media (max-width: 700px) {
+  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
     /* Full-screen ::part(dialog) comes from fullscreenMobileDialog in the
        static styles; these are the logs-specific companions. */
     .logs-content {

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -233,7 +233,7 @@ export const logsDialogStyles = css`
 
   @media (max-width: 700px) {
     /* The full-screen ::part(dialog) rule comes from
-       fullscreenMobileDialog("esphome-base-dialog", "700px") in the
+       fullscreenMobileDialog("esphome-base-dialog", 700) in the
        component's static styles; these are the logs-specific companions. */
     .logs-content {
       height: 100%;

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -232,25 +232,9 @@ export const logsDialogStyles = css`
   }
 
   @media (max-width: 700px) {
-    :host esphome-base-dialog::part(dialog) {
-      position: fixed;
-      inset: 0;
-      /* width/height are explicit because wa-dialog's
-         width: var(--width) and the UA's
-         max-height: calc(100% - ...) would otherwise keep the
-         dialog at its desktop size. The vh declaration is the
-         fallback for pre-2022 Safari / Chrome / Firefox that
-         don't recognise dvh; modern browsers pick the dvh line
-         which adjusts as iOS Safari's URL bar collapses. */
-      width: 100vw;
-      height: 100vh;
-      height: 100dvh;
-      max-width: none;
-      max-height: none;
-      margin: 0;
-      border-radius: 0;
-    }
-
+    /* The full-screen ::part(dialog) rule comes from
+       fullscreenMobileDialog("esphome-base-dialog", "700px") in the
+       component's static styles; these are the logs-specific companions. */
     .logs-content {
       height: 100%;
       max-height: none;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -15,6 +15,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -106,7 +107,13 @@ export class ESPHomeLogsDialog extends LitElement {
   @query("esphome-ansi-log")
   private _ansiLog?: ESPHomeAnsiLog;
 
-  static styles = [espHomeStyles, logsDialogStyles];
+  static styles = [
+    espHomeStyles,
+    logsDialogStyles,
+    // Full-screen on mobile; 700px to match this dialog's existing
+    // breakpoint (the rest of its mobile rules live in logs-dialog.styles).
+    fullscreenMobileDialog("esphome-base-dialog", "700px"),
+  ];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("_darkMode")) {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -112,7 +112,7 @@ export class ESPHomeLogsDialog extends LitElement {
     logsDialogStyles,
     // Full-screen on mobile; 700px to match this dialog's existing
     // breakpoint (the rest of its mobile rules live in logs-dialog.styles).
-    fullscreenMobileDialog("esphome-base-dialog", "700px"),
+    fullscreenMobileDialog("esphome-base-dialog", 700),
   ];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -110,8 +110,7 @@ export class ESPHomeLogsDialog extends LitElement {
   static styles = [
     espHomeStyles,
     logsDialogStyles,
-    // Full-screen on mobile; 700px to match this dialog's existing
-    // breakpoint (the rest of its mobile rules live in logs-dialog.styles).
+    // Full-screen on mobile; 700px matches its other mobile rules.
     fullscreenMobileDialog("esphome-base-dialog", 700),
   ];
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -110,8 +110,8 @@ export class ESPHomeLogsDialog extends LitElement {
   static styles = [
     espHomeStyles,
     logsDialogStyles,
-    // Full-screen on mobile; 700px matches its other mobile rules.
-    fullscreenMobileDialog("esphome-base-dialog", 700),
+    // Full-screen on mobile.
+    fullscreenMobileDialog("esphome-base-dialog"),
   ];
 
   protected willUpdate(changedProperties: Map<string, unknown>) {

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -18,6 +18,7 @@ import { customElement, state } from "lit/decorators.js";
 import type { OffloaderAlertSnapshotEntry } from "../api/types/remote-build-events.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { buildOffloadAlertsContext, localizeContext } from "../context/index.js";
+import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -71,7 +72,13 @@ export class ESPHomeSettingsDialog extends LitElement {
   @state()
   private _open = false;
 
-  static styles = [espHomeStyles, settingsSharedStyles, settingsRowStyles];
+  static styles = [
+    espHomeStyles,
+    settingsSharedStyles,
+    settingsRowStyles,
+    // Full-screen on mobile; the layout fills the sheet (see shared-styles).
+    fullscreenMobileDialog("esphome-base-dialog"),
+  ];
 
   open() {
     this._section = "appearance";

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -2,6 +2,11 @@ import { css } from "lit";
 
 import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
 
+/** Width at/below which the settings sidebar stacks above the content.
+ *  Wider than the full-screen breakpoint so tablets get the stacked nav
+ *  while the dialog is still a centered (not full-screen) box. */
+const SETTINGS_STACK_BREAKPOINT = 700;
+
 export const settingsSharedStyles = css`
   esphome-base-dialog {
     --width: min(800px, 95vw);
@@ -121,12 +126,11 @@ export const settingsSharedStyles = css`
     overflow-y: auto;
   }
 
-  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
-    /* The dialog is full-screen here (fullscreenMobileDialog), so the
-       layout fills it and the content body scrolls; nav stacks on top. */
+  /* Tablet and phone: stack the nav above the content. */
+  @media (max-width: ${SETTINGS_STACK_BREAKPOINT}px) {
     .layout {
       flex-direction: column;
-      height: 100%;
+      height: auto;
     }
     .sidebar {
       width: auto;
@@ -136,6 +140,14 @@ export const settingsSharedStyles = css`
     .nav {
       flex-direction: row;
       flex-wrap: wrap;
+    }
+  }
+
+  /* At the full-screen breakpoint (fullscreenMobileDialog) the dialog fills
+     the viewport, so the layout fills it and the content body scrolls. */
+  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+    .layout {
+      height: 100%;
     }
   }
 `;

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+
 export const settingsSharedStyles = css`
   esphome-base-dialog {
     --width: min(800px, 95vw);
@@ -119,10 +121,12 @@ export const settingsSharedStyles = css`
     overflow-y: auto;
   }
 
-  @media (max-width: 700px) {
+  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+    /* The dialog is full-screen here (fullscreenMobileDialog), so the
+       layout fills it and the content body scrolls; nav stacks on top. */
     .layout {
       flex-direction: column;
-      height: auto;
+      height: 100%;
     }
     .sidebar {
       width: auto;

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,6 +7,7 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { markJustCreated } from "../../util/just-created.js";
@@ -92,6 +93,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    fullscreenMobileDialog("wa-dialog"),
     css`
       wa-dialog {
         --width: 520px;
@@ -101,30 +103,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         --width: 750px;
       }
 
-      /* Mobile: drop both width variants to fullscreen so the
-         wizard's board picker and per-step bodies have room to
-         breathe instead of getting boxed into a 520px column
-         flanked by black gutters. Mirrors the same shape the
-         logs-dialog uses — the --width custom property alone
-         doesn't work because wa-dialog's internal dialog part
-         carries a max-width calc(100% - …) and a UA max-height
-         that keep the dialog at its desktop size unless we
-         override them on the part directly. The dvh fallback
-         after vh lets modern browsers shrink the dialog as iOS
-         Safari's URL bar collapses. #41 */
-      @media (max-width: 600px) {
-        wa-dialog::part(dialog) {
-          position: fixed;
-          inset: 0;
-          width: 100vw;
-          height: 100vh;
-          height: 100dvh;
-          max-width: none;
-          max-height: none;
-          margin: 0;
-          border-radius: 0;
-        }
-      }
+      /* Mobile full-screen comes from fullscreenMobileDialog() in the
+         static styles array; the wizard's board picker and per-step
+         bodies need the full width instead of a 520px column. #41 */
 
       wa-dialog::part(header) {
         background: var(--esphome-primary);

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -103,9 +103,8 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         --width: 750px;
       }
 
-      /* Mobile full-screen comes from fullscreenMobileDialog() in the
-         static styles array; the wizard's board picker and per-step
-         bodies need the full width instead of a 520px column. #41 */
+      /* Mobile full-screen comes from fullscreenMobileDialog in the static
+         styles so the board picker isn't boxed into a 520px column. #41 */
 
       wa-dialog::part(header) {
         background: var(--esphome-primary);

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -1,50 +1,26 @@
 import { type CSSResult, css } from "lit";
 
 /**
- * Shared mobile-layout fragments for app dialogs (issue #41).
+ * Mobile-layout fragments for app dialogs (issue #41). Both size with `dvh`
+ * (vh fallback) so they need no `viewport-fit=cover`.
  *
- * Every dialog renders through webawesome's `<wa-dialog>`, whose
- * native `<dialog>` centers on the viewport via `inset: 0; margin: auto`.
- * On phones two patterns are wanted:
- *
- * - {@link centeredMobileDialog}: short / form dialogs stay centered but
- *   get a dvh-aware height cap so tall content scrolls inside the box
- *   instead of overflowing the screen.
- * - {@link fullscreenMobileDialog}: content-heavy dialogs (build / log
- *   output, the create-config wizard, validate, install) fill the screen
- *   edge-to-edge.
- *
- * Sizing uses `dvh` (with a `vh` fallback) rather than `env(safe-area-*)`,
- * so it works without opting the whole app into `viewport-fit=cover` (which
- * would push the app's other fixed elements under the notch / home bar).
- *
- * `::part()` only pierces a single shadow level, so the rule must live in
- * the stylesheet of whichever component hosts the `<wa-dialog>`. Pass the
- * matching host: `"wa-dialog"` from a component that renders `<wa-dialog>`
- * directly (raw dialogs, and `base-dialog` itself), or
- * `"esphome-base-dialog"` from a consumer of `<esphome-base-dialog>` (the
- * part is re-exposed via `exportparts`). The outer tree wins the parts
- * cascade, so a consumer's `esphome-base-dialog::part(dialog)` override
- * beats base-dialog's own default.
- *
- * Both fragments default to the same breakpoint so reflow points stay in
- * lockstep across dialogs; pass a custom one only where a dialog already
- * shipped with a different threshold (e.g. logs-dialog at 700px).
+ * `::part()` pierces one shadow level, so the rule must live in the
+ * component hosting the `<wa-dialog>`: pass `"wa-dialog"` for a raw dialog
+ * (or base-dialog itself), `"esphome-base-dialog"` for a base-dialog
+ * consumer. The outer tree wins the parts cascade, so a consumer's
+ * fullscreen override beats base-dialog's centered default.
  */
 type DialogHost = "wa-dialog" | "esphome-base-dialog";
 
-/** Pre-built selector fragments so the host can be interpolated into the
- *  `css` template as a CSSResult, no `unsafeCSS` needed. */
+// Pre-built so the host interpolates as a CSSResult (no unsafeCSS).
 const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "wa-dialog": css`wa-dialog`,
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
-/** Default mobile breakpoint in px. */
 const MOBILE_DIALOG_BREAKPOINT = 600;
 
-/** Full-screen sheet on mobile. Mirrors the pattern logs-dialog and the
- *  create-config wizard used inline before this was shared. */
+/** Full-screen sheet on mobile. */
 export function fullscreenMobileDialog(
   host: DialogHost,
   breakpoint: number = MOBILE_DIALOG_BREAKPOINT
@@ -67,10 +43,8 @@ export function fullscreenMobileDialog(
   `;
 }
 
-/** Stay vertically centered (wa-dialog's native `margin: auto`) but cap
- *  the box to the dynamic viewport so tall content scrolls internally
- *  instead of running off-screen. Does not touch `inset` / `margin`, so
- *  the native centering is preserved. */
+/** Centered (native `margin: auto`) but capped to the viewport so tall
+ *  content scrolls inside instead of overflowing. */
 export function centeredMobileDialog(
   host: DialogHost,
   breakpoint: number = MOBILE_DIALOG_BREAKPOINT
@@ -80,8 +54,7 @@ export function centeredMobileDialog(
     @media (max-width: ${breakpoint}px) {
       ${sel}::part(dialog) {
         max-width: calc(100vw - var(--wa-space-l));
-        /* vh first as the fallback; browsers without dvh keep a working
-           cap, modern ones use the dvh line (tracks the URL bar). */
+        /* vh fallback, then dvh */
         max-height: calc(100vh - var(--wa-space-l));
         max-height: calc(100dvh - var(--wa-space-l));
       }

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -16,8 +16,8 @@ import { type CSSResult, css, unsafeCSS } from "lit";
  *
  * `::part()` only pierces a single shadow level, so the rule must live in
  * the stylesheet of whichever component hosts the `<wa-dialog>`. Pass the
- * matching host selector: `"wa-dialog"` from a component that renders
- * `<wa-dialog>` directly (raw dialogs, and `base-dialog` itself), or
+ * matching host: `"wa-dialog"` from a component that renders `<wa-dialog>`
+ * directly (raw dialogs, and `base-dialog` itself), or
  * `"esphome-base-dialog"` from a consumer of `<esphome-base-dialog>` (the
  * part is re-exposed via `exportparts`). The outer tree wins the parts
  * cascade, so a consumer's `esphome-base-dialog::part(dialog)` override
@@ -27,18 +27,21 @@ import { type CSSResult, css, unsafeCSS } from "lit";
  * lockstep across dialogs; pass a custom one only where a dialog already
  * shipped with a different threshold (e.g. logs-dialog at 700px).
  */
-const MOBILE_DIALOG_BREAKPOINT = "600px";
+type DialogHost = "wa-dialog" | "esphome-base-dialog";
+
+/** Default mobile breakpoint in px. */
+const MOBILE_DIALOG_BREAKPOINT = 600;
 
 /** Full-screen sheet on mobile. Mirrors the pattern logs-dialog and the
  *  create-config wizard used inline before this was shared. */
 export function fullscreenMobileDialog(
-  hostSelector: string,
-  breakpoint: string = MOBILE_DIALOG_BREAKPOINT
+  host: DialogHost,
+  breakpoint: number = MOBILE_DIALOG_BREAKPOINT
 ): CSSResult {
-  const host = unsafeCSS(hostSelector);
+  const sel = unsafeCSS(host);
   return css`
-    @media (max-width: ${unsafeCSS(breakpoint)}) {
-      ${host}::part(dialog) {
+    @media (max-width: ${breakpoint}px) {
+      ${sel}::part(dialog) {
         position: fixed;
         inset: 0;
         width: 100vw;
@@ -52,8 +55,8 @@ export function fullscreenMobileDialog(
 
       /* Keep the last action / log line clear of the home indicator on
          notched phones (no-op where the inset is 0). */
-      ${host}::part(body),
-      ${host}::part(footer) {
+      ${sel}::part(body),
+      ${sel}::part(footer) {
         padding-bottom: max(var(--wa-space-l), env(safe-area-inset-bottom));
       }
     }
@@ -65,16 +68,23 @@ export function fullscreenMobileDialog(
  *  scrolls internally instead of running off-screen. Does not touch
  *  `inset` / `margin`, so the native centering is preserved. */
 export function centeredMobileDialog(
-  hostSelector: string,
-  breakpoint: string = MOBILE_DIALOG_BREAKPOINT
+  host: DialogHost,
+  breakpoint: number = MOBILE_DIALOG_BREAKPOINT
 ): CSSResult {
-  const host = unsafeCSS(hostSelector);
+  const sel = unsafeCSS(host);
   return css`
-    @media (max-width: ${unsafeCSS(breakpoint)}) {
-      ${host}::part(dialog) {
+    @media (max-width: ${breakpoint}px) {
+      ${sel}::part(dialog) {
         max-width: calc(
           100vw - var(--wa-space-l) - env(safe-area-inset-left) - env(
               safe-area-inset-right
+            )
+        );
+        /* vh first as the fallback; browsers without dvh keep a working
+           cap, modern ones use the dvh line (tracks the URL bar). */
+        max-height: calc(
+          100vh - var(--wa-space-l) - env(safe-area-inset-top) - env(
+              safe-area-inset-bottom
             )
         );
         max-height: calc(

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -8,11 +8,15 @@ import { type CSSResult, css } from "lit";
  * On phones two patterns are wanted:
  *
  * - {@link centeredMobileDialog}: short / form dialogs stay centered but
- *   get a dvh- and safe-area-aware height cap so tall content scrolls
- *   inside the box instead of overflowing the screen.
+ *   get a dvh-aware height cap so tall content scrolls inside the box
+ *   instead of overflowing the screen.
  * - {@link fullscreenMobileDialog}: content-heavy dialogs (build / log
  *   output, the create-config wizard, validate, install) fill the screen
  *   edge-to-edge.
+ *
+ * Sizing uses `dvh` (with a `vh` fallback) rather than `env(safe-area-*)`,
+ * so it works without opting the whole app into `viewport-fit=cover` (which
+ * would push the app's other fixed elements under the notch / home bar).
  *
  * `::part()` only pierces a single shadow level, so the rule must live in
  * the stylesheet of whichever component hosts the `<wa-dialog>`. Pass the
@@ -59,21 +63,14 @@ export function fullscreenMobileDialog(
         margin: 0;
         border-radius: 0;
       }
-
-      /* Keep the last action / log line clear of the home indicator on
-         notched phones (no-op where the inset is 0). */
-      ${sel}::part(body),
-      ${sel}::part(footer) {
-        padding-bottom: max(var(--wa-space-l), env(safe-area-inset-bottom));
-      }
     }
   `;
 }
 
 /** Stay vertically centered (wa-dialog's native `margin: auto`) but cap
- *  the box to the dynamic viewport minus safe areas so tall content
- *  scrolls internally instead of running off-screen. Does not touch
- *  `inset` / `margin`, so the native centering is preserved. */
+ *  the box to the dynamic viewport so tall content scrolls internally
+ *  instead of running off-screen. Does not touch `inset` / `margin`, so
+ *  the native centering is preserved. */
 export function centeredMobileDialog(
   host: DialogHost,
   breakpoint: number = MOBILE_DIALOG_BREAKPOINT
@@ -82,23 +79,11 @@ export function centeredMobileDialog(
   return css`
     @media (max-width: ${breakpoint}px) {
       ${sel}::part(dialog) {
-        max-width: calc(
-          100vw - var(--wa-space-l) - env(safe-area-inset-left) - env(
-              safe-area-inset-right
-            )
-        );
+        max-width: calc(100vw - var(--wa-space-l));
         /* vh first as the fallback; browsers without dvh keep a working
            cap, modern ones use the dvh line (tracks the URL bar). */
-        max-height: calc(
-          100vh - var(--wa-space-l) - env(safe-area-inset-top) - env(
-              safe-area-inset-bottom
-            )
-        );
-        max-height: calc(
-          100dvh - var(--wa-space-l) - env(safe-area-inset-top) - env(
-              safe-area-inset-bottom
-            )
-        );
+        max-height: calc(100vh - var(--wa-space-l));
+        max-height: calc(100dvh - var(--wa-space-l));
       }
     }
   `;

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -1,0 +1,88 @@
+import { type CSSResult, css, unsafeCSS } from "lit";
+
+/**
+ * Shared mobile-layout fragments for app dialogs (issue #41).
+ *
+ * Every dialog renders through webawesome's `<wa-dialog>`, whose
+ * native `<dialog>` centers on the viewport via `inset: 0; margin: auto`.
+ * On phones two patterns are wanted:
+ *
+ * - {@link centeredMobileDialog}: short / form dialogs stay centered but
+ *   get a dvh- and safe-area-aware height cap so tall content scrolls
+ *   inside the box instead of overflowing the screen.
+ * - {@link fullscreenMobileDialog}: content-heavy dialogs (build / log
+ *   output, the create-config wizard, validate, install) fill the screen
+ *   edge-to-edge.
+ *
+ * `::part()` only pierces a single shadow level, so the rule must live in
+ * the stylesheet of whichever component hosts the `<wa-dialog>`. Pass the
+ * matching host selector: `"wa-dialog"` from a component that renders
+ * `<wa-dialog>` directly (raw dialogs, and `base-dialog` itself), or
+ * `"esphome-base-dialog"` from a consumer of `<esphome-base-dialog>` (the
+ * part is re-exposed via `exportparts`). The outer tree wins the parts
+ * cascade, so a consumer's `esphome-base-dialog::part(dialog)` override
+ * beats base-dialog's own default.
+ *
+ * Both fragments default to the same breakpoint so reflow points stay in
+ * lockstep across dialogs; pass a custom one only where a dialog already
+ * shipped with a different threshold (e.g. logs-dialog at 700px).
+ */
+const MOBILE_DIALOG_BREAKPOINT = "600px";
+
+/** Full-screen sheet on mobile. Mirrors the pattern logs-dialog and the
+ *  create-config wizard used inline before this was shared. */
+export function fullscreenMobileDialog(
+  hostSelector: string,
+  breakpoint: string = MOBILE_DIALOG_BREAKPOINT
+): CSSResult {
+  const host = unsafeCSS(hostSelector);
+  return css`
+    @media (max-width: ${unsafeCSS(breakpoint)}) {
+      ${host}::part(dialog) {
+        position: fixed;
+        inset: 0;
+        width: 100vw;
+        height: 100vh;
+        height: 100dvh;
+        max-width: none;
+        max-height: none;
+        margin: 0;
+        border-radius: 0;
+      }
+
+      /* Keep the last action / log line clear of the home indicator on
+         notched phones (no-op where the inset is 0). */
+      ${host}::part(body),
+      ${host}::part(footer) {
+        padding-bottom: max(var(--wa-space-l), env(safe-area-inset-bottom));
+      }
+    }
+  `;
+}
+
+/** Stay vertically centered (wa-dialog's native `margin: auto`) but cap
+ *  the box to the dynamic viewport minus safe areas so tall content
+ *  scrolls internally instead of running off-screen. Does not touch
+ *  `inset` / `margin`, so the native centering is preserved. */
+export function centeredMobileDialog(
+  hostSelector: string,
+  breakpoint: string = MOBILE_DIALOG_BREAKPOINT
+): CSSResult {
+  const host = unsafeCSS(hostSelector);
+  return css`
+    @media (max-width: ${unsafeCSS(breakpoint)}) {
+      ${host}::part(dialog) {
+        max-width: calc(
+          100vw - var(--wa-space-l) - env(safe-area-inset-left) - env(
+              safe-area-inset-right
+            )
+        );
+        max-height: calc(
+          100dvh - var(--wa-space-l) - env(safe-area-inset-top) - env(
+              safe-area-inset-bottom
+            )
+        );
+      }
+    }
+  `;
+}

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -18,16 +18,15 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
-const MOBILE_DIALOG_BREAKPOINT = 600;
+/** Single source of truth for the dialog mobile breakpoint (px). Import
+ *  this anywhere a companion rule must reflow at the same width. */
+export const MOBILE_DIALOG_BREAKPOINT = 600;
 
 /** Full-screen sheet on mobile. */
-export function fullscreenMobileDialog(
-  host: DialogHost,
-  breakpoint: number = MOBILE_DIALOG_BREAKPOINT
-): CSSResult {
+export function fullscreenMobileDialog(host: DialogHost): CSSResult {
   const sel = HOST_SELECTOR[host];
   return css`
-    @media (max-width: ${breakpoint}px) {
+    @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
       ${sel}::part(dialog) {
         position: fixed;
         inset: 0;
@@ -45,13 +44,10 @@ export function fullscreenMobileDialog(
 
 /** Centered (native `margin: auto`) but capped to the viewport so tall
  *  content scrolls inside instead of overflowing. */
-export function centeredMobileDialog(
-  host: DialogHost,
-  breakpoint: number = MOBILE_DIALOG_BREAKPOINT
-): CSSResult {
+export function centeredMobileDialog(host: DialogHost): CSSResult {
   const sel = HOST_SELECTOR[host];
   return css`
-    @media (max-width: ${breakpoint}px) {
+    @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
       ${sel}::part(dialog) {
         max-width: calc(100vw - var(--wa-space-l));
         /* vh fallback, then dvh */

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -1,4 +1,4 @@
-import { type CSSResult, css, unsafeCSS } from "lit";
+import { type CSSResult, css } from "lit";
 
 /**
  * Shared mobile-layout fragments for app dialogs (issue #41).
@@ -29,6 +29,13 @@ import { type CSSResult, css, unsafeCSS } from "lit";
  */
 type DialogHost = "wa-dialog" | "esphome-base-dialog";
 
+/** Pre-built selector fragments so the host can be interpolated into the
+ *  `css` template as a CSSResult, no `unsafeCSS` needed. */
+const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
+  "wa-dialog": css`wa-dialog`,
+  "esphome-base-dialog": css`esphome-base-dialog`,
+};
+
 /** Default mobile breakpoint in px. */
 const MOBILE_DIALOG_BREAKPOINT = 600;
 
@@ -38,7 +45,7 @@ export function fullscreenMobileDialog(
   host: DialogHost,
   breakpoint: number = MOBILE_DIALOG_BREAKPOINT
 ): CSSResult {
-  const sel = unsafeCSS(host);
+  const sel = HOST_SELECTOR[host];
   return css`
     @media (max-width: ${breakpoint}px) {
       ${sel}::part(dialog) {
@@ -71,7 +78,7 @@ export function centeredMobileDialog(
   host: DialogHost,
   breakpoint: number = MOBILE_DIALOG_BREAKPOINT
 ): CSSResult {
-  const sel = unsafeCSS(host);
+  const sel = HOST_SELECTOR[host];
   return css`
     @media (max-width: ${breakpoint}px) {
       ${sel}::part(dialog) {


### PR DESCRIPTION
# What does this implement/fix?

First pass on mobile dialog layout (issue #41). Every dialog renders through webawesome's native `<dialog>`, which centers via `margin: auto` against the layout viewport; on phones the visual viewport is shorter (collapsing URL bar), so taller dialogs get pushed down and run off the bottom, e.g. the build/Clean log dialog.

This adds a shared `src/styles/dialog-mobile.ts` with two fragments; `centeredMobileDialog()` keeps a dialog centered but caps its height to the dynamic viewport (`100dvh`, with a `100vh` fallback) so tall content scrolls inside instead of overflowing, and `fullscreenMobileDialog()` makes a dialog a full-screen sheet on mobile. The centered cap becomes the default for every `esphome-base-dialog` wrapper, and the content-heavy build/clean log (command dialog) goes full-screen with the log filling the sheet. The two pre-existing inline full-screen copies (logs dialog, create-config wizard) now route through the shared fragment, and the breakpoint lives in one exported `MOBILE_DIALOG_BREAKPOINT` constant (600px) referenced everywhere; logs is standardized onto it, so it now goes full-screen at 600px rather than its previous 700px (at 601 to 700px it becomes a centered, dvh-capped dialog).

Sizing uses `dvh` only, so no app-wide `viewport-fit=cover` is needed; the remaining issue #41 dialog items (Download and Validate windows overflow) are content-heavy dialogs that will get the same `fullscreenMobileDialog` treatment in follow-up PRs.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
