### PR TITLE
Auto-open the pin Advanced disclosure for YAML-cursor navigation

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -313,7 +313,11 @@ function renderPinAdvanced(
   };
 
   return html`
-    <div class="pin-advanced" data-field-key="${advancedKey}">
+    <div
+      class="pin-advanced"
+      data-field-key="${advancedKey}"
+      data-reveal-for="${fieldKeyAttr(path)}"
+    >
       <button
         type="button"
         class="pin-advanced-toggle"

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -48,6 +48,19 @@ export function advanceScrollGate(
   return { gate: { scrolledKey, lastFocusKey, tries }, scroll };
 }
 
+/** Open keys for disclosures that gate *path* — a disclosure declares the
+ *  path prefix it hides behind; a strict-ancestor prefix means it must open. */
+export function gatingDisclosureKeys(
+  decls: ReadonlyArray<{ prefix: string[]; key: string }>,
+  path: string[]
+): string[] {
+  return decls
+    .filter(
+      (d) => d.prefix.length < path.length && d.prefix.every((k, i) => k === path[i])
+    )
+    .map((d) => d.key);
+}
+
 /** The form surface this helper drives. */
 export interface FieldScrollHost {
   shadowRoot: ShadowRoot | null;
@@ -107,6 +120,12 @@ export class FieldScrollController {
     for (let i = 1; i < path.length; i++) {
       host.openNested(path.slice(0, i).join("."));
     }
+    // Custom disclosures (e.g. pin Advanced) aren't dotted-path keyed; they
+    // declare the prefix they hide behind in the DOM, so the controller stays
+    // agnostic to any renderer's key convention.
+    for (const k of gatingDisclosureKeys(this._gatingDecls(host.shadowRoot), path)) {
+      host.openNested(k);
+    }
     await host.updateComplete; // let any opened group render
     const cur = host.focusFieldPath;
     if (!cur || fieldKeyAttr(cur) !== key) return; // superseded by a newer move
@@ -150,6 +169,22 @@ export class FieldScrollController {
       if (len === path.length) this._scrolledKey = key;
       return;
     }
+  }
+
+  /** Read the gating-disclosure declarations a renderer rendered into the DOM:
+   *  ``data-reveal-for`` is the gated path prefix, ``data-field-key`` the open key. */
+  private _gatingDecls(root: ParentNode): { prefix: string[]; key: string }[] {
+    const decls: { prefix: string[]; key: string }[] = [];
+    for (const el of root.querySelectorAll<HTMLElement>("[data-reveal-for]")) {
+      const key = el.getAttribute("data-field-key");
+      if (key) {
+        decls.push({
+          prefix: parseFieldKey(el.getAttribute("data-reveal-for") ?? ""),
+          key,
+        });
+      }
+    }
+    return decls;
   }
 
   /** Find the field with *path*, recursing into nested custom-element shadow

--- a/src/components/device/field-scroll-controller.ts
+++ b/src/components/device/field-scroll-controller.ts
@@ -49,14 +49,18 @@ export function advanceScrollGate(
 }
 
 /** Open keys for disclosures that gate *path* — a disclosure declares the
- *  path prefix it hides behind; a strict-ancestor prefix means it must open. */
+ *  path prefix it hides behind; a strict-ancestor prefix means it must open.
+ *  An empty prefix gates nothing (a malformed decl mustn't match every path). */
 export function gatingDisclosureKeys(
   decls: ReadonlyArray<{ prefix: string[]; key: string }>,
   path: string[]
 ): string[] {
   return decls
     .filter(
-      (d) => d.prefix.length < path.length && d.prefix.every((k, i) => k === path[i])
+      (d) =>
+        d.prefix.length > 0 &&
+        d.prefix.length < path.length &&
+        d.prefix.every((k, i) => k === path[i])
     )
     .map((d) => d.key);
 }
@@ -172,7 +176,10 @@ export class FieldScrollController {
   }
 
   /** Read the gating-disclosure declarations a renderer rendered into the DOM:
-   *  ``data-reveal-for`` is the gated path prefix, ``data-field-key`` the open key. */
+   *  ``data-reveal-for`` is the gated path prefix, ``data-field-key`` the open key.
+   *  Only the host shadow root is scanned (where pin Advanced renders); a future
+   *  disclosure nested inside a child element's shadow root would need the same
+   *  recursion ``_find`` uses. */
   private _gatingDecls(root: ParentNode): { prefix: string[]; key: string }[] {
     const decls: { prefix: string[]; key: string }[] = [];
     for (const el of root.querySelectorAll<HTMLElement>("[data-reveal-for]")) {

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -177,6 +177,23 @@ describe("renderPinField long-form Advanced disclosure", () => {
     expect(ctx.renderEntry).not.toHaveBeenCalled();
   });
 
+  it("declares the gated path prefix so cursor-nav can reveal collapsed fields", () => {
+    const ctx = makeRenderCtx({ pin: 0 });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        config_entries: makeLongFormChildren(),
+      }),
+      ["pin"],
+      ctx
+    );
+    const disclosure = findTemplatesByAnchor(result, 'class="pin-advanced"')[0];
+    const bindings = extractAttributeBindings(disclosure);
+    expect(bindings["data-reveal-for"]).toBe('["pin"]');
+    expect(bindings["data-field-key"]).toBe("pin:pin-advanced");
+  });
+
   it("renders the long-form children when the disclosure is open", () => {
     // Toggle is keyed on `${path}:pin-advanced`; populating the
     // open-set simulates the user having clicked open.

--- a/test/components/device/field-scroll-gate.test.ts
+++ b/test/components/device/field-scroll-gate.test.ts
@@ -72,4 +72,12 @@ describe("gatingDisclosureKeys", () => {
   it("ignores a path that doesn't sit under the prefix", () => {
     expect(gatingDisclosureKeys(DECLS, ["other", "inverted"])).toEqual([]);
   });
+
+  it("ignores an empty-prefix decl instead of gating every path", () => {
+    // A malformed/empty ``data-reveal-for`` parses to []; an unguarded
+    // ``[].every`` would match every target and open the disclosure spuriously.
+    expect(
+      gatingDisclosureKeys([{ prefix: [], key: "bad" }], ["pin", "inverted"])
+    ).toEqual([]);
+  });
 });

--- a/test/components/device/field-scroll-gate.test.ts
+++ b/test/components/device/field-scroll-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   advanceScrollGate,
+  gatingDisclosureKeys,
   type ScrollGate,
 } from "../../../src/components/device/field-scroll-controller.js";
 
@@ -46,5 +47,29 @@ describe("advanceScrollGate", () => {
     const { gate, scroll } = advanceScrollGate(consumed, undefined, true, MAX);
     expect(scroll).toBe(false);
     expect(gate).toEqual({ scrolledKey: undefined, lastFocusKey: undefined, tries: 0 });
+  });
+});
+
+describe("gatingDisclosureKeys", () => {
+  const DECLS = [{ prefix: ["pin"], key: "pin:pin-advanced" }];
+
+  it("opens a disclosure gating a strict-descendant field", () => {
+    expect(gatingDisclosureKeys(DECLS, ["pin", "inverted"])).toEqual([
+      "pin:pin-advanced",
+    ]);
+  });
+
+  it("opens it for a deeply nested descendant", () => {
+    expect(gatingDisclosureKeys(DECLS, ["pin", "mode", "pullup"])).toEqual([
+      "pin:pin-advanced",
+    ]);
+  });
+
+  it("leaves the prefix path itself untouched", () => {
+    expect(gatingDisclosureKeys(DECLS, ["pin"])).toEqual([]);
+  });
+
+  it("ignores a path that doesn't sit under the prefix", () => {
+    expect(gatingDisclosureKeys(DECLS, ["other", "inverted"])).toEqual([]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

YAML-cursor navigation reveals and flashes the form field under the
cursor by opening every ancestor group first. `FieldScrollController`
opened groups by **dotted path prefix** (`"pin"`), but the pin long-form
**Advanced** disclosure (#430) is keyed `${path.join(".")}:pin-advanced`
(`"pin:pin-advanced"`) — a synthetic key the prefix walk never produces.
So clicking the YAML on a long-form pin field (`mode` / `inverted` /
`mode.pullup`) while that disclosure was **manually collapsed** couldn't
reveal the field; it fell back to scrolling the pin container.

Low impact in practice: the disclosure seed-opens by default when the pin
already carries long-form values, so only a user-collapsed disclosure hit
this.

The fix keeps the `:pin-advanced` key convention out of the shared
controller. The disclosure already renders a DOM element even when
collapsed; it now **declares the path prefix it gates** via a
`data-reveal-for` attribute, and its existing `data-field-key` is the open
key. `FieldScrollController` discovers that declaration generically (it
already reads `data-field-key` from the shadow DOM) and opens any
disclosure whose declared prefix is a strict ancestor of the target path —
agnostic to any renderer's keying scheme. A new pure `gatingDisclosureKeys`
helper holds the prefix-match decision (unit-tested without a DOM, mirroring
`advanceScrollGate`).

Composes cleanly: the pin picker itself (`["pin"]`) stays untouched;
`["pin","mode","pullup"]` opens both the dotted `pin.mode` group and the
disclosure in one re-render; `openNested` is idempotent and no-ops in
`requiredOnly` mode.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#585

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
