### PR TITLE
Migrate the yaml-validation dialog onto esphome-base-dialog

### DIFF
--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -1,17 +1,16 @@
 import { consume } from "@lit/context";
 import { mdiAlertOutline } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({ "alert-outline": mdiAlertOutline });
 
@@ -51,15 +50,13 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   /** First error's message, used as a hint under the count. */
   @property() firstErrorMessage = "";
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
 
   static styles = [
     espHomeStyles,
     modalDialogStyles,
-    dialogCloseButtonStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 480px;
       }
 
@@ -110,13 +107,21 @@ export class ESPHomeYamlValidationDialog extends LitElement {
 
   open() {
     this._resolvedExit = null;
-    this._dialog.open = true;
+    this._open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  // esphome-base-dialog never mutates its own open on a user-driven close
+  // (Escape / X / outside-click); the host owns flipping _open here, else a
+  // re-render re-asserts ?open and the dialog can't dismiss. Teardown +
+  // cancel-on-dismiss stay in _onAfterHide.
+  private _onRequestClose = (): void => {
+    this._open = false;
+  };
 
   protected render() {
     const messageKey =
@@ -128,10 +133,11 @@ export class ESPHomeYamlValidationDialog extends LitElement {
     });
     const canGoToError = this.firstErrorLine > 0;
     return html`
-      <wa-dialog
-        label=${this._localize("device.yaml_invalid_title")}
-        light-dismiss
-        @wa-after-hide=${this._onAfterHide}
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("device.yaml_invalid_title")}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
       >
         <div class="body">
           <div class="icon-wrap">
@@ -155,7 +161,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
             ${this._localize("device.yaml_invalid_save_anyway")}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -179,6 +185,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   }
 
   private _onAfterHide() {
+    this._open = false;
     this._enter.set(false);
     if (this._resolvedExit === null) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));

--- a/test/components/yaml-validation-dialog.test.ts
+++ b/test/components/yaml-validation-dialog.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the save-time YAML validation prompt's behaviour after the migration
+ * onto esphome-base-dialog: Enter takes the safe "Go to error" path (never
+ * force-save), the goto latch fires once, and the reactive ?open /
+ * request-close / after-hide -> cancel contract holds.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeYamlValidationDialog } from "../../src/components/yaml-validation-dialog.js";
+import { pressEnter } from "../_press-enter.js";
+
+async function mount(): Promise<ESPHomeYamlValidationDialog> {
+  const el = new ESPHomeYamlValidationDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const baseDialog = (el: ESPHomeYamlValidationDialog): HTMLElement =>
+  el.shadowRoot!.querySelector("esphome-base-dialog")!;
+
+describe("yaml-validation-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("goes to the first error on Enter when a line is known", async () => {
+    const el = await mount();
+    el.firstErrorLine = 12;
+    el.firstErrorCol = 4;
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    el.addEventListener("goto", onGoto as EventListener);
+    el.open();
+    pressEnter();
+    expect(onGoto).toHaveBeenCalledTimes(1);
+    expect(onGoto.mock.calls[0][0].detail).toEqual({ line: 12, col: 4 });
+  });
+
+  it("does nothing on Enter when no error line is known", async () => {
+    const el = await mount();
+    el.firstErrorLine = 0;
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    const onSaveAnyway = vi.fn();
+    el.addEventListener("goto", onGoto);
+    el.addEventListener("save-anyway", onSaveAnyway);
+    el.open();
+    pressEnter();
+    expect(onGoto).not.toHaveBeenCalled();
+    expect(onSaveAnyway).not.toHaveBeenCalled();
+  });
+
+  it("fires goto only once on a repeated Enter", async () => {
+    const el = await mount();
+    el.firstErrorLine = 3;
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    el.addEventListener("goto", onGoto);
+    el.open();
+    pressEnter();
+    pressEnter();
+    expect(onGoto).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not go to the error before the dialog is opened", async () => {
+    const el = await mount();
+    el.firstErrorLine = 3;
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    el.addEventListener("goto", onGoto);
+    pressEnter();
+    expect(onGoto).not.toHaveBeenCalled();
+  });
+});
+
+// The migration onto esphome-base-dialog introduced the reactive ?open binding,
+// the request-close handler, and the after-hide -> cancel path. Pin them so the
+// dismiss-cancels contract (the page-leave guard depends on it) can't regress.
+describe("yaml-validation-dialog dismiss / request-close", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("fires a single cancel when dismissed without a decision", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    const onCancel = vi.fn();
+    el.addEventListener("cancel", onCancel);
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire cancel after Go to error was chosen", async () => {
+    const el = await mount();
+    el.firstErrorLine = 7;
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    const onCancel = vi.fn();
+    el.addEventListener("goto", onGoto);
+    el.addEventListener("cancel", onCancel);
+    pressEnter(); // not open yet -> no-op
+    el.open();
+    pressEnter(); // resolves as "goto"
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onGoto).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("flips the reactive open flag to false on request-close", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(true);
+    baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-yaml-validation-dialog` — the save-time prompt shown when the backend rejects the current YAML (Cancel / Go to error / Save anyway) — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

Rendering `wa-dialog` directly meant this dialog missed the wrapper's shared behaviour: the title-ellipsis / close-button-clearance fix (#548), the busy light-dismiss gate, and the `wa-hide`/`wa-after-hide` wiring. `::part` only crosses one shadow boundary, so there's no global rule that reaches a dialog with its own `wa-dialog` — each one has to be migrated.

The conversion mirrors the already-migrated `esphome-confirm-dialog`: a state-driven `_open` flag bound with `?open`, a `request-close` handler that flips it, and `after-hide` for teardown plus the cancel-on-dismiss path. The public `open()` / `close()` methods and the `goto` / `save-anyway` / `cancel` events are unchanged, so the device-page consumer needs no edits.

`modalDialogStyles` already carries dual `wa-dialog::part(...)` + `esphome-base-dialog::part(...)` selectors for these migrations, so the body/header/title rules keep working; the now-dead `dialogCloseButtonStyles` import (the wrapper owns the close button) is dropped.

**Related issue or feature (if applicable):**

- part of #549 (next unchecked dialog in the list)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
