### PR TITLE
Show the log source in the logs dialog header

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -82,17 +82,12 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   plain ``<div class="actions">`` at the end of the
  *   body, and forcing them to migrate to a slotted footer
  *   would balloon the diff for no behaviour change.
- * - ``header-suffix`` slot: inline content rendered right
- *   after the title text in the header (e.g. a status /
- *   source chip). Empty for the common case, so existing
- *   dialogs are visually unchanged; the consumer owns the
- *   slotted element's styling. The header row and the title
- *   text are exposed as the ``label-row`` / ``title-text``
- *   parts (base-dialog's own, not forwarded from wa-dialog)
- *   so a consumer that slots a suffix can lay the row out —
- *   e.g. flex the row and ellipsize ``title-text`` so the
- *   suffix stays legible when space is tight. Dialogs that
- *   don't style these parts keep the default wrapping title.
+ * - ``header-suffix`` slot: inline content after the title
+ *   (e.g. a status chip). Empty by default, so other dialogs
+ *   are unchanged. The row and title are exposed as the
+ *   ``label-row`` / ``title-text`` parts so a consumer that
+ *   slots a suffix can flex the row and ellipsize the title
+ *   to keep the suffix legible when space is tight.
  *
  * **Part forwarding**. The inner ``<wa-dialog>`` is wrapped
  * in this element's shadow DOM, so consumer styles that

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -86,7 +86,13 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   after the title text in the header (e.g. a status /
  *   source chip). Empty for the common case, so existing
  *   dialogs are visually unchanged; the consumer owns the
- *   slotted element's styling.
+ *   slotted element's styling. The header row and the title
+ *   text are exposed as the ``label-row`` / ``title-text``
+ *   parts (base-dialog's own, not forwarded from wa-dialog)
+ *   so a consumer that slots a suffix can lay the row out —
+ *   e.g. flex the row and ellipsize ``title-text`` so the
+ *   suffix stays legible when space is tight. Dialogs that
+ *   don't style these parts keep the default wrapping title.
  *
  * **Part forwarding**. The inner ``<wa-dialog>`` is wrapped
  * in this element's shadow DOM, so consumer styles that
@@ -175,7 +181,9 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-request-close=${this._onWaRequestClose}
         @wa-after-hide=${this._onWaAfterHide}
       >
-        <header slot="label">${this.label}<slot name="header-suffix"></slot></header>
+        <header slot="label" part="label-row">
+          <span part="title-text">${this.label}</span><slot name="header-suffix"></slot>
+        </header>
         <slot></slot>
       </wa-dialog>
     `;

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -82,6 +82,11 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   plain ``<div class="actions">`` at the end of the
  *   body, and forcing them to migrate to a slotted footer
  *   would balloon the diff for no behaviour change.
+ * - ``header-suffix`` slot: inline content rendered right
+ *   after the title text in the header (e.g. a status /
+ *   source chip). Empty for the common case, so existing
+ *   dialogs are visually unchanged; the consumer owns the
+ *   slotted element's styling.
  *
  * **Part forwarding**. The inner ``<wa-dialog>`` is wrapped
  * in this element's shadow DOM, so consumer styles that
@@ -170,7 +175,7 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-request-close=${this._onWaRequestClose}
         @wa-after-hide=${this._onWaAfterHide}
       >
-        <header slot="label">${this.label}</header>
+        <header slot="label">${this.label}<slot name="header-suffix"></slot></header>
         <slot></slot>
       </wa-dialog>
     `;

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -13,6 +13,14 @@ import { fillTerminal } from "./process-terminal/process-terminal.styles.js";
  * from the shared termTokens / termButtonStyles in the component's styles.
  */
 export const logsDialogStyles = css`
+  :host {
+    /* Single source for the header's monospace stack — shared by the title
+       part and the transport chip so the two can't drift. Inherits through
+       the base-dialog shadow boundary (and to the slotted chip) via the
+       flattened tree. */
+    --logs-mono-font: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+  }
+
   esphome-base-dialog {
     /* Width history: 900 wrapped, 1100 still ~100px short, 1200 still wrapped
        on retina / HiDPI screens where ESPHome's ANSI-coloured output reads at
@@ -37,12 +45,32 @@ export const logsDialogStyles = css`
     color: var(--esphome-on-primary);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+    font-family: var(--logs-mono-font);
   }
   esphome-base-dialog::part(body) {
     padding: 0;
     background: var(--term-bg);
     overflow: hidden;
+  }
+
+  /* Transport chip beside the title (OTA / serial path / Web Serial). A subtle
+     pill tuned for the primary-coloured header so two log windows on different
+     transports are tellable apart at a glance. Monospace to match the title
+     and keep a /dev/cu… path legible. Slotted from logs-dialog via the
+     base-dialog header-suffix slot, so it lives in this shadow tree. */
+  .source-chip {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: var(--wa-space-s);
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-family: var(--logs-mono-font);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-normal);
+    color: var(--esphome-on-primary);
+    background: color-mix(in srgb, var(--esphome-on-primary) 16%, transparent);
+    border: 1px solid color-mix(in srgb, var(--esphome-on-primary) 32%, transparent);
+    white-space: nowrap;
   }
   esphome-base-dialog::part(footer) {
     display: none;

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -14,10 +14,7 @@ import { fillTerminal } from "./process-terminal/process-terminal.styles.js";
  */
 export const logsDialogStyles = css`
   :host {
-    /* Single source for the header's monospace stack — shared by the title
-       part and the transport chip so the two can't drift. Inherits through
-       the base-dialog shadow boundary (and to the slotted chip) via the
-       flattened tree. */
+    /* Shared by the title part and the chip so the two can't drift. */
     --logs-mono-font: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
   }
 
@@ -47,11 +44,8 @@ export const logsDialogStyles = css`
     font-weight: var(--wa-font-weight-bold);
     font-family: var(--logs-mono-font);
   }
-  /* Keep the title text and the transport chip on one row, and truncate the
-     device name first so the chip (the reason this header exists) stays whole
-     on a narrow / mobile header instead of a long /dev/cu… path overflowing.
-     Scoped to logs via base-dialog's own label-row / title-text parts, so
-     other dialogs keep their default wrapping title. */
+  /* Truncate the name before the chip so a long /dev/cu… path can't overflow
+     the narrow header. */
   esphome-base-dialog::part(label-row) {
     display: flex;
     align-items: center;
@@ -69,19 +63,13 @@ export const logsDialogStyles = css`
     overflow: hidden;
   }
 
-  /* Transport chip beside the title (OTA / serial path / Web Serial). A subtle
-     pill tuned for the primary-coloured header so two log windows on different
-     transports are tellable apart at a glance. Monospace to match the title
-     and keep a /dev/cu… path legible. Slotted from logs-dialog via the
-     base-dialog header-suffix slot, so it lives in this shadow tree. */
+  /* Transport chip beside the title: OTA / serial path / Web Serial. */
   .source-chip {
     display: inline-block;
     vertical-align: middle;
     margin-left: var(--wa-space-s);
-    /* The name yields first (title-text ellipsises); the chip holds its
-       size. max-width is the last-resort clamp so an extreme path on a tiny
-       screen ellipsises inside the chip rather than overflowing the header —
-       the full value is still available via the chip's title tooltip. */
+    /* Hold size so the name yields first; max-width is the last-resort clamp
+       (full value stays on the title tooltip). */
     flex-shrink: 0;
     max-width: 100%;
     overflow: hidden;

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -47,6 +47,22 @@ export const logsDialogStyles = css`
     font-weight: var(--wa-font-weight-bold);
     font-family: var(--logs-mono-font);
   }
+  /* Keep the title text and the transport chip on one row, and truncate the
+     device name first so the chip (the reason this header exists) stays whole
+     on a narrow / mobile header instead of a long /dev/cu… path overflowing.
+     Scoped to logs via base-dialog's own label-row / title-text parts, so
+     other dialogs keep their default wrapping title. */
+  esphome-base-dialog::part(label-row) {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+  esphome-base-dialog::part(title-text) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   esphome-base-dialog::part(body) {
     padding: 0;
     background: var(--term-bg);
@@ -62,6 +78,14 @@ export const logsDialogStyles = css`
     display: inline-block;
     vertical-align: middle;
     margin-left: var(--wa-space-s);
+    /* The name yields first (title-text ellipsises); the chip holds its
+       size. max-width is the last-resort clamp so an extreme path on a tiny
+       screen ellipsises inside the chip rather than overflowing the header —
+       the full value is still available via the chip's title tooltip. */
+    flex-shrink: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
     padding: 1px 8px;
     border-radius: 999px;
     font-family: var(--logs-mono-font);

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -256,7 +256,7 @@ export class ESPHomeLogsDialog extends LitElement {
         @request-close=${this._onDialogRequestClose}
         @after-hide=${this._onDialogHide}
       >
-        <span slot="header-suffix" class="source-chip">${source}</span>
+        <span slot="header-suffix" class="source-chip" title=${source}>${source}</span>
         <esphome-process-terminal
           .lines=${this._lines}
           placeholder=${this._localize("dashboard.logs_placeholder")}

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -234,6 +234,14 @@ export class ESPHomeLogsDialog extends LitElement {
 
   protected render() {
     const title = this._localize("dashboard.logs_title", { name: this.name });
+    // Surface which transport this window is streaming over so a user with
+    // several log windows open can tell them apart at a glance. ``_port`` is
+    // already "OTA" or the serial path (/dev/cu…) for every open() path;
+    // passive sessions are browser Web Serial, whose _port is an unrelated
+    // "OTA" fallback, so key off ``_passive`` for those.
+    const source = this._passive
+      ? this._localize("dashboard.logs_source_web_serial")
+      : this._port;
     const toggleLabel = this._localize(
       this._showStates ? "dashboard.logs_hide_states" : "dashboard.logs_show_states"
     );
@@ -248,6 +256,7 @@ export class ESPHomeLogsDialog extends LitElement {
         @request-close=${this._onDialogRequestClose}
         @after-hide=${this._onDialogHide}
       >
+        <span slot="header-suffix" class="source-chip">${source}</span>
         <esphome-process-terminal
           .lines=${this._lines}
           placeholder=${this._localize("dashboard.logs_placeholder")}

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -234,11 +234,7 @@ export class ESPHomeLogsDialog extends LitElement {
 
   protected render() {
     const title = this._localize("dashboard.logs_title", { name: this.name });
-    // Surface which transport this window is streaming over so a user with
-    // several log windows open can tell them apart at a glance. ``_port`` is
-    // already "OTA" or the serial path (/dev/cu…) for every open() path;
-    // passive sessions are browser Web Serial, whose _port is an unrelated
-    // "OTA" fallback, so key off ``_passive`` for those.
+    // Web Serial's _port is an unrelated "OTA" fallback, so key off _passive.
     const source = this._passive
       ? this._localize("dashboard.logs_source_web_serial")
       : this._port;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -60,6 +60,7 @@
     "update_stopped": "Stopped by user.",
     "update_uploading_header": "── Uploading ──",
     "logs_title": "Logs - {name}",
+    "logs_source_web_serial": "Web Serial",
     "logs_placeholder": "Waiting for logs…",
     "logs_stop": "Stop",
     "logs_start": "Start",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -231,6 +231,7 @@
     "update_stopped": "Arrêté par l'utilisateur.",
     "update_uploading_header": "── Téléversement ──",
     "logs_title": "Journaux - {name}",
+    "logs_source_web_serial": "Web Serial",
     "logs_placeholder": "En attente des journaux…",
     "logs_stop": "Arrêter",
     "logs_start": "Démarrer",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -60,6 +60,7 @@
     "update_stopped": "Felhasználó által leállítva.",
     "update_uploading_header": "── Feltöltés folyamatban ──",
     "logs_title": "Naplók – {name}",
+    "logs_source_web_serial": "Web Serial",
     "logs_placeholder": "Naplókra várakozás…",
     "logs_stop": "Leállítás",
     "logs_start": "Indítás",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -231,6 +231,7 @@
     "update_stopped": "Gestopt door gebruiker.",
     "update_uploading_header": "── Uploaden ──",
     "logs_title": "Logs - {name}",
+    "logs_source_web_serial": "Web Serial",
     "logs_placeholder": "Wachten op logs…",
     "logs_stop": "Stoppen",
     "logs_start": "Starten",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -60,6 +60,7 @@
     "update_stopped": "已被用户停止。",
     "update_uploading_header": "── 正在上传 ──",
     "logs_title": "日志 - {name}",
+    "logs_source_web_serial": "Web Serial",
     "logs_placeholder": "等待日志…",
     "logs_stop": "停止",
     "logs_start": "开始",

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -4,7 +4,11 @@
  * The states-toggle restart awaits stopStream before respawning; a close
  * during that await must not spawn a stream onto the closed dialog.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
 import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
 
 interface DeferredStop {
@@ -77,5 +81,45 @@ describe("logs-dialog states-toggle restart", () => {
     expect(stopStream).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((el as any)._streamId).toBe("stream-2");
+  });
+});
+
+describe("logs-dialog header source chip", () => {
+  function mount(): ESPHomeLogsDialog {
+    const el = new ESPHomeLogsDialog();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function chipText(el: ESPHomeLogsDialog): string {
+    return el.shadowRoot!.querySelector(".source-chip")?.textContent?.trim() ?? "";
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows OTA for an OTA session", async () => {
+    const el = mount();
+    el.open("OTA");
+    await el.updateComplete;
+    expect(chipText(el)).toBe("OTA");
+  });
+
+  it("shows the serial path for a server-serial session", async () => {
+    const el = mount();
+    el.open("/dev/cu.usbserial-110");
+    await el.updateComplete;
+    expect(chipText(el)).toBe("/dev/cu.usbserial-110");
+  });
+
+  it("shows the Web Serial label for a passive (Web Serial) session", async () => {
+    const el = mount();
+    el.openPassive();
+    await el.updateComplete;
+    // Identity _localize in tests returns the key verbatim.
+    expect(chipText(el)).toBe("dashboard.logs_source_web_serial");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

When you have several log windows open it's easy to lose track of which one is streaming over OTA and which is over serial. This adds the transport as a small monospace chip beside the dialog title, so each window self-identifies: OTA, the serial device path (e.g. /dev/cu.usbserial-110), or Web Serial.

The value comes straight from the dialog's existing state; _port is already "OTA" or the serial path for every open() path, and passive sessions are browser Web Serial, so no callers change. base-dialog gains a generic header-suffix slot (additive; other dialogs slot nothing there and look the same), and logs-dialog supplies the chip. One new localization key, logs_source_web_serial, added to every locale; "Web Serial" is kept verbatim in each since it is a proper API name already used that way across the existing strings.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
