### PR TITLE
Add a clear button to the device search box (fixes esphome/device-builder#1160)

### DIFF
--- a/src/components/dashboard/render-facets.ts
+++ b/src/components/dashboard/render-facets.ts
@@ -120,9 +120,8 @@ export function renderFacets(host: ESPHomePageDashboard): TemplateResult {
       : nothing}
   `;
 
-  // Badge / "Clear all" track facet selections only; a lone active
-  // search term is cleared from the search box's own clear control,
-  // not surfaced here.
+  // Badge counts facet selections only; a lone search term isn't a menu
+  // pill, so it's cleared from the search box's own × instead (#1160).
   return html`
     <div class="filter-group">
       <esphome-filters-menu

--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -1,4 +1,4 @@
-import { html, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { DashboardView } from "../../api/types/system.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { renderFacets } from "./render-facets.js";
@@ -73,6 +73,9 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
   const placeholder = host._yamlMode
     ? host._localize("yaml_search.placeholder")
     : host._localize("dashboard.search_placeholder");
+  // trim() to match _hasActiveFilters: a whitespace-only query filters
+  // nothing, so don't offer to clear it.
+  const hasQuery = host._search.trim().length > 0;
   // Decorative leading magnifier — the YAML-mode toggle lives as a
   // third option in the view-toggle radio group, not in here.
   return html`<div class="search-wrap">
@@ -106,6 +109,16 @@ export function renderSearchInput(host: ESPHomePageDashboard): TemplateResult {
         @keydown=${host._onSearchKeyDown}
       />
     </form>
+    ${hasQuery
+      ? html`<button
+          class="search-clear"
+          type="button"
+          aria-label=${host._localize("dashboard.search_clear")}
+          @click=${host._clearSearch}
+        >
+          <wa-icon library="mdi" name="close-circle" aria-hidden="true"></wa-icon>
+        </button>`
+      : nothing}
   </div>`;
 }
 

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -354,10 +354,39 @@ export const dashboardStyles = css`
      the placeholder. */
   .search-wrap .search-input {
     padding-left: 36px;
+    /* Room for the clear (×); mirrors the 36px leading-icon inset. */
+    padding-right: 36px;
     /* Share the toolbar control height so the search box matches the
        view-toggle / facet pills beside it (the input's default is the
        taller --wa-form-control-height). */
     min-height: var(--esphome-control-height);
+  }
+
+  /* Hide the native type="search" × so it doesn't double our own. */
+  .search-wrap .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  /* Our clear control — shown only when a query is present. */
+  .search-clear {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 18px;
+    color: var(--wa-color-text-quiet);
+    z-index: 1;
+  }
+
+  .search-clear:hover {
+    color: var(--wa-color-text-normal);
   }
 
   /* Decorative leading icon — magnifier in device mode, code-braces

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -3,6 +3,7 @@ import {
   mdiArrowLeft,
   mdiCheckboxMultipleMarkedOutline,
   mdiClipboardTextSearchOutline,
+  mdiCloseCircle,
   mdiCodeBraces,
   mdiMagnify,
   mdiPlus,
@@ -140,6 +141,7 @@ registerMdiIcons({
   "arrow-left": mdiArrowLeft,
   "checkbox-multiple-marked-outline": mdiCheckboxMultipleMarkedOutline,
   "clipboard-text-search-outline": mdiClipboardTextSearchOutline,
+  "close-circle": mdiCloseCircle,
   "code-braces": mdiCodeBraces,
   magnify: mdiMagnify,
   plus: mdiPlus,
@@ -565,8 +567,8 @@ export class ESPHomePageDashboard extends LitElement {
     );
   }
 
-  /** Drives the Filters-button badge. Search is excluded; its own box
-   *  stays visible, so its active state is already obvious. */
+  /** Drives the Filters-button badge — facets only. A lone search isn't
+   *  a menu pill, so it clears from the search box's own × instead. */
   get _activeFacetCount(): number {
     return (
       this._selectedLabels.length +
@@ -576,6 +578,14 @@ export class ESPHomePageDashboard extends LitElement {
       this._selectedUpdateStatus.length
     );
   }
+
+  /** Clear just the search box (facets untouched) and refocus it so the
+   *  user can retype. Wired to the in-input × control (#1160). */
+  _clearSearch = () => {
+    this._search = "";
+    this._syncYamlSearch();
+    this._searchInputEl?.focus();
+  };
 
   /** Wipe search + every facet selection in one shot. Wired to the
    *  empty-state's "Clear filters" button, which only renders when

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -39,6 +39,7 @@
     "unknown": "Unknown",
     "delete": "Delete",
     "search_placeholder": "Search devices…",
+    "search_clear": "Clear search",
     "device_singular": "device",
     "device_plural": "devices",
     "search_of": "of {total}",

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -56,7 +56,8 @@ describe("renderFacets", () => {
   });
 
   // _localize is stubbed to echo its key, so the count-label attribute
-  // reveals which singular/plural key was chosen.
+  // reveals which singular/plural key was chosen. The badge tracks facet
+  // selections only — a lone search term isn't counted here (#1160).
   it("uses the singular count label for exactly one active facet", () => {
     const menu = renderInto(makeHost({ _activeFacetCount: 1 })).querySelector(
       "esphome-filters-menu"

--- a/test/components/dashboard/render-toolbar.test.ts
+++ b/test/components/dashboard/render-toolbar.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins renderSearchInput's clear (×) control: hidden on an empty (or
+ * whitespace-only) query, shown when a query is typed, and wired to the
+ * host's _clearSearch handler (issue #1160). The handler's own behavior
+ * is covered in dashboard-clear-search.test.ts.
+ */
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { renderSearchInput } from "../../../src/components/dashboard/render-toolbar.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    _localize: (k: string) => k,
+    _yamlMode: false,
+    _search: "",
+    _syncYamlSearch: vi.fn(),
+    _onSearchKeyDown: vi.fn(),
+    _clearSearch: vi.fn(),
+    ...overrides,
+  } as unknown as ESPHomePageDashboard;
+}
+
+function renderInto(host: ESPHomePageDashboard): HTMLElement {
+  const container = document.createElement("div");
+  render(renderSearchInput(host), container);
+  return container;
+}
+
+describe("renderSearchInput", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("hides the clear button when the query is empty", () => {
+    const container = renderInto(makeHost({ _search: "" }));
+    expect(container.querySelector(".search-clear")).toBeNull();
+  });
+
+  it("hides the clear button for a whitespace-only query", () => {
+    const container = renderInto(makeHost({ _search: "   " }));
+    expect(container.querySelector(".search-clear")).toBeNull();
+  });
+
+  it("shows the clear button when a query is present", () => {
+    const container = renderInto(makeHost({ _search: "kitchen" }));
+    expect(container.querySelector(".search-clear")).not.toBeNull();
+  });
+
+  it("wires the clear button to the host's _clearSearch handler", () => {
+    const clearSearch = vi.fn();
+    const host = makeHost({ _search: "kitchen", _clearSearch: clearSearch });
+    renderInto(host).querySelector<HTMLButtonElement>(".search-clear")?.click();
+    expect(clearSearch).toHaveBeenCalledOnce();
+  });
+});

--- a/test/pages/dashboard-clear-search.test.ts
+++ b/test/pages/dashboard-clear-search.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins ESPHomePageDashboard._clearSearch: it empties the search term and
+ * resyncs YAML mode, leaving facet selections untouched (issue #1160).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+
+describe("_clearSearch", () => {
+  it("clears the search term, resyncs YAML, and leaves facets intact", () => {
+    const page = new ESPHomePageDashboard();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Object.assign(page as any, {
+      _search: "kitchen",
+      _selectedAreas: ["living"],
+    });
+    const sync = vi.spyOn(page, "_syncYamlSearch").mockImplementation(() => {});
+
+    page._clearSearch();
+
+    expect(page._search).toBe("");
+    expect(page._selectedAreas).toEqual(["living"]);
+    expect(sync).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

After the facet row collapsed into the "Filters" pop-up menu, a search term with **no facet selected** had no clear affordance when results still matched: the menu badge / "Clear all" tracks facet selections only, and the card-view empty state only renders when *zero* devices match. So typing a query that still matched devices left the user with no way to clear it.

This adds an explicit **clear (×) button inside the search box**, shown only when a query is present; it clears just the search term and refocuses the input. This matches the original design intent (a search "is cleared from the search box's own clear control") which had relied on the native `type="search"` × — unstyleable and absent in Firefox. The native control is now suppressed so the two don't double up.

The search term is deliberately **not** counted in the Filters-menu badge: it isn't represented among the menu's pills, so a "1" badge with nothing matching it inside the dropdown reads as a confusing phantom filter.

Works in card, table, and YAML-search toolbars (they share `renderSearchInput`).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1160

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).