### PR TITLE
Cap the card / row kebab menu to the viewport on mobile

### DIFF
--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -110,6 +110,12 @@ export class ESPHomeTableRowMenu extends LitElement {
         box-shadow: var(--wa-shadow-l);
         padding: var(--wa-space-xs) 0;
         animation: menu-in 0.12s ease-out;
+        /* This menu has many items; on short / mobile viewports it would
+           otherwise run off the bottom of the screen. Cap it to the
+           viewport (8px gutter each side, matching the reposition pad)
+           and scroll internally so it always fits. */
+        max-height: calc(100dvh - 16px);
+        overflow-y: auto;
       }
 
       @keyframes menu-in {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -113,7 +113,9 @@ export class ESPHomeTableRowMenu extends LitElement {
         /* This menu has many items; on short / mobile viewports it would
            otherwise run off the bottom of the screen. Cap it to the
            viewport (8px gutter each side, matching the reposition pad)
-           and scroll internally so it always fits. */
+           and scroll internally so it always fits. vh fallback first,
+           then dvh for browsers that track the dynamic viewport. */
+        max-height: calc(100vh - 16px);
         max-height: calc(100dvh - 16px);
         overflow-y: auto;
       }


### PR DESCRIPTION
# What does this implement/fix?

On mobile the kebab (3-dot) menu on device cards could open below the page (issue #41). The shared `esphome-table-row-menu` is a fixed-position list of about 14 items with no height cap, so on a short or landscape viewport it is taller than the screen; the reposition logic clamps its top edge but the menu still runs off the bottom. This caps the menu to the viewport (`max-height: calc(100dvh - 16px)`, matching the 8px reposition gutter) and scrolls it internally, so it always fits; the existing flip/clamp keeps the top on-screen. The table-row kebab uses the same component, so it benefits too.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
