### PR TITLE
Preserve trailing comments when saving a section from the form

### DIFF
--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -160,6 +160,8 @@ const listItemRegexFor = (dashIndent: string) => new RegExp(`^${dashIndent}-\\s+
  * line-by-line serializer. Skipping them here just keeps comments
  * from corrupting the structural read.
  */
+const isCommentLine = (line: string): boolean => line.trim().startsWith("#");
+
 const isBlankOrCommentLine = (line: string): boolean => {
   const trimmed = line.trim();
   return trimmed === "" || trimmed.startsWith("#");
@@ -995,6 +997,20 @@ export function updateSectionInYaml(
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
 
+  // The range runs to the next top-level key, swallowing trailing
+  // comments the splice would then wipe. If the trailing run holds a
+  // comment, stop the splice before it so those lines survive. Gating
+  // on a comment leaves pure-blank runs (incl. the terminal newline)
+  // to the normal splice, keeping block-scalar round-trips identical.
+  // (`> start + 1` keeps the header line in the splice.)
+  let runStart = end;
+  let trailingHasComment = false;
+  while (runStart > start + 1 && isBlankOrCommentLine(lines[runStart - 1])) {
+    if (isCommentLine(lines[runStart - 1])) trailingHasComment = true;
+    runStart--;
+  }
+  const spliceEnd = trailingHasComment ? runStart : end;
+
   // Top-level list-bodied section (globals): re-emit through the
   // mapping serializer's array branch — { sectionKey: array } yields
   // `sectionKey:` plus the dash items at the section's child indent.
@@ -1015,7 +1031,7 @@ export function updateSectionInYaml(
         indentStep: options.indentStep ?? (childIndent || ESPHOME_YAML_INDENT),
       }
     );
-    lines.splice(start, end - start, ...block);
+    lines.splice(start, spliceEnd - start, ...block);
     return lines.join("\n");
   }
 
@@ -1120,7 +1136,7 @@ export function updateSectionInYaml(
       indentStep: options.indentStep ?? detectedStep,
     }),
   ];
-  lines.splice(start, end - start, ...newLines);
+  lines.splice(start, spliceEnd - start, ...newLines);
   return lines.join("\n");
 }
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -162,10 +162,8 @@ const listItemRegexFor = (dashIndent: string) => new RegExp(`^${dashIndent}-\\s+
  */
 const isCommentLine = (line: string): boolean => line.trim().startsWith("#");
 
-const isBlankOrCommentLine = (line: string): boolean => {
-  const trimmed = line.trim();
-  return trimmed === "" || trimmed.startsWith("#");
-};
+const isBlankOrCommentLine = (line: string): boolean =>
+  line.trim() === "" || isCommentLine(line);
 
 /**
  * Walk forward from *startIdx* skipping blank and comment-only
@@ -997,17 +995,31 @@ export function updateSectionInYaml(
   const { start, end } = findSectionRange(lines, sectionKey, fromLine);
   if (start < 0) return yaml;
 
+  // List-item vs map shape and the section's child indent drive both
+  // the trailing-comment trim below and the serializer's indent step.
+  const isListItem = LIST_ITEM_START_RE.test(lines[start]);
+  const childIndent = _detectSectionChildIndent(lines, start, isListItem);
+
   // The range runs to the next top-level key, swallowing trailing
-  // comments the splice would then wipe. If the trailing run holds a
-  // comment, stop the splice before it so those lines survive. Gating
-  // on a comment leaves pure-blank runs (incl. the terminal newline)
-  // to the normal splice, keeping block-scalar round-trips identical.
-  // (`> start + 1` keeps the header line in the splice.)
+  // comments the splice would then wipe. Walk the trailing run back
+  // from `end`; if it holds a section-level comment, stop the splice
+  // before the run so those lines survive. A `#` line indented deeper
+  // than the section's children is block-scalar body content, not a
+  // YAML comment — break there so it stays on the byte-identical path
+  // rather than being duplicated. Pure-blank runs (incl. the terminal
+  // newline) also stay on that path. (`> start + 1` keeps the header.)
   let runStart = end;
   let trailingHasComment = false;
-  while (runStart > start + 1 && isBlankOrCommentLine(lines[runStart - 1])) {
-    if (isCommentLine(lines[runStart - 1])) trailingHasComment = true;
-    runStart--;
+  while (runStart > start + 1) {
+    const prev = lines[runStart - 1];
+    if (prev.trim() === "") {
+      runStart--;
+    } else if (isCommentLine(prev) && _leadingIndent(prev).length <= childIndent.length) {
+      trailingHasComment = true;
+      runStart--;
+    } else {
+      break;
+    }
   }
   const spliceEnd = trailingHasComment ? runStart : end;
 
@@ -1022,7 +1034,6 @@ export function updateSectionInYaml(
     // Emptied list (every item deleted) → drop the whole block instead
     // of leaving an invalid bare `sectionKey:`. serializeYamlValues
     // skips empty arrays, so the splice removes header + body.
-    const childIndent = _detectSectionChildIndent(lines, start, false);
     const block = serializeYamlValues(
       { [sectionKey]: raw },
       _leadingIndent(lines[start]),
@@ -1035,12 +1046,9 @@ export function updateSectionInYaml(
     return lines.join("\n");
   }
 
-  const isListItem = LIST_ITEM_START_RE.test(lines[start]);
-  // Match the user's existing indent step on save so 4-space (or
-  // other consistent) YAML doesn't get re-emitted with a mixed
-  // 2-space slice. Falls back to the canonical 2-space step when
-  // the section is otherwise empty.
-  const childIndent = _detectSectionChildIndent(lines, start, isListItem);
+  // `childIndent` (detected above) also matches the user's existing
+  // indent step on save, so 4-space (or other consistent) YAML isn't
+  // re-emitted with a mixed 2-space slice.
   let toSerialize = values;
   let dashLine = lines[start];
   if (isListItem) {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -374,6 +374,65 @@ describe("updateSectionInYaml — list item with inline key", () => {
   });
 });
 
+describe("updateSectionInYaml — trailing comments / blank lines", () => {
+  it("keeps a trailing comment block when toggling a nested value", () => {
+    // Reported bug: flipping `active` wiped the commented-out block
+    // between this section and the next.
+    const before = [
+      "esp32_ble_tracker:",
+      "  scan_parameters:",
+      "    active: false",
+      "# Bluetooth LED blinks when receiving Bluetooth advertising",
+      "#  on_ble_advertise:",
+      "#    then:",
+      "#      - output.turn_on: bluetooth_led",
+      "",
+      "",
+      "bluetooth_proxy:",
+      "",
+    ].join("\n");
+    const after = updateSectionInYaml(
+      before,
+      "esp32_ble_tracker",
+      { scan_parameters: { active: true } },
+      1
+    );
+    expect(after).toContain("active: true");
+    expect(after).toContain(
+      "# Bluetooth LED blinks when receiving Bluetooth advertising"
+    );
+    expect(after).toContain("#      - output.turn_on: bluetooth_led");
+    expect(after).toContain("bluetooth_proxy:");
+  });
+
+  it("still saves a section followed immediately by the next key", () => {
+    // No trailing run: the trim must not eat the section's last line.
+    const before = "wifi:\n  ssid: x\nlogger:\n";
+    const after = updateSectionInYaml(before, "wifi", { ssid: "y" }, 1);
+    expect(after).toContain("ssid: y");
+    expect(after).not.toContain("ssid: x");
+    expect(after).toContain("logger:");
+  });
+
+  it("keeps comments when the section body is comment-only", () => {
+    // Exercises the `> start + 1` guard: header replaced, comments kept.
+    const before = "wifi:\n  # configure later\n  # see docs\nlogger:\n";
+    const after = updateSectionInYaml(before, "wifi", { ssid: "y" }, 1);
+    expect(after).toContain("ssid: y");
+    expect(after).toContain("# configure later");
+    expect(after).toContain("# see docs");
+  });
+
+  it("is stable across repeated saves", () => {
+    // Same update twice yields an identical string, no drift.
+    const before = "wifi:\n  ssid: x\n# note\n\nlogger:\n";
+    const once = updateSectionInYaml(before, "wifi", { ssid: "y" }, 1);
+    const twice = updateSectionInYaml(once, "wifi", { ssid: "y" }, 1);
+    expect(twice).toBe(once);
+    expect(once).toContain("# note");
+  });
+});
+
 describe("removeSectionFromYaml — multi-item list", () => {
   // Pins the splice contract that surfaced the
   // wrong-section-deleted bug. The bug itself was at the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -431,6 +431,26 @@ describe("updateSectionInYaml — trailing comments / blank lines", () => {
     expect(twice).toBe(once);
     expect(once).toContain("# note");
   });
+
+  it("does not treat a block-scalar `#` body line as a trailing comment", () => {
+    // A `#`-prefixed line inside a `|` block scalar is literal text,
+    // not a comment. It's indented deeper than the section's children,
+    // so the trim must break there (not preserve it outside the
+    // splice) — otherwise the serializer re-emits it AND the kept tail
+    // retains it, duplicating the line.
+    const before = [
+      "mqtt:",
+      "  topic: foo",
+      "  log_format: |",
+      "    # not a comment, literal text in the block",
+      "sensor:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "mqtt", 1);
+    const after = updateSectionInYaml(before, "mqtt", values, 1);
+    expect(after).toBe(before);
+    expect(after.match(/# not a comment/g)).toHaveLength(1);
+  });
 });
 
 describe("removeSectionFromYaml — multi-item list", () => {


### PR DESCRIPTION
# What does this implement/fix?

Flipping a toggle in the section form, for example the active switch under esp32_ble_tracker scan_parameters, was wiping any commented out block that sat between that section and the next one. The section range walks forward to the next top level key, so it swallows the trailing comment and blank lines, and the splice that rewrites the section then replaced them with freshly serialized lines that had no comments.

When the trailing run contains a comment, the splice now stops short of it so the comments and the blank lines around them round trip. Pure blank runs keep the old behaviour, which keeps block scalar round trips byte identical.

Interleaved comments between keys inside a section are still dropped; that is the existing minimal parser limitation and is out of scope here.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
