### PR TITLE
Compact the table pagination footer on mobile

### DIFF
--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -139,7 +139,7 @@ export class ESPHomeTablePagination extends LitElement {
       /* ─── Mobile: compact footer ───
          At phone widths the full footer (row-count line + "Rows per page"
          label + selector + page-of + nav) wraps badly and eats vertical
-         space. Drop the redundant row-count line and the text label (the
+         space. Reclaim the row-count line and drop the text label (the
          selector keeps its aria-label, so it stays accessible) and let the
          remaining selector / page-of / nav cluster center and wrap onto at
          most two short rows. #521 */
@@ -149,8 +149,20 @@ export class ESPHomeTablePagination extends LitElement {
           padding: var(--wa-space-s) var(--wa-space-m);
           gap: var(--wa-space-xs) var(--wa-space-s);
         }
+        /* Visually hide the row-count rather than display:none so the
+           filtered total stays in the a11y tree (screen readers still
+           announce it); absolute positioning takes it out of the flow so
+           its vertical space is still reclaimed. */
         .info {
-          display: none;
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
         }
         .controls {
           flex-wrap: wrap;

--- a/src/components/dashboard/table-pagination.ts
+++ b/src/components/dashboard/table-pagination.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
@@ -134,6 +135,37 @@ export class ESPHomeTablePagination extends LitElement {
       .page-btn wa-icon {
         font-size: 16px;
       }
+
+      /* ─── Mobile: compact footer ───
+         At phone widths the full footer (row-count line + "Rows per page"
+         label + selector + page-of + nav) wraps badly and eats vertical
+         space. Drop the redundant row-count line and the text label (the
+         selector keeps its aria-label, so it stays accessible) and let the
+         remaining selector / page-of / nav cluster center and wrap onto at
+         most two short rows. #521 */
+      @media (max-width: ${MOBILE_BREAKPOINT}px) {
+        .pagination {
+          justify-content: center;
+          padding: var(--wa-space-s) var(--wa-space-m);
+          gap: var(--wa-space-xs) var(--wa-space-s);
+        }
+        .info {
+          display: none;
+        }
+        .controls {
+          flex-wrap: wrap;
+          justify-content: center;
+          gap: var(--wa-space-xs) var(--wa-space-s);
+        }
+        /* Selector alone — the "Rows per page" text is dropped here. */
+        .page-size span {
+          display: none;
+        }
+        /* Drop the 100px reservation so page-of hugs its text. */
+        .page-info {
+          min-width: 0;
+        }
+      }
     `,
   ];
 
@@ -148,7 +180,10 @@ export class ESPHomeTablePagination extends LitElement {
         <div class="controls">
           <div class="page-size">
             <span>${this._localize("dashboard.pagination_rows_per_page")}</span>
-            <select @change=${this._onPageSizeChange}>
+            <select
+              aria-label=${this._localize("dashboard.pagination_rows_per_page")}
+              @change=${this._onPageSizeChange}
+            >
               ${[10, 20, 25, 50, 100, ALL_PAGE_SIZE].map(
                 (size) =>
                   html`<option value=${size} ?selected=${this.pageSize === size}>

--- a/test/components/dashboard/table-pagination.test.ts
+++ b/test/components/dashboard/table-pagination.test.ts
@@ -65,3 +65,19 @@ describe("table-pagination All option", () => {
     expect(el.shadowRoot!.querySelector(".page-info")).not.toBeNull();
   });
 });
+
+describe("table-pagination accessibility", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // The visible "Rows per page" <span> is hidden on mobile (and was never
+  // programmatically tied to the <select>), so the selector carries its own
+  // aria-label to keep an accessible name on every viewport. Guard against a
+  // future change dropping it once the label is no longer visible.
+  it("gives the page-size selector an accessible name via aria-label", async () => {
+    const el = await mount({ pageSize: 25 });
+    const select = el.shadowRoot!.querySelector("select")!;
+    expect(select.getAttribute("aria-label")).toBe("dashboard.pagination_rows_per_page");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

On mobile the table-view pagination footer took up too much of the page; the "Rows per page" label collapsed into three stacked lines and the row-count line added more height.

The pagination component had no mobile rules, so the controls row stayed on one line and squeezed the label. This adds a mobile block at the shared breakpoint that hides the redundant "N row(s) total" line and the "Rows per page" text, then centers the selector, page-of, and nav buttons into one compact cluster that wraps to at most two short rows. The selector gets an aria-label so it stays accessible once its visible label is hidden; desktop is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/521

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
