### PR TITLE
Align the app header to the shared content gutter

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -33,13 +33,10 @@ export const dashboardStyles = css`
        dashboard host, so both toolbars resolve identical values and
        can't drift on mobile. Mobile override is in the @media block. */
     --toolbar-pad-top: var(--wa-space-l);
-    /* Horizontal content gutter shared by every full-width region in
-       both views: the toolbar (.toolbar / .controls), the card grid,
-       the YAML hit list, the table outline (.table-wrap), and the
-       table count row. Full on desktop, tightened on mobile in the
-       @media block below. Defined on the host so the device-table
-       shadow inherits it, keeping card and table views aligned. #41 */
-    --content-gutter: var(--wa-space-l);
+    /* --content-gutter (the horizontal inset shared by the toolbar, card
+       grid, YAML hit list, table outline, and count row) is defined once on
+       esphome-layout's :host and inherited here, so the header and the body
+       share one gutter. The device-table shadow inherits it too. #41 */
     /* Inter-row gap inside the toolbar. Card view's .toolbar and the
        table view's .toolbar-stack both use it, and the table count
        row mirrors it as padding-top, so the rows line up identically
@@ -72,12 +69,10 @@ export const dashboardStyles = css`
       padding-top: var(--wa-space-l);
     }
 
-    /* Tighten the shared gutters on mobile. Every full-width region
-       in both views inherits these, so the card and table layouts
-       stay in lockstep at narrow widths. #41 */
+    /* Tighten the toolbar's top padding on mobile (the --content-gutter
+       mobile trim lives on esphome-layout now, inherited here). #41 */
     :host {
       --toolbar-pad-top: var(--wa-space-s);
-      --content-gutter: var(--wa-space-s);
     }
   }
 

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -9,6 +9,7 @@ import {
   serverVersionContext,
   versionContext,
 } from "../context/index.js";
+import { MOBILE_BREAKPOINT } from "../styles/breakpoints.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { stripBase, withBase } from "../util/base-path.js";
 import { navigate } from "../util/navigation.js";
@@ -73,13 +74,23 @@ export class ESPHomeLayout extends LitElement {
       :host {
         display: block;
         min-height: 100%;
+        /* Single content inset for the header and the page slotted below,
+           so the logo / title line up with the toolbar and cards. The
+           dashboard page and the device-table inherit it through the slot;
+           trims on mobile to match the tighter body gutter. */
+        --content-gutter: var(--wa-space-l);
+      }
+      @media (max-width: ${MOBILE_BREAKPOINT}px) {
+        :host {
+          --content-gutter: var(--wa-space-s);
+        }
       }
 
       .app-header {
         display: flex;
         align-items: center;
         gap: var(--wa-space-m);
-        padding: 0 var(--wa-space-s);
+        padding: 0 var(--content-gutter);
         background: var(--esphome-primary);
         height: var(--esphome-header-height);
         box-sizing: border-box;


### PR DESCRIPTION
# What does this implement/fix?

Part of #39 (alignment). The app header content sat at a tighter inset than the body: the header used its own padding (--wa-space-s) so the logo started ~12px left of the search box and cards, which all sit at the 24px content gutter. So the logo and title did not line up with the content beneath them on desktop.

This hoists --content-gutter (and its mobile trim) up to esphome-layout's :host, the shell that wraps both the header and the slotted page, and points the header padding at it. The dashboard's now-redundant local definition is removed; it inherits the same token through the slot, so there is one gutter source for the header and the body. The mobile trim now uses the shared MOBILE_BREAKPOINT instead of a separate magic number. Verified with headless Chrome that on desktop the header logo, search box, and cards all align at 24, and on mobile they stay together at the tighter inset.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (header alignment)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
