### PR TITLE
Single-source the mobile breakpoint into a shared token

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
+
 export const dashboardStyles = css`
   :host {
     display: flex;
@@ -65,7 +67,7 @@ export const dashboardStyles = css`
   /* Mobile compacts the pill further (see .discovered-section-header
      @media block below), so the gutter tightens one more step to
      match the smaller pill. #41 */
-  @media (max-width: 600px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     :host([has-discovered]) {
       padding-top: var(--wa-space-l);
     }
@@ -210,7 +212,7 @@ export const dashboardStyles = css`
      (icon + count + Show), just denser padding and smaller text /
      icon. The expandable grid below keeps its existing sizing —
      this only compacts the collapsed-state header. #41 */
-  @media (max-width: 600px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     .discovered-section-header {
       padding: var(--wa-space-2xs) var(--wa-space-s);
       gap: var(--wa-space-xs);

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -1,7 +1,6 @@
 import { css } from "lit";
 
-/** Width at/below which the table reflows into stacked cards on phones. */
-const TABLE_STACK_BREAKPOINT = 600;
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 
 /** Layout, header, body, scroll, select, and actions styles for the device table. */
 export const tableLayoutStyles = css`
@@ -361,7 +360,7 @@ export const tableLayoutStyles = css`
      row is hidden, so column sorting isn't available on mobile; the
      default sort applies, and a row tap still opens the drawer with
      full detail. #41 */
-  @media (max-width: ${TABLE_STACK_BREAKPOINT}px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     .table-wrap {
       margin-bottom: var(--wa-space-s);
     }

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_BREAKPOINT } from "../../../styles/breakpoints.js";
+
 export const componentCatalogStyles = css`
   :host {
     display: flex;
@@ -126,7 +128,7 @@ export const componentCatalogStyles = css`
 
   /* Below ~600px (modal viewport on phones) collapse sidebar into a
      horizontal chip row above the grid. */
-  @media (max-width: 600px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     :host {
       flex-direction: column;
       height: auto;

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -126,7 +126,7 @@ export const componentCatalogStyles = css`
     align-content: start;
   }
 
-  /* Below ~600px (modal viewport on phones) collapse sidebar into a
+  /* Below the shared phone breakpoint (modal viewport on phones) collapse sidebar into a
      horizontal chip row above the grid. */
   @media (max-width: ${MOBILE_BREAKPOINT}px) {
     :host {

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "lit";
 
-import { MOBILE_DIALOG_BREAKPOINT } from "../styles/dialog-mobile.js";
+import { MOBILE_BREAKPOINT } from "../styles/breakpoints.js";
 import { fillTerminal } from "./process-terminal/process-terminal.styles.js";
 
 /**
@@ -76,7 +76,7 @@ export const logsDialogStyles = css`
   /* Full-screen sheet + terminal-fill on mobile come from
      fullscreenMobileDialog + fillTerminalOnMobile in the static styles; only
      the logs-specific expand-button hide remains here. */
-  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     .expand-btn {
       display: none;
     }

--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "lit";
 
-import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 
 /**
  * Terminal color tokens. Shared by ``<esphome-process-terminal>`` and its
@@ -285,7 +285,7 @@ export const fillTerminal = css`
  * breakpoint. Add to a stream dialog's ``static styles``.
  */
 export const fillTerminalOnMobile = css`
-  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     ${fillTerminal}
   }
 `;

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -1,6 +1,6 @@
 import { css } from "lit";
 
-import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 
 /** Width at/below which the settings sidebar stacks above the content.
  *  Wider than the full-screen breakpoint so tablets get the stacked nav
@@ -145,7 +145,7 @@ export const settingsSharedStyles = css`
 
   /* At the full-screen breakpoint (fullscreenMobileDialog) the dialog fills
      the viewport, so the layout fills it and the content body scrolls. */
-  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     .layout {
       height: 100%;
     }

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared layout breakpoints (px).
+ *
+ * Single source of truth for the phone cutoff used across the UI: dialogs go
+ * full-screen, the device table stacks into cards, dashboard gutters tighten,
+ * and the component catalog caps its height. Defined here (rather than in any
+ * one feature module) so every consumer can import it without coupling to an
+ * unrelated component.
+ */
+export const MOBILE_BREAKPOINT = 600;

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -1,5 +1,7 @@
 import { type CSSResult, css } from "lit";
 
+import { MOBILE_BREAKPOINT } from "./breakpoints.js";
+
 /**
  * Mobile-layout fragments for app dialogs (issue #41). Both size with `dvh`
  * (vh fallback) so they need no `viewport-fit=cover`.
@@ -18,15 +20,11 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
-/** Single source of truth for the dialog mobile breakpoint (px). Import
- *  this anywhere a companion rule must reflow at the same width. */
-export const MOBILE_DIALOG_BREAKPOINT = 600;
-
 /** Full-screen sheet on mobile. */
 export function fullscreenMobileDialog(host: DialogHost): CSSResult {
   const sel = HOST_SELECTOR[host];
   return css`
-    @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+    @media (max-width: ${MOBILE_BREAKPOINT}px) {
       ${sel}::part(dialog) {
         position: fixed;
         inset: 0;
@@ -47,7 +45,7 @@ export function fullscreenMobileDialog(host: DialogHost): CSSResult {
 export function centeredMobileDialog(host: DialogHost): CSSResult {
   const sel = HOST_SELECTOR[host];
   return css`
-    @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+    @media (max-width: ${MOBILE_BREAKPOINT}px) {
       ${sel}::part(dialog) {
         max-width: calc(100vw - var(--wa-space-l));
         /* vh fallback, then dvh */


### PR DESCRIPTION
# What does this implement/fix?

The 600px phone breakpoint was duplicated across the mobile work: two named constants (`MOBILE_DIALOG_BREAKPOINT`, `TABLE_STACK_BREAKPOINT`) plus three literal `@media (max-width: 600px)` rules, all meaning the same "switch to phone layout" cutoff. This extracts a single `MOBILE_BREAKPOINT` token in `src/styles/breakpoints.ts` and routes every consumer through it: the dialog fragments, the device table stacking, the dashboard gutter/pill trims, and the component catalog. No behaviour change; the cutoff is still 600px, now defined once. The 700px breakpoints (controls reflow, settings sidebar stack) are a deliberately different tablet cutoff and are left as-is.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
