### PR TITLE
Migrate the confirm dialog onto esphome-base-dialog

### DIFF
--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -1,17 +1,16 @@
 import { consume } from "@lit/context";
 import { mdiAlertOutline } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({ "alert-outline": mdiAlertOutline });
 
@@ -55,15 +54,14 @@ export class ESPHomeConfirmDialog extends LitElement {
   @property()
   icon = "alert-outline";
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   static styles = [
     espHomeStyles,
     modalDialogStyles,
-    dialogCloseButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 420px;
       }
 
@@ -119,17 +117,22 @@ export class ESPHomeConfirmDialog extends LitElement {
 
   open() {
     this._decided = false;
-    this._dialog.open = true;
+    this._open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
 
   protected render() {
     return html`
-      <wa-dialog label=${this.heading} light-dismiss @wa-after-hide=${this._onAfterHide}>
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this.heading}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
+      >
         <div class="body">
           ${this.destructive
             ? html`<div class="icon-wrap destructive">
@@ -158,7 +161,7 @@ export class ESPHomeConfirmDialog extends LitElement {
             ${this.confirmLabel || this.heading}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -181,7 +184,15 @@ export class ESPHomeConfirmDialog extends LitElement {
     this.dispatchEvent(new CustomEvent("secondary", { bubbles: true }));
   }
 
+  // Flip _open the moment a close is requested (X / Esc / outside-click),
+  // before wa-dialog finishes hiding, so a re-render can't re-assert ?open
+  // and cancel the in-progress hide. Teardown stays in after-hide.
+  private _onRequestClose = (): void => {
+    this._open = false;
+  };
+
   private _onAfterHide() {
+    this._open = false;
     this._enter.set(false);
     if (!this._decided) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));

--- a/src/styles/modal-dialog.ts
+++ b/src/styles/modal-dialog.ts
@@ -47,21 +47,28 @@
 import { css } from "lit";
 
 export const modalDialogStyles = css`
-  wa-dialog::part(header) {
+  /* Dual selectors so this one shared fragment styles both the raw
+     <wa-dialog> modals and the ones migrated onto <esphome-base-dialog>
+     (its parts are re-exported under the same names). #39 */
+  wa-dialog::part(header),
+  esphome-base-dialog::part(header) {
     padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
   }
 
-  wa-dialog::part(title) {
+  wa-dialog::part(title),
+  esphome-base-dialog::part(title) {
     font-size: var(--wa-font-size-m);
     font-weight: var(--wa-font-weight-bold);
     color: var(--wa-color-text-normal);
   }
 
-  wa-dialog::part(body) {
+  wa-dialog::part(body),
+  esphome-base-dialog::part(body) {
     padding: 0 var(--wa-space-l);
   }
 
-  wa-dialog::part(footer) {
+  wa-dialog::part(footer),
+  esphome-base-dialog::part(footer) {
     display: none;
   }
 

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -61,3 +61,50 @@ describe("confirm-dialog ENTER", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 });
+
+// The migration onto esphome-base-dialog introduced the reactive ?open binding,
+// the request-close handler, and the after-hide -> cancel path. Pin them so the
+// dismiss-cancels contract can't silently regress.
+describe("confirm-dialog dismiss / request-close", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const baseDialog = (el: ESPHomeConfirmDialog): HTMLElement =>
+    el.shadowRoot!.querySelector("esphome-base-dialog")!;
+
+  it("fires a single cancel when dismissed without a decision", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    const onCancel = vi.fn();
+    el.addEventListener("cancel", onCancel);
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire cancel when the dialog was confirmed", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    el.addEventListener("confirm", onConfirm);
+    el.addEventListener("cancel", onCancel);
+    pressEnter(); // confirms (non-destructive) -> _decided = true
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("flips the reactive open flag to false on request-close", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(true);
+    baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Part of #39, the dialog consistency cleanup. The confirm dialog used a raw wa-dialog directly while settings already uses the shared esphome-base-dialog, so it skipped the wrapper's busy gate, close-button styling, and event-scope handling.

This moves it onto esphome-base-dialog; the imperative _dialog.open toggle becomes a reactive _open flag wired to the wrapper's request-close and after-hide contract, the public open() and close() API and the confirm, secondary, cancel events are unchanged. The shared modalDialogStyles header, title, body, footer rules now carry a dual selector so one fragment styles both the raw and the wrapped dialogs as the rest migrate. Verified with headless Chrome that the rendered dialog is pixel identical to main; dialog size, header and body padding, title, icon, text, and the Cancel and Confirm buttons all match.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (dialog consistency)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

