### PR TITLE
Collapse logs toolbar buttons to icons on mobile

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -299,7 +299,9 @@ export class ESPHomeLogsDialog extends LitElement {
                 title=${this._localize("dashboard.logs_back_to_install_tooltip")}
               >
                 <wa-icon library="mdi" name="arrow-left"></wa-icon>
-                ${this._localize("dashboard.logs_back_to_install")}
+                <span class="term-btn__label"
+                  >${this._localize("dashboard.logs_back_to_install")}</span
+                >
               </button>`
             : ""}
           <div class="toolbar-slot" slot="toolbar-right">

--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -102,6 +102,26 @@ export const termButtonStyles = css`
   .toolbar-slot {
     display: contents;
   }
+
+  /* On narrow viewports collapse labelled icon buttons to icon-only so the
+     toolbar stays on one row instead of wrapping (#542 follow-up). The label
+     is visually hidden, not removed, so it still names the button for screen
+     readers; the title attribute keeps the tooltip. Icon-less buttons (e.g.
+     the command dialog's text-only Close) have no wa-icon, so they keep their
+     label and are never left empty. */
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
+    .term-btn:has(wa-icon) .term-btn__label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  }
 `;
 
 /**

--- a/src/components/process-terminal/toolbar-button.ts
+++ b/src/components/process-terminal/toolbar-button.ts
@@ -39,7 +39,7 @@ export function renderTermButton(opts: TermButtonOpts): TemplateResult {
     @click=${opts.onClick}
   >
     ${opts.icon ? html`<wa-icon library="mdi" name=${opts.icon}></wa-icon>` : nothing}
-    ${opts.label ?? nothing}
+    ${opts.label ? html`<span class="term-btn__label">${opts.label}</span>` : nothing}
   </button>`;
 }
 

--- a/test/components/process-terminal/toolbar-button.test.ts
+++ b/test/components/process-terminal/toolbar-button.test.ts
@@ -32,6 +32,17 @@ describe("renderTermButton", () => {
     expect(onClick).toHaveBeenCalledOnce();
   });
 
+  it("wraps the label in a .term-btn__label span so mobile can collapse it to icon-only", () => {
+    const btn = mount(
+      renderTermButton({ icon: "restart", label: "Reset device", onClick: () => {} })
+    );
+    const label = btn.querySelector(".term-btn__label");
+    expect(label?.textContent).toBe("Reset device");
+    // Icon stays a sibling of the (collapsible) label, not inside it.
+    expect(label?.querySelector("wa-icon")).toBeNull();
+    expect(btn.querySelector("wa-icon")?.getAttribute("name")).toBe("restart");
+  });
+
   it("uses title as the accessible name for an icon-only button", () => {
     const btn = mount(
       renderTermButton({ icon: "download", title: "Download", onClick: () => {} })


### PR DESCRIPTION
# What does this implement/fix?

On a narrow viewport the logs dialog toolbar wrapped onto a second row once enough labelled buttons were present (Reset device, Clear, Stop, plus the icon-only download); the Stop button dropped below the others.

This collapses labelled icon buttons to icon-only on mobile so the toolbar stays on one row. The label is wrapped in a span and visually hidden under the mobile breakpoint, not removed, so it still names the button for screen readers; the title attribute keeps the tooltip. Buttons with no icon (e.g. the command dialog's text-only Close) keep their label, so nothing is left empty. The rule lives in the shared term-button styles, so the command and firmware install toolbars get the same treatment.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
