### PR TITLE
Keep the dialog close button reachable when the title is long

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -248,6 +248,31 @@ export class ESPHomeBaseDialog extends LitElement {
         cursor: not-allowed;
         pointer-events: none;
       }
+
+      /* Keep the close (X) button reachable no matter how long the
+         title is. wa-dialog lays its header out as
+         [.title (flex: 1 1 auto)][.header-actions (the close button,
+         flex-shrink: 0)] but gives .title no min-width, so its default
+         min-width:auto (= min-content) lets a long unbroken title grow
+         the header past the dialog's right edge and shove the close
+         button off-screen (worst on a narrow / mobile viewport). Letting
+         the title column shrink to 0 and ellipsize fixes it for every
+         dialog built on this wrapper. The header-suffix (e.g. a status
+         chip) stays beside the truncated title via the label-row flex. */
+      wa-dialog::part(title) {
+        min-width: 0;
+      }
+      header[part="label-row"] {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+      }
+      [part="title-text"] {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     `,
   ];
 }

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -30,22 +30,11 @@ export const logsDialogStyles = css`
   }
 
   /* The primary header bar + title colour/size come from the shared
-     primaryDialogHeaderStyles; the log title is the only monospace one. */
+     primaryDialogHeaderStyles; the log title is the only monospace one.
+     The title ellipsis + close-button-clearance now live in base-dialog,
+     so a long /dev/cu… path can't overflow the header here either. */
   esphome-base-dialog::part(title) {
     font-family: var(--logs-mono-font);
-  }
-  /* Truncate the name before the chip so a long /dev/cu… path can't overflow
-     the narrow header. */
-  esphome-base-dialog::part(label-row) {
-    display: flex;
-    align-items: center;
-    min-width: 0;
-  }
-  esphome-base-dialog::part(title-text) {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   esphome-base-dialog::part(body) {
     padding: 0;


### PR DESCRIPTION
# What does this implement/fix?

On mobile, the Web Serial logs dialog overflowed sideways and the close X scrolled off-screen, so it could not be tapped. wa-dialog lays its header out as [title][close button] but gives the title no min-width, so a long title (the logs dialog embeds the device name) refused to shrink and pushed the header, and the X, past the dialog edge.

The fix lives in the shared esphome-base-dialog wrapper: let the title column shrink and ellipsize so the close button stays reachable no matter how long the title is. Every dialog built on the wrapper gets it; logs-dialog drops its now-redundant local copy of the truncation rules. A few dialogs still use wa-dialog directly and are tracked separately for migration.

**Related issue or feature (if applicable):**

- part of #39

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
