### PR TITLE
Add an Updates facet to filter devices needing an update

### DIFF
--- a/src/components/dashboard/render-facets.ts
+++ b/src/components/dashboard/render-facets.ts
@@ -9,6 +9,7 @@ import {
   computeAreaFacet,
   computePlatformFacet,
   computeStateFacet,
+  computeUpdateFacet,
 } from "../../util/facets.js";
 import "../facets/facet-filter.js";
 import "./filters-menu.js";
@@ -39,11 +40,13 @@ export function renderLabelsFilter(host: ESPHomePageDashboard): TemplateResult {
  *  doesn't sprout an empty / single-bucket pill that adds no
  *  signal.
  *
- *  In YAML-search mode the *labels* and *status* facets are
- *  suppressed — labels are device metadata (not in the YAML) and
- *  online/offline is runtime state (also not in the YAML), so
- *  filtering YAML matches by either is misleading. Area and
- *  platform stay because both come from the YAML itself.
+ *  In YAML-search mode the *labels*, *status*, and *updates*
+ *  facets are suppressed — labels are device metadata (not in the
+ *  YAML), and online/offline plus update/modified state are runtime
+ *  (also not in the YAML), so filtering YAML matches by any of them
+ *  is misleading. Area and platform stay because both come from the
+ *  YAML itself. The updates facet additionally renders only when the
+ *  fleet has something to update (no 0/0 noise pill).
  *
  *  On a narrow toolbar (``host._collapseFilters``, at/below 1100px)
  *  the pills collapse into a single "Filters" button + popover so the
@@ -52,6 +55,7 @@ export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
   const areaOptions = computeAreaFacet(host._devices);
   const platformOptions = computePlatformFacet(host._devices);
   const stateOptions = computeStateFacet(host._devices, host._localize);
+  const updateOptions = computeUpdateFacet(host._devices, host._localize);
   const multiSelectedLabel = host._localize("dashboard.filter_multi_selected", {
     count: "{count}",
   });
@@ -101,6 +105,18 @@ export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
             host._selectedStates = e.detail;
           }}
         ></esphome-facet-filter>`}
+    ${!yamlMode && updateOptions.length > 0
+      ? html`<esphome-facet-filter
+          name=${host._localize("dashboard.filter_update_status")}
+          clear-label=${clearLabel}
+          multi-selected-label=${multiSelectedLabel}
+          .options=${updateOptions}
+          .selected=${host._selectedUpdateStatus}
+          @facet-change=${(e: CustomEvent<string[]>) => {
+            host._selectedUpdateStatus = e.detail;
+          }}
+        ></esphome-facet-filter>`
+      : nothing}
   `;
 
   if (host._collapseFilters) {

--- a/src/components/dashboard/render-facets.ts
+++ b/src/components/dashboard/render-facets.ts
@@ -31,14 +31,15 @@ export function renderLabelsFilter(host: ESPHomePageDashboard): TemplateResult {
   ></esphome-labels-filter>`;
 }
 
-/** Facets row — sits next to the view toggle in the toolbar and
- *  carries one pill per active facet dimension. The labels pill
- *  always renders (its popover is the create path even when the
- *  catalog is empty); area / platform / status only render when
- *  the configured-device list has at least one usable value to
+/** Facets row — every facet pill collapses into a single "Filters"
+ *  button + popover so the toolbar stays one line regardless of how
+ *  many facets or selections are active (an inline pill row overflows
+ *  once selection badges widen the pills). The labels pill always
+ *  renders inside the popover (its popover is the create path even
+ *  when the catalog is empty); area / platform / status only render
+ *  when the configured-device list has at least one usable value to
  *  filter by, so a fresh dashboard with a single-platform fleet
- *  doesn't sprout an empty / single-bucket pill that adds no
- *  signal.
+ *  doesn't sprout an empty / single-bucket pill that adds no signal.
  *
  *  In YAML-search mode the *labels*, *status*, and *updates*
  *  facets are suppressed — labels are device metadata (not in the
@@ -46,11 +47,7 @@ export function renderLabelsFilter(host: ESPHomePageDashboard): TemplateResult {
  *  (also not in the YAML), so filtering YAML matches by any of them
  *  is misleading. Area and platform stay because both come from the
  *  YAML itself. The updates facet additionally renders only when the
- *  fleet has something to update (no 0/0 noise pill).
- *
- *  On a narrow toolbar (``host._collapseFilters``, at/below 1100px)
- *  the pills collapse into a single "Filters" button + popover so the
- *  row stays one line instead of wrapping on tablets/pads. */
+ *  fleet has something to update (no 0/0 noise pill). */
 export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
   const areaOptions = computeAreaFacet(host._devices);
   const platformOptions = computePlatformFacet(host._devices);
@@ -119,44 +116,25 @@ export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
       : nothing}
   `;
 
-  if (host._collapseFilters) {
-    // Badge / "Clear all" track facet selections only; a lone active
-    // search term is cleared from the search box's own clear control,
-    // not surfaced here.
-    return html`
-      <div class="filter-group">
-        <esphome-filters-menu
-          .activeCount=${host._activeFacetCount}
-          button-label=${host._localize("dashboard.filter_menu_button")}
-          clear-label=${clearLabel}
-          count-label=${host._localize(
-            host._activeFacetCount === 1
-              ? "dashboard.filter_menu_active_singular"
-              : "dashboard.filter_menu_active_plural",
-            { count: String(host._activeFacetCount) }
-          )}
-          @clear-filters=${host._clearAllFilters}
-        >
-          ${facetPills}
-        </esphome-filters-menu>
-      </div>
-    `;
-  }
-
+  // Badge / "Clear all" track facet selections only; a lone active
+  // search term is cleared from the search box's own clear control,
+  // not surfaced here.
   return html`
     <div class="filter-group">
-      ${facetPills}
-      ${host._hasActiveFilters
-        ? html`<button
-            class="filter-clear"
-            type="button"
-            title=${clearLabel}
-            @click=${host._clearAllFilters}
-          >
-            <wa-icon library="mdi" name="filter-remove-outline"></wa-icon>
-            ${clearLabel}
-          </button>`
-        : nothing}
+      <esphome-filters-menu
+        .activeCount=${host._activeFacetCount}
+        button-label=${host._localize("dashboard.filter_menu_button")}
+        clear-label=${clearLabel}
+        count-label=${host._localize(
+          host._activeFacetCount === 1
+            ? "dashboard.filter_menu_active_singular"
+            : "dashboard.filter_menu_active_plural",
+          { count: String(host._activeFacetCount) }
+        )}
+        @clear-filters=${host._clearAllFilters}
+      >
+        ${facetPills}
+      </esphome-filters-menu>
     </div>
   `;
 }

--- a/src/components/dashboard/render-facets.ts
+++ b/src/components/dashboard/render-facets.ts
@@ -52,7 +52,11 @@ export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
   const areaOptions = computeAreaFacet(host._devices);
   const platformOptions = computePlatformFacet(host._devices);
   const stateOptions = computeStateFacet(host._devices, host._localize);
-  const updateOptions = computeUpdateFacet(host._devices, host._localize);
+  const updateOptions = computeUpdateFacet(
+    host._devices,
+    host._localize,
+    host._selectedUpdateStatus
+  );
   const multiSelectedLabel = host._localize("dashboard.filter_multi_selected", {
     count: "{count}",
   });

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -297,9 +297,7 @@ export const dashboardStyles = css`
     row-gap: var(--wa-space-xs);
   }
 
-  /* Facet pills cluster inline with the view-toggle. flex-wrap
-     lets pills flow onto a second row of their own if too many
-     accumulate (large fleets with several areas / platforms). */
+  /* Wraps the Filters-menu button in the toolbar control strip. */
   .filter-group {
     display: inline-flex;
     align-items: center;
@@ -308,43 +306,6 @@ export const dashboardStyles = css`
     row-gap: var(--wa-space-2xs);
     flex-shrink: 1;
     min-width: 0;
-  }
-
-  /* Trailing "Clear filters" action on the desktop facet row. Shares the
-     toolbar control height so the strip stays aligned, but stays quiet
-     (borderless, muted) so it doesn't read as another facet pill. */
-  .filter-clear {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    height: var(--esphome-control-height);
-    padding: 0 10px;
-    border: none;
-    border-radius: var(--wa-border-radius-m);
-    background: transparent;
-    color: var(--wa-color-text-quiet);
-    font-family: inherit;
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-semibold, 600);
-    cursor: pointer;
-    flex-shrink: 0;
-    transition:
-      background-color 0.12s,
-      color 0.12s;
-  }
-
-  .filter-clear wa-icon {
-    font-size: 16px;
-  }
-
-  .filter-clear:hover {
-    color: var(--esphome-primary);
-    background: var(--esphome-tint);
-  }
-
-  .filter-clear:focus-visible {
-    outline: none;
-    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   /* The <form role="search"> wrapper is what suppresses Chrome's

--- a/src/components/facets/facet-styles.ts
+++ b/src/components/facets/facet-styles.ts
@@ -32,9 +32,11 @@ export const facetStyles = css`
     align-items: center;
     gap: 8px;
     /* Shared with the search input / view-toggle / clear-filters so the
-       toolbar row reads as one consistent control strip. */
-    height: var(--esphome-control-height);
-    padding: 0 10px 0 12px;
+       toolbar row reads as one consistent control strip. min-height
+       (not height) so a pill whose selection badges wrap to a second
+       line inside the Filters-menu popover grows instead of clipping. */
+    min-height: var(--esphome-control-height);
+    padding: 4px 10px 4px 12px;
     border-radius: var(--wa-border-radius-m);
     /* 2px dashes — the default 1px-thick dashed border renders as
        almost-solid hairline on hidpi displays, especially against
@@ -47,10 +49,21 @@ export const facetStyles = css`
     font-weight: var(--wa-font-weight-semibold, 600);
     cursor: pointer;
     flex-shrink: 0;
+    /* Cap to the container so a pill carrying wide selection badges
+       stays inside the Filters-menu popover instead of spilling past
+       its right edge; the badges shrink + clip rather than overflow. */
+    max-width: 100%;
+    box-sizing: border-box;
     transition:
       background-color 0.12s,
       border-color 0.12s,
       color 0.12s;
+  }
+
+  /* Facet name sits between the + icon and the badges; never let it
+     shrink — the badges absorb the squeeze when space is tight. */
+  .facet-trigger-name {
+    flex-shrink: 0;
   }
 
   /* Hover stays neutral on purpose — the trigger is one of several
@@ -90,14 +103,15 @@ export const facetStyles = css`
   }
 
   /* Right-side container for the active-state badges. Wraps to a
-     second row only when the badges would otherwise overflow —
-     normally everything stays on one line. */
+     second row when two named badges can't share one line inside the
+     Filters-menu popover, so a wide value (e.g. "Update available")
+     stays fully readable instead of clipping at the popover edge. */
   .facet-trigger-badges {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 4px;
-    max-width: 280px;
-    overflow: hidden;
+    min-width: 0;
   }
 
   /* One badge per selected value (≤ 2) or a single count badge

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -586,15 +586,15 @@ export class ESPHomePageDashboard extends LitElement {
     this._syncYamlSearch();
   };
 
-  /** Apply every active facet filter to the device list. Labels
-   *  use AND semantics (a device must carry every selected label,
-   *  the original "drill down by tag stack" behaviour we shipped
-   *  with the labels filter); area, platform, and status use OR
-   *  within the facet and AND across facets, the conventional
-   *  faceted-search shape.
+  /** Apply every active facet filter to the device list. Labels and
+   *  update-status use AND semantics (labels: a device must carry
+   *  every selected label, the original "drill down by tag stack";
+   *  updates: a device must satisfy every selected bucket); area,
+   *  platform, and status use OR within the facet and AND across
+   *  facets, the conventional faceted-search shape.
    *
-   *  Memoised on the five upstream references (``devices`` plus
-   *  the four selection arrays) so the two callers inside one
+   *  Memoised on the six upstream references (``devices`` plus
+   *  the five selection arrays) so the two callers inside one
    *  render cycle (``render()`` and ``_currentlyVisibleConfigurations``)
    *  share a single filter pass. Lit's reactive @state pattern
    *  hands out new array references on every selection change,

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -352,10 +352,11 @@ export class ESPHomePageDashboard extends LitElement {
     if (urlState.platforms !== undefined) this._selectedPlatforms = urlState.platforms;
     if (urlState.states !== undefined) this._selectedStates = urlState.states;
     if (urlState.updates !== undefined) {
-      // Reject unknown bucket ids from the user-editable URL so they
-      // don't count as active filters while narrowing nothing.
-      const valid = new Set<string>(UPDATE_FACET_BUCKETS);
-      this._selectedUpdateStatus = urlState.updates.filter((b) => valid.has(b));
+      // Normalize the user-editable URL to known buckets in canonical
+      // order, deduped — so unknown or duplicate ids can't inflate the
+      // active-filter count or render duplicate badges.
+      const requested = new Set(urlState.updates);
+      this._selectedUpdateStatus = UPDATE_FACET_BUCKETS.filter((b) => requested.has(b));
     }
     if (urlState.view !== undefined) this._view = urlState.view;
     if (urlState.yaml !== undefined) this._yamlMode = urlState.yaml;

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -207,6 +207,11 @@ export class ESPHomePageDashboard extends LitElement {
   @state() _selectedPlatforms: string[] = [];
   /** ``DeviceState`` values selected in the Status facet. */
   @state() _selectedStates: string[] = [];
+  /** Update-status buckets (``update_available`` / ``modified``)
+   *  selected in the Updates facet. AND semantics — a device must
+   *  satisfy every selected bucket — so selecting both narrows to
+   *  devices that are both update-available and modified. */
+  @state() _selectedUpdateStatus: string[] = [];
   @state() _yamlMode = false;
   @state() _yamlPreviewCount = 0;
   _yamlSearch = new YamlSearchController(this, () => this._api);
@@ -359,6 +364,7 @@ export class ESPHomePageDashboard extends LitElement {
     if (urlState.areas !== undefined) this._selectedAreas = urlState.areas;
     if (urlState.platforms !== undefined) this._selectedPlatforms = urlState.platforms;
     if (urlState.states !== undefined) this._selectedStates = urlState.states;
+    if (urlState.updates !== undefined) this._selectedUpdateStatus = urlState.updates;
     if (urlState.view !== undefined) this._view = urlState.view;
     if (urlState.yaml !== undefined) this._yamlMode = urlState.yaml;
 
@@ -393,6 +399,7 @@ export class ESPHomePageDashboard extends LitElement {
     "_selectedAreas",
     "_selectedPlatforms",
     "_selectedStates",
+    "_selectedUpdateStatus",
     "_view",
     "_yamlMode",
   ] as const;
@@ -414,6 +421,7 @@ export class ESPHomePageDashboard extends LitElement {
       areas: this._selectedAreas,
       platforms: this._selectedPlatforms,
       states: this._selectedStates,
+      updates: this._selectedUpdateStatus,
       view: this._view,
       yaml: this._yamlMode,
     });
@@ -560,7 +568,8 @@ export class ESPHomePageDashboard extends LitElement {
       this._selectedLabels.length > 0 ||
       this._selectedAreas.length > 0 ||
       this._selectedPlatforms.length > 0 ||
-      this._selectedStates.length > 0
+      this._selectedStates.length > 0 ||
+      this._selectedUpdateStatus.length > 0
     );
   }
 
@@ -571,7 +580,8 @@ export class ESPHomePageDashboard extends LitElement {
       this._selectedLabels.length +
       this._selectedAreas.length +
       this._selectedPlatforms.length +
-      this._selectedStates.length
+      this._selectedStates.length +
+      this._selectedUpdateStatus.length
     );
   }
 
@@ -585,6 +595,7 @@ export class ESPHomePageDashboard extends LitElement {
     this._selectedAreas = [];
     this._selectedPlatforms = [];
     this._selectedStates = [];
+    this._selectedUpdateStatus = [];
     this._syncYamlSearch();
   };
 
@@ -608,7 +619,8 @@ export class ESPHomePageDashboard extends LitElement {
       selectedLabels: string[],
       selectedAreas: string[],
       selectedPlatforms: string[],
-      selectedStates: string[]
+      selectedStates: string[],
+      selectedUpdateStatus: string[]
     ): ConfiguredDevice[] => {
       let out = devices;
       if (selectedLabels.length > 0) {
@@ -631,6 +643,16 @@ export class ESPHomePageDashboard extends LitElement {
         const set = new Set(selectedStates);
         out = out.filter((d) => set.has(d.state));
       }
+      if (selectedUpdateStatus.length > 0) {
+        // AND / narrowing: a device must satisfy every selected
+        // bucket (mirrors the labels facet, not the OR facets above).
+        const set = new Set(selectedUpdateStatus);
+        out = out.filter(
+          (d) =>
+            (!set.has("update_available") || d.update_available) &&
+            (!set.has("modified") || d.has_pending_changes)
+        );
+      }
       return out;
     }
   );
@@ -641,7 +663,8 @@ export class ESPHomePageDashboard extends LitElement {
       this._selectedLabels,
       this._selectedAreas,
       this._selectedPlatforms,
-      this._selectedStates
+      this._selectedStates,
+      this._selectedUpdateStatus
     );
   }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -233,16 +233,6 @@ export class ESPHomePageDashboard extends LitElement {
   @state() _tableSorting: SortingState | null = null;
   @state() _tableColumnVisibility: VisibilityState | null = null;
 
-  /** At/below 1100px the facet pills no longer fit inline (they widen
-   *  further once they carry selection badges), so they collapse into
-   *  the "Filters" menu. matchMedia, not CSS, so we render one set of
-   *  facets rather than a hidden duplicate. */
-  @state() _collapseFilters = false;
-  private _mql = window.matchMedia("(max-width: 1100px)");
-  private _onMqlChange = (e: MediaQueryListEvent) => {
-    this._collapseFilters = e.matches;
-  };
-
   private _adoptHighlightTimer: ReturnType<typeof setTimeout> | null = null;
   _pendingAdoptScroll: string | null = null;
   _actionDevice: ConfiguredDevice | null = null;
@@ -332,8 +322,6 @@ export class ESPHomePageDashboard extends LitElement {
     this._hydrateFromUrl();
     this.setAttribute("view", this._view);
     this.toggleAttribute("yaml", this._yamlMode);
-    this._collapseFilters = this._mql.matches;
-    this._mql.addEventListener("change", this._onMqlChange);
     this._showIgnored = localStorage.getItem("esphome-show-ignored") === "true";
     window.addEventListener("esphome-serial-setup", this._onSerialSetup);
     window.addEventListener("esphome-show-ignored-changed", this._onShowIgnoredChanged);
@@ -429,7 +417,6 @@ export class ESPHomePageDashboard extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._mql.removeEventListener("change", this._onMqlChange);
     window.removeEventListener("esphome-serial-setup", this._onSerialSetup);
     window.removeEventListener(
       "esphome-show-ignored-changed",

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -4,7 +4,6 @@ import {
   mdiCheckboxMultipleMarkedOutline,
   mdiClipboardTextSearchOutline,
   mdiCodeBraces,
-  mdiFilterRemoveOutline,
   mdiMagnify,
   mdiPlus,
   mdiTable,
@@ -95,6 +94,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { readDashboardUrl, writeDashboardUrl } from "../util/dashboard-url.js";
 import { matchesDeviceName, matchesMacAddress } from "../util/device-search.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../util/device-sort.js";
+import { UPDATE_FACET_BUCKETS, UPDATE_FACET_PREDICATES } from "../util/facets.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
@@ -141,7 +141,6 @@ registerMdiIcons({
   "checkbox-multiple-marked-outline": mdiCheckboxMultipleMarkedOutline,
   "clipboard-text-search-outline": mdiClipboardTextSearchOutline,
   "code-braces": mdiCodeBraces,
-  "filter-remove-outline": mdiFilterRemoveOutline,
   magnify: mdiMagnify,
   plus: mdiPlus,
   "view-grid": mdiViewGrid,
@@ -352,7 +351,12 @@ export class ESPHomePageDashboard extends LitElement {
     if (urlState.areas !== undefined) this._selectedAreas = urlState.areas;
     if (urlState.platforms !== undefined) this._selectedPlatforms = urlState.platforms;
     if (urlState.states !== undefined) this._selectedStates = urlState.states;
-    if (urlState.updates !== undefined) this._selectedUpdateStatus = urlState.updates;
+    if (urlState.updates !== undefined) {
+      // Reject unknown bucket ids from the user-editable URL so they
+      // don't count as active filters while narrowing nothing.
+      const valid = new Set<string>(UPDATE_FACET_BUCKETS);
+      this._selectedUpdateStatus = urlState.updates.filter((b) => valid.has(b));
+    }
     if (urlState.view !== undefined) this._view = urlState.view;
     if (urlState.yaml !== undefined) this._yamlMode = urlState.yaml;
 
@@ -634,10 +638,10 @@ export class ESPHomePageDashboard extends LitElement {
         // AND / narrowing: a device must satisfy every selected
         // bucket (mirrors the labels facet, not the OR facets above).
         const set = new Set(selectedUpdateStatus);
-        out = out.filter(
-          (d) =>
-            (!set.has("update_available") || d.update_available) &&
-            (!set.has("modified") || d.has_pending_changes)
+        out = out.filter((d) =>
+          UPDATE_FACET_BUCKETS.every(
+            (id) => !set.has(id) || UPDATE_FACET_PREDICATES[id](d)
+          )
         );
       }
       return out;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -320,6 +320,7 @@
     "filter_area": "Area",
     "filter_platform": "Platform",
     "filter_status": "Status",
+    "filter_update_status": "Updates",
     "filter_multi_selected": "{count} selected",
     "drawer_loaded_integrations": "Loaded Integrations",
     "drawer_auto_loaded_integrations": "Show {count} auto-loaded dependencies",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -212,6 +212,7 @@
     "filter_area": "Zone",
     "filter_platform": "Plateforme",
     "filter_status": "Statut",
+    "filter_update_status": "Mises à jour",
     "filter_multi_selected": "{count} sélectionnés",
     "drawer_loaded_integrations": "Intégrations chargées",
     "context_select": "Sélectionner",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -320,6 +320,7 @@
     "filter_area": "Terület",
     "filter_platform": "Platform",
     "filter_status": "Állapot",
+    "filter_update_status": "Frissítések",
     "filter_multi_selected": "{count} kijelölve",
     "drawer_loaded_integrations": "Betöltött integrációk",
     "drawer_auto_loaded_integrations": "{count} automatikusan betöltött függőség megjelenítése",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -212,6 +212,7 @@
     "filter_area": "Gebied",
     "filter_platform": "Platform",
     "filter_status": "Status",
+    "filter_update_status": "Updates",
     "filter_multi_selected": "{count} geselecteerd",
     "drawer_loaded_integrations": "Geladen integraties",
     "context_select": "Selecteren",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -320,6 +320,7 @@
     "filter_area": "区域",
     "filter_platform": "平台",
     "filter_status": "状态",
+    "filter_update_status": "更新",
     "filter_multi_selected": "已选择 {count} 项",
     "drawer_loaded_integrations": "已加载集成",
     "drawer_auto_loaded_integrations": "显示 {count} 个自动加载的依赖项",

--- a/src/util/dashboard-url.ts
+++ b/src/util/dashboard-url.ts
@@ -12,6 +12,8 @@
  *  - ``areas``     — comma-separated area names
  *  - ``platforms`` — comma-separated target_platform values
  *  - ``states``    — comma-separated DeviceState values
+ *  - ``updates``   — comma-separated update-status buckets
+ *                    (``update_available`` / ``modified``; AND semantics)
  *  - ``view``      — ``table`` (omitted for the cards default)
  *  - ``yaml``      — ``1`` (omitted for the device-search default)
  *
@@ -35,6 +37,7 @@ export interface DashboardUrlState {
   areas?: string[];
   platforms?: string[];
   states?: string[];
+  updates?: string[];
   view?: DashboardView;
   yaml?: boolean;
 }
@@ -72,6 +75,7 @@ export function readDashboardUrl(): DashboardUrlState {
     areas: fromCsv(p.get("areas")),
     platforms: fromCsv(p.get("platforms")),
     states: fromCsv(p.get("states")),
+    updates: fromCsv(p.get("updates")),
     view,
     yaml: p.get("yaml") === "1" ? true : undefined,
   };
@@ -88,6 +92,7 @@ export function writeDashboardUrl(state: DashboardUrlState): void {
   set("areas", toCsv(state.areas));
   set("platforms", toCsv(state.platforms));
   set("states", toCsv(state.states));
+  set("updates", toCsv(state.updates));
   set("view", state.view === DashboardView.TABLE ? "table" : undefined);
   set("yaml", state.yaml ? "1" : undefined);
   // ``replaceState`` keeps the back button clean — we don't want a

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -108,3 +108,30 @@ export function computeStateFacet(
     localize(labelKeyByState[raw as DeviceState] ?? "dashboard.unknown")
   );
 }
+
+/** Update-status facet — two orthogonal buckets a device can carry
+ *  at once: ``update_available`` (firmware behind latest) and
+ *  ``modified`` (local YAML not yet deployed). Empty buckets are
+ *  dropped so the dashboard hides the pill (and any single bucket
+ *  that no device matches) when the fleet is current. */
+export function computeUpdateFacet(
+  devices: ConfiguredDevice[],
+  localize: LocalizeFunc
+): FacetOption[] {
+  let updateAvailable = 0;
+  let modified = 0;
+  for (const d of devices) {
+    if (d.update_available) updateAvailable += 1;
+    if (d.has_pending_changes) modified += 1;
+  }
+  const counts = new Map<string, number>();
+  if (updateAvailable > 0) counts.set("update_available", updateAvailable);
+  if (modified > 0) counts.set("modified", modified);
+  const labelKeyById: Record<string, string> = {
+    update_available: "dashboard.status_update_available",
+    modified: "dashboard.status_modified",
+  };
+  return tallyToFacet(counts, (raw) =>
+    localize(labelKeyById[raw] ?? "dashboard.status_modified")
+  );
+}

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -109,9 +109,10 @@ export function computeStateFacet(
   );
 }
 
-/** The two update-status buckets, in display order. Exported so URL
- *  hydration can reject unknown ids before they inflate the active-
- *  filter count as no-op selections. */
+/** The two update-status buckets in canonical order — the order URL
+ *  hydration normalizes ``?updates=`` into (deduped, unknown ids
+ *  dropped). The *rendered* facet order is independent: ``tallyToFacet``
+ *  sorts the surfaced options by count then name. */
 export const UPDATE_FACET_BUCKETS = ["update_available", "modified"] as const;
 
 type UpdateBucket = (typeof UPDATE_FACET_BUCKETS)[number];

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -132,6 +132,6 @@ export function computeUpdateFacet(
     modified: "dashboard.status_modified",
   };
   return tallyToFacet(counts, (raw) =>
-    localize(labelKeyById[raw] ?? "dashboard.status_modified")
+    localize(labelKeyById[raw] ?? "dashboard.unknown")
   );
 }

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -109,29 +109,53 @@ export function computeStateFacet(
   );
 }
 
+/** The two update-status buckets, in display order. Exported so URL
+ *  hydration can reject unknown ids before they inflate the active-
+ *  filter count as no-op selections. */
+export const UPDATE_FACET_BUCKETS = ["update_available", "modified"] as const;
+
+type UpdateBucket = (typeof UPDATE_FACET_BUCKETS)[number];
+
+/** Each bucket's membership test — the single source of truth shared
+ *  by the facet's counts here and the dashboard's row filter, so the
+ *  bucket → device-field mapping isn't written twice. */
+export const UPDATE_FACET_PREDICATES: Record<
+  UpdateBucket,
+  (device: ConfiguredDevice) => boolean
+> = {
+  update_available: (d) => d.update_available,
+  modified: (d) => d.has_pending_changes,
+};
+
+const UPDATE_BUCKET_LABEL_KEY: Record<UpdateBucket, string> = {
+  update_available: "dashboard.status_update_available",
+  modified: "dashboard.status_modified",
+};
+
 /** Update-status facet — two orthogonal buckets a device can carry
  *  at once: ``update_available`` (firmware behind latest) and
- *  ``modified`` (local YAML not yet deployed). Empty buckets are
- *  dropped so the dashboard hides the pill (and any single bucket
- *  that no device matches) when the fleet is current. */
+ *  ``modified`` (local YAML not yet deployed). A bucket surfaces when
+ *  any device matches it *or* it's currently selected — so a filter
+ *  hydrated from the URL stays visible (and clearable) even after a
+ *  bulk update leaves the fleet current and its count at zero. When
+ *  nothing matches and nothing is selected the pill self-hides. */
 export function computeUpdateFacet(
   devices: ConfiguredDevice[],
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  selected: readonly string[] = []
 ): FacetOption[] {
-  let updateAvailable = 0;
-  let modified = 0;
+  const counts: Record<UpdateBucket, number> = { update_available: 0, modified: 0 };
   for (const d of devices) {
-    if (d.update_available) updateAvailable += 1;
-    if (d.has_pending_changes) modified += 1;
+    for (const id of UPDATE_FACET_BUCKETS) {
+      if (UPDATE_FACET_PREDICATES[id](d)) counts[id] += 1;
+    }
   }
-  const counts = new Map<string, number>();
-  if (updateAvailable > 0) counts.set("update_available", updateAvailable);
-  if (modified > 0) counts.set("modified", modified);
-  const labelKeyById: Record<string, string> = {
-    update_available: "dashboard.status_update_available",
-    modified: "dashboard.status_modified",
-  };
-  return tallyToFacet(counts, (raw) =>
-    localize(labelKeyById[raw] ?? "dashboard.unknown")
+  const selectedSet = new Set(selected);
+  const surfaced = new Map<string, number>();
+  for (const id of UPDATE_FACET_BUCKETS) {
+    if (counts[id] > 0 || selectedSet.has(id)) surfaced.set(id, counts[id]);
+  }
+  return tallyToFacet(surfaced, (raw) =>
+    localize(UPDATE_BUCKET_LABEL_KEY[raw as UpdateBucket] ?? "dashboard.unknown")
   );
 }

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -27,6 +27,7 @@ function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
     _selectedAreas: [],
     _selectedPlatforms: [],
     _selectedStates: [],
+    _selectedUpdateStatus: [],
     _collapseFilters: false,
     _activeFacetCount: 0,
     _hasActiveFilters: false,
@@ -88,5 +89,30 @@ describe("renderFacets responsive layout", () => {
 
     clearBtn!.click();
     expect(host._clearAllFilters).toHaveBeenCalledTimes(1);
+  });
+
+  // _localize echoes its key, so the Updates pill is identifiable by its
+  // name attribute. Empty _devices means the fleet is current.
+  const updatesPill = (root: HTMLElement) =>
+    [...root.querySelectorAll("esphome-facet-filter")].find(
+      (el) => el.getAttribute("name") === "dashboard.filter_update_status"
+    );
+
+  it("renders the Updates pill when a device needs an update", () => {
+    const host = makeHost({ _devices: [{ update_available: true }] });
+    expect(updatesPill(renderInto(host))).not.toBeUndefined();
+  });
+
+  it("suppresses the Updates pill when the fleet is current", () => {
+    const host = makeHost({ _devices: [] });
+    expect(updatesPill(renderInto(host))).toBeUndefined();
+  });
+
+  it("suppresses the Updates pill in YAML-search mode", () => {
+    const host = makeHost({
+      _devices: [{ has_pending_changes: true }],
+      _yamlMode: true,
+    });
+    expect(updatesPill(renderInto(host))).toBeUndefined();
   });
 });

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -90,6 +90,11 @@ describe("renderFacets", () => {
     expect(updatesPill(renderInto(host))).toBeUndefined();
   });
 
+  it("keeps the Updates pill when a filter is selected but the fleet is current", () => {
+    const host = makeHost({ _devices: [], _selectedUpdateStatus: ["update_available"] });
+    expect(updatesPill(renderInto(host))).not.toBeUndefined();
+  });
+
   it("suppresses the Updates pill in YAML-search mode", () => {
     const host = makeHost({
       _devices: [{ has_pending_changes: true }],

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -1,10 +1,10 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins the responsive switch in renderFacets: mobile collapses the
- * facet pills into a single <esphome-filters-menu>; desktop renders
- * the inline pill row plus a trailing "Clear filters" button that
- * appears only when something is filtered and calls _clearAllFilters.
+ * Pins renderFacets: every facet pill collapses into a single
+ * <esphome-filters-menu> (no inline pill row), the menu's count-label
+ * picks the singular/plural key off the active count, and the Updates
+ * pill only renders when the fleet has something to update.
  */
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,9 +15,9 @@ import { renderFacets } from "../../../src/components/dashboard/render-facets.js
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
 
 // Minimal host-shaped fake. Empty _devices means the Area/Platform/
-// Status facets compute no options and self-suppress, so the inline
-// row reduces to the always-present labels pill — enough to assert the
-// wrapper choice and the clear button without standing up the page.
+// Status facets compute no options and self-suppress, so the menu
+// reduces to the always-present labels pill — enough to assert the
+// wrapper choice without standing up the page.
 function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     _devices: [],
@@ -28,7 +28,6 @@ function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
     _selectedPlatforms: [],
     _selectedStates: [],
     _selectedUpdateStatus: [],
-    _collapseFilters: false,
     _activeFacetCount: 0,
     _hasActiveFilters: false,
     _clearAllFilters: vi.fn(),
@@ -44,51 +43,34 @@ function renderInto(host: ESPHomePageDashboard): HTMLElement {
   return container;
 }
 
-describe("renderFacets responsive layout", () => {
+describe("renderFacets", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
 
-  it("collapses to the Filters menu on a narrow toolbar", () => {
-    const host = makeHost({ _collapseFilters: true, _activeFacetCount: 2 });
-    const container = renderInto(host);
+  it("collapses every facet into a single Filters menu", () => {
+    const container = renderInto(makeHost({ _activeFacetCount: 2 }));
     expect(container.querySelector("esphome-filters-menu")).not.toBeNull();
-    // The inline desktop clear button is not used in the collapsed layout.
+    // No inline pill row / clear button — the menu owns clearing.
     expect(container.querySelector(".filter-clear")).toBeNull();
   });
 
   // _localize is stubbed to echo its key, so the count-label attribute
   // reveals which singular/plural key was chosen.
   it("uses the singular count label for exactly one active facet", () => {
-    const host = makeHost({ _collapseFilters: true, _activeFacetCount: 1 });
-    const menu = renderInto(host).querySelector("esphome-filters-menu");
+    const menu = renderInto(makeHost({ _activeFacetCount: 1 })).querySelector(
+      "esphome-filters-menu"
+    );
     expect(menu?.getAttribute("count-label")).toBe(
       "dashboard.filter_menu_active_singular"
     );
   });
 
   it("uses the plural count label for multiple active facets", () => {
-    const host = makeHost({ _collapseFilters: true, _activeFacetCount: 3 });
-    const menu = renderInto(host).querySelector("esphome-filters-menu");
+    const menu = renderInto(makeHost({ _activeFacetCount: 3 })).querySelector(
+      "esphome-filters-menu"
+    );
     expect(menu?.getAttribute("count-label")).toBe("dashboard.filter_menu_active_plural");
-  });
-
-  it("renders inline pills with no clear button when nothing is filtered", () => {
-    const host = makeHost({ _collapseFilters: false, _hasActiveFilters: false });
-    const container = renderInto(host);
-    expect(container.querySelector("esphome-filters-menu")).toBeNull();
-    expect(container.querySelector(".filter-group")).not.toBeNull();
-    expect(container.querySelector(".filter-clear")).toBeNull();
-  });
-
-  it("shows the clear button on desktop when filters are active", () => {
-    const host = makeHost({ _collapseFilters: false, _hasActiveFilters: true });
-    const container = renderInto(host);
-    const clearBtn = container.querySelector<HTMLButtonElement>(".filter-clear");
-    expect(clearBtn).not.toBeNull();
-
-    clearBtn!.click();
-    expect(host._clearAllFilters).toHaveBeenCalledTimes(1);
   });
 
   // _localize echoes its key, so the Updates pill is identifiable by its

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -41,4 +41,11 @@ describe("computeUpdateFacet", () => {
     );
     expect(ids).toEqual(["update_available"]);
   });
+
+  it("surfaces a selected bucket at count 0 so a URL filter stays clearable", () => {
+    const opts = computeUpdateFacet([device({})], localize, ["update_available"]);
+    expect(opts).toEqual([
+      { id: "update_available", name: expect.any(String), count: 0 },
+    ]);
+  });
 });

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -1,6 +1,4 @@
 /**
- * @vitest-environment happy-dom
- *
  * Pins computeUpdateFacet: per-bucket counts, empty-fleet → [], and
  * only-non-zero buckets surface (so the dashboard hides the pill /
  * drops a bucket nothing matches).
@@ -8,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet } from "../../src/util/facets.js";
 
 // computeUpdateFacet only reads update_available / has_pending_changes.
@@ -16,7 +15,7 @@ function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
 }
 
 // Echo the key so assertions key off the i18n id, not display copy.
-const localize = ((key: string) => key) as never;
+const localize = ((key: string) => key) as unknown as LocalizeFunc;
 
 describe("computeUpdateFacet", () => {
   it("returns [] for an up-to-date fleet", () => {

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pins computeUpdateFacet: per-bucket counts, empty-fleet → [], and
- * only-non-zero buckets surface (so the dashboard hides the pill /
- * drops a bucket nothing matches).
+ * matched buckets surface (so the pill hides / drops an unmatched
+ * bucket when the fleet is current) — except a currently-selected
+ * bucket stays at count 0 so a URL-hydrated filter remains clearable.
  */
 import { describe, expect, it } from "vitest";
 

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins computeUpdateFacet: per-bucket counts, empty-fleet → [], and
+ * only-non-zero buckets surface (so the dashboard hides the pill /
+ * drops a bucket nothing matches).
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ConfiguredDevice } from "../../src/api/types/devices.js";
+import { computeUpdateFacet } from "../../src/util/facets.js";
+
+// computeUpdateFacet only reads update_available / has_pending_changes.
+function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
+  return over as ConfiguredDevice;
+}
+
+// Echo the key so assertions key off the i18n id, not display copy.
+const localize = ((key: string) => key) as never;
+
+describe("computeUpdateFacet", () => {
+  it("returns [] for an up-to-date fleet", () => {
+    expect(computeUpdateFacet([device({}), device({})], localize)).toEqual([]);
+  });
+
+  it("counts update_available and modified into separate buckets", () => {
+    const devices = [
+      device({ update_available: true }),
+      device({ update_available: true, has_pending_changes: true }),
+      device({ has_pending_changes: true }),
+    ];
+    const byId = new Map(
+      computeUpdateFacet(devices, localize).map((o) => [o.id, o.count])
+    );
+    expect(byId.get("update_available")).toBe(2);
+    expect(byId.get("modified")).toBe(2);
+  });
+
+  it("drops a bucket no device matches", () => {
+    const ids = computeUpdateFacet([device({ update_available: true })], localize).map(
+      (o) => o.id
+    );
+    expect(ids).toEqual(["update_available"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds an **Updates** facet to the dashboard filter row so users can scope the device list to firmware that needs attention. The facet has two narrowing buckets:

- **Update available** — device firmware is behind the latest ESPHome version (`update_available`)
- **Modified** — local YAML has changes not yet deployed (`has_pending_changes`)

Like the Labels facet, the buckets use **AND / narrowing** semantics: selecting both keeps only devices that are *both* update-available and modified; selecting one narrows to that signal. The pill renders only when at least one device needs an update (no 0/0 noise pill on a current fleet) and is suppressed in YAML-search mode. The selection round-trips through a new `?updates=` URL param alongside the existing facet params.

Because "Select all" already scopes to the active facet filters and the bulk "Update" button already exists, this delivers the requested "update everything that needs updating" flow without a new button: **filter → Select all → Update**.

### Toolbar layout change (please review on its own merits)

Adding this facet pushed the inline pill row to overflow once pills carry selection badges (the Updates facet's two-chip state is the common case). So this PR also **always collapses every facet pill into the single "Filters" button + popover**, at every viewport width, and removes the old `matchMedia` responsive switch (`_collapseFilters` / `_mql`) that previously showed inline pills on desktop ≥1100px. Inside the popover, a pill's selection badges now wrap to a second line so two named chips (e.g. "Update available" + "Modified") stay fully readable instead of clipping. The dead `.filter-clear*` styles from the removed inline clear button are deleted. This is a real desktop UX change beyond the facet addition — calling it out explicitly here.

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3683
- fixes https://github.com/orgs/esphome/discussions/3686

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
