### PR TITLE
Scope long-form pin Mode flags to the pin's provider

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1381,9 +1381,11 @@ export class ESPHomeAPI {
     }
     const result: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(raw)) {
-      if (typeof key === "string" && Array.isArray(value)) {
-        result[key] = value.filter((m): m is string => typeof m === "string");
-      }
+      if (typeof key !== "string" || !Array.isArray(value)) continue;
+      const flags = value.filter((m): m is string => typeof m === "string");
+      // Omit empty-after-filter providers; an empty allow-list would scope the
+      // Mode group to zero checkboxes instead of falling back to show-all.
+      if (flags.length > 0) result[key] = flags;
     }
     return result;
   }

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1364,15 +1364,10 @@ export class ESPHomeAPI {
   }
 
   /**
-   * Map of external pin provider → the long-form `mode` flags it allows
-   * (`pca9554` → `["input", "output"]`). The visual editor scopes the pin
-   * Mode checkboxes against this; a provider absent from the map (or a native
-   * pin, which carries no provider key) shows every flag. Fetched once per
-   * session — the dataset only refreshes with a backend release.
-   *
-   * The WS layer doesn't enforce a shape, so the payload is filtered to the
-   * `{string: string[]}` contract here: a non-object becomes `{}`, and any
-   * non-string flag inside a value array is dropped.
+   * Map of external pin provider → allowed long-form `mode` flags
+   * (`pca9554` → `["input", "output"]`), fetched once per session. Filtered to
+   * the `{string: string[]}` contract: non-object → `{}`, non-string flags
+   * dropped, empty providers omitted.
    */
   async getPinRegistryModes(): Promise<Record<string, string[]>> {
     const raw = await this.sendCommand<unknown>("components/get_pin_registry_modes");

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1363,6 +1363,31 @@ export class ESPHomeAPI {
     return result;
   }
 
+  /**
+   * Map of external pin provider → the long-form `mode` flags it allows
+   * (`pca9554` → `["input", "output"]`). The visual editor scopes the pin
+   * Mode checkboxes against this; a provider absent from the map (or a native
+   * pin, which carries no provider key) shows every flag. Fetched once per
+   * session — the dataset only refreshes with a backend release.
+   *
+   * The WS layer doesn't enforce a shape, so the payload is filtered to the
+   * `{string: string[]}` contract here: a non-object becomes `{}`, and any
+   * non-string flag inside a value array is dropped.
+   */
+  async getPinRegistryModes(): Promise<Record<string, string[]>> {
+    const raw = await this.sendCommand<unknown>("components/get_pin_registry_modes");
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      return {};
+    }
+    const result: Record<string, string[]> = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof key === "string" && Array.isArray(value)) {
+        result[key] = value.filter((m): m is string => typeof m === "string");
+      }
+    }
+    return result;
+  }
+
   // ─── Automations ─────────────────────────────────────────
 
   /**

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1371,10 +1371,12 @@ export class ESPHomeAPI {
    */
   async getPinRegistryModes(): Promise<Record<string, string[]>> {
     const raw = await this.sendCommand<unknown>("components/get_pin_registry_modes");
+    // Null-prototype so an untrusted ``__proto__`` / ``constructor`` key can't
+    // pollute the prototype when assigned below.
+    const result: Record<string, string[]> = Object.create(null);
     if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-      return {};
+      return result;
     }
-    const result: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(raw)) {
       if (typeof key !== "string" || !Array.isArray(value)) continue;
       const flags = value.filter((m): m is string => typeof m === "string");

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -240,24 +240,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
     )}`;
   }
 
-  /**
-   * After every render, push the current value onto each <wa-select>
-   * imperatively. This is a workaround for a wa-select quirk where
-   * the value/selected wiring through Lit's template doesn't always
-   * land — especially on the first paint, when wa-select reads its
-   * value before the slotted options are connected. Each field div
-   * carries a `data-field-key` (the JSON-encoded path) so we can look
-   * up the right value for its select. Encoding the path as JSON
-   * rather than a dotted string keeps user-supplied map keys that
-   * contain a dot (a `logger.logs` row keyed `i2c.idf`) intact.
-   *
-   * We wait for each select's `updateComplete` (and one frame after
-   * that) to make sure wa-select's own first-render bookkeeping —
-   * `handleDefaultSlotChange`, `setSelectedOptions`, etc. — has run
-   * before we set `.value`. Otherwise our imperative set fights with
-   * wa-select's own initial value resolution and the displayed label
-   * stays blank.
-   */
+  /** Subscribe to the shared pin-registry-modes cache so the form repaints
+   *  (scoping the pin Mode checkboxes) once the map arrives. */
   connectedCallback(): void {
     super.connectedCallback();
     // Re-render when the shared pin-registry-modes map populates so the pin
@@ -299,6 +283,24 @@ export class ESPHomeConfigEntryForm extends LitElement {
     if (this._api) void fetchPinRegistryModes(this._api);
   }
 
+  /**
+   * After every render, push the current value onto each <wa-select>
+   * imperatively. This is a workaround for a wa-select quirk where
+   * the value/selected wiring through Lit's template doesn't always
+   * land — especially on the first paint, when wa-select reads its
+   * value before the slotted options are connected. Each field div
+   * carries a `data-field-key` (the JSON-encoded path) so we can look
+   * up the right value for its select. Encoding the path as JSON
+   * rather than a dotted string keeps user-supplied map keys that
+   * contain a dot (a `logger.logs` row keyed `i2c.idf`) intact.
+   *
+   * We wait for each select's `updateComplete` (and one frame after
+   * that) to make sure wa-select's own first-render bookkeeping —
+   * `handleDefaultSlotChange`, `setSelectedOptions`, etc. — has run
+   * before we set `.value`. Otherwise our imperative set fights with
+   * wa-select's own initial value resolution and the displayed label
+   * stays blank.
+   */
   private async _syncSelectValues() {
     if (!this.shadowRoot) return;
     const fields = this.shadowRoot.querySelectorAll<HTMLElement>("[data-field-key]");

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -101,6 +101,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _api?: ESPHomeAPI;
 
   private _unsubPinRegistryModes?: () => void;
+  private _pinRegistryModesKicked = false;
 
   /** Schema entries to render (recursive — NESTED entries contain
    *  their own `config_entries`). */
@@ -278,9 +279,12 @@ export class ESPHomeConfigEntryForm extends LitElement {
     super.updated(changed);
     void this._syncSelectValues();
     this._fieldScroll.maybeScroll(changed);
-    // Idempotent (the cache dedupes in-flight + resolved); kicks once the
-    // api context lands.
-    if (this._api) void fetchPinRegistryModes(this._api);
+    // Kick the shared fetch once, when the api context first lands — not on
+    // every render. The cache + subscribe handle dedupe and the repaint.
+    if (this._api && !this._pinRegistryModesKicked) {
+      this._pinRegistryModesKicked = true;
+      void fetchPinRegistryModes(this._api);
+    }
   }
 
   /**

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -24,13 +24,19 @@ import {
 } from "@mdi/js";
 import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
-import { localizeContext } from "../../context/index.js";
+import { apiContext, localizeContext } from "../../context/index.js";
 import { type ValidationError } from "../../util/config-validation.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
+import {
+  fetchPinRegistryModes,
+  getCachedPinRegistryModes,
+  subscribePinRegistryModes,
+} from "../../util/pin-registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { _isStructuralType, filterRenderable } from "./config-entry-render-filter.js";
 import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
@@ -87,6 +93,14 @@ export class ESPHomeConfigEntryForm extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   private _localize: LocalizeFunc = (key) => key;
+
+  /** WS client — used only to fetch the session-cached pin-registry-modes
+   *  map; ``subscribe`` so a late-arriving context kicks the fetch. */
+  @consume({ context: apiContext, subscribe: true })
+  @state()
+  private _api?: ESPHomeAPI;
+
+  private _unsubPinRegistryModes?: () => void;
 
   /** Schema entries to render (recursive — NESTED entries contain
    *  their own `config_entries`). */
@@ -244,6 +258,19 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * wa-select's own initial value resolution and the displayed label
    * stays blank.
    */
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Re-render when the shared pin-registry-modes map populates so the pin
+    // Mode checkboxes scope once it arrives.
+    this._unsubPinRegistryModes = subscribePinRegistryModes(() => this.requestUpdate());
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubPinRegistryModes?.();
+    this._unsubPinRegistryModes = undefined;
+  }
+
   protected willUpdate(changed: PropertyValues) {
     // A different entry list means the form was re-targeted to a
     // different component (e.g. the dep-flow detour swapping
@@ -267,6 +294,9 @@ export class ESPHomeConfigEntryForm extends LitElement {
     super.updated(changed);
     void this._syncSelectValues();
     this._fieldScroll.maybeScroll(changed);
+    // Idempotent (the cache dedupes in-flight + resolved); kicks once the
+    // api context lands.
+    if (this._api) void fetchPinRegistryModes(this._api);
   }
 
   private async _syncSelectValues() {
@@ -542,6 +572,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
       fromLine: this.fromLine,
       sectionKey: this.sectionKey,
       board: this.board,
+      pinRegistryModes: getCachedPinRegistryModes(),
       requiredOnly: this.requiredOnly,
       nestedOpenSections: this._nestedOpenSections,
       getAt: (path) => getIn(this.values, path),

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -348,11 +348,16 @@ function renderLongFormChild(
     return ctx.renderEntry(child, [...path, child.key]);
   }
   const modePath = [...path, child.key];
+  const modeValue = ctx.getAt(modePath);
   const allowed = providerAllowedModes(ctx.getAt(path), ctx.pinRegistryModes);
-  const scoped = allowed ? scopeModeChildren(child, allowed) : child;
+  // Keep any flag the value already sets visible even if the provider now
+  // disallows it, so a legacy/invalid config can be repaired from the editor.
+  const scoped = allowed
+    ? scopeModeChildren(child, allowed, presentModeFlags(modeValue))
+    : child;
   // A scalar shorthand (``mode: OUTPUT``) needs the display-expansion wrapper;
   // the object form goes through the normal nested dispatch.
-  return typeof ctx.getAt(modePath) === "string"
+  return typeof modeValue === "string"
     ? renderPinModeField(scoped, modePath, ctx)
     : ctx.renderEntry(scoped, modePath);
 }
@@ -375,11 +380,24 @@ function providerAllowedModes(
   return null;
 }
 
-/** Return *modeEntry* with its flag children narrowed to *allowed*. */
-function scopeModeChildren(modeEntry: ConfigEntry, allowed: string[]): ConfigEntry {
-  const children = (modeEntry.config_entries ?? []).filter((c) =>
-    allowed.includes(c.key)
-  );
+/** Flag keys the current ``mode`` value sets (object keys, or a scalar
+ *  shorthand's expansion) — kept visible so a legacy flag stays editable. */
+function presentModeFlags(modeValue: unknown): string[] {
+  if (typeof modeValue === "string") {
+    return Object.keys(expandPinModeShorthand(modeValue) ?? {});
+  }
+  return isPlainObject(modeValue) ? Object.keys(modeValue) : [];
+}
+
+/** *modeEntry* with its flag children narrowed to *allowed* plus any flag
+ *  *present* already sets, so a disallowed-but-set flag stays editable. */
+function scopeModeChildren(
+  modeEntry: ConfigEntry,
+  allowed: string[],
+  present: string[]
+): ConfigEntry {
+  const keep = new Set([...allowed, ...present]);
+  const children = (modeEntry.config_entries ?? []).filter((c) => keep.has(c.key));
   return { ...modeEntry, config_entries: children };
 }
 

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -337,10 +337,8 @@ function renderPinAdvanced(
   `;
 }
 
-/** Render one long-form pin field, scoping the ``mode`` flag group to the
- *  flags the pin's external provider allows (an expander like ``pca9554``
- *  drops pullup / pulldown / open_drain). A native pin or unknown provider
- *  keeps every flag. */
+/** Render one long-form pin field; the ``mode`` group is scoped to the flags
+ *  the pin's external provider allows (a native / unknown provider keeps all). */
 function renderLongFormChild(
   child: ConfigEntry,
   path: string[],
@@ -359,9 +357,8 @@ function renderLongFormChild(
     : ctx.renderEntry(scoped, modePath);
 }
 
-/** The pin value's provider key that the registry-modes map knows about, or
- *  ``null`` for a native pin (no provider key) / short form / unknown
- *  provider — all of which keep the full flag set. */
+/** Allowed mode flags for *pinValue*'s provider, or ``null`` (native pin,
+ *  short form, unknown provider, or empty list) to keep the full flag set. */
 function providerAllowedModes(
   pinValue: unknown,
   modesMap: Record<string, string[]> | undefined

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -326,17 +326,55 @@ function renderPinAdvanced(
       </button>
       ${isOpen
         ? html`<div class="pin-advanced-fields">
-            ${longFormFields.map((child) =>
-              child.key === "mode" &&
-              child.type === ConfigEntryType.NESTED &&
-              typeof ctx.getAt([...path, child.key]) === "string"
-                ? renderPinModeField(child, [...path, child.key], ctx)
-                : ctx.renderEntry(child, [...path, child.key])
-            )}
+            ${longFormFields.map((child) => renderLongFormChild(child, path, ctx))}
           </div>`
         : nothing}
     </div>
   `;
+}
+
+/** Render one long-form pin field, scoping the ``mode`` flag group to the
+ *  flags the pin's external provider allows (an expander like ``pca9554``
+ *  drops pullup / pulldown / open_drain). A native pin or unknown provider
+ *  keeps every flag. */
+function renderLongFormChild(
+  child: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx
+): unknown {
+  if (child.key !== "mode" || child.type !== ConfigEntryType.NESTED) {
+    return ctx.renderEntry(child, [...path, child.key]);
+  }
+  const modePath = [...path, child.key];
+  const allowed = providerAllowedModes(ctx.getAt(path), ctx.pinRegistryModes);
+  const scoped = allowed ? scopeModeChildren(child, allowed) : child;
+  // A scalar shorthand (``mode: OUTPUT``) needs the display-expansion wrapper;
+  // the object form goes through the normal nested dispatch.
+  return typeof ctx.getAt(modePath) === "string"
+    ? renderPinModeField(scoped, modePath, ctx)
+    : ctx.renderEntry(scoped, modePath);
+}
+
+/** The pin value's provider key that the registry-modes map knows about, or
+ *  ``null`` for a native pin (no provider key) / short form / unknown
+ *  provider — all of which keep the full flag set. */
+function providerAllowedModes(
+  pinValue: unknown,
+  modesMap: Record<string, string[]> | undefined
+): string[] | null {
+  if (!modesMap || !isPlainObject(pinValue)) return null;
+  for (const key of Object.keys(pinValue)) {
+    if (key in modesMap) return modesMap[key];
+  }
+  return null;
+}
+
+/** Return *modeEntry* with its flag children narrowed to *allowed*. */
+function scopeModeChildren(modeEntry: ConfigEntry, allowed: string[]): ConfigEntry {
+  const children = (modeEntry.config_entries ?? []).filter((c) =>
+    allowed.includes(c.key)
+  );
+  return { ...modeEntry, config_entries: children };
 }
 
 /**

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -364,7 +364,12 @@ function providerAllowedModes(
 ): string[] | null {
   if (!modesMap || !isPlainObject(pinValue)) return null;
   for (const key of Object.keys(pinValue)) {
-    if (key in modesMap) return modesMap[key];
+    // Own-property check, not ``in``, so a key like ``toString`` can't match
+    // an inherited member. An empty list means no scoping (show every flag).
+    if (Object.prototype.hasOwnProperty.call(modesMap, key)) {
+      const allowed = modesMap[key];
+      return allowed.length > 0 ? allowed : null;
+    }
   }
   return null;
 }

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -96,10 +96,8 @@ export interface RenderCtx {
    *  dropdown doesn't offer binary_sensor filters. */
   sectionKey: string;
   board: BoardCatalogEntry | null;
-  /** ``{provider_key: [allowed_mode_flags]}`` for external pin providers
-   *  (`pca9554` → `["input", "output"]`). The pin renderer scopes the
-   *  long-form Mode checkboxes to a provider's allowed flags; a provider
-   *  absent here (or a native pin) shows every flag. */
+  /** ``{provider_key: [allowed_mode_flags]}`` scoping the long-form pin Mode
+   *  checkboxes per external provider; absent provider / native pin → all flags. */
   pinRegistryModes?: Record<string, string[]>;
   requiredOnly: boolean;
   nestedOpenSections: Set<string>;

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -96,6 +96,11 @@ export interface RenderCtx {
    *  dropdown doesn't offer binary_sensor filters. */
   sectionKey: string;
   board: BoardCatalogEntry | null;
+  /** ``{provider_key: [allowed_mode_flags]}`` for external pin providers
+   *  (`pca9554` → `["input", "output"]`). The pin renderer scopes the
+   *  long-form Mode checkboxes to a provider's allowed flags; a provider
+   *  absent here (or a native pin) shows every flag. */
+  pinRegistryModes?: Record<string, string[]>;
   requiredOnly: boolean;
   nestedOpenSections: Set<string>;
   getAt: (path: string[]) => unknown;

--- a/src/util/pin-registry-modes-cache.ts
+++ b/src/util/pin-registry-modes-cache.ts
@@ -35,11 +35,24 @@ export function fetchPinRegistryModes(
   if (!_inflight) {
     _inflight = api
       .getPinRegistryModes()
-      .catch(() => ({}) as Record<string, string[]>)
+      .catch((err) => {
+        // Cache the empty map so a repeated render doesn't retry-storm, but
+        // log so the silent loss of Mode scoping for the session is visible.
+        console.warn("pin-registry-modes fetch failed; Mode flags unscoped", err);
+        return {} as Record<string, string[]>;
+      })
       .then((modes) => {
         _cache = modes;
         _inflight = undefined;
-        for (const cb of _listeners) cb();
+        // Isolate each listener so a throwing subscriber can't break the
+        // others or reject this (successfully resolved) shared promise.
+        for (const cb of _listeners) {
+          try {
+            cb();
+          } catch (err) {
+            console.error("pin-registry-modes listener threw", err);
+          }
+        }
         return modes;
       });
   }
@@ -51,4 +64,5 @@ export function fetchPinRegistryModes(
 export function _resetPinRegistryModesCache(): void {
   _cache = undefined;
   _inflight = undefined;
+  _listeners.clear();
 }

--- a/src/util/pin-registry-modes-cache.ts
+++ b/src/util/pin-registry-modes-cache.ts
@@ -32,9 +32,10 @@ export function fetchPinRegistryModes(
     _inflight = api
       .getPinRegistryModes()
       .catch((err) => {
-        // Cache {} so renders don't retry-storm; log so the lost scoping shows.
+        // Cache an empty map so renders don't retry-storm; log so the lost
+        // scoping shows. Null-prototype to match the populated map's shape.
         console.warn("pin-registry-modes fetch failed; Mode flags unscoped", err);
-        return {} as Record<string, string[]>;
+        return Object.create(null) as Record<string, string[]>;
       })
       .then((modes) => {
         _cache = modes;

--- a/src/util/pin-registry-modes-cache.ts
+++ b/src/util/pin-registry-modes-cache.ts
@@ -1,20 +1,16 @@
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 
 /**
- * Session-scoped cache of the ``{provider_key: [allowed_mode_flags]}`` map
- * (`components/get_pin_registry_modes`). The map is immutable for the WS
- * session — it only changes with a backend release — so it's fetched once and
- * shared across every pin renderer rather than re-issued per form. A failed
- * fetch caches an empty map (the editor then shows every flag) so a transient
- * error doesn't retry-storm on each render.
+ * Session cache of the ``{provider_key: [allowed_mode_flags]}`` map
+ * (`components/get_pin_registry_modes`), fetched once and shared across pin
+ * renderers. A failed fetch caches ``{}`` so renders don't retry-storm.
  */
 
 let _cache: Record<string, string[]> | undefined;
 let _inflight: Promise<Record<string, string[]>> | undefined;
 const _listeners = new Set<() => void>();
 
-/** Synchronously read the cached map; ``undefined`` until the first fetch
- *  resolves (renderers treat that as "show every flag"). */
+/** Read the cached map; ``undefined`` until the first fetch resolves. */
 export function getCachedPinRegistryModes(): Record<string, string[]> | undefined {
   return _cache;
 }
@@ -36,16 +32,14 @@ export function fetchPinRegistryModes(
     _inflight = api
       .getPinRegistryModes()
       .catch((err) => {
-        // Cache the empty map so a repeated render doesn't retry-storm, but
-        // log so the silent loss of Mode scoping for the session is visible.
+        // Cache {} so renders don't retry-storm; log so the lost scoping shows.
         console.warn("pin-registry-modes fetch failed; Mode flags unscoped", err);
         return {} as Record<string, string[]>;
       })
       .then((modes) => {
         _cache = modes;
         _inflight = undefined;
-        // Isolate each listener so a throwing subscriber can't break the
-        // others or reject this (successfully resolved) shared promise.
+        // Isolate listeners so one throw can't break others or reject this promise.
         for (const cb of _listeners) {
           try {
             cb();
@@ -59,8 +53,7 @@ export function fetchPinRegistryModes(
   return _inflight;
 }
 
-/** Test-only: drop the cached map and in-flight fetch so a fresh test run
- *  doesn't inherit another's session cache. */
+/** Test-only: reset the cached map, in-flight fetch, and listeners. */
 export function _resetPinRegistryModesCache(): void {
   _cache = undefined;
   _inflight = undefined;

--- a/src/util/pin-registry-modes-cache.ts
+++ b/src/util/pin-registry-modes-cache.ts
@@ -1,0 +1,54 @@
+import type { ESPHomeAPI } from "../api/esphome-api.js";
+
+/**
+ * Session-scoped cache of the ``{provider_key: [allowed_mode_flags]}`` map
+ * (`components/get_pin_registry_modes`). The map is immutable for the WS
+ * session — it only changes with a backend release — so it's fetched once and
+ * shared across every pin renderer rather than re-issued per form. A failed
+ * fetch caches an empty map (the editor then shows every flag) so a transient
+ * error doesn't retry-storm on each render.
+ */
+
+let _cache: Record<string, string[]> | undefined;
+let _inflight: Promise<Record<string, string[]>> | undefined;
+const _listeners = new Set<() => void>();
+
+/** Synchronously read the cached map; ``undefined`` until the first fetch
+ *  resolves (renderers treat that as "show every flag"). */
+export function getCachedPinRegistryModes(): Record<string, string[]> | undefined {
+  return _cache;
+}
+
+/** Subscribe to cache population; returns an unsubscribe function. */
+export function subscribePinRegistryModes(cb: () => void): () => void {
+  _listeners.add(cb);
+  return () => {
+    _listeners.delete(cb);
+  };
+}
+
+/** Fetch once per session; concurrent callers share the in-flight promise. */
+export function fetchPinRegistryModes(
+  api: ESPHomeAPI
+): Promise<Record<string, string[]>> {
+  if (_cache) return Promise.resolve(_cache);
+  if (!_inflight) {
+    _inflight = api
+      .getPinRegistryModes()
+      .catch(() => ({}) as Record<string, string[]>)
+      .then((modes) => {
+        _cache = modes;
+        _inflight = undefined;
+        for (const cb of _listeners) cb();
+        return modes;
+      });
+  }
+  return _inflight;
+}
+
+/** Test-only: drop the cached map and in-flight fetch so a fresh test run
+ *  doesn't inherit another's session cache. */
+export function _resetPinRegistryModesCache(): void {
+  _cache = undefined;
+  _inflight = undefined;
+}

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -67,10 +67,15 @@ const longFormPinEntry = () =>
     config_entries: [modeChild()],
   });
 
-const openModeCtx = (pin: unknown) =>
+const openModeCtx = (pin: unknown, pinRegistryModes?: Record<string, string[]>) =>
   makeRenderCtx(
     { pin },
-    { overrides: { nestedOpenSections: new Set(["pin:pin-advanced", "pin.mode"]) } }
+    {
+      overrides: {
+        nestedOpenSections: new Set(["pin:pin-advanced", "pin.mode"]),
+        ...(pinRegistryModes ? { pinRegistryModes } : {}),
+      },
+    }
   );
 
 const switchByLabel = (result: unknown, label: string) =>
@@ -184,5 +189,44 @@ describe("renderPinField — mode scalar shorthand expansion", () => {
     const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
     // No flag switches; the value falls through to the scalar notice.
     expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
+  });
+});
+
+describe("renderPinField — mode flags scoped to the pin registry", () => {
+  const PCA9554_MODES = { pca9554: ["input", "output"] };
+
+  it("hides flags an external provider doesn't allow (pca9554 -> no pullup)", () => {
+    const ctx = openModeCtx({ pca9554: "hub", number: 0, mode: "OUTPUT" }, PCA9554_MODES);
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Output")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Input")).toBeDefined();
+    expect(switchByLabel(result, "Pullup")).toBeUndefined();
+  });
+
+  it("keeps every flag for a native pin (no provider key in the value)", () => {
+    const ctx = openModeCtx({ number: "GPIO33", mode: "OUTPUT" }, PCA9554_MODES);
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Pullup")).toBeDefined();
+    expect(switchByLabel(result, "Input")).toBeDefined();
+    expect(switchByLabel(result, "Output")).toBeDefined();
+  });
+
+  it("keeps every flag when the registry map is absent (graceful fallback)", () => {
+    const ctx = openModeCtx({ pca9554: "hub", number: 0, mode: "OUTPUT" });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Pullup")).toBeDefined();
+  });
+
+  it("keeps every flag for an unknown provider not in the map", () => {
+    const ctx = openModeCtx(
+      { some_future_expander: "hub", number: 0, mode: "OUTPUT" },
+      PCA9554_MODES
+    );
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Pullup")).toBeDefined();
   });
 });

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -229,4 +229,14 @@ describe("renderPinField — mode flags scoped to the pin registry", () => {
 
     expect(switchByLabel(result, "Pullup")).toBeDefined();
   });
+
+  it("keeps every flag when the provider's allowed list is empty", () => {
+    // Defensive: an empty allow-list must fall back to show-all rather than
+    // scope the Mode group to zero checkboxes.
+    const ctx = openModeCtx({ weird: "hub", number: 0, mode: "OUTPUT" }, { weird: [] });
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Pullup")).toBeDefined();
+    expect(switchByLabel(result, "Output")).toBeDefined();
+  });
 });

--- a/test/components/device/config-entry-pin-renderer-runtime.test.ts
+++ b/test/components/device/config-entry-pin-renderer-runtime.test.ts
@@ -230,6 +230,20 @@ describe("renderPinField — mode flags scoped to the pin registry", () => {
     expect(switchByLabel(result, "Pullup")).toBeDefined();
   });
 
+  it("keeps a disallowed flag visible when the value already sets it (legacy repair)", () => {
+    // pca9554 disallows pullup, but a legacy config set INPUT_PULLUP; the
+    // Pullup checkbox must stay so the user can untick it to repair the config.
+    const ctx = openModeCtx(
+      { pca9554: "hub", number: 0, mode: "INPUT_PULLUP" },
+      PCA9554_MODES
+    );
+    const result = renderPinField(longFormPinEntry(), ["pin"], ctx);
+
+    expect(switchByLabel(result, "Pullup")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Input")?.["?checked"]).toBe(true);
+    expect(switchByLabel(result, "Output")).toBeDefined();
+  });
+
   it("keeps every flag when the provider's allowed list is empty", () => {
     // Defensive: an empty allow-list must fall back to show-all rather than
     // scope the Mode group to zero checkboxes.

--- a/test/util/pin-registry-modes-cache.test.ts
+++ b/test/util/pin-registry-modes-cache.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import {
+  _resetPinRegistryModesCache,
+  fetchPinRegistryModes,
+  getCachedPinRegistryModes,
+  subscribePinRegistryModes,
+} from "../../src/util/pin-registry-modes-cache.js";
+
+const makeApi = (impl: () => Promise<Record<string, string[]>>): ESPHomeAPI =>
+  ({ getPinRegistryModes: vi.fn(impl) }) as unknown as ESPHomeAPI;
+
+afterEach(() => {
+  _resetPinRegistryModesCache();
+});
+
+describe("pin-registry-modes-cache", () => {
+  it("fetches once and memoizes; concurrent callers share the promise", async () => {
+    const api = makeApi(async () => ({ pca9554: ["input", "output"] }));
+
+    const [a, b] = await Promise.all([
+      fetchPinRegistryModes(api),
+      fetchPinRegistryModes(api),
+    ]);
+
+    expect(a).toEqual({ pca9554: ["input", "output"] });
+    expect(b).toBe(a);
+    await fetchPinRegistryModes(api);
+    expect(api.getPinRegistryModes).toHaveBeenCalledTimes(1);
+    expect(getCachedPinRegistryModes()).toEqual({ pca9554: ["input", "output"] });
+  });
+
+  it("notifies subscribers when the map populates", async () => {
+    const cb = vi.fn();
+    subscribePinRegistryModes(cb);
+
+    await fetchPinRegistryModes(makeApi(async () => ({})));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches an empty map on fetch failure so it doesn't retry-storm", async () => {
+    const api = makeApi(async () => {
+      throw new Error("ws down");
+    });
+
+    expect(await fetchPinRegistryModes(api)).toEqual({});
+    await fetchPinRegistryModes(api);
+    expect(api.getPinRegistryModes).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The long-form pin **Mode** checkboxes (`input` / `output` / `pullup` / `pulldown` / `open_drain`) were offered in full for every pin, but an external pin provider allows only a subset: an I2C expander like `pca9554` permits `input` / `output`, a shift register `sn74hc595` only `output`. The editor let users tick flags ESPHome rejects (`[pullup] is an invalid option for [mode]`).

This is the frontend half of #584; the backend (esphome/device-builder#1163) derives a `{provider_key: [allowed_modes]}` map from ESPHome's `PIN_SCHEMA_REGISTRY` and ships it over `components/get_pin_registry_modes`.

## Changes

- `ESPHomeAPI.getPinRegistryModes()` — typed wrapper + payload-shape filter, mirroring `getIntegrationDocs`.
- `src/util/pin-registry-modes-cache.ts` — session-scoped cache (fetched once, shared across forms, subscribe-to-populate; a failed fetch caches `{}` so it doesn't retry-storm).
- `config-entry-form` consumes `apiContext`, kicks the fetch when the context lands, and threads the map onto `RenderCtx.pinRegistryModes` (re-rendering when it populates).
- `config-entry-pin-renderer` detects the provider key present in the pin value (`pca9554`) and narrows the Mode group's flag children to the allowed set before rendering. A native pin (no provider key), an unknown provider, or a missing map keeps every flag — no regression.

## Verification

Unit tests cover the scoping (pca9554 hides pullup; native keeps all; unknown provider / empty map fall back). Verified end-to-end in the browser against the backend branch: with the pca9554 switch the Mode group shows only **Input / Output**, while the native GPIO33 binary_sensor still shows all five.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/584
- Requires backend esphome/device-builder#1163 (the `components/get_pin_registry_modes` command + artefact); degrades gracefully to "show every flag" without it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
