### PR TITLE
Make optional enum selects clearable instead of a mid-list "(none)"

### DIFF
--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -23,6 +23,26 @@ import {
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
+// An empty-value "(none)" option marks an optional enum — surface a clear
+// (×) and drop the pseudo-option. Memoized per entry (stable catalog object).
+const _selectOptions = new WeakMap<
+  ConfigEntry,
+  { clearable: boolean; visibleOptions: NonNullable<ConfigEntry["options"]> }
+>();
+
+export function selectOptions(entry: ConfigEntry) {
+  let cached = _selectOptions.get(entry);
+  if (!cached) {
+    const options = entry.options ?? [];
+    cached = {
+      clearable: options.some((o) => o.value === ""),
+      visibleOptions: options.filter((o) => o.value !== ""),
+    };
+    _selectOptions.set(entry, cached);
+  }
+  return cached;
+}
+
 export function renderNumberField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   // A featured-entry preset can pin the choice to a short list — defer to
   // the suggestion-aware string renderer which converts back to number on change.
@@ -441,17 +461,19 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
     (o) => o.value.toLowerCase() === defaultStr.toLowerCase()
   );
   const placeholder = defaultOption?.label ?? defaultStr;
+  const { clearable, visibleOptions } = selectOptions(entry);
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
       <wa-select
         class=${invalid ? "invalid" : ""}
         ?disabled=${disabled}
+        .withClear=${clearable}
         placeholder=${placeholder}
         @change=${(e: Event) =>
           ctx.emitChange(path, (e.target as HTMLSelectElement).value)}
       >
-        ${(entry.options ?? []).map(
+        ${visibleOptions.map(
           (opt) =>
             html`<wa-option
               value=${opt.value}

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
@@ -473,6 +473,9 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         @change=${(e: Event) =>
           ctx.emitChange(path, (e.target as HTMLSelectElement).value)}
       >
+        ${clearable
+          ? html`<wa-icon slot="clear-icon" library="mdi" name="close"></wa-icon>`
+          : nothing}
         ${visibleOptions.map(
           (opt) =>
             html`<wa-option

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -415,7 +415,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           ?disabled=${disabled}
           placeholder=${String(entry.default_value ?? "")}
           @change=${(e: Event) =>
-            ctx.emitChange(path, (e.target as HTMLSelectElement).value)}
+            ctx.emitChange(path, (e.target as unknown as { value: string }).value)}
         >
           ${entry.suggestions.map((s) => {
             const v = String(s);
@@ -471,7 +471,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         .withClear=${clearable}
         placeholder=${placeholder}
         @change=${(e: Event) =>
-          ctx.emitChange(path, (e.target as HTMLSelectElement).value)}
+          ctx.emitChange(path, (e.target as unknown as { value: string }).value)}
       >
         ${clearable
           ? html`<wa-icon slot="clear-icon" library="mdi" name="close"></wa-icon>`

--- a/test/components/device/config-entry-select-clearable.test.ts
+++ b/test/components/device/config-entry-select-clearable.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import {
+  renderSelectField,
+  selectOptions,
+} from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+// The backend ships an empty-value "(none)" option for optional enums,
+// alphabetically mid-list (e.g. between `duration` and `energy` in
+// device_class). We surface a clear (×) and drop the pseudo-option.
+const OPTIONAL: ConfigValueOption[] = [
+  { value: "energy", label: "energy" },
+  { value: "", label: "(none)" },
+  { value: "power", label: "power" },
+] as never;
+
+const REQUIRED: ConfigValueOption[] = [
+  { value: "a", label: "a" },
+  { value: "b", label: "b" },
+] as never;
+
+function selectFor(options: ConfigValueOption[], value: string) {
+  const entry = makeEntry(ConfigEntryType.SELECT, { options });
+  return renderSelectField(
+    entry,
+    ["device_class"],
+    makeRenderCtx({ device_class: value })
+  );
+}
+
+describe("selectOptions", () => {
+  it("flags an empty-value option as clearable and filters it out", () => {
+    const entry = makeEntry(ConfigEntryType.SELECT, { options: OPTIONAL });
+    expect(selectOptions(entry)).toEqual({
+      clearable: true,
+      visibleOptions: [
+        { value: "energy", label: "energy" },
+        { value: "power", label: "power" },
+      ],
+    });
+  });
+
+  it("a required enum is not clearable and keeps every option", () => {
+    const entry = makeEntry(ConfigEntryType.SELECT, { options: REQUIRED });
+    expect(selectOptions(entry)).toEqual({ clearable: false, visibleOptions: REQUIRED });
+  });
+
+  it("memoizes the derivation per entry", () => {
+    const entry = makeEntry(ConfigEntryType.SELECT, { options: OPTIONAL });
+    expect(selectOptions(entry)).toBe(selectOptions(entry));
+  });
+});
+
+describe("renderSelectField — optional enum", () => {
+  it("makes the select clearable and renders no (none) option", () => {
+    const tpl = selectFor(OPTIONAL, "energy");
+    expect(findElementBindings(tpl, "wa-select")[0][".withClear"]).toBe(true);
+    const values = findElementBindings(tpl, "wa-option").map((b) => b.value);
+    expect(values).toEqual(["energy", "power"]);
+  });
+
+  it("leaves a required enum non-clearable with all options", () => {
+    const tpl = selectFor(REQUIRED, "a");
+    expect(findElementBindings(tpl, "wa-select")[0][".withClear"]).toBe(false);
+    expect(findElementBindings(tpl, "wa-option").map((b) => b.value)).toEqual(["a", "b"]);
+  });
+});

--- a/test/components/device/config-entry-select-clearable.test.ts
+++ b/test/components/device/config-entry-select-clearable.test.ts
@@ -14,12 +14,12 @@ const OPTIONAL: ConfigValueOption[] = [
   { value: "energy", label: "energy" },
   { value: "", label: "(none)" },
   { value: "power", label: "power" },
-] as never;
+];
 
 const REQUIRED: ConfigValueOption[] = [
   { value: "a", label: "a" },
   { value: "b", label: "b" },
-] as never;
+];
 
 function selectFor(options: ConfigValueOption[], value: string) {
   const entry = makeEntry(ConfigEntryType.SELECT, { options });


### PR DESCRIPTION
# What does this implement/fix?

Optional enum fields (e.g. a sensor's `device_class`) ship an empty-value
`(none)` option from the catalog, which sorts **mid-list** — so to clear
the field the user had to scroll the dropdown to find `(none)`, or type a
hacky `""`. (Screenshot: `(none)` sitting between `duration` and `energy`.)

Render those selects with a built-in clear (×) instead, and drop the
`(none)` pseudo-option from the list. `wa-select` fires a `change` event
with an empty value when cleared, which the existing change handler already
maps, so no new wiring. A required enum (no empty option) stays
non-clearable with its full option list.

The clearable/visible-options derivation is memoized per `ConfigEntry`
(a stable catalog object) via a `WeakMap`, matching the renderer
memoization pattern in `nested.ts` / `templatable.ts`.

Same "give the user a real clear affordance" intent as #576 (the search-box
×), applied to the structured editor's selects.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
