### PR TITLE
Run the leave guard before the header back arrow pops history

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -12,7 +12,7 @@ import {
 import { MOBILE_BREAKPOINT } from "../styles/breakpoints.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { stripBase, withBase } from "../util/base-path.js";
-import { navigate } from "../util/navigation.js";
+import { navigate, runLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
@@ -288,7 +288,7 @@ export class ESPHomeLayout extends LitElement {
     `,
   ];
 
-  private _goHome() {
+  private async _goHome() {
     // Prefer popping the history stack so the previous URL — and
     // therefore the dashboard's filter / search state encoded in
     // its query string — is restored verbatim. ``history.state`` is
@@ -298,6 +298,11 @@ export class ESPHomeLayout extends LitElement {
     // pop and we fall back to ``navigate("/")`` to stay inside the
     // SPA instead of exiting to the previous site.
     if (window.history.state !== null && typeof window.history.state === "object") {
+      // history.back() fires a raw popstate the router commits (unmounting the
+      // page) before the device editor's popstate guard can veto it, so honour
+      // the leave guard here — same gate navigate() applies. navigate("/") runs
+      // the guard itself, so the fallback isn't double-prompted.
+      if (!(await runLeaveGuard())) return;
       window.history.back();
       return;
     }

--- a/src/util/navigation.ts
+++ b/src/util/navigation.ts
@@ -9,10 +9,18 @@ export function setLeaveGuard(guard: LeaveGuard | null): void {
 }
 
 export async function navigate(url: string): Promise<void> {
-  if (activeGuard) {
-    const canLeave = await activeGuard();
-    if (!canLeave) return;
-  }
+  if (!(await runLeaveGuard())) return;
   window.history.pushState({}, "", withBase(url));
   window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+/**
+ * Run the active page-leave guard. Resolves ``true`` when it's safe to leave
+ * (no guard, or the guard resolved "proceed"). Used by ``navigate`` and by
+ * back-navigations that bypass it but still must honour the guard — the header
+ * back arrow's ``history.back()``, whose raw popstate the router commits before
+ * the device editor's own popstate guard can veto it.
+ */
+export async function runLeaveGuard(): Promise<boolean> {
+  return activeGuard ? activeGuard() : true;
 }

--- a/test/components/esphome-layout-back-button.test.ts
+++ b/test/components/esphome-layout-back-button.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { ESPHomeLayout } from "../../src/components/esphome-layout.js";
+import { setLeaveGuard } from "../../src/util/navigation.js";
 
 interface LayoutPrivateView {
   _path: string;
   readonly _showBack: boolean;
+  _goHome: () => Promise<void>;
 }
 
 function makeLayout(path: string): LayoutPrivateView {
@@ -23,5 +25,45 @@ describe("esphome-layout header back button visibility", () => {
   test("shown inside a device editor and other non-root routes", () => {
     expect(makeLayout("/device/living-room")._showBack).toBe(true);
     expect(makeLayout("/secrets")._showBack).toBe(true);
+  });
+});
+
+// The header back arrow pops history via history.back(), whose raw popstate the
+// router commits before the device editor's popstate guard can veto it. _goHome
+// therefore runs the active leave guard up front (like navigate() does) and
+// only pops when it resolves "proceed". Pin that gate so a dirty editor can't
+// be navigated away from without the prompt.
+describe("esphome-layout back arrow leave guard", () => {
+  afterEach(() => {
+    setLeaveGuard(null);
+    vi.restoreAllMocks();
+  });
+
+  test("pops history when no guard vetoes", async () => {
+    // history.state is an object (set by pushState) → the history.back() branch.
+    window.history.pushState({}, "", "/device/x");
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    await makeLayout("/device/x")._goHome();
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  test("does NOT pop history when the leave guard resolves false", async () => {
+    window.history.pushState({}, "", "/device/x");
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const guard = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(guard);
+    await makeLayout("/device/x")._goHome();
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  test("pops history when the leave guard resolves true", async () => {
+    window.history.pushState({}, "", "/device/x");
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+    await makeLayout("/device/x")._goHome();
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(back).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/util/navigation.test.ts
+++ b/test/util/navigation.test.ts
@@ -31,7 +31,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { navigate, setLeaveGuard } from "../../src/util/navigation.js";
+import { navigate, runLeaveGuard, setLeaveGuard } from "../../src/util/navigation.js";
 
 /* The vitest config runs in the ``node`` environment, which has
  * no ``window``. ``navigation.ts`` reaches for ``window.history``
@@ -183,5 +183,64 @@ describe("navigate", () => {
     await navPromise;
 
     expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/dashboard");
+  });
+});
+
+/**
+ * ``runLeaveGuard`` is the guard-only gate for back-navigations that bypass
+ * ``navigate()`` but must still honour the leave guard — the header back
+ * arrow's ``history.back()``, whose raw popstate the router commits before the
+ * device editor's own popstate guard can veto it. It must mirror the gating
+ * half of ``navigate()`` without touching history.
+ */
+describe("runLeaveGuard", () => {
+  afterEach(() => {
+    setLeaveGuard(null);
+  });
+
+  it("resolves true when no guard is registered", async () => {
+    await expect(runLeaveGuard()).resolves.toBe(true);
+  });
+
+  it("returns the guard's result (true → proceed)", async () => {
+    const guard = vi.fn(() => Promise.resolve(true));
+    setLeaveGuard(guard);
+    await expect(runLeaveGuard()).resolves.toBe(true);
+    expect(guard).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the guard's result (false → block) and calls it once", async () => {
+    const guard = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(guard);
+    await expect(runLeaveGuard()).resolves.toBe(false);
+    expect(guard).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits an asynchronous guard (dialog resolves after a microtask)", async () => {
+    let resolveGuard: ((v: boolean) => void) | undefined;
+    const guard = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveGuard = resolve;
+        })
+    );
+    setLeaveGuard(guard);
+
+    let settled: boolean | undefined;
+    const p = runLeaveGuard().then((v) => (settled = v));
+    await Promise.resolve();
+    expect(settled).toBeUndefined(); // still pending until the user chooses
+
+    resolveGuard?.(false);
+    await p;
+    expect(settled).toBe(false);
+  });
+
+  it("uses the latest registered guard and ignores a cleared one", async () => {
+    const stale = vi.fn(() => Promise.resolve(false));
+    setLeaveGuard(stale);
+    setLeaveGuard(null);
+    await expect(runLeaveGuard()).resolves.toBe(true);
+    expect(stale).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Fixes the device editor's **header back arrow (and logo) discarding unsaved YAML changes with no "Unsaved changes" prompt**.

### Root cause

The back arrow / logo pop history via `history.back()` when the current entry has SPA state (so the previous URL — and the dashboard's encoded filter/search state — is restored verbatim). `history.back()` fires a raw `popstate`, and the app's router (`@lit-labs/router`, created in `app-shell` and registered the moment app-shell mounts — before any page) handles it **first**: it re-renders the outlet to the new route, unmounting the device editor. The editor's `disconnectedCallback` then removes its own `popstate` guard *before that guard is ever invoked*, so the back-navigation sails through and the unsaved buffer is lost.

The editor's guard uses `window.addEventListener("popstate", …, { capture: true })` in an attempt to run first, but that can't win: for an event whose target is `window`, listeners fire in **registration order at AT_TARGET regardless of the `capture` flag**, and the parent router registers before the child page. (Confirmed by driving the real back arrow with Puppeteer: the device page's `disconnectedCallback` fires before its popstate listener could run.)

`navigate()` (in-app links, command palette) is unaffected — it `await`s the registered leave guard *before* touching history. Only the raw `history.back()` path relied on the broken popstate interception.

### Fix

Gate the back arrow the same way `navigate()` gates forward navigation: run the active leave guard up front. `_goHome` now `await`s a new `runLeaveGuard()` helper (exported from `util/navigation.ts`) before calling `history.back()`, and bails when the user picks Cancel. The `navigate("/")` fallback branch already runs the guard itself, so it isn't double-prompted.

Verified end-to-end with Puppeteer: dirty buffer + real back-arrow click now shows the prompt and keeps the editor mounted; **Discard** then navigates away; a non-dirty buffer still navigates immediately (no regression).

**Note / out of scope:** the browser's *native* Back button hits the same router race and is a separate, larger fix (the page-leave popstate guard in `device.ts` is what was meant to cover it). This PR fixes the in-app back arrow / logo reported by the user.

**Related issue or feature (if applicable):**

- n/a (found during manual QA of the dialog-migration work, #549)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
