### PR TITLE
Guard the stacked-table label against non-string column headers

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -581,14 +581,18 @@ export class ESPHomeDeviceTable extends LitElement {
                     // display:none on desktop, so it stays out of the a11y
                     // tree there (the column header already provides context).
                     // Name is the card title and actions is a button row, so
-                    // neither gets a label.
+                    // neither gets a label. Only string headers can be used as
+                    // a label; a future flexRender (template/function) header
+                    // would stringify to "[object Object]", so skip it.
                     const id = cell.column.id;
-                    const labeled = id !== "name" && id !== "actions";
+                    const header = cell.column.columnDef.header;
+                    const label =
+                      id !== "name" && id !== "actions" && typeof header === "string"
+                        ? header
+                        : null;
                     return html`<td role="gridcell" class="col-${id}">
-                      ${labeled
-                        ? html`<span class="cell-stack-label"
-                            >${cell.column.columnDef.header}</span
-                          >`
+                      ${label !== null
+                        ? html`<span class="cell-stack-label">${label}</span>`
                         : nothing}
                       ${flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </td>`;


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #517 (Kōan's one non-blocking note). The stacked-table mobile layout renders each cell's column header as a field label by interpolating `columnDef.header` directly, which assumes the header is a string. All current columns use plain localized strings, but a future flexRender (template/function) header would stringify to "[object Object]" in the label. This guards it: the label is only rendered when the header is a string, otherwise it is skipped and the cell still shows its value. No visible change today.

**Related issue or feature (if applicable):**

- part of #41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
