### PR TITLE
Hide the States toggle for server serial logs

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -24,7 +24,9 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
   type LogsSession,
+  OTA_PORT,
   hasSerialPort,
+  isOtaNetwork,
   isPassive,
   isStreaming,
 } from "./logs-session.js";
@@ -136,7 +138,7 @@ export class ESPHomeLogsDialog extends LitElement {
     }
   }
 
-  public open(port = "OTA", options: { onBackToInstall?: () => void } = {}) {
+  public open(port = OTA_PORT, options: { onBackToInstall?: () => void } = {}) {
     this._beginSession(options.onBackToInstall);
     this._reconnect = null;
     this._session = { kind: "ota", port, streamId: null };
@@ -307,13 +309,17 @@ export class ESPHomeLogsDialog extends LitElement {
                   disabled: !hasSerialPort(s),
                   onClick: this._onResetDevice,
                 })
-              : renderTermToggle({
-                  active: this._showStates,
-                  onClick: this._toggleShowStates,
-                  icon: "pulse",
-                  label: this._localize("dashboard.logs_states"),
-                  title: toggleLabel,
-                })}
+              : isOtaNetwork(s)
+                ? // States arrive only over the network/API connection, so the
+                  // toggle is hidden for a server serial source (#539).
+                  renderTermToggle({
+                    active: this._showStates,
+                    onClick: this._toggleShowStates,
+                    icon: "pulse",
+                    label: this._localize("dashboard.logs_states"),
+                    title: toggleLabel,
+                  })
+                : ""}
             <!-- Kept inline: the expand-btn class drives the mobile hide rule. -->
             <button
               type="button"

--- a/src/components/logs-session.ts
+++ b/src/components/logs-session.ts
@@ -37,6 +37,12 @@ export type LogsSession =
     }
   | { readonly kind: "dead" };
 
+/** Sentinel ``ota`` port for the network / OTA log source (as opposed to a
+ *  server serial device path like ``/dev/cu.usbserial-110``). Both run through
+ *  the backend ``logs`` WS subscription and so share the ``ota`` session kind;
+ *  the port is what tells them apart. */
+export const OTA_PORT = "OTA";
+
 /** Whether the streaming dot / Stop button should show (vs. the Start button). */
 export const isStreaming = (s: LogsSession): boolean =>
   (s.kind === "ota" && s.streamId !== null) ||
@@ -50,3 +56,11 @@ export const isPassive = (s: LogsSession): boolean =>
 /** A live Web Serial port is held — the only state where Reset Device can fire
  *  and the port can be torn down. */
 export const hasSerialPort = (s: LogsSession): boolean => s.kind === "serial";
+
+/** Whether the States toggle applies. Device states arrive only over the API /
+ *  network connection, so the toggle (which sets the backend ``--no-states``
+ *  flag) is meaningful only for the OTA source. Server serial shares the
+ *  ``ota`` kind but carries a device path instead of the ``OTA`` sentinel, so
+ *  it's excluded — toggling states there is a no-op (#539). */
+export const isOtaNetwork = (s: LogsSession): boolean =>
+  s.kind === "ota" && s.port === OTA_PORT;

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -2,6 +2,7 @@ import toast from "sonner-js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
+import { OTA_PORT } from "../components/logs-session.js";
 
 /**
  * Detail shape of the cancelable ``request-show-logs-after-install``
@@ -184,6 +185,6 @@ export async function handlePostInstallShowLogs(
        re-enumeration window) and starts reading. */
     await attachSerialLogStream(webSerialPort, logsDialog, localize);
   } else {
-    logsDialog.open(port ?? "OTA", { onBackToInstall: reopenInstall });
+    logsDialog.open(port ?? OTA_PORT, { onBackToInstall: reopenInstall });
   }
 }

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -158,6 +158,44 @@ describe("logs-dialog header source chip", () => {
   });
 });
 
+describe("logs-dialog States toggle gate (#539)", () => {
+  function mount(): ESPHomeLogsDialog {
+    const el = new ESPHomeLogsDialog();
+    (el as any)._api = { logs: () => "s1", stopStream: () => Promise.resolve() };
+    document.body.appendChild(el);
+    return el;
+  }
+
+  // The States toggle is the only toolbar control with aria-pressed.
+  const hasStatesToggle = (el: ESPHomeLogsDialog): boolean =>
+    el.shadowRoot!.querySelector("[aria-pressed]") !== null;
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows the States toggle for an OTA (network) session", async () => {
+    const el = mount();
+    el.open("OTA");
+    await el.updateComplete;
+    expect(hasStatesToggle(el)).toBe(true);
+  });
+
+  it("hides the States toggle for a server-serial session", async () => {
+    const el = mount();
+    el.open("/dev/cu.usbserial-110");
+    await el.updateComplete;
+    expect(hasStatesToggle(el)).toBe(false);
+  });
+
+  it("hides the States toggle for a passive (Web Serial) session", async () => {
+    const el = mount();
+    el.openPassive({ onReconnect: () => Promise.resolve() });
+    await el.updateComplete;
+    expect(hasStatesToggle(el)).toBe(false);
+  });
+});
+
 describe("logs-dialog passive Web Serial session (#526)", () => {
   let el: ESPHomeLogsDialog;
   let logs: ReturnType<typeof vi.fn>;

--- a/test/components/logs-session.test.ts
+++ b/test/components/logs-session.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   hasSerialPort,
+  isOtaNetwork,
   isPassive,
   isStreaming,
+  OTA_PORT,
   type LogsSession,
 } from "../../src/components/logs-session.js";
 
@@ -53,6 +55,23 @@ describe("logs-session selectors", () => {
       { kind: "idle" },
     ] as LogsSession[]) {
       expect(hasSerialPort(s)).toBe(false);
+    }
+  });
+
+  it("isOtaNetwork: only the OTA sentinel port, not a server serial path", () => {
+    expect(isOtaNetwork({ kind: "ota", port: OTA_PORT, streamId: "s1" })).toBe(true);
+    expect(isOtaNetwork({ kind: "ota", port: OTA_PORT, streamId: null })).toBe(true);
+    // Server serial rides the same `ota` kind but carries a device path (#539).
+    expect(
+      isOtaNetwork({ kind: "ota", port: "/dev/cu.usbserial-110", streamId: "s1" })
+    ).toBe(false);
+    for (const s of [
+      { kind: "serial", port: fakePort, cancel: noop, paused: false },
+      { kind: "reconnecting", paused: false },
+      { kind: "dead" },
+      { kind: "idle" },
+    ] as LogsSession[]) {
+      expect(isOtaNetwork(s)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The logs dialog showed the States toggle for server serial logs, but device states only arrive over the API / network connection; toggling them on a serial source just tore the stream down and respawned it with a `--no-states` flag that had no effect. Web Serial already hid the toggle, but server serial rides the same `ota` session as a real OTA / network session, so it inherited it.

Server serial and network OTA both run through the backend `logs` subscription and share the `ota` session kind; the port tells them apart (network uses the `OTA` sentinel, server serial carries a device path). Added an `isOtaNetwork` selector and gated the States toggle on it, so the toggle now shows only for the network source. The server serial source chip is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/539

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
