### PR TITLE
Ignore stray root-level .md / .png scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ build/
 .DS_Store
 .claude/*
 !.claude/skills/
+# Stray notes / screenshots dropped at the repo root during development.
+# The only root-level docs we track are README.md and CLAUDE.md.
+/*.md
+!/README.md
+!/CLAUDE.md
+/*.png


### PR DESCRIPTION
# What does this implement/fix?

Notes and screenshots dropped at the repo root during development (e.g.
`drift_risk.md`, scratch `*.png`) keep getting swept into commits by
`git add -A`. Ignore root-level `*.md` and `*.png`, negating the two docs
we actually track at the root (`README.md`, `CLAUDE.md`). The patterns
are anchored with a leading `/`, so nested docs (`docs/*.md`,
`src/**/*.md`) are unaffected.

**Related issue or feature (if applicable):**

- N/A — repo hygiene.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
