### PR TITLE
Migrate the feedback dialog onto esphome-base-dialog

### DIFF
--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -8,14 +8,14 @@ import {
   mdiOpenInNew,
 } from "@mdi/js";
 import { LitElement, css, html } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext, serverVersionContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "bug-outline": mdiBugOutline,
@@ -72,8 +72,8 @@ export class ESPHomeFeedbackDialog extends LitElement {
   @state()
   private _serverVersion = "";
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   private _hrefFor(link: (typeof LINKS)[number]): string {
     if (link.labelKey !== NEW_ISSUE_LABEL_KEY || !this._serverVersion) {
@@ -87,31 +87,26 @@ export class ESPHomeFeedbackDialog extends LitElement {
   static styles = [
     espHomeStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 460px;
       }
 
-      wa-dialog::part(header) {
+      /* Close-button styling comes from esphome-base-dialog (dialogCloseButtonStyles). */
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l) var(--wa-space-l);
       }
 
-      wa-dialog::part(footer) {
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
@@ -194,16 +189,31 @@ export class ESPHomeFeedbackDialog extends LitElement {
   ];
 
   open() {
-    this._dialog.open = true;
+    this._open = true;
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  // Flip the reactive flag on the initiating close (X / Esc / outside-click)
+  // before the hide animation, then let after-hide settle it.
+  private _onRequestClose = (): void => {
+    this._open = false;
+  };
+
+  private _onAfterHide = (): void => {
+    this._open = false;
+  };
 
   protected render() {
     return html`
-      <wa-dialog label=${this._localize("feedback.title")} light-dismiss>
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("feedback.title")}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
+      >
         <p class="description">${this._localize("feedback.description")}</p>
         <div class="links">
           <a
@@ -233,7 +243,7 @@ export class ESPHomeFeedbackDialog extends LitElement {
             `
           )}
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Part of #39, the dialog consistency cleanup, continuing the move onto the shared esphome-base-dialog wrapper. The feedback dialog rendered a raw wa-dialog directly, so it missed the wrapper's busy gate, close-button styling, and event-scope handling.

This moves it onto esphome-base-dialog; the imperative _dialog.open toggle becomes a reactive _open flag wired to the wrapper's request-close and after-hide events, and the public open() and close() API is unchanged. The dialog's part styling now points at esphome-base-dialog, and the redundant close-button rule is dropped since the wrapper supplies it. Verified with headless Chrome that the dialog is pixel identical to main; same 460px width, header and body padding, description, and all six links, with the one intended change being the close button settling to the standard 40x40 hit target the other dialogs already use, at the same right edge.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (dialog consistency)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
