### PR TITLE
Add components into the unsaved editor draft (fixes esphome/device-builder#1146)

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -941,11 +941,16 @@ export class ESPHomeAPI {
     args: {
       component_id: string;
       fields?: Record<string, unknown>;
-    }
+    },
+    // The editor's unsaved draft. When given, the backend merges into
+    // it and returns the result without writing disk, so unsaved edits
+    // survive; omit to merge into the on-disk YAML and persist.
+    yaml?: string
   ): Promise<AddComponentResponse> {
     return this.sendCommand<AddComponentResponse>("devices/add_component", {
       configuration,
       ...args,
+      ...(yaml !== undefined && { yaml }),
     });
   }
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -385,18 +385,26 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // not retarget the form to a dep after the user submitted.
     this._depNavSeq++;
     try {
-      const { yaml } = await this._api.addComponent(this.configuration, {
-        component_id: this._selected.id,
-        fields: e.detail.fields,
-      });
+      // Merge into the editor's current draft (`this.yaml`) so unsaved
+      // edits survive; the backend returns the merged YAML without
+      // persisting (it saves via the normal Save flow).
+      const { yaml } = await this._api.addComponent(
+        this.configuration,
+        {
+          component_id: this._selected.id,
+          fields: e.detail.fields,
+        },
+        this.yaml
+      );
 
-      // Notify the host so the page re-fetches / re-renders with the
-      // new YAML. We dispatch this BEFORE deciding whether to close —
-      // when restoring `_returnTo` the dialog stays open, but we still
-      // need the device to know the YAML changed (so the dependency
-      // we just added shows up in the original component's dropdown).
+      // Surface the merged YAML as an unsaved draft. We dispatch this
+      // BEFORE deciding whether to close — when restoring `_returnTo`
+      // the dialog stays open, but the device still needs the new YAML
+      // (so the dependency we just added shows up in the original
+      // component's dropdown). `yaml-draft` advances only the working
+      // buffer, leaving the dirty flag on so the user saves explicitly.
       this.dispatchEvent(
-        new CustomEvent("yaml-updated", {
+        new CustomEvent("yaml-draft", {
           detail: { yaml },
           bubbles: true,
           composed: true,
@@ -439,7 +447,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       } else if (this._bundleQueue.length > 0 && this._bundleProgress) {
         // Bundle in flight — pop the next featured id and refresh the
         // form for it. The just-updated `this.yaml` (carried in via
-        // the `yaml-updated` event) is still authoritative for the
+        // the `yaml-draft` event) is still authoritative for the
         // next step's ID-reference dropdown, since the host re-binds
         // it on re-render.
         const nextId = this._bundleQueue[0];

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -385,16 +385,19 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // not retarget the form to a dep after the user submitted.
     this._depNavSeq++;
     try {
-      // Merge into the editor's current draft (`this.yaml`) so unsaved
-      // edits survive; the backend returns the merged YAML without
-      // persisting (it saves via the normal Save flow).
+      // Merge into the editor's current draft so unsaved edits survive;
+      // the backend returns the merged YAML without persisting (it saves
+      // via the normal Save flow). Only send the draft when it's actually
+      // loaded — `yaml` defaults to "" before the config arrives, and
+      // merging into "" would drop the on-disk config, so an empty draft
+      // omits the arg and the backend falls back to the on-disk YAML.
       const { yaml } = await this._api.addComponent(
         this.configuration,
         {
           component_id: this._selected.id,
           fields: e.detail.fields,
         },
-        this.yaml
+        this.yaml || undefined
       );
 
       // Surface the merged YAML as an unsaved draft. We dispatch this

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -618,6 +618,28 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     await pending;
   });
 
+  it("addComponent forwards the draft yaml when given", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const pending = api.addComponent(
+      "foo.yaml",
+      { component_id: "i2c", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    const sent = ws.sentAs<{
+      message_id: string;
+      args: Record<string, unknown>;
+    }>(0);
+    expect(sent.args).toEqual({
+      configuration: "foo.yaml",
+      component_id: "i2c",
+      fields: {},
+      yaml: "esphome:\n  name: foo\n",
+    });
+    ws.receive({ message_id: sent.message_id, result: { yaml: "..." } });
+    await pending;
+  });
+
   it("firmwareInstall defaults port to OTA and force_local to false", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -55,4 +55,28 @@ describe("add-component-dialog preserves the editor draft (#1146)", () => {
     // Surfaced as an unsaved draft only.
     expect(seen).toEqual([{ type: "yaml-draft", yaml: "MERGED" }]);
   });
+
+  it("omits the draft when the editor yaml hasn't loaded, so it isn't merged into ''", async () => {
+    const dialog = new ESPHomeAddComponentDialog();
+    const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { addComponent },
+      _selected: { id: "i2c" },
+      _returnTo: { id: "orig" },
+      _depDomain: null,
+    });
+    dialog.configuration = "foo.yaml";
+    dialog.yaml = ""; // still loading — must not become the merge base
+
+    await (
+      dialog as unknown as { _onFormSubmit: (e: CustomEvent) => Promise<void> }
+    )._onFormSubmit(new CustomEvent("form-submit", { detail: { fields: {} } }));
+
+    // Third arg is undefined → backend falls back to the on-disk YAML.
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "i2c", fields: {} },
+      undefined
+    );
+  });
 });

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The add-component wizard must merge into the editor's unsaved draft
+ * and surface the result as a draft (so unsaved edits survive and the
+ * user saves explicitly), not as a saved update. Regression for #1146.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+
+describe("add-component-dialog preserves the editor draft (#1146)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("merges into this.yaml and dispatches yaml-draft, not yaml-updated", async () => {
+    const dialog = new ESPHomeAddComponentDialog();
+    const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
+    // `_returnTo` truthy drives the restore branch, which doesn't touch
+    // the wa-dialog query — keeps this a pure logic test, no render.
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { addComponent },
+      _selected: { id: "i2c" },
+      _returnTo: { id: "orig" },
+      _depDomain: null,
+    });
+    dialog.configuration = "foo.yaml";
+    dialog.yaml = "esphome:\n  name: foo\n";
+
+    const seen: Array<{ type: string; yaml: string }> = [];
+    const record = (e: Event) =>
+      seen.push({ type: e.type, yaml: (e as CustomEvent).detail.yaml });
+    dialog.addEventListener("yaml-draft", record);
+    dialog.addEventListener("yaml-updated", record);
+
+    await (
+      dialog as unknown as { _onFormSubmit: (e: CustomEvent) => Promise<void> }
+    )._onFormSubmit(
+      new CustomEvent("form-submit", { detail: { fields: { sda: "GPIO21" } } })
+    );
+
+    // The live draft is the merge base passed to the backend.
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "i2c", fields: { sda: "GPIO21" } },
+      "esphome:\n  name: foo\n"
+    );
+    // Surfaced as an unsaved draft only.
+    expect(seen).toEqual([{ type: "yaml-draft", yaml: "MERGED" }]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes the add-component wizard discarding unsaved YAML-editor changes.

With unsaved edits in the device YAML editor, using **Device Navigator → Components → Add component** (e.g. add an I2C bus) discarded those edits. Root cause: the dialog called `addComponent(config, {component_id, fields})` **without** the editor's draft, then dispatched `yaml-updated`. The device page's `_onYamlUpdated` advances **both** `_yaml` and `_savedYaml` to the backend's disk-based result, so the unsaved draft was overwritten and the dirty flag cleared.

This switches the wizard to the draft-preserving pattern the add-script / add-api-action dialogs already use:

- Pass `this.yaml` (the live editor draft) to `addComponent`, so the backend merges the new component into the draft and returns it **without persisting** (companion backend PR).
- Dispatch **`yaml-draft`** instead of `yaml-updated`, so only the working buffer advances; `_savedYaml` stays put, the Save button stays active, and the user saves explicitly when ready. This also keeps a mid-edit (possibly invalid) config from being auto-written to disk, per the reporter's note.

Because `add-config-dialog` is a thin wrapper that renders `<esphome-add-component-dialog>` (with `lockedCategories=CORE_CATEGORIES`), this also fixes the CORE-config wizard (api / wifi / logger / …).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1146

## Companion backend PR

esphome/device-builder#1147 — adds the optional `yaml` draft parameter to `devices/add_component` (merge into the draft, return without persisting). Lockstep; both land together.

## Testing

- `test/components/device/add-component-dialog-draft.test.ts`: submit merges into `this.yaml` (passed to `addComponent`) and dispatches `yaml-draft`, never `yaml-updated`.
- `test/api/esphome-api.test.ts`: `addComponent` forwards the draft `yaml` when given (and omits it when not).
- `npm run lint` clean; `npm run test` 1837 passed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
