### PR TITLE
Keep the firmware install footer on-screen when the log is expanded on mobile

### DIFF
--- a/src/components/firmware-install-dialog/styles.ts
+++ b/src/components/firmware-install-dialog/styles.ts
@@ -1,6 +1,6 @@
 import { css } from "lit";
 
-import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 
 export const firmwareInstallDialogStyles = css`
   :host {
@@ -227,7 +227,7 @@ export const firmwareInstallDialogStyles = css`
      so the log scrolls internally and the footer stays on-screen, instead of
      the whole card growing past the viewport and pushing the buttons below the
      fold. Desktop keeps the 50vh log (this block doesn't apply there). */
-  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     :host([expanded]) esphome-process-terminal {
       height: 100%;
     }

--- a/src/components/firmware-install-dialog/styles.ts
+++ b/src/components/firmware-install-dialog/styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_DIALOG_BREAKPOINT } from "../../styles/dialog-mobile.js";
+
 export const firmwareInstallDialogStyles = css`
   :host {
     --term-bg: #1e1e1e;
@@ -219,5 +221,27 @@ export const firmwareInstallDialogStyles = css`
   }
   .btn--ghost wa-icon {
     font-size: 14px;
+  }
+
+  /* #516 — expanded log on the full-screen mobile sheet: fill the dialog body
+     so the log scrolls internally and the footer stays on-screen, instead of
+     the whole card growing past the viewport and pushing the buttons below the
+     fold. Desktop keeps the 50vh log (this block doesn't apply there). */
+  @media (max-width: ${MOBILE_DIALOG_BREAKPOINT}px) {
+    :host([expanded]) esphome-process-terminal {
+      height: 100%;
+    }
+    :host([expanded]) [slot="status-extra"] {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+    :host([expanded]) .logs-container {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+    :host([expanded]) esphome-ansi-log {
+      --log-height: 100%;
+    }
   }
 `;

--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -209,6 +209,19 @@ export const processTerminalStyles = css`
   .card {
     display: flex;
     flex-direction: column;
+    /* Resolves to auto when the host height is indefinite (compact card);
+       fills when a driver gives the host a definite height (firmware install,
+       expanded log on the full-screen mobile sheet — #516). */
+    height: 100%;
+  }
+  /* Driver's slotted block (collapsible log + any instructions) becomes the
+     growing, internally-scrolling region when the card is given a definite
+     height; no-op while the card is auto-height. The footer (toolbar-right)
+     then pins to the bottom as the last flex item. Scoped to the card-only
+     slot, so the stream variant's slots are untouched. */
+  slot[name="status-extra"]::slotted(*) {
+    flex: 1 1 auto;
+    min-height: 0;
   }
   .status {
     display: flex;


### PR DESCRIPTION
# What does this implement/fix?

On the full-screen mobile sheet, an expanded compile or install log was a fixed 50vh; once the result buttons appeared the whole card grew past the viewport and pushed them below the fold. Now the card fills the dialog body so the log scrolls internally and the footer stays pinned. Desktop is unchanged, it still uses the 50vh log.

CSS only; the card variant gets a fill skeleton and the firmware install dialog opts in via a mobile media query gated on the existing expanded state.

**Related issue or feature (if applicable):**

- fixes #516

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
