### PR TITLE
Share one height token across the dashboard toolbar controls

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -308,14 +308,14 @@ export const dashboardStyles = css`
     min-width: 0;
   }
 
-  /* Trailing "Clear filters" action on the desktop facet row. Matches
-     the 36px pill height so the strip stays aligned, but stays quiet
+  /* Trailing "Clear filters" action on the desktop facet row. Shares the
+     toolbar control height so the strip stays aligned, but stays quiet
      (borderless, muted) so it doesn't read as another facet pill. */
   .filter-clear {
     display: inline-flex;
     align-items: center;
     gap: 5px;
-    height: 36px;
+    height: var(--esphome-control-height);
     padding: 0 10px;
     border: none;
     border-radius: var(--wa-border-radius-m);
@@ -391,6 +391,10 @@ export const dashboardStyles = css`
      the placeholder. */
   .search-wrap .search-input {
     padding-left: 36px;
+    /* Share the toolbar control height so the search box matches the
+       view-toggle / facet pills beside it (the input's default is the
+       taller --wa-form-control-height). */
+    min-height: var(--esphome-control-height);
   }
 
   /* Decorative leading icon — magnifier in device mode, code-braces
@@ -575,7 +579,6 @@ export const dashboardStyles = css`
   .device-count {
     font-size: var(--wa-font-size-xs);
     color: var(--wa-color-text-quiet);
-    padding-left: 2px;
   }
   .device-count strong {
     color: var(--wa-color-text-normal);
@@ -622,8 +625,8 @@ export const dashboardStyles = css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
+    width: var(--esphome-control-height);
+    height: var(--esphome-control-height);
     border: none;
     background: var(--wa-color-surface-raised);
     color: var(--wa-color-text-quiet);

--- a/src/components/facets/facet-styles.ts
+++ b/src/components/facets/facet-styles.ts
@@ -31,9 +31,9 @@ export const facetStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    /* Matches the 36px view-toggle / select-toggle squares so the
+    /* Shared with the search input / view-toggle / clear-filters so the
        toolbar row reads as one consistent control strip. */
-    height: 36px;
+    height: var(--esphome-control-height);
     padding: 0 10px 0 12px;
     border-radius: var(--wa-border-radius-m);
     /* 2px dashes — the default 1px-thick dashed border renders as

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -60,6 +60,10 @@ export const espHomeStyles = css`
     /* ─── Layout ─── */
     --esphome-header-height: 56px;
     --esphome-footer-height: 20px;
+    /* Height shared by the toolbar's interactive controls (search input,
+       view-toggle, facet pills, clear-filters) so the search row stays
+       pixel-aligned from one source. */
+    --esphome-control-height: 36px;
 
     font-family: var(--wa-font-family-body);
   }


### PR DESCRIPTION
# What does this implement/fix?

Part of #39 (the colors half merged in #533). This is the toolbar alignment piece. I validated the live dashboard with headless Chrome and the big "N devices" misalignment was already gone, but two 2px residuals remained: the search box rendered 2px taller than the view-toggle and facet pills beside it, and the device count had a stray padding-left that pushed its text off the gutter.

This routes the search input, view-toggle, facet pills, and clear-filters through one shared --esphome-control-height token (added next to --esphome-header-height in shared.ts), replacing the 36px magic number that was duplicated across facet-styles and the dashboard styles; the search box now matches that height instead of the taller form-control default. It also drops the device-count padding-left so the count text sits flush at the gutter with the search box and the cards. Verified with headless Chrome that all four controls report 36px and the count text left edge is back at the gutter.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (toolbar alignment)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
