### PR TITLE
Tighten the log surface padding

### DIFF
--- a/src/components/ansi-log.ts
+++ b/src/components/ansi-log.ts
@@ -292,7 +292,7 @@ export class ESPHomeAnsiLog extends LitElement {
           Consolas, monospace;
         font-variant-ligatures: none;
         font-size: 12px;
-        padding: 8px 12px;
+        padding: 8px;
         border-radius: 8px;
         height: 100%;
         overflow-y: auto;


### PR DESCRIPTION
# What does this implement/fix?

The log lines sat a little far from the left edge; the shared ansi-log surface used 12px horizontal padding, which read as too large a gap. This trims it to a uniform 8px in the one place the surface defines it, so every dialog that uses it (logs, compile, install) gets the tighter spacing.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
