### PR TITLE
Centralize the app color palette into a single HA-aware source

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -114,10 +114,8 @@
     <link rel="icon" type="image/svg+xml" />
     <style>
       :root {
-        /* Single source for the brand color when HA's --primary-color isn't
-           present (HA-ingress runs in an iframe and esphome-desktop has no HA,
-           so this fallback is what actually renders). Value matches HA's
-           default primary; re-tuning the brand is a one-line edit here. */
+        /* Single-source brand fallback for where HA isn't present
+           (esphome-desktop / standalone). Re-tune the brand here. */
         --esphome-brand-default: #009ac7;
       }
       :root,

--- a/public/index.html
+++ b/public/index.html
@@ -129,6 +129,9 @@
       .wa-dark .wa-invert {
         --wa-color-brand-fill-loud: var(--esphome-primary);
         --wa-color-brand-on-loud: var(--esphome-on-primary);
+        /* A tint of the brand, intentionally tracking --esphome-primary
+           rather than HA's --state-active-color (which is amber), so the
+           quiet brand fill stays on-brand and follows the single knob. */
         --wa-color-brand-fill-quiet: color-mix(
           in srgb,
           var(--esphome-primary),

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#038fc7" />
+    <!-- Tracks --esphome-brand-default below (HTML attr can't read a CSS var). -->
+    <meta name="theme-color" content="#009ac7" />
     <!--
       Content-Security-Policy - defense in depth against any future
       XSS that slips past Lit's auto-escaping. Catches injected
@@ -112,10 +113,17 @@
          document-relative URL would resolve against the route). -->
     <link rel="icon" type="image/svg+xml" />
     <style>
+      :root {
+        /* Single source for the brand color when HA's --primary-color isn't
+           present (HA-ingress runs in an iframe and esphome-desktop has no HA,
+           so this fallback is what actually renders). Value matches HA's
+           default primary; re-tuning the brand is a one-line edit here. */
+        --esphome-brand-default: #009ac7;
+      }
       :root,
       .wa-light,
       .wa-dark .wa-invert {
-        --wa-color-brand-fill-loud: var(--primary-color, #009fee);
+        --wa-color-brand-fill-loud: var(--primary-color, var(--esphome-brand-default));
         --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Tracks --esphome-brand-default below (HTML attr can't read a CSS var). -->
+    <!-- Tracks --esphome-primary's fallback below (HTML attr can't read a CSS var). -->
     <meta name="theme-color" content="#009ac7" />
     <!--
       Content-Security-Policy - defense in depth against any future
@@ -114,15 +114,27 @@
     <link rel="icon" type="image/svg+xml" />
     <style>
       :root {
-        /* Single-source brand fallback for where HA isn't present
-           (esphome-desktop / standalone). Re-tune the brand here. */
-        --esphome-brand-default: #009ac7;
+        /* App palette — the single place to adjust colors. Each is HA's theme
+           var when embedded, else the fallback; everything reads these tokens,
+           so editing a value here overrides HA everywhere. */
+        --esphome-primary: var(--primary-color, #009ac7);
+        --esphome-on-primary: var(--text-primary-color, #ffffff);
+        --esphome-success: var(--success-color, #2ecc71);
+        --esphome-warning: var(--warning-color, #f39c12);
+        --esphome-error: var(--error-color, #e74c3c);
+        --esphome-offline: var(--disabled-text-color, #95a5a6);
       }
       :root,
       .wa-light,
       .wa-dark .wa-invert {
-        --wa-color-brand-fill-loud: var(--primary-color, var(--esphome-brand-default));
-        --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
+        --wa-color-brand-fill-loud: var(--esphome-primary);
+        --wa-color-brand-on-loud: var(--esphome-on-primary);
+        --wa-color-brand-fill-quiet: color-mix(
+          in srgb,
+          var(--esphome-primary),
+          transparent 88%
+        );
+        --wa-color-brand-on-quiet: var(--esphome-primary);
       }
 
       body {

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -580,7 +580,7 @@ export const automationEditorStyles = css`
     align-items: center;
     gap: 2px;
     background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
-    color: var(--wa-color-brand-on-loud, #ffffff);
+    color: var(--wa-color-brand-on-loud, var(--esphome-on-primary));
     border: var(--wa-border-width-s) solid
       var(--wa-color-brand-fill-loud, var(--esphome-primary));
     padding: 2px var(--wa-space-s);

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -367,7 +367,7 @@ export const automationEditorStyles = css`
   }
 
   .ae-row-picker:hover:not(:disabled) {
-    color: var(--wa-color-brand-fill-loud, #009fee);
+    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
   }
 
   .ae-row-picker:disabled {
@@ -394,7 +394,7 @@ export const automationEditorStyles = css`
   }
 
   .ae-row-picker:hover:not(:disabled) wa-icon {
-    color: var(--wa-color-brand-fill-loud, #009fee);
+    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     opacity: 1;
   }
 
@@ -507,9 +507,9 @@ export const automationEditorStyles = css`
     gap: var(--wa-space-2xs);
     width: 100%;
     appearance: none;
-    border: 1px solid var(--wa-color-brand-fill-loud, #009fee);
+    border: 1px solid var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     background: var(--esphome-primary-light);
-    color: var(--wa-color-brand-fill-loud, #009fee);
+    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     padding: var(--wa-space-s) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -525,7 +525,7 @@ export const automationEditorStyles = css`
   .ae-add:hover:not(:disabled) {
     background: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, #009fee) 18%,
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)) 18%,
       transparent
     );
   }
@@ -579,9 +579,10 @@ export const automationEditorStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 2px;
-    background: var(--wa-color-brand-fill-loud, #009fee);
+    background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     color: var(--wa-color-brand-on-loud, #ffffff);
-    border: var(--wa-border-width-s) solid var(--wa-color-brand-fill-loud, #009fee);
+    border: var(--wa-border-width-s) solid
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     padding: 2px var(--wa-space-s);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -594,8 +595,16 @@ export const automationEditorStyles = css`
   }
 
   .ae-section-add:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--wa-color-brand-fill-loud, #009fee), black 10%);
-    border-color: color-mix(in srgb, var(--wa-color-brand-fill-loud, #009fee), black 10%);
+    background: color-mix(
+      in srgb,
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      black 10%
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      black 10%
+    );
   }
 
   .ae-section-add:disabled {

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -367,7 +367,7 @@ export const automationEditorStyles = css`
   }
 
   .ae-row-picker:hover:not(:disabled) {
-    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
   }
 
   .ae-row-picker:disabled {
@@ -394,7 +394,7 @@ export const automationEditorStyles = css`
   }
 
   .ae-row-picker:hover:not(:disabled) wa-icon {
-    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     opacity: 1;
   }
 
@@ -507,9 +507,9 @@ export const automationEditorStyles = css`
     gap: var(--wa-space-2xs);
     width: 100%;
     appearance: none;
-    border: 1px solid var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    border: 1px solid var(--wa-color-brand-fill-loud, var(--esphome-primary));
     background: var(--esphome-primary-light);
-    color: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    color: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     padding: var(--wa-space-s) var(--wa-space-m);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -525,7 +525,7 @@ export const automationEditorStyles = css`
   .ae-add:hover:not(:disabled) {
     background: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)) 18%,
+      var(--wa-color-brand-fill-loud, var(--esphome-primary)) 18%,
       transparent
     );
   }
@@ -579,10 +579,10 @@ export const automationEditorStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 2px;
-    background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     color: var(--wa-color-brand-on-loud, #ffffff);
     border: var(--wa-border-width-s) solid
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+      var(--wa-color-brand-fill-loud, var(--esphome-primary));
     padding: 2px var(--wa-space-s);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -597,12 +597,12 @@ export const automationEditorStyles = css`
   .ae-section-add:hover:not(:disabled) {
     background: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      var(--wa-color-brand-fill-loud, var(--esphome-primary)),
       black 10%
     );
     border-color: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      var(--wa-color-brand-fill-loud, var(--esphome-primary)),
       black 10%
     );
   }

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -276,7 +276,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
       .picker-row:hover .picker-row-add,
       .picker-row:focus-visible .picker-row-add {
         background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
-        color: var(--wa-color-brand-on-loud, #ffffff);
+        color: var(--wa-color-brand-on-loud, var(--esphome-on-primary));
       }
 
       .picker-empty {

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -275,7 +275,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
 
       .picker-row:hover .picker-row-add,
       .picker-row:focus-visible .picker-row-add {
-        background: var(--wa-color-brand-fill-loud, #009fee);
+        background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
         color: var(--wa-color-brand-on-loud, #ffffff);
       }
 

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -275,7 +275,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
 
       .picker-row:hover .picker-row-add,
       .picker-row:focus-visible .picker-row-add {
-        background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+        background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
         color: var(--wa-color-brand-on-loud, #ffffff);
       }
 

--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -154,10 +154,10 @@ export const deviceSectionConfigStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 2px;
-    background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+    background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
     color: var(--wa-color-brand-on-loud, #ffffff);
     border: var(--wa-border-width-s) solid
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
+      var(--wa-color-brand-fill-loud, var(--esphome-primary));
     padding: 2px var(--wa-space-s);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -172,12 +172,12 @@ export const deviceSectionConfigStyles = css`
   .api-actions-add:hover {
     background: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      var(--wa-color-brand-fill-loud, var(--esphome-primary)),
       black 10%
     );
     border-color: color-mix(
       in srgb,
-      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      var(--wa-color-brand-fill-loud, var(--esphome-primary)),
       black 10%
     );
   }

--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -155,7 +155,7 @@ export const deviceSectionConfigStyles = css`
     align-items: center;
     gap: 2px;
     background: var(--wa-color-brand-fill-loud, var(--esphome-primary));
-    color: var(--wa-color-brand-on-loud, #ffffff);
+    color: var(--wa-color-brand-on-loud, var(--esphome-on-primary));
     border: var(--wa-border-width-s) solid
       var(--wa-color-brand-fill-loud, var(--esphome-primary));
     padding: 2px var(--wa-space-s);

--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -154,9 +154,10 @@ export const deviceSectionConfigStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 2px;
-    background: var(--wa-color-brand-fill-loud, #009fee);
+    background: var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     color: var(--wa-color-brand-on-loud, #ffffff);
-    border: var(--wa-border-width-s) solid var(--wa-color-brand-fill-loud, #009fee);
+    border: var(--wa-border-width-s) solid
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default));
     padding: 2px var(--wa-space-s);
     border-radius: var(--wa-border-radius-m);
     cursor: pointer;
@@ -169,8 +170,16 @@ export const deviceSectionConfigStyles = css`
   }
 
   .api-actions-add:hover {
-    background: color-mix(in srgb, var(--wa-color-brand-fill-loud, #009fee), black 10%);
-    border-color: color-mix(in srgb, var(--wa-color-brand-fill-loud, #009fee), black 10%);
+    background: color-mix(
+      in srgb,
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      black 10%
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--wa-color-brand-fill-loud, var(--esphome-brand-default)),
+      black 10%
+    );
   }
 
   .api-actions-add wa-icon {

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -28,12 +28,11 @@ function applyWaTheme(): void {
 
 /**
  * Document-level theme bridges so the custom properties cascade into
- * every shadow root. `--esphome-svg-filter` inverts monochrome SVG
- * icons in dark mode (hue-rotate keeps tinted strokes). The
- * `--wa-color-brand-*` overrides point WebAwesome's brand palette at
- * HA's `--primary-color`, which HA injects (even under ingress) so the
- * panel adopts the user's theme; `--esphome-brand-default` is the
- * fallback where there's no HA (esphome-desktop / standalone).
+ * every shadow root: `--esphome-svg-filter` inverts monochrome SVG
+ * icons in dark mode (hue-rotate keeps tinted strokes), and the
+ * `.wa-light` / `.wa-dark` blocks map WebAwesome's surface/text tokens
+ * onto HA's (with fallbacks for esphome-desktop). The colour palette
+ * and the brand `--wa-color-*` tokens live in index.html.
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");
@@ -41,13 +40,6 @@ function applyEspHomeTokens(): void {
   style.textContent = `
     :root {
       --esphome-svg-filter: none;
-      --wa-color-brand-fill-loud: var(--primary-color, var(--esphome-brand-default));
-      --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
-      --wa-color-brand-fill-quiet: var(
-        --state-active-color,
-        color-mix(in srgb, var(--esphome-brand-default), transparent 88%)
-      );
-      --wa-color-brand-on-quiet: var(--primary-color, var(--esphome-brand-default));
     }
 
     /* Surfaces and text — remap WebAwesome's surface/text tokens to

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -41,15 +41,16 @@ function applyWaTheme(): void {
  * The ``--wa-color-brand-*`` overrides remap WebAwesome's default
  * cyan brand palette onto ``--primary-color`` (HA's primary), with
  * ``--esphome-brand-default`` (= HA's default primary ``#009ac7``,
- * defined once in index.html) as the fallback. In practice the
- * fallback is what renders: the HA panel runs as an **ingress
- * iframe**, so HA's ``--primary-color`` does not cross into this
- * document, and esphome-desktop has no HA at all. The ``var(…)``
- * hook still adapts automatically if a deployment ever runs
- * same-document where HA's vars cascade. Without this remap the
- * panel headers, primary buttons, FAB, and active view-toggle pip
- * burst in WebAwesome's own cyan. (HA's legacy ``--primary-color``
- * ``#03a9f4`` was retired upstream in favour of ``#009ac7``.)
+ * defined once in index.html) as the fallback. When embedded in HA,
+ * the ``var(…)`` hooks resolve: HA injects its full theme — including
+ * ``--primary-color`` and its own ``--wa-color-*`` map — onto the
+ * panel's root, even under ingress, so the panel adopts the user's
+ * HA theme (e.g. a theme that remaps ``--primary-color`` recolours
+ * the header to match). The fallback only renders where there's no
+ * HA: esphome-desktop and the standalone dev server. Without this
+ * remap the panel headers, primary buttons, FAB, and active
+ * view-toggle pip burst in WebAwesome's own cyan. (HA's legacy
+ * ``--primary-color`` ``#03a9f4`` was retired upstream for ``#009ac7``.)
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -27,30 +27,13 @@ function applyWaTheme(): void {
 }
 
 /**
- * Inject ESPHome-specific theme bridges that need to live at the
- * document level so CSS custom properties cascade into every
- * shadow root.
- *
- * `--esphome-svg-filter` adapts monochrome SVG icons (the ESPHome
- * component-catalog illustrations) to dark mode: in light mode it
- * stays `none`, in dark mode it inverts colours (with a
- * complementary hue rotation so any colour-tinted strokes survive
- * the round trip). Components apply it via
- * `filter: var(--esphome-svg-filter)` on `img[src$=".svg"]`.
- *
- * The ``--wa-color-brand-*`` overrides remap WebAwesome's default
- * cyan brand palette onto ``--primary-color`` (HA's primary), with
- * ``--esphome-brand-default`` (= HA's default primary ``#009ac7``,
- * defined once in index.html) as the fallback. When embedded in HA,
- * the ``var(…)`` hooks resolve: HA injects its full theme — including
- * ``--primary-color`` and its own ``--wa-color-*`` map — onto the
- * panel's root, even under ingress, so the panel adopts the user's
- * HA theme (e.g. a theme that remaps ``--primary-color`` recolours
- * the header to match). The fallback only renders where there's no
- * HA: esphome-desktop and the standalone dev server. Without this
- * remap the panel headers, primary buttons, FAB, and active
- * view-toggle pip burst in WebAwesome's own cyan. (HA's legacy
- * ``--primary-color`` ``#03a9f4`` was retired upstream for ``#009ac7``.)
+ * Document-level theme bridges so the custom properties cascade into
+ * every shadow root. `--esphome-svg-filter` inverts monochrome SVG
+ * icons in dark mode (hue-rotate keeps tinted strokes). The
+ * `--wa-color-brand-*` overrides point WebAwesome's brand palette at
+ * HA's `--primary-color`, which HA injects (even under ingress) so the
+ * panel adopts the user's theme; `--esphome-brand-default` is the
+ * fallback where there's no HA (esphome-desktop / standalone).
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");

--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -39,18 +39,17 @@ function applyWaTheme(): void {
  * `filter: var(--esphome-svg-filter)` on `img[src$=".svg"]`.
  *
  * The ``--wa-color-brand-*`` overrides remap WebAwesome's default
- * cyan brand palette to Home Assistant's primary palette when
- * embedded as an HA panel. ``--primary-color`` and friends are set
- * by HA's theme on the root; when the panel runs standalone those
- * variables are undefined and the fallback values (HA's current
- * ``--ha-color-primary-40`` = #009ac7, plus matching translucent
- * and white companions) keep the panel looking consistent with
- * HA's default theme anyway. (Note: HA used to resolve
- * ``--primary-color`` to the legacy Material Light Blue 500 value
- * ``#03a9f4`` — that's been retired upstream in favour of
- * ``#009ac7``.) Without this, the panel headers, primary buttons,
- * FAB, and active view-toggle pip burst in WebAwesome cyan, which
- * clashes hard against HA's blue sidebar and chrome.
+ * cyan brand palette onto ``--primary-color`` (HA's primary), with
+ * ``--esphome-brand-default`` (= HA's default primary ``#009ac7``,
+ * defined once in index.html) as the fallback. In practice the
+ * fallback is what renders: the HA panel runs as an **ingress
+ * iframe**, so HA's ``--primary-color`` does not cross into this
+ * document, and esphome-desktop has no HA at all. The ``var(…)``
+ * hook still adapts automatically if a deployment ever runs
+ * same-document where HA's vars cascade. Without this remap the
+ * panel headers, primary buttons, FAB, and active view-toggle pip
+ * burst in WebAwesome's own cyan. (HA's legacy ``--primary-color``
+ * ``#03a9f4`` was retired upstream in favour of ``#009ac7``.)
  */
 function applyEspHomeTokens(): void {
   const style = document.createElement("style");
@@ -58,10 +57,13 @@ function applyEspHomeTokens(): void {
   style.textContent = `
     :root {
       --esphome-svg-filter: none;
-      --wa-color-brand-fill-loud: var(--primary-color, #009fee);
+      --wa-color-brand-fill-loud: var(--primary-color, var(--esphome-brand-default));
       --wa-color-brand-on-loud: var(--text-primary-color, #ffffff);
-      --wa-color-brand-fill-quiet: var(--state-active-color, rgba(0, 159, 238, 0.12));
-      --wa-color-brand-on-quiet: var(--primary-color, #009fee);
+      --wa-color-brand-fill-quiet: var(
+        --state-active-color,
+        color-mix(in srgb, var(--esphome-brand-default), transparent 88%)
+      );
+      --wa-color-brand-on-quiet: var(--primary-color, var(--esphome-brand-default));
     }
 
     /* Surfaces and text — remap WebAwesome's surface/text tokens to
@@ -99,13 +101,13 @@ function applyEspHomeTokens(): void {
 function applySonnerOverrides(): void {
   const css = `
     [data-sonner-toast] [data-button] {
-      background: #009fee !important;
-      color: #ffffff !important;
+      background: var(--wa-color-brand-fill-loud) !important;
+      color: var(--wa-color-brand-on-loud) !important;
       border: none !important;
       font-weight: 600 !important;
     }
     [data-sonner-toast] [data-button]:hover {
-      background: color-mix(in srgb, #009fee, black 10%) !important;
+      background: color-mix(in srgb, var(--wa-color-brand-fill-loud), black 10%) !important;
     }
   `;
 

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -12,7 +12,7 @@ import { css } from "lit";
 export const espHomeStyles = css`
   :host {
     /* ─── Brand colors ─── */
-    --esphome-primary: var(--primary-color, #009fee);
+    --esphome-primary: var(--primary-color, var(--esphome-brand-default));
     /* Hover / active background for hand-rolled primary <button>s
        (the FAB, dialog confirm buttons, etc. that don't use
        wa-button[variant="primary"]). Defined once so the brand
@@ -21,14 +21,20 @@ export const espHomeStyles = css`
     --esphome-primary-hover: color-mix(in srgb, var(--esphome-primary), black 10%);
     --esphome-primary-light: color-mix(
       in srgb,
-      var(--primary-color, #009fee) 12%,
+      var(--primary-color, var(--esphome-brand-default)) 12%,
       transparent
     );
-    --esphome-secondary: color-mix(in srgb, var(--primary-color, #009fee), black 8%);
-    --esphome-success: #2ecc71;
-    --esphome-warning: #f39c12;
-    --esphome-error: #e74c3c;
-    --esphome-offline: #95a5a6;
+    --esphome-secondary: color-mix(
+      in srgb,
+      var(--primary-color, var(--esphome-brand-default)),
+      black 8%
+    );
+    /* Status colors hook HA's semantic vars, falling back to our own values
+       (the fallback is what renders under ingress / esphome-desktop). */
+    --esphome-success: var(--success-color, #2ecc71);
+    --esphome-warning: var(--warning-color, #f39c12);
+    --esphome-error: var(--error-color, #e74c3c);
+    --esphome-offline: var(--disabled-text-color, #95a5a6);
 
     /* Text color for use on primary / dark / colored backgrounds — white in both light and dark modes */
     --esphome-on-primary: var(--text-primary-color, #ffffff);

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -29,8 +29,7 @@ export const espHomeStyles = css`
       var(--primary-color, var(--esphome-brand-default)),
       black 8%
     );
-    /* Status colors hook HA's semantic vars, falling back to our own values
-       (the fallback is what renders under ingress / esphome-desktop). */
+    /* Hook HA's semantic vars; the hex is the esphome-desktop fallback. */
     --esphome-success: var(--success-color, #2ecc71);
     --esphome-warning: var(--warning-color, #f39c12);
     --esphome-error: var(--error-color, #e74c3c);

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -11,32 +11,14 @@ import { css } from "lit";
 /** ESPHome brand colors and design tokens. */
 export const espHomeStyles = css`
   :host {
-    /* ─── Brand colors ─── */
-    --esphome-primary: var(--primary-color, var(--esphome-brand-default));
-    /* Hover / active background for hand-rolled primary <button>s
-       (the FAB, dialog confirm buttons, etc. that don't use
-       wa-button[variant="primary"]). Defined once so the brand
-       hover can't drift across the ~two dozen buttons that share
-       it. wa-button has its own hover in the variant rules below. */
+    /* ─── Brand colors ───
+       The raw palette (--esphome-primary, --esphome-on-primary, and the
+       --esphome-success/warning/error/offline status colors) is the single
+       source in index.html — each is an HA theme var with a fallback. Here we
+       derive the brand variants from --esphome-primary so they track it. */
     --esphome-primary-hover: color-mix(in srgb, var(--esphome-primary), black 10%);
-    --esphome-primary-light: color-mix(
-      in srgb,
-      var(--primary-color, var(--esphome-brand-default)) 12%,
-      transparent
-    );
-    --esphome-secondary: color-mix(
-      in srgb,
-      var(--primary-color, var(--esphome-brand-default)),
-      black 8%
-    );
-    /* Hook HA's semantic vars; the hex is the esphome-desktop fallback. */
-    --esphome-success: var(--success-color, #2ecc71);
-    --esphome-warning: var(--warning-color, #f39c12);
-    --esphome-error: var(--error-color, #e74c3c);
-    --esphome-offline: var(--disabled-text-color, #95a5a6);
-
-    /* Text color for use on primary / dark / colored backgrounds — white in both light and dark modes */
-    --esphome-on-primary: var(--text-primary-color, #ffffff);
+    --esphome-primary-light: color-mix(in srgb, var(--esphome-primary) 12%, transparent);
+    --esphome-secondary: color-mix(in srgb, var(--esphome-primary), black 8%);
 
     /* Keyboard focus ring, defined once so every :focus-visible glow
        stays consistent. Two sizes: the default 3px ring for inputs /


### PR DESCRIPTION
# What does this implement/fix?

Up front: this is a consistency cleanup and centralization, not a decision on the final colors. We are not picking the "right" brand color or restyling anything; we are putting the palette in one place so a later discussion can retune it in a single spot.

Issue #39 notes the colors read as too blue and do not match Home Assistant. This centralizes the whole app palette into one block in index.html, where each color is its HA theme variable with a fallback; everything else reads those tokens. Embedded in HA the panel now adopts the user's theme (HA injects its vars onto the panel even under ingress, so e.g. a custom primary recolors the header to match); on esphome-desktop and standalone the fallback renders, with the brand fallback aligned to HA's default primary so it is no longer the old bright cyan.

Two cleanups came with it: the toast buttons stopped hardcoding cyan and now follow the brand token, and the three divergent cyan literals (#009fee, #038fc7, plus an rgba) collapsed to one. Because everything reads the tokens, the palette is adjustable in a single place and a value set there overrides HA.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (colors only; alignment and padding are separate follow-ups)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
