### PR TITLE
Remove dead empty-string branch in actionFieldLabel

### DIFF
--- a/src/util/action-field-label.ts
+++ b/src/util/action-field-label.ts
@@ -14,7 +14,10 @@ import type { LocalizeFunc } from "../common/localize.js";
  */
 export function actionFieldLabel(field: string, localize: LocalizeFunc): string {
   const base = field.endsWith("_action") ? field.slice(0, -"_action".length) : field;
-  const words = base.replace(/_/g, " ").trim() || field;
-  const name = words ? words[0].toUpperCase() + words.slice(1) : words;
+  // ``|| "action"`` keeps ``words`` non-empty (a bare ``_action`` key the
+  // parser can't actually produce, or an empty field), so the
+  // sentence-case below is always safe — no dead empty-string branch.
+  const words = (base || field).replace(/_/g, " ").trim() || "action";
+  const name = words[0].toUpperCase() + words.slice(1);
   return localize("device.action_field_label", { name });
 }

--- a/test/util/action-field-label.test.ts
+++ b/test/util/action-field-label.test.ts
@@ -31,4 +31,10 @@ describe("actionFieldLabel", () => {
   it("handles a key without the suffix", () => {
     expect(actionFieldLabel("sequence", localize)).toBe("Sequence action");
   });
+
+  it("falls back without throwing on an empty field", () => {
+    // Not reachable from the call sites (the parser only passes matched
+    // `*_action` keys), but the util must not crash if reused.
+    expect(actionFieldLabel("", localize)).toBe("Action action");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #580. A late Kōan review flagged a dead branch in `actionFieldLabel`: the `words ? … : words` ternary could never take the false branch, since `words` was `… || field` and `field` is always a non-empty `*_action` key at the call sites. It read as if an empty case was handled when it wasn't.

This collapses it to a guaranteed-non-empty `words` (falling back to "action") and drops the ternary, so the sentence-case is always safe and there's no misleading dead code. Added a test for the unreachable empty-field path so the fallback is pinned.

**Related issue or feature (if applicable):**

- Follow-up to #580

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
