### PR TITLE
Show inline automations on components without an id

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -23,6 +23,7 @@ import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
 import {
+  instanceComponentId,
   parseYamlAutomations,
   parseYamlTopLevelSections,
   sectionKeyOf,
@@ -570,9 +571,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
    * automation" / triggers-list shortcut. Returns ``null`` when the
    * section can't host inline ``on_*:`` automations (api has its own
    * shortcut; script/interval have their own navigator CTAs; data-
-   * only blocks like substitutions never carry triggers; component
-   * list items without an ``id:`` can't be addressed by the
-   * structured editor).
+   * only blocks like substitutions never carry triggers; flat
+   * single-instance blocks have no positional id to address).
+   * id-less list-item instances resolve to the backend's positional
+   * ``<domain>_<idx>`` id, so they host automations like id'd ones.
    */
   private _shortcutTarget():
     | null
@@ -591,8 +593,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       this._resolvedFromLine !== undefined
         ? (candidates.find((s) => s.fromLine === this._resolvedFromLine) ?? candidates[0])
         : candidates[0];
-    if (!match.id) return null;
-    return { kind: "component_on", componentId: match.id };
+    const componentId = instanceComponentId(sections, match);
+    if (componentId === null) return null;
+    return { kind: "component_on", componentId };
   }
 
   /**

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -5,7 +5,13 @@
  * unaffected; import from there or from here directly.
  */
 
-import type { YamlSection } from "./yaml-sections.js";
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import {
+  instanceComponentId,
+  parseYamlTopLevelSections,
+  smallestContainingSection,
+  type YamlSection,
+} from "./yaml-sections-core.js";
 
 /**
  * Synchronous fallback parser for automation sections. The navigator
@@ -33,6 +39,9 @@ import type { YamlSection } from "./yaml-sections.js";
  */
 export function parseYamlAutomations(yaml: string): YamlSection[] {
   const lines = yaml.split("\n");
+  // Memoised on `yaml`, so resolving an id-less host's positional id is
+  // free when the caller already parsed sections this render.
+  const sections = parseYamlTopLevelSections(yaml);
   const automations: YamlSection[] = [];
 
   for (let i = 0; i < lines.length; i++) {
@@ -44,11 +53,14 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
     const fromLine = i + 1; // 1-indexed CM line
     const toLine = _findBlockEnd(lines, i, indent);
 
-    // Walk backwards to identify the enclosing block (esphome:
-    // device-level, or a configured-component instance with its id).
-    const ancestry = _walkAncestry(lines, i, indent);
+    // Resolve the host from the shared section parse — one source of
+    // truth for parentKey / id / name / index. An id-less list instance
+    // gets the backend's positional ``<domain>_<idx>`` so it surfaces
+    // and round-trips like an id'd one; a flat block (``esphome:``)
+    // hosts device-level triggers instead.
+    const host = smallestContainingSection(sections, fromLine);
 
-    if (ancestry.parentKey === "esphome") {
+    if (host && host.parentKey === undefined && host.key === "esphome") {
       automations.push({
         key: `automation:device_on:${eventName}`,
         // ``displayLabel`` is the legacy "Esphome → on_boot" label;
@@ -61,13 +73,32 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
         parentKey: "esphome",
         eventKey: eventName,
       });
-    } else if (ancestry.componentId) {
-      const componentId = ancestry.componentId;
-      const labelHead = ancestry.parentName || componentId;
+      continue;
+    }
+
+    // One source of truth: the helper returns the declared / positional id
+    // for a list-item host and null for a flat block (``sun:`` with an id is
+    // still null — the backend can't address it), so this matches what
+    // ``_shortcutTarget`` resolves for the same section. Only a *direct*
+    // ``on_*`` child of the list item scopes to it: the backend parses an
+    // instance's own ``on_*`` keys, not ones nested under a sub-mapping
+    // (``sensor[i].temperature.on_value``), so a deeper handler falls
+    // through to ``unscoped`` rather than claiming a handle that
+    // ``automations/parse`` won't confirm.
+    let componentId: string | null = null;
+    if (
+      host &&
+      host.parentKey !== undefined &&
+      indent === _itemChildIndent(lines, host.fromLine)
+    ) {
+      componentId = instanceComponentId(sections, host);
+    }
+    if (host && componentId) {
+      const labelHead = host.name || componentId;
       const base = {
         id: componentId,
-        name: ancestry.parentName ?? undefined,
-        parentKey: ancestry.parentKey ?? undefined,
+        name: host.name ?? undefined,
+        parentKey: host.parentKey,
         eventKey: eventName,
       };
       // List-shaped trigger (``time.on_time``): one row per cron entry,
@@ -93,18 +124,20 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
           toLine,
         });
       }
-    } else {
-      // No clear ancestry — keep the event as the bare display
-      // label and emit a non-namespaced key so it doesn't collide
-      // with a properly-resolved automation later.
-      automations.push({
-        key: `automation:unscoped:${eventName}:${fromLine}`,
-        displayLabel: eventName,
-        fromLine,
-        toLine,
-        eventKey: eventName,
-      });
+      continue;
     }
+
+    // No addressable host (a flat non-esphome block like ``wifi:``, or
+    // no resolvable enclosing block) — keep the event as the bare
+    // display label and emit a non-namespaced key so it doesn't
+    // collide with a properly-resolved automation later.
+    automations.push({
+      key: `automation:unscoped:${eventName}:${fromLine}`,
+      displayLabel: eventName,
+      fromLine,
+      toLine,
+      eventKey: eventName,
+    });
   }
 
   // Top-level ``script:`` / ``interval:`` list items. These don't
@@ -193,59 +226,16 @@ function _findBlockEnd(lines: string[], startIdx: number, indent: number): numbe
   return lines.length;
 }
 
-interface Ancestry {
-  parentKey: string | null;
-  parentName: string | null;
-  componentId: string | null;
-}
-
-/**
- * Walk backwards from an ``on_*:`` line to identify the enclosing
- * block. Returns:
- *
- * - ``parentKey`` — the nearest top-level key
- *   (``esphome``, ``binary_sensor``, …) discovered by scanning to
- *   a column-0 anchor.
- * - ``parentName`` — the configured component's ``name:`` if found,
- *   used as a display label.
- * - ``componentId`` — the configured component's ``id:`` if found,
- *   used as the stable identifier.
- */
-function _walkAncestry(lines: string[], startIdx: number, childIndent: number): Ancestry {
-  let parentKey: string | null = null;
-  let parentName: string | null = null;
-  let componentId: string | null = null;
-  // True once we've crossed our list item's leading ``-`` (at indent
-  // < childIndent). Beyond that boundary we keep scanning *only* to
-  // find the top-level key; we no longer harvest id / name (those
-  // would belong to a previous sibling, not us).
-  let crossedItemBoundary = false;
-  for (let j = startIdx - 1; j >= 0; j--) {
-    const line = lines[j];
-    if (line.trim() === "") continue;
-    const topLevel = line.match(/^([a-zA-Z_][\w]*)\s*:/);
-    if (topLevel) {
-      parentKey = topLevel[1];
-      break;
-    }
-    const lineIndent = (line.match(/^(\s*)/) ?? ["", ""])[1].length;
-    // A list-item dash at an indent shallower than our handler is
-    // our own item's leading row (we're somewhere inside it). Cross
-    // it but keep walking — the top-level key still sits above us.
-    if (lineIndent < childIndent && /^\s*-\s/.test(line)) {
-      crossedItemBoundary = true;
-      continue;
-    }
-    // Deeper lines (nested blocks under our handler's siblings)
-    // can't contribute id / name for our automation.
-    if (lineIndent > childIndent) continue;
-    if (crossedItemBoundary) continue;
-    const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?([^"'\s]+)["']?\s*$/);
-    if (idMatch && !componentId) componentId = idMatch[1];
-    const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
-    if (nameMatch && !parentName) parentName = nameMatch[1];
-  }
-  return { parentKey, parentName, componentId };
+/** Column where a list item's direct child keys sit — the first key
+ *  after the ``- `` marker on *dashFromLine* (1-indexed). Derived from the
+ *  line rather than assuming a fixed step, since configs may put any
+ *  number of spaces after the dash; falls back to one indent past the
+ *  dash when the dash line carries no inline key. */
+function _itemChildIndent(lines: string[], dashFromLine: number): number {
+  const dashLine = lines[dashFromLine - 1] ?? "";
+  const inline = dashLine.match(/^\s*-\s+(?=\S)/)?.[0].length;
+  if (inline !== undefined) return inline;
+  return _dashIndent(dashLine) + ESPHOME_YAML_INDENT.length;
 }
 
 /** Top-level key block (``script:`` / ``interval:``) with its
@@ -273,8 +263,7 @@ function _findChildBlock(
   childKey: string
 ): { fromLine: number; toLine: number } | null {
   // Locate the parent block's child indent by reading the first
-  // non-blank child line and capturing its leading whitespace —
-  // matches the convention used by ``_walkAncestry``.
+  // non-blank child line and capturing its leading whitespace.
   let childIndent: number | null = null;
   for (let i = parentFromLine; i < parentToLine && i < lines.length; i++) {
     const line = lines[i];

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -1,0 +1,321 @@
+/**
+ * Pure top-level-section parsing primitives, split out of
+ * `yaml-sections.ts` so `yaml-automations.ts` can reuse them without a
+ * circular import: `yaml-sections.ts` imports the synchronous automation
+ * parser from `yaml-automations.ts`, so the shared section helpers must
+ * live in a module neither of those depends on. This is a leaf module —
+ * it imports nothing from `yaml-sections.ts` / `yaml-automations.ts`.
+ *
+ * `yaml-sections.ts` re-exports everything here, so existing call sites
+ * importing these from `./yaml-sections.js` are unaffected.
+ */
+
+import { LIST_SECTIONS } from "./section-entry-overrides.js";
+
+export interface YamlSection {
+  key: string;
+  fromLine: number; // 1-indexed (CodeMirror convention)
+  toLine: number; // 1-indexed, inclusive
+  name?: string; // "name:" value from a YAML list item
+  id?: string; // "id:" value from a YAML list item
+  platform?: string; // "platform:" value from a YAML list item
+  parentKey?: string; // top-level key when this is an expanded list item
+  /**
+   * Human-readable label for the navigator. Set when ``key`` is a
+   * stable machine identifier (e.g. an automation's
+   * ``automation:component_on:<id>:on_press``) that wouldn't render
+   * well in the UI. Navigator consumers prefer ``displayLabel`` when
+   * present and fall back to ``key`` otherwise.
+   */
+  displayLabel?: string;
+  /**
+   * Bare trigger event key (``on_press``, ``on_turn_on``) for
+   * automation entries. The navigator combines this with
+   * ``parentKey`` to look up the trigger's pretty name in the
+   * catalog (``binary_sensor.on_press`` → "Pressed").
+   */
+  eventKey?: string;
+  /**
+   * Free-form metadata payload — currently used to surface the
+   * ``interval: 60s`` time on an interval entry so the navigator
+   * can show "Every 60s" instead of "interval #1". Optional for
+   * everything else.
+   */
+  meta?: Record<string, string>;
+}
+
+/**
+ * Trim predicate: true for blank lines and unindented (top-level)
+ * comments that act as banners between sections. INDENTED comments
+ * are treated as content of the surrounding section — a config like
+ *
+ *     wifi:
+ *       ssid: x
+ *       # password set via secrets
+ *
+ * has the trailing comment as part of `wifi:`, so dropping it from
+ * the section's range would mis-locate the user-visible content.
+ * Only top-level `#` lines decorate the next section.
+ */
+function _isBlankOrBannerComment(line: string): boolean {
+  if (line.trim() === "") return true;
+  // A banner comment starts at column 0 — any leading whitespace
+  // means it belongs to the surrounding indented block.
+  return line.startsWith("#");
+}
+
+/**
+ * Single-entry memo for `parseYamlTopLevelSections`. The hot path
+ * is the YAML pane's cursor channel: the page's
+ * `_onYamlCursorLine` handler calls `sectionAtLine` on every line
+ * transition, which in turn re-parses the document. Hold-arrow
+ * scrolling and find-jumps fire that many times in a row, and the
+ * page hands us the same `_yaml` string instance until the user
+ * types, so this collapses to O(1) on the typical render cycle.
+ *
+ * The navigator also calls `parseYamlTopLevelSections` directly
+ * (twice per render — top-level sections + automation siblings),
+ * so the same memo also covers the navigator's render hot path.
+ *
+ * Same shape as `createScanMemo` in `config-entry-yaml-scan.ts`,
+ * but inlined here because the closure only needs to cache one
+ * function's input/output and a separate factory would be
+ * over-engineered for a single-keyed memo.
+ */
+let _topLevelSectionsKey: string | undefined;
+let _topLevelSectionsValue: YamlSection[] | undefined;
+
+/**
+ * Extracts top-level YAML keys and their line ranges.
+ * Top-level keys have no leading whitespace (e.g. `esphome:`, `wifi:`).
+ * Sections containing YAML list items (e.g. `light:\n  - platform: binary`)
+ * are expanded so each list item becomes its own section with name/platform metadata.
+ */
+export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
+  if (_topLevelSectionsKey === yaml && _topLevelSectionsValue) {
+    return _topLevelSectionsValue;
+  }
+  const lines = yaml.split("\n");
+  const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
+    if (match) {
+      if (rawSections.length > 0) {
+        // The previous section content ends one line before the new
+        // top-level key. Walk backward over trailing blank /
+        // comment-only lines: those typically decorate the upcoming
+        // section ("## Substitutions ##" sitting above
+        // ``substitutions:``) rather than belonging to the one
+        // ending. Without the trim, hovering ``runtime_stats`` in the
+        // navigator highlights the comment block that visually
+        // documents ``substitutions``.
+        const prev = rawSections[rawSections.length - 1];
+        const prevStart = prev.fromLine - 1; // 0-indexed
+        let endIdx = i - 1;
+        while (endIdx > prevStart && _isBlankOrBannerComment(lines[endIdx])) {
+          endIdx--;
+        }
+        prev.toLine = endIdx + 1;
+      }
+      rawSections.push({
+        key: match[1],
+        fromLine: i + 1, // convert 0-indexed array to 1-indexed CM line
+        toLine: lines.length,
+      });
+    }
+  }
+
+  // Trim trailing blank / comment-only lines from the final section
+  // for the same reason as above — a comment block at the very end
+  // of the file (or right before EOF whitespace) shouldn't extend
+  // the last section's hover-highlight range.
+  if (rawSections.length > 0) {
+    const last = rawSections[rawSections.length - 1];
+    const lastStart = last.fromLine - 1; // 0-indexed
+    let endIdx = lines.length - 1;
+    // Drop the conventional trailing newline-empty-string before
+    // the trim loop so we don't double-count it.
+    if (endIdx >= 0 && lines[endIdx] === "") endIdx--;
+    while (endIdx > lastStart && _isBlankOrBannerComment(lines[endIdx])) {
+      endIdx--;
+    }
+    last.toLine = endIdx + 1;
+  }
+
+  // Expand list items within each section
+  const sections: YamlSection[] = [];
+  for (const raw of rawSections) {
+    sections.push(..._expandListItems(lines, raw));
+  }
+
+  _topLevelSectionsKey = yaml;
+  _topLevelSectionsValue = sections;
+  return sections;
+}
+
+/**
+ * Test-only: clear the `parseYamlTopLevelSections` memo so cached
+ * results from a prior test case don't leak into the next. Mirrors
+ * `_clearScanMemos` in `config-entry-yaml-scan.ts`.
+ */
+export function _clearYamlSectionsMemo(): void {
+  _topLevelSectionsKey = undefined;
+  _topLevelSectionsValue = undefined;
+}
+
+/**
+ * If a top-level section contains YAML list items (`  - `), expand each into
+ * its own YamlSection with name, platform, and parentKey metadata.
+ * Otherwise return the section as-is.
+ */
+function _expandListItems(
+  lines: string[],
+  section: { key: string; fromLine: number; toLine: number }
+): YamlSection[] {
+  // LIST_SECTIONS members keep their list items hidden from the
+  // navigator — the user navigates to the whole block (edited as a
+  // repeatable list), not the individual entries (e.g. globals).
+  if (LIST_SECTIONS.has(section.key)) {
+    return [
+      {
+        key: section.key,
+        fromLine: section.fromLine,
+        toLine: section.toLine,
+      },
+    ];
+  }
+
+  const keyIdx = section.fromLine - 1; // 0-indexed line of the top-level key
+  const endIdx = section.toLine - 1; // 0-indexed last line (inclusive)
+
+  // Find list item starts (`  - ` or `  -\n`)
+  const listStarts: number[] = [];
+  for (let i = keyIdx + 1; i <= endIdx; i++) {
+    if (/^  -\s/.test(lines[i]) || /^  -$/.test(lines[i])) {
+      listStarts.push(i);
+    }
+  }
+
+  if (listStarts.length === 0) {
+    // Single-instance section (e.g. `uart:` configured as a flat
+    // dict with `id:`, `tx_pin:` etc. directly under it). Extract a
+    // top-level `id:`/`name:` so the navigator can show them as the
+    // primary label instead of falling back to the bare key.
+    let name = "";
+    let id = "";
+    for (let i = keyIdx + 1; i <= endIdx; i++) {
+      const nameMatch = lines[i].match(/^\s{2}name:\s*["']?(.+?)["']?\s*$/);
+      if (nameMatch) name = nameMatch[1];
+      const idMatch = lines[i].match(/^\s{2}id:\s*["']?(\S+?)["']?\s*$/);
+      if (idMatch) id = idMatch[1];
+    }
+    return [
+      {
+        key: section.key,
+        fromLine: section.fromLine,
+        toLine: section.toLine,
+        name: name || undefined,
+        id: id || undefined,
+      },
+    ];
+  }
+
+  const items: YamlSection[] = [];
+  for (let idx = 0; idx < listStarts.length; idx++) {
+    const itemStart = listStarts[idx];
+    const itemEnd = idx + 1 < listStarts.length ? listStarts[idx + 1] - 1 : endIdx;
+
+    let name = "";
+    let id = "";
+    let platform = "";
+    // Only the list item's own top-level keys count: the dash line's
+    // inline key, plus continuation keys at exactly the direct-child
+    // indent. Deeper lines belong to nested sub-mappings (a sensor
+    // platform's temperature:/humidity: blocks, the debug component's
+    // per-metric sensors) whose name:/id: must not override the item's.
+    const dashIndent = lines[itemStart].match(/^ */)?.[0].length ?? 0;
+    const childIndent = dashIndent + 2;
+    for (let j = itemStart; j <= itemEnd; j++) {
+      const line = lines[j];
+      if (j !== itemStart) {
+        const indent = line.match(/^ */)?.[0].length ?? 0;
+        if (indent !== childIndent) continue;
+      }
+      const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
+      if (nameMatch) name = nameMatch[1];
+      const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
+      if (idMatch) id = idMatch[1];
+      const platformMatch = line.match(/^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/);
+      if (platformMatch) platform = platformMatch[1];
+    }
+
+    items.push({
+      key: section.key,
+      fromLine: itemStart + 1, // 1-indexed
+      toLine: itemEnd + 1, // 1-indexed
+      name: name || undefined,
+      id: id || undefined,
+      platform: platform || undefined,
+      parentKey: section.key,
+    });
+  }
+
+  return items;
+}
+
+/** Smallest-span section in *sections* whose ``[fromLine, toLine]``
+ *  range covers *line* (1-indexed), or ``null`` when *line* falls in
+ *  no section. */
+export function smallestContainingSection(
+  sections: YamlSection[],
+  line: number
+): YamlSection | null {
+  let best: YamlSection | null = null;
+  let bestSpan = Number.POSITIVE_INFINITY;
+  for (const s of sections) {
+    if (line < s.fromLine || line > s.toLine) continue;
+    const span = s.toLine - s.fromLine;
+    if (span < bestSpan) {
+      best = s;
+      bestSpan = span;
+    }
+  }
+  return best;
+}
+
+/**
+ * Addressable component id for the list-item instance `match` among
+ * `sections`: its declared ``id:`` when present, else the backend's
+ * positional ``<domain>_<idx>`` (``idx`` = the instance's 0-based
+ * position in the ``<domain>:`` list, document order). Mirrors the
+ * backend's inline-automation scheme (``parsing.py`` emits
+ * ``f"{domain}_{idx}"``, ``inline.py`` resolves it back) so the handle
+ * round-trips through ``automations/upsert`` / ``delete``.
+ *
+ * Returns ``null`` for a flat single-instance block (``sun:``,
+ * ``mqtt:``, ``wifi:`` …) — **even when it declares an explicit
+ * ``id:``**. The backend addresses inline ``on_*:`` handlers under list
+ * domains only (``isinstance(section, list)``), so a flat host is not
+ * addressable. The ``parentKey`` check therefore comes first: a flat
+ * block with an id must still return ``null`` so the shortcut gate and
+ * the parser agree (both treat it as unscoped) rather than offering a
+ * shortcut that resolves to nothing.
+ */
+export function instanceComponentId(
+  sections: YamlSection[],
+  match: YamlSection
+): string | null {
+  const domain = match.parentKey;
+  if (domain === undefined) return null;
+  if (match.id) return match.id;
+  // Position among same-domain instances in document order. Counting by
+  // ``fromLine`` (unique per list item) is a single allocation-free pass
+  // and, unlike ``indexOf``, doesn't depend on ``match`` being the same
+  // object reference held in ``sections``.
+  let idx = 0;
+  for (const s of sections) {
+    if (s.parentKey === domain && s.fromLine < match.fromLine) idx++;
+  }
+  return `${domain}_${idx}`;
+}

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,41 +1,25 @@
-import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { parseYamlAutomations } from "./yaml-automations.js";
+import {
+  _clearYamlSectionsMemo,
+  instanceComponentId,
+  parseYamlTopLevelSections,
+  smallestContainingSection,
+  type YamlSection,
+} from "./yaml-sections-core.js";
 
-// Re-exported so existing consumers can keep importing the synchronous
-// automation parser from this module.
-export { parseYamlAutomations };
-
-export interface YamlSection {
-  key: string;
-  fromLine: number; // 1-indexed (CodeMirror convention)
-  toLine: number; // 1-indexed, inclusive
-  name?: string; // "name:" value from a YAML list item
-  id?: string; // "id:" value from a YAML list item
-  platform?: string; // "platform:" value from a YAML list item
-  parentKey?: string; // top-level key when this is an expanded list item
-  /**
-   * Human-readable label for the navigator. Set when ``key`` is a
-   * stable machine identifier (e.g. an automation's
-   * ``automation:component_on:<id>:on_press``) that wouldn't render
-   * well in the UI. Navigator consumers prefer ``displayLabel`` when
-   * present and fall back to ``key`` otherwise.
-   */
-  displayLabel?: string;
-  /**
-   * Bare trigger event key (``on_press``, ``on_turn_on``) for
-   * automation entries. The navigator combines this with
-   * ``parentKey`` to look up the trigger's pretty name in the
-   * catalog (``binary_sensor.on_press`` → "Pressed").
-   */
-  eventKey?: string;
-  /**
-   * Free-form metadata payload — currently used to surface the
-   * ``interval: 60s`` time on an interval entry so the navigator
-   * can show "Every 60s" instead of "interval #1". Optional for
-   * everything else.
-   */
-  meta?: Record<string, string>;
-}
+// The section-parsing primitives live in ``yaml-sections-core.ts`` (a
+// leaf module) so ``yaml-automations.ts`` can reuse them without a
+// circular import. Re-exported here so existing call sites importing
+// them — or ``parseYamlAutomations`` — from ``./yaml-sections.js`` are
+// unaffected.
+export {
+  _clearYamlSectionsMemo,
+  instanceComponentId,
+  parseYamlAutomations,
+  parseYamlTopLevelSections,
+  smallestContainingSection,
+  type YamlSection,
+};
 
 export interface CategorizedSections {
   core: YamlSection[];
@@ -123,226 +107,6 @@ export function categorizeSections(sections: YamlSection[]): CategorizedSections
   }
 
   return { core, components, automations };
-}
-
-/**
- * Trim predicate: true for blank lines and unindented (top-level)
- * comments that act as banners between sections. INDENTED comments
- * are treated as content of the surrounding section — a config like
- *
- *     wifi:
- *       ssid: x
- *       # password set via secrets
- *
- * has the trailing comment as part of `wifi:`, so dropping it from
- * the section's range would mis-locate the user-visible content.
- * Only top-level `#` lines decorate the next section.
- */
-function _isBlankOrBannerComment(line: string): boolean {
-  if (line.trim() === "") return true;
-  // A banner comment starts at column 0 — any leading whitespace
-  // means it belongs to the surrounding indented block.
-  return line.startsWith("#");
-}
-
-/**
- * Single-entry memo for `parseYamlTopLevelSections`. The hot path
- * is the YAML pane's cursor channel: the page's
- * `_onYamlCursorLine` handler calls `sectionAtLine` on every line
- * transition, which in turn re-parses the document. Hold-arrow
- * scrolling and find-jumps fire that many times in a row, and the
- * page hands us the same `_yaml` string instance until the user
- * types, so this collapses to O(1) on the typical render cycle.
- *
- * The navigator also calls `parseYamlTopLevelSections` directly
- * (twice per render — top-level sections + automation siblings),
- * so the same memo also covers the navigator's render hot path.
- *
- * Same shape as `createScanMemo` in `config-entry-yaml-scan.ts`,
- * but inlined here because the closure only needs to cache one
- * function's input/output and a separate factory would be
- * over-engineered for a single-keyed memo.
- */
-let _topLevelSectionsKey: string | undefined;
-let _topLevelSectionsValue: YamlSection[] | undefined;
-
-/**
- * Extracts top-level YAML keys and their line ranges.
- * Top-level keys have no leading whitespace (e.g. `esphome:`, `wifi:`).
- * Sections containing YAML list items (e.g. `light:\n  - platform: binary`)
- * are expanded so each list item becomes its own section with name/platform metadata.
- */
-export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
-  if (_topLevelSectionsKey === yaml && _topLevelSectionsValue) {
-    return _topLevelSectionsValue;
-  }
-  const lines = yaml.split("\n");
-  const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
-    if (match) {
-      if (rawSections.length > 0) {
-        // The previous section content ends one line before the new
-        // top-level key. Walk backward over trailing blank /
-        // comment-only lines: those typically decorate the upcoming
-        // section ("## Substitutions ##" sitting above
-        // ``substitutions:``) rather than belonging to the one
-        // ending. Without the trim, hovering ``runtime_stats`` in the
-        // navigator highlights the comment block that visually
-        // documents ``substitutions``.
-        const prev = rawSections[rawSections.length - 1];
-        const prevStart = prev.fromLine - 1; // 0-indexed
-        let endIdx = i - 1;
-        while (endIdx > prevStart && _isBlankOrBannerComment(lines[endIdx])) {
-          endIdx--;
-        }
-        prev.toLine = endIdx + 1;
-      }
-      rawSections.push({
-        key: match[1],
-        fromLine: i + 1, // convert 0-indexed array to 1-indexed CM line
-        toLine: lines.length,
-      });
-    }
-  }
-
-  // Trim trailing blank / comment-only lines from the final section
-  // for the same reason as above — a comment block at the very end
-  // of the file (or right before EOF whitespace) shouldn't extend
-  // the last section's hover-highlight range.
-  if (rawSections.length > 0) {
-    const last = rawSections[rawSections.length - 1];
-    const lastStart = last.fromLine - 1; // 0-indexed
-    let endIdx = lines.length - 1;
-    // Drop the conventional trailing newline-empty-string before
-    // the trim loop so we don't double-count it.
-    if (endIdx >= 0 && lines[endIdx] === "") endIdx--;
-    while (endIdx > lastStart && _isBlankOrBannerComment(lines[endIdx])) {
-      endIdx--;
-    }
-    last.toLine = endIdx + 1;
-  }
-
-  // Expand list items within each section
-  const sections: YamlSection[] = [];
-  for (const raw of rawSections) {
-    sections.push(..._expandListItems(lines, raw));
-  }
-
-  _topLevelSectionsKey = yaml;
-  _topLevelSectionsValue = sections;
-  return sections;
-}
-
-/**
- * Test-only: clear the `parseYamlTopLevelSections` memo so cached
- * results from a prior test case don't leak into the next. Mirrors
- * `_clearScanMemos` in `config-entry-yaml-scan.ts`.
- */
-export function _clearYamlSectionsMemo(): void {
-  _topLevelSectionsKey = undefined;
-  _topLevelSectionsValue = undefined;
-}
-
-/**
- * If a top-level section contains YAML list items (`  - `), expand each into
- * its own YamlSection with name, platform, and parentKey metadata.
- * Otherwise return the section as-is.
- */
-function _expandListItems(
-  lines: string[],
-  section: { key: string; fromLine: number; toLine: number }
-): YamlSection[] {
-  // LIST_SECTIONS members keep their list items hidden from the
-  // navigator — the user navigates to the whole block (edited as a
-  // repeatable list), not the individual entries (e.g. globals).
-  if (LIST_SECTIONS.has(section.key)) {
-    return [
-      {
-        key: section.key,
-        fromLine: section.fromLine,
-        toLine: section.toLine,
-      },
-    ];
-  }
-
-  const keyIdx = section.fromLine - 1; // 0-indexed line of the top-level key
-  const endIdx = section.toLine - 1; // 0-indexed last line (inclusive)
-
-  // Find list item starts (`  - ` or `  -\n`)
-  const listStarts: number[] = [];
-  for (let i = keyIdx + 1; i <= endIdx; i++) {
-    if (/^  -\s/.test(lines[i]) || /^  -$/.test(lines[i])) {
-      listStarts.push(i);
-    }
-  }
-
-  if (listStarts.length === 0) {
-    // Single-instance section (e.g. `uart:` configured as a flat
-    // dict with `id:`, `tx_pin:` etc. directly under it). Extract a
-    // top-level `id:`/`name:` so the navigator can show them as the
-    // primary label instead of falling back to the bare key.
-    let name = "";
-    let id = "";
-    for (let i = keyIdx + 1; i <= endIdx; i++) {
-      const nameMatch = lines[i].match(/^\s{2}name:\s*["']?(.+?)["']?\s*$/);
-      if (nameMatch) name = nameMatch[1];
-      const idMatch = lines[i].match(/^\s{2}id:\s*["']?(\S+?)["']?\s*$/);
-      if (idMatch) id = idMatch[1];
-    }
-    return [
-      {
-        key: section.key,
-        fromLine: section.fromLine,
-        toLine: section.toLine,
-        name: name || undefined,
-        id: id || undefined,
-      },
-    ];
-  }
-
-  const items: YamlSection[] = [];
-  for (let idx = 0; idx < listStarts.length; idx++) {
-    const itemStart = listStarts[idx];
-    const itemEnd = idx + 1 < listStarts.length ? listStarts[idx + 1] - 1 : endIdx;
-
-    let name = "";
-    let id = "";
-    let platform = "";
-    // Only the list item's own top-level keys count: the dash line's
-    // inline key, plus continuation keys at exactly the direct-child
-    // indent. Deeper lines belong to nested sub-mappings (a sensor
-    // platform's temperature:/humidity: blocks, the debug component's
-    // per-metric sensors) whose name:/id: must not override the item's.
-    const dashIndent = lines[itemStart].match(/^ */)?.[0].length ?? 0;
-    const childIndent = dashIndent + 2;
-    for (let j = itemStart; j <= itemEnd; j++) {
-      const line = lines[j];
-      if (j !== itemStart) {
-        const indent = line.match(/^ */)?.[0].length ?? 0;
-        if (indent !== childIndent) continue;
-      }
-      const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
-      if (nameMatch) name = nameMatch[1];
-      const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
-      if (idMatch) id = idMatch[1];
-      const platformMatch = line.match(/^\s+(?:-\s+)?platform:\s*["']?(\S+?)["']?\s*$/);
-      if (platformMatch) platform = platformMatch[1];
-    }
-
-    items.push({
-      key: section.key,
-      fromLine: itemStart + 1, // 1-indexed
-      toLine: itemEnd + 1, // 1-indexed
-      name: name || undefined,
-      id: id || undefined,
-      platform: platform || undefined,
-      parentKey: section.key,
-    });
-  }
-
-  return items;
 }
 
 /**
@@ -445,33 +209,21 @@ export function sectionAtLine(yaml: string, line: number): YamlSection | null {
   // automation parser doesn't touch (regular components, ``wifi:``,
   // ``esphome:``, etc.).
   // Skip ``automation:unscoped:*`` entries: those mark inline
-  // ``on_*:`` handlers whose host component has no ``id:`` and so
-  // can't be addressed by the structured editor (location decoder
-  // returns null for them). Routing a click there would hand the
-  // section editor an unknown key and surface as an error; better
+  // ``on_*:`` handlers with no addressable host (a flat single-
+  // instance block, or no resolvable enclosing block) — the location
+  // decoder returns null for them. Routing a click there would hand
+  // the section editor an unknown key and surface as an error; better
   // to fall through to the enclosing top-level section so the user
-  // lands somewhere useful.
+  // lands somewhere useful. id-less list-item instances are *not*
+  // unscoped (they resolve to a positional ``<domain>_<idx>``), so
+  // their triggers route normally.
   const autos = parseYamlAutomations(yaml).filter(
     (s) => !s.key.startsWith("automation:unscoped:")
   );
-  const autoHit = _smallestContaining(autos, line);
+  const autoHit = smallestContainingSection(autos, line);
   if (autoHit) return autoHit;
   const tops = parseYamlTopLevelSections(yaml);
-  return _smallestContaining(tops, line);
-}
-
-function _smallestContaining(sections: YamlSection[], line: number): YamlSection | null {
-  let best: YamlSection | null = null;
-  let bestSpan = Number.POSITIVE_INFINITY;
-  for (const s of sections) {
-    if (line < s.fromLine || line > s.toLine) continue;
-    const span = s.toLine - s.fromLine;
-    if (span < bestSpan) {
-      best = s;
-      bestSpan = span;
-    }
-  }
-  return best;
+  return smallestContainingSection(tops, line);
 }
 
 /**

--- a/test/components/device/section-config-shortcut-target.test.ts
+++ b/test/components/device/section-config-shortcut-target.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins `_shortcutTarget` — the per-section "+ Add automation" / triggers-
+ * list gate. It is the second consumer of `instanceComponentId`; the
+ * regression Kōan/Copilot flagged was this gate drifting from
+ * `parseYamlAutomations` (a flat block with an explicit id offered a
+ * shortcut the parser scoped as `unscoped`). These tests lock the gate's
+ * classification and assert it agrees with the parser for the same YAML.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import {
+  _clearYamlSectionsMemo,
+  parseYamlAutomations,
+} from "../../../src/util/yaml-sections.js";
+
+type Target =
+  | null
+  | { kind: "device_on" }
+  | { kind: "component_on"; componentId: string };
+
+/** Drive `_shortcutTarget` in isolation — it reads only `yaml`,
+ *  `sectionKey`, and `_resolvedFromLine`, no DOM / API. */
+const shortcutTarget = (
+  yaml: string,
+  sectionKey: string,
+  resolvedFromLine?: number
+): Target => {
+  const c = new ESPHomeDeviceSectionConfig();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = c as any;
+  inner.yaml = yaml;
+  inner.sectionKey = sectionKey;
+  if (resolvedFromLine !== undefined) inner._resolvedFromLine = resolvedFromLine;
+  return inner._shortcutTarget();
+};
+
+beforeEach(() => {
+  _clearYamlSectionsMemo();
+});
+
+describe("_shortcutTarget", () => {
+  it("returns device_on for the esphome block", () => {
+    expect(shortcutTarget("esphome:\n  name: x\n", "esphome")).toEqual({
+      kind: "device_on",
+    });
+  });
+
+  it("returns null for hide-keys (api / script / substitutions …)", () => {
+    const yaml = "substitutions:\n  foo: bar\n";
+    expect(shortcutTarget(yaml, "substitutions")).toBeNull();
+  });
+
+  it("scopes an id-less list instance to its positional id", () => {
+    const yaml = `switch:
+  - platform: template
+    name: My Switch
+    on_turn_on:
+      - logger.log: "on"
+`;
+    expect(shortcutTarget(yaml, "switch.template")).toEqual({
+      kind: "component_on",
+      componentId: "switch_0",
+    });
+  });
+
+  it("uses the declared id for an id'd list instance", () => {
+    const yaml = `switch:
+  - platform: gpio
+    id: my_relay
+    on_turn_on:
+      - logger.log: "on"
+`;
+    expect(shortcutTarget(yaml, "switch.gpio")).toEqual({
+      kind: "component_on",
+      componentId: "my_relay",
+    });
+  });
+
+  it("returns null for a flat block even with an explicit id (no broken shortcut)", () => {
+    // The exact regression: `sun:` is a flat single-instance block that
+    // can carry an id and host on_sunrise, but the backend can't address
+    // it, so the gate must offer no shortcut (matching the parser's
+    // `unscoped`).
+    const yaml = `sun:
+  id: my_sun
+  latitude: 0°
+  on_sunrise:
+    - then:
+        - logger.log: "x"
+`;
+    expect(shortcutTarget(yaml, "sun")).toBeNull();
+  });
+
+  it("routes multi-instance sections by _resolvedFromLine", () => {
+    const yaml = `switch:
+  - platform: template
+    name: A
+    on_turn_on:
+      - logger.log: "a"
+  - platform: template
+    name: B
+    on_turn_on:
+      - logger.log: "b"
+`;
+    expect(shortcutTarget(yaml, "switch.template", 2)).toEqual({
+      kind: "component_on",
+      componentId: "switch_0",
+    });
+    expect(shortcutTarget(yaml, "switch.template", 6)).toEqual({
+      kind: "component_on",
+      componentId: "switch_1",
+    });
+  });
+
+  it("agrees with parseYamlAutomations on the component id (no caller drift)", () => {
+    // Same fixture through both callers; the triggers list filters parsed
+    // automations by `s.id === target.componentId`, so these must match.
+    const cases: Array<[string, string]> = [
+      [
+        `switch:\n  - platform: template\n    name: My Switch\n    on_turn_on:\n      - logger.log: "on"\n`,
+        "switch.template",
+      ],
+      [
+        `switch:\n  - platform: gpio\n    id: my_relay\n    on_turn_on:\n      - logger.log: "on"\n`,
+        "switch.gpio",
+      ],
+    ];
+    for (const [yaml, sectionKey] of cases) {
+      _clearYamlSectionsMemo();
+      const target = shortcutTarget(yaml, sectionKey);
+      const parsed = parseYamlAutomations(yaml).find((s) =>
+        s.key.startsWith("automation:component_on:")
+      );
+      expect(target).not.toBeNull();
+      expect(parsed?.id).toBe(
+        (target as { kind: "component_on"; componentId: string }).componentId
+      );
+    }
+  });
+});

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -3,6 +3,7 @@ import { parseYamlSectionValues } from "../../src/util/yaml-section-values.js";
 import {
   _clearYamlSectionsMemo,
   categorizeSections,
+  instanceComponentId,
   parseYamlAutomations,
   parseYamlTopLevelSections,
   resolveCurrentFromLine,
@@ -584,6 +585,225 @@ describe("parseYamlAutomations", () => {
     expect(items.map((s) => s.key)).toEqual([
       "automation:component_on:my_button:on_press",
     ]);
+  });
+
+  it("scopes an id-less component's on_* to its positional <domain>_<idx>", () => {
+    const yaml = `switch:
+  - platform: template
+    name: "My Switch"
+    on_turn_on:
+      - logger.log: "on"
+`;
+    const result = parseYamlAutomations(yaml);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("automation:component_on:switch_0:on_turn_on");
+    expect(result[0].id).toBe("switch_0");
+    // Label still prefers the instance name when one is present.
+    expect(result[0].displayLabel).toBe("My Switch → on_turn_on");
+  });
+
+  it("labels a nameless id-less component by its positional id", () => {
+    const yaml = `switch:
+  - platform: template
+    on_turn_on:
+      - logger.log: "on"
+`;
+    const [entry] = parseYamlAutomations(yaml);
+    expect(entry.key).toBe("automation:component_on:switch_0:on_turn_on");
+    expect(entry.displayLabel).toBe("switch_0 → on_turn_on");
+  });
+
+  it("splits an id-less time.on_time list under its positional id", () => {
+    const yaml = `time:
+  - platform: sntp
+    on_time:
+      - seconds: 0
+        then:
+          - logger.log: "tick"
+      - cron: "0 0 12 * * *"
+        then:
+          - logger.log: "noon"
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:time_0:")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:time_0:on_time:0",
+      "automation:component_on:time_0:on_time:1",
+    ]);
+  });
+
+  it("advances the positional index across id'd siblings in the same domain", () => {
+    const yaml = `switch:
+  - platform: template
+    on_turn_on:
+      - logger.log: "a"
+  - platform: gpio
+    id: my_relay
+    on_turn_on:
+      - logger.log: "b"
+  - platform: template
+    on_turn_on:
+      - logger.log: "c"
+`;
+    const ids = parseYamlAutomations(yaml)
+      .filter((s) => s.key.startsWith("automation:component_on:"))
+      .map((s) => s.id);
+    expect(ids).toEqual(["switch_0", "my_relay", "switch_2"]);
+  });
+
+  it("indexes id-less instances across mixed platforms in one domain", () => {
+    const yaml = `sensor:
+  - platform: dht
+    on_value:
+      - logger.log: "a"
+  - platform: adc
+    on_value:
+      - logger.log: "b"
+`;
+    const ids = parseYamlAutomations(yaml)
+      .filter((s) => s.key.startsWith("automation:component_on:"))
+      .map((s) => s.id);
+    expect(ids).toEqual(["sensor_0", "sensor_1"]);
+  });
+
+  it("leaves a flat single-instance block's on_* unscoped", () => {
+    const yaml = `wifi:
+  on_connect:
+    - logger.log: "up"
+`;
+    const [entry] = parseYamlAutomations(yaml);
+    expect(entry.key).toBe("automation:unscoped:on_connect:2");
+    expect(entry.id).toBeUndefined();
+  });
+
+  it("scopes a direct on_value on a single-value sensor", () => {
+    const yaml = `sensor:
+  - platform: adc
+    pin: GPIO1
+    on_value:
+      - logger.log: "v"
+`;
+    const [entry] = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:")
+    );
+    expect(entry.key).toBe("automation:component_on:sensor_0:on_value");
+  });
+
+  it("scopes a direct on_* regardless of spaces after the dash (no fixed +2)", () => {
+    // Extra spaces after the dash push the item's child column past
+    // dash+2; the handler aligned there is still a direct trigger and
+    // must scope, not be mistaken for a nested one.
+    const yaml = `switch:
+  -   platform: template
+      on_turn_on:
+        - logger.log: "on"
+`;
+    const [entry] = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:")
+    );
+    expect(entry.key).toBe("automation:component_on:switch_0:on_turn_on");
+  });
+
+  it("leaves a nested sub-component on_* unscoped (backend parses direct keys only)", () => {
+    // ``on_value`` lives under the ``temperature:`` sub-mapping, not as a
+    // direct key on the dht list item, so the backend's instance.items()
+    // scan never sees it. The fallback parser must not claim a
+    // ``sensor_0`` handle ``automations/parse`` won't confirm.
+    const yaml = `sensor:
+  - platform: dht
+    temperature:
+      name: Temp
+      on_value:
+        - logger.log: "x"
+`;
+    const entry = parseYamlAutomations(yaml).find((s) => s.key.includes("on_value"));
+    expect(entry?.key).toBe("automation:unscoped:on_value:5");
+    expect(entry?.id).toBeUndefined();
+  });
+
+  it("leaves a flat block with an explicit id unscoped (backend addresses lists only)", () => {
+    // ``sun:`` is a flat single-instance component that can carry an ``id:``
+    // and host ``on_sunrise:`` — but the backend only resolves inline
+    // handlers under list domains, so the shortcut gate and the parser must
+    // both treat it as unscoped rather than emitting a component_on the
+    // backend can't address.
+    const yaml = `sun:
+  id: my_sun
+  latitude: 0°
+  longitude: 0°
+  on_sunrise:
+    - logger.log: "up"
+`;
+    const [entry] = parseYamlAutomations(yaml);
+    expect(entry.key).toBe("automation:unscoped:on_sunrise:5");
+    expect(entry.id).toBeUndefined();
+  });
+});
+
+describe("instanceComponentId", () => {
+  const componentIdAt = (yaml: string, fromLine: number): string | null => {
+    const sections = parseYamlTopLevelSections(yaml);
+    const match = sections.find((s) => s.fromLine === fromLine);
+    if (!match) throw new Error(`no section at line ${fromLine}`);
+    return instanceComponentId(sections, match);
+  };
+
+  it("returns the declared id when present", () => {
+    const yaml = `switch:
+  - platform: gpio
+    id: my_relay
+`;
+    expect(componentIdAt(yaml, 2)).toBe("my_relay");
+  });
+
+  it("synthesises <domain>_<idx> for an id-less list instance", () => {
+    const yaml = `switch:
+  - platform: template
+  - platform: gpio
+`;
+    expect(componentIdAt(yaml, 2)).toBe("switch_0");
+    expect(componentIdAt(yaml, 3)).toBe("switch_1");
+  });
+
+  it("advances the index across id'd siblings (backend enumerate parity)", () => {
+    const yaml = `switch:
+  - platform: template
+  - platform: gpio
+    id: my_relay
+  - platform: template
+`;
+    expect(componentIdAt(yaml, 2)).toBe("switch_0");
+    expect(componentIdAt(yaml, 3)).toBe("my_relay");
+    expect(componentIdAt(yaml, 5)).toBe("switch_2");
+  });
+
+  it("returns null for a flat single-instance block", () => {
+    const yaml = `wifi:
+  ssid: home
+`;
+    expect(componentIdAt(yaml, 1)).toBeNull();
+  });
+
+  it("returns null for a flat block even when it declares an explicit id", () => {
+    const yaml = `sun:
+  id: my_sun
+  latitude: 0°
+`;
+    expect(componentIdAt(yaml, 1)).toBeNull();
+  });
+
+  it("indexes by fromLine order, not object identity (reconstructed match still resolves)", () => {
+    const yaml = `switch:
+  - platform: template
+  - platform: gpio
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    const real = sections.find((s) => s.fromLine === 3);
+    if (!real) throw new Error("no section at line 3");
+    // A detached copy: different object identity, same fromLine/parentKey.
+    const detached = { ...real };
+    expect(instanceComponentId(sections, detached)).toBe("switch_1");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

In the Visual Editor, a component instance with no `id:` field showed no per-section "Automations" list and no "+ Add automation" shortcut — even though components like `switch` and `time` legitimately host inline `on_*:` triggers (`on_turn_on`, `on_time`, …) without an id. Adding an `id:` made the automations appear.

The backend already handles id-less instances: it addresses them by a positional `<domain>_<idx>` synthetic id (`idx` = the instance's position in the `<domain>:` list, document order), and `automations/parse` / `upsert` / `delete` all resolve that handle. The frontend simply never produced it — the shortcut gate returned `null` without a literal `id:`, and the keystroke-time parser dropped id-less inline handlers into an `unscoped` bucket.

This change mirrors the backend's convention on the frontend:

- A single `instanceComponentId(sections, match)` helper returns the declared `id:` or the positional `<domain>_<idx>`. Both the shortcut gate (`_shortcutTarget`) and the parser (`parseYamlAutomations`) consume it, so the two cannot drift apart (which would silently break the `s.id === target.componentId` match).
- Flat single-instance blocks (`wifi:` and friends) stay `unscoped` — the backend only synthesises ids for list domains, so a non-list host has no positional id to address.
- The parser's component path is unified on the shared section parse, retiring the separate `_walkAncestry` line-walk so `parentKey` / `id` / `name` / index all come from one source of truth (`parseYamlTopLevelSections`). The containment helper is exported as `smallestContainingSection` and reused.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1134

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
