### PR TITLE
Follow the install compile then upload chain

### DIFF
--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -61,6 +61,14 @@ export interface FirmwareJob {
    *  dataclass defaults to ``""`` for every other job type so the
    *  field is always present on the wire — required here matches. */
   new_name: string;
+  /** Job id of the prerequisite this job is chained behind, or ``""``
+   *  when it has none. An install's UPLOAD carries its COMPILE's
+   *  ``job_id`` here: it stays QUEUED off the upload lane until the
+   *  compile succeeds, then runs. The backend defaults the field to
+   *  ``""`` for every unchained job so it's always present on the wire.
+   *  The install dialog reads it to follow the compile → upload chain
+   *  to completion instead of reporting success when the compile ends. */
+  depends_on: string;
   /** 0–100 progress, monotonically non-decreasing while the job runs.
    *  `null` until the underlying tooling (PlatformIO/esptool) emits a
    *  percentage we can latch onto. */

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -61,13 +61,10 @@ export interface FirmwareJob {
    *  dataclass defaults to ``""`` for every other job type so the
    *  field is always present on the wire — required here matches. */
   new_name: string;
-  /** Job id of the prerequisite this job is chained behind, or ``""``
-   *  when it has none. An install's UPLOAD carries its COMPILE's
-   *  ``job_id`` here: it stays QUEUED off the upload lane until the
-   *  compile succeeds, then runs. The backend defaults the field to
-   *  ``""`` for every unchained job so it's always present on the wire.
-   *  The install dialog reads it to follow the compile → upload chain
-   *  to completion instead of reporting success when the compile ends. */
+  /** Job id of the prerequisite this job is chained behind, or ``""`` when
+   *  it has none. An install's UPLOAD carries its COMPILE's ``job_id``: it
+   *  stays QUEUED off the upload lane until the compile succeeds. Always
+   *  present on the wire (the backend defaults it to ``""``). */
   depends_on: string;
   /** 0–100 progress, monotonically non-decreasing while the job runs.
    *  `null` until the underlying tooling (PlatformIO/esptool) emits a

--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -61,10 +61,8 @@ export interface FirmwareJob {
    *  dataclass defaults to ``""`` for every other job type so the
    *  field is always present on the wire — required here matches. */
   new_name: string;
-  /** Job id of the prerequisite this job is chained behind, or ``""`` when
-   *  it has none. An install's UPLOAD carries its COMPILE's ``job_id``: it
-   *  stays QUEUED off the upload lane until the compile succeeds. Always
-   *  present on the wire (the backend defaults it to ``""``). */
+  /** Prerequisite job id, or ``""``. An install's UPLOAD carries its
+   *  COMPILE's ``job_id`` (held until the compile succeeds). */
   depends_on: string;
   /** 0–100 progress, monotonically non-decreasing while the job runs.
    *  `null` until the underlying tooling (PlatformIO/esptool) emits a

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -2,9 +2,8 @@ import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-j
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import type { ESPHomeApp } from "../app-shell.js";
 
-// Mirrors the backend's _PRIMARY_JOB_TYPES retention pool — deduplicated to
-// one terminal entry per (device, job type), so an install's COMPILE and its
-// dependent UPLOAD both survive rather than the upload evicting the compile.
+// Mirrors the backend's retention pool — deduped to one terminal entry per
+// (device, job type) so an install's compile and upload both survive.
 const PRIMARY_JOB_TYPES: ReadonlySet<JobType> = new Set([
   JobType.COMPILE,
   JobType.UPLOAD,
@@ -90,10 +89,9 @@ function upsertJob(host: ESPHomeApp, job: FirmwareJob): void {
   host._activeJobs = active;
 }
 
-// Terminal: keep in _firmwareJobs history; drop older terminal of the same
-// type for the same device (a re-compile replaces the prior compile, not its
-// upload); clear per-device active slot. Cancellations with a live successor
-// are a backend supersede — drop silently.
+// Terminal: keep in history but drop the older terminal of the same type for
+// this device (a re-compile replaces the prior compile, not its upload); clear
+// the active slot. A cancellation with a live successor is a supersede — drop it.
 function terminateJob(host: ESPHomeApp, job: FirmwareJob): void {
   if (job.status === JobStatus.CANCELLED && job.configuration) {
     const supersededByActive = [...host._firmwareJobs.values()].some(

--- a/src/components/app-shell/jobs.ts
+++ b/src/components/app-shell/jobs.ts
@@ -2,8 +2,9 @@ import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-j
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import type { ESPHomeApp } from "../app-shell.js";
 
-// Mirrors the backend's _PRIMARY_JOB_TYPES retention pool — job types
-// deduplicated to one terminal entry per device.
+// Mirrors the backend's _PRIMARY_JOB_TYPES retention pool — deduplicated to
+// one terminal entry per (device, job type), so an install's COMPILE and its
+// dependent UPLOAD both survive rather than the upload evicting the compile.
 const PRIMARY_JOB_TYPES: ReadonlySet<JobType> = new Set([
   JobType.COMPILE,
   JobType.UPLOAD,
@@ -89,9 +90,10 @@ function upsertJob(host: ESPHomeApp, job: FirmwareJob): void {
   host._activeJobs = active;
 }
 
-// Terminal: keep in _firmwareJobs history; drop older terminal for same device
-// (re-compile replaces rather than stacks); clear per-device active slot.
-// Cancellations with a live successor are a backend supersede — drop silently.
+// Terminal: keep in _firmwareJobs history; drop older terminal of the same
+// type for the same device (a re-compile replaces the prior compile, not its
+// upload); clear per-device active slot. Cancellations with a live successor
+// are a backend supersede — drop silently.
 function terminateJob(host: ESPHomeApp, job: FirmwareJob): void {
   if (job.status === JobStatus.CANCELLED && job.configuration) {
     const supersededByActive = [...host._firmwareJobs.values()].some(
@@ -113,7 +115,7 @@ function terminateJob(host: ESPHomeApp, job: FirmwareJob): void {
     for (const [id, existing] of next) {
       if (id === job.job_id) continue;
       if (
-        PRIMARY_JOB_TYPES.has(existing.job_type) &&
+        existing.job_type === job.job_type &&
         existing.configuration === job.configuration &&
         isTerminalJobStatus(existing.status)
       ) {

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -165,6 +165,10 @@ export class ESPHomeCommandDialog extends LitElement {
   // to "open in editor" (YAML help). Reset per open().
   @state() _failedDuringValidate = false;
 
+  // Flips true when an install COMPILE succeeded but its dependent UPLOAD is
+  // missing — the build itself was fine, so the clean/reset hint is suppressed.
+  @state() _installMissingUpload = false;
+
   // Locally-primed status / source so the queued overlay + remote-builder
   // sub-line paint on the first frame instead of waiting for the next jobs
   // context update.
@@ -258,6 +262,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this._resetPendingLines();
     this._statusMessage = "";
     this._userStopped = false;
+    this._installMissingUpload = false;
     // Fresh attach is a fresh session — reset toggle defaults so a prior
     // opt-out doesn't silently inherit.
     this._showSecrets = false;

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -39,6 +39,7 @@ import {
   detachStream,
   followJob,
   onForceLocalClick,
+  resetRunState,
   startCommand,
   stopCommand,
   toggleShowSecrets,
@@ -257,12 +258,7 @@ export class ESPHomeCommandDialog extends LitElement {
     this.name = displayName;
     this._commandType = JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
     this._port = job.port || "OTA";
-    this._state = "running";
-    this._lines = [];
-    this._resetPendingLines();
-    this._statusMessage = "";
-    this._userStopped = false;
-    this._installMissingUpload = false;
+    resetRunState(this);
     // Fresh attach is a fresh session — reset toggle defaults so a prior
     // opt-out doesn't silently inherit.
     this._showSecrets = false;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,5 +1,5 @@
 import { APIError } from "../../api/api-error.js";
-import { type FirmwareJob, JobStatus } from "../../api/types/firmware-jobs.js";
+import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
@@ -134,10 +134,14 @@ export async function startFirmwareJob(host: ESPHomeCommandDialog): Promise<void
     return;
   }
 
+  primeAndFollow(host, job);
+}
+
+// Prime status + build source from the API response so the queued overlay and
+// remote-builder sub-line paint on the first frame, then attach the follow_job
+// stream. Leaves _commandType to the caller (the install chain relies on it).
+function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
   host._jobId = job.job_id;
-  // Prime from the API response so the queued overlay shows immediately;
-  // the matching job_queued event lands in firmwareJobsContext shortly after
-  // and the getter prefers that live value going forward.
   host._jobStatus = job.status;
   host._primedSource = {
     source: job.source,
@@ -163,14 +167,13 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
 
-      // An install runs as a COMPILE then a dependent UPLOAD on a separate
-      // lane (backend #1131); a finished compile is only half the install.
-      // Hand off to the upload and let its terminal result decide success,
-      // so we don't report the device flashed the moment it compiled. The
-      // upload carries depends_on === this compile's job_id; followJob
-      // handles it whether it's still queued, running, or already terminal.
+      // An install is a COMPILE then a dependent UPLOAD (#1131); follow the
+      // upload (depends_on === this compile) so success reflects the flash,
+      // not just the compile.
       if (success && host._commandType === "install") {
-        const upload = [...host._jobs.values()].find((j) => j.depends_on === jobId);
+        const upload = [...host._jobs.values()].find(
+          (j) => j.job_type === JobType.UPLOAD && j.depends_on === jobId
+        );
         if (upload) {
           host._jobId = upload.job_id;
           host._jobStatus = upload.status;
@@ -271,7 +274,13 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
       }
     }
     const job = await host._api.firmwareInstall(configuration, port, true);
-    host.followJob(job, host.name);
+    // Re-attach via primeAndFollow keeping _commandType "install"; the public
+    // followJob would derive "compile" from the returned COMPILE job (#1131)
+    // and skip the install → upload chain. Clear the cancelled attempt first.
+    await detachStream(host);
+    host._lines = [];
+    host._resetPendingLines();
+    primeAndFollow(host, job);
   } catch (err) {
     host._state = "error";
     host._statusMessage = host._localize("command.force_local_failed");

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -162,6 +162,23 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       host._flushPendingLines();
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
+
+      // An install runs as a COMPILE then a dependent UPLOAD on a separate
+      // lane (backend #1131); a finished compile is only half the install.
+      // Hand off to the upload and let its terminal result decide success,
+      // so we don't report the device flashed the moment it compiled. The
+      // upload carries depends_on === this compile's job_id; followJob
+      // handles it whether it's still queued, running, or already terminal.
+      if (success && host._commandType === "install") {
+        const upload = [...host._jobs.values()].find((j) => j.depends_on === jobId);
+        if (upload) {
+          host._jobId = upload.job_id;
+          host._jobStatus = upload.status;
+          followJob(host, upload.job_id);
+          return;
+        }
+      }
+
       host._state = success ? "success" : "error";
       host._statusMessage = host._localize(
         success

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -167,10 +167,17 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
 
-      // An install is a COMPILE then a dependent UPLOAD (#1131); follow the
-      // upload (depends_on === this compile) so success reflects the flash,
-      // not just the compile.
-      if (success && host._commandType === "install") {
+      // An install is a COMPILE then a dependent UPLOAD (#1131); when the
+      // COMPILE succeeds, follow the upload (depends_on === this compile) so
+      // success reflects the flash, not just the compile. Gate on the finished
+      // job being the COMPILE so the upload's own completion (which re-enters
+      // this handler) falls straight through to success.
+      const finished = host._jobs.get(jobId);
+      if (
+        success &&
+        host._commandType === "install" &&
+        finished?.job_type === JobType.COMPILE
+      ) {
         const upload = [...host._jobs.values()].find(
           (j) => j.job_type === JobType.UPLOAD && j.depends_on === jobId
         );

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -179,14 +179,19 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           (j) => j.job_type === JobType.UPLOAD && j.depends_on === jobId
         );
         if (upload) {
-          host._jobId = upload.job_id;
-          host._jobStatus = upload.status;
-          followJob(host, upload.job_id);
+          // primeAndFollow re-primes the source snapshot from the upload (the
+          // local flash) so the remote-builder sub-line doesn't linger on the
+          // compile's receiver while the upload runs.
+          primeAndFollow(host, upload);
           return;
         }
-        // The backend creates the upload at install time, so a miss is a real
-        // gap — surface it rather than report a flash that didn't happen.
+        // Compile succeeded but there's no upload step — the device was never
+        // flashed, so don't report success (a real backend/transport gap).
         console.warn("install compile succeeded but no dependent upload for job", jobId);
+        host._state = "error";
+        host._statusMessage = host._localize("command.install_failed");
+        host._jobId = "";
+        return;
       }
 
       host._state = success ? "success" : "error";

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -36,9 +36,10 @@ export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {
   }
 }
 
-export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
-  await detachStream(host);
-  host._jobId = "";
+// Reset the per-run state a fresh attach starts from: the output buffer,
+// status banner, and the failure flags that gate the reset/validation hints.
+// Shared by every entry point that reuses the singleton dialog for a new run.
+export function resetRunState(host: ESPHomeCommandDialog): void {
   host._state = "running";
   host._lines = [];
   host._resetPendingLines();
@@ -46,6 +47,12 @@ export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
   host._userStopped = false;
   host._failedDuringValidate = false;
   host._installMissingUpload = false;
+}
+
+export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
+  await detachStream(host);
+  host._jobId = "";
+  resetRunState(host);
   // Clear primed snapshots so a Retry that picks a different source can't
   // leak the prior job's REMOTE label into renderBuildFailureSuggestion
   // before the new _jobs context update lands. open() already clears these
@@ -298,11 +305,7 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
     // attempt and reset the run state (the public followJob did this), then
     // re-attach via primeAndFollow.
     await detachStream(host);
-    host._lines = [];
-    host._resetPendingLines();
-    host._state = "running";
-    host._statusMessage = "";
-    host._installMissingUpload = false;
+    resetRunState(host);
     primeAndFollow(host, job);
   } catch (err) {
     host._state = "error";

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -176,6 +176,10 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
         host._commandType === "install" &&
         finished?.job_type === JobType.COMPILE
       ) {
+        // The held UPLOAD is created at install time (#1131); its job_queued is
+        // ordered ahead of this compile's job_completed on the shared WS, so it
+        // is normally already in _jobs. A miss is therefore a real backend gap,
+        // not a still-arriving event for a legitimately-running install.
         const upload = [...host._jobs.values()].find(
           (j) => j.job_type === JobType.UPLOAD && j.depends_on === jobId
         );
@@ -186,8 +190,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           primeAndFollow(host, upload);
           return;
         }
-        // Compile succeeded but there's no upload step — the device was never
-        // flashed, so don't report success (a real backend/transport gap).
+        // No upload step — the device was never flashed, so don't report success.
         console.warn("install compile succeeded but no dependent upload for job", jobId);
         host._state = "error";
         host._statusMessage = host._localize("command.install_failed");

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -137,9 +137,8 @@ export async function startFirmwareJob(host: ESPHomeCommandDialog): Promise<void
   primeAndFollow(host, job);
 }
 
-// Prime status + build source from the API response so the queued overlay and
-// remote-builder sub-line paint on the first frame, then attach the follow_job
-// stream. Leaves _commandType to the caller (the install chain relies on it).
+// Prime status + source so the overlay paints on the first frame, then follow.
+// Leaves _commandType to the caller (the install chain relies on it).
 function primeAndFollow(host: ESPHomeCommandDialog, job: FirmwareJob): void {
   host._jobId = job.job_id;
   host._jobStatus = job.status;
@@ -167,11 +166,9 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
 
-      // An install is a COMPILE then a dependent UPLOAD (#1131); when the
-      // COMPILE succeeds, follow the upload (depends_on === this compile) so
-      // success reflects the flash, not just the compile. Gate on the finished
-      // job being the COMPILE so the upload's own completion (which re-enters
-      // this handler) falls straight through to success.
+      // On a successful install COMPILE, follow its dependent UPLOAD so success
+      // reflects the flash (#1131). Gate on the finished job being the COMPILE
+      // so the upload's own completion falls straight through to success.
       const finished = host._jobs.get(jobId);
       if (
         success &&
@@ -187,9 +184,8 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           followJob(host, upload.job_id);
           return;
         }
-        // The backend creates the held upload at install time, so a miss is a
-        // transport/backend gap, not version skew; surface it rather than
-        // silently reporting the device flashed after only compiling.
+        // The backend creates the upload at install time, so a miss is a real
+        // gap — surface it rather than report a flash that didn't happen.
         console.warn("install compile succeeded but no dependent upload for job", jobId);
       }
 
@@ -285,9 +281,9 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
       }
     }
     const job = await host._api.firmwareInstall(configuration, port, true);
-    // Re-attach via primeAndFollow keeping _commandType "install"; the public
-    // followJob would derive "compile" from the returned COMPILE job (#1131)
-    // and skip the install → upload chain. Clear the cancelled attempt first.
+    // Keep _commandType "install": the public followJob would derive "compile"
+    // from the returned COMPILE (#1131) and skip the chain. Clear the cancelled
+    // attempt, then re-attach via primeAndFollow.
     await detachStream(host);
     host._lines = [];
     host._resetPendingLines();

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -180,6 +180,10 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
           followJob(host, upload.job_id);
           return;
         }
+        // The backend creates the held upload at install time, so a miss is a
+        // transport/backend gap, not version skew; surface it rather than
+        // silently reporting the device flashed after only compiling.
+        console.warn("install compile succeeded but no dependent upload for job", jobId);
       }
 
       host._state = success ? "success" : "error";

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -45,6 +45,7 @@ export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
   host._statusMessage = "";
   host._userStopped = false;
   host._failedDuringValidate = false;
+  host._installMissingUpload = false;
   // Clear primed snapshots so a Retry that picks a different source can't
   // leak the prior job's REMOTE label into renderBuildFailureSuggestion
   // before the new _jobs context update lands. open() already clears these
@@ -190,6 +191,9 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
         console.warn("install compile succeeded but no dependent upload for job", jobId);
         host._state = "error";
         host._statusMessage = host._localize("command.install_failed");
+        // The compile succeeded, so the clean/reset build-failure hint is
+        // misleading here — suppress it.
+        host._installMissingUpload = true;
         host._jobId = "";
         return;
       }
@@ -288,10 +292,14 @@ export async function onForceLocalClick(host: ESPHomeCommandDialog): Promise<voi
     const job = await host._api.firmwareInstall(configuration, port, true);
     // Keep _commandType "install": the public followJob would derive "compile"
     // from the returned COMPILE (#1131) and skip the chain. Clear the cancelled
-    // attempt, then re-attach via primeAndFollow.
+    // attempt and reset the run state (the public followJob did this), then
+    // re-attach via primeAndFollow.
     await detachStream(host);
     host._lines = [];
     host._resetPendingLines();
+    host._state = "running";
+    host._statusMessage = "";
+    host._installMissingUpload = false;
     primeAndFollow(host, job);
   } catch (err) {
     host._state = "error";

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -106,6 +106,9 @@ export function renderResetSuggestion(
 ): TemplateResult | typeof nothing {
   if (host._state !== "error") return nothing;
   if (host._userStopped) return nothing;
+  // A compile that succeeded but found no upload step isn't a build failure —
+  // clean/reset wouldn't help.
+  if (host._installMissingUpload) return nothing;
   if (host._commandType === "validate" || host._failedDuringValidate) {
     return renderValidationFailureSuggestion(host);
   }

--- a/test/_make-firmware-job.ts
+++ b/test/_make-firmware-job.ts
@@ -1,0 +1,34 @@
+import {
+  type FirmwareJob,
+  JobSource,
+  JobStatus,
+  JobType,
+} from "../src/api/types/firmware-jobs.js";
+
+export function makeFirmwareJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
+  return {
+    job_id: "job-1",
+    configuration: "kitchen.yaml",
+    job_type: JobType.COMPILE,
+    status: JobStatus.QUEUED,
+    created_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    completed_at: null,
+    exit_code: null,
+    output: [],
+    error: null,
+    port: "OTA",
+    new_name: "",
+    depends_on: "",
+    progress: null,
+    source: JobSource.LOCAL,
+    source_pin_sha256: "",
+    source_label: "",
+    source_esphome_version: "",
+    remote_peer: "",
+    remote_peer_label: "",
+    device_name: "",
+    device_friendly_name: "",
+    ...overrides,
+  };
+}

--- a/test/components/app-shell-jobs-dedup.test.ts
+++ b/test/components/app-shell-jobs-dedup.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Terminal-job dedup in the live jobs context keys on (config, type).
+ *
+ * An install is a COMPILE then a dependent UPLOAD sharing a configuration
+ * (backend #1131). Dedup-per-config-alone let the upload's completion evict
+ * the compile from the live list (the build log vanished until a reload).
+ * Keying on type too keeps both, matching the backend's retention.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type FirmwareJob,
+  JobSource,
+  JobStatus,
+  JobType,
+} from "../../src/api/types/firmware-jobs.js";
+import type { ESPHomeApp } from "../../src/components/app-shell.js";
+import { handleJobEvent } from "../../src/components/app-shell/jobs.js";
+
+function makeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
+  return {
+    job_id: "job-1",
+    configuration: "kitchen.yaml",
+    job_type: JobType.COMPILE,
+    status: JobStatus.COMPLETED,
+    created_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    completed_at: null,
+    exit_code: null,
+    output: [],
+    error: null,
+    port: "OTA",
+    new_name: "",
+    depends_on: "",
+    progress: null,
+    source: JobSource.LOCAL,
+    source_pin_sha256: "",
+    source_label: "",
+    source_esphome_version: "",
+    remote_peer: "",
+    remote_peer_label: "",
+    device_name: "",
+    device_friendly_name: "",
+    ...overrides,
+  };
+}
+
+function makeHost(): ESPHomeApp {
+  return {
+    _firmwareJobs: new Map(),
+    _activeJobs: new Map(),
+    _recentJobs: new Map(),
+    _recentJobTimers: new Map(),
+  } as unknown as ESPHomeApp;
+}
+
+describe("live jobs dedup (config, type)", () => {
+  it("keeps an install's compile and upload terminals for the same config", () => {
+    const host = makeHost();
+    handleJobEvent(
+      host,
+      "job_completed",
+      makeJob({ job_id: "c", job_type: JobType.COMPILE })
+    );
+    handleJobEvent(
+      host,
+      "job_completed",
+      makeJob({ job_id: "u", job_type: JobType.UPLOAD, depends_on: "c" })
+    );
+    expect(new Set(host._firmwareJobs.keys())).toEqual(new Set(["c", "u"]));
+  });
+
+  it("still collapses two compiles for the same config to the newest", () => {
+    const host = makeHost();
+    handleJobEvent(
+      host,
+      "job_completed",
+      makeJob({ job_id: "c1", job_type: JobType.COMPILE })
+    );
+    handleJobEvent(
+      host,
+      "job_completed",
+      makeJob({ job_id: "c2", job_type: JobType.COMPILE })
+    );
+    expect(new Set(host._firmwareJobs.keys())).toEqual(new Set(["c2"]));
+  });
+});

--- a/test/components/app-shell-jobs-dedup.test.ts
+++ b/test/components/app-shell-jobs-dedup.test.ts
@@ -1,48 +1,10 @@
-/**
- * Terminal-job dedup in the live jobs context keys on (config, type).
- *
- * An install is a COMPILE then a dependent UPLOAD sharing a configuration
- * (backend #1131). Dedup-per-config-alone let the upload's completion evict
- * the compile from the live list (the build log vanished until a reload).
- * Keying on type too keeps both, matching the backend's retention.
- */
+// Live-jobs dedup keys on (config, type) so an install's compile and upload
+// both survive — the upload's terminal must not evict the compile (#1131).
 import { describe, expect, it } from "vitest";
-import {
-  type FirmwareJob,
-  JobSource,
-  JobStatus,
-  JobType,
-} from "../../src/api/types/firmware-jobs.js";
+import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeApp } from "../../src/components/app-shell.js";
 import { handleJobEvent } from "../../src/components/app-shell/jobs.js";
-
-function makeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
-  return {
-    job_id: "job-1",
-    configuration: "kitchen.yaml",
-    job_type: JobType.COMPILE,
-    status: JobStatus.COMPLETED,
-    created_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    completed_at: null,
-    exit_code: null,
-    output: [],
-    error: null,
-    port: "OTA",
-    new_name: "",
-    depends_on: "",
-    progress: null,
-    source: JobSource.LOCAL,
-    source_pin_sha256: "",
-    source_label: "",
-    source_esphome_version: "",
-    remote_peer: "",
-    remote_peer_label: "",
-    device_name: "",
-    device_friendly_name: "",
-    ...overrides,
-  };
-}
+import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
 
 function makeHost(): ESPHomeApp {
   return {
@@ -53,18 +15,21 @@ function makeHost(): ESPHomeApp {
   } as unknown as ESPHomeApp;
 }
 
+const done = (overrides: Parameters<typeof makeJob>[0]) =>
+  makeJob({ status: JobStatus.COMPLETED, ...overrides });
+
 describe("live jobs dedup (config, type)", () => {
   it("keeps an install's compile and upload terminals for the same config", () => {
     const host = makeHost();
     handleJobEvent(
       host,
       "job_completed",
-      makeJob({ job_id: "c", job_type: JobType.COMPILE })
+      done({ job_id: "c", job_type: JobType.COMPILE })
     );
     handleJobEvent(
       host,
       "job_completed",
-      makeJob({ job_id: "u", job_type: JobType.UPLOAD, depends_on: "c" })
+      done({ job_id: "u", job_type: JobType.UPLOAD, depends_on: "c" })
     );
     expect(new Set(host._firmwareJobs.keys())).toEqual(new Set(["c", "u"]));
   });
@@ -74,12 +39,12 @@ describe("live jobs dedup (config, type)", () => {
     handleJobEvent(
       host,
       "job_completed",
-      makeJob({ job_id: "c1", job_type: JobType.COMPILE })
+      done({ job_id: "c1", job_type: JobType.COMPILE })
     );
     handleJobEvent(
       host,
       "job_completed",
-      makeJob({ job_id: "c2", job_type: JobType.COMPILE })
+      done({ job_id: "c2", job_type: JobType.COMPILE })
     );
     expect(new Set(host._firmwareJobs.keys())).toEqual(new Set(["c2"]));
   });

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -7,7 +7,7 @@
  * report success once the upload finishes, instead of declaring the device
  * flashed the moment it compiled.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   type FirmwareJob,
   JobSource,
@@ -114,6 +114,7 @@ describe("command-dialog install chain follow", () => {
       ])
     );
 
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     host._jobId = "c1";
     followJob(host, "c1");
     follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
@@ -130,6 +131,25 @@ describe("command-dialog install chain follow", () => {
     expect(host._statusMessage).toBe("command.install_success");
     expect(host._jobId).toBe("");
     expect(flipped()).toBe(true);
+    // The upload's completion must not re-trigger the missing-upload warning.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("warns (and falls through to success) when a compile has no dependent upload", () => {
+    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
+    // No upload in context — a genuine backend/transport gap, not the happy path.
+    const { host, follows, flipped } = makeHost(new Map([["c1", compile]]));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(host._state).toBe("success");
+    expect(flipped()).toBe(true);
+    warn.mockRestore();
   });
 
   it("does not follow the upload when the compile fails", () => {

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -49,6 +49,7 @@ function makeHost(
     _lines: [] as string[],
     _showLogsAfterInstall: true,
     _failedDuringValidate: false,
+    _installMissingUpload: false,
     _localize: (key: string) => key,
     _flipToLogs: () => {
       flipped = true;
@@ -116,6 +117,8 @@ describe("command-dialog install chain follow", () => {
     // The device was never flashed — must not report a successful install.
     expect(host._state).toBe("error");
     expect(host._statusMessage).toBe("command.install_failed");
+    // Flagged so the clean/reset build-failure hint is suppressed (compile was fine).
+    expect(host._installMissingUpload).toBe(true);
     expect(flipped()).toBe(false);
     warn.mockRestore();
   });

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -15,7 +15,10 @@ import {
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
-import { followJob } from "../../src/components/command-dialog/commands.js";
+import {
+  followJob,
+  onForceLocalClick,
+} from "../../src/components/command-dialog/commands.js";
 
 interface StreamCbs {
   onOutput: (line: string) => void;
@@ -51,7 +54,10 @@ function makeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
   };
 }
 
-function makeHost(jobs: Map<string, FirmwareJob>) {
+function makeHost(
+  jobs: Map<string, FirmwareJob>,
+  apiExtra: Record<string, unknown> = {}
+) {
   const follows: Record<string, StreamCbs> = {};
   let flipped = false;
   let streamSeq = 0;
@@ -61,6 +67,7 @@ function makeHost(jobs: Map<string, FirmwareJob>) {
         follows[jobId] = cbs;
         return `stream-${++streamSeq}`;
       },
+      ...apiExtra,
     },
     _jobs: jobs,
     _commandType: "install",
@@ -69,6 +76,11 @@ function makeHost(jobs: Map<string, FirmwareJob>) {
     _state: "running",
     _statusMessage: "",
     _streamId: "",
+    _switchingToLocal: false,
+    configuration: "kitchen.yaml",
+    name: "kitchen",
+    _port: "OTA",
+    _lines: [] as string[],
     _showLogsAfterInstall: true,
     _failedDuringValidate: false,
     _localize: (key: string) => key,
@@ -76,6 +88,7 @@ function makeHost(jobs: Map<string, FirmwareJob>) {
       flipped = true;
     },
     _flushPendingLines: () => {},
+    _resetPendingLines: () => {},
     _enqueueLine: () => {},
   };
   return {
@@ -143,5 +156,46 @@ describe("command-dialog install chain follow", () => {
     expect(host._jobId).toBe("");
     expect(follows.u1).toBeUndefined();
     expect(flipped()).toBe(false);
+  });
+
+  it("build-locally stays in install mode and follows the new compile into its upload", async () => {
+    // firmwareInstall returns a COMPILE after #1131; the override must not let
+    // the dialog drop into compile mode (which would skip the upload chain).
+    const jobs = new Map<string, FirmwareJob>();
+    const newCompile = makeJob({
+      job_id: "c2",
+      job_type: JobType.COMPILE,
+      status: JobStatus.QUEUED,
+    });
+    const newUpload = makeJob({
+      job_id: "u2",
+      job_type: JobType.UPLOAD,
+      status: JobStatus.QUEUED,
+      depends_on: "c2",
+    });
+    const { host, follows } = makeHost(jobs, {
+      firmwareCancel: async () => {},
+      stopStream: async () => {},
+      firmwareInstall: async () => {
+        jobs.set("c2", newCompile);
+        jobs.set("u2", newUpload);
+        return newCompile;
+      },
+    });
+    host._jobId = "c1"; // the remote compile being cancelled
+
+    await onForceLocalClick(host);
+
+    expect(host._commandType).toBe("install");
+    expect(host._jobId).toBe("c2");
+    expect(follows.c2).toBeDefined();
+
+    follows.c2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+    expect(host._jobId).toBe("u2");
+    expect(host._state).toBe("running");
+
+    follows.u2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+    expect(host._state).toBe("success");
+    expect(host._statusMessage).toBe("command.install_success");
   });
 });

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -48,6 +48,7 @@ function makeHost(
     _port: "OTA",
     _lines: [] as string[],
     _showLogsAfterInstall: true,
+    _userStopped: false,
     _failedDuringValidate: false,
     _installMissingUpload: false,
     _localize: (key: string) => key,
@@ -202,12 +203,20 @@ describe("command-dialog install chain follow", () => {
       },
     });
     host._jobId = "c1"; // the remote compile being cancelled
+    // Stale per-session flags from the cancelled remote attempt.
+    host._userStopped = true;
+    host._failedDuringValidate = true;
+    host._installMissingUpload = true;
 
     await onForceLocalClick(host);
 
     expect(host._commandType).toBe("install");
     expect(host._jobId).toBe("c2");
     expect(follows.c2).toBeDefined();
+    // The new local run starts clean — stale flags can't mis-route its hint.
+    expect(host._userStopped).toBe(false);
+    expect(host._failedDuringValidate).toBe(false);
+    expect(host._installMissingUpload).toBe(false);
 
     follows.c2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
     expect(host._jobId).toBe("u2");

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -65,21 +65,39 @@ function makeHost(
   };
 }
 
-describe("command-dialog install chain follow", () => {
-  it("follows the compile into its upload and only succeeds after the upload", () => {
-    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
-    const upload = makeJob({
-      job_id: "u1",
-      job_type: JobType.UPLOAD,
-      status: JobStatus.QUEUED,
-      depends_on: "c1",
-    });
-    const { host, follows, flipped } = makeHost(
+// A host pre-loaded with an install chain: a COMPILE "c1" and its held UPLOAD
+// "u1" (depends_on "c1"). Overrides tweak either job (e.g. a REMOTE compile).
+function installChainHost(
+  compileOverrides: Partial<FirmwareJob> = {},
+  uploadOverrides: Partial<FirmwareJob> = {}
+) {
+  const compile = makeJob({
+    job_id: "c1",
+    job_type: JobType.COMPILE,
+    ...compileOverrides,
+  });
+  const upload = makeJob({
+    job_id: "u1",
+    job_type: JobType.UPLOAD,
+    status: JobStatus.QUEUED,
+    depends_on: "c1",
+    ...uploadOverrides,
+  });
+  return {
+    ...makeHost(
       new Map([
         ["c1", compile],
         ["u1", upload],
       ])
-    );
+    ),
+    compile,
+    upload,
+  };
+}
+
+describe("command-dialog install chain follow", () => {
+  it("follows the compile into its upload and only succeeds after the upload", () => {
+    const { host, follows, flipped } = installChainHost();
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     host._jobId = "c1";
@@ -127,24 +145,10 @@ describe("command-dialog install chain follow", () => {
     // The compile ran on a remote builder; the upload is local. After hand-off
     // the primed source must track the upload so the remote-builder sub-line
     // doesn't linger on the compile's receiver.
-    const compile = makeJob({
-      job_id: "c1",
-      job_type: JobType.COMPILE,
+    const { host, follows } = installChainHost({
       source: JobSource.REMOTE,
       source_label: "builder",
     });
-    const upload = makeJob({
-      job_id: "u1",
-      job_type: JobType.UPLOAD,
-      status: JobStatus.QUEUED,
-      depends_on: "c1",
-    });
-    const { host, follows } = makeHost(
-      new Map([
-        ["c1", compile],
-        ["u1", upload],
-      ])
-    );
     host._primedSource = {
       source: JobSource.REMOTE,
       source_label: "builder",
@@ -160,19 +164,7 @@ describe("command-dialog install chain follow", () => {
   });
 
   it("does not follow the upload when the compile fails", () => {
-    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
-    const upload = makeJob({
-      job_id: "u1",
-      job_type: JobType.UPLOAD,
-      status: JobStatus.QUEUED,
-      depends_on: "c1",
-    });
-    const { host, follows, flipped } = makeHost(
-      new Map([
-        ["c1", compile],
-        ["u1", upload],
-      ])
-    );
+    const { host, follows, flipped } = installChainHost();
 
     host._jobId = "c1";
     followJob(host, "c1");

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -1,16 +1,8 @@
-/**
- * Install follows the COMPILE then its dependent UPLOAD (backend #1131).
- *
- * firmware/install returns the COMPILE job; the UPLOAD is held off its lane
- * (depends_on === compile job_id) until the compile succeeds, then flashes.
- * followJob must hand off to the upload on a successful compile and only
- * report success once the upload finishes, instead of declaring the device
- * flashed the moment it compiled.
- */
+// Install follows the COMPILE then its dependent UPLOAD (#1131): success is
+// reported only after the upload, not when the compile finishes.
 import { describe, expect, it, vi } from "vitest";
 import {
   type FirmwareJob,
-  JobSource,
   JobStatus,
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
@@ -19,39 +11,12 @@ import {
   followJob,
   onForceLocalClick,
 } from "../../src/components/command-dialog/commands.js";
+import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
 
 interface StreamCbs {
   onOutput: (line: string) => void;
   onResult: (data: unknown) => void;
   onError: (error: string) => void;
-}
-
-function makeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
-  return {
-    job_id: "job-1",
-    configuration: "kitchen.yaml",
-    job_type: JobType.COMPILE,
-    status: JobStatus.RUNNING,
-    created_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    completed_at: null,
-    exit_code: null,
-    output: [],
-    error: null,
-    port: "OTA",
-    new_name: "",
-    depends_on: "",
-    progress: null,
-    source: JobSource.LOCAL,
-    source_pin_sha256: "",
-    source_label: "",
-    source_esphome_version: "",
-    remote_peer: "",
-    remote_peer_label: "",
-    device_name: "",
-    device_friendly_name: "",
-    ...overrides,
-  };
 }
 
 function makeHost(

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Install follows the COMPILE then its dependent UPLOAD (backend #1131).
+ *
+ * firmware/install returns the COMPILE job; the UPLOAD is held off its lane
+ * (depends_on === compile job_id) until the compile succeeds, then flashes.
+ * followJob must hand off to the upload on a successful compile and only
+ * report success once the upload finishes, instead of declaring the device
+ * flashed the moment it compiled.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type FirmwareJob,
+  JobSource,
+  JobStatus,
+  JobType,
+} from "../../src/api/types/firmware-jobs.js";
+import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { followJob } from "../../src/components/command-dialog/commands.js";
+
+interface StreamCbs {
+  onOutput: (line: string) => void;
+  onResult: (data: unknown) => void;
+  onError: (error: string) => void;
+}
+
+function makeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
+  return {
+    job_id: "job-1",
+    configuration: "kitchen.yaml",
+    job_type: JobType.COMPILE,
+    status: JobStatus.RUNNING,
+    created_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    completed_at: null,
+    exit_code: null,
+    output: [],
+    error: null,
+    port: "OTA",
+    new_name: "",
+    depends_on: "",
+    progress: null,
+    source: JobSource.LOCAL,
+    source_pin_sha256: "",
+    source_label: "",
+    source_esphome_version: "",
+    remote_peer: "",
+    remote_peer_label: "",
+    device_name: "",
+    device_friendly_name: "",
+    ...overrides,
+  };
+}
+
+function makeHost(jobs: Map<string, FirmwareJob>) {
+  const follows: Record<string, StreamCbs> = {};
+  let flipped = false;
+  let streamSeq = 0;
+  const host = {
+    _api: {
+      firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
+        follows[jobId] = cbs;
+        return `stream-${++streamSeq}`;
+      },
+    },
+    _jobs: jobs,
+    _commandType: "install",
+    _jobId: "",
+    _jobStatus: JobStatus.RUNNING,
+    _state: "running",
+    _statusMessage: "",
+    _streamId: "",
+    _showLogsAfterInstall: true,
+    _failedDuringValidate: false,
+    _localize: (key: string) => key,
+    _flipToLogs: () => {
+      flipped = true;
+    },
+    _flushPendingLines: () => {},
+    _enqueueLine: () => {},
+  };
+  return {
+    host: host as unknown as ESPHomeCommandDialog,
+    follows,
+    flipped: () => flipped,
+  };
+}
+
+describe("command-dialog install chain follow", () => {
+  it("follows the compile into its upload and only succeeds after the upload", () => {
+    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
+    const upload = makeJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      status: JobStatus.QUEUED,
+      depends_on: "c1",
+    });
+    const { host, follows, flipped } = makeHost(
+      new Map([
+        ["c1", compile],
+        ["u1", upload],
+      ])
+    );
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    // Compile done, but the install is not — it's now following the upload.
+    expect(host._state).toBe("running");
+    expect(host._jobId).toBe("u1");
+    expect(follows.u1).toBeDefined();
+    expect(flipped()).toBe(false);
+
+    follows.u1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(host._state).toBe("success");
+    expect(host._statusMessage).toBe("command.install_success");
+    expect(host._jobId).toBe("");
+    expect(flipped()).toBe(true);
+  });
+
+  it("does not follow the upload when the compile fails", () => {
+    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
+    const upload = makeJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      status: JobStatus.QUEUED,
+      depends_on: "c1",
+    });
+    const { host, follows, flipped } = makeHost(
+      new Map([
+        ["c1", compile],
+        ["u1", upload],
+      ])
+    );
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.install_failed");
+    expect(host._jobId).toBe("");
+    expect(follows.u1).toBeUndefined();
+    expect(flipped()).toBe(false);
+  });
+});

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   type FirmwareJob,
+  JobSource,
   JobStatus,
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
@@ -101,7 +102,7 @@ describe("command-dialog install chain follow", () => {
     warn.mockRestore();
   });
 
-  it("warns (and falls through to success) when a compile has no dependent upload", () => {
+  it("warns and fails (not success) when a compile has no dependent upload", () => {
     const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
     // No upload in context — a genuine backend/transport gap, not the happy path.
     const { host, follows, flipped } = makeHost(new Map([["c1", compile]]));
@@ -112,9 +113,47 @@ describe("command-dialog install chain follow", () => {
     follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
 
     expect(warn).toHaveBeenCalledOnce();
-    expect(host._state).toBe("success");
-    expect(flipped()).toBe(true);
+    // The device was never flashed — must not report a successful install.
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.install_failed");
+    expect(flipped()).toBe(false);
     warn.mockRestore();
+  });
+
+  it("re-primes the build source from the upload on hand-off", () => {
+    // The compile ran on a remote builder; the upload is local. After hand-off
+    // the primed source must track the upload so the remote-builder sub-line
+    // doesn't linger on the compile's receiver.
+    const compile = makeJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      source: JobSource.REMOTE,
+      source_label: "builder",
+    });
+    const upload = makeJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      status: JobStatus.QUEUED,
+      depends_on: "c1",
+    });
+    const { host, follows } = makeHost(
+      new Map([
+        ["c1", compile],
+        ["u1", upload],
+      ])
+    );
+    host._primedSource = {
+      source: JobSource.REMOTE,
+      source_label: "builder",
+      source_esphome_version: "",
+    };
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(host._primedSource?.source).toBe(JobSource.LOCAL);
+    expect(host._primedSource?.source_label).toBe("");
   });
 
   it("does not follow the upload when the compile fails", () => {

--- a/test/components/command-dialog-reattach-reset.test.ts
+++ b/test/components/command-dialog-reattach-reset.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The command dialog is a reused singleton: clicking a job in firmware-tasks
+ * reattaches via the public followJob without going through open()/startCommand.
+ * That path must clear per-session flags, else a prior install's missing-upload
+ * failure leaves _installMissingUpload set and suppresses the clean/reset hint
+ * on a subsequently-replayed real build failure. Pin the reset here.
+ */
+import { describe, expect, it } from "vitest";
+import { type FirmwareJob, JobType } from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
+
+describe("command-dialog public followJob state reset", () => {
+  it("clears a stale _installMissingUpload on reattach", () => {
+    const el = new ESPHomeCommandDialog() as unknown as {
+      _installMissingUpload: boolean;
+      _streamId: string;
+      _api: { firmwareFollowJob: () => string };
+      followJob: (job: FirmwareJob, displayName: string) => void;
+    };
+    // Left over from a prior install whose compile succeeded but found no upload.
+    el._installMissingUpload = true;
+    el._streamId = "";
+    el._api = { firmwareFollowJob: () => "stream-1" } as never;
+
+    el.followJob(makeFirmwareJob({ job_id: "j1", job_type: JobType.COMPILE }), "device");
+
+    expect(el._installMissingUpload).toBe(false);
+  });
+});

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -42,6 +42,7 @@ interface Host {
   _userStopped: boolean;
   _commandType: string;
   _failedDuringValidate: boolean;
+  _installMissingUpload: boolean;
   _jobId: string;
   _jobs: Map<string, FirmwareJob>;
   _primedSource: {
@@ -61,6 +62,7 @@ function baseHost(overrides: Partial<Host> = {}): Host {
     _userStopped: false,
     _commandType: "install",
     _failedDuringValidate: false,
+    _installMissingUpload: false,
     _jobId: "job-1",
     _jobs: new Map(),
     _primedSource: null,
@@ -88,6 +90,12 @@ describe("renderResetSuggestion — local build", () => {
     // primed snapshot — the renderer must not assume REMOTE.
     const host = baseHost({ _jobs: new Map(), _primedSource: null });
     expectFallbackToLocal(render(host), host);
+  });
+
+  it("renders nothing when the install compile succeeded but had no upload", () => {
+    // The compile was fine; clean/reset wouldn't help a missing upload step.
+    const host = baseHost({ _installMissingUpload: true });
+    expectNoSuggestion(render(host));
   });
 });
 

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -41,6 +41,7 @@ function fakeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     error: "",
     port: "OTA",
     new_name: "",
+    depends_on: "",
     progress: null,
     source: JobSource.LOCAL,
     source_pin_sha256: "",

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import { renderResetSuggestion } from "../../src/components/command-dialog/renderers.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
 import {
   expectFallbackToLocal,
   expectLocalSuggestion,
@@ -28,31 +29,12 @@ import {
 } from "./_reset-suggestion-helpers.js";
 
 function fakeJob(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
-  return {
-    job_id: "job-1",
-    configuration: "kitchen.yaml",
+  return makeFirmwareJob({
     job_type: JobType.INSTALL,
     status: JobStatus.FAILED,
-    created_at: "2026-01-01T00:00:00Z",
-    started_at: null,
-    completed_at: null,
-    exit_code: null,
-    output: [],
     error: "",
-    port: "OTA",
-    new_name: "",
-    depends_on: "",
-    progress: null,
-    source: JobSource.LOCAL,
-    source_pin_sha256: "",
-    source_label: "",
-    source_esphome_version: "",
-    remote_peer: "",
-    remote_peer_label: "",
-    device_name: "",
-    device_friendly_name: "",
     ...overrides,
-  };
+  });
 }
 
 interface Host {

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
-import { JobSource, JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
+import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { firmwareJobDisplayName } from "../../src/util/firmware-job-display.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
 
 /**
  * Build a structurally-accurate ``FirmwareJob`` for tests.
@@ -13,31 +14,13 @@ import { firmwareJobDisplayName } from "../../src/util/firmware-job-display.js";
  * silently drift behind a forced cast.
  */
 function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
-  return {
-    job_id: "job-1",
-    configuration: "kitchen.yaml",
+  return makeFirmwareJob({
     job_type: JobType.INSTALL,
     status: JobStatus.RUNNING,
-    created_at: "2026-05-11T00:00:00Z",
-    started_at: null,
-    completed_at: null,
-    exit_code: null,
-    output: [],
-    error: null,
     port: "",
-    new_name: "",
-    depends_on: "",
-    progress: null,
-    source: JobSource.LOCAL,
-    source_pin_sha256: "",
-    source_label: "",
-    source_esphome_version: "",
-    remote_peer: "",
-    remote_peer_label: "",
-    device_name: "",
-    device_friendly_name: "",
+    created_at: "2026-05-11T00:00:00Z",
     ...overrides,
-  };
+  });
 }
 
 /**

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -26,6 +26,7 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     error: null,
     port: "",
     new_name: "",
+    depends_on: "",
     progress: null,
     source: JobSource.LOCAL,
     source_pin_sha256: "",

--- a/test/util/firmware-job-status.test.ts
+++ b/test/util/firmware-job-status.test.ts
@@ -27,6 +27,7 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
     error: null,
     port: "",
     new_name: "",
+    depends_on: "",
     progress: null,
     source: JobSource.LOCAL,
     source_pin_sha256: "",

--- a/test/util/firmware-job-status.test.ts
+++ b/test/util/firmware-job-status.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
-import { JobSource, JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
+import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
 import {
   TERMINAL_JOB_STATUSES,
   isTerminalJob,
   isTerminalJobStatus,
 } from "../../src/util/firmware-job-status.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
 
 /**
  * Build a structurally-accurate ``FirmwareJob`` for tests. Mirrors
@@ -14,31 +15,13 @@ import {
  * a forced cast.
  */
 function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
-  return {
-    job_id: "job-1",
+  return makeFirmwareJob({
     configuration: "test.yaml",
     job_type: JobType.INSTALL,
-    status: JobStatus.QUEUED,
-    created_at: "2026-05-04T12:00:00Z",
-    started_at: null,
-    completed_at: null,
-    exit_code: null,
-    output: [],
-    error: null,
     port: "",
-    new_name: "",
-    depends_on: "",
-    progress: null,
-    source: JobSource.LOCAL,
-    source_pin_sha256: "",
-    source_label: "",
-    source_esphome_version: "",
-    remote_peer: "",
-    remote_peer_label: "",
-    device_name: "",
-    device_friendly_name: "",
+    created_at: "2026-05-04T12:00:00Z",
     ...overrides,
-  };
+  });
 }
 
 describe("TERMINAL_JOB_STATUSES", () => {


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1131, which splits `firmware/install` into a COMPILE job plus a dependent UPLOAD job (a `depends_on` chain) so the two pipeline on separate lanes.

- The install dialog (`command-dialog`) follows the chain: on a successful COMPILE it hands off to the dependent UPLOAD and reports success only after the flash, instead of declaring the device flashed when the compile finished. The hand-off is gated on the finished job being the COMPILE (so the upload's own completion falls through to success) and re-primes the build source from the upload (local flash) so the remote-builder sub-line doesn't linger. A successful compile with no upload step fails the command rather than reporting a flash that never happened, and suppresses the misleading clean/reset hint.
- The "build locally instead" override keeps `_commandType` as `install` (the public `followJob` would derive `compile` from the post-#1131 COMPILE return and skip the chain) and resets the run state on re-attach; the shared `primeAndFollow` helper is reused for both the initial follow and the override.
- The live firmware-jobs context dedups terminal primary jobs by `(configuration, job_type)` instead of by configuration alone, so an install's UPLOAD completing no longer evicts its COMPILE — both rows stay (matching the backend's retention), live and after reload.
- Adds the `depends_on` field to the `FirmwareJob` type and a shared `test/_make-firmware-job.ts` factory (the four divergent per-file job builders now delegate to it).

This is a two-row install in the firmware-tasks history (a compile and an upload), reviewable separately; collapsing them into a single "Install" row was considered and left out as unnecessary.

**Related issue or feature (if applicable):**

- fixes <link to issue>

Companion to esphome/device-builder#1131.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

