### PR TITLE
Make the Download (firmware install) dialog full-screen on mobile

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -16,6 +16,7 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 import { type FirmwareBinary, JobSource } from "../api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import type { DetectedChip } from "../util/web-serial.js";
@@ -124,7 +125,14 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   _compileReject: ((err: Error) => void) | null = null;
   _detected: DetectedChip | null = null;
 
-  static styles = [espHomeStyles, firmwareInstallDialogStyles, remoteBuildHintStyles];
+  static styles = [
+    espHomeStyles,
+    firmwareInstallDialogStyles,
+    remoteBuildHintStyles,
+    // Content-heavy (build status + expandable log): full-screen on mobile
+    // so it doesn't overflow a centered box. #41
+    fullscreenMobileDialog("esphome-base-dialog"),
+  ];
 
   installWebSerial(device: ConfiguredDevice) {
     this._init(device);


### PR DESCRIPTION
# What does this implement/fix?

On mobile the Download (firmware install) dialog rendered as a centered box and overflowed the viewport, and it overflowed further when the build status / log expanded (issue #41). This makes it full-screen on mobile via the shared `fullscreenMobileDialog` fragment, so it fills the viewport and the body scrolls internally; the expandable build log no longer pushes content off-screen. Desktop is unchanged.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
