### PR TITLE
Update existing English values on Lokalise upload and widen triggers

### DIFF
--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -1,15 +1,19 @@
 name: Upload translations
 
 # Push the English source strings to Lokalise whenever en.json lands on
-# main, so translators always see the latest keys. Only new keys are
-# added; existing translations are left untouched (see
-# build-scripts/translations.ts).
+# main, so translators always see the latest keys. New keys are added and
+# the English copy of existing keys is updated; keys removed from en.json
+# are left in the project (so a moved key keeps its translations for reuse)
+# and translated locales are left untouched (see build-scripts/translations.ts).
 
 on:
   push:
     branches: [main]
     paths:
       - "src/translations/en.json"
+      - "build-scripts/translations.ts"
+      - "build-scripts/translations-lib.ts"
+      - ".github/workflows/translations-upload.yml"
   workflow_dispatch:
 
 permissions:

--- a/build-scripts/translations.ts
+++ b/build-scripts/translations.ts
@@ -6,8 +6,9 @@
 //                                                pull locales from the latest GitHub release
 //
 // The base language (en.json) is the in-repo source of truth: `upload`
-// adds its keys to Lokalise, `download` writes every other locale back
-// into src/translations/ and never touches en.json.
+// pushes its keys to Lokalise, adding new keys and updating the English
+// copy of existing keys (other locales are untouched); `download` writes
+// every other locale back into src/translations/ and never touches en.json.
 //
 // `download --source release` needs no Lokalise token: it reads the
 // `translations.zip` asset the release workflow attaches to the latest
@@ -125,9 +126,12 @@ class LokaliseClient {
       convert_placeholders: false,
       // Keys use manual _singular/_plural suffixes, not ICU plurals.
       detect_icu_plurals: false,
-      // Never clobber translator edits to existing keys on upload — an
-      // upload only adds new keys and leaves the rest untouched.
-      replace_modified: false,
+      // Push reworded English copy for existing keys, not just new keys —
+      // en.json is the source of truth for the base language. Only the
+      // English file is uploaded (lang_iso: en), so this updates English
+      // translations only and never clobbers translator edits in other
+      // locales, which aren't part of this upload.
+      replace_modified: true,
       // When set, keys absent from the uploaded base file are deleted from
       // the project. Off by default; opt in via `upload --cleanup`.
       cleanup_mode: opts.cleanupMode ?? false,


### PR DESCRIPTION
# What does this implement/fix?

Changes the Lokalise upload so reworded English copy for existing keys actually reaches Lokalise, and broadens what triggers the upload workflow.

- Flip `replace_modified` to `true` in `build-scripts/translations.ts`. Previously the upload only added new keys; editing the English value of an existing key never propagated to Lokalise, so translators kept seeing the old wording. Because only the English base file is uploaded (`lang_iso: en`), this updates English translations only and never clobbers translator edits in other locales (they aren't part of this upload).
- Trigger `translations-upload.yml` on changes to the translation scripts (`build-scripts/translations.ts`, `build-scripts/translations-lib.ts`) and to the workflow file itself, not just `src/translations/en.json`.

Removed keys are intentionally left in Lokalise (no `--cleanup`), so a moved key keeps its translations for reuse.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).