### PR TITLE
Widen the full-screen mobile terminal toolbar side padding

### DIFF
--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -196,6 +196,12 @@ export const processTerminalStyles = css`
     flex-wrap: wrap;
     gap: var(--wa-space-xs);
     padding: 6px var(--wa-space-m);
+    /* On the full-screen mobile sheet the side padding widens (see
+       fillTerminalOnMobile) so the end buttons (States / Stop) clear the
+       phone's curved corners; everywhere else it falls back to the flat
+       padding above, so the windowed / card terminal is byte-identical. */
+    padding-left: var(--process-terminal-toolbar-pad-x, var(--wa-space-m));
+    padding-right: var(--process-terminal-toolbar-pad-x, var(--wa-space-m));
     background: var(--term-bg-alt);
     border-top: 1px solid var(--term-border);
   }
@@ -320,5 +326,12 @@ export const fillTerminal = css`
 export const fillTerminalOnMobile = css`
   @media (max-width: ${MOBILE_BREAKPOINT}px) {
     ${fillTerminal}
+    /* The dialog is edge-to-edge here, so the toolbar's end buttons sit in the
+       phone's curved bottom corners. Widen the side padding to pull them in;
+       the var inherits into the terminal's shadow DOM where the toolbar reads
+       it. Uniform across devices, no viewport-fit / safe-area dependency. */
+    esphome-process-terminal {
+      --process-terminal-toolbar-pad-x: 20px;
+    }
   }
 `;


### PR DESCRIPTION
# What does this implement/fix?

On a phone the logs / process-terminal dialog goes full-screen edge-to-edge, so the toolbar's end buttons (States on the left, Stop on the right) land in the curved bottom corners and are hard to tap. This widens the toolbar's left and right padding to a flat 20px, but only on the full-screen mobile sheet, so those buttons pull in clear of the curve.

It's a single var set in the mobile fill context (`fillTerminalOnMobile`); the var inherits into the terminal's shadow DOM where the toolbar reads it, and falls back to the normal padding everywhere else, so the windowed and desktop terminals are unchanged. Uniform across devices, no `viewport-fit=cover` and no `env(safe-area-inset-*)`, so nothing else in the app shell is affected.

**Related issue or feature (if applicable):**

- part of #39

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
