### PR TITLE
Fix dialogs unable to reopen after a user-driven close (wa-hide event)

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -11,7 +11,7 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *
  * Every dialog in the app spent ~20 lines on identical
  * scaffolding — the ``?open`` binding, the
- * ``?light-dismiss`` busy-gate, the ``@wa-request-close``
+ * ``?light-dismiss`` busy-gate, the ``@wa-hide``
  * / ``@wa-after-hide`` wiring, and ``dialogCloseButtonStyles``
  * to dress the built-in close button. This element bundles
  * all of that into one place so consumers carry just the
@@ -30,7 +30,7 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   outside-click can't dismiss while a WS round-trip is
  *   in flight.
  * - The wrapper proactively ``preventDefault()``s
- *   ``wa-request-close`` so Escape / X-button click /
+ *   ``wa-hide`` so Escape / X-button click /
  *   programmatic close are all silently absorbed, even
  *   when the consumer doesn't wire their own
  *   ``@request-close`` veto handler. The busy gate is
@@ -44,7 +44,7 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  * **Events re-emitted**:
  *
  * - ``@request-close`` mirrors ``wa-dialog``'s
- *   ``wa-request-close`` (cancellable; ``preventDefault()``
+ *   ``wa-hide`` (cancellable; ``preventDefault()``
  *   to veto for host-side reasons like unsaved changes).
  *   Not fired when the wrapper vetoes for ``busy`` — the
  *   host can't override the busy gate.
@@ -56,13 +56,13 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *
  * **Close paths**:
  *
- * All close paths flow through ``wa-request-close`` so
+ * All close paths flow through ``wa-hide`` so
  * busy gate + host veto are evaluated uniformly:
  *
  * - Escape key / outside-click / built-in X button →
- *   ``wa-dialog`` fires ``wa-request-close`` directly.
+ *   ``wa-dialog`` fires ``wa-hide`` directly.
  * - Reactive ``?open`` flip from the host → ``wa-dialog``
- *   fires ``wa-request-close`` as part of its hide
+ *   fires ``wa-hide`` as part of its hide
  *   sequence.
  *
  * The wrapper never mutates its own ``open`` property in
@@ -125,7 +125,7 @@ export class ESPHomeBaseDialog extends LitElement {
    *  Without ``reflect: true``, only the boolean-attribute
    *  form would update the attribute, so property /
    *  imperative writers would get the functional gate
-   *  (wa-request-close veto) but not the visual dim on the
+   *  (wa-hide veto) but not the visual dim on the
    *  close button. */
   @property({ type: Boolean, reflect: true }) busy = false;
 
@@ -143,7 +143,11 @@ export class ESPHomeBaseDialog extends LitElement {
     this._hasFooter = this.querySelector(':scope > [slot="footer"]') !== null;
   }
 
-  private _onWaRequestClose = (e: Event): void => {
+  private _onWaHide = (e: Event): void => {
+    // wa-dialog fires the cancelable ``wa-hide`` to request a
+    // close (Escape / X / outside-click / reactive ?open flip);
+    // preventDefault() on it vetoes the close.
+    //
     // ``wa-dialog``'s events bubble + compose, so the same
     // event type fired by a nested ``wa-dialog`` (e.g. an
     // ``esphome-confirm-dialog`` inside our slotted body)
@@ -188,7 +192,7 @@ export class ESPHomeBaseDialog extends LitElement {
         exportparts="dialog,header,title,body,footer,close-button,close-button__base"
         ?open=${this.open}
         ?light-dismiss=${!this.busy}
-        @wa-request-close=${this._onWaRequestClose}
+        @wa-hide=${this._onWaHide}
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label" part="label-row">
@@ -237,7 +241,7 @@ export class ESPHomeBaseDialog extends LitElement {
       }
 
       /* Busy visual on wa-dialog's built-in close. The
-         functional gate is the wa-request-close veto
+         functional gate is the wa-hide veto
          above — clicking the X while busy silently
          absorbs the event and the dialog stays open. The
          CSS here is the user-facing cue (button looks

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -147,7 +147,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
 
   protected render() {
     // ?busy gates outside-click + Esc + close-button while a round-trip is
-    // in flight. Base-dialog vetoes wa-request-close when busy — without
+    // in flight. Base-dialog vetoes wa-hide when busy — without
     // this, a successful request_pair could fire pair-request-sent against
     // an already-closed dialog.
     return html`

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -545,7 +545,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     }
     // ?busy gates outside-click + Esc + close-button while
     // the submit_job WS round-trip is in flight: base-dialog
-    // flips light-dismiss off and vetoes wa-request-close
+    // flips light-dismiss off and vetoes wa-hide
     // when busy, so the dialog can't dismiss between the
     // submit and the ack returning. Orphaning that response
     // would fire remote-build-job-submitted against an

--- a/test/components/base-dialog-nested-filter.test.ts
+++ b/test/components/base-dialog-nested-filter.test.ts
@@ -1,12 +1,17 @@
 // @vitest-environment happy-dom
 import { describe, expect, test, vi } from "vitest";
 
+// Stub the real wa-dialog: happy-dom can't run its form-associated
+// close button (reads ElementInternals.validity), and these tests only
+// need the wrapper's own event wiring, not wa-dialog's internals.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
 import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
 
 /**
  * Regression coverage for ``esphome-base-dialog``'s nested-wa-dialog
  * leak filter. Web Awesome's ``wa-dialog`` fires
- * ``wa-after-hide`` / ``wa-request-close`` with ``bubbles + composed``,
+ * ``wa-after-hide`` / ``wa-hide`` with ``bubbles + composed``,
  * so a wa-dialog opened *inside* the slotted body of a base-dialog
  * (e.g. the receiver-side accept flow opening an
  * ``esphome-confirm-dialog`` while the Settings dialog is open) would
@@ -26,7 +31,7 @@ import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
  */
 
 interface BaseDialogPrivateView extends EventTarget {
-  _onWaRequestClose(e: Event): void;
+  _onWaHide(e: Event): void;
   _onWaAfterHide(e: Event): void;
 }
 
@@ -84,12 +89,12 @@ describe("esphome-base-dialog nested-wa-dialog filter", () => {
     expect(reemits).toHaveBeenCalledTimes(1);
   });
 
-  test("wa-request-close from a nested wa-dialog does not re-emit request-close", () => {
+  test("wa-hide from a nested wa-dialog does not re-emit request-close", () => {
     const base = makeBase();
     const reemits = vi.fn();
     base.addEventListener("request-close", reemits);
 
-    const event = new Event("wa-request-close", {
+    const event = new Event("wa-hide", {
       bubbles: true,
       cancelable: true,
     });
@@ -104,17 +109,17 @@ describe("esphome-base-dialog nested-wa-dialog filter", () => {
       writable: false,
     });
 
-    base._onWaRequestClose(event);
+    base._onWaHide(event);
 
     expect(reemits).not.toHaveBeenCalled();
   });
 
-  test("wa-request-close from base-dialog's own wa-dialog re-emits request-close", () => {
+  test("wa-hide from base-dialog's own wa-dialog re-emits request-close", () => {
     const base = makeBase();
     const reemits = vi.fn();
     base.addEventListener("request-close", reemits);
 
-    const event = new Event("wa-request-close", {
+    const event = new Event("wa-hide", {
       bubbles: true,
       cancelable: true,
     });
@@ -128,8 +133,32 @@ describe("esphome-base-dialog nested-wa-dialog filter", () => {
       writable: false,
     });
 
-    base._onWaRequestClose(event);
+    base._onWaHide(event);
 
     expect(reemits).toHaveBeenCalledTimes(1);
+  });
+
+  // Binding-level guard: the wrapper must listen for the event wa-dialog
+  // actually fires (``wa-hide``), not the nonexistent ``wa-request-close``.
+  // Dispatching the real event on the rendered wa-dialog must re-emit
+  // request-close; a stale ``wa-request-close`` must not. Without this the
+  // host never flips _open on a user close, so the dialog can't reopen.
+  test("rendered wrapper re-emits request-close on its wa-dialog's wa-hide", async () => {
+    const base = new ESPHomeBaseDialog();
+    base.open = true;
+    document.body.appendChild(base);
+    await base.updateComplete;
+
+    const wa = base.shadowRoot!.querySelector("wa-dialog")!;
+    const reemits = vi.fn();
+    base.addEventListener("request-close", reemits);
+
+    wa.dispatchEvent(new Event("wa-request-close", { bubbles: true, cancelable: true }));
+    expect(reemits).not.toHaveBeenCalled();
+
+    wa.dispatchEvent(new Event("wa-hide", { bubbles: true, cancelable: true }));
+    expect(reemits).toHaveBeenCalledTimes(1);
+
+    base.remove();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

`esphome-base-dialog` bound its close handler to `@wa-request-close`. In webawesome 3.7.0 the cancelable close-request event is `wa-hide` (its `requestClose()` dispatches `WaHideEvent` and vetoes on `preventDefault()`); the string `wa-request-close` does not appear anywhere in the installed `@home-assistant/webawesome` package.

Because the handler was wired to an event the wrapper's `wa-dialog` never dispatches, it never ran. Verified in a browser by mounting `esphome-base-dialog`, opening it, and triggering a user-driven close on its `wa-dialog`:

- The wrapper never re-emitted its `request-close` event, so a host that flips `_open` in `_onRequestClose` never saw it.
- The host's `_open` stayed `true` after the close; calling `open()` again set `_open = true` (no change → no re-render), so the dialog did not reopen.

The same browser check confirms the fix: after binding to `wa-hide`, the close re-emits `request-close`, `_open` goes `false`, and a subsequent `open()` reopens the dialog. A close driven by the host setting `_open = false` directly (e.g. a success path) does not hit this, because that flip is a real state change.

The wrapper is shared by every dialog built on it (clone, rename, add-api-action, add-script, pair-build-server, remote-build-job), so the defect was in the shared binding.

**Related issue or feature (if applicable):**

- fixes a dialog being unable to reopen after a user-driven close (Escape / X / backdrop)

## How

- Bind the wrapper's close handler to `@wa-hide` (the cancelable close-request event webawesome 3.7.0 dispatches) instead of `@wa-request-close`. Handler logic (nested-dialog filter, busy veto, `request-close` re-emit) is unchanged.
- Update the `wa-request-close` references in the wrapper's docstring and two consumers' comments to `wa-hide`.
- Add a binding-level regression test: render the wrapper, dispatch the real `wa-hide` on its inner `wa-dialog`, and assert `request-close` is re-emitted (and that `wa-request-close` is not). The pre-existing tests invoked the handler directly, so they did not exercise the event-name binding; this test fails on the old binding and passes on the new one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes (165 files, 1826 tests).
- [x] Tests have been added to verify that the new code works (where applicable).
