### PR TITLE
Enable section folding in the YAML editor

### DIFF
--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -9,7 +9,13 @@
  * - Block:   `value: !lambda |-\n  return x;`
  */
 import { cppLanguage } from "@codemirror/lang-cpp";
-import { LRLanguage, LanguageSupport, indentService } from "@codemirror/language";
+import {
+  LRLanguage,
+  LanguageSupport,
+  foldInside,
+  foldNodeProp,
+  indentService,
+} from "@codemirror/language";
 import type { Input, SyntaxNodeRef } from "@lezer/common";
 import { parseMixed } from "@lezer/common";
 import { parser as yamlParser } from "@lezer/yaml";
@@ -80,6 +86,20 @@ export const esphomeYamlLanguage = LRLanguage.define({
   name: "esphome-yaml",
   parser: yamlParser.configure({
     wrap: parseMixed(nestLambdas),
+    // Restore the fold ranges the bare @lezer/yaml parser doesn't carry
+    // but @codemirror/lang-yaml's yamlLanguage adds — without these the
+    // editor's fold gutter has nothing to fold. Block mappings/sequences
+    // fold from the end of their opening line; flow collections fold
+    // inside their delimiters.
+    props: [
+      foldNodeProp.add({
+        "FlowMapping FlowSequence": foldInside,
+        "Item Pair BlockLiteral": (node, state) => ({
+          from: state.doc.lineAt(node.from).to,
+          to: node.to,
+        }),
+      }),
+    ],
   }),
   languageData: {
     commentTokens: { line: "#" },

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -1,4 +1,9 @@
-import { getIndentation, indentUnit } from "@codemirror/language";
+import {
+  ensureSyntaxTree,
+  foldable,
+  getIndentation,
+  indentUnit,
+} from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
@@ -90,6 +95,45 @@ describe("esphome-yaml indent service", () => {
     expect(indentAt("on_boot:\n  - lambda: |-\n")).toBe(6);
     expect(indentAt("foo:\n  bar: >+\n")).toBe(4);
     expect(indentAt("foo:\n  bar: |\n")).toBe(4);
+  });
+});
+
+/**
+ * `foldable` is CodeMirror's official query for the fold range a given
+ * line opens — using it (rather than reading the parser props directly)
+ * keeps the test resilient to internal API changes. Returns `{from, to}`
+ * for the collapsible region, or `null` when the line opens nothing.
+ */
+function foldAt(yaml: string, lineNumber: number): { from: number; to: number } | null {
+  const state = EditorState.create({
+    doc: yaml,
+    extensions: [indentUnit.of(ESPHOME_YAML_INDENT), esphomeYaml()],
+  });
+  // Force a full parse so the fold service sees the whole tree.
+  ensureSyntaxTree(state, state.doc.length);
+  const line = state.doc.line(lineNumber);
+  return foldable(state, line.from, line.to);
+}
+
+describe("esphome-yaml folding", () => {
+  it("folds a top-level block from the end of its opening line", () => {
+    const yaml = "wifi:\n  ssid: x\n  password: y\n";
+    const range = foldAt(yaml, 1);
+    expect(range).not.toBeNull();
+    // Fold starts at the end of the `wifi:` line, not the start — the
+    // header stays visible when collapsed.
+    expect(range!.from).toBe(yaml.indexOf("\n"));
+    // ...and extends through the last child line.
+    expect(range!.to).toBe("wifi:\n  ssid: x\n  password: y".length);
+  });
+
+  it("does not fold a leaf key with no children", () => {
+    expect(foldAt("wifi:\n  ssid: x\n", 2)).toBeNull();
+  });
+
+  it("folds a list section", () => {
+    const yaml = "sensor:\n  - platform: dht\n    pin: D1\n";
+    expect(foldAt(yaml, 1)).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Restores collapsible sections in the YAML editor, matching the legacy dashboard editor.

The editor already mounts CodeMirror's fold gutter through `basicSetup`, but folding never did anything: the custom `esphomeYamlLanguage` is built from the bare `@lezer/yaml` parser and only configures `wrap: parseMixed(nestLambdas)` for embedded C++ lambdas, so it never attached the `foldNodeProp` that `@codemirror/lang-yaml`'s `yamlLanguage` carries. With no fold ranges registered, no fold arrows appeared and nothing could be collapsed.

This attaches the same `foldNodeProp` to the parser config, reusing the upstream definition: `"Item Pair BlockLiteral"` folds normal indented blocks from the end of their opening line (a top-level `wifi:` collapses its children while the header stays visible), and `"FlowMapping FlowSequence"` folds inline `{...}` / `[...]` collections.

**Related issue or feature (if applicable):**

- Related discussion: https://github.com/orgs/esphome/discussions/3680

The "section names pinned at the top" half of that discussion is out of scope here; this is folding only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
