### PR TITLE
Add schema-backed hover docs to the YAML editor

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -8,10 +8,12 @@ import { basicSetup, EditorView } from "codemirror";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
-import { apiContext, darkModeContext } from "../context/index.js";
+import { type LocalizeFunc } from "../common/localize.js";
+import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { vscodeDark, vscodeLight } from "../util/yaml-editor-theme.js";
+import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import { createBackendYamlLinter } from "../util/yaml-lint-backend.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 import {
@@ -53,6 +55,10 @@ export class ESPHomeYamlEditor extends LitElement {
   @consume({ context: apiContext })
   @state()
   private _api?: ESPHomeAPI;
+
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
 
   @property() value = "";
 
@@ -268,6 +274,39 @@ export class ESPHomeYamlEditor extends LitElement {
           color: this._darkMode ? "#9aa0a6" : "#5e6772",
           marginTop: "4px",
         },
+        // ─── Hover docs tooltip ─────────────────────────────────────
+        ".cm-tooltip.cm-tooltip-hover": {
+          background: this._darkMode ? "#1f1f23" : "#ffffff",
+          border: this._darkMode ? "1px solid #3a3a44" : "1px solid #e1e4e8",
+          borderRadius: "8px",
+          boxShadow: this._darkMode
+            ? "0 8px 24px rgba(0,0,0,0.5)"
+            : "0 8px 24px rgba(0,0,0,0.12)",
+          maxWidth: "460px",
+        },
+        ".cm-esphome-hover": {
+          padding: "10px 14px",
+          fontSize: "12.5px",
+          lineHeight: "1.5",
+          color: this._darkMode ? "#f0f0f5" : "#1a1a1a",
+        },
+        ".cm-esphome-hover p:last-child": {
+          marginBottom: "0",
+        },
+        ".cm-esphome-hover .cm-esphome-info-meta": {
+          fontStyle: "italic",
+        },
+        ".cm-esphome-info .md-code, .cm-esphome-hover .md-code": {
+          fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+          fontSize: "0.92em",
+          padding: "1px 4px",
+          borderRadius: "4px",
+          background: this._darkMode ? "#2a2a32" : "#f0f1f3",
+        },
+        ".cm-esphome-info .md-link, .cm-esphome-hover .md-link": {
+          color: this._darkMode ? "#7fc4ff" : "#0b5cad",
+          textDecoration: "underline",
+        },
       }),
       EditorView.updateListener.of((update) => {
         // LOAD-BEARING ORDER: `yaml-change` MUST be dispatched
@@ -333,6 +372,10 @@ export class ESPHomeYamlEditor extends LitElement {
           closeOnBlur: true,
           maxRenderedOptions: 60,
         })
+      );
+      // Catalog-backed hover docs (description + "See also" link).
+      extensions.push(
+        createYamlHoverTooltip(this._api, () => this._localize("device.see_also"))
       );
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -648,6 +648,7 @@
     "field_locked_by_board": "Set by the board",
     "bundle_step_progress": "Step {current} of {total} — Adding {name}",
     "docs": "Docs",
+    "see_also": "See also:",
     "advanced_options": "Advanced options",
     "show_advanced": "Show advanced settings",
     "enable_entity": "Enable {name}",

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -270,6 +270,23 @@ export function fetchBundle(api: ESPHomeAPI, name: string): Promise<SchemaBundle
 }
 
 /**
+ * Component/domain docs for a top-level key, read from
+ * ``esphome.json``'s ``core.components`` / ``core.platforms`` maps —
+ * the same source the legacy dashboard hovered. Covers single-instance
+ * components (``esphome``, ``wifi``) *and* bare platform-group domains
+ * (``binary_sensor``, ``button``) the flattened catalog doesn't carry.
+ * Returns ``null`` when the bundle fails to load or the key is absent.
+ */
+export async function getComponentDocs(
+  api: ESPHomeAPI,
+  name: string
+): Promise<string | null> {
+  const core = (await fetchBundle(api, "esphome"))?.core;
+  if (!core) return null;
+  return core.components?.[name]?.docs ?? core.platforms?.[name]?.docs ?? null;
+}
+
+/**
  * Read the trigger keys (``on_boot``, ``on_press``, …) for a
  * component. Walks the schema's ``extends`` chain so triggers
  * inherited from a shared parent schema (e.g.

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -585,7 +585,20 @@ export async function getConfigVarDocsAtPath(
         new Set()
       );
       if (!found) return null;
-      if (i === path.length - 1) return found.docs ?? null;
+      if (i === path.length - 1) {
+        // A typed discriminator's own docs name the variants only as a
+        // ``Supported … are:`` lead-in; append the variant list so the
+        // hover isn't cut off mid-sentence.
+        if (found.type === "typed" && found.typed_key === path[i] && found.types) {
+          const list = Object.keys(found.types)
+            .map((n) => `\`${n}\``)
+            .join(", ");
+          return list
+            ? `${found.docs ? `${found.docs} ` : ""}${list}`
+            : (found.docs ?? null);
+        }
+        return found.docs ?? null;
+      }
       cv = found;
     }
     return null;
@@ -605,6 +618,9 @@ async function findCvInCv(
   visited: Set<string>
 ): Promise<SchemaConfigVar | null> {
   if (cv.type === "typed") {
+    // The discriminator key itself (``type:`` on a typed schema, e.g.
+    // ethernet) carries its docs on the typed cv, not in any variant.
+    if (cv.typed_key === key) return cv;
     for (const variant of Object.values(cv.types ?? {})) {
       if (!variant) continue;
       const found = await findCvInSchema(

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -623,6 +623,11 @@ export async function getConfigVarDocsAtPath(
     }
     return null;
   })();
+  // Don't memoize a transient failure — evict on rejection so the next
+  // hover retries instead of replaying a rejected promise forever.
+  promise.catch(() => {
+    if (configVarDocsCache.get(cacheKey) === promise) configVarDocsCache.delete(cacheKey);
+  });
   configVarDocsCache.set(cacheKey, promise);
   return promise;
 }

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -158,6 +158,7 @@ let versionPromise: Promise<string> | null = null;
 export function _resetSchemaCacheForTests() {
   cache.clear();
   configVarKeysCache.clear();
+  configVarDocsCache.clear();
   versionPromise = null;
 }
 
@@ -178,9 +179,13 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
   const promise = (async () => {
     const { esphome_version } = await api.getVersion();
     if (esphome_version.endsWith("dev")) return "dev";
-    const probe = await fetch(`${SCHEMA_HOST}/${esphome_version}/esphome.json`, {
-      method: "HEAD",
-    });
+    // Probe with GET, not HEAD: the schema CDN serves HEAD responses
+    // *without* the ``access-control-allow-origin`` header and caches
+    // that headerless entry under the URL, so a HEAD probe poisons the
+    // cache and the browser then blocks the real GET of the same bundle
+    // by CORS. A GET probe caches a CORS-clean entry the bundle fetch
+    // reuses. (GET also warms ``esphome.json``, which we need anyway.)
+    const probe = await fetch(`${SCHEMA_HOST}/${esphome_version}/esphome.json`);
     if (probe.ok) return esphome_version;
     // Only fall back to ``dev`` for a definitive
     // "this version isn't published" answer (404). Transient
@@ -539,6 +544,113 @@ async function loadSchemaCv(
   ];
   if (!cv || typeof cv !== "object") return null;
   return cv;
+}
+
+/** Memoise nested-path docs by ``<bundle>|<component>|<a.b.c>``. */
+const configVarDocsCache = new Map<string, Promise<string | null>>();
+
+/**
+ * Resolve the ``docs`` string for a config-var reached by descending
+ * *path* relative to the component's ``CONFIG_SCHEMA`` — e.g.
+ * ``["scan_parameters", "active"]`` under ``esp32_ble_tracker``.
+ * Walks ``extends`` chains and ``typed`` variants at each level.
+ * Returns ``null`` when the path doesn't resolve or carries no docs.
+ */
+export async function getConfigVarDocsAtPath(
+  api: ESPHomeAPI,
+  bundleName: string,
+  componentKey: string,
+  path: string[]
+): Promise<string | null> {
+  if (path.length === 0) return null;
+  const cacheKey = `${bundleName}|${componentKey}|${path.join(".")}`;
+  const cached = configVarDocsCache.get(cacheKey);
+  if (cached) return cached;
+  const promise = (async () => {
+    let cv = await loadSchemaCv(
+      api,
+      bundleName,
+      componentKey,
+      "CONFIG_SCHEMA",
+      new Set()
+    );
+    for (let i = 0; i < path.length; i++) {
+      if (!cv) return null;
+      const found = await findCvInCv(
+        api,
+        bundleName,
+        componentKey,
+        cv,
+        path[i],
+        new Set()
+      );
+      if (!found) return null;
+      if (i === path.length - 1) return found.docs ?? null;
+      cv = found;
+    }
+    return null;
+  })();
+  configVarDocsCache.set(cacheKey, promise);
+  return promise;
+}
+
+/** Find the config-var named *key* reachable from *cv* — descending a
+ *  ``typed`` union's variants or a ``schema``'s config_vars/extends. */
+async function findCvInCv(
+  api: ESPHomeAPI,
+  bundleName: string,
+  componentKey: string,
+  cv: SchemaConfigVar,
+  key: string,
+  visited: Set<string>
+): Promise<SchemaConfigVar | null> {
+  if (cv.type === "typed") {
+    for (const variant of Object.values(cv.types ?? {})) {
+      if (!variant) continue;
+      const found = await findCvInSchema(
+        api,
+        bundleName,
+        componentKey,
+        variant,
+        key,
+        visited
+      );
+      if (found) return found;
+    }
+    return null;
+  }
+  const schema = "schema" in cv ? cv.schema : undefined;
+  if (!schema) return null;
+  return findCvInSchema(api, bundleName, componentKey, schema, key, visited);
+}
+
+/** Look up *key* in a ``SchemaSchema``: its own ``config_vars`` first,
+ *  then each ``extends`` reference (recursively). */
+async function findCvInSchema(
+  api: ESPHomeAPI,
+  bundleName: string,
+  componentKey: string,
+  schema: SchemaSchema,
+  key: string,
+  visited: Set<string>
+): Promise<SchemaConfigVar | null> {
+  const direct = schema.config_vars?.[key];
+  if (direct) return direct;
+  for (const ext of schema.extends ?? []) {
+    const ref = parseExtendsRef(ext);
+    if (!ref) continue;
+    const cv = await loadSchemaCv(
+      api,
+      ref.bundle,
+      ref.componentKey,
+      ref.schemaName,
+      visited
+    );
+    if (!cv) continue;
+    const found = await findCvInCv(api, ref.bundle, ref.componentKey, cv, key, visited);
+    if (found) return found;
+  }
+  return null;
 }
 
 export interface SchemaEnumValue {

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -215,11 +215,8 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
  * schema-driven extras when ``null``.
  */
 export function fetchBundle(api: ESPHomeAPI, name: string): Promise<SchemaBundle | null> {
-  // "core" is a component *inside* esphome.json (the core actions /
-  // conditions live at ``esphome.json[core]``), not a bundle of its own.
-  // A "core.*" registry ref would otherwise fetch a nonexistent core.json
-  // and 404. The ``bundle["core"]`` lookups still resolve against
-  // esphome.json.
+  // "core" lives inside esphome.json (no core.json exists); a "core.*"
+  // registry ref would otherwise 404. `bundle["core"]` still resolves.
   if (name === "core") name = "esphome";
   // First-line dedupe: concurrent callers asking for the same
   // bundle name (before we know the version) share one promise.

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -215,6 +215,12 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
  * schema-driven extras when ``null``.
  */
 export function fetchBundle(api: ESPHomeAPI, name: string): Promise<SchemaBundle | null> {
+  // "core" is a component *inside* esphome.json (the core actions /
+  // conditions live at ``esphome.json[core]``), not a bundle of its own.
+  // A "core.*" registry ref would otherwise fetch a nonexistent core.json
+  // and 404. The ``bundle["core"]`` lookups still resolve against
+  // esphome.json.
+  if (name === "core") name = "esphome";
   // First-line dedupe: concurrent callers asking for the same
   // bundle name (before we know the version) share one promise.
   // Once the version resolves, the entry gets re-keyed under

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -172,6 +172,26 @@ export function getTopLevelKey(state: EditorState, pos: number): string | null {
 }
 
 /**
+ * Collect the key chain from the top-level mapping down to the pair
+ * enclosing *pos* (``esp32_ble_tracker`` → ``scan_parameters`` →
+ * ``active``). Returns ``[]`` when *pos* isn't inside a mapping pair.
+ * List-item wrappers contribute no key — only ``Pair`` keys land in
+ * the chain — so a field under ``- platform: gpio`` yields
+ * ``[<domain>, <field>]``, matching how the schema nests platform
+ * fields directly under the component.
+ */
+export function getKeyPath(state: EditorState, pos: number): string[] {
+  const keys: string[] = [];
+  let cur = findEnclosingPair(syntaxTree(state).resolveInner(pos, -1));
+  while (cur) {
+    const k = getPairKey(state, cur);
+    if (k) keys.push(k);
+    cur = findEnclosingPair(cur.parent?.parent ?? null);
+  }
+  return keys.reverse();
+}
+
+/**
  * Read the ``platform:`` value of the enclosing list-item, if any
  * (``binary_sensor: - platform: gpio`` → ``"gpio"``). Returns
  * ``null`` when the cursor isn't inside a list-item that declares

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -144,7 +144,7 @@ const RE_ENUM_VALUE = /^[A-Za-z0-9_./-]*$/;
 // the moment the user types past the dot.
 const RE_KEY_OR_ACTION = /^[A-Za-z0-9_.]*$/;
 
-interface CatalogIndex {
+export interface CatalogIndex {
   /** Loaded list of components — used for top-level keys. */
   components: ComponentCatalogEntry[];
   /** id → component for direct lookups. */
@@ -160,7 +160,7 @@ let catalogPromise: Promise<CatalogIndex> | null = null;
  * (~1k entries) to keep entirely in memory; caching avoids re-fetching
  * on every keystroke.
  */
-function loadCatalog(api: ESPHomeAPI): Promise<CatalogIndex> {
+export function loadCatalog(api: ESPHomeAPI): Promise<CatalogIndex> {
   if (catalogPromise) return catalogPromise;
   catalogPromise = (async () => {
     const res = await api.getComponents({ limit: 2000 });
@@ -535,7 +535,7 @@ function registryToCompletion(e: SchemaRegistryEntry, registryKey: string): Comp
  * the ``_BINARY_SENSOR_SCHEMA`` referenced by the platform's
  * ``extends`` chain — ``getTriggerKeys`` follows that chain.
  */
-function bundleFor(
+export function bundleFor(
   topLevelKey: string,
   platformValue: string | null
 ): { bundle: string; componentKey: string } {

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -637,7 +637,6 @@ export async function resolveAvailableEntries(
 function resolveCompletionContext(
   state: EditorState,
   pos: number,
-  allLines: string[],
   lineIdx: number,
   indent: number
 ): {
@@ -664,8 +663,8 @@ function resolveCompletionContext(
   }
   return {
     bundleCtx: null,
-    platformValue: readPlatformSibling(allLines, lineIdx, indent),
-    topLevelKey: findTopLevelBlock(allLines, lineIdx),
+    platformValue: readPlatformSibling(state.doc, lineIdx, indent),
+    topLevelKey: findTopLevelBlock(state.doc, lineIdx),
   };
 }
 
@@ -689,8 +688,6 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       const idx = commentStart.index + commentStart[0].length - 1;
       if (colInLine > idx) return null;
     }
-
-    const allLines = state.doc.toString().split("\n");
 
     // ── Value position: `key:` already on this line, cursor after the colon.
     // Value position: cursor is past ``  key: partial`` (plain) or
@@ -742,7 +739,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       // `platform:` value → suggest components whose category matches the
       // parent top-level block (e.g. sensor: → platforms in sensor category).
       if (key === "platform") {
-        const block = findTopLevelBlock(allLines, lineInfo.number - 1);
+        const block = findTopLevelBlock(state.doc, lineInfo.number - 1);
         if (block) {
           const candidates = catalog.byCategory.get(block) ?? [];
           if (candidates.length > 0) {
@@ -756,14 +753,13 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       }
 
       // Resolve the entry being set so we can value-complete against it.
-      const parent = findParentKey(allLines, lineInfo.number - 1, indent);
+      const parent = findParentKey(state.doc, lineInfo.number - 1, indent);
       // We're in a top-level value (rare — most top-level values
       // are mappings). Bail.
       if (!parent) return null;
       const completionCtx = resolveCompletionContext(
         state,
         pos,
-        allLines,
         lineInfo.number - 1,
         indent
       );
@@ -861,13 +857,12 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     }
 
     // Nested → config_entries of the parent block (or platform-merged).
-    const parent = findParentKey(allLines, lineInfo.number - 1, indent);
+    const parent = findParentKey(state.doc, lineInfo.number - 1, indent);
     if (!parent) return null;
 
     const completionCtx = resolveCompletionContext(
       state,
       pos,
-      allLines,
       lineInfo.number - 1,
       indent
     );

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -21,6 +21,7 @@ import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import {
   getActions,
+  getComponentDocs,
   getConfigVarDocsAtPath,
   getConfigVarValueOptions,
   getRegistryEntries,
@@ -105,7 +106,9 @@ function findConfigEntry(entries: ConfigEntry[], key: string): ConfigEntry | und
 }
 
 /** Catalog field description + docs link — the fallback for keys the
- *  schema walk doesn't carry docs for. */
+ *  schema walk doesn't carry docs for. Prefixes the field type in bold
+ *  (``**string**: …``) to match the legacy editor, whose schema-sourced
+ *  docs carry that prefix verbatim. */
 function fieldTarget(
   entry: ConfigEntry,
   owner: ComponentCatalogEntry | undefined
@@ -113,7 +116,7 @@ function fieldTarget(
   const docsUrl = entry.help_link || owner?.docs_url || null;
   if (!entry.description && !docsUrl) return null;
   return {
-    description: entry.description || null,
+    description: entry.description ? `**${entry.type}**: ${entry.description}` : null,
     docsUrl,
     docsTitle: owner?.name || null,
   };
@@ -140,10 +143,12 @@ export async function resolveHoverTarget(
   const lineIdx = line.number - 1;
   const allLines = state.doc.toString().split("\n");
 
-  // Top-level component key → its catalog description. Always shown
-  // (even though the structured editor documents it) so a hover
-  // confirms what a block is at a glance.
+  // Top-level component / domain key → its docs. Prefer the schema's
+  // core component/platform docs (covers bare domains like
+  // ``binary_sensor:`` the catalog lacks), falling back to the catalog.
   if (indent === 0) {
+    const schemaDocs = await getComponentDocs(api, key);
+    if (schemaDocs) return docsTarget(schemaDocs);
     const c = catalog.byId.get(key);
     return c ? componentTarget(c) : null;
   }

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -125,10 +125,9 @@ function fieldTarget(
 }
 
 /**
- * True when the structured editor can't render a form for the component —
- * it has no ``config_entries`` (e.g. ``ethernet``) or is an always-YAML
- * section (``packages`` / ``external_components``). Mirrors the structured
- * editor's own ``isYamlOnlySection`` so hover and form stay in lockstep.
+ * True when the structured editor has no form for the component (no
+ * ``config_entries`` like ``ethernet``, or an always-YAML section). Same
+ * check the structured editor uses, so hover and form stay in sync.
  */
 async function isYamlOnlyComponent(
   api: ESPHomeAPI,
@@ -140,10 +139,9 @@ async function isYamlOnlyComponent(
   try {
     comp = await fetchComponent(api, componentId);
   } catch {
-    return true; // can't tell → leave the hover on rather than break it
+    return true; // fetch failed → leave the hover on
   }
-  // `config_entries` is absent (not just empty) on form-less components
-  // like ethernet — optional-chain both so the gate can't throw.
+  // `config_entries` is absent (not []) on form-less components.
   return isYamlOnlySection(topLevelKey, comp?.config_entries?.length ?? 0);
 }
 
@@ -168,22 +166,13 @@ export async function resolveHoverTarget(
   const lineIdx = line.number - 1;
   const allLines = state.doc.toString().split("\n");
 
-  // Resolve the top-level component (and platform, for platform lists)
-  // up front so we can gate the whole hover on it.
-  const bundleCtx = indent === 0 ? null : resolveBundleContext(state, pos);
-  const topLevelKey =
-    indent === 0 ? key : (bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx));
-  const platformValue =
-    indent === 0
-      ? null
-      : bundleCtx
-        ? bundleCtx.platformValue
-        : readPlatformSibling(allLines, lineIdx, indent);
+  const bundleCtx = resolveBundleContext(state, pos);
+  const topLevelKey = bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx);
+  const platformValue = bundleCtx
+    ? bundleCtx.platformValue
+    : readPlatformSibling(allLines, lineIdx, indent);
 
-  // Only document what the structured editor can't render a form for —
-  // components with no config_entries (e.g. ethernet) or the always-YAML
-  // sections (packages / external_components). The form already documents
-  // everything else on screen, so a tooltip there would just duplicate it.
+  // Don't duplicate the structured editor: skip components it can form-edit.
   if (topLevelKey && !(await isYamlOnlyComponent(api, topLevelKey, platformValue))) {
     return null;
   }

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -324,6 +324,6 @@ export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => s
     // Only a deliberate pause triggers the tooltip — the 300ms default
     // fires on an incidental pointer rest while editing, which reads as
     // noise. Hide it the moment the doc changes (the user resumed typing).
-    { hideOnChange: true, hoverTime: 700 }
+    { hideOnChange: true, hoverTime: 500 }
   );
 }

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -159,10 +159,16 @@ export async function resolveHoverTarget(
   const colonIdx = line.text.indexOf(":");
   const overValue = colonIdx >= 0 && colInLine > colonIdx && rest.trim().length > 0;
 
-  // 1. Enum value → that option's meaning (the form's dropdown never
-  //    shows per-value docs, so this is always worth surfacing).
+  // 1. Value position.
   if (overValue) {
     if (!topLevelKey) return null;
+    // ``platform: <value>`` → the platform component's description.
+    if (key === "platform") {
+      const c = catalog.byId.get(`${topLevelKey}.${unquote(rest.trim())}`);
+      return c ? componentTarget(c) : null;
+    }
+    // Otherwise an enum value → that option's meaning (the form's
+    // dropdown never shows per-value docs).
     const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
     const options = await getConfigVarValueOptions(api, bundle, componentKey, key);
     return docsTarget(options.find((o) => o.value === unquote(rest.trim()))?.docs);
@@ -212,7 +218,11 @@ export async function resolveHoverTarget(
     path.slice(1)
   );
   if (schemaDocs) return docsTarget(schemaDocs);
-  const comp = catalog.byId.get(componentKey) ?? catalog.byId.get(topLevelKey);
+  // Catalog fallback. The catalog keys platforms as ``<domain>.<stem>``
+  // (``binary_sensor.gpio``), the reverse of the schema bundle's
+  // ``<stem>.<domain>`` componentKey — use the catalog form here.
+  const catalogId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
+  const comp = catalog.byId.get(catalogId);
   const entry = comp ? findConfigEntry(comp.config_entries ?? [], key) : undefined;
   return entry ? fieldTarget(entry, comp) : null;
 }

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -136,8 +136,15 @@ async function isYamlOnlyComponent(
   platformValue: string | null
 ): Promise<boolean> {
   const componentId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
-  const comp = await fetchComponent(api, componentId);
-  return isYamlOnlySection(topLevelKey, comp?.config_entries.length ?? 0);
+  let comp: ComponentCatalogEntry | null;
+  try {
+    comp = await fetchComponent(api, componentId);
+  } catch {
+    return true; // can't tell → leave the hover on rather than break it
+  }
+  // `config_entries` is absent (not just empty) on form-less components
+  // like ethernet — optional-chain both so the gate can't throw.
+  return isYamlOnlySection(topLevelKey, comp?.config_entries?.length ?? 0);
 }
 
 /**

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -1,0 +1,279 @@
+/**
+ * Schema-driven hover docs for the ESPHome YAML editor.
+ *
+ * The structured editor panel already documents a component's visible
+ * ``config_entries`` (and the component header), so a hover that repeats
+ * those is noise. This resolver instead surfaces docs for the keys that
+ * only exist in raw YAML — resolving against the full schema bundle
+ * (``schema.esphome.io`` via ``esphome-schema.ts``) and *suppressing*
+ * anything the form already shows:
+ *
+ *   - enum values (``device_class: garage_door`` → that option's meaning)
+ *   - automation actions / triggers (``on_press:``, ``logger.log`` — the
+ *     backend strips these from ``config_entries``)
+ *   - registry/filter list entries (``sensor.filters`` members)
+ *   - deeply-nested schema keys not in the curated catalog
+ *
+ * Top-level component keys always show their catalog description; nested
+ * keys the structured editor already documents (visible ``config_entries``)
+ * resolve to ``null`` (no tooltip).
+ */
+import type { EditorState } from "@codemirror/state";
+import { hoverTooltip, type Tooltip } from "@codemirror/view";
+import { html, nothing, render } from "lit";
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type { ComponentCatalogEntry } from "../api/types/components.js";
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import {
+  getActions,
+  getConfigVarDocsAtPath,
+  getConfigVarValueOptions,
+  getRegistryEntries,
+  getTriggerKeys,
+  lookupRegistryRef,
+} from "./esphome-schema.js";
+import { isSafeLinkHref, renderMarkdown } from "./markdown.js";
+import {
+  collectTopLevelKeys,
+  getKeyPath,
+  isUnderAutomationItem,
+  resolveBundleContext,
+} from "./yaml-ast.js";
+import { bundleFor, loadCatalog, type CatalogIndex } from "./yaml-completion.js";
+import {
+  findParentKey,
+  findTopLevelBlock,
+  indentOf,
+  RE_INLINE_COMMENT_BOUNDARY,
+  RE_PAIR_LINE,
+  readPlatformSibling,
+  stripComment,
+} from "./yaml-line-walker.js";
+
+/** Resolved hover content — Markdown docs plus an optional "See also" link. */
+export interface HoverTarget {
+  description: string | null;
+  docsUrl: string | null;
+  docsTitle: string | null;
+}
+
+/** Strip one layer of matched quotes (mirrors the AST / line-walker). */
+function unquote(value: string): string {
+  if (value.length < 2) return value;
+  const q = value[0];
+  if ((q === '"' || q === "'") && value[value.length - 1] === q) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Trailing ``See also: [Title](url)`` footer the schema docstrings carry,
+ * usually italic-wrapped (``*See also: [Light Component](…)*``). It's
+ * pulled out so it renders as a real "See also" link — the inline
+ * Markdown renderer deliberately doesn't recurse into italic, so left in
+ * place the link would show as raw ``[text](url)`` text.
+ */
+const SEE_ALSO_RE = /\s*\*?\s*See also:\s*\[([^\]]+)\]\(([^)]+)\)\*?\s*$/i;
+
+/** Build a hover target from a schema docs string, splitting off any
+ *  trailing "See also" link into a proper docs link. */
+function docsTarget(docs: string | null | undefined): HoverTarget | null {
+  if (!docs) return null;
+  const m = docs.match(SEE_ALSO_RE);
+  const description = (m ? docs.slice(0, m.index) : docs).trim() || null;
+  const docsUrl = m ? m[2] : null;
+  if (!description && !docsUrl) return null;
+  return { description, docsUrl, docsTitle: m ? m[1] : null };
+}
+
+/** Catalog description for a top-level component, with its docs link. */
+function componentTarget(c: ComponentCatalogEntry): HoverTarget | null {
+  if (!c.description && !c.docs_url) return null;
+  return {
+    description: c.description || null,
+    docsUrl: c.docs_url || null,
+    docsTitle: c.name || null,
+  };
+}
+
+/** Find a ConfigEntry by key anywhere in the (recursive) entry tree. */
+function findConfigEntry(entries: ConfigEntry[], key: string): ConfigEntry | undefined {
+  for (const e of entries) {
+    if (e.key === key) return e;
+    const nested = e.config_entries?.length
+      ? findConfigEntry(e.config_entries, key)
+      : undefined;
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+/** True when *key* is a visible (non-hidden) catalog field of *comp* —
+ *  i.e. the structured editor already documents it, so hover should not. */
+function formDocuments(comp: ComponentCatalogEntry | undefined, key: string): boolean {
+  if (!comp) return false;
+  const entry = findConfigEntry(comp.config_entries ?? [], key);
+  return !!entry && !entry.hidden;
+}
+
+/**
+ * Resolve schema docs for the YAML token under *pos*, or ``null`` when
+ * nothing applies (or the structured editor already documents it).
+ * Reuses the completion source's context helpers so hover and completion
+ * agree on structure.
+ */
+export async function resolveHoverTarget(
+  state: EditorState,
+  pos: number,
+  api: ESPHomeAPI,
+  catalog: CatalogIndex
+): Promise<HoverTarget | null> {
+  const line = state.doc.lineAt(pos);
+  const stripped = stripComment(line.text);
+  const m = stripped.match(RE_PAIR_LINE);
+  if (!m) return null;
+  const key = m[1];
+  const rest = m[2];
+  const indent = indentOf(stripped);
+  const lineIdx = line.number - 1;
+  const allLines = state.doc.toString().split("\n");
+
+  // Top-level component key → its catalog description. Always shown
+  // (even though the structured editor documents it) so a hover
+  // confirms what a block is at a glance.
+  if (indent === 0) {
+    const c = catalog.byId.get(key);
+    return c ? componentTarget(c) : null;
+  }
+
+  const bundleCtx = resolveBundleContext(state, pos);
+  const topLevelKey = bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx);
+  const platformValue = bundleCtx
+    ? bundleCtx.platformValue
+    : readPlatformSibling(allLines, lineIdx, indent);
+
+  // Pointer over the value (right of the first colon) with a value present.
+  const colInLine = pos - line.from;
+  const colonIdx = line.text.indexOf(":");
+  const overValue = colonIdx >= 0 && colInLine > colonIdx && rest.trim().length > 0;
+
+  // 1. Enum value → that option's meaning (the form's dropdown never
+  //    shows per-value docs, so this is always worth surfacing).
+  if (overValue) {
+    if (!topLevelKey) return null;
+    const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
+    const options = await getConfigVarValueOptions(api, bundle, componentKey, key);
+    return docsTarget(options.find((o) => o.value === unquote(rest.trim()))?.docs);
+  }
+
+  const isListItem = /^\s*-\s/.test(line.text);
+
+  // 2. Automation action key (list item under then:/else:/on_*:/*_action:).
+  if (isListItem && isUnderAutomationItem(state, pos)) {
+    const tops = collectTopLevelKeys(state);
+    const bundles = [...new Set([...tops, "esphome"])];
+    const actions = await getActions(api, bundles, [...tops, "core"]);
+    return docsTarget(actions.find((a) => a.key === key)?.docs);
+  }
+
+  // 3. Trigger key (on_*).
+  if (key.startsWith("on_") && topLevelKey) {
+    const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
+    const triggers = await getTriggerKeys(api, bundle, componentKey);
+    const hit = triggers.find((t) => t.key === key);
+    if (hit?.docs) return docsTarget(hit.docs);
+  }
+
+  const parent = findParentKey(allLines, lineIdx, indent);
+
+  // 4. Registry / filter list entry (parent key is a registry config-var).
+  if (isListItem && parent && topLevelKey) {
+    const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
+    const ref = await lookupRegistryRef(api, bundle, componentKey, parent.key);
+    if (ref) {
+      const entries = await getRegistryEntries(api, ref);
+      const hit = entries.find((e) => e.key === key);
+      if (hit?.docs) return docsTarget(hit.docs);
+    }
+  }
+
+  // 5. Nested / plain key. Suppress what the structured editor documents:
+  //    top-level component keys and visible catalog config_entries.
+  const path = getKeyPath(state, pos);
+  if (indent === 0 || path.length <= 1 || !topLevelKey) return null;
+  const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
+  const comp = catalog.byId.get(componentKey) ?? catalog.byId.get(topLevelKey);
+  if (formDocuments(comp, key)) return null;
+  return docsTarget(
+    await getConfigVarDocsAtPath(api, bundle, componentKey, path.slice(1))
+  );
+}
+
+/** Build the tooltip DOM: Markdown description + optional "See also" link. */
+function buildHoverDom(target: HoverTarget, seeAlsoLabel: string): HTMLElement {
+  const dom = document.createElement("div");
+  dom.className = "cm-esphome-info cm-esphome-hover";
+  const seeAlso =
+    target.docsUrl && isSafeLinkHref(target.docsUrl)
+      ? html`<div class="cm-esphome-info-meta">
+          ${seeAlsoLabel}
+          <a
+            class="md-link"
+            href=${target.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            >${target.docsTitle ?? target.docsUrl}</a
+          >
+        </div>`
+      : nothing;
+  render(
+    html`${target.description
+      ? html`<p>${renderMarkdown(target.description)}</p>`
+      : nothing}${seeAlso}`,
+    dom
+  );
+  return dom;
+}
+
+/** True when *pos* sits inside a ``# comment`` on its line. */
+function inComment(state: EditorState, pos: number): boolean {
+  const line = state.doc.lineAt(pos);
+  const before = line.text.slice(0, pos - line.from);
+  const m = before.match(RE_INLINE_COMMENT_BOUNDARY);
+  if (!m || m.index === undefined) return false;
+  return pos - line.from > m.index + m[0].length - 1;
+}
+
+/**
+ * CodeMirror hover-tooltip extension backed by the component catalog.
+ * ``getSeeAlsoLabel`` is read per-tooltip so a locale switch is picked
+ * up without rebuilding the editor.
+ */
+export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => string) {
+  return hoverTooltip(
+    async (view, pos): Promise<Tooltip | null> => {
+      if (inComment(view.state, pos)) return null;
+      const word = view.state.wordAt(pos);
+      if (!word) return null;
+      let catalog: CatalogIndex;
+      try {
+        catalog = await loadCatalog(api);
+      } catch {
+        return null;
+      }
+      const target = await resolveHoverTarget(view.state, pos, api, catalog);
+      if (!target) return null;
+      return {
+        pos: word.from,
+        end: word.to,
+        above: true,
+        create: () => ({ dom: buildHoverDom(target, getSeeAlsoLabel()) }),
+      };
+    },
+    // Only a deliberate pause triggers the tooltip — the 300ms default
+    // fires on an incidental pointer rest while editing, which reads as
+    // noise. Hide it the moment the doc changes (the user resumed typing).
+    { hideOnChange: true, hoverTime: 700 }
+  );
+}

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -19,6 +19,8 @@ import { html, nothing, render } from "lit";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
+import { isYamlOnlySection } from "../components/device/yaml-only-sections.js";
+import { fetchComponent } from "./component-name-cache.js";
 import {
   getActions,
   getComponentDocs,
@@ -123,6 +125,22 @@ function fieldTarget(
 }
 
 /**
+ * True when the structured editor can't render a form for the component —
+ * it has no ``config_entries`` (e.g. ``ethernet``) or is an always-YAML
+ * section (``packages`` / ``external_components``). Mirrors the structured
+ * editor's own ``isYamlOnlySection`` so hover and form stay in lockstep.
+ */
+async function isYamlOnlyComponent(
+  api: ESPHomeAPI,
+  topLevelKey: string,
+  platformValue: string | null
+): Promise<boolean> {
+  const componentId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
+  const comp = await fetchComponent(api, componentId);
+  return isYamlOnlySection(topLevelKey, comp?.config_entries.length ?? 0);
+}
+
+/**
  * Resolve hover docs for the YAML token under *pos*, or ``null`` when
  * nothing maps. Reuses the completion source's context helpers so hover
  * and completion agree on structure.
@@ -143,6 +161,26 @@ export async function resolveHoverTarget(
   const lineIdx = line.number - 1;
   const allLines = state.doc.toString().split("\n");
 
+  // Resolve the top-level component (and platform, for platform lists)
+  // up front so we can gate the whole hover on it.
+  const bundleCtx = indent === 0 ? null : resolveBundleContext(state, pos);
+  const topLevelKey =
+    indent === 0 ? key : (bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx));
+  const platformValue =
+    indent === 0
+      ? null
+      : bundleCtx
+        ? bundleCtx.platformValue
+        : readPlatformSibling(allLines, lineIdx, indent);
+
+  // Only document what the structured editor can't render a form for —
+  // components with no config_entries (e.g. ethernet) or the always-YAML
+  // sections (packages / external_components). The form already documents
+  // everything else on screen, so a tooltip there would just duplicate it.
+  if (topLevelKey && !(await isYamlOnlyComponent(api, topLevelKey, platformValue))) {
+    return null;
+  }
+
   // Top-level component / domain key → its docs. Prefer the schema's
   // core component/platform docs (covers bare domains like
   // ``binary_sensor:`` the catalog lacks), falling back to the catalog.
@@ -152,12 +190,6 @@ export async function resolveHoverTarget(
     const c = catalog.byId.get(key);
     return c ? componentTarget(c) : null;
   }
-
-  const bundleCtx = resolveBundleContext(state, pos);
-  const topLevelKey = bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx);
-  const platformValue = bundleCtx
-    ? bundleCtx.platformValue
-    : readPlatformSibling(allLines, lineIdx, indent);
 
   // Pointer over the value (right of the first colon) with a value present.
   const colInLine = pos - line.from;

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -135,13 +135,8 @@ async function isYamlOnlyComponent(
   platformValue: string | null
 ): Promise<boolean> {
   const componentId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
-  let comp: ComponentCatalogEntry | null;
-  try {
-    comp = await fetchComponent(api, componentId);
-  } catch {
-    return true; // fetch failed → leave the hover on
-  }
-  // `config_entries` is absent (not []) on form-less components.
+  const comp = await fetchComponent(api, componentId);
+  // `config_entries` is absent (not []) on form-less components like ethernet.
   return isYamlOnlySection(topLevelKey, comp?.config_entries?.length ?? 0);
 }
 
@@ -306,13 +301,16 @@ export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => s
       if (inComment(view.state, pos)) return null;
       const word = view.state.wordAt(pos);
       if (!word) return null;
-      let catalog: CatalogIndex;
+      let target: HoverTarget | null;
       try {
-        catalog = await loadCatalog(api);
-      } catch {
+        const catalog = await loadCatalog(api);
+        target = await resolveHoverTarget(view.state, pos, api, catalog);
+      } catch (err) {
+        // Any catalog/schema fetch failure degrades to no tooltip; log it so
+        // a real outage (loadCatalog is shared with completion) is visible.
+        console.debug("[yaml-hover] failed to resolve hover docs:", err);
         return null;
       }
-      const target = await resolveHoverTarget(view.state, pos, api, catalog);
       if (!target) return null;
       return {
         pos: word.from,

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -306,9 +306,10 @@ export function createYamlHoverTooltip(api: ESPHomeAPI, getSeeAlsoLabel: () => s
         const catalog = await loadCatalog(api);
         target = await resolveHoverTarget(view.state, pos, api, catalog);
       } catch (err) {
-        // Any catalog/schema fetch failure degrades to no tooltip; log it so
-        // a real outage (loadCatalog is shared with completion) is visible.
-        console.debug("[yaml-hover] failed to resolve hover docs:", err);
+        // The catalog/schema fetches degrade gracefully on their own, so
+        // reaching here is an unexpected error — warn (visible by default,
+        // unlike debug) since a persistent failure silently kills hovers.
+        console.warn("[yaml-hover] failed to resolve hover docs:", err);
         return null;
       }
       if (!target) return null;

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -1,22 +1,17 @@
 /**
  * Schema-driven hover docs for the ESPHome YAML editor.
  *
- * The structured editor panel already documents a component's visible
- * ``config_entries`` (and the component header), so a hover that repeats
- * those is noise. This resolver instead surfaces docs for the keys that
- * only exist in raw YAML — resolving against the full schema bundle
- * (``schema.esphome.io`` via ``esphome-schema.ts``) and *suppressing*
- * anything the form already shows:
+ * Full parity with the legacy editor's hover: every YAML token that maps
+ * to something documented gets a tooltip. Docs come from the full schema
+ * bundle (``schema.esphome.io`` via ``esphome-schema.ts``), with the
+ * component catalog as the fallback:
  *
- *   - enum values (``device_class: garage_door`` → that option's meaning)
- *   - automation actions / triggers (``on_press:``, ``logger.log`` — the
- *     backend strips these from ``config_entries``)
+ *   - top-level component keys → catalog description
+ *   - enum values (``device_class: garage_door``) → that option's meaning
+ *   - automation actions / triggers (``on_press:``, ``logger.log``)
  *   - registry/filter list entries (``sensor.filters`` members)
- *   - deeply-nested schema keys not in the curated catalog
- *
- * Top-level component keys always show their catalog description; nested
- * keys the structured editor already documents (visible ``config_entries``)
- * resolve to ``null`` (no tooltip).
+ *   - any config key, nested or not → schema docs, else its catalog
+ *     ``config_entry`` description
  */
 import type { EditorState } from "@codemirror/state";
 import { hoverTooltip, type Tooltip } from "@codemirror/view";
@@ -109,19 +104,25 @@ function findConfigEntry(entries: ConfigEntry[], key: string): ConfigEntry | und
   return undefined;
 }
 
-/** True when *key* is a visible (non-hidden) catalog field of *comp* —
- *  i.e. the structured editor already documents it, so hover should not. */
-function formDocuments(comp: ComponentCatalogEntry | undefined, key: string): boolean {
-  if (!comp) return false;
-  const entry = findConfigEntry(comp.config_entries ?? [], key);
-  return !!entry && !entry.hidden;
+/** Catalog field description + docs link — the fallback for keys the
+ *  schema walk doesn't carry docs for. */
+function fieldTarget(
+  entry: ConfigEntry,
+  owner: ComponentCatalogEntry | undefined
+): HoverTarget | null {
+  const docsUrl = entry.help_link || owner?.docs_url || null;
+  if (!entry.description && !docsUrl) return null;
+  return {
+    description: entry.description || null,
+    docsUrl,
+    docsTitle: owner?.name || null,
+  };
 }
 
 /**
- * Resolve schema docs for the YAML token under *pos*, or ``null`` when
- * nothing applies (or the structured editor already documents it).
- * Reuses the completion source's context helpers so hover and completion
- * agree on structure.
+ * Resolve hover docs for the YAML token under *pos*, or ``null`` when
+ * nothing maps. Reuses the completion source's context helpers so hover
+ * and completion agree on structure.
  */
 export async function resolveHoverTarget(
   state: EditorState,
@@ -198,16 +199,22 @@ export async function resolveHoverTarget(
     }
   }
 
-  // 5. Nested / plain key. Suppress what the structured editor documents:
-  //    top-level component keys and visible catalog config_entries.
+  // 5. Nested / plain key. Full parity with the legacy editor — every
+  //    key gets docs: the schema walk first, then the catalog field
+  //    description for keys the schema doesn't carry docs for.
   const path = getKeyPath(state, pos);
-  if (indent === 0 || path.length <= 1 || !topLevelKey) return null;
+  if (path.length <= 1 || !topLevelKey) return null;
   const { bundle, componentKey } = bundleFor(topLevelKey, platformValue);
-  const comp = catalog.byId.get(componentKey) ?? catalog.byId.get(topLevelKey);
-  if (formDocuments(comp, key)) return null;
-  return docsTarget(
-    await getConfigVarDocsAtPath(api, bundle, componentKey, path.slice(1))
+  const schemaDocs = await getConfigVarDocsAtPath(
+    api,
+    bundle,
+    componentKey,
+    path.slice(1)
   );
+  if (schemaDocs) return docsTarget(schemaDocs);
+  const comp = catalog.byId.get(componentKey) ?? catalog.byId.get(topLevelKey);
+  const entry = comp ? findConfigEntry(comp.config_entries ?? [], key) : undefined;
+  return entry ? fieldTarget(entry, comp) : null;
 }
 
 /** Build the tooltip DOM: Markdown description + optional "See also" link. */

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -159,13 +159,12 @@ export async function resolveHoverTarget(
   const rest = m[2];
   const indent = indentOf(stripped);
   const lineIdx = line.number - 1;
-  const allLines = state.doc.toString().split("\n");
 
   const bundleCtx = resolveBundleContext(state, pos);
-  const topLevelKey = bundleCtx?.topLevelKey ?? findTopLevelBlock(allLines, lineIdx);
+  const topLevelKey = bundleCtx?.topLevelKey ?? findTopLevelBlock(state.doc, lineIdx);
   const platformValue = bundleCtx
     ? bundleCtx.platformValue
-    : readPlatformSibling(allLines, lineIdx, indent);
+    : readPlatformSibling(state.doc, lineIdx, indent);
 
   // Don't duplicate the structured editor: skip components it can form-edit.
   if (topLevelKey && !(await isYamlOnlyComponent(api, topLevelKey, platformValue))) {
@@ -220,7 +219,7 @@ export async function resolveHoverTarget(
     if (hit?.docs) return docsTarget(hit.docs);
   }
 
-  const parent = findParentKey(allLines, lineIdx, indent);
+  const parent = findParentKey(state.doc, lineIdx, indent);
 
   // 4. Registry / filter list entry (parent key is a registry config-var).
   if (isListItem && parent && topLevelKey) {

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -3,15 +3,16 @@
  * ``yaml-ast.ts`` when partial / unparseable input means the
  * Lezer parse tree can't answer a structural question.
  *
- * These look only at the raw text of individual lines, so they're
- * insulated from the editor state and can be exercised in unit
- * tests without an ``EditorState`` mock. The completion source's
- * ``resolveCompletionContext`` prefers the AST answer and falls
- * back to these for the corner cases where the AST is silent.
+ * The multi-line walkers read lines off CodeMirror's ``Text``
+ * (``doc.line(n)``), scanning only the bounded range around the cursor —
+ * never the whole document. The completion source prefers the AST answer
+ * and falls back to these where the parse tree is silent.
  *
  * Anything structural that needs to span multiple lines belongs
  * in ``yaml-ast.ts``; anything single-line-text-shape stays here.
  */
+
+import type { Text } from "@codemirror/state";
 
 // ─── Shared regex constants ─────────────────────────────────────────
 
@@ -77,12 +78,12 @@ export interface ParentKey {
  * the cursor.
  */
 export function findParentKey(
-  lines: string[],
+  doc: Text,
   lineIdx: number,
   belowIndent: number
 ): ParentKey | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
-    const stripped = stripComment(lines[i]);
+    const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     const ind = indentOf(stripped);
     if (ind >= belowIndent) continue;
@@ -93,9 +94,9 @@ export function findParentKey(
 }
 
 /** Walk back from *lineIdx* to the first column-0 ``key:`` line. */
-export function findTopLevelBlock(lines: string[], lineIdx: number): string | null {
+export function findTopLevelBlock(doc: Text, lineIdx: number): string | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
-    const stripped = stripComment(lines[i]);
+    const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     if (indentOf(stripped) !== 0) continue;
     const m = stripped.match(RE_TOP_LEVEL_KEY);
@@ -118,7 +119,7 @@ export function findTopLevelBlock(lines: string[], lineIdx: number): string | nu
  * the parse tree doesn't yet have the structure.
  */
 export function readPlatformSibling(
-  lines: string[],
+  doc: Text,
   lineIdx: number,
   indent: number
 ): string | null {
@@ -130,7 +131,7 @@ export function readPlatformSibling(
   // the walker stops at the immediate enclosing block and misses
   // the outer platform declaration entirely.
   for (let i = lineIdx - 1; i >= 0; i--) {
-    const raw = lines[i];
+    const raw = doc.line(i + 1).text;
     const stripped = stripComment(raw);
     if (!stripped.trim()) continue;
     const ind = indentOf(stripped);
@@ -144,7 +145,7 @@ export function readPlatformSibling(
   // top-of-block, then forward-scan for the ``platform:`` sibling.
   let topOfBlock = lineIdx;
   for (let i = lineIdx - 1; i >= 0; i--) {
-    const raw = lines[i];
+    const raw = doc.line(i + 1).text;
     const stripped = stripComment(raw);
     if (!stripped.trim()) continue;
     const ind = indentOf(stripped);
@@ -154,8 +155,8 @@ export function readPlatformSibling(
       if (/^\s*-\s/.test(raw)) break;
     }
   }
-  for (let i = topOfBlock; i < lines.length; i++) {
-    const stripped = stripComment(lines[i]);
+  for (let i = topOfBlock; i < doc.lines; i++) {
+    const stripped = stripComment(doc.line(i + 1).text);
     if (!stripped.trim()) continue;
     const ind = indentOf(stripped);
     if (i !== topOfBlock && ind < indent) break;

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -3,6 +3,7 @@ import {
   _resetSchemaCacheForTests,
   fetchBundle,
   getActions,
+  getConfigVarDocsAtPath,
   getConfigVarKeys,
   getConfigVarValueOptions,
   getRegistryEntries,
@@ -989,6 +990,91 @@ describe("getRegistryEntryKeys", () => {
       "delay"
     );
     expect(keys.map((k) => k.key)).toEqual(["time"]);
+  });
+});
+
+describe("getConfigVarDocsAtPath", () => {
+  // ethernet-shaped: CONFIG_SCHEMA is a typed union whose ``type:``
+  // discriminator carries its own docs, and each variant pulls the
+  // common fields in via ``extends``.
+  const ETH_BUNDLE = {
+    ethernet: {
+      schemas: {
+        CONFIG_SCHEMA: {
+          type: "typed",
+          typed_key: "type",
+          docs: "The type of LAN chipset.",
+          types: {
+            LAN8720: { config_vars: {}, extends: ["ethernet.RMII_SCHEMA"] },
+          },
+        },
+        RMII_SCHEMA: {
+          type: "schema",
+          schema: {
+            config_vars: {
+              mdc_pin: { type: "pin", docs: "MDC pin." },
+              clk: {
+                type: "schema",
+                schema: {
+                  config_vars: { mode: { type: "string", docs: "Clock mode." } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  function mockEth() {
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+      return new Response(JSON.stringify(ETH_BUNDLE), { status: 200 });
+    });
+  }
+
+  it("returns the typed discriminator's docs with the variant list appended", async () => {
+    mockEth();
+    const docs = await getConfigVarDocsAtPath(
+      makeApi() as never,
+      "ethernet",
+      "ethernet",
+      ["type"]
+    );
+    expect(docs).toBe("The type of LAN chipset. `LAN8720`");
+  });
+
+  it("resolves a field carried into a variant via extends", async () => {
+    mockEth();
+    const docs = await getConfigVarDocsAtPath(
+      makeApi() as never,
+      "ethernet",
+      "ethernet",
+      ["mdc_pin"]
+    );
+    expect(docs).toBe("MDC pin.");
+  });
+
+  it("walks into a nested schema config-var", async () => {
+    mockEth();
+    const docs = await getConfigVarDocsAtPath(
+      makeApi() as never,
+      "ethernet",
+      "ethernet",
+      ["clk", "mode"]
+    );
+    expect(docs).toBe("Clock mode.");
+  });
+
+  it("returns null for an unknown key", async () => {
+    mockEth();
+    const docs = await getConfigVarDocsAtPath(
+      makeApi() as never,
+      "ethernet",
+      "ethernet",
+      ["nope"]
+    );
+    expect(docs).toBeNull();
   });
 });
 

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -80,8 +80,7 @@ afterEach(() => {
 
 describe("fetchBundle", () => {
   it("uses the version reported by the API when schema.esphome.io has it", async () => {
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+    fetchSpy.mockImplementation(async (url: string) => {
       if (url.includes("/2026.5.0/esphome.json"))
         return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       throw new Error(`unexpected fetch ${url}`);
@@ -94,9 +93,9 @@ describe("fetchBundle", () => {
   });
 
   it("falls back to /dev/ when the version-specific bundle is missing", async () => {
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      // HEAD probe says the version-specific bundle isn't published yet.
-      if (init?.method === "HEAD") return new Response(null, { status: 404 });
+    fetchSpy.mockImplementation(async (url: string) => {
+      // Version-specific probe 404s → resolveVersion falls back to dev.
+      if (url.includes("/2026.5.0/")) return new Response(null, { status: 404 });
       if (url.includes("/dev/esphome.json"))
         return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       throw new Error(`unexpected fetch ${url}`);
@@ -115,35 +114,39 @@ describe("fetchBundle", () => {
   });
 
   it("returns null on a non-2xx response", async () => {
-    fetchSpy.mockImplementation(async (_url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+    // Probe esphome.json succeeds; the requested bundle 500s → null.
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(null, { status: 500 });
     });
-    const bundle = await fetchBundle(makeApi() as never, "esphome");
+    const bundle = await fetchBundle(makeApi() as never, "sensor");
     expect(bundle).toBeNull();
   });
 
   it("deduplicates concurrent requests for the same bundle", async () => {
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
-      if (url.includes("esphome.json"))
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
         return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+      if (url.endsWith("/sensor.json"))
+        return new Response(JSON.stringify(SENSOR_BUNDLE), { status: 200 });
       throw new Error(`unexpected fetch ${url}`);
     });
     const api = makeApi() as never;
-    await Promise.all([fetchBundle(api, "esphome"), fetchBundle(api, "esphome")]);
-    // One HEAD probe + one GET, regardless of how many in-flight callers.
-    const gets = fetchSpy.mock.calls.filter(
-      (c) => (c[1] as RequestInit | undefined)?.method !== "HEAD"
+    await Promise.all([fetchBundle(api, "sensor"), fetchBundle(api, "sensor")]);
+    // Concurrent callers for the same bundle share one network GET.
+    const sensorGets = fetchSpy.mock.calls.filter((c) =>
+      String(c[0]).endsWith("/sensor.json")
     );
-    expect(gets.length).toBe(1);
+    expect(sensorGets.length).toBe(1);
   });
 });
 
 describe("getTriggerKeys", () => {
   it("returns trigger keys from a top-level component (esphome)", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
     });
     const triggers = await getTriggerKeys(makeApi() as never, "esphome", "esphome");
@@ -158,7 +161,8 @@ describe("getTriggerKeys", () => {
 
   it("returns trigger keys from a platform-style component (binary_sensor.gpio)", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(SENSOR_BUNDLE), { status: 200 });
     });
     const triggers = await getTriggerKeys(
@@ -179,7 +183,8 @@ describe("getTriggerKeys", () => {
 
   it("returns [] when the component key isn't in the bundle", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
     });
     const triggers = await getTriggerKeys(makeApi() as never, "esphome", "nope");
@@ -188,7 +193,8 @@ describe("getTriggerKeys", () => {
 
   it("returns [] when the component has no trigger config-vars", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(
         JSON.stringify({
           plain: {
@@ -243,7 +249,8 @@ describe("getTriggerKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       if (url.includes("gpio.json"))
         return new Response(JSON.stringify(GPIO_BUNDLE), { status: 200 });
       if (url.includes("binary_sensor.json"))
@@ -288,8 +295,9 @@ describe("getTriggerKeys", () => {
         },
       },
     };
-    fetchSpy.mockImplementation(async (_url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const triggers = await getTriggerKeys(makeApi() as never, "child", "child");
@@ -338,7 +346,8 @@ const CORE_BUNDLE = {
 describe("getActions", () => {
   it("aggregates actions across the requested bundles", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       if (url.includes("logger.json"))
         return new Response(JSON.stringify(LOGGER_BUNDLE), { status: 200 });
       if (url.includes("light.json"))
@@ -362,7 +371,8 @@ describe("getActions", () => {
 
   it("emits core actions without a domain prefix", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(CORE_BUNDLE), { status: 200 });
     });
     const actions = await getActions(makeApi() as never, ["core"], ["core"]);
@@ -385,7 +395,8 @@ describe("getActions", () => {
     // Both bundles carry the same ``logger.log`` action — the
     // aggregator should not list it twice.
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(LOGGER_BUNDLE), { status: 200 });
     });
     const actions = await getActions(
@@ -403,7 +414,8 @@ describe("getActions", () => {
     // legacy editor used (only suggest actions from components
     // actually present in the YAML).
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(
         JSON.stringify({
           ...LOGGER_BUNDLE,
@@ -472,7 +484,8 @@ describe("getConfigVarKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       if (url.includes("uptime.json"))
         return new Response(JSON.stringify(UPTIME_BUNDLE), { status: 200 });
       if (url.includes("sensor.json"))
@@ -517,7 +530,8 @@ describe("getConfigVarKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(CHILD_BUNDLE), { status: 200 });
     });
     const keys = await getConfigVarKeys(makeApi() as never, "child", "child");
@@ -541,7 +555,8 @@ describe("getConfigVarKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const keys = await getConfigVarKeys(makeApi() as never, "thing", "thing");
@@ -604,7 +619,8 @@ describe("getConfigVarValueOptions", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       if (url.includes("uptime.json"))
         return new Response(JSON.stringify(UPTIME_BUNDLE), { status: 200 });
       if (url.includes("sensor.json"))
@@ -639,7 +655,8 @@ describe("getConfigVarValueOptions", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const values = await getConfigVarValueOptions(
@@ -712,7 +729,8 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       if (url.includes("uptime.json"))
         return new Response(JSON.stringify(UPTIME_BUNDLE), { status: 200 });
       if (url.includes("sensor.json"))
@@ -764,7 +782,8 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const keys = await getConfigVarKeys(makeApi() as never, "thing", "thing");
@@ -784,7 +803,8 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const ref = await lookupRegistryRef(makeApi() as never, "thing", "thing", "name");
@@ -793,7 +813,8 @@ describe("lookupRegistryRef + getRegistryEntries", () => {
 
   it("returns [] when the registry ref points at a missing slot", async () => {
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify({ thing: { schemas: {} } }), { status: 200 });
     });
     const entries = await getRegistryEntries(makeApi() as never, "thing.filter");
@@ -869,7 +890,8 @@ describe("getRegistryEntryKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(GLOBALS_BUNDLE), { status: 200 });
     });
     const keys = await getRegistryEntryKeys(
@@ -908,7 +930,8 @@ describe("getRegistryEntryKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const keys = await getRegistryEntryKeys(
@@ -927,7 +950,8 @@ describe("getRegistryEntryKeys", () => {
   it("returns [] for a missing registry entry", async () => {
     const BUNDLE = { thing: { action: {} } };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(BUNDLE), { status: 200 });
     });
     const keys = await getRegistryEntryKeys(
@@ -954,7 +978,8 @@ describe("getRegistryEntryKeys", () => {
       },
     };
     fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
     });
     const keys = await getRegistryEntryKeys(
@@ -975,58 +1000,62 @@ describe("resolveVersion (probe failure handling)", () => {
     // cached version so a later caller can retry once conditions
     // recover.
     let probeAttempts = 0;
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") {
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json")) {
         probeAttempts += 1;
         if (probeAttempts === 1) return new Response(null, { status: 503 });
-        return new Response(null, { status: 200 });
-      }
-      if (url.includes("/2026.5.0/esphome.json"))
         return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+      }
+      if (url.endsWith("/sensor.json"))
+        return new Response(JSON.stringify(SENSOR_BUNDLE), { status: 200 });
       throw new Error(`unexpected ${url}`);
     });
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const first = await fetchBundle(makeApi() as never, "esphome");
+    const first = await fetchBundle(makeApi() as never, "sensor");
     expect(first).toBeNull();
-    const second = await fetchBundle(makeApi() as never, "esphome");
+    const second = await fetchBundle(makeApi() as never, "sensor");
     expect(second).not.toBeNull();
     expect(probeAttempts).toBe(2);
     debugSpy.mockRestore();
   });
 
   it("treats a 404 probe as a stable 'dev' signal (no retries)", async () => {
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 404 });
-      if (url.includes("/dev/esphome.json"))
-        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.includes("/2026.5.0/esphome.json"))
+        return new Response(null, { status: 404 });
+      if (url.includes("/dev/sensor.json"))
+        return new Response(JSON.stringify(SENSOR_BUNDLE), { status: 200 });
       throw new Error(`unexpected ${url}`);
     });
-    const bundle = await fetchBundle(makeApi() as never, "esphome");
+    const bundle = await fetchBundle(makeApi() as never, "sensor");
     expect(bundle).not.toBeNull();
-    await fetchBundle(makeApi() as never, "esphome");
-    const heads = fetchSpy.mock.calls.filter(
-      (c) => (c[1] as RequestInit | undefined)?.method === "HEAD"
+    await fetchBundle(makeApi() as never, "sensor");
+    // The version probe (2026.5.0/esphome.json) fires once; the dev
+    // fallback is cached for the session.
+    const probes = fetchSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("/2026.5.0/esphome.json")
     );
-    expect(heads.length).toBe(1);
+    expect(probes.length).toBe(1);
   });
 });
 
 describe("fetchBundle (negative cache eviction)", () => {
   it("evicts a failed lookup so the next caller retries", async () => {
     let attempt = 0;
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
       attempt += 1;
       if (attempt === 1) throw new TypeError("Failed to fetch");
-      return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+      return new Response(JSON.stringify(SENSOR_BUNDLE), { status: 200 });
     });
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-    const first = await fetchBundle(makeApi() as never, "esphome");
+    const first = await fetchBundle(makeApi() as never, "sensor");
     expect(first).toBeNull();
     // The second call should NOT see the cached null — it should
     // fire a fresh fetch (the cache evicted the failed entry) and
     // get the now-successful response.
-    const second = await fetchBundle(makeApi() as never, "esphome");
+    const second = await fetchBundle(makeApi() as never, "sensor");
     expect(second).not.toBeNull();
     debugSpy.mockRestore();
   });

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -142,6 +142,19 @@ describe("fetchBundle", () => {
     );
     expect(sensorGets.length).toBe(1);
   });
+
+  it("resolves the 'core' alias to esphome.json, never core.json", async () => {
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const bundle = await fetchBundle(makeApi() as never, "core");
+    expect(bundle).not.toBeNull();
+    expect(fetchSpy.mock.calls.some((c) => String(c[0]).endsWith("/core.json"))).toBe(
+      false
+    );
+  });
 });
 
 describe("getTriggerKeys", () => {
@@ -372,12 +385,16 @@ describe("getActions", () => {
   });
 
   it("emits core actions without a domain prefix", async () => {
-    fetchSpy.mockImplementation(async (url: string, init?: RequestInit) => {
+    // Core actions live inside esphome.json under the `core` component
+    // (there is no core.json); the `core` bundle name aliases to it.
+    fetchSpy.mockImplementation(async (url: string) => {
       if (url.endsWith("/esphome.json"))
-        return new Response(JSON.stringify(ESPHOME_BUNDLE), { status: 200 });
-      return new Response(JSON.stringify(CORE_BUNDLE), { status: 200 });
+        return new Response(JSON.stringify({ ...ESPHOME_BUNDLE, ...CORE_BUNDLE }), {
+          status: 200,
+        });
+      throw new Error(`unexpected fetch ${url}`);
     });
-    const actions = await getActions(makeApi() as never, ["core"], ["core"]);
+    const actions = await getActions(makeApi() as never, ["esphome"], ["core"]);
     expect(actions.map((a) => a.key).sort()).toEqual(["delay", "if"]);
   });
 

--- a/test/util/esphome-schema.test.ts
+++ b/test/util/esphome-schema.test.ts
@@ -3,6 +3,7 @@ import {
   _resetSchemaCacheForTests,
   fetchBundle,
   getActions,
+  getComponentDocs,
   getConfigVarDocsAtPath,
   getConfigVarKeys,
   getConfigVarValueOptions,
@@ -990,6 +991,27 @@ describe("getRegistryEntryKeys", () => {
       "delay"
     );
     expect(keys.map((k) => k.key)).toEqual(["time"]);
+  });
+});
+
+describe("getComponentDocs", () => {
+  it("reads docs from core.components and core.platforms", async () => {
+    const BUNDLE = {
+      core: {
+        components: { wifi: { docs: "Wi-Fi docs." } },
+        platforms: { binary_sensor: { docs: "Binary sensor docs." } },
+      },
+    };
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith("/esphome.json"))
+        return new Response(JSON.stringify(BUNDLE), { status: 200 });
+      throw new Error(`unexpected ${url}`);
+    });
+    expect(await getComponentDocs(makeApi() as never, "wifi")).toBe("Wi-Fi docs.");
+    expect(await getComponentDocs(makeApi() as never, "binary_sensor")).toBe(
+      "Binary sensor docs."
+    );
+    expect(await getComponentDocs(makeApi() as never, "nope")).toBeNull();
   });
 });
 

--- a/test/util/yaml-completion-top-level.test.ts
+++ b/test/util/yaml-completion-top-level.test.ts
@@ -278,8 +278,9 @@ describe("createYamlCompletionSource (auto-fire at value position)", () => {
     _resetSchemaCacheForTests();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string, init?: RequestInit) => {
-        if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      vi.fn(async (url: string) => {
+        // Version probe (GET ``<version>/esphome.json``) — any 200 resolves it.
+        if (url.endsWith("/esphome.json")) return new Response("{}", { status: 200 });
         if (url.includes("uptime.json")) {
           return new Response(
             JSON.stringify({

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
 import { ConfigEntryType, type ConfigEntry } from "../../src/api/types/config-entries.js";
+import { fetchComponent } from "../../src/util/component-name-cache.js";
 import * as schema from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import type { CatalogIndex } from "../../src/util/yaml-completion.js";
@@ -22,6 +23,12 @@ vi.mock("../../src/util/esphome-schema.js", async (importOriginal) => ({
   getConfigVarDocsAtPath: vi.fn(),
 }));
 
+// The hover gate reads each component's `config_entries` to decide whether
+// the structured editor already renders a form for it.
+vi.mock("../../src/util/component-name-cache.js", () => ({
+  fetchComponent: vi.fn(),
+}));
+
 function comp(c: Partial<ComponentCatalogEntry>): ComponentCatalogEntry {
   return { config_entries: [], ...c } as unknown as ComponentCatalogEntry;
 }
@@ -29,49 +36,33 @@ function field(f: Partial<ConfigEntry>): ConfigEntry {
   return f as unknown as ConfigEntry;
 }
 
-// Only `esphome` is in the catalog (with a visible `name` field) so the
-// suppression path has something to match; everything else is schema-only.
+// Components the structured editor renders a form for (non-empty
+// `config_entries`). Everything else resolves as YAML-only → hover shown.
+const FORM_BACKED: Record<string, ConfigEntry[]> = {
+  esphome: [field({ key: "name" })],
+  wifi: [field({ key: "ssid" })],
+  "binary_sensor.gpio": [field({ key: "pin" })],
+};
+
+// The slim catalog passed to the resolver — used for component / field
+// descriptions once a token clears the gate. `ethernet` is YAML-only.
 const CATALOG: CatalogIndex = {
   components: [],
   byCategory: new Map(),
   byId: new Map<string, ComponentCatalogEntry>([
     [
-      "esphome",
+      "ethernet",
       comp({
-        id: "esphome",
-        name: "ESPHome Core",
-        description: "Core firmware configuration.",
-        docs_url: "https://esphome.io/components/esphome",
+        id: "ethernet",
+        name: "Ethernet",
+        description: "Wired networking for the node.",
+        docs_url: "https://esphome.io/components/ethernet",
         config_entries: [
           field({
-            key: "name",
+            key: "type",
             type: ConfigEntryType.STRING,
-            description: "The node name.",
-            help_link: "https://esphome.io/components/esphome#name",
-          }),
-        ],
-      }),
-    ],
-    // Platform component — keyed `<domain>.<stem>` (the reverse of the
-    // schema bundle's componentKey) to pin the catalog-fallback lookup.
-    [
-      "binary_sensor.gpio",
-      comp({
-        id: "binary_sensor.gpio",
-        name: "GPIO Binary Sensor",
-        description: "A binary sensor on a GPIO pin.",
-        docs_url: "https://esphome.io/components/binary_sensor/gpio",
-        config_entries: [
-          field({
-            key: "pin",
-            description: "The pin to monitor.",
-            config_entries: [
-              field({
-                key: "inverted",
-                type: ConfigEntryType.BOOLEAN,
-                description: "Invert the level.",
-              }),
-            ],
+            description: "The Ethernet chip type.",
+            help_link: "https://esphome.io/components/ethernet#type",
           }),
         ],
       }),
@@ -104,85 +95,75 @@ beforeEach(() => {
   vi.mocked(schema.getRegistryEntries).mockResolvedValue([]);
   vi.mocked(schema.lookupRegistryRef).mockResolvedValue(null);
   vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue(null);
+  vi.mocked(fetchComponent).mockImplementation((_api, id) =>
+    Promise.resolve(comp({ id, config_entries: FORM_BACKED[id] ?? [] }))
+  );
 });
 
-describe("resolveHoverTarget", () => {
-  it("shows enum value docs when hovering a value", async () => {
+describe("resolveHoverTarget — gated to YAML-only components", () => {
+  it("returns null on a comment line", async () => {
+    expect(await hover("# just a comment\nethernet:\n", "comment")).toBeNull();
+  });
+
+  // ─── Suppressed: the structured editor already documents these ───
+
+  it("suppresses a top-level component that has a form", async () => {
+    expect(await hover("wifi:\n  ssid: x\n", "wifi")).toBeNull();
+  });
+
+  it("suppresses a nested key inside a form-backed platform component", async () => {
+    const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
+    expect(await hover(doc, "inverted")).toBeNull();
+  });
+
+  it("suppresses an enum value inside a form-backed component", async () => {
     vi.mocked(schema.getConfigVarValueOptions).mockResolvedValue([
       { value: "garage_door", docs: "Garage door class." },
     ]);
-    const doc = "binary_sensor:\n  - platform: template\n    device_class: garage_door\n";
-    const target = await hover(doc, "garage_door");
-    expect(target?.description).toBe("Garage door class.");
+    const doc = "binary_sensor:\n  - platform: gpio\n    device_class: garage_door\n";
+    expect(await hover(doc, "garage_door")).toBeNull();
   });
 
-  it("shows action docs inside an automation body", async () => {
+  it("suppresses a platform value for a form-backed platform component", async () => {
+    const doc = "binary_sensor:\n  - platform: gpio\n    name: x\n";
+    expect(await hover(doc, "gpio")).toBeNull();
+  });
+
+  it("suppresses an automation action inside a form-backed component", async () => {
     vi.mocked(schema.getActions).mockResolvedValue([
       { key: "logger.log", docs: "Log a message." },
     ]);
     const doc = 'esphome:\n  on_boot:\n    then:\n      - logger.log: "hi"\n';
-    const target = await hover(doc, "logger.log");
-    expect(target?.description).toBe("Log a message.");
+    expect(await hover(doc, "logger.log")).toBeNull();
   });
 
-  it("shows trigger docs for an on_* key", async () => {
-    vi.mocked(schema.getTriggerKeys).mockResolvedValue([
-      { key: "on_press", docs: "Pressed." },
-    ]);
-    const doc =
-      "binary_sensor:\n  - platform: gpio\n    on_press:\n      - logger.log: x\n";
-    const target = await hover(doc, "on_press");
-    expect(target?.description).toBe("Pressed.");
+  // ─── Shown: components the structured editor can't render a form for ───
+
+  it("shows the component description for a YAML-only component", async () => {
+    const target = await hover("ethernet:\n  type: W5500\n", "ethernet");
+    expect(target?.description).toBe("Wired networking for the node.");
+    expect(target?.docsUrl).toBe("https://esphome.io/components/ethernet");
   });
 
-  it("walks the schema for a deeply-nested key", async () => {
-    vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("Scan actively.");
-    const doc = "esp32_ble_tracker:\n  scan_parameters:\n    active: false\n";
-    const target = await hover(doc, "active");
-    expect(target?.description).toBe("Scan actively.");
+  it("walks the schema for a nested key in a YAML-only component", async () => {
+    vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("The Ethernet chip type.");
+    const target = await hover("ethernet:\n  type: W5500\n", "type");
+    expect(target?.description).toBe("The Ethernet chip type.");
     expect(vi.mocked(schema.getConfigVarDocsAtPath)).toHaveBeenCalledWith(
       API,
-      "esp32_ble_tracker",
-      "esp32_ble_tracker",
-      ["scan_parameters", "active"]
+      "ethernet",
+      "ethernet",
+      ["type"]
     );
   });
 
-  it("shows schema docs for a config-entry field (full parity)", async () => {
-    vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("Schema name docs.");
-    const target = await hover('esphome:\n  name: "x"\n', "name");
-    expect(target?.description).toBe("Schema name docs.");
+  it("falls back to the catalog field description for a YAML-only component", async () => {
+    const target = await hover("ethernet:\n  type: W5500\n", "type");
+    expect(target?.description).toBe("**string**: The Ethernet chip type.");
+    expect(target?.docsUrl).toBe("https://esphome.io/components/ethernet#type");
   });
 
-  it("falls back to the catalog field description (with type prefix) when the schema has none", async () => {
-    // getConfigVarDocsAtPath defaults to null in beforeEach.
-    const target = await hover('esphome:\n  name: "x"\n', "name");
-    expect(target?.description).toBe("**string**: The node name.");
-    expect(target?.docsUrl).toBe("https://esphome.io/components/esphome#name");
-  });
-
-  it("always shows a top-level component description", async () => {
-    const target = await hover('esphome:\n  name: "x"\n', "esphome");
-    expect(target?.description).toBe("Core firmware configuration.");
-    expect(target?.docsUrl).toBe("https://esphome.io/components/esphome");
-  });
-
-  it("shows the platform component description for platform: <value>", async () => {
-    const doc = "binary_sensor:\n  - platform: gpio\n    name: x\n";
-    const target = await hover(doc, "gpio");
-    expect(target?.description).toBe("A binary sensor on a GPIO pin.");
-    expect(target?.docsUrl).toBe("https://esphome.io/components/binary_sensor/gpio");
-  });
-
-  it("falls back to the catalog for a nested platform field (correct <domain>.<stem> id)", async () => {
-    // Schema walk returns null (default mock) → catalog fallback, which
-    // must key the platform as binary_sensor.gpio, not gpio.binary_sensor.
-    const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
-    const target = await hover(doc, "inverted");
-    expect(target?.description).toBe("**boolean**: Invert the level.");
-  });
-
-  it("shows a bare-domain description from the schema core docs", async () => {
+  it("shows a bare-domain description for a platform domain with no form", async () => {
     vi.mocked(schema.getComponentDocs).mockResolvedValue(
       "With ESPHome you can use different types of binary sensors."
     );
@@ -190,15 +171,5 @@ describe("resolveHoverTarget", () => {
     expect(target?.description).toBe(
       "With ESPHome you can use different types of binary sensors."
     );
-  });
-
-  it("returns null on a comment line", async () => {
-    expect(await hover("# just a comment\nesphome:\n", "comment")).toBeNull();
-  });
-
-  it("returns null when the schema has no docs for the key", async () => {
-    expect(
-      await hover("esp32_ble_tracker:\n  scan_parameters:\n    active: false\n", "active")
-    ).toBeNull();
   });
 });

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -156,12 +156,6 @@ describe("resolveHoverTarget — gated to YAML-only components", () => {
     expect(target?.description).toBe("Wired networking for the node.");
   });
 
-  it("fails open (shows the hover) when the component fetch rejects", async () => {
-    vi.mocked(fetchComponent).mockRejectedValue(new Error("offline"));
-    const target = await hover("ethernet:\n  type: W5500\n", "ethernet");
-    expect(target?.description).toBe("Wired networking for the node.");
-  });
-
   it("walks the schema for a nested key in a YAML-only component", async () => {
     vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("The Ethernet chip type.");
     const target = await hover("ethernet:\n  type: W5500\n", "type");

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -41,7 +41,13 @@ const CATALOG: CatalogIndex = {
         name: "ESPHome Core",
         description: "Core firmware configuration.",
         docs_url: "https://esphome.io/components/esphome",
-        config_entries: [field({ key: "name" })],
+        config_entries: [
+          field({
+            key: "name",
+            description: "The node name.",
+            help_link: "https://esphome.io/components/esphome#name",
+          }),
+        ],
       }),
     ],
   ]),
@@ -115,9 +121,17 @@ describe("resolveHoverTarget", () => {
     );
   });
 
-  it("suppresses a visible catalog config_entry (form documents it)", async () => {
-    expect(await hover('esphome:\n  name: "x"\n', "name")).toBeNull();
-    expect(vi.mocked(schema.getConfigVarDocsAtPath)).not.toHaveBeenCalled();
+  it("shows schema docs for a config-entry field (full parity)", async () => {
+    vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("Schema name docs.");
+    const target = await hover('esphome:\n  name: "x"\n', "name");
+    expect(target?.description).toBe("Schema name docs.");
+  });
+
+  it("falls back to the catalog field description when the schema has none", async () => {
+    // getConfigVarDocsAtPath defaults to null in beforeEach.
+    const target = await hover('esphome:\n  name: "x"\n', "name");
+    expect(target?.description).toBe("The node name.");
+    expect(target?.docsUrl).toBe("https://esphome.io/components/esphome#name");
   });
 
   it("always shows a top-level component description", async () => {

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -50,6 +50,26 @@ const CATALOG: CatalogIndex = {
         ],
       }),
     ],
+    // Platform component — keyed `<domain>.<stem>` (the reverse of the
+    // schema bundle's componentKey) to pin the catalog-fallback lookup.
+    [
+      "binary_sensor.gpio",
+      comp({
+        id: "binary_sensor.gpio",
+        name: "GPIO Binary Sensor",
+        description: "A binary sensor on a GPIO pin.",
+        docs_url: "https://esphome.io/components/binary_sensor/gpio",
+        config_entries: [
+          field({
+            key: "pin",
+            description: "The pin to monitor.",
+            config_entries: [
+              field({ key: "inverted", description: "Invert the level." }),
+            ],
+          }),
+        ],
+      }),
+    ],
   ]),
 };
 
@@ -138,6 +158,21 @@ describe("resolveHoverTarget", () => {
     const target = await hover('esphome:\n  name: "x"\n', "esphome");
     expect(target?.description).toBe("Core firmware configuration.");
     expect(target?.docsUrl).toBe("https://esphome.io/components/esphome");
+  });
+
+  it("shows the platform component description for platform: <value>", async () => {
+    const doc = "binary_sensor:\n  - platform: gpio\n    name: x\n";
+    const target = await hover(doc, "gpio");
+    expect(target?.description).toBe("A binary sensor on a GPIO pin.");
+    expect(target?.docsUrl).toBe("https://esphome.io/components/binary_sensor/gpio");
+  });
+
+  it("falls back to the catalog for a nested platform field (correct <domain>.<stem> id)", async () => {
+    // Schema walk returns null (default mock) → catalog fallback, which
+    // must key the platform as binary_sensor.gpio, not gpio.binary_sensor.
+    const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
+    const target = await hover(doc, "inverted");
+    expect(target?.description).toBe("Invert the level.");
   });
 
   it("returns null on a comment line", async () => {

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -3,7 +3,7 @@ import { EditorState } from "@codemirror/state";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
-import type { ConfigEntry } from "../../src/api/types/config-entries.js";
+import { ConfigEntryType, type ConfigEntry } from "../../src/api/types/config-entries.js";
 import * as schema from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import type { CatalogIndex } from "../../src/util/yaml-completion.js";
@@ -13,6 +13,7 @@ import { resolveHoverTarget } from "../../src/util/yaml-hover.js";
 // (bundleFor consumers, parse helpers) real.
 vi.mock("../../src/util/esphome-schema.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/util/esphome-schema.js")>()),
+  getComponentDocs: vi.fn(),
   getConfigVarValueOptions: vi.fn(),
   getActions: vi.fn(),
   getTriggerKeys: vi.fn(),
@@ -44,6 +45,7 @@ const CATALOG: CatalogIndex = {
         config_entries: [
           field({
             key: "name",
+            type: ConfigEntryType.STRING,
             description: "The node name.",
             help_link: "https://esphome.io/components/esphome#name",
           }),
@@ -64,7 +66,11 @@ const CATALOG: CatalogIndex = {
             key: "pin",
             description: "The pin to monitor.",
             config_entries: [
-              field({ key: "inverted", description: "Invert the level." }),
+              field({
+                key: "inverted",
+                type: ConfigEntryType.BOOLEAN,
+                description: "Invert the level.",
+              }),
             ],
           }),
         ],
@@ -91,6 +97,7 @@ function hover(doc: string, token: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(schema.getComponentDocs).mockResolvedValue(null);
   vi.mocked(schema.getConfigVarValueOptions).mockResolvedValue([]);
   vi.mocked(schema.getActions).mockResolvedValue([]);
   vi.mocked(schema.getTriggerKeys).mockResolvedValue([]);
@@ -147,10 +154,10 @@ describe("resolveHoverTarget", () => {
     expect(target?.description).toBe("Schema name docs.");
   });
 
-  it("falls back to the catalog field description when the schema has none", async () => {
+  it("falls back to the catalog field description (with type prefix) when the schema has none", async () => {
     // getConfigVarDocsAtPath defaults to null in beforeEach.
     const target = await hover('esphome:\n  name: "x"\n', "name");
-    expect(target?.description).toBe("The node name.");
+    expect(target?.description).toBe("**string**: The node name.");
     expect(target?.docsUrl).toBe("https://esphome.io/components/esphome#name");
   });
 
@@ -172,7 +179,17 @@ describe("resolveHoverTarget", () => {
     // must key the platform as binary_sensor.gpio, not gpio.binary_sensor.
     const doc = "binary_sensor:\n  - platform: gpio\n    pin:\n      inverted: false\n";
     const target = await hover(doc, "inverted");
-    expect(target?.description).toBe("Invert the level.");
+    expect(target?.description).toBe("**boolean**: Invert the level.");
+  });
+
+  it("shows a bare-domain description from the schema core docs", async () => {
+    vi.mocked(schema.getComponentDocs).mockResolvedValue(
+      "With ESPHome you can use different types of binary sensors."
+    );
+    const target = await hover("binary_sensor:\n  - platform: gpio\n", "binary_sensor");
+    expect(target?.description).toBe(
+      "With ESPHome you can use different types of binary sensors."
+    );
   });
 
   it("returns null on a comment line", async () => {

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -1,0 +1,138 @@
+import { ensureSyntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
+import type { ConfigEntry } from "../../src/api/types/config-entries.js";
+import * as schema from "../../src/util/esphome-schema.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import type { CatalogIndex } from "../../src/util/yaml-completion.js";
+import { resolveHoverTarget } from "../../src/util/yaml-hover.js";
+
+// Stub the network-backed schema lookups; keep the rest of the module
+// (bundleFor consumers, parse helpers) real.
+vi.mock("../../src/util/esphome-schema.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/util/esphome-schema.js")>()),
+  getConfigVarValueOptions: vi.fn(),
+  getActions: vi.fn(),
+  getTriggerKeys: vi.fn(),
+  getRegistryEntries: vi.fn(),
+  lookupRegistryRef: vi.fn(),
+  getConfigVarDocsAtPath: vi.fn(),
+}));
+
+function comp(c: Partial<ComponentCatalogEntry>): ComponentCatalogEntry {
+  return { config_entries: [], ...c } as unknown as ComponentCatalogEntry;
+}
+function field(f: Partial<ConfigEntry>): ConfigEntry {
+  return f as unknown as ConfigEntry;
+}
+
+// Only `esphome` is in the catalog (with a visible `name` field) so the
+// suppression path has something to match; everything else is schema-only.
+const CATALOG: CatalogIndex = {
+  components: [],
+  byCategory: new Map(),
+  byId: new Map<string, ComponentCatalogEntry>([
+    [
+      "esphome",
+      comp({
+        id: "esphome",
+        name: "ESPHome Core",
+        description: "Core firmware configuration.",
+        docs_url: "https://esphome.io/components/esphome",
+        config_entries: [field({ key: "name" })],
+      }),
+    ],
+  ]),
+};
+
+const API = {} as unknown as ESPHomeAPI;
+
+function stateFor(doc: string): EditorState {
+  const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+  ensureSyntaxTree(state, state.doc.length);
+  return state;
+}
+function posOf(doc: string, token: string): number {
+  const idx = doc.indexOf(token);
+  if (idx < 0) throw new Error(`token not found: ${token}`);
+  return idx + 1;
+}
+function hover(doc: string, token: string) {
+  return resolveHoverTarget(stateFor(doc), posOf(doc, token), API, CATALOG);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(schema.getConfigVarValueOptions).mockResolvedValue([]);
+  vi.mocked(schema.getActions).mockResolvedValue([]);
+  vi.mocked(schema.getTriggerKeys).mockResolvedValue([]);
+  vi.mocked(schema.getRegistryEntries).mockResolvedValue([]);
+  vi.mocked(schema.lookupRegistryRef).mockResolvedValue(null);
+  vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue(null);
+});
+
+describe("resolveHoverTarget", () => {
+  it("shows enum value docs when hovering a value", async () => {
+    vi.mocked(schema.getConfigVarValueOptions).mockResolvedValue([
+      { value: "garage_door", docs: "Garage door class." },
+    ]);
+    const doc = "binary_sensor:\n  - platform: template\n    device_class: garage_door\n";
+    const target = await hover(doc, "garage_door");
+    expect(target?.description).toBe("Garage door class.");
+  });
+
+  it("shows action docs inside an automation body", async () => {
+    vi.mocked(schema.getActions).mockResolvedValue([
+      { key: "logger.log", docs: "Log a message." },
+    ]);
+    const doc = 'esphome:\n  on_boot:\n    then:\n      - logger.log: "hi"\n';
+    const target = await hover(doc, "logger.log");
+    expect(target?.description).toBe("Log a message.");
+  });
+
+  it("shows trigger docs for an on_* key", async () => {
+    vi.mocked(schema.getTriggerKeys).mockResolvedValue([
+      { key: "on_press", docs: "Pressed." },
+    ]);
+    const doc =
+      "binary_sensor:\n  - platform: gpio\n    on_press:\n      - logger.log: x\n";
+    const target = await hover(doc, "on_press");
+    expect(target?.description).toBe("Pressed.");
+  });
+
+  it("walks the schema for a deeply-nested key", async () => {
+    vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("Scan actively.");
+    const doc = "esp32_ble_tracker:\n  scan_parameters:\n    active: false\n";
+    const target = await hover(doc, "active");
+    expect(target?.description).toBe("Scan actively.");
+    expect(vi.mocked(schema.getConfigVarDocsAtPath)).toHaveBeenCalledWith(
+      API,
+      "esp32_ble_tracker",
+      "esp32_ble_tracker",
+      ["scan_parameters", "active"]
+    );
+  });
+
+  it("suppresses a visible catalog config_entry (form documents it)", async () => {
+    expect(await hover('esphome:\n  name: "x"\n', "name")).toBeNull();
+    expect(vi.mocked(schema.getConfigVarDocsAtPath)).not.toHaveBeenCalled();
+  });
+
+  it("always shows a top-level component description", async () => {
+    const target = await hover('esphome:\n  name: "x"\n', "esphome");
+    expect(target?.description).toBe("Core firmware configuration.");
+    expect(target?.docsUrl).toBe("https://esphome.io/components/esphome");
+  });
+
+  it("returns null on a comment line", async () => {
+    expect(await hover("# just a comment\nesphome:\n", "comment")).toBeNull();
+  });
+
+  it("returns null when the schema has no docs for the key", async () => {
+    expect(
+      await hover("esp32_ble_tracker:\n  scan_parameters:\n    active: false\n", "active")
+    ).toBeNull();
+  });
+});

--- a/test/util/yaml-hover.test.ts
+++ b/test/util/yaml-hover.test.ts
@@ -145,6 +145,23 @@ describe("resolveHoverTarget — gated to YAML-only components", () => {
     expect(target?.docsUrl).toBe("https://esphome.io/components/ethernet");
   });
 
+  it("does not throw when the component body omits config_entries", async () => {
+    // ethernet's real body has no `config_entries` key at all (not [] —
+    // absent). The gate must optional-chain it, not crash the hover.
+    vi.mocked(fetchComponent).mockResolvedValue({
+      id: "ethernet",
+      name: "Ethernet",
+    } as unknown as ComponentCatalogEntry);
+    const target = await hover("ethernet:\n  type: W5500\n", "ethernet");
+    expect(target?.description).toBe("Wired networking for the node.");
+  });
+
+  it("fails open (shows the hover) when the component fetch rejects", async () => {
+    vi.mocked(fetchComponent).mockRejectedValue(new Error("offline"));
+    const target = await hover("ethernet:\n  type: W5500\n", "ethernet");
+    expect(target?.description).toBe("Wired networking for the node.");
+  });
+
   it("walks the schema for a nested key in a YAML-only component", async () => {
     vi.mocked(schema.getConfigVarDocsAtPath).mockResolvedValue("The Ethernet chip type.");
     const target = await hover("ethernet:\n  type: W5500\n", "type");

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -1,3 +1,4 @@
+import { Text } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import {
   findParentKey,
@@ -6,6 +7,9 @@ import {
   readPlatformSibling,
   stripComment,
 } from "../../src/util/yaml-line-walker.js";
+
+/** Build a CodeMirror `Text` doc from an array of lines. */
+const t = (lines: string[]) => Text.of(lines);
 
 describe("indentOf", () => {
   it("counts leading spaces", () => {
@@ -54,7 +58,7 @@ describe("findParentKey", () => {
   it("finds the nearest ancestor key strictly less indented", () => {
     // From line 6 (indent 4) → walks up → ``- platform: gpio`` at
     // indent 2, regex captures ``platform``.
-    expect(findParentKey(lines, 6, 4)).toEqual({
+    expect(findParentKey(t(lines), 6, 4)).toEqual({
       key: "platform",
       indent: 2,
       lineIdx: 3,
@@ -62,12 +66,12 @@ describe("findParentKey", () => {
   });
 
   it("returns null when there's no shallower key", () => {
-    expect(findParentKey(lines, 0, 0)).toBeNull();
+    expect(findParentKey(t(lines), 0, 0)).toBeNull();
   });
 
   it("skips blank and comment-only lines", () => {
     const noisy = ["wifi:", "", "  # hi", "  ssid: x"];
-    expect(findParentKey(noisy, 3, 2)).toEqual({
+    expect(findParentKey(t(noisy), 3, 2)).toEqual({
       key: "wifi",
       indent: 0,
       lineIdx: 0,
@@ -84,12 +88,12 @@ describe("findTopLevelBlock", () => {
   ];
 
   it("returns the most recent column-0 key above the cursor", () => {
-    expect(findTopLevelBlock(lines, 3)).toBe("wifi");
-    expect(findTopLevelBlock(lines, 1)).toBe("esphome");
+    expect(findTopLevelBlock(t(lines), 3)).toBe("wifi");
+    expect(findTopLevelBlock(t(lines), 1)).toBe("esphome");
   });
 
   it("returns null when the cursor is the top of the doc", () => {
-    expect(findTopLevelBlock(lines, 0)).toBeNull();
+    expect(findTopLevelBlock(t(lines), 0)).toBeNull();
   });
 });
 
@@ -108,7 +112,7 @@ describe("readPlatformSibling (regex fallback)", () => {
     // ``platform:`` value directly instead of breaking on
     // ``ind < cursorIndent``.
     const lines = ["binary_sensor:", "  - platform: template", "    name: hi"];
-    expect(readPlatformSibling(lines, 2, 4)).toBe("template");
+    expect(readPlatformSibling(t(lines), 2, 4)).toBe("template");
   });
 
   it("reads platform sibling for a deeply-nested cursor (``device_class:`` user-reported case)", () => {
@@ -122,7 +126,7 @@ describe("readPlatformSibling (regex fallback)", () => {
       "    name: zwave",
       "    device_class: ",
     ];
-    expect(readPlatformSibling(lines, 3, 4)).toBe("uptime");
+    expect(readPlatformSibling(t(lines), 3, 4)).toBe("uptime");
   });
 
   it("walks past intermediate keys to find a platform several levels up", () => {
@@ -142,7 +146,7 @@ describe("readPlatformSibling (regex fallback)", () => {
       "    filters:",
       "      - ",
     ];
-    expect(readPlatformSibling(lines, 4, 6)).toBe("uptime");
+    expect(readPlatformSibling(t(lines), 4, 6)).toBe("uptime");
   });
 
   it("strips quotes from quoted platform values", () => {
@@ -151,13 +155,13 @@ describe("readPlatformSibling (regex fallback)", () => {
     // walker has to accept both forms and return the unquoted
     // string so the schema-bundle lookup succeeds.
     const dq = ["sensor:", '  - platform: "dht"', "    pin: 5"];
-    expect(readPlatformSibling(dq, 2, 4)).toBe("dht");
+    expect(readPlatformSibling(t(dq), 2, 4)).toBe("dht");
     const sq = ["sensor:", "  - platform: 'dht'", "    pin: 5"];
-    expect(readPlatformSibling(sq, 2, 4)).toBe("dht");
+    expect(readPlatformSibling(t(sq), 2, 4)).toBe("dht");
   });
 
   it("returns null when there's no platform sibling", () => {
     const lines = ["wifi:", "  ssid: x", "  password: y"];
-    expect(readPlatformSibling(lines, 2, 2)).toBeNull();
+    expect(readPlatformSibling(t(lines), 2, 2)).toBeNull();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

> **Transitional.** This exists to keep parity with the legacy dashboard's
> Monaco hover. As the structured editor grows to cover more components,
> these tooltips get less valuable — they only fire for what the form
> *can't* document — so we'll likely remove this entirely down the line.
> Scoped narrowly on purpose to minimise what we'd later rip out.

Adds schema-backed **hover documentation** to the YAML editor — but only
for the things the **structured editor can't already document on screen**.

The structured editor renders a form (with field docs) for every component
that has `config_entries`. Hovering those would just duplicate what's
already visible, so the hover is gated to the components it *can't*
form-edit, using the structured editor's own `isYamlOnlySection` so the two
stay in sync.

### What gets a hover vs. what doesn't

A token gets a tooltip only when its resolved component has **no
`config_entries`** (no form), or is a hardcoded YAML-only section
(`packages`, `external_components`).

- **Hover shows** — form-less components: `ethernet`, `spi`, `psram`,
  `lvgl`, `json`, `libretiny`, `packages`, `external_components`, and ~20
  other niche ones, plus bare platform-domain headers (`sensor:`,
  `binary_sensor:`, `light:`, …) that have no top-level form.
- **Hover excluded** — everything form-backed (~206 sections): `esphome`,
  `wifi`, `api`, `logger`, `web_server`, `mqtt`, `captive_portal`,
  `globals`, `substitutions`, … and every `- platform:` item's fields
  (`sensor.dht`, `binary_sensor.gpio`, `ota.esphome`, …), since the
  resolved `domain.platform` component carries `config_entries`.

So hover is off for the bulk of real config (which the form documents) and
on for the form-less components the editor can't represent. For the shown
components, every token still resolves docs (component description, nested
keys, enum values) from the schema bundle (`schema.esphome.io`) with the
catalog as fallback.

**Also fixed:** `fetchBundle` now aliases the `core` bundle to
`esphome.json` (where the core action/condition registries actually live);
a `core.*` registry ref was fetching a nonexistent `core.json` → 404,
breaking schema-backed hover/completion.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
