### PR TITLE
Share one primary dialog header so the close button stays flush

### DIFF
--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -29,6 +29,8 @@ import {
   firmwareJobsContext,
   localizeContext,
 } from "../context/index.js";
+import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
+import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../util/firmware-job-status.js";
@@ -125,7 +127,12 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     this._stopTicker();
   }
 
-  static styles = [espHomeStyles, firmwareJobsDialogStyles];
+  static styles = [
+    espHomeStyles,
+    primaryDialogHeaderStyles,
+    dialogCloseButtonStyles,
+    firmwareJobsDialogStyles,
+  ];
 
   /** Bucket the live jobs Map into sorted / active / terminal lists.
    *  Memoised on the upstream Map reference; the context provider

--- a/src/components/firmware-jobs-dialog/styles.ts
+++ b/src/components/firmware-jobs-dialog/styles.ts
@@ -5,29 +5,8 @@ export const firmwareJobsDialogStyles = css`
     --width: min(620px, 95vw);
   }
 
-  wa-dialog::part(header) {
-    background: var(--esphome-primary);
-    padding: 0 var(--wa-space-m);
-    height: 40px;
-    box-sizing: border-box;
-  }
-
-  wa-dialog::part(title) {
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-  }
-
-  wa-dialog::part(close-button__base) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-    min-width: unset;
-    min-height: unset;
-    color: var(--esphome-on-primary);
-    cursor: pointer;
-  }
+  /* Primary header bar + flush 40x40 close button come from the shared
+     primaryDialogHeaderStyles / dialogCloseButtonStyles fragments. */
 
   wa-dialog::part(footer) {
     display: none;

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -14,18 +14,7 @@ export const installMethodDialogStyles = css`
     --width: 460px;
   }
 
-  esphome-base-dialog::part(header) {
-    background: var(--esphome-primary);
-    padding: 0 var(--wa-space-m);
-    height: 40px;
-    box-sizing: border-box;
-  }
-
-  esphome-base-dialog::part(title) {
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-  }
+  /* Primary header bar comes from primaryDialogHeaderStyles (shared). */
 
   /* Close-button styling is bundled in
      <esphome-base-dialog> via dialogCloseButtonStyles,

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -18,6 +18,7 @@ import { DeviceState } from "../api/types/devices.js";
 import type { SerialPort } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../util/environment.js";
@@ -134,7 +135,12 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     }
   }
 
-  static styles = [espHomeStyles, inputStyles, installMethodDialogStyles];
+  static styles = [
+    espHomeStyles,
+    primaryDialogHeaderStyles,
+    inputStyles,
+    installMethodDialogStyles,
+  ];
 
   protected render() {
     const methodTitleKey =

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -29,19 +29,9 @@ export const logsDialogStyles = css`
     --width: min(1300px, 94vw);
   }
 
-  /* Match the device-editor's title bar so the dialog reads as part of the
-     dashboard chrome; the body stays terminal-themed. */
-  esphome-base-dialog::part(header) {
-    background: var(--esphome-primary);
-    /* Right padding 0 so the close button sits flush with the corner. */
-    padding: 0 0 0 var(--wa-space-m);
-    height: 40px;
-    box-sizing: border-box;
-  }
+  /* The primary header bar + title colour/size come from the shared
+     primaryDialogHeaderStyles; the log title is the only monospace one. */
   esphome-base-dialog::part(title) {
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
     font-family: var(--logs-mono-font);
   }
   /* Truncate the name before the chip so a long /dev/cu… path can't overflow

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -17,6 +17,7 @@ import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { downloadAnsiText } from "../util/download-text.js";
@@ -119,6 +120,7 @@ export class ESPHomeLogsDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    primaryDialogHeaderStyles,
     termTokens,
     termButtonStyles,
     logsDialogStyles,

--- a/src/components/settings-dialog.ts
+++ b/src/components/settings-dialog.ts
@@ -18,6 +18,7 @@ import { customElement, state } from "lit/decorators.js";
 import type { OffloaderAlertSnapshotEntry } from "../api/types/remote-build-events.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { buildOffloadAlertsContext, localizeContext } from "../context/index.js";
+import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -75,6 +76,7 @@ export class ESPHomeSettingsDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    primaryDialogHeaderStyles,
     settingsSharedStyles,
     settingsRowStyles,
     // Full-screen as soon as the nav stacks (700px, not the 600px phone

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -14,20 +14,7 @@ export const settingsSharedStyles = css`
     --width: min(800px, 95vw);
   }
 
-  esphome-base-dialog::part(header) {
-    background: var(--esphome-primary);
-    /* Right padding is 0 so the 40x40 close button sits flush
-       with the dialog's corner. */
-    padding: 0 0 0 var(--wa-space-m);
-    height: 40px;
-    box-sizing: border-box;
-  }
-
-  esphome-base-dialog::part(title) {
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-  }
+  /* Primary header bar + title come from primaryDialogHeaderStyles (shared). */
 
   esphome-base-dialog::part(footer) {
     display: none;

--- a/src/styles/dialog-header.ts
+++ b/src/styles/dialog-header.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared primary-colour dialog header.
+ *
+ * The settings, logs, install-method, and firmware-jobs dialogs all dress their
+ * title bar the same way: a full-bleed `--esphome-primary` band, 40px tall, with
+ * the title in `--esphome-on-primary`. The block was copy-pasted per dialog and
+ * two copies set the right padding wrong (`0 var(--wa-space-m)` instead of
+ * `0 0 0 var(--wa-space-m)`), which pushed the close button in from the corner.
+ * Defining it once here keeps the bar identical and keeps the 40x40 close button
+ * (from `dialogCloseButtonStyles`) flush in the corner. #39
+ *
+ * Dual selectors so the one fragment covers both the raw `<wa-dialog>` dialogs
+ * and the ones migrated onto `<esphome-base-dialog>` (parts re-exported by name).
+ * Dialogs with their own title type (logs is monospace) layer that on top.
+ */
+import { css } from "lit";
+
+export const primaryDialogHeaderStyles = css`
+  wa-dialog::part(header),
+  esphome-base-dialog::part(header) {
+    background: var(--esphome-primary);
+    /* Right padding 0 so the 40x40 close button sits flush with the corner. */
+    padding: 0 0 0 var(--wa-space-m);
+    height: 40px;
+    box-sizing: border-box;
+  }
+
+  wa-dialog::part(title),
+  esphome-base-dialog::part(title) {
+    color: var(--esphome-on-primary);
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-bold);
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

Part of #39. The close button looked misaligned on the firmware tasks and install method dialogs; it sat inset from the corner and, on firmware tasks, rendered a touch larger than elsewhere. Headless Chrome showed the cause: four dialogs (settings, logs, install method, firmware tasks) each hand rolled the same primary 40px header, and two of them set the right padding to 0 var(--wa-space-m) instead of 0 0 0 var(--wa-space-m), which pushed the close button in; firmware tasks also lacked the shared 40x40 close button styling so its X measured 43px.

This pulls the primary header into one shared primaryDialogHeaderStyles fragment (full bleed primary bar, 40px tall, flush right edge, on-primary title) with dual selectors so it covers both the raw wa-dialog dialogs and the ones on esphome-base-dialog, and adds the existing dialogCloseButtonStyles to firmware tasks. Verified with headless Chrome that the close button is now a flush 40x40 in the corner on firmware tasks and settings is unchanged; logs keeps its monospace title on top of the shared bar. No behaviour change, styles only.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (dialog header consistency)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
