### PR TITLE
Reuse refocusSearchInput in _clearSearch

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -69,6 +69,7 @@ import { renderYamlMode } from "../components/dashboard/render-yaml.js";
 import {
   maybeFireEmptyStatePreview,
   onSearchKeyDown,
+  refocusSearchInput,
   setSearchMode,
   syncYamlSearch,
 } from "../components/dashboard/search.js";
@@ -584,7 +585,7 @@ export class ESPHomePageDashboard extends LitElement {
   _clearSearch = () => {
     this._search = "";
     this._syncYamlSearch();
-    this._searchInputEl?.focus();
+    refocusSearchInput(this);
   };
 
   /** Wipe search + every facet selection in one shot. Wired to the


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the Kōan review on #576: `_clearSearch` focused the input
directly via `this._searchInputEl?.focus()` instead of the existing
`refocusSearchInput(host)` helper. The helper wraps the focus in
`requestAnimationFrame` and also reaches into the `<wa-input>` shadow root
for the inner `<input>`, so reusing it both matches the established pattern
(`setSearchMode` already calls it) and stays correct if the input element
is ever made conditional.

No behaviour change for the current render — the `.search-input` is always
present, so the synchronous focus already landed; this just routes through
the shared helper.

**Related issue or feature (if applicable):**

- Addresses the suggestion in https://github.com/esphome/device-builder-frontend/pull/576#issuecomment-4613930871

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
