### PR TITLE
Migrate the firmware jobs dialog onto esphome-base-dialog

### DIFF
--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -1,4 +1,3 @@
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import { consume } from "@lit/context";
@@ -29,13 +28,13 @@ import {
   firmwareJobsContext,
   localizeContext,
 } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../util/firmware-job-status.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import "./base-dialog.js";
 import "./command-dialog.js";
 import type { ESPHomeCommandDialog } from "./command-dialog.js";
 import "./confirm-dialog.js";
@@ -78,7 +77,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   @state()
   _devices: ConfiguredDevice[] = [];
 
-  @query("wa-dialog") private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
   @query("esphome-command-dialog") private _commandDialog!: ESPHomeCommandDialog;
   // Logs dialog for the post-install hand-off when reattaching from this
   // surface. Without one, request-show-logs-after-install would no-op. (#139)
@@ -96,18 +95,18 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
   open() {
     this._now = Date.now();
-    this._dialog.open = true;
+    this._open = true;
     this._startTicker();
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
     this._stopTicker();
   }
 
   // Open the Reset Build Environment confirm flow without needing this
-  // dialog open. The confirm + command dialogs are siblings of the wa-dialog
-  // in this host's shadow DOM, so they work even when the wa-dialog is closed
+  // dialog open. The confirm + command dialogs are siblings of the jobs
+  // dialog in this host's shadow DOM, so they work even when it's closed
   // — surfaces like the header kebab can entry-point the same flow.
   openResetBuildEnv() {
     this._confirmDialog.open();
@@ -127,12 +126,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     this._stopTicker();
   }
 
-  static styles = [
-    espHomeStyles,
-    primaryDialogHeaderStyles,
-    dialogCloseButtonStyles,
-    firmwareJobsDialogStyles,
-  ];
+  static styles = [espHomeStyles, primaryDialogHeaderStyles, firmwareJobsDialogStyles];
 
   /** Bucket the live jobs Map into sorted / active / terminal lists.
    *  Memoised on the upstream Map reference; the context provider
@@ -153,10 +147,11 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     const hasJobs = sorted.length > 0;
 
     return html`
-      <wa-dialog
-        light-dismiss
-        label=${this._localize("firmware_jobs.title")}
-        @wa-after-hide=${this._stopTicker}
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("firmware_jobs.title")}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
       >
         <div class="toolbar">
           <button
@@ -182,7 +177,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
             : nothing}
         </div>
         ${hasJobs ? renderGroups(this, active, terminal) : renderEmpty(this._localize)}
-      </wa-dialog>
+      </esphome-base-dialog>
       <esphome-command-dialog
         @open-reset-build-env=${this._onLocalResetEvent}
         @request-show-logs-after-install=${this._onPostInstallShowLogs}
@@ -209,6 +204,17 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
       clearInterval(this._tickHandle);
       this._tickHandle = null;
     }
+  };
+
+  // Flip _open on the initiating close so a ticker-driven re-render can't
+  // re-assert ?open mid-hide; the ticker is torn down once hidden.
+  private _onRequestClose = (): void => {
+    this._open = false;
+  };
+
+  private _onAfterHide = (): void => {
+    this._open = false;
+    this._stopTicker();
   };
 
   _jobDisplayName(job: FirmwareJob): string {

--- a/src/components/firmware-jobs-dialog/styles.ts
+++ b/src/components/firmware-jobs-dialog/styles.ts
@@ -1,18 +1,18 @@
 import { css } from "lit";
 
 export const firmwareJobsDialogStyles = css`
-  wa-dialog {
+  esphome-base-dialog {
     --width: min(620px, 95vw);
   }
 
   /* Primary header bar + flush 40x40 close button come from the shared
-     primaryDialogHeaderStyles / dialogCloseButtonStyles fragments. */
+     primaryDialogHeaderStyles fragment + esphome-base-dialog. */
 
-  wa-dialog::part(footer) {
+  esphome-base-dialog::part(footer) {
     display: none;
   }
 
-  wa-dialog::part(body) {
+  esphome-base-dialog::part(body) {
     padding: 0;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Part of #39, the dialog consistency cleanup. The firmware jobs dialog rendered a raw wa-dialog directly; this moves it onto the shared esphome-base-dialog wrapper, finishing what #543 started for this dialog (its flush close button already came from the shared primary header fragment).

The imperative _dialog.open toggle becomes a reactive _open flag wired to the wrapper's request-close and after-hide events; after-hide also tears down the relative-time ticker, exactly as the old wa-after-hide did. The public open(), close(), and openResetBuildEnv() API is unchanged, and the sibling command, logs, and confirm dialogs are untouched. The dialog's part styling now points at esphome-base-dialog, and the local dialogCloseButtonStyles is dropped since the wrapper supplies it. Verified with headless Chrome that the dialog is pixel identical to main; same 620px width, flush 40x40 close button, header and body padding, toolbar, and job rows.

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/device-builder-frontend/issues/39 (dialog consistency)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
