### PR TITLE
Derive list-item child indent instead of assuming dash + 2

### DIFF
--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -5,9 +5,9 @@
  * unaffected; import from there or from here directly.
  */
 
-import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import {
   instanceComponentId,
+  listItemChildIndent,
   parseYamlTopLevelSections,
   smallestContainingSection,
   type YamlSection,
@@ -89,7 +89,7 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
     if (
       host &&
       host.parentKey !== undefined &&
-      indent === _itemChildIndent(lines, host.fromLine)
+      indent === listItemChildIndent(lines[host.fromLine - 1] ?? "")
     ) {
       componentId = instanceComponentId(sections, host);
     }
@@ -224,18 +224,6 @@ function _findBlockEnd(lines: string[], startIdx: number, indent: number): numbe
     if (lineIndent <= indent) return j;
   }
   return lines.length;
-}
-
-/** Column where a list item's direct child keys sit — the first key
- *  after the ``- `` marker on *dashFromLine* (1-indexed). Derived from the
- *  line rather than assuming a fixed step, since configs may put any
- *  number of spaces after the dash; falls back to one indent past the
- *  dash when the dash line carries no inline key. */
-function _itemChildIndent(lines: string[], dashFromLine: number): number {
-  const dashLine = lines[dashFromLine - 1] ?? "";
-  const inline = dashLine.match(/^\s*-\s+(?=\S)/)?.[0].length;
-  if (inline !== undefined) return inline;
-  return _dashIndent(dashLine) + ESPHOME_YAML_INDENT.length;
 }
 
 /** Top-level key block (``script:`` / ``interval:``) with its

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -10,6 +10,7 @@
  * importing these from `./yaml-sections.js` are unaffected.
  */
 
+import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 
 export interface YamlSection {
@@ -234,8 +235,7 @@ function _expandListItems(
     // indent. Deeper lines belong to nested sub-mappings (a sensor
     // platform's temperature:/humidity: blocks, the debug component's
     // per-metric sensors) whose name:/id: must not override the item's.
-    const dashIndent = lines[itemStart].match(/^ */)?.[0].length ?? 0;
-    const childIndent = dashIndent + 2;
+    const childIndent = listItemChildIndent(lines[itemStart]);
     for (let j = itemStart; j <= itemEnd; j++) {
       const line = lines[j];
       if (j !== itemStart) {
@@ -318,4 +318,19 @@ export function instanceComponentId(
     if (s.parentKey === domain && s.fromLine < match.fromLine) idx++;
   }
   return `${domain}_${idx}`;
+}
+
+/**
+ * Column where a list item's direct child keys sit — the first key after
+ * the ``- `` marker on *dashLine*. Derived from the line rather than
+ * assuming a fixed step: configs may put any number of spaces after the
+ * dash (``-   platform:`` → children align past ``dash + 2``), and a
+ * fixed ``+2`` would miss continuation ``id:`` / ``name:`` keys. Falls
+ * back to one indent past the dash when the dash carries no inline key.
+ */
+export function listItemChildIndent(dashLine: string): number {
+  const inline = dashLine.match(/^\s*-\s+(?=\S)/)?.[0].length;
+  if (inline !== undefined) return inline;
+  const dashIndent = dashLine.match(/^ */)?.[0].length ?? 0;
+  return dashIndent + ESPHOME_YAML_INDENT.length;
 }

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -52,6 +52,19 @@ wifi:
     expect(sections[1].name).toBe("bedroom");
   });
 
+  it("extracts continuation id/name when the dash has extra spaces", () => {
+    // ``-   platform`` pushes the child column past dash+2; id/name on
+    // continuation lines must still be picked up (a fixed +2 missed them).
+    const yaml = `switch:
+  -   platform: gpio
+      id: my_relay
+      name: My Relay
+`;
+    const sw = parseYamlTopLevelSections(yaml).find((s) => s.parentKey === "switch");
+    expect(sw?.id).toBe("my_relay");
+    expect(sw?.name).toBe("My Relay");
+  });
+
   it("keeps a LIST_SECTIONS member (globals) as one un-expanded section", () => {
     // A plain list section (sensor above) expands per item; a
     // LIST_SECTIONS member stays a single header entry so the nav
@@ -703,6 +716,22 @@ describe("parseYamlAutomations", () => {
       s.key.startsWith("automation:component_on:")
     );
     expect(entry.key).toBe("automation:component_on:switch_0:on_turn_on");
+  });
+
+  it("uses the declared id under an extra-space dash (not a positional fallback)", () => {
+    // Regression: a continuation ``id:`` under ``-   platform`` was missed,
+    // so the trigger scoped to ``switch_0`` instead of the real id — a
+    // handle the backend (which sees the id structurally) can't match.
+    const yaml = `switch:
+  -   platform: gpio
+      id: my_relay
+      on_turn_on:
+        - logger.log: "on"
+`;
+    const [entry] = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:")
+    );
+    expect(entry.key).toBe("automation:component_on:my_relay:on_turn_on");
   });
 
   it("leaves a nested sub-component on_* unscoped (backend parses direct keys only)", () => {


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #552 (a post-merge Copilot review flagged this). `_expandListItems` derived a list item's `id` / `name` / `platform` only from continuation lines at exactly `dashIndent + 2`. When the dash carries extra spaces — e.g. `-   platform: gpio` — the item's keys align to the first content column (past `dash + 2`), so a continuation `id:` was **missed**. `instanceComponentId` then fell back to a positional `<domain>_<idx>` instead of the declared id, drifting from the backend (which parses the id structurally) and breaking inline-automation round-trips for that instance:

```yaml
switch:
  -   platform: gpio   # extra spaces after the dash
      id: my_relay     # was dropped → instanceComponentId returned "switch_0"
      on_turn_on:
        - logger.log: "on"
```

Fix: a shared `listItemChildIndent` helper derives the child column from the dash line (the first key after `- `) rather than assuming a fixed step, used by both `_expandListItems` and the automation parser's direct-child check (replacing the per-file `_itemChildIndent`, so the two can't drift). Standard single-space dashes are unaffected. Falls back to one `ESPHOME_YAML_INDENT` step past the dash when the dash carries no inline key.

Tests: continuation `id`/`name` extraction under an extra-space dash; `instanceComponentId` / the parser using the declared id (not a positional fallback) for that shape.

**Related issue or feature (if applicable):**

- follow-up to #552

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
