### PR TITLE
Make YAML editor validation errors clearer and better placed

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -309,6 +309,47 @@ export const deviceEditorStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
+  /* Document-level "configuration invalid" banner above the editor.
+     A flex child of .editor-pane (column + gap), so it sits above the
+     editor body and the body's flex:1 reclaims the rest. */
+  .invalid-banner {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--wa-space-s);
+    padding: var(--wa-space-s) var(--wa-space-m);
+    border-radius: var(--wa-border-radius-m);
+    background: var(--wa-color-danger-fill-quiet);
+    border: var(--wa-border-width-s) solid var(--wa-color-danger-60);
+    color: var(--wa-color-danger-text-normal);
+  }
+
+  .invalid-banner-icon {
+    flex: 0 0 auto;
+    font-size: 1.25rem;
+    margin-top: 0.05rem;
+    color: var(--wa-color-danger-60);
+  }
+
+  .invalid-banner-text {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    line-height: 1.4;
+    min-width: 0;
+  }
+
+  .invalid-banner-error {
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-semibold);
+    word-break: break-word;
+  }
+
+  .invalid-banner-more {
+    font-size: var(--wa-font-size-2xs);
+    opacity: 0.85;
+  }
+
   .editor-pane-body {
     flex: 1;
     overflow: hidden;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -1,5 +1,6 @@
 import { consume } from "@lit/context";
 import {
+  mdiAlertCircleOutline,
   mdiCheckCircleOutline,
   mdiContentSave,
   mdiDockLeft,
@@ -27,6 +28,7 @@ import "../yaml-editor.js";
 import "./device-board-info.js";
 
 registerMdiIcons({
+  "alert-circle-outline": mdiAlertCircleOutline,
   "check-circle-outline": mdiCheckCircleOutline,
   "content-save": mdiContentSave,
   eye: mdiEye,
@@ -39,6 +41,9 @@ registerMdiIcons({
 });
 
 export type DeviceLayoutMode = "both" | "left" | "right";
+
+/** Cap the errors listed in the invalid banner; the rest collapse to "+N more". */
+const MAX_BANNER_ERRORS = 6;
 
 @customElement("esphome-device-editor")
 export class ESPHomeDeviceEditor extends LitElement {
@@ -158,6 +163,11 @@ export class ESPHomeDeviceEditor extends LitElement {
   // secret *name* and are passed through as-is).
   @state()
   private _revealSensitive = false;
+
+  /** Live lint error messages from the editor's backend linter. Drives the
+   *  "configuration invalid" banner above the editor. */
+  @state()
+  private _liveErrors: string[] = [];
 
   static styles = [espHomeStyles, deviceEditorStyles];
 
@@ -342,6 +352,29 @@ export class ESPHomeDeviceEditor extends LitElement {
               ? html`<div class="pane-divider"></div>`
               : nothing}
             <div class="editor-pane editor-pane--right">
+              ${!this._showDiff && this._liveErrors.length > 0
+                ? html`<div class="invalid-banner" role="alert">
+                    <wa-icon
+                      library="mdi"
+                      name="alert-circle-outline"
+                      class="invalid-banner-icon"
+                    ></wa-icon>
+                    <div class="invalid-banner-text">
+                      ${this._liveErrors
+                        .slice(0, MAX_BANNER_ERRORS)
+                        .map(
+                          (msg) => html`<span class="invalid-banner-error">${msg}</span>`
+                        )}
+                      ${this._liveErrors.length > MAX_BANNER_ERRORS
+                        ? html`<span class="invalid-banner-more"
+                            >${this._localize("device.editor_invalid_more", {
+                              count: this._liveErrors.length - MAX_BANNER_ERRORS,
+                            })}</span
+                          >`
+                        : nothing}
+                    </div>
+                  </div>`
+                : nothing}
               <div class="editor-pane-body">
                 ${this._showDiff
                   ? html`<esphome-yaml-diff
@@ -355,6 +388,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                       .scrollToHighlight=${this.scrollToHighlight}
                       .revealSensitive=${this._revealSensitive}
                       @yaml-change=${this._onYamlChange}
+                      @yaml-diagnostics=${this._onYamlDiagnostics}
                     ></esphome-yaml-editor>`}
               </div>
             </div>
@@ -409,6 +443,11 @@ export class ESPHomeDeviceEditor extends LitElement {
   }
 
   updated(changed: Map<string, unknown>) {
+    // Switching device clears the banner until the new file re-lints, so a
+    // stale "invalid" never flashes over a freshly-opened valid config.
+    if (changed.has("configuration")) {
+      this._liveErrors = [];
+    }
     if (this._showDiff && changed.has("_showDiffButton") && !this._showDiffButton) {
       this._showDiff = false;
       return;
@@ -416,6 +455,10 @@ export class ESPHomeDeviceEditor extends LitElement {
     if (this._showDiff && changed.has("savedYaml") && this.yaml === this.savedYaml) {
       this._showDiff = false;
     }
+  }
+
+  private _onYamlDiagnostics(e: CustomEvent<{ errors: string[] }>) {
+    this._liveErrors = e.detail.errors;
   }
 
   private _setLayout(layout: DeviceLayoutMode) {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -457,8 +457,22 @@ export class ESPHomeDeviceEditor extends LitElement {
     }
   }
 
-  private _onYamlDiagnostics(e: CustomEvent<{ errors: string[] }>) {
-    this._liveErrors = e.detail.errors;
+  private _onYamlDiagnostics(
+    e: CustomEvent<{ errors: string[]; configuration: string }>
+  ) {
+    // Ignore a late lint result for a since-switched device, so a stale
+    // "invalid" banner can't flash over the freshly-opened config.
+    if (e.detail.configuration !== this.configuration) return;
+    const next = e.detail.errors;
+    // The banner is an `aria-live` region — only reassign when the list
+    // actually changed so an unchanged lint pass doesn't re-announce it.
+    if (
+      next.length === this._liveErrors.length &&
+      next.every((msg, i) => msg === this._liveErrors[i])
+    ) {
+      return;
+    }
+    this._liveErrors = next;
   }
 
   private _setLayout(layout: DeviceLayoutMode) {

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -343,10 +343,10 @@ export class ESPHomeYamlEditor extends LitElement {
         createBackendYamlLinter({
           api: this._api,
           getConfiguration: () => this.configuration,
-          onResult: (errors) =>
+          onResult: (errors, configuration) =>
             this.dispatchEvent(
               new CustomEvent("yaml-diagnostics", {
-                detail: { errors },
+                detail: { errors, configuration },
                 bubbles: true,
                 composed: true,
               })

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -12,7 +12,10 @@ import { apiContext, darkModeContext } from "../context/index.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { vscodeDark, vscodeLight } from "../util/yaml-editor-theme.js";
-import { createBackendYamlLinter } from "../util/yaml-lint-backend.js";
+import {
+  createBackendYamlLinter,
+  lintErrorLineGutter,
+} from "../util/yaml-lint-backend.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 import {
   sensitiveValueMaskExtension,
@@ -20,6 +23,11 @@ import {
 } from "../util/yaml-sensitive-mask.js";
 
 export type HighlightRange = Pick<YamlSection, "fromLine" | "toLine">;
+
+// `#` must be percent-encoded (`%23`) inside a data-URI background-image.
+const errorDot = (fill: string, stroke: string): string =>
+  `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">` +
+  `<circle cx="20" cy="20" r="14" fill="${fill}" stroke="${stroke}" stroke-width="6"/></svg>')`;
 
 // Module-level singletons so they survive editor rebuilds
 const setHighlight = StateEffect.define<HighlightRange | null>();
@@ -134,7 +142,7 @@ export class ESPHomeYamlEditor extends LitElement {
             ? "rgba(99, 179, 237, 0.2)"
             : "rgba(59, 130, 246, 0.1)",
         },
-        // ─── Diagnostics: red wavy underline only (no gutter pill) ──
+        // ─── Diagnostics: red wavy underline + gutter marker ────────
         ".cm-lintRange-error": {
           backgroundImage: this._darkMode
             ? 'url(\'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 3"><path d="M0 3 L1.5 0 L3 3 L4.5 0 L6 3" fill="none" stroke="%23ff6b6b" stroke-width="0.9" stroke-linecap="round"/></svg>\')'
@@ -162,6 +170,7 @@ export class ESPHomeYamlEditor extends LitElement {
           color: this._darkMode ? "#f0f0f5" : "#1a1a1a",
           fontFamily: "inherit",
           fontSize: "12.5px",
+          fontWeight: "500",
           lineHeight: "1.5",
         },
         ".cm-diagnostic + .cm-diagnostic": {
@@ -175,6 +184,17 @@ export class ESPHomeYamlEditor extends LitElement {
         },
         ".cm-diagnostic-info": {
           borderLeftColor: this._darkMode ? "#4dabf7" : "#0b5cad",
+        },
+        // A red dot replaces the line number on error lines — no separate
+        // lint gutter, so an error never reflows the editor.
+        ".cm-lineNumbers .cm-gutterElement.cm-lint-error-line": {
+          color: "transparent",
+          backgroundImage: this._darkMode
+            ? errorDot("%23ff6b6b", "%23d92d20")
+            : errorDot("%23d92d20", "%23a51d12"),
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "right 3px center",
+          backgroundSize: "0.7em",
         },
         // ─── Autocompletion popup ───────────────────────────────────
         ".cm-tooltip.cm-tooltip-autocomplete": {
@@ -317,12 +337,22 @@ export class ESPHomeYamlEditor extends LitElement {
     ];
 
     if (this._api && this.configuration) {
-      // Backend lint — wavy underlines only, no gutter pill.
+      // `lintErrorLineGutter` reads the linter's diagnostics, so it must be
+      // wired after `createBackendYamlLinter`.
       extensions.push(
         createBackendYamlLinter({
           api: this._api,
           getConfiguration: () => this.configuration,
-        })
+          onResult: (errors) =>
+            this.dispatchEvent(
+              new CustomEvent("yaml-diagnostics", {
+                detail: { errors },
+                bubbles: true,
+                composed: true,
+              })
+            ),
+        }),
+        lintErrorLineGutter
       );
       // Schema-driven completion off the components catalog.
       extensions.push(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -589,6 +589,7 @@
     "section_components_desc": "You can add components after finishing your core configuration e.g. sensors.",
     "section_automations_desc": "You can set up automations once the core config and at least one component is added.",
     "editor_title_ready": "Editing {name}",
+    "editor_invalid_more": "…and {count} more",
     "layout_components_only": "Show components only",
     "layout_split": "Split view",
     "layout_yaml_only": "Show YAML editor only",

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -28,12 +28,13 @@ interface BackendLinterOptions {
   /** Live accessor — the configuration may change over the editor's lifetime. */
   getConfiguration: () => string;
   /**
-   * Called after every lint pass with the resulting error messages, so the
-   * host can surface a document-level "configuration invalid" indicator that
-   * names the actual errors. Fires with `[]` for an empty/un-configured
-   * buffer or a failed round-trip.
+   * Called after every lint pass with the resulting error messages and the
+   * configuration they were computed for, so the host can surface a
+   * document-level "configuration invalid" indicator that names the actual
+   * errors and ignore a late result from a since-switched device. Fires with
+   * `[]` for an empty/un-configured buffer or a failed round-trip.
    */
-  onResult?: (errors: string[]) => void;
+  onResult?: (errors: string[], configuration: string) => void;
 }
 
 /**
@@ -128,6 +129,12 @@ function indentOf(text: string): number {
 
 /** Match a `key:` declaration, capturing its indent and the key token. */
 const KEY_LINE_RE = /^(\s*)([^\s:#][^:]*?)\s*:(?:\s|$)/;
+
+/** The key declared on the line containing *offset*, or `null`. */
+function keyAt(doc: Text, offset: number): string | null {
+  const hit = doc.lineAt(offset).text.match(KEY_LINE_RE);
+  return hit ? hit[2] : null;
+}
 
 /**
  * Move a block-level validation error onto the key of its enclosing block.
@@ -232,12 +239,12 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
     async (view) => {
       const configuration = opts.getConfiguration();
       if (!configuration) {
-        opts.onResult?.([]);
+        opts.onResult?.([], configuration);
         return [];
       }
       const content = view.state.doc.toString();
       if (!content.trim()) {
-        opts.onResult?.([]);
+        opts.onResult?.([], configuration);
         return [];
       }
 
@@ -248,7 +255,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // Surface backend errors quietly in the console — we don't want a
         // network blip to flood the editor with spurious diagnostics.
         console.debug("[yaml-lint] validate_yaml failed:", err);
-        opts.onResult?.([]);
+        opts.onResult?.([], configuration);
         return [];
       }
       _lastValidated.set(configuration, { content, result: res, at: performance.now() });
@@ -275,20 +282,21 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
 
       // Schema/validation errors carry an explicit range.
       for (const err of res.validation_errors ?? []) {
-        const message = sanitizeMessage((err.message ?? "Invalid configuration").trim());
+        const message =
+          sanitizeMessage((err.message ?? "").trim()) || "Invalid configuration";
         const { from, to } = retargetBlockDiagnostic(
           view.state.doc,
           rangeToOffsets(view, err.range)
         );
         // Pinned on the `esphome:` core block → whole-config error → banner.
-        if (view.state.doc.sliceString(from, to) === CORE_BLOCK_KEY) {
+        if (keyAt(view.state.doc, from) === CORE_BLOCK_KEY) {
           bannerErrors.push(message);
           continue;
         }
         diagnostics.push({ from, to, severity: "error", source: "esphome", message });
       }
 
-      opts.onResult?.(bannerErrors);
+      opts.onResult?.(bannerErrors, configuration);
       return diagnostics;
     },
     {

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -10,9 +10,16 @@
  * Wired via `linter()` (no `lintGutter()` — diagnostics show as red wavy
  * underlines only, never as a round pill in the gutter).
  */
-import { linter, type Diagnostic } from "@codemirror/lint";
-import type { Extension } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
+import { forEachDiagnostic, linter, type Diagnostic } from "@codemirror/lint";
+import {
+  RangeSetBuilder,
+  StateField,
+  type EditorState,
+  type Extension,
+  type RangeSet,
+  type Text,
+} from "@codemirror/state";
+import { gutterLineClass, GutterMarker, type EditorView } from "@codemirror/view";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { EditorValidateResponse } from "../api/types/editor.js";
 
@@ -20,6 +27,13 @@ interface BackendLinterOptions {
   api: ESPHomeAPI;
   /** Live accessor — the configuration may change over the editor's lifetime. */
   getConfiguration: () => string;
+  /**
+   * Called after every lint pass with the resulting error messages, so the
+   * host can surface a document-level "configuration invalid" indicator that
+   * names the actual errors. Fires with `[]` for an empty/un-configured
+   * buffer or a failed round-trip.
+   */
+  onResult?: (errors: string[]) => void;
 }
 
 /**
@@ -57,10 +71,95 @@ export function __setLastValidatedForTesting(
   _lastValidated.set(configuration, { content, result, at: performance.now() });
 }
 
-/** Match `line N, column M` (1-indexed) anywhere in a YAML parse error message. */
-const YAML_LINE_COL_RE = /line\s+(\d+)\s*,\s*column\s+(\d+)/i;
+/** Match `line N, column M` (1-indexed) globally in a YAML parse error message. */
+const YAML_LINE_COL_RE = /line\s+(\d+)\s*,\s*column\s+(\d+)/gi;
 /** Fallback: bare `line N` if the column is missing from the message. */
-const YAML_LINE_RE = /line\s+(\d+)/i;
+const YAML_LINE_RE = /line\s+(\d+)/gi;
+
+/** A quoted path (POSIX `/` or Windows `\`) — keep the basename, drop the dir. */
+const QUOTED_PATH_RE = /"([^"]*[/\\])([^"/\\]+)"/g;
+
+/** ESPHome's root block — where structural "whole config" errors land. */
+const CORE_BLOCK_KEY = "esphome";
+
+/**
+ * Strip absolute directory paths out of a backend error message.
+ *
+ * ESPHome / PyYAML errors embed the config's absolute path
+ * (`"/Users/me/esphome/foo.yaml"` or `"C:\\Users\\me\\foo.yaml"`),
+ * leaking the host filesystem layout and username into the UI. Collapse
+ * any quoted path to its basename.
+ */
+export function sanitizeMessage(message: string): string {
+  return message.replace(QUOTED_PATH_RE, '"$2"');
+}
+
+/**
+ * Pull the real error location out of a PyYAML parse message.
+ *
+ * PyYAML reports the context mark (where the enclosing block started,
+ * often line 1) first and the problem mark (where the bad token was
+ * found) last, so the LAST `line N, column M` is the actual location.
+ * Falls back to a bare `line N`; `null` when the message carries no
+ * position at all.
+ */
+export function parseYamlErrorPosition(
+  message: string
+): { line: number; col: number | null } | null {
+  const colMatches = [...message.matchAll(YAML_LINE_COL_RE)];
+  if (colMatches.length) {
+    const last = colMatches[colMatches.length - 1];
+    return { line: Number.parseInt(last[1], 10), col: Number.parseInt(last[2], 10) };
+  }
+  const lineMatches = [...message.matchAll(YAML_LINE_RE)];
+  if (lineMatches.length) {
+    return {
+      line: Number.parseInt(lineMatches[lineMatches.length - 1][1], 10),
+      col: null,
+    };
+  }
+  return null;
+}
+
+/** Leading-whitespace width of a line. */
+function indentOf(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+/** Match a `key:` declaration, capturing its indent and the key token. */
+const KEY_LINE_RE = /^(\s*)([^\s:#][^:]*?)\s*:(?:\s|$)/;
+
+/**
+ * Move a block-level validation error onto the key of its enclosing block.
+ *
+ * ESPHome marks "Component not found" / "Platform missing" on the block's
+ * value mapping, so a multi-line range spans the children. Walk it up to
+ * the first less-indented `key:` line (clamp to the first line if none).
+ * Single-line ranges are already precise and pass through untouched.
+ */
+export function retargetBlockDiagnostic(
+  doc: Text,
+  fallback: { from: number; to: number }
+): { from: number; to: number } {
+  const startLine = doc.lineAt(fallback.from);
+  if (doc.lineAt(fallback.to).number === startLine.number) return fallback;
+
+  const startIndent = indentOf(startLine.text);
+  for (let n = startLine.number - 1; n >= 1; n--) {
+    const line = doc.line(n);
+    const text = line.text;
+    if (!text.trim() || text.trimStart().startsWith("#")) continue; // skip blank/comment
+    if (indentOf(text) >= startIndent) continue; // still inside the block
+    const hit = text.match(KEY_LINE_RE); // first less-indented line = enclosing key
+    if (hit) {
+      const from = line.from + hit[1].length;
+      return { from, to: from + hit[2].length };
+    }
+    break; // less-indented but not a key — fall through to the clamp
+  }
+  // No enclosing key — at least keep the underline on the first line.
+  return { from: startLine.from + startIndent, to: startLine.to };
+}
 
 /**
  * Translate an upstream range (0-indexed start_line/start_col/end_line/end_col)
@@ -132,9 +231,15 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
   return linter(
     async (view) => {
       const configuration = opts.getConfiguration();
-      if (!configuration) return [];
+      if (!configuration) {
+        opts.onResult?.([]);
+        return [];
+      }
       const content = view.state.doc.toString();
-      if (!content.trim()) return [];
+      if (!content.trim()) {
+        opts.onResult?.([]);
+        return [];
+      }
 
       let res: EditorValidateResponse;
       try {
@@ -143,49 +248,47 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // Surface backend errors quietly in the console — we don't want a
         // network blip to flood the editor with spurious diagnostics.
         console.debug("[yaml-lint] validate_yaml failed:", err);
+        opts.onResult?.([]);
         return [];
       }
       _lastValidated.set(configuration, { content, result: res, at: performance.now() });
 
       const diagnostics: Diagnostic[] = [];
+      // Whole-config errors (a structural error esphome pins on the root
+      // `esphome:` block, or an unplaceable parse error) go in the banner
+      // instead of a squiggle; localized errors keep their squiggle.
+      const bannerErrors: string[] = [];
 
       // YAML parse errors — usually one, no range, message contains
       // "line N, column M".
       for (const err of res.yaml_errors ?? []) {
         const msg = err.message ?? "";
-        let line: number | null = null;
-        let col: number | null = null;
-        const both = msg.match(YAML_LINE_COL_RE);
-        if (both) {
-          line = Number.parseInt(both[1], 10);
-          col = Number.parseInt(both[2], 10);
-        } else {
-          const lineOnly = msg.match(YAML_LINE_RE);
-          if (lineOnly) line = Number.parseInt(lineOnly[1], 10);
+        const message = sanitizeMessage(msg.trim()) || "Invalid YAML";
+        const pos = parseYamlErrorPosition(msg);
+        if (pos === null) {
+          bannerErrors.push(message); // no position to squiggle
+          continue;
         }
-        if (line === null || Number.isNaN(line)) continue;
-        const { from, to } = lineToOffsets(view, line, col);
-        diagnostics.push({
-          from,
-          to,
-          severity: "error",
-          source: "yaml",
-          message: msg.trim() || "Invalid YAML",
-        });
+        const { from, to } = lineToOffsets(view, pos.line, pos.col);
+        diagnostics.push({ from, to, severity: "error", source: "yaml", message });
       }
 
       // Schema/validation errors carry an explicit range.
       for (const err of res.validation_errors ?? []) {
-        const { from, to } = rangeToOffsets(view, err.range);
-        diagnostics.push({
-          from,
-          to,
-          severity: "error",
-          source: "esphome",
-          message: (err.message ?? "Invalid configuration").trim(),
-        });
+        const message = sanitizeMessage((err.message ?? "Invalid configuration").trim());
+        const { from, to } = retargetBlockDiagnostic(
+          view.state.doc,
+          rangeToOffsets(view, err.range)
+        );
+        // Pinned on the `esphome:` core block → whole-config error → banner.
+        if (view.state.doc.sliceString(from, to) === CORE_BLOCK_KEY) {
+          bannerErrors.push(message);
+          continue;
+        }
+        diagnostics.push({ from, to, severity: "error", source: "esphome", message });
       }
 
+      opts.onResult?.(bannerErrors);
       return diagnostics;
     },
     {
@@ -196,3 +299,39 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
     }
   );
 }
+
+/** Tags a line so its line-number gutter cell renders the error icon. */
+const errorLineMarker = new (class extends GutterMarker {
+  elementClass = "cm-lint-error-line";
+})();
+
+/** One marker per line that carries a lint error, sorted by document offset. */
+function errorLineGutterMarkers(state: EditorState): RangeSet<GutterMarker> {
+  const lineStarts: number[] = [];
+  const seen = new Set<number>();
+  forEachDiagnostic(state, (diagnostic, from) => {
+    if (diagnostic.severity !== "error") return;
+    const start = state.doc.lineAt(from).from;
+    if (!seen.has(start)) {
+      seen.add(start);
+      lineStarts.push(start);
+    }
+  });
+  lineStarts.sort((a, b) => a - b);
+  const builder = new RangeSetBuilder<GutterMarker>();
+  for (const start of lineStarts) builder.add(start, start, errorLineMarker);
+  return builder.finish();
+}
+
+/**
+ * Replace the line number with an error icon on lines carrying a lint
+ * error, instead of reserving a separate lint-gutter column. The
+ * line-number gutter keeps a fixed width, so an error never reflows the
+ * editor and the icon stays aligned with the number column. Must be wired
+ * after the linter so the diagnostics state it reads is populated.
+ */
+export const lintErrorLineGutter: Extension = StateField.define<RangeSet<GutterMarker>>({
+  create: errorLineGutterMarkers,
+  update: (_value, tr) => errorLineGutterMarkers(tr.state),
+  provide: (field) => gutterLineClass.from(field),
+});

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -13,10 +13,126 @@
  * in ``returns_null_for_different_content``.
  */
 
+import { EditorState } from "@codemirror/state";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.resetModules();
+});
+
+describe("retargetBlockDiagnostic", () => {
+  const DOC = [
+    "esphome:", // 0
+    "  name: test", // 1
+    "  friendly_name: test", // 2
+    "", // 3
+    "# Replace with your platform", // 4
+    "esp8266:", // 5
+    "  board: esp01_1m", // 6
+    "", // 7
+    "apccci:", // 8
+    "  id: api_server", // 9
+    "  encryption:", // 10
+    '    key: "x"', // 11
+  ].join("\n");
+
+  /** Char offset of the first occurrence of `text` in DOC. */
+  const offsetOf = (text: string) => DOC.indexOf(text);
+
+  it("snaps a multi-line 'Component not found' child range onto the key", async () => {
+    const { retargetBlockDiagnostic } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = EditorState.create({ doc: DOC }).doc;
+    // esphome marks the value mapping → spans the `id:`…`key:` children.
+    const fallback = { from: offsetOf("  id: api_server") + 2, to: offsetOf('"x"') + 3 };
+    const { from, to } = retargetBlockDiagnostic(doc, fallback);
+    expect(doc.sliceString(from, to)).toBe("apccci");
+  });
+
+  it("snaps a 'Platform missing' esphome-block range onto the esphome key", async () => {
+    const { retargetBlockDiagnostic } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = EditorState.create({ doc: DOC }).doc;
+    // esphome marks the esphome value mapping → spans name…the comment.
+    const fallback = { from: offsetOf("  name: test") + 2, to: offsetOf("esp8266:") };
+    const { from, to } = retargetBlockDiagnostic(doc, fallback);
+    expect(doc.sliceString(from, to)).toBe("esphome");
+  });
+
+  it("leaves a single-line range untouched (already precise / key-marked)", async () => {
+    const { retargetBlockDiagnostic } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = EditorState.create({ doc: DOC }).doc;
+    const keyStart = offsetOf("apccci:");
+    expect(retargetBlockDiagnostic(doc, { from: keyStart, to: keyStart + 6 })).toEqual({
+      from: keyStart,
+      to: keyStart + 6,
+    });
+  });
+
+  it("clamps to the first line when the block has no enclosing key", async () => {
+    const { retargetBlockDiagnostic } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = EditorState.create({ doc: DOC }).doc;
+    // A multi-line range starting at a top-level key (no shallower line above).
+    const apccciLine = doc.lineAt(offsetOf("apccci:"));
+    const fallback = { from: apccciLine.from, to: offsetOf('"x"') + 3 };
+    const { from, to } = retargetBlockDiagnostic(doc, fallback);
+    expect(from).toBe(apccciLine.from);
+    expect(to).toBe(apccciLine.to);
+    expect(doc.sliceString(from, to)).toBe("apccci:");
+  });
+});
+
+describe("sanitizeMessage", () => {
+  it("collapses a POSIX absolute path to its basename", async () => {
+    const { sanitizeMessage } = await import("../../src/util/yaml-lint-backend.js");
+    expect(
+      sanitizeMessage('in "/Users/bdraco/esphome/foo.yaml", line 17, column 2')
+    ).toBe('in "foo.yaml", line 17, column 2');
+  });
+
+  it("collapses a Windows absolute path to its basename", async () => {
+    const { sanitizeMessage } = await import("../../src/util/yaml-lint-backend.js");
+    expect(sanitizeMessage('in "C:\\Users\\bdraco\\esphome\\foo.yaml"')).toBe(
+      'in "foo.yaml"'
+    );
+  });
+
+  it("strips every quoted path and leaves bare filenames untouched", async () => {
+    const { sanitizeMessage } = await import("../../src/util/yaml-lint-backend.js");
+    expect(
+      sanitizeMessage('"/a/b/x.yaml" includes "/c/d/y.yaml" but "z.yaml" stays')
+    ).toBe('"x.yaml" includes "y.yaml" but "z.yaml" stays');
+  });
+});
+
+describe("parseYamlErrorPosition", () => {
+  it("returns the last (problem-mark) line/column, not the first", async () => {
+    const { parseYamlErrorPosition } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const msg =
+      "while parsing a block mapping in x, line 1, column 1 expected <block end>, " +
+      "but found '<scalar>' in x, line 17, column 2";
+    expect(parseYamlErrorPosition(msg)).toEqual({ line: 17, col: 2 });
+  });
+
+  it("falls back to a bare `line N` with a null column", async () => {
+    const { parseYamlErrorPosition } =
+      await import("../../src/util/yaml-lint-backend.js");
+    expect(
+      parseYamlErrorPosition("could not determine a constructor for line 4")
+    ).toEqual({
+      line: 4,
+      col: null,
+    });
+  });
+
+  it("returns null when the message carries no position", async () => {
+    const { parseYamlErrorPosition } =
+      await import("../../src/util/yaml-lint-backend.js");
+    expect(parseYamlErrorPosition("mapping values are not allowed here")).toBeNull();
+  });
 });
 
 describe("getLastValidatedResult", () => {


### PR DESCRIPTION
# What does this implement/fix?

Several improvements to how the YAML editor's backend linter surfaces
ESPHome config errors. Before, a structural error underlined the wrong
lines (and leaked absolute paths), and there was no document-level signal
that the whole config failed to validate.

- **Point block-level errors at the offending key.** ESPHome marks
  errors like `Component not found` / `Platform missing` on the block's
  *value* mapping, so the red underline smeared across the child lines,
  blank lines, and comments instead of the offending `key:`. A multi-line
  range now walks up to its enclosing key and marks just that token.
- **Line-number-as-error-dot instead of a lint-gutter column.** The
  error line's number becomes a red dot (via `gutterLineClass`) rather
  than reserving a separate `lintGutter()` column, so an error never
  widens the gutter or reflows the editor.
- **Document-level errors go in a banner above the editor.** A structural
  error esphome pins on the root `esphome:` block (e.g. "Platform
  missing"), or a parse error with no usable position, surfaces in a
  banner — squiggling the `esphome:` header is noise. Localized errors (a
  component typo, a syntax error on a line) keep their inline squiggle.
  The banner and the squiggle are mutually exclusive.
- **Correct YAML parse-error position.** PyYAML reports the context mark
  (where the block started, often line 1) first and the problem mark
  (where the bad token was found) last; we now use the last `line N,
  column M`, so the squiggle lands on the real line.
- **No path leak.** Absolute filesystem paths embedded in PyYAML /
  ESPHome messages (`"/Users/me/esphome/foo.yaml"`, `"C:\…\foo.yaml"`)
  are collapsed to their basename so the host's directory layout and
  username don't reach the UI.

New unit tests cover the key-retarget walk, the path sanitizer, and the
parse-error position extraction.

**Related issue or feature (if applicable):**

- Companion backend fix: esphome/esphome#16777 (points the "Component not found" range at the key). The frontend heuristic handles it for the currently pinned esphome too, so this stands alone.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
