### PR TITLE
Sync the structured editor and YAML editor at field granularity

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -11,6 +11,29 @@ export const configEntryFormStyles = css`
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-2xs);
+    border-radius: var(--wa-border-radius-m);
+  }
+
+  /* Brief glow when navigated to from the YAML cursor — mirrors the
+     dashboard's just-added card flash. */
+  .field--highlight {
+    animation: field-highlight-glow 2s ease-out 1;
+  }
+  @keyframes field-highlight-glow {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 40%);
+    }
+    50% {
+      box-shadow: 0 0 0 6px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    }
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 100%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .field--highlight {
+      animation: none;
+    }
   }
 
   .field-label {

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -14,28 +14,6 @@ export const configEntryFormStyles = css`
     border-radius: var(--wa-border-radius-m);
   }
 
-  /* Brief glow when navigated to from the YAML cursor — mirrors the
-     dashboard's just-added card flash. */
-  .field--highlight {
-    animation: field-highlight-glow 2s ease-out 1;
-  }
-  @keyframes field-highlight-glow {
-    0% {
-      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 40%);
-    }
-    50% {
-      box-shadow: 0 0 0 6px color-mix(in srgb, var(--esphome-primary), transparent 70%);
-    }
-    100% {
-      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 100%);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .field--highlight {
-      animation: none;
-    }
-  }
-
   .field-label {
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-semibold);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -34,6 +34,7 @@ import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
+import { decideFieldFocus } from "./field-interaction.js";
 
 import "@home-assistant/webawesome/dist/components/divider/divider.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -299,13 +300,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
           n instanceof HTMLElement && n.hasAttribute("data-field-key")
       );
     if (!el) return;
-    const path = parseFieldKey(el.getAttribute("data-field-key") ?? "");
+    const path = this._pathOf(el);
     if (!path.length) return;
-    const key = path.join(" ");
-    if (e.type === "change" && key !== this._focusedFieldKey) return;
-    const moved = key !== this._focusedFieldKey;
-    this._focusedFieldKey = key;
-    if (e.type === "input" && !moved) return; // same field, mid-typing: no re-emit
+    const { emit, focusedKey } = decideFieldFocus(
+      e.type,
+      fieldKeyAttr(path),
+      this._focusedFieldKey
+    );
+    this._focusedFieldKey = focusedKey;
+    if (!emit) return;
     this.dispatchEvent(
       new CustomEvent<{ path: string[] }>("field-focus", {
         detail: { path },
@@ -314,6 +317,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
       })
     );
   };
+
+  /** Decode a field element's ``data-field-key`` to its path. */
+  private _pathOf(el: Element): string[] {
+    return parseFieldKey(el.getAttribute("data-field-key") ?? "");
+  }
 
   protected updated(changed: PropertyValues) {
     super.updated(changed);
@@ -332,7 +340,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const fp = this.focusFieldPath;
     if (
       fp?.length &&
-      this._scrolledFocusKey !== fp.join(" ") &&
+      this._scrolledFocusKey !== fieldKeyAttr(fp) &&
       this._focusScrollTries < MAX_FOCUS_SCROLL_TRIES &&
       (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
     ) {
@@ -365,7 +373,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       target.scrollIntoView({ block: "center" });
       // Flash, but not for the same field twice within 10s — moving the
       // cursor around inside one field shouldn't keep re-pulsing it.
-      const key = path.slice(0, len).join(" ");
+      const key = fieldKeyAttr(path.slice(0, len));
       const now = Date.now();
       if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
         this._lastFlashKey = key;
@@ -374,7 +382,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         void target.offsetWidth;
         target.classList.add("field--highlight");
       }
-      this._scrolledFocusKey = path.join(" ");
+      this._scrolledFocusKey = fieldKeyAttr(path);
       return;
     }
   }
@@ -384,7 +392,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  at shadow boundaries. */
   private _findFieldElement(root: ParentNode, path: string[]): HTMLElement | null {
     for (const el of root.querySelectorAll<HTMLElement>("[data-field-key]")) {
-      const p = parseFieldKey(el.getAttribute("data-field-key") ?? "");
+      const p = this._pathOf(el);
       if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
     }
     for (const el of root.querySelectorAll<HTMLElement>("*")) {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -158,6 +158,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _lastFlashKey?: string;
   private _lastFlashAt = 0;
 
+  /** The ``focusFieldPath`` already scrolled to. Lets a switch into a
+   *  section retry across the entries/values renders until the field
+   *  exists, while a later value edit doesn't re-scroll a consumed one. */
+  private _scrolledFocusKey?: string;
+
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
    * picked before typing a numeric value. Keyed by dotted path.
@@ -285,24 +290,26 @@ export class ESPHomeConfigEntryForm extends LitElement {
   protected updated(changed: PropertyValues) {
     super.updated(changed);
     void this._syncSelectValues();
-    // Re-attempt on ``entries`` too: switching sections loads the new
-    // form's entries asynchronously, so the field isn't in the DOM yet
-    // on the ``focusFieldPath`` change alone. (``entries`` only changes
-    // on a section switch, not on value edits, so this won't scroll
-    // unbidden mid-editing.)
+    // A new cursor target hasn't been scrolled to yet.
+    if (changed.has("focusFieldPath")) this._scrolledFocusKey = undefined;
+    // Re-attempt while the target is unscrolled and any of these change:
+    // entries + values arrive in separate renders on a section switch, so
+    // the field may not be in the DOM until values lands. Consuming the
+    // target on success keeps a later value edit from re-scrolling.
+    const fp = this.focusFieldPath;
     if (
-      (changed.has("focusFieldPath") || changed.has("entries")) &&
-      this.focusFieldPath?.length
+      fp?.length &&
+      this._scrolledFocusKey !== fp.join(" ") &&
+      (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
     ) {
-      void this._scrollToFocusField(this.focusFieldPath);
+      void this._scrollToFocusField(fp);
     }
   }
 
   /**
    * Scroll the YAML-selected field into view, opening collapsed ancestor
-   * groups first. One-shot and tied to the current ``focusFieldPath``: a
-   * newer cursor move (or a field that never renders) can't leave it
-   * retrying on every later update.
+   * groups first. Tied to the current ``focusFieldPath`` (bails if a newer
+   * cursor move superseded it) and marks it consumed once found.
    */
   private async _scrollToFocusField(path: string[]) {
     if (!this.shadowRoot) return;
@@ -332,6 +339,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         void target.offsetWidth;
         target.classList.add("field--highlight");
       }
+      this._scrolledFocusKey = path.join(" ");
       return;
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -294,6 +294,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
           n instanceof HTMLElement && n.hasAttribute("data-field-key")
       );
     if (!el) return;
+    // Only real field paths (JSON arrays from ``fieldKeyAttr``) map to a YAML
+    // line. Synthetic disclosure keys like ``pin:pin-advanced`` would strand
+    // the page in a doomed pending-field-line retry — skip them.
+    const attr = el.getAttribute("data-field-key") ?? "";
+    if (!attr.startsWith("[")) return;
     const path = this._pathOf(el);
     if (!path.length) return;
     const { emit, focusedKey } = decideFieldFocus(

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -153,6 +153,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @state()
   private _nestedOpenSections: Set<string> = new Set();
 
+  /** Last field flashed + when, so the same field isn't re-pulsed within
+   *  10s as the cursor moves around inside it. */
+  private _lastFlashKey?: string;
+  private _lastFlashAt = 0;
+
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
    * picked before typing a numeric value. Keyed by dotted path.
@@ -316,10 +321,17 @@ export class ESPHomeConfigEntryForm extends LitElement {
       // ``center`` (not ``nearest``) so a tall field — long description
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });
-      // Restart the flash even when the same field is re-targeted.
-      target.classList.remove("field--highlight");
-      void target.offsetWidth;
-      target.classList.add("field--highlight");
+      // Flash, but not for the same field twice within 10s — moving the
+      // cursor around inside one field shouldn't keep re-pulsing it.
+      const key = path.slice(0, len).join(" ");
+      const now = Date.now();
+      if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
+        this._lastFlashKey = key;
+        this._lastFlashAt = now;
+        target.classList.remove("field--highlight");
+        void target.offsetWidth;
+        target.classList.add("field--highlight");
+      }
       return;
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -35,6 +35,7 @@ import { registerMdiIcons } from "../../util/register-icons.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
 import { decideFieldFocus } from "./field-interaction.js";
+import { FieldScrollController } from "./field-scroll-controller.js";
 
 import "@home-assistant/webawesome/dist/components/divider/divider.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -77,11 +78,6 @@ registerMdiIcons({
 
 /** Events that surface "the user is on this field" for YAML highlight sync. */
 const FIELD_INTERACTION_EVENTS = ["focusin", "input", "change"] as const;
-
-/** Renders to spend looking for a cursor-targeted field before giving up.
- *  entries + values land in separate renders, so one retry isn't enough;
- *  the cap stops an unbounded shadow-DOM walk for a never-rendered path. */
-const MAX_FOCUS_SCROLL_TRIES = 3;
 
 /** Detail emitted with `value-change` events. */
 export interface ConfigEntryValueChange {
@@ -166,19 +162,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  once and a later user collapse isn't re-overridden. */
   private _seededNestedOpen: Set<string> = new Set();
 
-  /** Last field flashed + when, so the same field isn't re-pulsed within
-   *  10s as the cursor moves around inside it. */
-  private _lastFlashKey?: string;
-  private _lastFlashAt = 0;
-
-  /** The ``focusFieldPath`` already scrolled to. Lets a switch into a
-   *  section retry across the entries/values renders until the field
-   *  exists, while a later value edit doesn't re-scroll a consumed one. */
-  private _scrolledFocusKey?: string;
-
-  /** Render attempts spent locating the current ``focusFieldPath``, bounded
-   *  by ``MAX_FOCUS_SCROLL_TRIES`` so a never-rendered path stops retrying. */
-  private _focusScrollTries = 0;
+  /** Scrolls the YAML-cursor-selected field into view (the structured side
+   *  of the field sync); driven from ``updated``. */
+  private _fieldScroll = new FieldScrollController(this);
 
   /** Field currently being edited (last ``focusin`` / ``input``). A ``change``
    *  fires on blur, so it must match this to highlight; else leaving A for B
@@ -330,84 +316,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   protected updated(changed: PropertyValues) {
     super.updated(changed);
     void this._syncSelectValues();
-    // A new cursor target hasn't been scrolled to yet; reset the retry budget.
-    if (changed.has("focusFieldPath")) {
-      this._scrolledFocusKey = undefined;
-      this._focusScrollTries = 0;
-    }
-    // Re-attempt while the target is unscrolled and any of these change:
-    // entries + values arrive in separate renders on a section switch, so
-    // the field may not be in the DOM until values lands. The bounded retry
-    // budget stops an endless shadow-DOM walk (and a spontaneous later
-    // scroll) for a path this form never renders; consuming the target on
-    // success keeps a later value edit from re-scrolling.
-    const fp = this.focusFieldPath;
-    if (
-      fp?.length &&
-      this._scrolledFocusKey !== fieldKeyAttr(fp) &&
-      this._focusScrollTries < MAX_FOCUS_SCROLL_TRIES &&
-      (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
-    ) {
-      this._focusScrollTries++;
-      void this._scrollToFocusField(fp);
-    }
-  }
-
-  /**
-   * Scroll the YAML-selected field into view, opening collapsed ancestor
-   * groups first. Tied to the current ``focusFieldPath`` (bails if a newer
-   * cursor move superseded it) and marks it consumed once found.
-   */
-  private async _scrollToFocusField(path: string[]) {
-    if (!this.shadowRoot) return;
-    for (let i = 1; i < path.length; i++) {
-      this.openNested(path.slice(0, i).join("."));
-    }
-    await this.updateComplete; // let any opened group render
-    if (this.focusFieldPath !== path) return; // superseded by a newer move
-    // Try the exact field, then progressively shorter prefixes: a
-    // list-of-maps field (globals / filter items, whose form paths carry
-    // a synthetic index the YAML path lacks) at least scrolls its
-    // container into view.
-    for (let len = path.length; len >= 1; len--) {
-      const target = this._findFieldElement(this.shadowRoot, path.slice(0, len));
-      if (!target) continue;
-      // ``center`` (not ``nearest``) so a tall field — long description
-      // plus input — lands fully in view instead of clipped at the fold.
-      target.scrollIntoView({ block: "center" });
-      // Flash, but not for the same field twice within 10s — moving the
-      // cursor around inside one field shouldn't keep re-pulsing it.
-      const key = fieldKeyAttr(path.slice(0, len));
-      const now = Date.now();
-      if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
-        this._lastFlashKey = key;
-        this._lastFlashAt = now;
-        target.classList.remove("field--highlight");
-        void target.offsetWidth;
-        target.classList.add("field--highlight");
-      }
-      this._scrolledFocusKey = fieldKeyAttr(path);
-      return;
-    }
-  }
-
-  /** Find the field with *path*, recursing into nested custom-element
-   *  shadow roots (registry lists, etc.) since ``querySelectorAll`` stops
-   *  at shadow boundaries. */
-  private _findFieldElement(root: ParentNode, path: string[]): HTMLElement | null {
-    for (const el of root.querySelectorAll<HTMLElement>("[data-field-key]")) {
-      const p = this._pathOf(el);
-      if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
-    }
-    // Only custom elements (hyphenated tag) carry a shadow root, so skip the
-    // plain-element subtree and recurse just into those.
-    for (const el of root.querySelectorAll<HTMLElement>("*")) {
-      if (!el.localName.includes("-")) continue;
-      const sr = (el as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot;
-      const found = sr ? this._findFieldElement(sr, path) : null;
-      if (found) return found;
-    }
-    return null;
+    this._fieldScroll.maybeScroll(changed);
   }
 
   private async _syncSelectValues() {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -287,16 +287,23 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _scrollPendingFieldIntoView() {
     const path = this._pendingScrollPath;
     if (!path || !this.shadowRoot) return;
-    const target = this._findFieldElement(this.shadowRoot, path);
-    if (!target) return;
-    this._pendingScrollPath = undefined;
-    // ``center`` (not ``nearest``) so a tall field — long description plus
-    // input — lands fully in view instead of clipped at the fold.
-    target.scrollIntoView({ block: "center" });
-    // Restart the flash even when the same field is re-targeted.
-    target.classList.remove("field--highlight");
-    void target.offsetWidth;
-    target.classList.add("field--highlight");
+    // Try the exact field, then progressively shorter prefixes: a
+    // list-of-maps field (globals / filter items, whose form paths carry
+    // a synthetic index the YAML path lacks) at least scrolls its
+    // container into view.
+    for (let len = path.length; len >= 1; len--) {
+      const target = this._findFieldElement(this.shadowRoot, path.slice(0, len));
+      if (!target) continue;
+      this._pendingScrollPath = undefined;
+      // ``center`` (not ``nearest``) so a tall field — long description
+      // plus input — lands fully in view instead of clipped at the fold.
+      target.scrollIntoView({ block: "center" });
+      // Restart the flash even when the same field is re-targeted.
+      target.classList.remove("field--highlight");
+      void target.offsetWidth;
+      target.classList.add("field--highlight");
+      return;
+    }
   }
 
   /** Find the field with *path*, recursing into nested custom-element

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -163,6 +163,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  exists, while a later value edit doesn't re-scroll a consumed one. */
   private _scrolledFocusKey?: string;
 
+  /** Field with focus (last ``focusin``). A ``change`` fires on blur, so it
+   *  must match this to highlight — else leaving A for B re-points at A. */
+  private _focusedFieldKey?: string;
+
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
    * picked before typing a numeric value. Keyed by dotted path.
@@ -265,9 +269,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   /** Field focused or changed → tell the page which field, to highlight its
    *  YAML line. ``change`` covers selects / switches whose click doesn't
-   *  reliably surface a focusin. Walks ``composedPath`` (not ``closest``)
-   *  so a field whose ``data-field-key`` lives inside a nested renderer's
-   *  shadow root — the pin / registry-list editors — is still found. */
+   *  reliably surface a focusin, but a ``change`` fires on *blur* — so when
+   *  moving from field A to B it can land after B's ``focusin`` and re-point
+   *  the highlight at A. Gate ``change`` to the field that holds focus (the
+   *  last ``focusin``). Walks ``composedPath`` (not ``closest``) so a field
+   *  whose ``data-field-key`` lives inside a nested renderer's shadow root —
+   *  the pin / registry-list editors — is still found. */
   private _onFieldInteraction = (e: Event) => {
     const el = e
       .composedPath()
@@ -278,6 +285,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (!el) return;
     const path = parseFieldKey(el.getAttribute("data-field-key") ?? "");
     if (!path.length) return;
+    const key = path.join(" ");
+    if (e.type === "focusin") this._focusedFieldKey = key;
+    else if (key !== this._focusedFieldKey) return;
     this.dispatchEvent(
       new CustomEvent<{ path: string[] }>("field-focus", {
         detail: { path },

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -77,6 +77,11 @@ registerMdiIcons({
 /** Events that surface "the user is on this field" for YAML highlight sync. */
 const FIELD_INTERACTION_EVENTS = ["focusin", "input", "change"] as const;
 
+/** Renders to spend looking for a cursor-targeted field before giving up.
+ *  entries + values land in separate renders, so one retry isn't enough;
+ *  the cap stops an unbounded shadow-DOM walk for a never-rendered path. */
+const MAX_FOCUS_SCROLL_TRIES = 3;
+
 /** Detail emitted with `value-change` events. */
 export interface ConfigEntryValueChange {
   path: string[];
@@ -165,6 +170,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  section retry across the entries/values renders until the field
    *  exists, while a later value edit doesn't re-scroll a consumed one. */
   private _scrolledFocusKey?: string;
+
+  /** Render attempts spent locating the current ``focusFieldPath``, bounded
+   *  by ``MAX_FOCUS_SCROLL_TRIES`` so a never-rendered path stops retrying. */
+  private _focusScrollTries = 0;
 
   /** Field currently being edited (last ``focusin`` / ``input``). A ``change``
    *  fires on blur, so it must match this to highlight; else leaving A for B
@@ -309,18 +318,25 @@ export class ESPHomeConfigEntryForm extends LitElement {
   protected updated(changed: PropertyValues) {
     super.updated(changed);
     void this._syncSelectValues();
-    // A new cursor target hasn't been scrolled to yet.
-    if (changed.has("focusFieldPath")) this._scrolledFocusKey = undefined;
+    // A new cursor target hasn't been scrolled to yet; reset the retry budget.
+    if (changed.has("focusFieldPath")) {
+      this._scrolledFocusKey = undefined;
+      this._focusScrollTries = 0;
+    }
     // Re-attempt while the target is unscrolled and any of these change:
     // entries + values arrive in separate renders on a section switch, so
-    // the field may not be in the DOM until values lands. Consuming the
-    // target on success keeps a later value edit from re-scrolling.
+    // the field may not be in the DOM until values lands. The bounded retry
+    // budget stops an endless shadow-DOM walk (and a spontaneous later
+    // scroll) for a path this form never renders; consuming the target on
+    // success keeps a later value edit from re-scrolling.
     const fp = this.focusFieldPath;
     if (
       fp?.length &&
       this._scrolledFocusKey !== fp.join(" ") &&
+      this._focusScrollTries < MAX_FOCUS_SCROLL_TRIES &&
       (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
     ) {
+      this._focusScrollTries++;
       void this._scrollToFocusField(fp);
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -243,19 +243,22 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener("focusin", this._onFocusIn);
+    this.addEventListener("focusin", this._onFieldInteraction);
+    this.addEventListener("change", this._onFieldInteraction);
   }
 
   disconnectedCallback() {
-    this.removeEventListener("focusin", this._onFocusIn);
+    this.removeEventListener("focusin", this._onFieldInteraction);
+    this.removeEventListener("change", this._onFieldInteraction);
     super.disconnectedCallback();
   }
 
-  /** Field focused → tell the page which field, to highlight its YAML line.
-   *  Walks ``composedPath`` (not ``closest``) so a field whose
-   *  ``data-field-key`` lives inside a nested renderer's shadow root — the
-   *  pin / registry-list editors — is still found. */
-  private _onFocusIn = (e: Event) => {
+  /** Field focused or changed → tell the page which field, to highlight its
+   *  YAML line. ``change`` covers selects / switches whose click doesn't
+   *  reliably surface a focusin. Walks ``composedPath`` (not ``closest``)
+   *  so a field whose ``data-field-key`` lives inside a nested renderer's
+   *  shadow root — the pin / registry-list editors — is still found. */
+  private _onFieldInteraction = (e: Event) => {
     const el = e
       .composedPath()
       .find(
@@ -277,7 +280,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
   protected updated(changed: PropertyValues) {
     super.updated(changed);
     void this._syncSelectValues();
-    if (changed.has("focusFieldPath") && this.focusFieldPath?.length) {
+    // Re-attempt on ``entries`` too: switching sections loads the new
+    // form's entries asynchronously, so the field isn't in the DOM yet
+    // on the ``focusFieldPath`` change alone. (``entries`` only changes
+    // on a section switch, not on value edits, so this won't scroll
+    // unbidden mid-editing.)
+    if (
+      (changed.has("focusFieldPath") || changed.has("entries")) &&
+      this.focusFieldPath?.length
+    ) {
       void this._scrollToFocusField(this.focusFieldPath);
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -252,6 +252,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (changed.has("entries") && changed.get("entries") !== undefined) {
       this._pendingUnits.clear();
       this._editingMagnitudes.clear();
+      // The form instance is reused across sections; reset the seed markers
+      // so a disclosure default-opens again for the new component (a key like
+      // "pin:pin-advanced" recurs across sections that each have a pin).
+      this._seededNestedOpen.clear();
     }
   }
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -153,10 +153,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @state()
   private _nestedOpenSections: Set<string> = new Set();
 
-  /** Pending scroll target; survives the re-render that opening a
-   *  collapsed ancestor group triggers. */
-  private _pendingScrollPath?: string[];
-
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
    * picked before typing a numeric value. Keyed by dotted path.
@@ -274,19 +270,23 @@ export class ESPHomeConfigEntryForm extends LitElement {
     super.updated(changed);
     void this._syncSelectValues();
     if (changed.has("focusFieldPath") && this.focusFieldPath?.length) {
-      this._pendingScrollPath = this.focusFieldPath;
-      // Open collapsed ancestor groups so the field is in the DOM to find.
-      for (let i = 1; i < this.focusFieldPath.length; i++) {
-        this.openNested(this.focusFieldPath.slice(0, i).join("."));
-      }
+      void this._scrollToFocusField(this.focusFieldPath);
     }
-    if (this._pendingScrollPath) this._scrollPendingFieldIntoView();
   }
 
-  /** Scroll the pending field into view once it's in the DOM; clears it. */
-  private _scrollPendingFieldIntoView() {
-    const path = this._pendingScrollPath;
-    if (!path || !this.shadowRoot) return;
+  /**
+   * Scroll the YAML-selected field into view, opening collapsed ancestor
+   * groups first. One-shot and tied to the current ``focusFieldPath``: a
+   * newer cursor move (or a field that never renders) can't leave it
+   * retrying on every later update.
+   */
+  private async _scrollToFocusField(path: string[]) {
+    if (!this.shadowRoot) return;
+    for (let i = 1; i < path.length; i++) {
+      this.openNested(path.slice(0, i).join("."));
+    }
+    await this.updateComplete; // let any opened group render
+    if (this.focusFieldPath !== path) return; // superseded by a newer move
     // Try the exact field, then progressively shorter prefixes: a
     // list-of-maps field (globals / filter items, whose form paths carry
     // a synthetic index the YAML path lacks) at least scrolls its
@@ -294,7 +294,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
     for (let len = path.length; len >= 1; len--) {
       const target = this._findFieldElement(this.shadowRoot, path.slice(0, len));
       if (!target) continue;
-      this._pendingScrollPath = undefined;
       // ``center`` (not ``nearest``) so a tall field — long description
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -295,6 +295,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (!target) return;
     this._pendingScrollPath = undefined;
     target.scrollIntoView({ block: "nearest" });
+    // Restart the flash even when the same field is re-targeted.
+    target.classList.remove("field--highlight");
+    void target.offsetWidth;
+    target.classList.add("field--highlight");
   }
 
   private async _syncSelectValues() {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -251,9 +251,17 @@ export class ESPHomeConfigEntryForm extends LitElement {
     super.disconnectedCallback();
   }
 
-  /** Field focused → tell the page which field, to highlight its YAML line. */
+  /** Field focused → tell the page which field, to highlight its YAML line.
+   *  Walks ``composedPath`` (not ``closest``) so a field whose
+   *  ``data-field-key`` lives inside a nested renderer's shadow root — the
+   *  pin / registry-list editors — is still found. */
   private _onFocusIn = (e: Event) => {
-    const el = (e.target as HTMLElement | null)?.closest?.("[data-field-key]");
+    const el = e
+      .composedPath()
+      .find(
+        (n): n is HTMLElement =>
+          n instanceof HTMLElement && n.hasAttribute("data-field-key")
+      );
     if (!el) return;
     const path = parseFieldKey(el.getAttribute("data-field-key") ?? "");
     if (!path.length) return;

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -162,6 +162,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @state()
   private _nestedOpenSections: Set<string> = new Set();
 
+  /** Keys already default-opened by ``_seedNestedOpen`` so the seed fires
+   *  once and a later user collapse isn't re-overridden. */
+  private _seededNestedOpen: Set<string> = new Set();
+
   /** Last field flashed + when, so the same field isn't re-pulsed within
    *  10s as the cursor moves around inside it. */
   private _lastFlashKey?: string;
@@ -679,6 +683,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       errorAt: (path) => this.errors.get(path.join(".")) ?? null,
       emitChange: (path, value) => this._emitChange(path, value),
       toggleNested: (key) => this._toggleNested(key),
+      seedNestedOpen: (key) => this._seedNestedOpen(key),
       requestAddComponent: (domain) => this._requestAddComponent(domain),
       scopeValues: (path) => this._scopeValues(path),
       filterRenderable: this._filterRenderable,
@@ -758,6 +763,17 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const next = new Set(this._nestedOpenSections);
     next.add(key);
     this._nestedOpenSections = next;
+  }
+
+  /**
+   * Open *key* once as a default (honoring a later user collapse). Mutates
+   * in place so seeding mid-render schedules no update; the seeded marker
+   * keeps it to one shot.
+   */
+  private _seedNestedOpen(key: string) {
+    if (this.requiredOnly || this._seededNestedOpen.has(key)) return;
+    this._seededNestedOpen.add(key);
+    this._nestedOpenSections.add(key);
   }
 
   /**

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -34,7 +34,7 @@ import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
-import { decideFieldFocus } from "./field-interaction.js";
+import { FieldFocusController } from "./field-focus-controller.js";
 import { FieldScrollController } from "./field-scroll-controller.js";
 
 import "@home-assistant/webawesome/dist/components/divider/divider.js";
@@ -75,13 +75,6 @@ registerMdiIcons({
   "open-in-new": mdiOpenInNew,
   plus: mdiPlus,
 });
-
-/** Events that surface "the user is on this field" for YAML highlight sync.
- *  ``pointerdown`` is load-bearing: ``wa-input``'s nested ``delegatesFocus``
- *  shadow roots keep ``document.activeElement`` pinned to the outer host, so
- *  ``focusin`` only fires on first entry to the form, never when moving
- *  between fields. ``pointerdown`` fires on every click regardless. */
-const FIELD_INTERACTION_EVENTS = ["focusin", "pointerdown", "input", "change"] as const;
 
 /** Detail emitted with `value-change` events. */
 export interface ConfigEntryValueChange {
@@ -170,10 +163,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  of the field sync); driven from ``updated``. */
   private _fieldScroll = new FieldScrollController(this);
 
-  /** Field currently being edited (last ``focusin`` / ``input``). A ``change``
-   *  fires on blur, so it must match this to highlight; else leaving A for B
-   *  re-points the highlight back at A. */
-  private _focusedFieldKey?: string;
+  /** Emits ``field-focus`` as the user moves between fields (the other side
+   *  of the sync); owns its own listener lifecycle. */
+  private _fieldFocus = new FieldFocusController(this);
 
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
@@ -262,60 +254,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
       this._editingMagnitudes.clear();
     }
   }
-
-  connectedCallback() {
-    super.connectedCallback();
-    for (const t of FIELD_INTERACTION_EVENTS) {
-      this.addEventListener(t, this._onFieldInteraction);
-    }
-  }
-
-  disconnectedCallback() {
-    for (const t of FIELD_INTERACTION_EVENTS) {
-      this.removeEventListener(t, this._onFieldInteraction);
-    }
-    super.disconnectedCallback();
-  }
-
-  /** A field was focused, typed in, or committed → tell the page which field,
-   *  to highlight its YAML line. ``focusin`` / ``input`` mark the field being
-   *  edited (``input`` is authoritative: it only fires on the live field, so
-   *  it catches one whose ``focusin`` didn't surface, e.g. a just-added
-   *  required input). ``change`` fires on *blur*, so it would re-point the
-   *  highlight at the field just left; honor it only while that field still
-   *  holds focus. Walks ``composedPath`` (not ``closest``) so a field
-   *  whose ``data-field-key`` lives inside a nested renderer's shadow root —
-   *  the pin / registry-list editors — is still found. */
-  private _onFieldInteraction = (e: Event) => {
-    const el = e
-      .composedPath()
-      .find(
-        (n): n is HTMLElement =>
-          n instanceof HTMLElement && n.hasAttribute("data-field-key")
-      );
-    if (!el) return;
-    // Only real field paths (JSON arrays from ``fieldKeyAttr``) map to a YAML
-    // line. Synthetic disclosure keys like ``pin:pin-advanced`` would strand
-    // the page in a doomed pending-field-line retry — skip them.
-    const attr = el.getAttribute("data-field-key") ?? "";
-    if (!attr.startsWith("[")) return;
-    const path = this._pathOf(el);
-    if (!path.length) return;
-    const { emit, focusedKey } = decideFieldFocus(
-      e.type,
-      fieldKeyAttr(path),
-      this._focusedFieldKey
-    );
-    this._focusedFieldKey = focusedKey;
-    if (!emit) return;
-    this.dispatchEvent(
-      new CustomEvent<{ path: string[] }>("field-focus", {
-        detail: { path },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  };
 
   /** Decode a field element's ``data-field-key`` to its path. */
   private _pathOf(el: Element): string[] {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -74,6 +74,9 @@ registerMdiIcons({
   plus: mdiPlus,
 });
 
+/** Events that surface "the user is on this field" for YAML highlight sync. */
+const FIELD_INTERACTION_EVENTS = ["focusin", "input", "change"] as const;
+
 /** Detail emitted with `value-change` events. */
 export interface ConfigEntryValueChange {
   path: string[];
@@ -163,8 +166,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
    *  exists, while a later value edit doesn't re-scroll a consumed one. */
   private _scrolledFocusKey?: string;
 
-  /** Field with focus (last ``focusin``). A ``change`` fires on blur, so it
-   *  must match this to highlight — else leaving A for B re-points at A. */
+  /** Field currently being edited (last ``focusin`` / ``input``). A ``change``
+   *  fires on blur, so it must match this to highlight; else leaving A for B
+   *  re-points the highlight back at A. */
   private _focusedFieldKey?: string;
 
   /**
@@ -257,22 +261,25 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener("focusin", this._onFieldInteraction);
-    this.addEventListener("change", this._onFieldInteraction);
+    for (const t of FIELD_INTERACTION_EVENTS) {
+      this.addEventListener(t, this._onFieldInteraction);
+    }
   }
 
   disconnectedCallback() {
-    this.removeEventListener("focusin", this._onFieldInteraction);
-    this.removeEventListener("change", this._onFieldInteraction);
+    for (const t of FIELD_INTERACTION_EVENTS) {
+      this.removeEventListener(t, this._onFieldInteraction);
+    }
     super.disconnectedCallback();
   }
 
-  /** Field focused or changed → tell the page which field, to highlight its
-   *  YAML line. ``change`` covers selects / switches whose click doesn't
-   *  reliably surface a focusin, but a ``change`` fires on *blur* — so when
-   *  moving from field A to B it can land after B's ``focusin`` and re-point
-   *  the highlight at A. Gate ``change`` to the field that holds focus (the
-   *  last ``focusin``). Walks ``composedPath`` (not ``closest``) so a field
+  /** A field was focused, typed in, or committed → tell the page which field,
+   *  to highlight its YAML line. ``focusin`` / ``input`` mark the field being
+   *  edited (``input`` is authoritative: it only fires on the live field, so
+   *  it catches one whose ``focusin`` didn't surface, e.g. a just-added
+   *  required input). ``change`` fires on *blur*, so it would re-point the
+   *  highlight at the field just left; honor it only while that field still
+   *  holds focus. Walks ``composedPath`` (not ``closest``) so a field
    *  whose ``data-field-key`` lives inside a nested renderer's shadow root —
    *  the pin / registry-list editors — is still found. */
   private _onFieldInteraction = (e: Event) => {
@@ -286,8 +293,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     const path = parseFieldKey(el.getAttribute("data-field-key") ?? "");
     if (!path.length) return;
     const key = path.join(" ");
-    if (e.type === "focusin") this._focusedFieldKey = key;
-    else if (key !== this._focusedFieldKey) return;
+    if (e.type === "change" && key !== this._focusedFieldKey) return;
+    const moved = key !== this._focusedFieldKey;
+    this._focusedFieldKey = key;
+    if (e.type === "input" && !moved) return; // same field, mid-typing: no re-emit
     this.dispatchEvent(
       new CustomEvent<{ path: string[] }>("field-focus", {
         detail: { path },

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -252,9 +252,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (changed.has("entries") && changed.get("entries") !== undefined) {
       this._pendingUnits.clear();
       this._editingMagnitudes.clear();
-      // The form instance is reused across sections; reset the seed markers
-      // so a disclosure default-opens again for the new component (a key like
-      // "pin:pin-advanced" recurs across sections that each have a pin).
+      // Re-seed disclosures for the new component; a key like "pin:pin-advanced"
+      // recurs across sections, and the form instance is reused.
       this._seededNestedOpen.clear();
     }
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -438,9 +438,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
           // ignore
         }
       }
-      const key = field.getAttribute("data-field-key");
-      if (!key) continue;
-      const path = parseFieldKey(key);
+      const path = this._pathOf(field);
+      if (!path.length) continue;
       const value = getIn(this.values, path);
       // ``wa-select`` only carries primitive values; if the YAML
       // path resolves to an object (transient state from a partial

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -76,8 +76,12 @@ registerMdiIcons({
   plus: mdiPlus,
 });
 
-/** Events that surface "the user is on this field" for YAML highlight sync. */
-const FIELD_INTERACTION_EVENTS = ["focusin", "input", "change"] as const;
+/** Events that surface "the user is on this field" for YAML highlight sync.
+ *  ``pointerdown`` is load-bearing: ``wa-input``'s nested ``delegatesFocus``
+ *  shadow roots keep ``document.activeElement`` pinned to the outer host, so
+ *  ``focusin`` only fires on first entry to the form, never when moving
+ *  between fields. ``pointerdown`` fires on every click regardless. */
+const FIELD_INTERACTION_EVENTS = ["focusin", "pointerdown", "input", "change"] as const;
 
 /** Detail emitted with `value-change` events. */
 export interface ConfigEntryValueChange {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -287,18 +287,32 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _scrollPendingFieldIntoView() {
     const path = this._pendingScrollPath;
     if (!path || !this.shadowRoot) return;
-    const fields = this.shadowRoot.querySelectorAll<HTMLElement>("[data-field-key]");
-    const target = Array.from(fields).find((f) => {
-      const p = parseFieldKey(f.getAttribute("data-field-key") ?? "");
-      return p.length === path.length && p.every((k, i) => k === path[i]);
-    });
+    const target = this._findFieldElement(this.shadowRoot, path);
     if (!target) return;
     this._pendingScrollPath = undefined;
-    target.scrollIntoView({ block: "nearest" });
+    // ``center`` (not ``nearest``) so a tall field — long description plus
+    // input — lands fully in view instead of clipped at the fold.
+    target.scrollIntoView({ block: "center" });
     // Restart the flash even when the same field is re-targeted.
     target.classList.remove("field--highlight");
     void target.offsetWidth;
     target.classList.add("field--highlight");
+  }
+
+  /** Find the field with *path*, recursing into nested custom-element
+   *  shadow roots (registry lists, etc.) since ``querySelectorAll`` stops
+   *  at shadow boundaries. */
+  private _findFieldElement(root: ParentNode, path: string[]): HTMLElement | null {
+    for (const el of root.querySelectorAll<HTMLElement>("[data-field-key]")) {
+      const p = parseFieldKey(el.getAttribute("data-field-key") ?? "");
+      if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
+    }
+    for (const el of root.querySelectorAll<HTMLElement>("*")) {
+      const sr = (el as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot;
+      const found = sr ? this._findFieldElement(sr, path) : null;
+      if (found) return found;
+    }
+    return null;
   }
 
   private async _syncSelectValues() {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -146,8 +146,16 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @property({ attribute: false })
   presentComponents: Set<string> = new Set();
 
+  /** Instance-relative field path to scroll into view, from the YAML cursor. */
+  @property({ attribute: false })
+  focusFieldPath?: string[];
+
   @state()
   private _nestedOpenSections: Set<string> = new Set();
+
+  /** Pending scroll target; survives the re-render that opening a
+   *  collapsed ancestor group triggers. */
+  private _pendingScrollPath?: string[];
 
   /**
    * Transient unit choice for FLOAT_WITH_UNIT entries the user
@@ -237,9 +245,56 @@ export class ESPHomeConfigEntryForm extends LitElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener("focusin", this._onFocusIn);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener("focusin", this._onFocusIn);
+    super.disconnectedCallback();
+  }
+
+  /** Field focused → tell the page which field, to highlight its YAML line. */
+  private _onFocusIn = (e: Event) => {
+    const el = (e.target as HTMLElement | null)?.closest?.("[data-field-key]");
+    if (!el) return;
+    const path = parseFieldKey(el.getAttribute("data-field-key") ?? "");
+    if (!path.length) return;
+    this.dispatchEvent(
+      new CustomEvent<{ path: string[] }>("field-focus", {
+        detail: { path },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
+
   protected updated(changed: PropertyValues) {
     super.updated(changed);
     void this._syncSelectValues();
+    if (changed.has("focusFieldPath") && this.focusFieldPath?.length) {
+      this._pendingScrollPath = this.focusFieldPath;
+      // Open collapsed ancestor groups so the field is in the DOM to find.
+      for (let i = 1; i < this.focusFieldPath.length; i++) {
+        this.openNested(this.focusFieldPath.slice(0, i).join("."));
+      }
+    }
+    if (this._pendingScrollPath) this._scrollPendingFieldIntoView();
+  }
+
+  /** Scroll the pending field into view once it's in the DOM; clears it. */
+  private _scrollPendingFieldIntoView() {
+    const path = this._pendingScrollPath;
+    if (!path || !this.shadowRoot) return;
+    const fields = this.shadowRoot.querySelectorAll<HTMLElement>("[data-field-key]");
+    const target = Array.from(fields).find((f) => {
+      const p = parseFieldKey(f.getAttribute("data-field-key") ?? "");
+      return p.length === path.length && p.every((k, i) => k === path[i]);
+    });
+    if (!target) return;
+    this._pendingScrollPath = undefined;
+    target.scrollIntoView({ block: "nearest" });
   }
 
   private async _syncSelectValues() {

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -399,7 +399,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
       const p = this._pathOf(el);
       if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
     }
+    // Only custom elements (hyphenated tag) carry a shadow root, so skip the
+    // plain-element subtree and recurse just into those.
     for (const el of root.querySelectorAll<HTMLElement>("*")) {
+      if (!el.localName.includes("-")) continue;
       const sr = (el as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot;
       const found = sr ? this._findFieldElement(sr, path) : null;
       if (found) return found;

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -275,9 +275,16 @@ function renderPinAdvanced(
   // Reuse the form's ``nestedOpenSections`` machinery so the
   // open/closed state survives a re-render and follows the same
   // semantics as a regular ``nested`` group's expand toggle.
-  // Default closed — the long-form fields are an opt-in
-  // disclosure, never on the main form.
-  const isOpen = ctx.nestedOpenSections.has(advancedKey);
+  // Default closed for a short-form pin (opt-in disclosure) — but
+  // open when the pin already carries long-form advanced values
+  // (``mode`` / ``inverted`` / …): a field set in YAML shouldn't be
+  // hidden behind the toggle, and cursor-sync needs it rendered to
+  // scroll to.
+  const pinValues = ctx.scopeValues(path);
+  const hasAdvancedValue =
+    isLongForm &&
+    Object.keys(pinValues).some((k) => k !== "number" && pinValues[k] !== undefined);
+  const isOpen = ctx.nestedOpenSections.has(advancedKey) || hasAdvancedValue;
 
   const onAdvancedToggle = () => {
     // Locked / disabled fields (board-preset pins, parent-disabled

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -272,19 +272,17 @@ function renderPinAdvanced(
   if (longFormFields.length === 0) return nothing;
 
   const advancedKey = `${path.join(".")}:pin-advanced`;
-  // Reuse the form's ``nestedOpenSections`` machinery so the
-  // open/closed state survives a re-render and follows the same
-  // semantics as a regular ``nested`` group's expand toggle.
-  // Default closed for a short-form pin (opt-in disclosure) — but
-  // open when the pin already carries long-form advanced values
-  // (``mode`` / ``inverted`` / …): a field set in YAML shouldn't be
-  // hidden behind the toggle, and cursor-sync needs it rendered to
-  // scroll to.
+  // Reuse the form's ``nestedOpenSections`` machinery so the open/closed
+  // state survives a re-render. Default closed (opt-in disclosure), but
+  // seed open when the pin already carries long-form values (``mode`` /
+  // ``inverted`` / …) so a field set in YAML isn't hidden — seeded, not
+  // forced, so reading ``isOpen`` from the set honors a later user collapse.
   const pinValues = ctx.scopeValues(path);
   const hasAdvancedValue =
     isLongForm &&
     Object.keys(pinValues).some((k) => k !== "number" && pinValues[k] !== undefined);
-  const isOpen = ctx.nestedOpenSections.has(advancedKey) || hasAdvancedValue;
+  if (hasAdvancedValue) ctx.seedNestedOpen(advancedKey);
+  const isOpen = ctx.nestedOpenSections.has(advancedKey);
 
   const onAdvancedToggle = () => {
     // Locked / disabled fields (board-preset pins, parent-disabled

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -96,6 +96,9 @@ export interface RenderCtx {
   errorAt: (path: string[]) => ValidationError | null;
   emitChange: (path: string[], value: unknown) => void;
   toggleNested: (key: string) => void;
+  /** Open *key* once as a default (e.g. a pin disclosure with long-form
+   *  values), without overriding a later explicit user collapse. */
+  seedNestedOpen: (key: string) => void;
   requestAddComponent: (domain: string) => void;
   scopeValues: (path: string[]) => Record<string, unknown>;
   filterRenderable: (

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -19,13 +19,19 @@ import { isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { configEntryFormStyles } from "./config-entry-form.styles.js";
+import { fieldHighlightStyles } from "./field-highlight.styles.js";
 import type { PasswordInputValueChange } from "./password-input.js";
 
 /** Stylesheets every element that hosts ``ctx.renderEntry`` output
  *  needs in its shadow root: field shell, input styling, and the
  *  layout rules for compound widgets (``.time-period-inputs``,
  *  ``.nested-fields``, …) the per-field renderers emit. */
-export const fieldRendererStyles = [espHomeStyles, inputStyles, configEntryFormStyles];
+export const fieldRendererStyles = [
+  espHomeStyles,
+  inputStyles,
+  configEntryFormStyles,
+  fieldHighlightStyles,
+];
 
 registerMdiIcons({
   "key-variant": mdiKeyVariant,

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -181,7 +181,7 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
     const valuePath = [...path, rowKey];
     const complex = !isPrimitiveOrNullish(map[rowKey]);
     return html`
-      <div class="map-row">
+      <div class="map-row" data-field-key=${fieldKeyAttr(valuePath)}>
         <input
           type="text"
           class="multi-input map-key-input"

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -87,6 +87,10 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   @property({ type: Number })
   selectedFromLine?: number;
 
+  /** Instance-relative field path to scroll into view, from the YAML cursor. */
+  @property({ attribute: false })
+  focusFieldPath?: string[];
+
   @query("esphome-device-section-config")
   private _sectionConfig!: ESPHomeDeviceSectionConfig;
 
@@ -331,6 +335,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
       .configuration=${this.configuration}
       .sectionKey=${key}
       .fromLine=${this.selectedFromLine}
+      .focusFieldPath=${this.focusFieldPath}
       .yaml=${this.yaml}
       .board=${this.board}
       .boardName=${this.board?.name ?? ""}

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -119,6 +119,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   @property({ type: Number })
   selectedFromLine?: number;
 
+  /** Instance-relative field path to scroll into view, from the YAML cursor. */
+  @property({ attribute: false })
+  focusFieldPath?: string[];
+
   /** Yaml content at last save/load — compared against current yaml to detect changes. */
   @property({ attribute: false })
   savedYaml = "";
@@ -333,6 +337,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 .configuration=${this.configuration}
                 .selectedSection=${this.selectedSection}
                 .selectedFromLine=${this.selectedFromLine}
+                .focusFieldPath=${this.focusFieldPath}
                 .justCreated=${this.justCreated}
                 ?yamlPaneVisible=${effectiveLayout !== "left"}
                 @show-yaml-editor=${this._onShowYamlEditor}

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -83,6 +83,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   // duplicates — a small shift maps the click back to the closest match.
   @property({ type: Number }) fromLine?: number;
 
+  // Instance-relative field path to scroll into view, from the YAML cursor.
+  @property({ attribute: false }) focusFieldPath?: string[];
+
   // Same string the YAML pane shows including unsaved edits. Save and delete
   // operate on this rather than re-fetching: the navigator emits fromLine
   // relative to live YAML, so an out-of-sync version would point the splice
@@ -380,6 +383,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
               .yaml=${this.yaml}
               .fromLine=${this._resolvedFromLine}
               .sectionKey=${this.sectionKey}
+              .focusFieldPath=${this.focusFieldPath}
               .presentComponents=${this._presentComponents}
               ?show-advanced=${showAdvanced}
               @value-change=${this._onValueChange}

--- a/src/components/device/field-focus-controller.ts
+++ b/src/components/device/field-focus-controller.ts
@@ -1,0 +1,71 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
+import { decideFieldFocus } from "./field-interaction.js";
+
+/** Events that surface "the user is on this field" for YAML highlight sync.
+ *  ``pointerdown`` is load-bearing: ``wa-input``'s nested ``delegatesFocus``
+ *  shadow roots keep ``document.activeElement`` pinned to the outer host, so
+ *  ``focusin`` only fires on first entry to the form, never when moving
+ *  between fields. ``pointerdown`` fires on every click regardless. */
+const FIELD_INTERACTION_EVENTS = ["focusin", "pointerdown", "input", "change"] as const;
+
+type FieldFocusHost = ReactiveControllerHost & HTMLElement;
+
+/**
+ * Listens for field interactions on the form and emits a bubbling
+ * ``field-focus`` ``CustomEvent<{ path }>`` for the YAML highlight sync, so
+ * the page can highlight the matching line. Decides emit vs. skip via
+ * ``decideFieldFocus`` (``input`` authoritative, ``change`` only while
+ * focused, ``pointerdown`` for the delegatesFocus gap).
+ */
+export class FieldFocusController implements ReactiveController {
+  /** Field currently being edited (last ``focusin`` / ``input`` / pointer). */
+  private _focusedKey?: string;
+
+  constructor(private readonly host: FieldFocusHost) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    for (const t of FIELD_INTERACTION_EVENTS) {
+      this.host.addEventListener(t, this._onInteraction);
+    }
+  }
+
+  hostDisconnected(): void {
+    for (const t of FIELD_INTERACTION_EVENTS) {
+      this.host.removeEventListener(t, this._onInteraction);
+    }
+  }
+
+  private _onInteraction = (e: Event) => {
+    const el = e
+      .composedPath()
+      .find(
+        (n): n is HTMLElement =>
+          n instanceof HTMLElement && n.hasAttribute("data-field-key")
+      );
+    if (!el) return;
+    // Only real field paths (JSON arrays from ``fieldKeyAttr``) map to a YAML
+    // line. Synthetic disclosure keys like ``pin:pin-advanced`` would strand
+    // the page in a doomed pending-field-line retry — skip them.
+    const attr = el.getAttribute("data-field-key") ?? "";
+    if (!attr.startsWith("[")) return;
+    const path = parseFieldKey(attr);
+    if (!path.length) return;
+    const { emit, focusedKey } = decideFieldFocus(
+      e.type,
+      fieldKeyAttr(path),
+      this._focusedKey
+    );
+    this._focusedKey = focusedKey;
+    if (!emit) return;
+    this.host.dispatchEvent(
+      new CustomEvent<{ path: string[] }>("field-focus", {
+        detail: { path },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
+}

--- a/src/components/device/field-focus-controller.ts
+++ b/src/components/device/field-focus-controller.ts
@@ -2,22 +2,15 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
 import { decideFieldFocus } from "./field-interaction.js";
 
-/** Events that surface "the user is on this field" for YAML highlight sync.
- *  ``pointerdown`` is load-bearing: ``wa-input``'s nested ``delegatesFocus``
- *  shadow roots keep ``document.activeElement`` pinned to the outer host, so
- *  ``focusin`` only fires on first entry to the form, never when moving
- *  between fields. ``pointerdown`` fires on every click regardless. */
+// ``pointerdown`` is load-bearing: ``wa-input``'s nested ``delegatesFocus``
+// keeps ``document.activeElement`` on the outer host, so ``focusin`` fires
+// only on first entry, not when moving between fields.
 const FIELD_INTERACTION_EVENTS = ["focusin", "pointerdown", "input", "change"] as const;
 
 type FieldFocusHost = ReactiveControllerHost & HTMLElement;
 
-/**
- * Listens for field interactions on the form and emits a bubbling
- * ``field-focus`` ``CustomEvent<{ path }>`` for the YAML highlight sync, so
- * the page can highlight the matching line. Decides emit vs. skip via
- * ``decideFieldFocus`` (``input`` authoritative, ``change`` only while
- * focused, ``pointerdown`` for the delegatesFocus gap).
- */
+/** Emits a bubbling ``field-focus`` event as the user moves between fields
+ *  (emit/skip decided by ``decideFieldFocus``), for the YAML highlight sync. */
 export class FieldFocusController implements ReactiveController {
   /** Field currently being edited (last ``focusin`` / ``input`` / pointer). */
   private _focusedKey?: string;

--- a/src/components/device/field-highlight.styles.ts
+++ b/src/components/device/field-highlight.styles.ts
@@ -1,11 +1,7 @@
 import { css } from "lit";
 
-/**
- * One-shot glow for a field the YAML cursor navigated to (the structured side
- * of the field sync). Split into its own sheet so it lives with the feature
- * and doesn't grow the already-large ``config-entry-form.styles``; added to
- * ``fieldRendererStyles`` so it shares the form's shadow-root scope.
- */
+/** One-shot glow for a field the YAML cursor navigated to; in
+ *  ``fieldRendererStyles`` so it shares the form's shadow-root scope. */
 export const fieldHighlightStyles = css`
   /* Brief glow when navigated to from the YAML cursor — mirrors the
      dashboard's just-added card flash. */

--- a/src/components/device/field-highlight.styles.ts
+++ b/src/components/device/field-highlight.styles.ts
@@ -1,0 +1,31 @@
+import { css } from "lit";
+
+/**
+ * One-shot glow for a field the YAML cursor navigated to (the structured side
+ * of the field sync). Split into its own sheet so it lives with the feature
+ * and doesn't grow the already-large ``config-entry-form.styles``; added to
+ * ``fieldRendererStyles`` so it shares the form's shadow-root scope.
+ */
+export const fieldHighlightStyles = css`
+  /* Brief glow when navigated to from the YAML cursor — mirrors the
+     dashboard's just-added card flash. */
+  .field--highlight {
+    animation: field-highlight-glow 2s ease-out 1;
+  }
+  @keyframes field-highlight-glow {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 40%);
+    }
+    50% {
+      box-shadow: 0 0 0 6px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    }
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 100%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .field--highlight {
+      animation: none;
+    }
+  }
+`;

--- a/src/components/device/field-interaction.ts
+++ b/src/components/device/field-interaction.ts
@@ -12,13 +12,10 @@ export interface FieldFocusDecision {
 }
 
 /**
- * Decide whether *type* on the field keyed *key* should highlight its YAML
- * line, given the currently focused field. ``focusin`` / ``input`` mark the
- * edited field (``input`` is authoritative: it only fires on the live field,
- * so it catches one whose ``focusin`` didn't surface, e.g. a just-added
- * required input). ``input`` re-emits only when focus moved, not mid-typing.
- * ``change`` fires on blur, so it is honored only while its field still holds
- * focus — else moving A→B re-points the highlight back at A.
+ * Decide whether *type* should highlight the field keyed *key*, and the next
+ * focused key. ``input`` is authoritative (catches a field whose ``focusin``
+ * didn't surface) and re-emits only when focus moved; ``change`` is honored
+ * only while its field still holds focus, so moving A to B doesn't re-point at A.
  */
 export function decideFieldFocus(
   type: string,

--- a/src/components/device/field-interaction.ts
+++ b/src/components/device/field-interaction.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure decision for the structured form's field-focus highlight sync,
+ * split out so it can be unit-tested without mounting the form element
+ * (its ``wa-*`` deps don't load under the node test env).
+ */
+
+/** Outcome of a field interaction: whether to (re)highlight the field's
+ *  YAML line, and which field is now considered focused. */
+export interface FieldFocusDecision {
+  emit: boolean;
+  focusedKey: string | undefined;
+}
+
+/**
+ * Decide whether *type* on the field keyed *key* should highlight its YAML
+ * line, given the currently focused field. ``focusin`` / ``input`` mark the
+ * edited field (``input`` is authoritative: it only fires on the live field,
+ * so it catches one whose ``focusin`` didn't surface, e.g. a just-added
+ * required input). ``input`` re-emits only when focus moved, not mid-typing.
+ * ``change`` fires on blur, so it is honored only while its field still holds
+ * focus — else moving A→B re-points the highlight back at A.
+ */
+export function decideFieldFocus(
+  type: string,
+  key: string,
+  focusedKey: string | undefined
+): FieldFocusDecision {
+  if (type === "change") return { emit: key === focusedKey, focusedKey };
+  const moved = key !== focusedKey;
+  return { emit: type === "focusin" || moved, focusedKey: key };
+}

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -113,18 +113,27 @@ export class FieldScrollController {
     // Try the exact field, then progressively shorter prefixes: a
     // list-of-maps field (globals / filter items, whose form paths carry
     // a synthetic index the YAML path lacks) at least scrolls its
-    // container into view.
+    // container into view. Only an exact match consumes the target; a
+    // prefix-only match still scrolls but leaves the budget to refine to the
+    // exact field once it renders (FLASH_DEDUP_MS guards against re-pulsing).
     for (let len = path.length; len >= 1; len--) {
       const target = this._find(host.shadowRoot, path.slice(0, len));
       if (!target) continue;
       // ``center`` (not ``nearest``) so a tall field — long description
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });
-      // Keyed on the matched prefix (the full key marks the target consumed
-      // below); debounced so a field isn't re-pulsed on every cursor nudge.
+      // Keyed on the matched prefix; debounced so it isn't re-pulsed on every
+      // cursor nudge. Skipped under reduced-motion: the animation is disabled
+      // there, so adding the class only strands it (animationend never fires).
       const matchedKey = fieldKeyAttr(path.slice(0, len));
       const now = Date.now();
-      if (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > FLASH_DEDUP_MS) {
+      const reduceMotion = window.matchMedia?.(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+      if (
+        !reduceMotion &&
+        (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > FLASH_DEDUP_MS)
+      ) {
         this._lastFlashKey = matchedKey;
         this._lastFlashAt = now;
         target.classList.remove(FLASH_CLASS);
@@ -138,7 +147,7 @@ export class FieldScrollController {
           { once: true }
         );
       }
-      this._scrolledKey = key;
+      if (len === path.length) this._scrolledKey = key;
       return;
     }
   }

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -13,6 +13,41 @@ const FLASH_CLASS = "field--highlight";
  *  around inside one field shouldn't keep re-flashing it. */
 const FLASH_DEDUP_MS = 10_000;
 
+/** Mutable gating state for the scroll retry, split out so the decision is
+ *  unit-testable without a DOM. */
+export interface ScrollGate {
+  /** Key (``fieldKeyAttr``) of the target already scrolled to, or undefined. */
+  scrolledKey?: string;
+  /** Last target key seen; resets the budget on value change rather than on
+   *  the fresh array reference ``focusFieldPath`` gets every cursor move. */
+  lastFocusKey?: string;
+  /** Scroll attempts spent on the current target. */
+  tries: number;
+}
+
+/**
+ * Advance the scroll gate for the current target *key* and decide whether to
+ * (re)attempt the scroll. Resets the budget when the target changes by value;
+ * attempts while unscrolled, within *maxTries*, and a relevant prop changed.
+ * Pure — ``scrolledKey`` is only cleared here; a successful scroll sets it.
+ */
+export function advanceScrollGate(
+  gate: ScrollGate,
+  key: string | undefined,
+  relevantChange: boolean,
+  maxTries: number
+): { gate: ScrollGate; scroll: boolean } {
+  let { scrolledKey, lastFocusKey, tries } = gate;
+  if (key !== lastFocusKey) {
+    lastFocusKey = key;
+    scrolledKey = undefined;
+    tries = 0;
+  }
+  const scroll = !!key && scrolledKey !== key && tries < maxTries && relevantChange;
+  if (scroll) tries++;
+  return { gate: { scrolledKey, lastFocusKey, tries }, scroll };
+}
+
 /** The form surface this helper drives. */
 export interface FieldScrollHost {
   shadowRoot: ShadowRoot | null;
@@ -48,21 +83,22 @@ export class FieldScrollController {
   maybeScroll(changed: PropertyValues): void {
     const fp = this.host.focusFieldPath;
     const key = fp?.length ? fieldKeyAttr(fp) : undefined;
-    if (key !== this._lastFocusKey) {
-      this._lastFocusKey = key;
-      this._scrolledKey = undefined;
-      this._tries = 0;
-    }
-    if (
-      fp?.length &&
-      key &&
-      this._scrolledKey !== key &&
-      this._tries < MAX_TRIES &&
-      (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
-    ) {
-      this._tries++;
-      void this._scrollTo(fp, key);
-    }
+    const relevant =
+      changed.has("focusFieldPath") || changed.has("entries") || changed.has("values");
+    const { gate, scroll } = advanceScrollGate(
+      {
+        scrolledKey: this._scrolledKey,
+        lastFocusKey: this._lastFocusKey,
+        tries: this._tries,
+      },
+      key,
+      relevant,
+      MAX_TRIES
+    );
+    this._scrolledKey = gate.scrolledKey;
+    this._lastFocusKey = gate.lastFocusKey;
+    this._tries = gate.tries;
+    if (scroll && fp?.length && key) void this._scrollTo(fp, key);
   }
 
   private async _scrollTo(path: string[], key: string): Promise<void> {

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -1,0 +1,106 @@
+import type { PropertyValues } from "lit";
+import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
+
+/** Renders to spend looking for a cursor-targeted field before giving up.
+ *  entries + values land in separate renders, so one retry isn't enough;
+ *  the cap stops an unbounded shadow-DOM walk for a never-rendered path. */
+const MAX_TRIES = 3;
+
+/** The form surface this helper drives. */
+export interface FieldScrollHost {
+  shadowRoot: ShadowRoot | null;
+  /** Instance-relative field path the YAML cursor is on, or empty. */
+  focusFieldPath?: string[];
+  /** Force a nested group open so a deep field renders before the search. */
+  openNested(key: string): void;
+  updateComplete: Promise<boolean>;
+}
+
+/**
+ * Scrolls the YAML-cursor-selected field into view and flashes it, retrying
+ * across the entries/values renders until the field exists (bounded) and
+ * honoring an already-in-viewport line by not re-pulsing within 10s. Owned
+ * by the form and driven from its ``updated`` via ``maybeScroll``.
+ */
+export class FieldScrollController {
+  private _lastFlashKey?: string;
+  private _lastFlashAt = 0;
+  /** ``focusFieldPath`` already scrolled to; a later value edit doesn't
+   *  re-scroll a consumed target. */
+  private _scrolledKey?: string;
+  private _tries = 0;
+
+  constructor(private readonly host: FieldScrollHost) {}
+
+  /** Call from the host's ``updated``: (re)attempt the scroll when the target
+   *  or its surrounding data changed and it hasn't been reached yet. */
+  maybeScroll(changed: PropertyValues): void {
+    // A new cursor target hasn't been scrolled to yet; reset the retry budget.
+    if (changed.has("focusFieldPath")) {
+      this._scrolledKey = undefined;
+      this._tries = 0;
+    }
+    const fp = this.host.focusFieldPath;
+    if (
+      fp?.length &&
+      this._scrolledKey !== fieldKeyAttr(fp) &&
+      this._tries < MAX_TRIES &&
+      (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
+    ) {
+      this._tries++;
+      void this._scrollTo(fp);
+    }
+  }
+
+  private async _scrollTo(path: string[]): Promise<void> {
+    const { host } = this;
+    if (!host.shadowRoot) return;
+    for (let i = 1; i < path.length; i++) {
+      host.openNested(path.slice(0, i).join("."));
+    }
+    await host.updateComplete; // let any opened group render
+    if (host.focusFieldPath !== path) return; // superseded by a newer move
+    // Try the exact field, then progressively shorter prefixes: a
+    // list-of-maps field (globals / filter items, whose form paths carry
+    // a synthetic index the YAML path lacks) at least scrolls its
+    // container into view.
+    for (let len = path.length; len >= 1; len--) {
+      const target = this._find(host.shadowRoot, path.slice(0, len));
+      if (!target) continue;
+      // ``center`` (not ``nearest``) so a tall field — long description
+      // plus input — lands fully in view instead of clipped at the fold.
+      target.scrollIntoView({ block: "center" });
+      // Flash, but not for the same field twice within 10s — moving the
+      // cursor around inside one field shouldn't keep re-pulsing it.
+      const key = fieldKeyAttr(path.slice(0, len));
+      const now = Date.now();
+      if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
+        this._lastFlashKey = key;
+        this._lastFlashAt = now;
+        target.classList.remove("field--highlight");
+        void target.offsetWidth;
+        target.classList.add("field--highlight");
+      }
+      this._scrolledKey = fieldKeyAttr(path);
+      return;
+    }
+  }
+
+  /** Find the field with *path*, recursing into nested custom-element shadow
+   *  roots (registry lists, etc.) since ``querySelectorAll`` stops at them. */
+  private _find(root: ParentNode, path: string[]): HTMLElement | null {
+    for (const el of root.querySelectorAll<HTMLElement>("[data-field-key]")) {
+      const p = parseFieldKey(el.getAttribute("data-field-key") ?? "");
+      if (p.length === path.length && p.every((k, i) => k === path[i])) return el;
+    }
+    // Only custom elements (hyphenated tag) carry a shadow root, so skip the
+    // plain-element subtree and recurse just into those.
+    for (const el of root.querySelectorAll<HTMLElement>("*")) {
+      if (!el.localName.includes("-")) continue;
+      const sr = (el as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot;
+      const found = sr ? this._find(sr, path) : null;
+      if (found) return found;
+    }
+    return null;
+  }
+}

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -81,11 +81,12 @@ export class FieldScrollController {
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });
       // Flash, but not for the same field twice within 10s — moving the
-      // cursor around inside one field shouldn't keep re-pulsing it.
-      const key = fieldKeyAttr(path.slice(0, len));
+      // cursor around inside one field shouldn't keep re-pulsing it. Keyed on
+      // the matched prefix (the full key marks the target consumed below).
+      const matchedKey = fieldKeyAttr(path.slice(0, len));
       const now = Date.now();
-      if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
-        this._lastFlashKey = key;
+      if (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
+        this._lastFlashKey = matchedKey;
         this._lastFlashAt = now;
         target.classList.remove(FLASH_CLASS);
         void target.offsetWidth;

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -9,6 +9,10 @@ const MAX_TRIES = 3;
 /** Class that runs the one-shot glow; defined in ``config-entry-form.styles``. */
 const FLASH_CLASS = "field--highlight";
 
+/** Don't re-pulse the same field within this window — moving the cursor
+ *  around inside one field shouldn't keep re-flashing it. */
+const FLASH_DEDUP_MS = 10_000;
+
 /** The form surface this helper drives. */
 export interface FieldScrollHost {
   shadowRoot: ShadowRoot | null;
@@ -80,12 +84,11 @@ export class FieldScrollController {
       // ``center`` (not ``nearest``) so a tall field — long description
       // plus input — lands fully in view instead of clipped at the fold.
       target.scrollIntoView({ block: "center" });
-      // Flash, but not for the same field twice within 10s — moving the
-      // cursor around inside one field shouldn't keep re-pulsing it. Keyed on
-      // the matched prefix (the full key marks the target consumed below).
+      // Keyed on the matched prefix (the full key marks the target consumed
+      // below); debounced so a field isn't re-pulsed on every cursor nudge.
       const matchedKey = fieldKeyAttr(path.slice(0, len));
       const now = Date.now();
-      if (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
+      if (matchedKey !== this._lastFlashKey || now - this._lastFlashAt > FLASH_DEDUP_MS) {
         this._lastFlashKey = matchedKey;
         this._lastFlashAt = now;
         target.classList.remove(FLASH_CLASS);

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -6,6 +6,9 @@ import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js"
  *  the cap stops an unbounded shadow-DOM walk for a never-rendered path. */
 const MAX_TRIES = 3;
 
+/** Class that runs the one-shot glow; defined in ``config-entry-form.styles``. */
+const FLASH_CLASS = "field--highlight";
+
 /** The form surface this helper drives. */
 export interface FieldScrollHost {
   shadowRoot: ShadowRoot | null;
@@ -28,6 +31,10 @@ export class FieldScrollController {
   /** ``focusFieldPath`` already scrolled to; a later value edit doesn't
    *  re-scroll a consumed target. */
   private _scrolledKey?: string;
+  /** Last target key seen — ``focusFieldPath`` is a fresh array on every
+   *  cursor-line move, so the retry budget resets on value change, not
+   *  reference change (else the same field re-scrolls on each move). */
+  private _lastFocusKey?: string;
   private _tries = 0;
 
   constructor(private readonly host: FieldScrollHost) {}
@@ -35,31 +42,34 @@ export class FieldScrollController {
   /** Call from the host's ``updated``: (re)attempt the scroll when the target
    *  or its surrounding data changed and it hasn't been reached yet. */
   maybeScroll(changed: PropertyValues): void {
-    // A new cursor target hasn't been scrolled to yet; reset the retry budget.
-    if (changed.has("focusFieldPath")) {
+    const fp = this.host.focusFieldPath;
+    const key = fp?.length ? fieldKeyAttr(fp) : undefined;
+    if (key !== this._lastFocusKey) {
+      this._lastFocusKey = key;
       this._scrolledKey = undefined;
       this._tries = 0;
     }
-    const fp = this.host.focusFieldPath;
     if (
       fp?.length &&
-      this._scrolledKey !== fieldKeyAttr(fp) &&
+      key &&
+      this._scrolledKey !== key &&
       this._tries < MAX_TRIES &&
       (changed.has("focusFieldPath") || changed.has("entries") || changed.has("values"))
     ) {
       this._tries++;
-      void this._scrollTo(fp);
+      void this._scrollTo(fp, key);
     }
   }
 
-  private async _scrollTo(path: string[]): Promise<void> {
+  private async _scrollTo(path: string[], key: string): Promise<void> {
     const { host } = this;
     if (!host.shadowRoot) return;
     for (let i = 1; i < path.length; i++) {
       host.openNested(path.slice(0, i).join("."));
     }
     await host.updateComplete; // let any opened group render
-    if (host.focusFieldPath !== path) return; // superseded by a newer move
+    const cur = host.focusFieldPath;
+    if (!cur || fieldKeyAttr(cur) !== key) return; // superseded by a newer move
     // Try the exact field, then progressively shorter prefixes: a
     // list-of-maps field (globals / filter items, whose form paths carry
     // a synthetic index the YAML path lacks) at least scrolls its
@@ -77,11 +87,18 @@ export class FieldScrollController {
       if (key !== this._lastFlashKey || now - this._lastFlashAt > 10_000) {
         this._lastFlashKey = key;
         this._lastFlashAt = now;
-        target.classList.remove("field--highlight");
+        target.classList.remove(FLASH_CLASS);
         void target.offsetWidth;
-        target.classList.add("field--highlight");
+        target.classList.add(FLASH_CLASS);
+        // Drop the class once the one-shot glow ends so it isn't left on the
+        // element (and can't linger across a re-render).
+        target.addEventListener(
+          "animationend",
+          () => target.classList.remove(FLASH_CLASS),
+          { once: true }
+        );
       }
-      this._scrolledKey = fieldKeyAttr(path);
+      this._scrolledKey = key;
       return;
     }
   }

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -324,9 +324,9 @@ export class ESPHomeYamlEditor extends LitElement {
           const line = update.state.doc.lineAt(head).number;
           if (line !== this._lastReportedCursorLine) {
             this._lastReportedCursorLine = line;
-            // Instance-relative field path (drop the top-level key) so the
-            // page can scroll the matching form field into view.
-            const path = getKeyPath(update.state, head).slice(1);
+            // Full key path; the page derives the form-relative path
+            // (it knows whether the section keys fields under its key).
+            const path = getKeyPath(update.state, head);
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
                 detail: { line, path },

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,7 +1,7 @@
 import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
-import { EditorState, StateEffect, StateField } from "@codemirror/state";
+import { EditorState, StateEffect, StateField, type Range } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { basicSetup, EditorView } from "codemirror";
@@ -41,11 +41,18 @@ const highlightField = StateField.define<DecorationSet>({
         if (!effect.value) return Decoration.none;
         const { fromLine, toLine } = effect.value;
         const doc = tr.state.doc;
-        const from = doc.line(Math.max(1, fromLine)).from;
-        const to = doc.line(Math.min(doc.lines, toLine)).to;
-        return Decoration.set([
-          Decoration.mark({ class: "cm-esphome-highlight" }).range(from, to),
-        ]);
+        const lo = Math.max(1, fromLine);
+        const hi = Math.min(doc.lines, toLine);
+        // Per-line decorations (not one end-anchored mark): a line class
+        // covers the whole line regardless of content, so the highlight
+        // doesn't lag behind text typed into the line from the form.
+        const decos: Range<Decoration>[] = [];
+        for (let ln = lo; ln <= hi; ln++) {
+          decos.push(
+            Decoration.line({ class: "cm-esphome-highlight" }).range(doc.line(ln).from)
+          );
+        }
+        return Decoration.set(decos);
       }
     }
     return deco.map(tr.changes);

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -10,6 +10,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import { apiContext, darkModeContext } from "../context/index.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { getKeyPath } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { vscodeDark, vscodeLight } from "../util/yaml-editor-theme.js";
 import { createBackendYamlLinter } from "../util/yaml-lint-backend.js";
@@ -303,9 +304,12 @@ export class ESPHomeYamlEditor extends LitElement {
           const line = update.state.doc.lineAt(head).number;
           if (line !== this._lastReportedCursorLine) {
             this._lastReportedCursorLine = line;
+            // Instance-relative field path (drop the top-level key) so the
+            // page can scroll the matching form field into view.
+            const path = getKeyPath(update.state, head).slice(1);
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
-                detail: { line },
+                detail: { line, path },
                 bubbles: true,
                 composed: true,
               })

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -396,8 +396,11 @@ export class ESPHomeYamlEditor extends LitElement {
     const pos = this._view.state.doc.line(
       Math.min(line, this._view.state.doc.lines)
     ).from;
+    // ``nearest`` scrolls only when the line is outside the viewport, so a
+    // structured-editor field highlight doesn't jolt the YAML pane when the
+    // line is already visible.
     this._view.dispatch({
-      effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }),
+      effects: EditorView.scrollIntoView(pos, { y: "nearest", yMargin: 50 }),
     });
   }
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,7 +1,7 @@
 import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
-import { EditorState, StateEffect, StateField, type Range } from "@codemirror/state";
+import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { basicSetup, EditorView } from "codemirror";
@@ -45,16 +45,20 @@ const highlightField = StateField.define<DecorationSet>({
         const doc = tr.state.doc;
         const lo = Math.max(1, fromLine);
         const hi = Math.min(doc.lines, toLine);
-        // Per-line decorations (not one end-anchored mark): a line class
-        // covers the whole line regardless of content, so the highlight
-        // doesn't lag behind text typed into the line from the form.
-        const decos: Range<Decoration>[] = [];
-        for (let ln = lo; ln <= hi; ln++) {
-          decos.push(
-            Decoration.line({ class: "cm-esphome-highlight" }).range(doc.line(ln).from)
-          );
+        // Single-line field highlight: a line decoration covers the whole line
+        // regardless of content, so it doesn't lag behind text typed into the
+        // line from the form. Multi-line section highlight: one mark spanning
+        // the block, instead of a decoration per line for a large section.
+        if (lo === hi) {
+          return Decoration.set([
+            Decoration.line({ class: "cm-esphome-highlight" }).range(doc.line(lo).from),
+          ]);
         }
-        return Decoration.set(decos);
+        const from = doc.line(lo).from;
+        const to = doc.line(hi).to;
+        return Decoration.set([
+          Decoration.mark({ class: "cm-esphome-highlight" }).range(from, to),
+        ]);
       }
     }
     return deco.map(tr.changes);

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1127,10 +1127,15 @@ export class ESPHomePageDevice extends LitElement {
    *  optional/empty field) so a stale single-line highlight can't linger. */
   private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
     const path = e.detail.path;
-    if (!path?.length || this._selectedFromLine === undefined) return;
-    const section = parseYamlTopLevelSections(this._yaml).find(
-      (s) => s.fromLine === this._selectedFromLine
-    );
+    if (!path?.length || !this._selectedSection) return;
+    // Prefer the exact instance via fromLine; fall back to the section
+    // key (``_selectedFromLine`` is unset for sections reached through a
+    // section-select that carried no line, e.g. single-instance blocks).
+    const sections = parseYamlTopLevelSections(this._yaml);
+    const section =
+      (this._selectedFromLine !== undefined
+        ? sections.find((s) => s.fromLine === this._selectedFromLine)
+        : undefined) ?? sections.find((s) => sectionKeyOf(s) === this._selectedSection);
     if (!section) return;
     const line = findFieldLine(this._yaml, section, path);
     this._highlightRange =

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -34,7 +34,7 @@ import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { LIST_SECTIONS, MAP_SECTIONS } from "../util/section-entry-overrides.js";
+import { LIST_SECTIONS } from "../util/section-entry-overrides.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
 import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
@@ -1108,13 +1108,12 @@ export class ESPHomePageDevice extends LitElement {
     this._pendingFieldLine = false;
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
-    // Drop the top-level key to get the form-relative path — except for
-    // list/map sections (globals, substitutions), whose form keys fields
-    // under that key.
+    // Drop the top-level key to get the form-relative path. LIST_SECTIONS
+    // (globals) are the exception: their form keys fields under the
+    // section key, so keep it. (MAP sections like substitutions render at
+    // an empty path, so their fields are section-relative — slice as usual.)
     const full = e.detail.path ?? [];
-    const keepsKey =
-      full.length > 0 && (LIST_SECTIONS.has(full[0]) || MAP_SECTIONS.has(full[0]));
-    const rel = keepsKey ? full : full.slice(1);
+    const rel = full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const sectionKey = sectionKeyOf(match);
     if (
       sectionKey === this._selectedSection &&

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1147,31 +1147,32 @@ export class ESPHomePageDevice extends LitElement {
     );
   }
 
-  /** Resolve *path* to its YAML line in the current section and highlight
-   *  just that line. Returns false (highlight untouched) when unresolved. */
-  private _highlightFieldLine(path: string[]): boolean {
+  /** Resolve *path* in the current section and highlight just its YAML line.
+   *  Returns the section used (so callers can fall back to its range) and
+   *  whether the exact line was found and highlighted. */
+  private _highlightFieldLine(path: string[]): {
+    section?: YamlSection;
+    found: boolean;
+  } {
     const section = this._focusedSection();
     const line = section ? findFieldLine(this._yaml, section, path) : null;
-    if (line === null) return false;
-    this._highlightRange = { fromLine: line, toLine: line };
-    this._scrollToHighlight = true;
-    return true;
+    if (line !== null) {
+      this._highlightRange = { fromLine: line, toLine: line };
+      this._scrollToHighlight = true;
+    }
+    return { section, found: line !== null };
   }
 
   /** Form field focused → highlight just that field's YAML line. */
   private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
     const path = (this._focusedFieldPath = e.detail.path);
     if (!path.length) return;
-    if (this._highlightFieldLine(path)) {
-      this._pendingFieldLine = false;
-      return;
-    }
+    const { section, found } = this._highlightFieldLine(path);
+    this._pendingFieldLine = !found;
     // No line yet: a value the user just set (icon, a new id) writes to YAML
-    // on a debounce, so the line appears on a later update. Highlight the
-    // whole section meanwhile and flag a retry to upgrade to the exact line.
-    this._pendingFieldLine = true;
-    const section = this._focusedSection();
-    if (section) {
+    // on a debounce, so the line appears on a later update; highlight the
+    // whole section meanwhile, and the retry upgrades to the exact line.
+    if (!found && section) {
       this._highlightRange = { fromLine: section.fromLine, toLine: section.toLine };
       this._scrollToHighlight = true;
     }
@@ -1181,7 +1182,9 @@ export class ESPHomePageDevice extends LitElement {
    *  upgrade the highlight from the whole section to that line. */
   private _retryPendingFieldLine() {
     if (!this._pendingFieldLine || !this._focusedFieldPath?.length) return;
-    if (this._highlightFieldLine(this._focusedFieldPath)) this._pendingFieldLine = false;
+    if (this._highlightFieldLine(this._focusedFieldPath).found) {
+      this._pendingFieldLine = false;
+    }
   }
 
   private _onYamlHighlight(

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1095,31 +1095,36 @@ export class ESPHomePageDevice extends LitElement {
    * `updateListener`.
    */
   private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
-    // Drop the top-level key to get the form-relative path — except for
-    // list sections (globals), whose form keys fields under that key.
-    // Set before the section early-return below, or moving between fields
-    // in the same section wouldn't update the form's scroll target.
-    const full = e.detail.path ?? [];
-    this._focusFieldPath =
-      full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
+    // Drop the top-level key to get the form-relative path — except for
+    // list sections (globals), whose form keys fields under that key.
+    const full = e.detail.path ?? [];
+    const rel = full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const sectionKey = sectionKeyOf(match);
     if (
       sectionKey === this._selectedSection &&
       match.fromLine === this._selectedFromLine
     ) {
+      // Same section: update the field target directly for intra-section
+      // moves (the switch below would early-return and freeze it).
+      this._focusFieldPath = rel;
       return;
     }
+    // Cross-section: set the field path only when the switch actually
+    // applies, so a guard veto (unsaved edits) can't point the old
+    // section's form at a path meant for the new one.
     this._guardSectionSwitch(() => {
       this._selectedSection = sectionKey;
       this._selectedFromLine = match.fromLine;
+      this._focusFieldPath = rel;
       this._updateUrl();
     });
   }
 
-  /** Form field focused → highlight just that field's YAML line (leaves
-   *  the section highlight when the field can't be located). */
+  /** Form field focused → highlight just that field's YAML line, falling
+   *  back to the whole section when the field has no YAML line yet (an
+   *  optional/empty field) so a stale single-line highlight can't linger. */
   private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
     const path = e.detail.path;
     if (!path?.length || this._selectedFromLine === undefined) return;
@@ -1128,8 +1133,10 @@ export class ESPHomePageDevice extends LitElement {
     );
     if (!section) return;
     const line = findFieldLine(this._yaml, section, path);
-    if (line === null) return;
-    this._highlightRange = { fromLine: line, toLine: line };
+    this._highlightRange =
+      line !== null
+        ? { fromLine: line, toLine: line }
+        : { fromLine: section.fromLine, toLine: section.toLine };
     this._scrollToHighlight = true;
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -34,7 +34,7 @@ import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { LIST_SECTIONS } from "../util/section-entry-overrides.js";
+import { LIST_SECTIONS, MAP_SECTIONS } from "../util/section-entry-overrides.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
 import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
@@ -1098,9 +1098,12 @@ export class ESPHomePageDevice extends LitElement {
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     // Drop the top-level key to get the form-relative path — except for
-    // list sections (globals), whose form keys fields under that key.
+    // list/map sections (globals, substitutions), whose form keys fields
+    // under that key.
     const full = e.detail.path ?? [];
-    const rel = full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
+    const keepsKey =
+      full.length > 0 && (LIST_SECTIONS.has(full[0]) || MAP_SECTIONS.has(full[0]));
+    const rel = keepsKey ? full : full.slice(1);
     const sectionKey = sectionKeyOf(match);
     if (
       sectionKey === this._selectedSection &&

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -147,9 +147,12 @@ export class ESPHomePageDevice extends LitElement {
 
   /** Form-relative path of the last focused field, and whether its YAML
    *  line wasn't found yet (a just-added value whose debounced write is
-   *  pending) — drives a one-shot re-resolve on the next YAML update. */
+   *  pending) — drives a one-shot re-resolve on the next YAML update.
+   *  ``_pendingFieldSection`` pins the section it was queued for so a
+   *  navigation away cancels the retry instead of resolving in the wrong one. */
   private _focusedFieldPath?: string[];
   private _pendingFieldLine = false;
+  private _pendingFieldSection?: { section: string | null; fromLine?: number };
 
   /** Per-page navigation stack — each entry is a section the user
    *  visited *before* the current one, ordered oldest-first. The
@@ -1105,7 +1108,7 @@ export class ESPHomePageDevice extends LitElement {
   private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
     // The user is driving from the YAML pane now — drop any pending
     // form-field retry so it can't re-highlight after they've moved on.
-    this._pendingFieldLine = false;
+    this._clearPendingFieldLine();
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     // Drop the top-level key to get the form-relative path. LIST_SECTIONS
@@ -1113,7 +1116,10 @@ export class ESPHomePageDevice extends LitElement {
     // section key, so keep it. (MAP sections like substitutions render at
     // an empty path, so their fields are section-relative — slice as usual.)
     const full = e.detail.path ?? [];
-    const rel = full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
+    // LIST_SECTIONS (globals) key fields under the section key, so keep it —
+    // but only with a child segment; a bare ``["globals"]`` header reduces
+    // to [] (a non-field line), not a whole-section field highlight.
+    const rel = full.length > 1 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const sectionKey = sectionKeyOf(match);
     if (
       sectionKey === this._selectedSection &&
@@ -1168,23 +1174,42 @@ export class ESPHomePageDevice extends LitElement {
     const path = (this._focusedFieldPath = e.detail.path);
     if (!path.length) return;
     const { section, found } = this._highlightFieldLine(path);
-    this._pendingFieldLine = !found;
-    // No line yet: a value the user just set (icon, a new id) writes to YAML
-    // on a debounce, so the line appears on a later update; highlight the
-    // whole section meanwhile, and the retry upgrades to the exact line.
-    if (!found && section) {
-      this._highlightRange = { fromLine: section.fromLine, toLine: section.toLine };
-      this._scrollToHighlight = true;
+    if (found) {
+      this._clearPendingFieldLine();
+      return;
     }
+    // Line not written yet (just-set icon / new id, debounced): highlight the
+    // whole section meanwhile and queue a retry scoped to this section.
+    this._pendingFieldLine = true;
+    this._pendingFieldSection = {
+      section: this._selectedSection,
+      fromLine: this._selectedFromLine,
+    };
+    this._highlightRange = section
+      ? { fromLine: section.fromLine, toLine: section.toLine }
+      : null;
+    this._scrollToHighlight = section !== undefined;
   }
 
   /** Once the pending field's YAML line exists (debounced write landed),
-   *  upgrade the highlight from the whole section to that line. */
+   *  upgrade the highlight to that line — unless the user navigated away. */
   private _retryPendingFieldLine() {
     if (!this._pendingFieldLine || !this._focusedFieldPath?.length) return;
-    if (this._highlightFieldLine(this._focusedFieldPath).found) {
-      this._pendingFieldLine = false;
+    if (
+      this._pendingFieldSection?.section !== this._selectedSection ||
+      this._pendingFieldSection?.fromLine !== this._selectedFromLine
+    ) {
+      this._clearPendingFieldLine();
+      return;
     }
+    if (this._highlightFieldLine(this._focusedFieldPath).found) {
+      this._clearPendingFieldLine();
+    }
+  }
+
+  private _clearPendingFieldLine() {
+    this._pendingFieldLine = false;
+    this._pendingFieldSection = undefined;
   }
 
   private _onYamlHighlight(

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -37,7 +37,12 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
 import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
-import { sectionAtLine, sectionKeyOf } from "../util/yaml-sections.js";
+import {
+  findFieldLine,
+  parseYamlTopLevelSections,
+  sectionAtLine,
+  sectionKeyOf,
+} from "../util/yaml-sections.js";
 import { summarizeValidation } from "../util/yaml-validation-summary.js";
 import { devicePageStyles } from "./device-styles.js";
 
@@ -132,6 +137,11 @@ export class ESPHomePageDevice extends LitElement {
 
   @state()
   private _selectedFromLine?: number = this._readUrlLine();
+
+  /** Instance-relative field path the YAML cursor is on, for the form to
+   *  scroll into view; empty on a section header / non-field line. */
+  @state()
+  private _focusFieldPath?: string[];
 
   /** Per-page navigation stack — each entry is a section the user
    *  visited *before* the current one, ordered oldest-first. The
@@ -843,6 +853,7 @@ export class ESPHomePageDevice extends LitElement {
           @section-select=${this._onSectionSelect}
           @section-mount=${this._onSectionMount}
           @section-unmount=${this._onSectionUnmount}
+          @field-focus=${this._onFieldFocus}
           @dirty-change=${this._onSectionDirtyChange}
           @nav-section-show=${this._onNavSectionShow}
           @nav-collapse=${this._onNavCollapse}
@@ -864,6 +875,7 @@ export class ESPHomePageDevice extends LitElement {
             .configuration=${this.id}
             .selectedSection=${this._selectedSection}
             .selectedFromLine=${this._selectedFromLine}
+            .focusFieldPath=${this._focusFieldPath}
             .justCreated=${this._justCreated}
             @just-created-dismiss=${this._dismissJustCreated}
             ?hasUnsavedEdits=${this._isDirty}
@@ -1081,7 +1093,10 @@ export class ESPHomePageDevice extends LitElement {
    * `if` blocks in `yaml-editor.ts:_buildExtensions`'s
    * `updateListener`.
    */
-  private _onYamlCursorLine(e: CustomEvent<{ line: number }>) {
+  private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
+    // Set before the section early-return below, or moving between fields
+    // in the same section wouldn't update the form's scroll target.
+    this._focusFieldPath = e.detail.path;
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     const sectionKey = sectionKeyOf(match);
@@ -1096,6 +1111,21 @@ export class ESPHomePageDevice extends LitElement {
       this._selectedFromLine = match.fromLine;
       this._updateUrl();
     });
+  }
+
+  /** Form field focused → highlight just that field's YAML line (leaves
+   *  the section highlight when the field can't be located). */
+  private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
+    const path = e.detail.path;
+    if (!path?.length || this._selectedFromLine === undefined) return;
+    const section = parseYamlTopLevelSections(this._yaml).find(
+      (s) => s.fromLine === this._selectedFromLine
+    );
+    if (!section) return;
+    const line = findFieldLine(this._yaml, section, path);
+    if (line === null) return;
+    this._highlightRange = { fromLine: line, toLine: line };
+    this._scrollToHighlight = true;
   }
 
   private _onYamlHighlight(

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -34,6 +34,7 @@ import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { LIST_SECTIONS } from "../util/section-entry-overrides.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { resolveSectionForUrlLine } from "../util/url-line-resolver.js";
 import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
@@ -1094,9 +1095,13 @@ export class ESPHomePageDevice extends LitElement {
    * `updateListener`.
    */
   private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
+    // Drop the top-level key to get the form-relative path — except for
+    // list sections (globals), whose form keys fields under that key.
     // Set before the section early-return below, or moving between fields
     // in the same section wouldn't update the form's scroll target.
-    this._focusFieldPath = e.detail.path;
+    const full = e.detail.path ?? [];
+    this._focusFieldPath =
+      full.length > 0 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     const sectionKey = sectionKeyOf(match);

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -43,6 +43,7 @@ import {
   parseYamlTopLevelSections,
   sectionAtLine,
   sectionKeyOf,
+  type YamlSection,
 } from "../util/yaml-sections.js";
 import { summarizeValidation } from "../util/yaml-validation-summary.js";
 import { devicePageStyles } from "./device-styles.js";
@@ -143,6 +144,12 @@ export class ESPHomePageDevice extends LitElement {
    *  scroll into view; empty on a section header / non-field line. */
   @state()
   private _focusFieldPath?: string[];
+
+  /** Form-relative path of the last focused field, and whether its YAML
+   *  line wasn't found yet (a just-added value whose debounced write is
+   *  pending) — drives a one-shot re-resolve on the next YAML update. */
+  private _focusedFieldPath?: string[];
+  private _pendingFieldLine = false;
 
   /** Per-page navigation stack — each entry is a section the user
    *  visited *before* the current one, ordered oldest-first. The
@@ -1062,6 +1069,7 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onYamlChange(e: CustomEvent<{ value: string }>) {
     this._yaml = e.detail.value;
+    this._retryPendingFieldLine();
   }
 
   /**
@@ -1095,6 +1103,9 @@ export class ESPHomePageDevice extends LitElement {
    * `updateListener`.
    */
   private _onYamlCursorLine(e: CustomEvent<{ line: number; path?: string[] }>) {
+    // The user is driving from the YAML pane now — drop any pending
+    // form-field retry so it can't re-highlight after they've moved on.
+    this._pendingFieldLine = false;
     const match = sectionAtLine(this._yaml, e.detail.line);
     if (!match) return;
     // Drop the top-level key to get the form-relative path — except for
@@ -1125,26 +1136,47 @@ export class ESPHomePageDevice extends LitElement {
     });
   }
 
-  /** Form field focused → highlight just that field's YAML line, falling
-   *  back to the whole section when the field has no YAML line yet (an
-   *  optional/empty field) so a stale single-line highlight can't linger. */
-  private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
-    const path = e.detail.path;
-    if (!path?.length || !this._selectedSection) return;
-    // Prefer the exact instance via fromLine; fall back to the section
-    // key (``_selectedFromLine`` is unset for sections reached through a
-    // section-select that carried no line, e.g. single-instance blocks).
+  /** The YamlSection backing the current selection, resolved by line
+   *  (exact instance) then by key (single-instance / unset line). */
+  private _focusedSection(): YamlSection | undefined {
+    if (!this._selectedSection) return undefined;
     const sections = parseYamlTopLevelSections(this._yaml);
-    const section =
+    return (
       (this._selectedFromLine !== undefined
         ? sections.find((s) => s.fromLine === this._selectedFromLine)
-        : undefined) ?? sections.find((s) => sectionKeyOf(s) === this._selectedSection);
-    if (!section) return;
+        : undefined) ?? sections.find((s) => sectionKeyOf(s) === this._selectedSection)
+    );
+  }
+
+  /** Form field focused → highlight just that field's YAML line. */
+  private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
+    this._focusedFieldPath = e.detail.path;
+    const path = this._focusedFieldPath;
+    const section = path?.length ? this._focusedSection() : undefined;
+    if (!section || !path) return;
     const line = findFieldLine(this._yaml, section, path);
+    // No line yet → highlight the section and flag a retry: a value the
+    // user just set (icon, a new id) writes to YAML on a debounce, so the
+    // line appears on a later update — _retryPendingFieldLine upgrades to
+    // the exact line then.
+    this._pendingFieldLine = line === null;
     this._highlightRange =
       line !== null
         ? { fromLine: line, toLine: line }
         : { fromLine: section.fromLine, toLine: section.toLine };
+    this._scrollToHighlight = true;
+  }
+
+  /** Once the pending field's YAML line exists (debounced write landed),
+   *  upgrade the highlight from the whole section to that line. */
+  private _retryPendingFieldLine() {
+    const path = this._focusedFieldPath;
+    if (!this._pendingFieldLine || !path?.length) return;
+    const section = this._focusedSection();
+    const line = section ? findFieldLine(this._yaml, section, path) : null;
+    if (line === null) return; // still not written; wait for the next update
+    this._pendingFieldLine = false;
+    this._highlightRange = { fromLine: line, toLine: line };
     this._scrollToHighlight = true;
   }
 
@@ -1177,6 +1209,7 @@ export class ESPHomePageDevice extends LitElement {
      * stays put so the right-pane Save button activates and the
      * user sees the buffer is dirty. */
     this._yaml = e.detail.yaml;
+    this._retryPendingFieldLine();
   }
 
   private _onSectionSelect(

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1147,36 +1147,41 @@ export class ESPHomePageDevice extends LitElement {
     );
   }
 
+  /** Resolve *path* to its YAML line in the current section and highlight
+   *  just that line. Returns false (highlight untouched) when unresolved. */
+  private _highlightFieldLine(path: string[]): boolean {
+    const section = this._focusedSection();
+    const line = section ? findFieldLine(this._yaml, section, path) : null;
+    if (line === null) return false;
+    this._highlightRange = { fromLine: line, toLine: line };
+    this._scrollToHighlight = true;
+    return true;
+  }
+
   /** Form field focused → highlight just that field's YAML line. */
   private _onFieldFocus(e: CustomEvent<{ path: string[] }>) {
-    this._focusedFieldPath = e.detail.path;
-    const path = this._focusedFieldPath;
-    const section = path?.length ? this._focusedSection() : undefined;
-    if (!section || !path) return;
-    const line = findFieldLine(this._yaml, section, path);
-    // No line yet → highlight the section and flag a retry: a value the
-    // user just set (icon, a new id) writes to YAML on a debounce, so the
-    // line appears on a later update — _retryPendingFieldLine upgrades to
-    // the exact line then.
-    this._pendingFieldLine = line === null;
-    this._highlightRange =
-      line !== null
-        ? { fromLine: line, toLine: line }
-        : { fromLine: section.fromLine, toLine: section.toLine };
-    this._scrollToHighlight = true;
+    const path = (this._focusedFieldPath = e.detail.path);
+    if (!path.length) return;
+    if (this._highlightFieldLine(path)) {
+      this._pendingFieldLine = false;
+      return;
+    }
+    // No line yet: a value the user just set (icon, a new id) writes to YAML
+    // on a debounce, so the line appears on a later update. Highlight the
+    // whole section meanwhile and flag a retry to upgrade to the exact line.
+    this._pendingFieldLine = true;
+    const section = this._focusedSection();
+    if (section) {
+      this._highlightRange = { fromLine: section.fromLine, toLine: section.toLine };
+      this._scrollToHighlight = true;
+    }
   }
 
   /** Once the pending field's YAML line exists (debounced write landed),
    *  upgrade the highlight from the whole section to that line. */
   private _retryPendingFieldLine() {
-    const path = this._focusedFieldPath;
-    if (!this._pendingFieldLine || !path?.length) return;
-    const section = this._focusedSection();
-    const line = section ? findFieldLine(this._yaml, section, path) : null;
-    if (line === null) return; // still not written; wait for the next update
-    this._pendingFieldLine = false;
-    this._highlightRange = { fromLine: line, toLine: line };
-    this._scrollToHighlight = true;
+    if (!this._pendingFieldLine || !this._focusedFieldPath?.length) return;
+    if (this._highlightFieldLine(this._focusedFieldPath)) this._pendingFieldLine = false;
   }
 
   private _onYamlHighlight(

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -172,6 +172,22 @@ export function getTopLevelKey(state: EditorState, pos: number): string | null {
 }
 
 /**
+ * Key chain from the top-level mapping down to the pair enclosing
+ * *pos*. List-item wrappers add no key, so ``slice(1)`` is the field
+ * path relative to the component instance (the form's ``data-field-key``).
+ */
+export function getKeyPath(state: EditorState, pos: number): string[] {
+  const keys: string[] = [];
+  let cur = findEnclosingPair(syntaxTree(state).resolveInner(pos, -1));
+  while (cur) {
+    const k = getPairKey(state, cur);
+    if (k) keys.push(k);
+    cur = findEnclosingPair(cur.parent?.parent ?? null);
+  }
+  return keys.reverse();
+}
+
+/**
  * Read the ``platform:`` value of the enclosing list-item, if any
  * (``binary_sensor: - platform: gpio`` → ``"gpio"``). Returns
  * ``null`` when the cursor isn't inside a list-item that declares

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -14,6 +14,11 @@ import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
 
+/** A YAML list-item line: leading indent, a dash, then a space or EOL. */
+const RE_LIST_ITEM = /^\s*-(\s|$)/;
+/** A field-path segment that addresses a list index (``["areas","0",…]``). */
+const RE_PATH_INDEX = /^\d+$/;
+
 export interface YamlSection {
   key: string;
   fromLine: number; // 1-indexed (CodeMirror convention)
@@ -321,8 +326,11 @@ export function listItemChildIndent(dashLine: string): number {
 
 /**
  * 1-indexed YAML line of the instance-relative field *relPath* within
- * *section* (``["pin","number"]`` → the nested ``number:`` line), or
- * ``null`` so callers fall back to the whole-section range.
+ * *section*, or ``null`` so callers fall back to the whole-section range.
+ * Descends both mapping keys (``["pin","number"]`` → the nested
+ * ``number:`` line) and list indices (``["areas","0","id"]`` → the ``id:``
+ * line of the first ``areas`` item) — the latter is how list-of-maps form
+ * fields (areas, globals) key their children.
  */
 export function findFieldLine(
   yaml: string,
@@ -337,29 +345,67 @@ export function findFieldLine(
   const start = section.fromLine - 1;
   const end = Math.min(section.toLine - 1, lines.length - 1);
   if (start < 0 || start >= lines.length) return null;
-  const header = lines[start];
-  const isList = /^\s*-\s/.test(header);
-  // A list item's inline key (``- platform: gpio``) is a direct child, so
-  // the header line is measured at the child indent, not its dash column.
-  const childIndent = isList
-    ? listItemChildIndent(header)
-    : indentOf(header) + ESPHOME_YAML_INDENT.length;
-  const stack: { indent: number; key: string }[] = [];
-  for (let i = start; i <= end; i++) {
-    const stripped = stripComment(lines[i]);
-    if (!stripped.trim()) continue;
-    const m = stripped.match(RE_PAIR_LINE);
-    if (!m) continue;
-    const indent = i === start && isList ? childIndent : indentOf(stripped);
-    if (indent < childIndent) continue;
-    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
-    stack.push({ indent, key: m[1] });
-    if (
-      stack.length === relPath.length &&
-      stack.every((s, idx) => s.key === relPath[idx])
-    ) {
-      return i + 1;
+
+  // A dash item's inline key (``- name: x``) sits at the content column
+  // after ``- ``, not the dash column.
+  const keyIndentOf = (line: string): number =>
+    RE_LIST_ITEM.test(line) ? listItemChildIndent(line) : indentOf(line);
+  const firstChildIndent = (lo: number, hi: number): number | null => {
+    for (let i = lo; i <= hi; i++) {
+      const s = stripComment(lines[i]);
+      if (s.trim()) return indentOf(s);
     }
+    return null;
+  };
+
+  // Descend *path* within [lo, hi]; keys / dashes for this level sit at
+  // *baseIndent*.
+  const descend = (
+    lo: number,
+    hi: number,
+    baseIndent: number,
+    path: string[]
+  ): number | null => {
+    const seg = path[0];
+    const rest = path.slice(1);
+    if (RE_PATH_INDEX.test(seg)) {
+      const dashes: number[] = [];
+      for (let i = lo; i <= hi; i++) {
+        const s = stripComment(lines[i]);
+        if (s.trim() && indentOf(s) === baseIndent && RE_LIST_ITEM.test(s))
+          dashes.push(i);
+      }
+      const itemLo = dashes[Number(seg)];
+      if (itemLo === undefined) return null;
+      if (rest.length === 0) return itemLo + 1;
+      const itemHi = Number(seg) + 1 < dashes.length ? dashes[Number(seg) + 1] - 1 : hi;
+      return descend(itemLo, itemHi, listItemChildIndent(lines[itemLo]), rest);
+    }
+    for (let i = lo; i <= hi; i++) {
+      const s = stripComment(lines[i]);
+      if (!s.trim() || keyIndentOf(s) !== baseIndent) continue;
+      const m = s.match(RE_PAIR_LINE);
+      if (!m || m[1] !== seg) continue;
+      if (rest.length === 0) return i + 1;
+      let blockHi = hi;
+      for (let j = i + 1; j <= hi; j++) {
+        const cs = stripComment(lines[j]);
+        if (cs.trim() && indentOf(cs) <= baseIndent) {
+          blockHi = j - 1;
+          break;
+        }
+      }
+      const childIndent = firstChildIndent(i + 1, blockHi);
+      return childIndent === null ? null : descend(i + 1, blockHi, childIndent, rest);
+    }
+    return null;
+  };
+
+  if (RE_LIST_ITEM.test(lines[start])) {
+    // List-item section: keys live at the item's child indent, and the
+    // header line itself carries the inline key.
+    return descend(start, end, listItemChildIndent(lines[start]), relPath);
   }
-  return null;
+  const childIndent = firstChildIndent(start + 1, end);
+  return childIndent === null ? null : descend(start + 1, end, childIndent, relPath);
 }

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -12,6 +12,7 @@
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
+import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
 
 export interface YamlSection {
   key: string;
@@ -316,4 +317,46 @@ export function listItemChildIndent(dashLine: string): number {
   if (inline !== undefined) return inline;
   const dashIndent = dashLine.match(/^ */)?.[0].length ?? 0;
   return dashIndent + ESPHOME_YAML_INDENT.length;
+}
+
+/**
+ * 1-indexed YAML line of the instance-relative field *relPath* within
+ * *section* (``["pin","number"]`` → the nested ``number:`` line), or
+ * ``null`` so callers fall back to the whole-section range.
+ */
+export function findFieldLine(
+  yaml: string,
+  section: YamlSection,
+  relPath: string[]
+): number | null {
+  if (relPath.length === 0) return null;
+  const lines = yaml.split("\n");
+  const start = section.fromLine - 1;
+  const end = Math.min(section.toLine - 1, lines.length - 1);
+  if (start < 0 || start >= lines.length) return null;
+  const header = lines[start];
+  const isList = /^\s*-\s/.test(header);
+  // A list item's inline key (``- platform: gpio``) is a direct child, so
+  // the header line is measured at the child indent, not its dash column.
+  const childIndent = isList
+    ? listItemChildIndent(header)
+    : indentOf(header) + ESPHOME_YAML_INDENT.length;
+  const stack: { indent: number; key: string }[] = [];
+  for (let i = start; i <= end; i++) {
+    const stripped = stripComment(lines[i]);
+    if (!stripped.trim()) continue;
+    const m = stripped.match(RE_PAIR_LINE);
+    if (!m) continue;
+    const indent = i === start && isList ? childIndent : indentOf(stripped);
+    if (indent < childIndent) continue;
+    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+    stack.push({ indent, key: m[1] });
+    if (
+      stack.length === relPath.length &&
+      stack.every((s, idx) => s.key === relPath[idx])
+    ) {
+      return i + 1;
+    }
+  }
+  return null;
 }

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -337,8 +337,8 @@ export function findFieldLine(
   section: YamlSection,
   relPath: string[]
 ): number | null {
-  // List/map sections (globals, substitutions) key their form fields
-  // under the section key; drop it so the path is section-relative.
+  // Accept an optional leading section key (some callers pass it, e.g.
+  // ``["globals", …]``) and strip it so the path is section-relative.
   if (relPath[0] === section.key) relPath = relPath.slice(1);
   if (relPath.length === 0) return null;
   const lines = yaml.split("\n");

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -375,11 +375,16 @@ export function findFieldLine(
         if (s.trim() && indentOf(s) === baseIndent && RE_LIST_ITEM.test(s))
           dashes.push(i);
       }
-      const itemLo = dashes[Number(seg)];
-      if (itemLo === undefined) return null;
-      if (rest.length === 0) return itemLo + 1;
-      const itemHi = Number(seg) + 1 < dashes.length ? dashes[Number(seg) + 1] - 1 : hi;
-      return descend(itemLo, itemHi, listItemChildIndent(lines[itemLo]), rest);
+      // A numeric segment is a list index only where this level actually has
+      // dash items; with none it's a literal numeric mapping key (a ``0:``
+      // substitution), so fall through to the key match below.
+      if (dashes.length) {
+        const itemLo = dashes[Number(seg)];
+        if (itemLo === undefined) return null;
+        if (rest.length === 0) return itemLo + 1;
+        const itemHi = Number(seg) + 1 < dashes.length ? dashes[Number(seg) + 1] - 1 : hi;
+        return descend(itemLo, itemHi, listItemChildIndent(lines[itemLo]), rest);
+      }
     }
     for (let i = lo; i <= hi; i++) {
       const s = stripComment(lines[i]);

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -329,6 +329,9 @@ export function findFieldLine(
   section: YamlSection,
   relPath: string[]
 ): number | null {
+  // List/map sections (globals, substitutions) key their form fields
+  // under the section key; drop it so the path is section-relative.
+  if (relPath[0] === section.key) relPath = relPath.slice(1);
   if (relPath.length === 0) return null;
   const lines = yaml.split("\n");
   const start = section.fromLine - 1;

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,6 +1,7 @@
 import { parseYamlAutomations } from "./yaml-automations.js";
 import {
   _clearYamlSectionsMemo,
+  findFieldLine,
   instanceComponentId,
   parseYamlTopLevelSections,
   smallestContainingSection,
@@ -14,6 +15,7 @@ import {
 // unaffected.
 export {
   _clearYamlSectionsMemo,
+  findFieldLine,
   instanceComponentId,
   parseYamlAutomations,
   parseYamlTopLevelSections,

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -100,6 +100,7 @@ export function makeRenderCtx(
     errorAt: () => null,
     emitChange: vi.fn(),
     toggleNested: vi.fn(),
+    seedNestedOpen: vi.fn(),
     requestAddComponent: vi.fn(),
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,

--- a/test/components/device/field-interaction.test.ts
+++ b/test/components/device/field-interaction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { decideFieldFocus } from "../../../src/components/device/field-interaction.js";
+
+const A = '["a"]';
+const B = '["b"]';
+
+describe("decideFieldFocus", () => {
+  it("focusin emits and becomes the focused field", () => {
+    expect(decideFieldFocus("focusin", A, undefined)).toEqual({
+      emit: true,
+      focusedKey: A,
+    });
+  });
+
+  it("focusin re-focusing the same field still emits (harmless re-assert)", () => {
+    expect(decideFieldFocus("focusin", A, A)).toEqual({ emit: true, focusedKey: A });
+  });
+
+  it("input on a newly-edited field emits and claims focus (missed focusin)", () => {
+    // The areas/globals id bug: a just-added required input whose focusin
+    // didn't surface — typing in it must still highlight it.
+    expect(decideFieldFocus("input", B, A)).toEqual({ emit: true, focusedKey: B });
+  });
+
+  it("input while mid-typing in the focused field does not re-emit", () => {
+    expect(decideFieldFocus("input", A, A)).toEqual({ emit: false, focusedKey: A });
+  });
+
+  it("change on the focused field emits", () => {
+    expect(decideFieldFocus("change", A, A)).toEqual({ emit: true, focusedKey: A });
+  });
+
+  it("change on a field that already lost focus is dropped (blur re-point)", () => {
+    // Moving A->B: A's blur-time change must not re-point the highlight at A.
+    expect(decideFieldFocus("change", A, B)).toEqual({ emit: false, focusedKey: B });
+  });
+});

--- a/test/components/device/field-interaction.test.ts
+++ b/test/components/device/field-interaction.test.ts
@@ -34,4 +34,15 @@ describe("decideFieldFocus", () => {
     // Moving A->B: A's blur-time change must not re-point the highlight at A.
     expect(decideFieldFocus("change", A, B)).toEqual({ emit: false, focusedKey: B });
   });
+
+  it("pointerdown on a different field emits and claims focus", () => {
+    // wa-input's nested delegatesFocus keeps document.activeElement pinned to
+    // the outer host, so focusin only fires on first entry; pointerdown is the
+    // reliable per-click signal for moving between fields.
+    expect(decideFieldFocus("pointerdown", B, A)).toEqual({ emit: true, focusedKey: B });
+  });
+
+  it("pointerdown on the already-focused field does not re-emit", () => {
+    expect(decideFieldFocus("pointerdown", A, A)).toEqual({ emit: false, focusedKey: A });
+  });
 });

--- a/test/components/device/field-scroll-gate.test.ts
+++ b/test/components/device/field-scroll-gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceScrollGate,
+  type ScrollGate,
+} from "../../../src/components/device/field-scroll-controller.js";
+
+const MAX = 3;
+const A = '["a"]';
+const B = '["b"]';
+const fresh = (): ScrollGate => ({ tries: 0 });
+
+describe("advanceScrollGate", () => {
+  it("scrolls a new target and spends one try", () => {
+    const { gate, scroll } = advanceScrollGate(fresh(), A, true, MAX);
+    expect(scroll).toBe(true);
+    expect(gate).toEqual({ scrolledKey: undefined, lastFocusKey: A, tries: 1 });
+  });
+
+  it("does not scroll without a relevant prop change", () => {
+    expect(advanceScrollGate(fresh(), A, false, MAX).scroll).toBe(false);
+  });
+
+  it("does not re-scroll a consumed target (same key, new array ref)", () => {
+    // The Copilot value-dedup fix: focusFieldPath is a fresh array each cursor
+    // move, but the same logical field shouldn't re-scroll once reached.
+    const consumed: ScrollGate = { scrolledKey: A, lastFocusKey: A, tries: 1 };
+    const { gate, scroll } = advanceScrollGate(consumed, A, true, MAX);
+    expect(scroll).toBe(false);
+    expect(gate).toEqual(consumed);
+  });
+
+  it("resets the budget and re-scrolls when the target changes by value", () => {
+    const consumed: ScrollGate = { scrolledKey: A, lastFocusKey: A, tries: 3 };
+    const { gate, scroll } = advanceScrollGate(consumed, B, true, MAX);
+    expect(scroll).toBe(true);
+    expect(gate).toEqual({ scrolledKey: undefined, lastFocusKey: B, tries: 1 });
+  });
+
+  it("stops retrying after maxTries for an unresolved target", () => {
+    const exhausted: ScrollGate = { lastFocusKey: A, tries: MAX };
+    expect(advanceScrollGate(exhausted, A, true, MAX).scroll).toBe(false);
+  });
+
+  it("clearing the target (empty path) resets and never scrolls", () => {
+    const consumed: ScrollGate = { scrolledKey: A, lastFocusKey: A, tries: 1 };
+    const { gate, scroll } = advanceScrollGate(consumed, undefined, true, MAX);
+    expect(scroll).toBe(false);
+    expect(gate).toEqual({ scrolledKey: undefined, lastFocusKey: undefined, tries: 0 });
+  });
+});

--- a/test/components/device/render-map-field.test.ts
+++ b/test/components/device/render-map-field.test.ts
@@ -85,6 +85,7 @@ function makeCtx(values: Record<string, unknown>): CtxStub {
     errorAt: () => null,
     emitChange: emitChange,
     toggleNested: () => {},
+    seedNestedOpen: () => {},
     requestAddComponent: () => {},
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -81,6 +81,7 @@ function makeCtx(values: Record<string, unknown>): CtxStub {
     errorAt: () => null,
     emitChange,
     toggleNested: () => {},
+    seedNestedOpen: () => {},
     requestAddComponent: () => {},
     scopeValues: () => ({}),
     filterRenderable,

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -50,6 +50,7 @@ function makeCtx(values: Record<string, unknown>): {
     errorAt: () => null,
     emitChange,
     toggleNested: () => {},
+    seedNestedOpen: () => {},
     requestAddComponent: () => {},
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -21,11 +21,12 @@ describe("getKeyPath", () => {
     ]);
   });
 
-  it("drops the list-item wrapper — slice(1) is the form field path", () => {
+  it("omits list-item wrappers — slice(1) drops the section key for the form path", () => {
     const doc =
       "binary_sensor:\n  - platform: gpio\n    name: x\n    pin:\n      number: D1\n";
-    // The structured form keys fields relative to the instance, so the
-    // page uses getKeyPath(...).slice(1) to match `data-field-key`.
+    // getKeyPath only collects mapping-pair keys (the ``- `` list-item adds
+    // none), so the chain here is [binary_sensor, name]; the page slices off
+    // the leading section key to match the instance-relative data-field-key.
     expect(pathAt(doc, "name").slice(1)).toEqual(["name"]);
     expect(pathAt(doc, "number").slice(1)).toEqual(["pin", "number"]);
   });

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -1,0 +1,36 @@
+import { ensureSyntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { getKeyPath } from "../../src/util/yaml-ast.js";
+
+function pathAt(doc: string, token: string): string[] {
+  const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+  ensureSyntaxTree(state, state.doc.length);
+  const pos = doc.indexOf(token) + 1;
+  return getKeyPath(state, pos);
+}
+
+describe("getKeyPath", () => {
+  it("returns the full key chain for a nested field", () => {
+    const doc = "esp32_ble_tracker:\n  scan_parameters:\n    active: false\n";
+    expect(pathAt(doc, "active")).toEqual([
+      "esp32_ble_tracker",
+      "scan_parameters",
+      "active",
+    ]);
+  });
+
+  it("drops the list-item wrapper — slice(1) is the form field path", () => {
+    const doc =
+      "binary_sensor:\n  - platform: gpio\n    name: x\n    pin:\n      number: D1\n";
+    // The structured form keys fields relative to the instance, so the
+    // page uses getKeyPath(...).slice(1) to match `data-field-key`.
+    expect(pathAt(doc, "name").slice(1)).toEqual(["name"]);
+    expect(pathAt(doc, "number").slice(1)).toEqual(["pin", "number"]);
+  });
+
+  it("returns [] outside any mapping pair", () => {
+    expect(pathAt("# comment\n", "comment")).toEqual([]);
+  });
+});

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  _clearYamlSectionsMemo,
+  findFieldLine,
+  parseYamlTopLevelSections,
+  type YamlSection,
+} from "../../src/util/yaml-sections-core.js";
+
+function sectionAt(yaml: string, fromLine: number): YamlSection {
+  _clearYamlSectionsMemo();
+  const s = parseYamlTopLevelSections(yaml).find((x) => x.fromLine === fromLine);
+  if (!s) throw new Error(`no section at line ${fromLine}`);
+  return s;
+}
+
+const LIST_YAML = [
+  "binary_sensor:",
+  "  - platform: gpio",
+  "    name: Pan Water",
+  "    device_class: moisture",
+  "    pin:",
+  "      number: GPIO33",
+  "      mode: INPUT_PULLUP",
+  "",
+].join("\n");
+
+describe("findFieldLine", () => {
+  it("locates a top-level field inside a list item", () => {
+    const section = sectionAt(LIST_YAML, 2); // `- platform: gpio`
+    expect(findFieldLine(LIST_YAML, section, ["name"])).toBe(3);
+    expect(findFieldLine(LIST_YAML, section, ["device_class"])).toBe(4);
+    expect(findFieldLine(LIST_YAML, section, ["platform"])).toBe(2);
+  });
+
+  it("locates a nested field", () => {
+    const section = sectionAt(LIST_YAML, 2);
+    expect(findFieldLine(LIST_YAML, section, ["pin"])).toBe(5);
+    expect(findFieldLine(LIST_YAML, section, ["pin", "number"])).toBe(6);
+    expect(findFieldLine(LIST_YAML, section, ["pin", "mode"])).toBe(7);
+  });
+
+  it("returns null for an unresolved path", () => {
+    const section = sectionAt(LIST_YAML, 2);
+    expect(findFieldLine(LIST_YAML, section, ["nope"])).toBeNull();
+    expect(findFieldLine(LIST_YAML, section, [])).toBeNull();
+  });
+
+  it("locates a field in a flat (non-list) section", () => {
+    const yaml = ["wifi:", "  ssid: x", "  ap:", "    ssid: y", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["ssid"])).toBe(2);
+    expect(findFieldLine(yaml, section, ["ap"])).toBe(3);
+    expect(findFieldLine(yaml, section, ["ap", "ssid"])).toBe(4);
+  });
+
+  it("targets the correct instance among duplicates", () => {
+    const yaml = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    name: First",
+      "  - platform: gpio",
+      "    name: Second",
+      "",
+    ].join("\n");
+    const second = sectionAt(yaml, 4); // the second `- platform: gpio`
+    expect(findFieldLine(yaml, second, ["name"])).toBe(5);
+  });
+});

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -84,6 +84,13 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["areas", "0", "name_add_mac"])).toBeNull();
   });
 
+  it("resolves a numeric mapping key instead of reading it as a list index", () => {
+    const yaml = ["substitutions:", "  0: zero", "  name: x", ""].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["substitutions", "0"])).toBe(2);
+    expect(findFieldLine(yaml, section, ["substitutions", "name"])).toBe(3);
+  });
+
   it("targets the correct instance among duplicates", () => {
     const yaml = [
       "binary_sensor:",

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -62,6 +62,25 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["substitutions", "friendly_name"])).toBe(3);
   });
 
+  it("descends a list index into a list-of-maps item (areas)", () => {
+    const yaml = [
+      "esphome:",
+      "  name: x",
+      "  areas:",
+      "    - name: zombie",
+      "      id: ff",
+      "    - name: other",
+      "      id: gg",
+      "",
+    ].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["name"])).toBe(2);
+    expect(findFieldLine(yaml, section, ["areas", "0", "name"])).toBe(4);
+    expect(findFieldLine(yaml, section, ["areas", "0", "id"])).toBe(5);
+    expect(findFieldLine(yaml, section, ["areas", "1", "id"])).toBe(7);
+    expect(findFieldLine(yaml, section, ["areas", "0"])).toBe(4);
+  });
+
   it("targets the correct instance among duplicates", () => {
     const yaml = [
       "binary_sensor:",

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -53,6 +53,15 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["ap", "ssid"])).toBe(4);
   });
 
+  it("strips a leading section key (list/map sections key fields under it)", () => {
+    const yaml = ["substitutions:", "  devicename: x", "  friendly_name: y", ""].join(
+      "\n"
+    );
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["substitutions", "devicename"])).toBe(2);
+    expect(findFieldLine(yaml, section, ["substitutions", "friendly_name"])).toBe(3);
+  });
+
   it("targets the correct instance among duplicates", () => {
     const yaml = [
       "binary_sensor:",

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -79,6 +79,9 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["areas", "0", "id"])).toBe(5);
     expect(findFieldLine(yaml, section, ["areas", "1", "id"])).toBe(7);
     expect(findFieldLine(yaml, section, ["areas", "0"])).toBe(4);
+    // An optional child absent from the item: null drives the caller's
+    // whole-section fallback rather than a stale single-line highlight.
+    expect(findFieldLine(yaml, section, ["areas", "0", "name_add_mac"])).toBeNull();
   });
 
   it("targets the correct instance among duplicates", () => {


### PR DESCRIPTION
# What does this implement/fix?

Adds **field-level** sync between the structured (visual) editor and the YAML editor on the device page. Section-level sync already worked (clicking a section highlights the whole block, and the YAML cursor selects the matching section); this extends it so the *specific field* lines up in both directions:

- **YAML to structured:** placing the cursor on a field in the YAML (e.g. `name:` / `device_class:` inside a sensor) now scrolls that field into view in the form, opening its collapsed group if needed, instead of leaving it below the fold.
- **Structured to YAML:** focusing a field in the form (e.g. `name`) now highlights just that field's line in the YAML and scrolls to it, instead of highlighting the whole section block.

Clicking outside a field (the section header) keeps the existing whole-section behaviour, and any field path that can't be resolved falls back to the section range, so this is purely additive.

How it works:

- The YAML editor adds the cursor's field path to its `yaml-cursor-line` event (`getKeyPath(state, head)`, the instance-relative path that matches the form's `data-field-key`). The page threads it down to `config-entry-form`, where `FieldScrollController` scrolls the matching `[data-field-key]` into view: it opens ancestor groups, retries across the separate entries/values renders (bounded), and gives the field a one-shot flash.
- The form's `FieldFocusController` emits a `field-focus` event as the user moves between fields, deciding which field is active via the pure `decideFieldFocus` helper. It listens on `focusin`, `pointerdown`, `input`, and `change`. `pointerdown` is load-bearing: `wa-input`'s nested `delegatesFocus` shadow roots keep `document.activeElement` pinned to the outer host, so `focusin` only fires on first entry to the form, not when moving between fields.
- The page resolves the field path to its exact YAML line via the pure `findFieldLine(yaml, section, relPath)` util and sets a single-line `highlightRange` (scoped to the section it was queued for). The highlight is a per-line CodeMirror decoration for a single line (so it tracks text typed in from the form) and a single mark for a multi-line section range.
- The shared scroll-into-view now uses `y: "nearest"` instead of `y: "start"`, so neither a field highlight nor a section selection jolts the YAML pane when the target is already on screen; it only scrolls when the line is off-screen.

The pure helpers (`getKeyPath`, `findFieldLine`, `decideFieldFocus`, `advanceScrollGate`) are split out and unit-tested.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

