### PR TITLE
Offer the OTA or serial choice when opening device logs

### DIFF
--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -68,7 +68,9 @@ export async function openLogs(
   // Offer the OTA-vs-serial choice whenever a serial path exists — browser
   // WebSerial, or serial ports on the server (mirrors the old dashboard's
   // logs-target behavior; see #525). With no serial option at all, skip the
-  // picker and open OTA logs directly.
+  // picker and open OTA logs directly. The device's online/offline state is
+  // intentionally not consulted: the picker (or OTA fallback) is purely
+  // serial-path driven, and the picker already gates its own OTA row on state.
   const hasWebSerial = "serial" in navigator;
   let hasServerPorts = false;
   if (!hasWebSerial) {
@@ -76,7 +78,11 @@ export async function openLogs(
     // serial path.
     try {
       hasServerPorts = (await host._api.getSerialPorts()).length > 0;
-    } catch {
+    } catch (err) {
+      // Lockstep deployment means this command exists, so a rejection is a
+      // real WS/backend fault, not version drift; log it but still fall
+      // through to OTA logs so the user isn't left without any path.
+      console.warn("getSerialPorts failed; falling back to OTA logs", err);
       hasServerPorts = false;
     }
   }

--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -1,4 +1,4 @@
-import { type ConfiguredDevice, DeviceState } from "../../api/types/devices.js";
+import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import type { CommandType } from "../command-dialog.js";
@@ -61,14 +61,32 @@ export function showJobProgress(
   );
 }
 
-export function openLogs(host: ESPHomePageDashboard, device: ConfiguredDevice): void {
-  if (device.state === DeviceState.ONLINE) {
-    host._logsDialog.configuration = device.configuration;
-    host._logsDialog.name = device.friendly_name || device.name;
-    host._logsDialog.open();
-  } else {
+export async function openLogs(
+  host: ESPHomePageDashboard,
+  device: ConfiguredDevice
+): Promise<void> {
+  // Offer the OTA-vs-serial choice whenever a serial path exists — browser
+  // WebSerial, or serial ports on the server (mirrors the old dashboard's
+  // logs-target behavior; see #525). With no serial option at all, skip the
+  // picker and open OTA logs directly.
+  const hasWebSerial = "serial" in navigator;
+  let hasServerPorts = false;
+  if (!hasWebSerial) {
+    // Only pay the backend round-trip when WebSerial can't already provide a
+    // serial path.
+    try {
+      hasServerPorts = (await host._api.getSerialPorts()).length > 0;
+    } catch {
+      hasServerPorts = false;
+    }
+  }
+  if (hasWebSerial || hasServerPorts) {
     host._installMethodDevice = device;
     host._installMethodMode = "logs";
     host._installMethodOpen = true;
+    return;
   }
+  host._logsDialog.configuration = device.configuration;
+  host._logsDialog.name = device.friendly_name || device.name;
+  host._logsDialog.open();
 }

--- a/test/components/dashboard/open-logs.test.ts
+++ b/test/components/dashboard/open-logs.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { openLogs } from "../../../src/components/dashboard/install.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+function makeDevice(): ConfiguredDevice {
+  return {
+    name: "kitchen",
+    friendly_name: "Kitchen",
+    configuration: "kitchen.yaml",
+  } as ConfiguredDevice;
+}
+
+interface StubHost {
+  _api: Pick<ESPHomeAPI, "getSerialPorts">;
+  _logsDialog: { configuration?: string; name?: string; open: ReturnType<typeof vi.fn> };
+  _installMethodDevice?: ConfiguredDevice;
+  _installMethodMode?: "install" | "logs";
+  _installMethodOpen: boolean;
+}
+
+function makeHost(getSerialPorts: () => Promise<unknown>): StubHost {
+  return {
+    _api: { getSerialPorts: vi.fn(getSerialPorts) } as unknown as StubHost["_api"],
+    _logsDialog: { open: vi.fn() },
+    _installMethodOpen: false,
+  };
+}
+
+/** Toggle `navigator.serial` presence; returns a restore function. */
+function withWebSerial(present: boolean): () => void {
+  const had = "serial" in navigator;
+  const previous = (navigator as unknown as { serial?: unknown }).serial;
+  if (present) {
+    Object.defineProperty(navigator, "serial", { configurable: true, value: {} });
+  } else if (had) {
+    delete (navigator as unknown as { serial?: unknown }).serial;
+  }
+  return () => {
+    if (had) {
+      Object.defineProperty(navigator, "serial", { configurable: true, value: previous });
+    } else {
+      delete (navigator as unknown as { serial?: unknown }).serial;
+    }
+  };
+}
+
+describe("openLogs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the method picker when WebSerial is available, without touching the backend", async () => {
+    const restore = withWebSerial(true);
+    try {
+      const host = makeHost(async () => []);
+      await openLogs(host as unknown as ESPHomePageDashboard, makeDevice());
+
+      expect(host._installMethodOpen).toBe(true);
+      expect(host._installMethodMode).toBe("logs");
+      expect(host._installMethodDevice?.configuration).toBe("kitchen.yaml");
+      expect(host._logsDialog.open).not.toHaveBeenCalled();
+      // WebSerial alone is a serial path; no need to enumerate server ports.
+      expect(host._api.getSerialPorts).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens the method picker when the server reports serial ports (no WebSerial)", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => [{ port: "/dev/ttyUSB0", desc: "USB serial" }]);
+      await openLogs(host as unknown as ESPHomePageDashboard, makeDevice());
+
+      expect(host._api.getSerialPorts).toHaveBeenCalledTimes(1);
+      expect(host._installMethodOpen).toBe(true);
+      expect(host._installMethodMode).toBe("logs");
+      expect(host._logsDialog.open).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens OTA logs directly when there is no serial path at all", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => []);
+      await openLogs(host as unknown as ESPHomePageDashboard, makeDevice());
+
+      expect(host._installMethodOpen).toBe(false);
+      expect(host._logsDialog.open).toHaveBeenCalledTimes(1);
+      expect(host._logsDialog.configuration).toBe("kitchen.yaml");
+      expect(host._logsDialog.name).toBe("Kitchen");
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to OTA logs when the serial-port lookup fails", async () => {
+    const restore = withWebSerial(false);
+    try {
+      const host = makeHost(async () => {
+        throw new Error("backend unavailable");
+      });
+      await openLogs(host as unknown as ESPHomePageDashboard, makeDevice());
+
+      expect(host._installMethodOpen).toBe(false);
+      expect(host._logsDialog.open).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Clicking Logs on an online device jumped straight to wireless logs, so the only way to reach serial logs was to take the device offline or go through install. This shows the existing install method picker in logs mode whenever a serial path is available; browser WebSerial, or serial ports on the server. When neither exists, it opens OTA logs directly as before. This restores the old dashboard behavior where Logs asked whether you wanted wireless or serial.

The picker, its logs mode, and all three logs paths (OTA, server serial, WebSerial) already existed; the only change is the decision about when to show it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/525

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
