### PR TITLE
Fix clipped no-results empty state in the mobile table view

### DIFF
--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -411,7 +411,7 @@ export const tableLayoutStyles = css`
     }
 
     /* The empty-state cell is excluded from the reset above so it stays
-       centered, but the base td's nowrap / max-width / clip would otherwise
+       centered, but the base td's nowrap / max-width / ellipsis would otherwise
        crop the slotted YAML-pivot banner against the card edge on mobile
        (the cell leaves the table formatting context here, so max-width
        finally bites). Let it wrap and fill the card. #518 */

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -409,6 +409,20 @@ export const tableLayoutStyles = css`
       overflow: visible;
       text-overflow: clip;
     }
+
+    /* The empty-state cell is excluded from the reset above so it stays
+       centered, but the base td's nowrap / max-width / clip would otherwise
+       crop the slotted YAML-pivot banner against the card edge on mobile
+       (the cell leaves the table formatting context here, so max-width
+       finally bites). Let it wrap and fill the card. #518 */
+    td.no-results {
+      max-width: none;
+      white-space: normal;
+      overflow: visible;
+      /* The desktop var(--wa-space-4xl) vertical pad is oversized inside a
+         phone card; trim to a card-appropriate step. */
+      padding: var(--wa-space-xl) var(--wa-space-m);
+    }
     .cell-stack-label {
       display: inline;
       flex-shrink: 0;


### PR DESCRIPTION
# What does this implement/fix?

In the table view on mobile the empty state was clipped; the slotted "Try YAML search" pivot banner overflowed the card and got cut off on both edges.

The mobile card layout resets cell styles with `td:not(.no-results)`, so the empty-state cell kept the base `td` rules (`white-space: nowrap`, `overflow: hidden`, `max-width: 250px`). Those are inert on desktop where the colspan cell sits in a table layout, but once the table reflows to flex cards the cell leaves that context and the constraints crop the banner. This adds a `td.no-results` rule to the mobile block so the copy and the banner wrap and fill the card.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/518

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
