### PR TITLE
Migrate the onboarding Wi-Fi dialog onto esphome-base-dialog

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -1,7 +1,7 @@
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
-import { LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { centeredMobileDialog } from "../styles/dialog-mobile.js";
@@ -81,8 +81,8 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   default slot is all they need.
  * - ``footer`` slot: forwarded to ``wa-dialog``'s footer for the
  *   dialogs that do use a pinned footer row (e.g. the onboarding
- *   wizard). Empty by default; dialogs that hide the footer via
- *   ``::part(footer) { display: none }`` are unaffected.
+ *   wizard). Only forwarded when a consumer fills it, so footer-less
+ *   dialogs render unchanged (see ``willUpdate``).
  * - ``header-suffix`` slot: inline content after the title
  *   (e.g. a status chip). Empty by default, so other dialogs
  *   are unchanged. The row and title are exposed as the
@@ -128,6 +128,20 @@ export class ESPHomeBaseDialog extends LitElement {
    *  (wa-request-close veto) but not the visual dim on the
    *  close button. */
   @property({ type: Boolean, reflect: true }) busy = false;
+
+  /** Whether a consumer has slotted footer content. Gates the
+   *  forwarding ``<slot name="footer">`` — see ``willUpdate``. */
+  @state() private _hasFooter = false;
+
+  // wa-dialog turns its footer chrome (border-top + padding) on by
+  // testing for a direct ``[slot="footer"]`` child element, not for
+  // flattened slot content. An always-present forwarding slot is itself
+  // such a child, so it would draw an empty footer bar on every
+  // footer-less consumer. Mirror that same presence test against our
+  // own light DOM and only forward when a consumer fills the footer.
+  protected willUpdate(): void {
+    this._hasFooter = this.querySelector(':scope > [slot="footer"]') !== null;
+  }
 
   private _onWaRequestClose = (e: Event): void => {
     // ``wa-dialog``'s events bubble + compose, so the same
@@ -181,7 +195,7 @@ export class ESPHomeBaseDialog extends LitElement {
           <span part="title-text">${this.label}</span><slot name="header-suffix"></slot>
         </header>
         <slot></slot>
-        <slot name="footer" slot="footer"></slot>
+        ${this._hasFooter ? html`<slot name="footer" slot="footer"></slot>` : nothing}
       </wa-dialog>
     `;
   }

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -75,13 +75,14 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *
  * **Slots**:
  *
- * - Default slot: dialog body. Consumers put their form
- *   fields, error banner, and actions row inline here.
- *   The wrapper doesn't impose a ``slot="footer"`` because
- *   most existing dialogs render the actions row as a
- *   plain ``<div class="actions">`` at the end of the
- *   body, and forcing them to migrate to a slotted footer
- *   would balloon the diff for no behaviour change.
+ * - Default slot: dialog body. Most dialogs render their form
+ *   fields, error banner, and actions row inline here (a plain
+ *   ``<div class="actions">`` at the end of the body), so the
+ *   default slot is all they need.
+ * - ``footer`` slot: forwarded to ``wa-dialog``'s footer for the
+ *   dialogs that do use a pinned footer row (e.g. the onboarding
+ *   wizard). Empty by default; dialogs that hide the footer via
+ *   ``::part(footer) { display: none }`` are unaffected.
  * - ``header-suffix`` slot: inline content after the title
  *   (e.g. a status chip). Empty by default, so other dialogs
  *   are unchanged. The row and title are exposed as the
@@ -180,6 +181,7 @@ export class ESPHomeBaseDialog extends LitElement {
           <span part="title-text">${this.label}</span><slot name="header-suffix"></slot>
         </header>
         <slot></slot>
+        <slot name="footer" slot="footer"></slot>
       </wa-dialog>
     `;
   }

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -14,8 +14,8 @@ import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { type PasswordInputValueChange } from "./device/password-input-event.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 import "./device/password-input.js";
 
 registerMdiIcons({ wifi: mdiWifi });
@@ -62,8 +62,8 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   @state()
   private _error: string | null = null;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   @query("#onboarding-ssid")
   private _ssidInput?: HTMLInputElement;
@@ -92,14 +92,14 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._saving = false;
     this._error = null;
     this._exitedExplicitly = false;
-    this._dialog.open = true;
+    this._open = true;
     this._enter.set(true);
     // autofocus is unreliable for a shadow-DOM input shown after first paint.
     void this.updateComplete.then(() => this._ssidInput?.focus());
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
 
   static styles = [
@@ -107,7 +107,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     inputStyles,
     dialogActionButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 480px;
       }
 
@@ -190,10 +190,12 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
-        label=${this._localize("onboarding.wifi.title")}
-        @wa-request-close=${this._onRequestClose}
-        @wa-after-hide=${this._onAfterHide}
+      <esphome-base-dialog
+        ?open=${this._open}
+        ?busy=${this._saving}
+        .label=${this._localize("onboarding.wifi.title")}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
       >
         <div class="body">
           <p class="intro">
@@ -272,7 +274,7 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
               : this._localize("onboarding.wifi.save")}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -363,18 +365,16 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   }
 
   /**
-   * Block close requests while a save / decline is in flight. The
-   * X / Escape / backdrop-click would otherwise hide the dialog
-   * before the network round-trip resolves; a failed save would
-   * then route through ``_onAfterHide`` → session-dismiss with
-   * the user never seeing the inline error. Same pattern as
-   * ``adopt-dialog`` (``_onRequestClose`` + ``e.preventDefault()``
-   * gate on its ``_busy`` flag).
+   * Flip the reactive flag on the initiating close so a re-render
+   * can't re-assert ?open mid-hide; teardown stays in after-hide.
+   * The save / decline veto is handled by esphome-base-dialog's busy
+   * gate (``?busy=${this._saving}``): while saving it absorbs the
+   * X / Escape / backdrop-click and never emits request-close, so
+   * this handler only runs once the round-trip has resolved — the
+   * dialog can't hide before the user sees an inline save error.
    */
-  private _onRequestClose = (e: Event) => {
-    if (this._saving) {
-      e.preventDefault();
-    }
+  private _onRequestClose = (): void => {
+    this._open = false;
   };
 
   /**

--- a/test/components/onboarding-wifi-dialog.test.ts
+++ b/test/components/onboarding-wifi-dialog.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { describe, expect, test, vi } from "vitest";
 
+// The save-success path fires a toast; stub it so these unit tests
+// don't need a rendered toaster container.
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
 import { ESPHomeOnboardingWifiDialog } from "../../src/components/onboarding-wifi-dialog.js";
 
 /**
@@ -17,9 +23,17 @@ import { ESPHomeOnboardingWifiDialog } from "../../src/components/onboarding-wif
 interface DialogPrivateView extends EventTarget {
   _ssid: string;
   _password: string;
-  _api: { setOnboardingWifi: (ssid: string, password: string) => Promise<unknown> };
+  _open: boolean;
+  _saving: boolean;
+  _error: string | null;
+  _exitedExplicitly: boolean;
+  _api: {
+    setOnboardingWifi: (ssid: string, password: string) => Promise<unknown>;
+    markOnboardingAcknowledged?: () => Promise<unknown>;
+  };
   readonly _passwordTooShort: boolean;
   _save(): Promise<void>;
+  _onRequestClose(): void;
 }
 
 function makeDialog(): DialogPrivateView {
@@ -83,5 +97,59 @@ describe("onboarding-wifi-dialog password-length gate", () => {
     await dialog._save();
 
     expect(setOnboardingWifi).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Regression coverage for the esphome-base-dialog migration (#546).
+ *
+ * The migration moved the save-in-flight close veto onto base-dialog's
+ * ``?busy`` gate and replaced the imperative ``dialog.open`` with a
+ * reactive ``_open`` flag, so the close / error paths are the part most
+ * likely to silently regress. These pin the contract the host still
+ * owns: a failed save keeps the dialog open with an inline error, a
+ * successful save closes it and suppresses the session-dismiss, and the
+ * reactive close path flips ``_open``.
+ */
+describe("onboarding-wifi-dialog close / error gating", () => {
+  test("a failed save shows the inline error and leaves the dialog open", async () => {
+    const dialog = makeDialog();
+    const setOnboardingWifi = vi.fn().mockRejectedValue(new Error("write failed"));
+    dialog._api = { setOnboardingWifi };
+    dialog._open = true;
+    dialog._ssid = "MyNetwork";
+    dialog._password = "12345678";
+
+    await dialog._save();
+
+    expect(dialog._error).toBeTruthy(); // inline error surfaced
+    expect(dialog._open).toBe(true); // dialog stays open to retry
+    expect(dialog._saving).toBe(false); // re-enabled for another attempt
+  });
+
+  test("a successful save closes the dialog and marks it exited explicitly", async () => {
+    const dialog = makeDialog();
+    const setOnboardingWifi = vi.fn().mockResolvedValue(undefined);
+    const markOnboardingAcknowledged = vi.fn().mockResolvedValue(undefined);
+    dialog._api = { setOnboardingWifi, markOnboardingAcknowledged };
+    dialog._open = true;
+    dialog._ssid = "MyNetwork";
+    dialog._password = "12345678";
+
+    const acked = vi.fn();
+    dialog.addEventListener("onboarding-acknowledged", acked);
+
+    await dialog._save();
+
+    expect(dialog._open).toBe(false); // closed via the reactive flag
+    expect(dialog._exitedExplicitly).toBe(true); // suppresses the session-dismiss
+    expect(acked).toHaveBeenCalledTimes(1);
+  });
+
+  test("_onRequestClose flips the reactive open flag", () => {
+    const dialog = makeDialog();
+    dialog._open = true;
+    dialog._onRequestClose();
+    expect(dialog._open).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Migrates the onboarding Wi-Fi wizard, the last of the four raw `wa-dialog` surfaces, onto the shared `esphome-base-dialog` wrapper so its open/close wiring, busy gate, and close-button styling all come from one place.

This wizard is the only one that pins its actions row with `slot="footer"`, so `esphome-base-dialog` now forwards a footer slot through to the inner `wa-dialog`; dialogs that hide the footer are unaffected. Imperative `dialog.open` becomes a reactive `_open` flag with an `?open` binding, and the save-in-flight veto moves off a bespoke `request-close` `preventDefault` onto base-dialog's `?busy` gate.

Verified pixel-identical before/after via headless Chrome (CDP); content stays at the same gutter and the footer buttons render unchanged. Typing into the SSID field keeps focus and every keystroke, the same input node is reused across re-renders.

**Related issue or feature (if applicable):**

- part of #39

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
