### PR TITLE
Document how to contribute translations via Lokalise

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ python3 -m build --wheel
 
 ## Translations
 
+### Contributing translations
+
+Translations are crowd-sourced through Lokalise — **no coding or GitHub account required**. To help translate the dashboard into your language:
+
+1. Open the project's public signup link and join: <https://app.lokalise.com/public/974668436a17ffd6803f51.79180045/>
+2. Pick your language and start translating. Only **native speakers** should submit translations; proofreading existing work is just as valuable, even for a language that looks "complete".
+3. **Don't translate proper nouns** like `ESPHome`, `ESPHome Device Builder`, or `Home Assistant`, and leave `{placeholder}` tokens (e.g. `{count}`) exactly as they are — the words around a token can be reordered, but the token itself must stay verbatim.
+
+Don't see your language? It has to be added to the project once before it shows up — request it in the [Discord language thread](https://discord.com/channels/429907082951524364/1511452603391938705) and someone will add it. Translated strings ship with the next release; any key a translator hasn't filled in yet falls back to English automatically.
+
+### How it works
+
 `src/translations/en.json` is the English source of truth and the **only translation file committed to the repo**. Every other locale lives in [Lokalise](https://lokalise.com/); those files are gitignored and pulled on demand with a small TypeScript tool at `build-scripts/translations.ts` (run directly by Node — no build step). That direct `.ts` execution relies on Node's native type stripping, so it needs **Node 22.18+** (CI runs Node 24); on older Node it fails with `ERR_UNKNOWN_FILE_EXTENSION`.
 
 ```bash


### PR DESCRIPTION
# What does this implement/fix?

Adds a translator-facing **Contributing translations** section to the README so non-developers can find the Lokalise project and start translating. It includes:

- The public Lokalise signup link: <https://app.lokalise.com/public/974668436a17ffd6803f51.79180045/>
- The Discord language-request thread for requesting a new language (it has to be added to the project once before it appears).
- Guidance modeled on Home Assistant's: native speakers only, don't translate proper nouns (`ESPHome`, `Home Assistant`), and leave `{placeholder}` tokens verbatim.

The existing maintainer/tooling prose is grouped under a new **How it works** heading. Docs-only; no code or behaviour change.

**Related issue or feature (if applicable):**

- N/A — follows up the Lokalise integration (#558).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] \`npm run lint\` passes.
- [x] \`npm run test\` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).