### PR TITLE
Take the settings dialog full screen once the nav stacks

### DIFF
--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -22,6 +22,7 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
+  SETTINGS_DIALOG_BREAKPOINT,
   settingsRowStyles,
   settingsSharedStyles,
 } from "./settings-dialog/shared-styles.js";
@@ -76,8 +77,10 @@ export class ESPHomeSettingsDialog extends LitElement {
     espHomeStyles,
     settingsSharedStyles,
     settingsRowStyles,
-    // Full-screen on mobile; the layout fills the sheet (see shared-styles).
-    fullscreenMobileDialog("esphome-base-dialog"),
+    // Full-screen as soon as the nav stacks (700px, not the 600px phone
+    // cutoff) so the 600-700 band doesn't float as a half-collapsed centered
+    // box; the layout fills the sheet (see shared-styles).
+    fullscreenMobileDialog("esphome-base-dialog", SETTINGS_DIALOG_BREAKPOINT),
   ];
 
   open() {

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -1,11 +1,13 @@
 import { css } from "lit";
 
-import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
-
-/** Width at/below which the settings sidebar stacks above the content.
- *  Wider than the full-screen breakpoint so tablets get the stacked nav
- *  while the dialog is still a centered (not full-screen) box. */
-const SETTINGS_STACK_BREAKPOINT = 700;
+/** Width at/below which the settings dialog switches to its compact layout:
+ *  the sidebar stacks above the content as a wrapped nav, and the dialog goes
+ *  full-screen. This is wider than the shared phone cutoff (MOBILE_BREAKPOINT,
+ *  600px) on purpose -- between 600 and 700 a centered box with the nav already
+ *  stacked on top floated as an awkward half-collapsed panel, so the dialog
+ *  commits to the full-screen sheet as soon as the nav stacks. settings-dialog.ts
+ *  passes this value to fullscreenMobileDialog() so the two stay in lockstep. */
+export const SETTINGS_DIALOG_BREAKPOINT = 700;
 
 export const settingsSharedStyles = css`
   esphome-base-dialog {
@@ -126,11 +128,14 @@ export const settingsSharedStyles = css`
     overflow-y: auto;
   }
 
-  /* Tablet and phone: stack the nav above the content. */
-  @media (max-width: ${SETTINGS_STACK_BREAKPOINT}px) {
+  /* Compact layout: the dialog goes full-screen (see fullscreenMobileDialog in
+     settings-dialog.ts, driven by the same SETTINGS_DIALOG_BREAKPOINT) and the
+     nav stacks above the content. height: 100% fills the full-screen sheet so
+     the content body scrolls instead of the dialog collapsing to content. */
+  @media (max-width: ${SETTINGS_DIALOG_BREAKPOINT}px) {
     .layout {
       flex-direction: column;
-      height: auto;
+      height: 100%;
     }
     .sidebar {
       width: auto;
@@ -140,14 +145,6 @@ export const settingsSharedStyles = css`
     .nav {
       flex-direction: row;
       flex-wrap: wrap;
-    }
-  }
-
-  /* At the full-screen breakpoint (fullscreenMobileDialog) the dialog fills
-     the viewport, so the layout fills it and the content body scrolls. */
-  @media (max-width: ${MOBILE_BREAKPOINT}px) {
-    .layout {
-      height: 100%;
     }
   }
 `;

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -20,11 +20,17 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
-/** Full-screen sheet on mobile. */
-export function fullscreenMobileDialog(host: DialogHost): CSSResult {
+/** Full-screen sheet on mobile. Pass a custom `breakpoint` for dialogs whose
+ *  layout needs to go full-screen earlier than the shared phone cutoff (e.g.
+ *  the settings dialog, whose stacked-nav band would otherwise float as an
+ *  awkward centered box between the phone cutoff and its own stack point). */
+export function fullscreenMobileDialog(
+  host: DialogHost,
+  breakpoint: number = MOBILE_BREAKPOINT
+): CSSResult {
   const sel = HOST_SELECTOR[host];
   return css`
-    @media (max-width: ${MOBILE_BREAKPOINT}px) {
+    @media (max-width: ${breakpoint}px) {
       ${sel}::part(dialog) {
         position: fixed;
         inset: 0;


### PR DESCRIPTION
# What does this implement/fix?

The settings dialog looked broken at narrow tablet widths, roughly between 600px and 700px wide. The nav stacked to the top there, but the dialog stayed a centered box with no fixed height, so it collapsed into a half empty floating panel. Below 600px it already went full screen and looked fine, so this just moves the full screen cutoff up to where the nav stacks (700px); now the whole range below 700px renders as that same full screen sheet. Only the settings dialog opts into the wider cutoff, so the device table and other dialogs are untouched.

**Related issue or feature (if applicable):**

- Partial fix for #39

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
