### PR TITLE
Show and expand pin mode scalar shorthand in the structured editor

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -8,9 +8,10 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { BoardPin } from "../../api/types/boards.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
-import { PinFeature, PinMode } from "../../api/types/config-entries.js";
+import { ConfigEntryType, PinFeature, PinMode } from "../../api/types/config-entries.js";
 import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.js";
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { expandPinModeShorthand } from "../../util/pin-mode.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -19,6 +20,8 @@ import {
   renderStringField,
   type RenderCtx,
 } from "./config-entry-renderers-shared.js";
+import { renderNestedField } from "./config-entry-renderers/nested.js";
+import { renderBooleanField } from "./config-entry-renderers/primitives.js";
 
 /**
  * Parse a pin reference into a GPIO number. Used both for the field's
@@ -323,9 +326,77 @@ function renderPinAdvanced(
       </button>
       ${isOpen
         ? html`<div class="pin-advanced-fields">
-            ${longFormFields.map((child) => ctx.renderEntry(child, [...path, child.key]))}
+            ${longFormFields.map((child) =>
+              child.key === "mode" &&
+              child.type === ConfigEntryType.NESTED &&
+              typeof ctx.getAt([...path, child.key]) === "string"
+                ? renderPinModeField(child, [...path, child.key], ctx)
+                : ctx.renderEntry(child, [...path, child.key])
+            )}
           </div>`
         : nothing}
     </div>
   `;
+}
+
+/**
+ * Render the pin ``mode`` group. A scalar shorthand (``mode: OUTPUT``)
+ * is expanded to its flag dict for display so the existing checkboxes
+ * reflect it; the YAML scalar is kept until the user toggles a flag,
+ * which writes the flag-object form. Object form and unrecognised
+ * shorthands fall through to the normal nested renderer.
+ */
+function renderPinModeField(
+  entry: ConfigEntry,
+  modePath: string[],
+  ctx: RenderCtx
+): unknown {
+  const raw = ctx.getAt(modePath);
+  const expanded = typeof raw === "string" ? expandPinModeShorthand(raw) : null;
+  if (!expanded) return renderNestedField(entry, modePath, ctx);
+  return renderNestedField(entry, modePath, pinModeDisplayCtx(ctx, modePath, expanded));
+}
+
+/** Wrap *ctx* so reads under *modePath* see *expanded* (a flag dict from a
+ *  scalar shorthand) and a flag-child write promotes the mode to the
+ *  flag-object form, replacing the scalar only on edit. */
+function pinModeDisplayCtx(
+  ctx: RenderCtx,
+  modePath: string[],
+  expanded: Record<string, boolean>
+): RenderCtx {
+  const modeKey = modePath.join(".");
+  const flagOf = (path: string[]): string | null =>
+    path.length === modePath.length + 1 &&
+    path.slice(0, modePath.length).join(".") === modeKey
+      ? path[modePath.length]
+      : null;
+  const wrapped: RenderCtx = {
+    ...ctx,
+    getAt: (path) => {
+      if (path.join(".") === modeKey) return expanded;
+      const flag = flagOf(path);
+      return flag !== null ? expanded[flag] : ctx.getAt(path);
+    },
+    scopeValues: (path) =>
+      path.join(".") === modeKey ? { ...expanded } : ctx.scopeValues(path),
+    emitChange: (path, value) => {
+      const flag = flagOf(path);
+      if (flag === null) {
+        ctx.emitChange(path, value);
+        return;
+      }
+      const next = { ...expanded };
+      if (value) next[flag] = true;
+      else delete next[flag];
+      ctx.emitChange(modePath, next);
+    },
+  };
+  // The mode children are booleans; render them through the wrapper so the
+  // checkboxes read/write the expanded flags.
+  wrapped.renderEntry = (child, path) =>
+    child.type === ConfigEntryType.BOOLEAN
+      ? renderBooleanField(child, path, wrapped)
+      : ctx.renderEntry(child, path);
+  return wrapped;
 }

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -114,7 +114,9 @@ function hasMaterialValue(entry: ConfigEntry, values: Record<string, unknown>): 
       if (value instanceof YamlRawValue) return true;
       return Array.isArray(value) && value.length > 0;
     }
-    if (!isPlainObject(value)) return false;
+    // A scalar at a NESTED key is a shorthand the user set in YAML (e.g.
+    // a pin ``mode: OUTPUT``); it's material even though it can't recurse.
+    if (!isPlainObject(value)) return value !== undefined;
     return (entry.config_entries ?? []).some((child) => hasMaterialValue(child, value));
   }
   return value !== undefined;
@@ -145,7 +147,11 @@ export function filterRenderable(
           asRecord(values[entry.key]),
           opts
         );
-        if (renderableChildren.length === 0) continue;
+        // Keep a group whose own value is a scalar shorthand (no child
+        // renders for it, but the user set it) so it stays visible.
+        if (renderableChildren.length === 0 && !hasMaterialValue(entry, values)) {
+          continue;
+        }
       }
     } else if (
       opts.requiredOnly &&

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -7,7 +7,9 @@ import {
   effectiveDisabled,
   fieldKeyAttr,
   labelFor,
+  renderFieldError,
   renderHelpLink,
+  renderLabel,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -32,6 +34,23 @@ function _enableStash(ctx: RenderCtx): Map<string, Record<string, unknown>> {
 // set tracks groups the user explicitly *collapsed*. Otherwise groups default
 // closed and the set tracks groups they *opened*.
 export function renderNestedField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
+  // A scalar at a NESTED key (an unmodellable shorthand the user set in
+  // YAML) renders read-only with its value, not as an empty flag group.
+  const raw = ctx.getAt(path);
+  if (
+    !entry.multi_value &&
+    (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean")
+  ) {
+    return html`
+      <div class="field" data-field-key=${fieldKeyAttr(path)}>
+        ${renderLabel(entry, ctx)}
+        <p class="field-description">
+          ${ctx.localize("device.value_set_in_yaml", { value: String(raw) })}
+        </p>
+        ${renderFieldError(path, ctx)}
+      </div>
+    `;
+  }
   const key = path.join(".");
   const inSet = ctx.nestedOpenSections.has(key);
   const isOpen = ctx.requiredOnly ? !inSet : inSet;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -659,6 +659,7 @@
     "multi_value_remove": "Remove",
     "multi_value_yaml_only": "This list contains YAML the visual editor can't model — edit it directly in the YAML pane on the right.",
     "value_yaml_only": "This value can't be modeled by the visual editor — edit it directly in the YAML pane on the right.",
+    "value_set_in_yaml": "Set to {value} in YAML; edit it in the YAML pane on the right.",
     "registry_list_loading": "Loading catalog…",
     "registry_list_select": "Select an option…",
     "registry_list_empty_catalog": "No options available for this registry.",

--- a/src/util/pin-mode.ts
+++ b/src/util/pin-mode.ts
@@ -1,0 +1,28 @@
+/**
+ * ESPHome GPIO pin `mode:` accepts both a flag object
+ * (`{output: true, pullup: true}`) and a scalar shorthand string
+ * (`OUTPUT`, `INPUT_PULLUP`, …). The shorthands are fixed,
+ * platform-independent presets of the same five flags, so they expand
+ * losslessly onto the catalog's flag checkboxes. Mirrors `PIN_MODES`
+ * in ESPHome's `esphome/pins.py` `_set_mode`.
+ */
+
+/** Scalar mode shorthands → their flag dict. Keys are upper-cased. */
+export const PIN_MODE_SHORTHANDS: Readonly<
+  Record<string, Readonly<Record<string, boolean>>>
+> = {
+  INPUT: { input: true },
+  OUTPUT: { output: true },
+  INPUT_PULLUP: { input: true, pullup: true },
+  OUTPUT_OPEN_DRAIN: { output: true, open_drain: true },
+  INPUT_PULLDOWN_16: { input: true, pulldown: true },
+  INPUT_PULLDOWN: { input: true, pulldown: true },
+  INPUT_OUTPUT_OPEN_DRAIN: { input: true, output: true, open_drain: true },
+};
+
+/** Expand a scalar pin-mode shorthand to its flag dict; null if unknown.
+ *  Case-insensitive (ESPHome matches on `mode.upper()`). */
+export function expandPinModeShorthand(value: string): Record<string, boolean> | null {
+  const flags = PIN_MODE_SHORTHANDS[value.toUpperCase()];
+  return flags ? { ...flags } : null;
+}

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -40,6 +40,42 @@ const pinEntry = () =>
     pin_features: [],
   });
 
+const flag = (key: string, label: string) =>
+  makeEntry(ConfigEntryType.BOOLEAN, { key, label, advanced: true });
+
+const modeChild = () =>
+  makeEntry(ConfigEntryType.NESTED, {
+    key: "mode",
+    label: "Mode",
+    advanced: true,
+    config_entries: [
+      flag("input", "Input"),
+      flag("output", "Output"),
+      flag("pullup", "Pullup"),
+    ],
+  });
+
+/** Pin entry carrying the long-form ``mode`` flag group, with the
+ *  Advanced disclosure and the Mode group pre-opened so the flag
+ *  switches render. */
+const longFormPinEntry = () =>
+  makeEntry(ConfigEntryType.PIN, {
+    key: "pin",
+    label: "Pin",
+    required: true,
+    pin_features: [],
+    config_entries: [modeChild()],
+  });
+
+const openModeCtx = (pin: unknown) =>
+  makeRenderCtx(
+    { pin },
+    { overrides: { nestedOpenSections: new Set(["pin:pin-advanced", "pin.mode"]) } }
+  );
+
+const switchByLabel = (result: unknown, label: string) =>
+  findElementBindings(result, "wa-switch").find((b) => b["aria-label"] === label);
+
 describe("renderPinField — long-form pin block selection", () => {
   it("marks the GPIO33 option ?selected=true when the YAML uses { number: 'GPIO33', ... }", () => {
     const ctx = makeRenderCtx({
@@ -102,5 +138,42 @@ describe("renderPinField — long-form pin block selection", () => {
       (o) => o["?selected"] === true
     );
     expect(selected.length).toBe(0);
+  });
+});
+
+describe("renderPinField — mode scalar shorthand expansion", () => {
+  it("ticks the matching flag checkbox for a scalar shorthand (mode: OUTPUT)", () => {
+    const ctx = openModeCtx({ number: 0, mode: "OUTPUT" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Output")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Input")?.["?checked"]).toBe(false);
+    expect(switchByLabel(result, "Pullup")?.["?checked"]).toBe(false);
+  });
+
+  it("promotes the scalar to the flag-object form when a flag is toggled", () => {
+    const ctx = openModeCtx({ number: 0, mode: "OUTPUT" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    const onChange = switchByLabel(result, "Pullup")?.["@change"] as (e: unknown) => void;
+    onChange({ target: { checked: true } });
+
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "mode"], {
+      output: true,
+      pullup: true,
+    });
+  });
+
+  it("does not emit a change just from rendering (YAML scalar preserved)", () => {
+    const ctx = openModeCtx({ number: 0, mode: "OUTPUT" });
+    renderPinField(longFormPinEntry(), ["pin"], ctx);
+    expect(ctx.emitChange).not.toHaveBeenCalled();
+  });
+
+  it("renders a read-only notice for an unknown shorthand (mode: BOGUS)", () => {
+    const ctx = openModeCtx({ number: 0, mode: "BOGUS" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+    // No flag switches; the value falls through to the scalar notice.
+    expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
   });
 });

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -151,6 +151,15 @@ describe("renderPinField — mode scalar shorthand expansion", () => {
     expect(switchByLabel(result, "Pullup")?.["?checked"]).toBe(false);
   });
 
+  it("ticks both flags of a compound shorthand (mode: INPUT_PULLUP)", () => {
+    const ctx = openModeCtx({ number: "GPIO33", mode: "INPUT_PULLUP" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Input")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Pullup")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Output")?.["?checked"]).toBe(false);
+  });
+
   it("promotes the scalar to the flag-object form when a flag is toggled", () => {
     const ctx = openModeCtx({ number: 0, mode: "OUTPUT" });
     const result = renderPinField(longFormPinEntry(), ["pin"], ctx);

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -693,3 +693,45 @@ describe("collectRenderablePaths", () => {
     expect([...paths]).toEqual(["devices"]);
   });
 });
+
+describe("filterRenderable — NESTED with a scalar value", () => {
+  const modeEntry = () =>
+    makeEntry({
+      key: "mode",
+      type: ConfigEntryType.NESTED,
+      advanced: true,
+      config_entries: [
+        makeEntry({ key: "output", type: ConfigEntryType.BOOLEAN, advanced: true }),
+      ],
+    });
+
+  it("keeps an advanced NESTED entry whose value is a scalar shorthand", () => {
+    // pin ``mode: OUTPUT`` — the value is a string, not an object, and
+    // no child renders for it, but the user set it, so it stays visible
+    // without the Show advanced toggle.
+    const out = filterRenderable(
+      [modeEntry()],
+      { mode: "OUTPUT" },
+      { requiredOnly: false, showAdvanced: false }
+    );
+    expect(out.map((e) => e.key)).toEqual(["mode"]);
+  });
+
+  it("still drops an advanced NESTED entry with no value and no children", () => {
+    const out = filterRenderable(
+      [modeEntry()],
+      {},
+      { requiredOnly: false, showAdvanced: false }
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("keeps an object-form NESTED entry with a filled child (unchanged)", () => {
+    const out = filterRenderable(
+      [modeEntry()],
+      { mode: { output: true } },
+      { requiredOnly: false, showAdvanced: false }
+    );
+    expect(out.map((e) => e.key)).toEqual(["mode"]);
+  });
+});

--- a/test/components/device/render-nested-field-scalar-notice.test.ts
+++ b/test/components/device/render-nested-field-scalar-notice.test.ts
@@ -1,0 +1,36 @@
+/**
+ * A scalar at a NESTED key (a shorthand the visual editor can't model
+ * with its flag group, e.g. a pin ``mode: OUTPUT``) renders as a
+ * read-only notice showing the value, not an empty collapsible group.
+ */
+import { describe, expect, it } from "vitest";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderNestedField } from "../../../src/components/device/config-entry-renderers.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
+
+const modeEntry = () =>
+  makeConfigEntry({
+    key: "mode",
+    type: ConfigEntryType.NESTED,
+    config_entries: [makeConfigEntry({ key: "output", type: ConfigEntryType.BOOLEAN })],
+  });
+
+describe("renderNestedField — scalar value", () => {
+  it("renders a read-only notice (no collapsible group) for a scalar", () => {
+    const tpl = renderNestedField(
+      modeEntry(),
+      ["mode"],
+      makeRenderCtx({ mode: "OUTPUT" })
+    );
+    expect(findTemplatesByAnchor(tpl, "field-description")).not.toHaveLength(0);
+    expect(findTemplatesByAnchor(tpl, "nested-toggle")).toHaveLength(0);
+  });
+
+  it("renders the normal collapsible group for an object value", () => {
+    const tpl = renderNestedField(modeEntry(), ["mode"], makeRenderCtx({ mode: {} }));
+    expect(findTemplatesByAnchor(tpl, "nested-toggle")).not.toHaveLength(0);
+    expect(findTemplatesByAnchor(tpl, "field-description")).toHaveLength(0);
+  });
+});

--- a/test/util/pin-mode.test.ts
+++ b/test/util/pin-mode.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { expandPinModeShorthand, PIN_MODE_SHORTHANDS } from "../../src/util/pin-mode.js";
+
+describe("expandPinModeShorthand", () => {
+  it("expands every shorthand to its documented flag dict", () => {
+    expect(expandPinModeShorthand("INPUT")).toEqual({ input: true });
+    expect(expandPinModeShorthand("OUTPUT")).toEqual({ output: true });
+    expect(expandPinModeShorthand("INPUT_PULLUP")).toEqual({
+      input: true,
+      pullup: true,
+    });
+    expect(expandPinModeShorthand("OUTPUT_OPEN_DRAIN")).toEqual({
+      output: true,
+      open_drain: true,
+    });
+    expect(expandPinModeShorthand("INPUT_PULLDOWN")).toEqual({
+      input: true,
+      pulldown: true,
+    });
+    expect(expandPinModeShorthand("INPUT_PULLDOWN_16")).toEqual({
+      input: true,
+      pulldown: true,
+    });
+    expect(expandPinModeShorthand("INPUT_OUTPUT_OPEN_DRAIN")).toEqual({
+      input: true,
+      output: true,
+      open_drain: true,
+    });
+  });
+
+  it("matches case-insensitively (ESPHome upper-cases first)", () => {
+    expect(expandPinModeShorthand("output")).toEqual({ output: true });
+    expect(expandPinModeShorthand("Input_Pullup")).toEqual({
+      input: true,
+      pullup: true,
+    });
+  });
+
+  it("returns null for an unknown shorthand", () => {
+    expect(expandPinModeShorthand("BOGUS")).toBeNull();
+    expect(expandPinModeShorthand("")).toBeNull();
+  });
+
+  it("returns a fresh object that doesn't alias the shared table", () => {
+    const a = expandPinModeShorthand("OUTPUT")!;
+    a.pullup = true;
+    expect(PIN_MODE_SHORTHANDS.OUTPUT).toEqual({ output: true });
+    expect(expandPinModeShorthand("OUTPUT")).toEqual({ output: true });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A pin written in long form with a scalar **mode shorthand** (`mode: OUTPUT`) was mishandled in the structured editor: it read as "no value set", so the advanced gate dropped it, the pin **Advanced** disclosure disappeared entirely, and forcing it visible via "Show advanced" painted an empty **Mode** group that didn't reflect `OUTPUT`.

The mode shorthands (`OUTPUT`, `INPUT_PULLUP`, …) are fixed, platform-independent presets of the same five flags the catalog already models (`input`/`output`/`pullup`/`pulldown`/`open_drain`), per ESPHome's `_set_mode` / `PIN_MODES`. So `mode: OUTPUT` is exactly `mode: {output: true}` and the existing flag checkboxes can model it.

Changes:

- Treat a defined scalar at a NESTED key as a material value, so it stays visible without "Show advanced", and keep such a group even when no child renders for it (`config-entry-render-filter.ts`).
- Expand a known mode shorthand to its flags for display so the checkboxes reflect it; the YAML scalar is preserved until the user toggles a flag, which writes the flag-object form (`config-entry-pin-renderer.ts`, new `src/util/pin-mode.ts`).
- For an unknown shorthand, or any other NESTED scalar, render a read-only "edit in YAML" notice showing the value instead of an empty group (`config-entry-renderers/nested.ts`).

Verified in the browser: with `mode: OUTPUT`, the pin Advanced disclosure opens, the Mode group shows **Output** toggled on, and the YAML still reads `OUTPUT` until a flag is changed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/579

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
