### PR TITLE
Surface inline automations on flat singleton components (sun:, mqtt:)

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -588,11 +588,13 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       this._resolvedFromLine !== undefined
         ? (candidates.find((s) => s.fromLine === this._resolvedFromLine) ?? candidates[0])
         : candidates[0];
-    // Only host automations where the domain actually has triggers
+    // Only host automations where the section actually has triggers
     // (mirrors the backend's ``_component_trigger_domains`` gate), so a
-    // trigger-less component like ``web_server:`` shows no panel.
-    const domain = match.parentKey ?? match.key;
-    if (!this._triggerCatalog.hasTriggersFor(domain)) return null;
+    // trigger-less component like ``web_server:`` shows no panel. Check the
+    // bare domain and the qualified ``<domain>.<platform>``, since a
+    // trigger may be scoped to either (``switch`` vs ``output.slow_pwm``).
+    const scopes = [match.parentKey ?? match.key, this.sectionKey];
+    if (!this._triggerCatalog.hasTriggersFor(scopes)) return null;
     return { kind: "component_on", componentId: instanceComponentId(sections, match) };
   }
 

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -567,14 +567,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   }
 
   /**
-   * Classify the current section for the per-section "+ Add
-   * automation" / triggers-list shortcut. Returns ``null`` when the
-   * section can't host inline ``on_*:`` automations (api has its own
-   * shortcut; script/interval have their own navigator CTAs; data-
-   * only blocks like substitutions never carry triggers; flat
-   * single-instance blocks have no positional id to address).
-   * id-less list-item instances resolve to the backend's positional
-   * ``<domain>_<idx>`` id, so they host automations like id'd ones.
+   * Target for the per-section "+ Add automation" / triggers-list
+   * shortcut: ``null`` for ``SHORTCUT_HIDE_KEYS`` (api / script / data-
+   * only blocks), ``device_on`` for ``esphome:``, else ``component_on``
+   * keyed by the instance's addressable id (list item or flat singleton).
    */
   private _shortcutTarget():
     | null
@@ -582,10 +578,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     | { kind: "component_on"; componentId: string } {
     if (SHORTCUT_HIDE_KEYS.has(this.sectionKey)) return null;
     if (this.sectionKey === "esphome") return { kind: "device_on" };
-    // Otherwise this should be a regular component instance — a list
-    // item under a top-level platform block. Look it up by matching
-    // section key, biased toward the section's currently-resolved
-    // fromLine so multi-instance components route to the right entry.
+    // A configured component (list item or flat singleton), matched by
+    // section key and biased to the resolved fromLine for multi-instance.
     const sections = parseYamlTopLevelSections(this.yaml);
     const candidates = sections.filter((s) => sectionKeyOf(s) === this.sectionKey);
     if (candidates.length === 0) return null;
@@ -593,9 +587,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       this._resolvedFromLine !== undefined
         ? (candidates.find((s) => s.fromLine === this._resolvedFromLine) ?? candidates[0])
         : candidates[0];
-    const componentId = instanceComponentId(sections, match);
-    if (componentId === null) return null;
-    return { kind: "component_on", componentId };
+    return { kind: "component_on", componentId: instanceComponentId(sections, match) };
   }
 
   /**

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -568,9 +568,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   /**
    * Target for the per-section "+ Add automation" / triggers-list
-   * shortcut: ``null`` for ``SHORTCUT_HIDE_KEYS`` (api / script / data-
-   * only blocks), ``device_on`` for ``esphome:``, else ``component_on``
-   * keyed by the instance's addressable id (list item or flat singleton).
+   * shortcut: ``null`` for ``SHORTCUT_HIDE_KEYS`` and domains with no
+   * catalog triggers (so trigger-less components like ``web_server:`` show
+   * no panel); ``device_on`` for ``esphome:``; else ``component_on`` keyed
+   * by the instance's addressable id (list item or flat singleton).
    */
   private _shortcutTarget():
     | null
@@ -587,6 +588,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
       this._resolvedFromLine !== undefined
         ? (candidates.find((s) => s.fromLine === this._resolvedFromLine) ?? candidates[0])
         : candidates[0];
+    // Only host automations where the domain actually has triggers
+    // (mirrors the backend's ``_component_trigger_domains`` gate), so a
+    // trigger-less component like ``web_server:`` shows no panel.
+    const domain = match.parentKey ?? match.key;
+    if (!this._triggerCatalog.hasTriggersFor(domain)) return null;
     return { kind: "component_on", componentId: instanceComponentId(sections, match) };
   }
 

--- a/src/components/device/trigger-catalog-controller.ts
+++ b/src/components/device/trigger-catalog-controller.ts
@@ -67,13 +67,15 @@ export class TriggerCatalogController implements ReactiveController {
     return triggers.find((t) => t.id === catalogId)?.name || fallback;
   }
 
-  /** True when the catalog has a component trigger for `domain`. Fails
-   *  open until the catalog loads so a section's existing automations are
-   *  never briefly hidden mid-fetch. */
-  hasTriggersFor(domain: string): boolean {
+  /** True when the catalog has a component trigger scoped to any of
+   *  `scopes` (a section's bare domain and its qualified
+   *  ``<domain>.<platform>`` — triggers list one or the other). Fails open
+   *  until the catalog loads so existing automations aren't briefly hidden
+   *  mid-fetch. */
+  hasTriggersFor(scopes: string[]): boolean {
     const { platform, boardId } = this._context();
     const triggers = getCachedAutomationTriggers(platform, boardId);
     if (!triggers) return true;
-    return triggers.some((t) => t.applies_to.includes(domain));
+    return triggers.some((t) => t.applies_to.some((a) => scopes.includes(a)));
   }
 }

--- a/src/components/device/trigger-catalog-controller.ts
+++ b/src/components/device/trigger-catalog-controller.ts
@@ -66,4 +66,14 @@ export class TriggerCatalogController implements ReactiveController {
     const catalogId = domain === "esphome" ? eventKey : `${domain}.${eventKey}`;
     return triggers.find((t) => t.id === catalogId)?.name || fallback;
   }
+
+  /** True when the catalog has a component trigger for `domain`. Fails
+   *  open until the catalog loads so a section's existing automations are
+   *  never briefly hidden mid-fetch. */
+  hasTriggersFor(domain: string): boolean {
+    const { platform, boardId } = this._context();
+    const triggers = getCachedAutomationTriggers(platform, boardId);
+    if (!triggers) return true;
+    return triggers.some((t) => t.applies_to.includes(domain));
+  }
 }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -53,11 +53,8 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
     const fromLine = i + 1; // 1-indexed CM line
     const toLine = _findBlockEnd(lines, i, indent);
 
-    // Resolve the host from the shared section parse — one source of
-    // truth for parentKey / id / name / index. An id-less list instance
-    // gets the backend's positional ``<domain>_<idx>`` so it surfaces
-    // and round-trips like an id'd one; a flat block (``esphome:``)
-    // hosts device-level triggers instead.
+    // The enclosing section: a list-item instance, a flat singleton, or
+    // the ``esphome:`` block (device-level, handled next).
     const host = smallestContainingSection(sections, fromLine);
 
     if (host && host.parentKey === undefined && host.key === "esphome") {
@@ -76,21 +73,10 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
       continue;
     }
 
-    // One source of truth: the helper returns the declared / positional id
-    // for a list-item host and null for a flat block (``sun:`` with an id is
-    // still null — the backend can't address it), so this matches what
-    // ``_shortcutTarget`` resolves for the same section. Only a *direct*
-    // ``on_*`` child of the list item scopes to it: the backend parses an
-    // instance's own ``on_*`` keys, not ones nested under a sub-mapping
-    // (``sensor[i].temperature.on_value``), so a deeper handler falls
-    // through to ``unscoped`` rather than claiming a handle that
-    // ``automations/parse`` won't confirm.
+    // Only a direct ``on_*`` child scopes to the host; a deeper handler
+    // (``sensor[i].temperature.on_value``) isn't addressable → ``unscoped``.
     let componentId: string | null = null;
-    if (
-      host &&
-      host.parentKey !== undefined &&
-      indent === listItemChildIndent(lines[host.fromLine - 1] ?? "")
-    ) {
+    if (host && indent === listItemChildIndent(lines[host.fromLine - 1] ?? "")) {
       componentId = instanceComponentId(sections, host);
     }
     if (host && componentId) {
@@ -98,7 +84,9 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
       const base = {
         id: componentId,
         name: host.name ?? undefined,
-        parentKey: host.parentKey,
+        // Domain (``key`` for a flat singleton) — the catalog is keyed
+        // ``<domain>.<event>``, so this resolves the trigger name.
+        parentKey: host.parentKey ?? host.key,
         eventKey: eventName,
       };
       // List-shaped trigger (``time.on_time``): one row per cron entry,

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -285,34 +285,17 @@ export function smallestContainingSection(
 }
 
 /**
- * Addressable component id for the list-item instance `match` among
- * `sections`: its declared ``id:`` when present, else the backend's
- * positional ``<domain>_<idx>`` (``idx`` = the instance's 0-based
- * position in the ``<domain>:`` list, document order). Mirrors the
- * backend's inline-automation scheme (``parsing.py`` emits
- * ``f"{domain}_{idx}"``, ``inline.py`` resolves it back) so the handle
- * round-trips through ``automations/upsert`` / ``delete``.
- *
- * Returns ``null`` for a flat single-instance block (``sun:``,
- * ``mqtt:``, ``wifi:`` …) — **even when it declares an explicit
- * ``id:``**. The backend addresses inline ``on_*:`` handlers under list
- * domains only (``isinstance(section, list)``), so a flat host is not
- * addressable. The ``parentKey`` check therefore comes first: a flat
- * block with an id must still return ``null`` so the shortcut gate and
- * the parser agree (both treat it as unscoped) rather than offering a
- * shortcut that resolves to nothing.
+ * Addressable id for `match`, mirroring the backend so the handle
+ * round-trips through ``automations/upsert``: a list item → its ``id:`` or
+ * positional ``<domain>_<idx>``; a flat singleton (``sun:``, ``parentKey``
+ * unset) → its ``id:`` or the domain.
  */
-export function instanceComponentId(
-  sections: YamlSection[],
-  match: YamlSection
-): string | null {
+export function instanceComponentId(sections: YamlSection[], match: YamlSection): string {
   const domain = match.parentKey;
-  if (domain === undefined) return null;
+  if (domain === undefined) return match.id ?? match.key;
   if (match.id) return match.id;
-  // Position among same-domain instances in document order. Counting by
-  // ``fromLine`` (unique per list item) is a single allocation-free pass
-  // and, unlike ``indexOf``, doesn't depend on ``match`` being the same
-  // object reference held in ``sections``.
+  // Count by ``fromLine`` (not ``indexOf``): allocation-free and doesn't
+  // depend on ``match`` being the array's own object reference.
   let idx = 0;
   for (const s of sections) {
     if (s.parentKey === domain && s.fromLine < match.fromLine) idx++;

--- a/test/components/device/section-config-shortcut-target.test.ts
+++ b/test/components/device/section-config-shortcut-target.test.ts
@@ -8,13 +8,19 @@
  * shortcut the parser scoped as `unscoped`). These tests lock the gate's
  * classification and assert it agrees with the parser for the same YAML.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { AutomationTrigger } from "../../../src/api/types/automations.js";
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import {
+  _clearAutomationCatalogCache,
+  fetchAutomationTriggers,
+} from "../../../src/util/automation-catalog-cache.js";
 import {
   _clearYamlSectionsMemo,
   parseYamlAutomations,
@@ -41,8 +47,25 @@ const shortcutTarget = (
   return inner._shortcutTarget();
 };
 
+/** Seed the module trigger cache (keyed on undefined platform/board, as a
+ *  boardless test component resolves) so ``hasTriggersFor`` sees them. */
+const seedTriggers = (ids: string[]): Promise<unknown> => {
+  const triggers = ids.map((id) => ({
+    id,
+    applies_to: [id.split(".")[0]],
+  })) as unknown as AutomationTrigger[];
+  const api = { getAutomationTriggers: async () => triggers } as unknown as ESPHomeAPI;
+  return fetchAutomationTriggers(api, undefined, undefined);
+};
+
 beforeEach(() => {
   _clearYamlSectionsMemo();
+});
+
+afterEach(() => {
+  // Drop any seeded catalog so other tests keep their fail-open (no
+  // catalog → ``hasTriggersFor`` returns true) behavior.
+  _clearAutomationCatalogCache();
 });
 
 describe("_shortcutTarget", () => {
@@ -158,5 +181,16 @@ describe("_shortcutTarget", () => {
         (target as { kind: "component_on"; componentId: string }).componentId
       );
     }
+  });
+
+  it("hides the panel for a trigger-less domain once the catalog loads", async () => {
+    await seedTriggers(["sun.on_sunrise", "switch.on_turn_on"]);
+    // web_server has no catalog triggers → no automations panel.
+    expect(shortcutTarget("web_server:\n  port: 80\n", "web_server")).toBeNull();
+    // sun does → still offered.
+    expect(shortcutTarget("sun:\n  id: my_sun\n", "sun")).toEqual({
+      kind: "component_on",
+      componentId: "my_sun",
+    });
   });
 });

--- a/test/components/device/section-config-shortcut-target.test.ts
+++ b/test/components/device/section-config-shortcut-target.test.ts
@@ -83,11 +83,9 @@ describe("_shortcutTarget", () => {
     });
   });
 
-  it("returns null for a flat block even with an explicit id (no broken shortcut)", () => {
-    // The exact regression: `sun:` is a flat single-instance block that
-    // can carry an id and host on_sunrise, but the backend can't address
-    // it, so the gate must offer no shortcut (matching the parser's
-    // `unscoped`).
+  it("scopes a flat singleton block to its id (sun → its declared id)", () => {
+    // With backend flat-component support (#1139), `sun:` is addressable
+    // by its `id:`, so the section hosts automations like a list item.
     const yaml = `sun:
   id: my_sun
   latitude: 0°
@@ -95,7 +93,24 @@ describe("_shortcutTarget", () => {
     - then:
         - logger.log: "x"
 `;
-    expect(shortcutTarget(yaml, "sun")).toBeNull();
+    expect(shortcutTarget(yaml, "sun")).toEqual({
+      kind: "component_on",
+      componentId: "my_sun",
+    });
+  });
+
+  it("scopes an id-less flat singleton block to its domain", () => {
+    const yaml = `mqtt:
+  broker: test
+  on_message:
+    - topic: x/y
+      then:
+        - logger.log: "m"
+`;
+    expect(shortcutTarget(yaml, "mqtt")).toEqual({
+      kind: "component_on",
+      componentId: "mqtt",
+    });
   });
 
   it("routes multi-instance sections by _resolvedFromLine", () => {

--- a/test/components/device/section-config-shortcut-target.test.ts
+++ b/test/components/device/section-config-shortcut-target.test.ts
@@ -48,12 +48,14 @@ const shortcutTarget = (
 };
 
 /** Seed the module trigger cache (keyed on undefined platform/board, as a
- *  boardless test component resolves) so ``hasTriggersFor`` sees them. */
-const seedTriggers = (ids: string[]): Promise<unknown> => {
-  const triggers = ids.map((id) => ({
-    id,
-    applies_to: [id.split(".")[0]],
-  })) as unknown as AutomationTrigger[];
+ *  boardless test component resolves) so ``hasTriggersFor`` sees them.
+ *  A bare id seeds ``applies_to: [<domain>]``; a ``[id, applies_to]`` pair
+ *  seeds an explicit (e.g. platform-qualified) scope. */
+const seedTriggers = (specs: Array<string | [string, string[]]>): Promise<unknown> => {
+  const triggers = specs.map((s) => {
+    const [id, applies_to] = typeof s === "string" ? [s, [s.split(".")[0]]] : s;
+    return { id, applies_to };
+  }) as unknown as AutomationTrigger[];
   const api = { getAutomationTriggers: async () => triggers } as unknown as ESPHomeAPI;
   return fetchAutomationTriggers(api, undefined, undefined);
 };
@@ -191,6 +193,17 @@ describe("_shortcutTarget", () => {
     expect(shortcutTarget("sun:\n  id: my_sun\n", "sun")).toEqual({
       kind: "component_on",
       componentId: "my_sun",
+    });
+  });
+
+  it("matches a trigger scoped to the qualified <domain>.<platform>", async () => {
+    // output's triggers list the platform-qualified scope (``output.slow_pwm``),
+    // not the bare domain — the gate must still offer the panel.
+    await seedTriggers([["slow_pwm.output.turn_on_action", ["output.slow_pwm"]]]);
+    const yaml = `output:\n  - platform: slow_pwm\n    id: my_out\n    pin: GPIO1\n`;
+    expect(shortcutTarget(yaml, "output.slow_pwm")).toEqual({
+      kind: "component_on",
+      componentId: "my_out",
     });
   });
 });

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -707,14 +707,19 @@ describe("parseYamlAutomations", () => {
     expect(ids).toEqual(["sensor_0", "sensor_1"]);
   });
 
-  it("leaves a flat single-instance block's on_* unscoped", () => {
+  it("scopes an id-less flat singleton's on_* to its domain", () => {
+    // Flat singleton (no list items) → addressed by the domain name,
+    // mirroring the backend's singleton_component_id (#1139).
     const yaml = `wifi:
   on_connect:
     - logger.log: "up"
 `;
     const [entry] = parseYamlAutomations(yaml);
-    expect(entry.key).toBe("automation:unscoped:on_connect:2");
-    expect(entry.id).toBeUndefined();
+    expect(entry.key).toBe("automation:component_on:wifi:on_connect");
+    expect(entry.id).toBe("wifi");
+    // parentKey carries the domain so the trigger catalog (keyed
+    // ``<domain>.<event>``) resolves the pretty name.
+    expect(entry.parentKey).toBe("wifi");
   });
 
   it("scopes a direct on_value on a single-value sensor", () => {
@@ -778,12 +783,9 @@ describe("parseYamlAutomations", () => {
     expect(entry?.id).toBeUndefined();
   });
 
-  it("leaves a flat block with an explicit id unscoped (backend addresses lists only)", () => {
-    // ``sun:`` is a flat single-instance component that can carry an ``id:``
-    // and host ``on_sunrise:`` — but the backend only resolves inline
-    // handlers under list domains, so the shortcut gate and the parser must
-    // both treat it as unscoped rather than emitting a component_on the
-    // backend can't address.
+  it("scopes a flat block's on_* to its declared id", () => {
+    // ``sun:`` is a flat singleton hosting ``on_sunrise:``; with backend
+    // flat-component support (#1139) it's addressable by its ``id:``.
     const yaml = `sun:
   id: my_sun
   latitude: 0°
@@ -792,8 +794,9 @@ describe("parseYamlAutomations", () => {
     - logger.log: "up"
 `;
     const [entry] = parseYamlAutomations(yaml);
-    expect(entry.key).toBe("automation:unscoped:on_sunrise:5");
-    expect(entry.id).toBeUndefined();
+    expect(entry.key).toBe("automation:component_on:my_sun:on_sunrise");
+    expect(entry.id).toBe("my_sun");
+    expect(entry.parentKey).toBe("sun");
   });
 });
 
@@ -834,19 +837,19 @@ describe("instanceComponentId", () => {
     expect(componentIdAt(yaml, 5)).toBe("switch_2");
   });
 
-  it("returns null for a flat single-instance block", () => {
+  it("resolves an id-less flat singleton block to its domain", () => {
     const yaml = `wifi:
   ssid: home
 `;
-    expect(componentIdAt(yaml, 1)).toBeNull();
+    expect(componentIdAt(yaml, 1)).toBe("wifi");
   });
 
-  it("returns null for a flat block even when it declares an explicit id", () => {
+  it("resolves a flat block with an explicit id to that id", () => {
     const yaml = `sun:
   id: my_sun
   latitude: 0°
 `;
-    expect(componentIdAt(yaml, 1)).toBeNull();
+    expect(componentIdAt(yaml, 1)).toBe("my_sun");
   });
 
   it("indexes by fromLine order, not object identity (reconstructed match still resolves)", () => {


### PR DESCRIPTION
# What does this implement/fix?

Inline `on_*:` automations on flat singleton components (`sun:`, `mqtt:`, `wifi:`, …) are now shown and editable in the Visual Editor — the frontend counterpart to the backend's flat-component support (esphome/device-builder#1139).

- `instanceComponentId` addresses a flat singleton by its declared `id:`, else the domain name — mirroring the backend's `singleton_component_id` (`id or domain`).
- `parseYamlAutomations` scopes a flat block's direct `on_*` to that id (handlers nested under a sub-mapping stay `unscoped`), carrying the domain in `parentKey` so the trigger catalog resolves the pretty name.
- `_shortcutTarget` offers the per-section triggers list + "+ Add automation", gated on catalog trigger availability (`hasTriggersFor`, mirroring the backend's `_component_trigger_domains`). The panel shows only on components that host triggers: flat singletons like `sun`/`mqtt`/`wifi`/`logger` get it; trigger-less components (flat or list, e.g. `web_server:`/`output`/`i2c`) get none. It fails open until the catalog loads, so existing automations are never briefly hidden.

Verified against backend `main` (#1139) in a browser: `sun:` shows "Sun → On Sunrise" with edit/delete + "+ Add automation"; `web_server:` shows no panel.

**Related issue or feature (if applicable):**

- fixes the flat-component half of esphome/device-builder#1138
- frontend counterpart to esphome/device-builder#1139

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
