### PR TITLE
Migrate the unsaved-changes dialog onto esphome-base-dialog

### DIFF
--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -1,15 +1,15 @@
 import { consume } from "@lit/context";
 import { mdiAlertOutline, mdiContentSave } from "@mdi/js";
 import { LitElement, css, html } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "./base-dialog.js";
 
 registerMdiIcons({
   "alert-outline": mdiAlertOutline,
@@ -22,8 +22,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   @state()
   private _localize: LocalizeFunc = (key) => key;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
 
   private _resolved = false;
 
@@ -32,27 +31,38 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
 
   open() {
     this._resolved = false;
-    this._dialog.open = true;
+    this._open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._dialog.open = false;
+    this._open = false;
   }
+
+  // esphome-base-dialog never mutates its own open on a user-driven close
+  // (Escape / outside-click); the host owns flipping _open here, else a
+  // re-render re-asserts ?open and the dialog can't dismiss. Teardown +
+  // cancel-on-dismiss stay in _onAfterHide.
+  private _onRequestClose = (): void => {
+    this._open = false;
+  };
 
   static styles = [
     espHomeStyles,
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 460px;
       }
 
-      wa-dialog::part(header),
-      wa-dialog::part(footer) {
+      /* This prompt renders its own icon + heading in the body, so the
+         wrapper's title/close-button header isn't used — hide it (and the
+         unused footer). The shared close-button-clearance fix is moot here. */
+      esphome-base-dialog::part(header),
+      esphome-base-dialog::part(footer) {
         display: none;
       }
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0;
       }
 
@@ -157,7 +167,11 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog light-dismiss @wa-after-hide=${this._onAfterHide}>
+      <esphome-base-dialog
+        ?open=${this._open}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onAfterHide}
+      >
         <div class="body">
           <div class="icon-wrap">
             <wa-icon library="mdi" name="alert-outline"></wa-icon>
@@ -179,7 +193,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
             ${this._localize("device.save_and_leave")}
           </button>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -197,6 +211,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   }
 
   private _onAfterHide() {
+    this._open = false;
     this._enter.set(false);
     if (!this._resolved) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));

--- a/test/components/unsaved-changes-dialog.test.ts
+++ b/test/components/unsaved-changes-dialog.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the unsaved-changes prompt's behaviour after the migration onto
+ * esphome-base-dialog: Enter takes the primary "Save and leave" path (never
+ * Discard), the save latch fires once, and the reactive ?open /
+ * request-close / after-hide -> cancel contract holds (the page-leave guard
+ * depends on a definitive answer for every dismiss path).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeUnsavedChangesDialog } from "../../src/components/unsaved-changes-dialog.js";
+import { pressEnter } from "../_press-enter.js";
+
+async function mount(): Promise<ESPHomeUnsavedChangesDialog> {
+  const el = new ESPHomeUnsavedChangesDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const baseDialog = (el: ESPHomeUnsavedChangesDialog): HTMLElement =>
+  el.shadowRoot!.querySelector("esphome-base-dialog")!;
+
+describe("unsaved-changes-dialog ENTER", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("saves and leaves on Enter (never discards)", async () => {
+    const el = await mount();
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
+    el.addEventListener("save", onSave);
+    el.addEventListener("discard", onDiscard);
+    el.open();
+    pressEnter();
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
+  });
+
+  it("fires save only once on a repeated Enter", async () => {
+    const el = await mount();
+    const onSave = vi.fn();
+    el.addEventListener("save", onSave);
+    el.open();
+    pressEnter();
+    pressEnter();
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save before the dialog is opened", async () => {
+    const el = await mount();
+    const onSave = vi.fn();
+    el.addEventListener("save", onSave);
+    pressEnter();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});
+
+// The migration onto esphome-base-dialog introduced the reactive ?open binding,
+// the request-close handler, and the after-hide -> cancel path. Pin them so the
+// dismiss-cancels contract can't silently regress.
+describe("unsaved-changes-dialog dismiss / request-close", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("fires a single cancel when dismissed without a decision", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    const onCancel = vi.fn();
+    el.addEventListener("cancel", onCancel);
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire cancel after a decision (save)", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    el.addEventListener("save", onSave);
+    el.addEventListener("cancel", onCancel);
+    pressEnter(); // saves -> _resolved = true
+    baseDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("flips the reactive open flag to false on request-close", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(true);
+    baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-unsaved-changes-dialog` — the "you have unsaved changes" prompt (Cancel / Discard / Save and leave) shown by the page-leave guard in the device editor — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

Rendering `wa-dialog` directly meant this dialog missed the wrapper's shared behaviour: the busy light-dismiss gate, the `wa-hide`/`wa-after-hide` wiring (including the reopen fix), and mobile sizing. `::part` only crosses one shadow boundary, so there's no global rule that reaches a dialog with its own `wa-dialog`.

The conversion mirrors the already-migrated `esphome-confirm-dialog`: a state-driven `_open` flag bound with `?open`, a `request-close` handler that flips it, and `after-hide` for teardown plus the cancel-on-dismiss path. The public `open()` / `close()` methods and the `save` / `discard` / `cancel` events are unchanged, so the device-page consumer needs no edits.

Unlike the other migrated prompts, this one renders its own warning icon + heading in the body and has no header title, so the wrapper header (and the unused footer) stay hidden via `esphome-base-dialog::part(header){display:none}`. The look is unchanged — the title-ellipsis / close-button-clearance fix from #548 simply doesn't apply to a header-less dialog; the migration is for the other shared behaviour.

**Related issue or feature (if applicable):**

- part of #549 (next unchecked dialog in the list)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
