### PR TITLE
Stack the device table into cards on mobile

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -573,14 +573,19 @@ export class ESPHomeDeviceTable extends LitElement {
                         </span>
                       </td>`
                     : nothing}
-                  ${row
-                    .getVisibleCells()
-                    .map(
-                      (cell: any) =>
-                        html`<td role="gridcell" class="col-${cell.column.id}">
-                          ${flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </td>`
-                    )}
+                  ${row.getVisibleCells().map(
+                    (cell: any) =>
+                      // data-label feeds the stacked mobile layout
+                      // (table-styles.ts): each cell shows its column
+                      // header as the field label via ::before.
+                      html`<td
+                        role="gridcell"
+                        class="col-${cell.column.id}"
+                        data-label=${cell.column.columnDef.header}
+                      >
+                        ${flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>`
+                  )}
                   <td role="gridcell" class="actions-col">
                     <button
                       class="actions-btn"

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -573,19 +573,26 @@ export class ESPHomeDeviceTable extends LitElement {
                         </span>
                       </td>`
                     : nothing}
-                  ${row.getVisibleCells().map(
-                    (cell: any) =>
-                      // data-label feeds the stacked mobile layout
-                      // (table-styles.ts): each cell shows its column
-                      // header as the field label via ::before.
-                      html`<td
-                        role="gridcell"
-                        class="col-${cell.column.id}"
-                        data-label=${cell.column.columnDef.header}
-                      >
-                        ${flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>`
-                  )}
+                  ${row.getVisibleCells().map((cell: any) => {
+                    // The stacked mobile layout (table-styles.ts) shows each
+                    // cell's column header as a field label. It's a real
+                    // span (not a CSS ::before) so screen readers announce
+                    // it on mobile, where the <thead> is hidden; the span is
+                    // display:none on desktop, so it stays out of the a11y
+                    // tree there (the column header already provides context).
+                    // Name is the card title and actions is a button row, so
+                    // neither gets a label.
+                    const id = cell.column.id;
+                    const labeled = id !== "name" && id !== "actions";
+                    return html`<td role="gridcell" class="col-${id}">
+                      ${labeled
+                        ? html`<span class="cell-stack-label"
+                            >${cell.column.columnDef.header}</span
+                          >`
+                        : nothing}
+                      ${flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>`;
+                  })}
                   <td role="gridcell" class="actions-col">
                     <button
                       class="actions-btn"

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -1,5 +1,8 @@
 import { css } from "lit";
 
+/** Width at/below which the table reflows into stacked cards on phones. */
+const TABLE_STACK_BREAKPOINT = 600;
+
 /** Layout, header, body, scroll, select, and actions styles for the device table. */
 export const tableLayoutStyles = css`
   :host {
@@ -338,12 +341,115 @@ export const tableLayoutStyles = css`
     font-size: var(--wa-font-size-s);
   }
 
-  /* Mobile bottom-margin trim for the table outline. The horizontal
-     margins already tighten via --content-gutter; only the bottom
-     gap (a separate vertical step) needs trimming here. #41 */
-  @media (max-width: 600px) {
+  /* ─── Mobile: stacked-card layout ───
+     On phones the desktop table doesn't fit (7+ columns, horizontal
+     scroll only), so each row reflows into a card with one
+     "label: value" line per cell (data-label comes from the column
+     header in device-table.ts). The header row is hidden, so column
+     sorting isn't available on mobile; the default sort applies, and a
+     row tap still opens the drawer with full detail. #41 */
+  @media (max-width: ${TABLE_STACK_BREAKPOINT}px) {
     .table-wrap {
       margin-bottom: var(--wa-space-s);
+    }
+
+    /* Vertical scroll only; the horizontal-overflow shadows are moot. */
+    .table-scroll {
+      background: none;
+    }
+
+    thead {
+      display: none;
+    }
+
+    table,
+    tbody {
+      display: block;
+    }
+
+    tbody tr {
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      gap: 2px;
+      margin: var(--wa-space-s);
+      padding: var(--wa-space-s) var(--wa-space-m);
+      border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+      border-radius: var(--wa-border-radius-m);
+      background: var(--wa-color-surface-default);
+    }
+    /* Desktop drops the last row's bottom border; restore it per card. */
+    tbody tr:last-child {
+      border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    }
+
+    /* Data cells become label/value rows. */
+    td:not(.no-results) {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: var(--wa-space-m);
+      max-width: none;
+      padding: 3px 0;
+      border: none;
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+    }
+    td:not(.no-results)::before {
+      content: attr(data-label);
+      flex-shrink: 0;
+      font-size: var(--wa-font-size-2xs);
+      font-weight: var(--wa-font-weight-bold);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--wa-color-text-quiet);
+    }
+
+    /* Name is the card title (first, larger, no label). */
+    td.col-name {
+      order: -1;
+      padding-right: 28px;
+      padding-bottom: var(--wa-space-2xs);
+    }
+    td.col-name::before {
+      display: none;
+    }
+    td.col-name .cell-name {
+      font-size: var(--wa-font-size-m);
+      font-weight: var(--wa-font-weight-bold);
+    }
+
+    /* Inline actions become a button row at the bottom, divided off. */
+    td.col-actions {
+      order: 1;
+      justify-content: flex-start;
+      margin-top: var(--wa-space-xs);
+      padding-top: var(--wa-space-s);
+      border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    }
+    td.col-actions::before {
+      display: none;
+    }
+
+    /* Row-end kebab pins to the card's top-right corner. */
+    td.actions-col {
+      position: absolute;
+      top: var(--wa-space-xs);
+      right: var(--wa-space-xs);
+      width: auto;
+      min-width: 0;
+      max-width: none;
+      padding: 0;
+    }
+
+    /* Select checkbox sits at the top of the card. */
+    td.select-col {
+      order: -2;
+      width: auto;
+      min-width: 0;
+      max-width: none;
+      justify-content: flex-start;
     }
   }
 `;

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -10,6 +10,9 @@ export const tableLayoutStyles = css`
     flex-direction: column;
     flex: 1;
     min-height: 0;
+    /* Row-end kebab button footprint; the stacked-card name padding
+       derives its kebab clearance from this so the two can't drift. */
+    --table-kebab-size: 30px;
   }
 
   /* Slotted content uses content-driven height — flex-shrink:0
@@ -312,8 +315,8 @@ export const tableLayoutStyles = css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 30px;
-    height: 30px;
+    width: var(--table-kebab-size);
+    height: var(--table-kebab-size);
     border: none;
     border-radius: var(--wa-border-radius-m);
     background: transparent;
@@ -341,13 +344,23 @@ export const tableLayoutStyles = css`
     font-size: var(--wa-font-size-s);
   }
 
+  /* Per-cell field label for the stacked mobile layout. Hidden on
+     desktop (so it stays out of the a11y tree where the column header
+     already labels the cell); shown on mobile by the media block. It's
+     a real element rather than a ::before so screen readers announce it
+     when the <thead> is hidden. */
+  .cell-stack-label {
+    display: none;
+  }
+
   /* ─── Mobile: stacked-card layout ───
      On phones the desktop table doesn't fit (7+ columns, horizontal
      scroll only), so each row reflows into a card with one
-     "label: value" line per cell (data-label comes from the column
-     header in device-table.ts). The header row is hidden, so column
-     sorting isn't available on mobile; the default sort applies, and a
-     row tap still opens the drawer with full detail. #41 */
+     "label: value" line per cell (the label is .cell-stack-label,
+     rendered from the column header in device-table.ts). The header
+     row is hidden, so column sorting isn't available on mobile; the
+     default sort applies, and a row tap still opens the drawer with
+     full detail. #41 */
   @media (max-width: ${TABLE_STACK_BREAKPOINT}px) {
     .table-wrap {
       margin-bottom: var(--wa-space-s);
@@ -396,8 +409,8 @@ export const tableLayoutStyles = css`
       overflow: visible;
       text-overflow: clip;
     }
-    td:not(.no-results)::before {
-      content: attr(data-label);
+    .cell-stack-label {
+      display: inline;
       flex-shrink: 0;
       font-size: var(--wa-font-size-2xs);
       font-weight: var(--wa-font-weight-bold);
@@ -406,14 +419,14 @@ export const tableLayoutStyles = css`
       color: var(--wa-color-text-quiet);
     }
 
-    /* Name is the card title (first, larger, no label). */
+    /* Name is the card title (first, larger, no label). The right pad
+       reserves room for the absolutely-positioned kebab so a long name
+       can't slide under it; derived from the kebab footprint so the two
+       stay in sync. */
     td.col-name {
       order: -1;
-      padding-right: 28px;
+      padding-right: calc(var(--table-kebab-size) + var(--wa-space-xs));
       padding-bottom: var(--wa-space-2xs);
-    }
-    td.col-name::before {
-      display: none;
     }
     td.col-name .cell-name {
       font-size: var(--wa-font-size-m);
@@ -427,9 +440,6 @@ export const tableLayoutStyles = css`
       margin-top: var(--wa-space-xs);
       padding-top: var(--wa-space-s);
       border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    }
-    td.col-actions::before {
-      display: none;
     }
 
     /* Row-end kebab pins to the card's top-right corner. */


### PR DESCRIPTION
# What does this implement/fix?

The device table didn't fit on mobile (issue #41): with several columns and only a horizontal scrollbar, phones got a tiny scroll-only view of a desktop table. This reflows each row into a stacked card at phone widths (<=600px), the classic responsive-table pattern; each cell shows its column header as a "label: value" line, the device name is the card title, the action buttons become a row at the bottom, and the row-end kebab pins to the card's top-right. The header row is hidden (so column sorting isn't available on mobile; the default sort applies), and there's no horizontal scroll. A row tap still opens the device drawer with full detail, so nothing is lost. Desktop and tablet are unchanged.

It's a small footprint: each data cell already carries a `col-<id>` class, so the only markup change is a `data-label` attribute (from the column header) on each cell; the rest is one breakpoint-scoped CSS block in the table styles.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
