### PR TITLE
Color ESPHome multi-line log continuations in WebSerial logs

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -5,6 +5,7 @@ import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { ArchivedDevice, BulkActionResult } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
+import { ESPHomeLogParser } from "../../util/esphome-log-parser.js";
 import {
   connectToPort,
   detectChip,
@@ -424,6 +425,11 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
   const decoder = new TextDecoder();
   let buffer = "";
   let cancelled = false;
+  // Raw UART logs skip the backend's per-line formatting, so a multi-line
+  // ESPHome record (color opened once, continuation lines indented) loses
+  // its color/header when split on \n. Re-apply them per line, exactly like
+  // the backend's esphome-logs CLI does via aioesphomeapi's LogParser.
+  const parser = new ESPHomeLogParser();
   const readLoop = async () => {
     try {
       while (true) {
@@ -448,7 +454,7 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
                unconditionally (the line break is preserved before
                stamping), so we match that behaviour here for parity
                between the two web serial paths. */
-            const stamped = `${formatSerialTimestamp(new Date())}${cleaned}`;
+            const stamped = `${formatSerialTimestamp(new Date())}${parser.parseLine(cleaned)}`;
             dialog._lines = [...dialog._lines, stamped];
           }
         }

--- a/src/util/esphome-log-parser.ts
+++ b/src/util/esphome-log-parser.ts
@@ -1,0 +1,100 @@
+/**
+ * Stateful ESPHome log parser — ports the algorithm from
+ * ``aioesphomeapi``'s ``log_parser.py`` (the same logic the
+ * ``esphome logs`` CLI uses) so client-side log sources render
+ * identically to the backend-streamed ones.
+ *
+ * Why this exists: ESPHome emits a multi-line config record (e.g. a
+ * ``[C]`` ``dump_config`` block) as a *single* log message — the color
+ * is opened on the first line and the reset only lands on the last; the
+ * continuation lines are merely indented, with no header and no color
+ * of their own. When the message is split on ``\n`` (as the WebSerial
+ * reader does, reading raw UART bytes), each continuation line ends up
+ * colorless and prefix-less.
+ *
+ * The backend's ``esphome logs`` CLI avoids this by running every line
+ * through aioesphomeapi's ``LogParser``, which records the entry line's
+ * prefix + color and re-applies them to each continuation line. Logs
+ * that don't reach the backend (WebSerial — read straight off the
+ * device UART) need the same treatment in the browser; this module is
+ * that treatment.
+ *
+ * It is intentionally timestamp-agnostic: callers prepend their own
+ * ``[HH:MM:SS]`` prefix after parsing, which reproduces aioesphomeapi's
+ * ``timestamp + color + prefix + line`` continuation shape.
+ */
+
+// Reset emitted in real-ESC form (what the device sends); the renderer
+// (ansi-log) accepts both the ESC byte and the literal ``\033`` text.
+const ANSI_RESET = "\u001b[0m";
+
+// A leading SGR color sequence in either form ESPHome uses: the real
+// ESC byte (device UART) or the literal ``\033`` text (backend transport).
+const LEADING_COLOR_RE = /^(?:\u001b|\\033)\[[0-9;]*m/;
+
+// True when a line carries any ANSI sequence — used to decide whether a
+// trailing reset is needed so color can't bleed past the line.
+const HAS_ANSI_RE = /(?:\u001b|\\033)\[/;
+
+/** Already ends in a reset (either escape form)? */
+function endsWithReset(line: string): boolean {
+  return line.endsWith("\u001b[0m") || line.endsWith("\\033[0m");
+}
+
+/** A line needs a trailing reset when it opened color but never closed it. */
+function needsReset(line: string): boolean {
+  return line.length > 0 && HAS_ANSI_RE.test(line) && !endsWithReset(line);
+}
+
+/** Split an entry line into its leading color code and its ``…]:`` prefix
+ *  (the prefix carries no color so the color can be re-applied
+ *  independently on continuation lines). */
+function extractPrefixAndColor(line: string): { prefix: string; color: string } {
+  let color = "";
+  let rest = line;
+  const colorMatch = LEADING_COLOR_RE.exec(line);
+  if (colorMatch) {
+    color = colorMatch[0];
+    rest = line.slice(color.length);
+  }
+  const bracketColon = rest.indexOf("]:");
+  const prefix = bracketColon !== -1 ? rest.slice(0, bracketColon + 2) : "";
+  return { prefix, color };
+}
+
+/**
+ * Streaming parser: feed it one raw device line at a time (no
+ * timestamp) and it returns the line with color/prefix carried onto
+ * continuation lines. One instance per log session — it threads the
+ * last entry's prefix + color across calls.
+ */
+export class ESPHomeLogParser {
+  private _prefix = "";
+  private _color = "";
+
+  /** Parse a single raw line (without trailing newline). */
+  parseLine(line: string): string {
+    // A continuation line is one ESPHome indented under the previous
+    // entry — it starts with whitespace. Everything else is a new entry.
+    if (line === "" || !/^\s/.test(line)) {
+      const { prefix, color } = extractPrefixAndColor(line);
+      this._prefix = prefix;
+      this._color = color;
+      return needsReset(line) ? line + ANSI_RESET : line;
+    }
+
+    // Continuation line. Blank ones carry nothing; pass through.
+    if (line.trim() === "") return line;
+
+    // No entry seen yet (stream joined mid-record): just close any color.
+    if (!this._prefix && !this._color) {
+      return needsReset(line) ? line + ANSI_RESET : line;
+    }
+
+    // Re-apply the entry's color + prefix so the continuation renders
+    // like the backend's per-line output: ``<color>[…]: <content><reset>``.
+    const body = this._prefix ? `${this._prefix} ${line}` : line;
+    const out = `${this._color}${body}`;
+    return this._color && !endsWithReset(out) ? out + ANSI_RESET : out;
+  }
+}

--- a/src/util/esphome-log-parser.ts
+++ b/src/util/esphome-log-parser.ts
@@ -74,17 +74,24 @@ export class ESPHomeLogParser {
 
   /** Parse a single raw line (without trailing newline). */
   parseLine(line: string): string {
-    // A continuation line is one ESPHome indented under the previous
-    // entry — it starts with whitespace. Everything else is a new entry.
-    if (line === "" || !/^\s/.test(line)) {
+    // Blank lines (empty or whitespace-only) carry nothing and must NOT
+    // disturb the carried entry context — a bare line inside a multi-line
+    // record (or a ``\n\n`` that splits to "") would otherwise clear the
+    // prefix/color and leave the rest of the block uncolored.
+    if (line.trim() === "") return line;
+
+    // Continuation detection keys off leading whitespace rather than
+    // aioesphomeapi's "doesn't match the [X][tag]: entry regex" test. This
+    // is a deliberate adaptation for the raw UART stream, which interleaves
+    // non-ESPHome output (esptool / PlatformIO) at column 0: that output
+    // must pass through as plain new-entry lines, not be re-colored as
+    // continuations of a preceding ESPHome record.
+    if (!/^\s/.test(line)) {
       const { prefix, color } = extractPrefixAndColor(line);
       this._prefix = prefix;
       this._color = color;
       return needsReset(line) ? line + ANSI_RESET : line;
     }
-
-    // Continuation line. Blank ones carry nothing; pass through.
-    if (line.trim() === "") return line;
 
     // No entry seen yet (stream joined mid-record): just close any color.
     if (!this._prefix && !this._color) {

--- a/test/util/esphome-log-parser.test.ts
+++ b/test/util/esphome-log-parser.test.ts
@@ -79,4 +79,15 @@ describe("ESPHomeLogParser", () => {
     p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`);
     expect(p.parseLine("   ")).toBe("   ");
   });
+
+  it("preserves carried color across an empty line within a block", () => {
+    const p = new ESPHomeLogParser();
+    p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`);
+    // A fully empty line must pass through without clearing state, so the
+    // continuation after it still inherits the entry's color/prefix.
+    expect(p.parseLine("")).toBe("");
+    expect(p.parseLine("  Hostname: 'ol'")).toBe(
+      `${MAGENTA}[C][wifi:1248]:   Hostname: 'ol'${RESET}`
+    );
+  });
 });

--- a/test/util/esphome-log-parser.test.ts
+++ b/test/util/esphome-log-parser.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { ESPHomeLogParser } from "../../src/util/esphome-log-parser.js";
+
+// Build the ESC byte at runtime so the test source stays free of raw
+// control characters (the device sends real ESC; the renderer accepts it).
+const ESC = String.fromCharCode(0x1b);
+const RESET = `${ESC}[0m`;
+const MAGENTA = `${ESC}[0;35m`; // [C] config color
+
+describe("ESPHomeLogParser", () => {
+  it("appends a reset to an entry line that opened color but never closed it", () => {
+    const p = new ESPHomeLogParser();
+    // First line of a multi-line dump_config block: color opens, no reset.
+    expect(p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`)).toBe(
+      `${MAGENTA}[C][wifi:1248]: WiFi:${RESET}`
+    );
+  });
+
+  it("re-applies the entry color + prefix to an indented continuation line", () => {
+    const p = new ESPHomeLogParser();
+    p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`);
+    // The device sends continuation lines indented, with no color/header.
+    // The parser rebuilds them to match the backend's per-line output:
+    // <color>[prefix]: <content><reset>.
+    expect(p.parseLine("  Local MAC: 24:4C:AB:03:E6:B8")).toBe(
+      `${MAGENTA}[C][wifi:1248]:   Local MAC: 24:4C:AB:03:E6:B8${RESET}`
+    );
+    expect(p.parseLine("  Hostname: 'ol'")).toBe(
+      `${MAGENTA}[C][wifi:1248]:   Hostname: 'ol'${RESET}`
+    );
+  });
+
+  it("matches the backend esphome-logs per-line shape once timestamped", () => {
+    // What devices/logs (backend) emits vs what WebSerial + this parser
+    // produce must be identical after the caller prepends the timestamp.
+    const ts = "[12:09:30.050]";
+    const p = new ESPHomeLogParser();
+    p.parseLine(`${MAGENTA}[C][wifi:1526]: WiFi:`);
+    const got = ts + p.parseLine("  Local MAC: 24:4C:AB:03:E6:B8");
+    expect(got).toBe(
+      `${ts}${MAGENTA}[C][wifi:1526]:   Local MAC: 24:4C:AB:03:E6:B8${RESET}`
+    );
+  });
+
+  it("leaves a self-contained entry line (already reset) untouched", () => {
+    const p = new ESPHomeLogParser();
+    const line = `${MAGENTA}[C][wifi:1248]:   Hostname: 'ol'${RESET}`;
+    expect(p.parseLine(line)).toBe(line);
+  });
+
+  it("passes plain non-ESPHome lines through unchanged (esptool / pio output)", () => {
+    const p = new ESPHomeLogParser();
+    expect(p.parseLine("Writing at 0x0... (2%)")).toBe("Writing at 0x0... (2%)");
+    expect(p.parseLine("Compiling .pioenvs/ol/src/main.cpp.o")).toBe(
+      "Compiling .pioenvs/ol/src/main.cpp.o"
+    );
+  });
+
+  it("does not invent a prefix for a continuation before any entry is seen", () => {
+    const p = new ESPHomeLogParser();
+    // Joined mid-record: indented, no entry context yet → pass through.
+    expect(p.parseLine("  orphan continuation")).toBe("  orphan continuation");
+  });
+
+  it("switches prefix/color when a new entry interrupts a block", () => {
+    const p = new ESPHomeLogParser();
+    p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`);
+    const green = `${ESC}[0;32m`;
+    // A new [I] entry resets the carried prefix/color...
+    p.parseLine(`${green}[I][app:151]: ESPHome version`);
+    // ...so the next continuation inherits the new entry, not the old one.
+    expect(p.parseLine("  detail line")).toBe(
+      `${green}[I][app:151]:   detail line${RESET}`
+    );
+  });
+
+  it("leaves blank continuation lines as-is", () => {
+    const p = new ESPHomeLogParser();
+    p.parseLine(`${MAGENTA}[C][wifi:1248]: WiFi:`);
+    expect(p.parseLine("   ")).toBe("   ");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

WebSerial logs are read straight off the device UART and split on newlines. A multi-line ESPHome log record (a `dump_config` `[C]` block, say) opens its color once on the entry line and only resets on the last; the continuation lines are merely indented, with no header or color of their own. Splitting that on `\n` left every continuation line colorless and prefix-less, so config dumps rendered half-uncolored.

Backend-streamed logs don't hit this: the `esphome logs` CLI already re-applies the prefix + color to each line via aioesphomeapi's `LogParser`. WebSerial bypasses the backend entirely, so it had no equivalent.

This adds `ESPHomeLogParser`, a small TypeScript port of that `LogParser`: a stateful per-line parser that records the entry line's `[…]:` prefix + leading color and re-applies them (with a trailing reset) to continuation lines, so the output matches the backend's per-line shape. Every raw serial line runs through it before timestamping in `streamSerialToDialog`. It is a single shared library so any future client-side raw-log source can reuse it.

**Related issue or feature (if applicable):**

- Follow-up to the dialog-unification work in #513 (continuation-line coloring on WebSerial logs).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
