### PR TITLE
Use listItemChildIndent for trigger-entry detection

### DIFF
--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -342,10 +342,11 @@ function _isTriggerEntry(
   const dashLine = lines[item.fromLine - 1] ?? "";
   // The first key can sit inline on the dash: ``- seconds: 0``.
   if (_DASH_TRIGGER_ENTRY_KEY_RE.test(dashLine)) return true;
-  // Otherwise a sibling key at the item's own content indent (``- `` is a
-  // dash plus one space, so two columns in). A deeper match — a ``then:``
+  // Otherwise a sibling key at the item's own content indent — the column
+  // of the first key after ``- ``, derived (not assumed ``+2``) so an
+  // extra-space dash doesn't throw it off. A deeper match — a ``then:``
   // nested under an ``if`` action — is not the entry's own key.
-  const contentIndent = _dashIndent(dashLine) + 2;
+  const contentIndent = listItemChildIndent(dashLine);
   for (let i = item.fromLine; i < item.toLine && i < lines.length; i++) {
     const m = lines[i].match(_TRIGGER_ENTRY_KEY_RE);
     if (m && m[1].length === contentIndent) return true;

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -584,6 +584,33 @@ describe("parseYamlAutomations", () => {
     expect(items.map((s) => s.key)).toEqual(["automation:component_on:my_time:on_time"]);
   });
 
+  it("splits a list-shaped on_time when entries use an extra-space dash and a non-trigger first key", () => {
+    // ``-   id:`` — the inline key isn't a trigger key, so the inline
+    // short-circuit doesn't fire; the sibling ``seconds:`` aligns past
+    // dash+2, so a fixed step would miss it and the block would collapse
+    // to one un-indexed row.
+    const yaml = `time:
+  - platform: sntp
+    id: my_time
+    on_time:
+      -   id: morning
+          seconds: 0
+          then:
+            - logger.log: "a"
+      -   id: noon
+          seconds: 30
+          then:
+            - logger.log: "b"
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:my_time:on_time")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:my_time:on_time:0",
+      "automation:component_on:my_time:on_time:1",
+    ]);
+  });
+
   it("does not split a bare action list into per-action rows", () => {
     const yaml = `binary_sensor:
   - platform: gpio


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #554 — the optional consistency item Kōan flagged on that PR. `_isTriggerEntry` still derived a cron entry's content indent with the hardcoded `_dashIndent(dashLine) + 2`, the last site carrying the assumption #554 centralized into `listItemChildIndent`.

It's the same latent bug for the sibling-key path: with an extra-space entry dash whose *first inline key isn't a trigger key*, the sibling trigger key aligns past `dash + 2` and is missed — and because the inline key isn't a trigger key, the `_DASH_TRIGGER_ENTRY_KEY_RE` short-circuit doesn't fire either. The `on_time:` list then collapses to a single un-indexed row instead of one row per entry:

```yaml
on_time:
  -   id: morning   # inline key is `id:` → not a trigger key
      seconds: 0    # aligns at col 6, but dash+2 = 4 → missed
      then:
        - logger.log: "a"
```

Fix: route this third site through the shared `listItemChildIndent` helper so every list-item child-indent derivation agrees ("can't drift"). Standard single-space dashes are unaffected (the helper returns the same column there). Adds a regression test for the extra-space, non-trigger-first-key `on_time` shape.

**Related issue or feature (if applicable):**

- follow-up to #554

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
