### PR TITLE
Flow the dashboard on mobile so the table view footer isn't clipped

### DIFF
--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -73,6 +73,15 @@ export const dashboardStyles = css`
        mobile trim lives on esphome-layout now, inherited here). #41 */
     :host {
       --toolbar-pad-top: var(--wa-space-s);
+      /* On phones the table reflows into stacked cards (table-styles.ts),
+         so the desktop fixed-height / internal-scroll layout no longer
+         applies. Flow the whole dashboard in the app's scroll container
+         like the card / YAML views do: removes the dead space the flex:1
+         table-scroll stretched open above the pagination row, and reserves
+         space for the fixed footer so it stops clipping the bottom card. */
+      height: auto;
+      overflow: visible;
+      padding-bottom: var(--esphome-footer-height);
     }
   }
 

--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -365,9 +365,13 @@ export const tableLayoutStyles = css`
       margin-bottom: var(--wa-space-s);
     }
 
-    /* Vertical scroll only; the horizontal-overflow shadows are moot. */
+    /* Vertical scroll only; the horizontal-overflow shadows are moot.
+       The dashboard host now flows on mobile (styles.ts), so the table
+       sizes to its content — drop the internal scroll region so there's
+       no phantom nested scrollbar. */
     .table-scroll {
       background: none;
+      overflow: visible;
     }
 
     thead {


### PR DESCRIPTION
# What does this implement/fix?

On mobile, the table view kept the desktop fixed height, internal scroll layout even though the table reflows into stacked cards there; that left dead space above the pagination row and let the fixed footer clip the bottom card.

This makes the dashboard flow in the app's scroll container on phones, the same way the card and YAML views already do, so the page sizes to its content and reserves space for the footer. Desktop is unchanged.

**Related issue or feature (if applicable):**

- part of #39

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
