### PR TITLE
Migrate the create-config wizard onto esphome-base-dialog

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -83,6 +83,9 @@ import { centeredMobileDialog } from "../styles/dialog-mobile.js";
  *   dialogs that do use a pinned footer row (e.g. the onboarding
  *   wizard). Only forwarded when a consumer fills it, so footer-less
  *   dialogs render unchanged (see ``willUpdate``).
+ * - ``header-prefix`` slot: inline content before the title
+ *   (e.g. a wizard back button). Empty by default. Symmetric
+ *   with ``header-suffix``.
  * - ``header-suffix`` slot: inline content after the title
  *   (e.g. a status chip). Empty by default, so other dialogs
  *   are unchanged. The row and title are exposed as the
@@ -196,7 +199,8 @@ export class ESPHomeBaseDialog extends LitElement {
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label" part="label-row">
-          <span part="title-text">${this.label}</span><slot name="header-suffix"></slot>
+          <slot name="header-prefix"></slot><span part="title-text">${this.label}</span
+          ><slot name="header-suffix"></slot>
         </header>
         <slot></slot>
         ${this._hasFooter ? html`<slot name="footer" slot="footer"></slot>` : nothing}

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -254,6 +254,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
       <esphome-base-dialog
         class=${this._step === "board" ? "wide" : ""}
         ?open=${this._open}
+        ?busy=${this._submitting}
         .label=${this._title}
         @request-close=${this._onRequestClose}
         @after-hide=${this._onHide}
@@ -263,7 +264,13 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         @import-file=${this._onImportFile}
       >
         ${this._step !== "method"
-          ? html`<button slot="header-prefix" class="back-button" @click=${this._onBack}>
+          ? html`<button
+              slot="header-prefix"
+              class="back-button"
+              title=${this._localize("layout.back")}
+              aria-label=${this._localize("layout.back")}
+              @click=${this._onBack}
+            >
               <wa-icon library="mdi" name="arrow-left"></wa-icon>
             </button>`
           : nothing}

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
@@ -15,8 +15,8 @@ import { markPendingHighlight } from "../../util/pending-highlight.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { safeUploadFilename } from "../../util/safe-upload-filename.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "../base-dialog.js";
 import "./wizard-step-board.js";
 import "./wizard-step-empty-config.js";
 import "./wizard-step-method.js";
@@ -88,25 +88,22 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   @state()
   private _createError = "";
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
-
   static styles = [
     espHomeStyles,
-    fullscreenMobileDialog("wa-dialog"),
+    fullscreenMobileDialog("esphome-base-dialog"),
     css`
-      wa-dialog {
+      esphome-base-dialog {
         --width: 520px;
       }
 
-      wa-dialog.wide {
+      esphome-base-dialog.wide {
         --width: 750px;
       }
 
       /* Mobile full-screen comes from fullscreenMobileDialog in the static
          styles so the board picker isn't boxed into a 520px column. #41 */
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         background: var(--esphome-primary);
         /* Right padding is 0 so the close button sits flush with the
            dialog's corner — the button is explicitly sized to a 40x40
@@ -117,16 +114,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         box-sizing: border-box;
       }
 
-      wa-dialog::part(title) {
-        color: var(--esphome-on-primary);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-      }
-
-      .dialog-label {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-xs);
+      /* Title text lives in base-dialog's title-text span; colour/weight
+         cascade in from the forwarded title part. */
+      esphome-base-dialog::part(title) {
         color: var(--esphome-on-primary);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
@@ -149,7 +139,7 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         opacity: 1;
       }
 
-      wa-dialog::part(close-button__base) {
+      esphome-base-dialog::part(close-button__base) {
         background: transparent;
         border: none;
         box-shadow: none;
@@ -165,12 +155,8 @@ export class ESPHomeCreateConfigDialog extends LitElement {
         cursor: pointer;
       }
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);
-      }
-
-      wa-dialog::part(footer) {
-        display: none;
       }
 
       .error {
@@ -219,7 +205,6 @@ export class ESPHomeCreateConfigDialog extends LitElement {
     this._importFile = null;
     this._submitting = false;
     this._resetCreateErrors();
-    this._dialog.open = true;
     this._open = true;
   }
 
@@ -235,13 +220,19 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   }
 
   public close() {
-    this._dialog.open = false;
+    this._open = false;
   }
 
-  // wa-dialog only hides on light-dismiss / Escape / close; the step
-  // components stay mounted, so flip _open to drop their Enter listeners.
-  private _onHide = (e: Event) => {
-    if (e.target !== this._dialog) return; // ignore bubbled child wa-* hides
+  // esphome-base-dialog never flips its own open on a user-driven close
+  // (Escape / X / outside-click); the host owns _open, else a re-render
+  // re-asserts ?open and the dialog can't dismiss.
+  private _onRequestClose = () => {
+    this._open = false;
+  };
+
+  // The step components stay mounted while the dialog is merely hidden, so
+  // drop their Enter listeners once it has fully hidden.
+  private _onHide = () => {
     this._open = false;
   };
 
@@ -260,27 +251,26 @@ export class ESPHomeCreateConfigDialog extends LitElement {
 
   protected render() {
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         class=${this._step === "board" ? "wide" : ""}
-        light-dismiss
-        @wa-after-hide=${this._onHide}
+        ?open=${this._open}
+        .label=${this._title}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onHide}
         @next-step=${this._onNextStep}
         @finish-setup=${this._onFinishSetup}
         @create-empty-config=${this._onCreateEmptyConfig}
         @import-file=${this._onImportFile}
       >
-        <span slot="label" class="dialog-label">
-          ${this._step !== "method"
-            ? html`<button class="back-button" @click=${this._onBack}>
-                <wa-icon library="mdi" name="arrow-left"></wa-icon>
-              </button>`
-            : nothing}
-          ${this._title}
-        </span>
+        ${this._step !== "method"
+          ? html`<button slot="header-prefix" class="back-button" @click=${this._onBack}>
+              <wa-icon library="mdi" name="arrow-left"></wa-icon>
+            </button>`
+          : nothing}
         ${this._renderStep()}
         ${this._importError ? html`<p class="error">${this._importError}</p>` : nothing}
         ${this._createError ? html`<p class="error">${this._createError}</p>` : nothing}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 

--- a/test/components/base-dialog-header-prefix.test.ts
+++ b/test/components/base-dialog-header-prefix.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test } from "vitest";
+
+// Stub the real wa-dialog (happy-dom can't run its form-associated close
+// button); these tests only exercise the wrapper's own header markup.
+import { vi } from "vitest";
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+
+/**
+ * Regression coverage for the ``header-prefix`` slot added so the
+ * create-config wizard can render a back button to the LEFT of the title
+ * (#549). Pins that the slot renders before the title and stays an empty
+ * no-op when a consumer doesn't fill it, so a future header refactor can't
+ * silently drop it or reorder it past the title.
+ */
+async function mount(prefix?: string): Promise<ESPHomeBaseDialog> {
+  const el = new ESPHomeBaseDialog();
+  el.label = "Title";
+  if (prefix) el.innerHTML = prefix;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("esphome-base-dialog header-prefix slot", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders the prefix slot before the title", async () => {
+    const el = await mount();
+    const prefix = el.shadowRoot!.querySelector('slot[name="header-prefix"]')!;
+    const title = el.shadowRoot!.querySelector('[part="title-text"]')!;
+    expect(prefix).toBeTruthy();
+    // title must come AFTER the prefix slot in the header.
+    expect(
+      prefix.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  test("is empty by default (no slotted content)", async () => {
+    const el = await mount();
+    const prefix = el.shadowRoot!.querySelector(
+      'slot[name="header-prefix"]'
+    ) as HTMLSlotElement;
+    expect(prefix.assignedElements()).toHaveLength(0);
+  });
+
+  test("accepts slotted content (e.g. a wizard back button)", async () => {
+    const el = await mount('<button slot="header-prefix" class="back">x</button>');
+    const prefix = el.shadowRoot!.querySelector(
+      'slot[name="header-prefix"]'
+    ) as HTMLSlotElement;
+    const assigned = prefix.assignedElements();
+    expect(assigned).toHaveLength(1);
+    expect(assigned[0].classList.contains("back")).toBe(true);
+  });
+});

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -39,10 +39,10 @@ async function mount(api: Partial<ESPHomeAPI>): Promise<ESPHomeCreateConfigDialo
   return el;
 }
 
-// The parent listens for create-empty-config on its wa-dialog; emit it the
-// way a wizard step would (bubbling, composed).
+// The parent listens for create-empty-config on its esphome-base-dialog; emit
+// it the way a wizard step would (bubbling, composed).
 function emitCreate(el: ESPHomeCreateConfigDialog, name: string): void {
-  const wd = el.shadowRoot!.querySelector("wa-dialog")!;
+  const wd = el.shadowRoot!.querySelector("esphome-base-dialog")!;
   wd.dispatchEvent(
     new CustomEvent("create-empty-config", {
       detail: { name },
@@ -54,7 +54,7 @@ function emitCreate(el: ESPHomeCreateConfigDialog, name: string): void {
 
 // Same shape for the basic-setup flow (board + WiFi + name).
 function emitFinish(el: ESPHomeCreateConfigDialog, name: string): void {
-  const wd = el.shadowRoot!.querySelector("wa-dialog")!;
+  const wd = el.shadowRoot!.querySelector("esphome-base-dialog")!;
   wd.dispatchEvent(
     new CustomEvent("finish-setup", {
       detail: { board: { id: "esp32dev" }, name, wifiSsid: "net", wifiPassword: "pw" },

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -132,3 +132,42 @@ describe("create-config-dialog create de-dupe + retry", () => {
     );
   });
 });
+
+// The migration onto esphome-base-dialog swapped the imperative
+// `_dialog.open = …` for a reactive `_open` flag. _onRequestClose flipping
+// _open back to false is the load-bearing part — without it a user-driven
+// close (Escape / X / outside-click) wouldn't dismiss. Pin the contract.
+describe("create-config-dialog open/close contract", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const isOpen = (el: ESPHomeCreateConfigDialog): boolean =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._open;
+
+  it("open() and openAtBoardStep() set the reactive open flag", async () => {
+    const el = await mount({});
+    expect(isOpen(el)).toBe(true);
+    el.close();
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(false);
+    el.openAtBoardStep();
+    expect(isOpen(el)).toBe(true);
+  });
+
+  it("flips _open to false on request-close from the wrapper", async () => {
+    const el = await mount({});
+    expect(isOpen(el)).toBe(true);
+    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
+      new CustomEvent("request-close")
+    );
+    expect(isOpen(el)).toBe(false);
+  });
+
+  it("close() sets _open to false", async () => {
+    const el = await mount({});
+    el.close();
+    expect(isOpen(el)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-create-config-dialog` — the new-device wizard (method → board → setup / empty-config / import) — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

Rendering `wa-dialog` directly meant the wizard missed the wrapper's shared behaviour: the busy/light-dismiss gate, the `wa-hide`/`wa-after-hide` wiring (incl. the reopen fix), and the title-ellipsis / close-button-clearance fix (#548).

The conversion uses the established reactive pattern: a state-driven `_open` flag (the dialog already tracked `_open` for the steps' Enter listeners — it's now the single source of truth), a `request-close` handler, and `after-hide` teardown. The public `open()` / `openWithBoard()` / `openAtBoardStep()` methods and the child-step events (`next-step`, `finish-setup`, `create-empty-config`, `import-file`) are unchanged, so the dashboard consumer needs no edits.

### New: `header-prefix` slot on `esphome-base-dialog`

Unlike the other migrated dialogs, the wizard renders a **back arrow to the left of the title** inside the header. The wrapper only had a `header-suffix` slot (content *after* the title), so I added a `header-prefix` slot (symmetric, rendered before the title). It's **empty by default**, so the ~8 already-migrated dialogs are unaffected; only the wizard fills it. The primary-colored header, 40×40 close button, wide (750px) board step, and fullscreen-on-mobile all carry over via the forwarded `::part`s.

Verified in the browser: header look unchanged (blue bar, white title + close X), back arrow appears on non-first steps and steps back correctly, board step is wider, close/Escape/outside-click + reopen all work, and the create flows still land in the device editor.

**Related issue or feature (if applicable):**

- part of #549 (next unchecked dialog in the list)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
