### PR TITLE
Stop Ctrl+Z from undoing the editor to a blank document (fixes esphome/device-builder#1150)

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -348,20 +348,16 @@ export class ESPHomeYamlEditor extends LitElement {
       parent: this._container,
     });
 
-    // Apply any pending highlight after mount. The remount paths in
-    // `updated()` (config change, initial-load baseline) early-return
-    // before the `highlightRange` branch, so a same-cycle deep-link
-    // (`?line=N` sets value + highlightRange together) relies on this
-    // to mark *and* scroll to the requested line.
-    if (this.highlightRange) {
-      this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
-      this._scrollToHighlight();
-    }
+    // Remount paths in updated() return before the highlightRange
+    // branch, so re-apply a pending highlight (+ scroll) here.
+    if (this.highlightRange) this._applyHighlight();
   }
 
-  /** Scroll the current highlight into view when `scrollToHighlight`. */
-  private _scrollToHighlight() {
-    if (!this._view || !this.highlightRange || !this.scrollToHighlight) return;
+  /** Set (or clear) the highlight mark and scroll it into view. */
+  private _applyHighlight() {
+    if (!this._view) return;
+    this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
+    if (!this.highlightRange || !this.scrollToHighlight) return;
     const line = Math.max(1, this.highlightRange.fromLine);
     const pos = this._view.state.doc.line(
       Math.min(line, this._view.state.doc.lines)
@@ -434,18 +430,10 @@ export class ESPHomeYamlEditor extends LitElement {
 
     if (changed.has("value") && this._view) {
       const current = this._view.state.doc.toString();
-      // First non-empty population of a pristine, never-edited editor:
-      // the editor mounts empty (default `value` is "") and is filled by
-      // an async source — the device YAML load, or an external
-      // `yaml-draft` (e.g. a wizard) before any typing. Dispatching that
-      // would record an undoable empty→content step, letting Ctrl+Z
-      // unwind to a blank editor (#1150). Remount instead so the
-      // populated YAML is the document baseline with fresh history — the
-      // same reset the configuration-change branch above uses.
-      //
-      // The `undoDepth === 0` gate scopes this to the never-edited
-      // window: once the user has edited or cleared the doc, history is
-      // non-empty, so a later external repopulate stays undoable.
+      // First population of a never-edited editor: remount so the async
+      // value is the undo baseline, else Ctrl+Z unwinds to blank (#1150).
+      // The undoDepth gate keeps later external repopulates (after the
+      // user edits/clears) undoable.
       if (current === "" && this.value !== "" && undoDepth(this._view.state) === 0) {
         this._remountEditor();
         return;
@@ -515,8 +503,7 @@ export class ESPHomeYamlEditor extends LitElement {
     }
 
     if (changed.has("highlightRange") && this._view) {
-      this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
-      this._scrollToHighlight();
+      this._applyHighlight();
     }
 
     if (changed.has("revealSensitive") && this._view) {

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -348,10 +348,27 @@ export class ESPHomeYamlEditor extends LitElement {
       parent: this._container,
     });
 
-    // Apply any pending highlight after mount
+    // Apply any pending highlight after mount. The remount paths in
+    // `updated()` (config change, initial-load baseline) early-return
+    // before the `highlightRange` branch, so a same-cycle deep-link
+    // (`?line=N` sets value + highlightRange together) relies on this
+    // to mark *and* scroll to the requested line.
     if (this.highlightRange) {
       this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
+      this._scrollToHighlight();
     }
+  }
+
+  /** Scroll the current highlight into view when `scrollToHighlight`. */
+  private _scrollToHighlight() {
+    if (!this._view || !this.highlightRange || !this.scrollToHighlight) return;
+    const line = Math.max(1, this.highlightRange.fromLine);
+    const pos = this._view.state.doc.line(
+      Math.min(line, this._view.state.doc.lines)
+    ).from;
+    this._view.dispatch({
+      effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }),
+    });
   }
 
   /**
@@ -499,15 +516,7 @@ export class ESPHomeYamlEditor extends LitElement {
 
     if (changed.has("highlightRange") && this._view) {
       this._view.dispatch({ effects: setHighlight.of(this.highlightRange) });
-      if (this.highlightRange && this.scrollToHighlight) {
-        const line = Math.max(1, this.highlightRange.fromLine);
-        const pos = this._view.state.doc.line(
-          Math.min(line, this._view.state.doc.lines)
-        ).from;
-        this._view.dispatch({
-          effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }),
-        });
-      }
+      this._scrollToHighlight();
     }
 
     if (changed.has("revealSensitive") && this._view) {

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,5 +1,5 @@
 import { autocompletion } from "@codemirror/autocomplete";
-import { indentWithTab } from "@codemirror/commands";
+import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
 import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
@@ -424,7 +424,12 @@ export class ESPHomeYamlEditor extends LitElement {
       // editor (#1150). Remount instead so the loaded YAML is the
       // document baseline with fresh history — same reset the
       // configuration-change branch above uses.
-      if (current === "" && this.value !== "") {
+      //
+      // Gate on empty history (`undoDepth === 0`) so this only fires for
+      // the pristine initial load — not when the user has cleared the
+      // doc themselves and an external action (e.g. a dialog's
+      // `yaml-draft`) repopulates it, which must stay undoable.
+      if (current === "" && this.value !== "" && undoDepth(this._view.state) === 0) {
         this._remountEditor();
         return;
       }

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -417,6 +417,17 @@ export class ESPHomeYamlEditor extends LitElement {
 
     if (changed.has("value") && this._view) {
       const current = this._view.state.doc.toString();
+      // Initial population: the editor mounted empty (default `value`
+      // is "") before the device YAML loaded async, so the first
+      // non-empty value arrives here. Dispatching it would record an
+      // undoable empty→content step, letting Ctrl+Z unwind to a blank
+      // editor (#1150). Remount instead so the loaded YAML is the
+      // document baseline with fresh history — same reset the
+      // configuration-change branch above uses.
+      if (current === "" && this.value !== "") {
+        this._remountEditor();
+        return;
+      }
       if (current !== this.value) {
         // Same-document patch (section-editor save, …).
         //

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -417,18 +417,18 @@ export class ESPHomeYamlEditor extends LitElement {
 
     if (changed.has("value") && this._view) {
       const current = this._view.state.doc.toString();
-      // Initial population: the editor mounted empty (default `value`
-      // is "") before the device YAML loaded async, so the first
-      // non-empty value arrives here. Dispatching it would record an
-      // undoable empty→content step, letting Ctrl+Z unwind to a blank
-      // editor (#1150). Remount instead so the loaded YAML is the
-      // document baseline with fresh history — same reset the
-      // configuration-change branch above uses.
+      // First non-empty population of a pristine, never-edited editor:
+      // the editor mounts empty (default `value` is "") and is filled by
+      // an async source — the device YAML load, or an external
+      // `yaml-draft` (e.g. a wizard) before any typing. Dispatching that
+      // would record an undoable empty→content step, letting Ctrl+Z
+      // unwind to a blank editor (#1150). Remount instead so the
+      // populated YAML is the document baseline with fresh history — the
+      // same reset the configuration-change branch above uses.
       //
-      // Gate on empty history (`undoDepth === 0`) so this only fires for
-      // the pristine initial load — not when the user has cleared the
-      // doc themselves and an external action (e.g. a dialog's
-      // `yaml-draft`) repopulates it, which must stay undoable.
+      // The `undoDepth === 0` gate scopes this to the never-edited
+      // window: once the user has edited or cleared the doc, history is
+      // non-empty, so a later external repopulate stays undoable.
       if (current === "" && this.value !== "" && undoDepth(this._view.state) === 0) {
         this._remountEditor();
         return;

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -65,8 +65,8 @@ describe("yaml-editor undo baseline (#1150)", () => {
   it("still scrolls to the highlight when value + highlightRange load in one cycle", async () => {
     const el = await mount(); // empty
     const spy = vi.spyOn(
-      el as unknown as { _scrollToHighlight: () => void },
-      "_scrollToHighlight"
+      el as unknown as { _applyHighlight: () => void },
+      "_applyHighlight"
     );
 
     // Deep-link load: page sets YAML, highlightRange and scrollToHighlight

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -7,7 +7,7 @@
  */
 import { undo, undoDepth } from "@codemirror/commands";
 import type { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
 
@@ -60,5 +60,24 @@ describe("yaml-editor undo baseline (#1150)", () => {
     // And undo still works (no wiped stack).
     undo(view);
     expect(view.state.doc.toString()).not.toBe("logger:\n");
+  });
+
+  it("still scrolls to the highlight when value + highlightRange load in one cycle", async () => {
+    const el = await mount(); // empty
+    const spy = vi.spyOn(
+      el as unknown as { _scrollToHighlight: () => void },
+      "_scrollToHighlight"
+    );
+
+    // Deep-link load: page sets YAML, highlightRange and scrollToHighlight
+    // together. The initial-load remount early-returns before the
+    // highlightRange branch, so the scroll must run via _mountEditor.
+    el.value = "a\nb\nc\nd\ne\n";
+    el.highlightRange = { fromLine: 4, toLine: 4 };
+    el.scrollToHighlight = true;
+    await el.updateComplete;
+
+    expect(viewOf(el).state.doc.toString()).toBe("a\nb\nc\nd\ne\n");
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -5,7 +5,7 @@
  * and the device YAML loads async afterwards. That first content load
  * must not be an undoable step, or Ctrl+Z unwinds the editor to blank.
  */
-import { undoDepth } from "@codemirror/commands";
+import { undo, undoDepth } from "@codemirror/commands";
 import type { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -35,5 +35,30 @@ describe("yaml-editor undo baseline (#1150)", () => {
     expect(view.state.doc.toString()).toBe("wifi:\n  ssid: x\n");
     // Loaded content is the baseline — nothing to undo back to (no blank).
     expect(undoDepth(view.state)).toBe(0);
+  });
+
+  it("keeps an external repopulate undoable after the user clears the doc", async () => {
+    const el = await mount();
+    el.value = "wifi:\n  ssid: x\n"; // initial load (baselined)
+    await el.updateComplete;
+    const view = viewOf(el);
+
+    // User clears the editor themselves — recorded in history.
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: "" } });
+    expect(view.state.doc.toString()).toBe("");
+    expect(undoDepth(view.state)).toBeGreaterThan(0);
+
+    // An external action (e.g. a dialog's yaml-draft) repopulates it.
+    // History is non-empty, so this must NOT remount and wipe the undo
+    // stack — the same view stays mounted and the change is undoable.
+    el.value = "logger:\n";
+    await el.updateComplete;
+    expect(viewOf(el)).toBe(view); // not remounted
+    expect(view.state.doc.toString()).toBe("logger:\n");
+    expect(undoDepth(view.state)).toBeGreaterThan(0); // history preserved
+
+    // And undo still works (no wiped stack).
+    undo(view);
+    expect(view.state.doc.toString()).not.toBe("logger:\n");
   });
 });

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression for #1150: the editor mounts empty (value defaults to "")
+ * and the device YAML loads async afterwards. That first content load
+ * must not be an undoable step, or Ctrl+Z unwinds the editor to blank.
+ */
+import { undoDepth } from "@codemirror/commands";
+import type { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
+
+async function mount(): Promise<ESPHomeYamlEditor> {
+  const el = new ESPHomeYamlEditor();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const viewOf = (el: ESPHomeYamlEditor): EditorView =>
+  (el as unknown as { _view: EditorView })._view;
+
+describe("yaml-editor undo baseline (#1150)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does not record the initial async content load in undo history", async () => {
+    const el = await mount(); // mounts with empty doc
+    el.value = "wifi:\n  ssid: x\n"; // YAML arrives later
+    await el.updateComplete;
+
+    const view = viewOf(el);
+    expect(view.state.doc.toString()).toBe("wifi:\n  ssid: x\n");
+    // Loaded content is the baseline — nothing to undo back to (no blank).
+    expect(undoDepth(view.state)).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes Ctrl+Z (undo) in the device YAML editor unwinding past the loaded document all the way to a **blank** editor. Undo now stops at the content as it was when the document was opened.

Root cause: `<esphome-yaml-editor>` mounts its CodeMirror `EditorView` with `doc: this.value`, but `value` defaults to `""`, so on the common timing the editor mounts **empty**. The device YAML loads asynchronously afterwards and arrives as the first non-empty `value`, which was applied in `updated()` via a normal `view.dispatch({changes})` with `history()` active — making the empty→loaded population an undoable transaction. Ctrl+Z then unwound it to blank.

## How

In `yaml-editor.ts`'s `value`-change branch, when the current doc is empty and the incoming `value` is non-empty (the initial async population), remount via the existing `_remountEditor()` instead of dispatching a change. That recreates the `EditorState` with `doc: this.value`, so the loaded YAML is the document baseline with **fresh, empty undo history** — the same baseline reset the `configuration`-change branch already uses for device switches. All other updates (section-editor saves, wizard `yaml-draft` syncs, where the doc is non-empty) keep the existing minimal-diff dispatch unchanged, so cursor/scroll preservation is untouched.

Covers the cases: editor mounted with content already present (unchanged), editor mounted empty then content arrives (now baselined), and a genuinely empty device YAML (no remount; undo correctly stops at empty, which is the opened state).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1150

## Testing

- Added `test/components/yaml-editor-undo.test.ts`: mounts the editor empty, sets `value` to YAML (the async-load path), and asserts `undoDepth(view.state) === 0` with the doc showing the content. Verified it fails without the fix (`undoDepth === 1`) and passes with it.
- `npm run lint` clean; `npm run test` 1845 passed.
- Manual: open a device, edit, Ctrl+Z repeatedly — stops at the opened YAML, never blanks; section-editor save then Ctrl+Z still undoes normally; switching devices still resets cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
