### PR TITLE
Migrate the labels-filter create dialog onto esphome-base-dialog

### DIFF
--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -41,8 +41,8 @@ import { facetStyles } from "../facets/facet-styles.js";
 import "./label-form.js";
 import { labelsFilterStyles } from "./labels-filter.styles.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "../base-dialog.js";
 
 registerMdiIcons({
   "arrow-left": mdiArrowLeft,
@@ -167,12 +167,12 @@ export class ESPHomeLabelsFilter extends LitElement {
 
   private _renderCreateDialog() {
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         class="create-dialog"
         ?open=${this._createOpen}
-        light-dismiss
-        label=${this._localize("dashboard.labels_create")}
-        @wa-after-hide=${this._onCreateDialogHide}
+        .label=${this._localize("dashboard.labels_create")}
+        @request-close=${this._closeCreateDialog}
+        @after-hide=${this._onCreateDialogHide}
       >
         <esphome-label-form
           .existingNames=${this._catalog.map((l) => l.name)}
@@ -181,7 +181,7 @@ export class ESPHomeLabelsFilter extends LitElement {
           @label-created=${this._onLabelCreated}
           @editing-cancel=${this._closeCreateDialog}
         ></esphome-label-form>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -200,9 +200,8 @@ export class ESPHomeLabelsFilter extends LitElement {
   };
 
   private _onCreateDialogHide = () => {
-    // ``light-dismiss`` and the form's own Cancel/Esc paths both
-    // funnel through ``wa-after-hide``. Mirror our state back so
-    // the next open call is clean.
+    // Light-dismiss / Escape / the form's Cancel all funnel through the
+    // wrapper's after-hide. Mirror our state back so the next open is clean.
     this._createOpen = false;
   };
 

--- a/test/components/labels/labels-filter.test.ts
+++ b/test/components/labels/labels-filter.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the "Create label" sub-dialog's reactive open/close contract after the
+ * migration onto esphome-base-dialog (#549): the dialog tracks _createOpen via
+ * ?open, and request-close / after-hide both mirror the flag back to false so a
+ * user-driven close (Escape / X / outside-click) actually dismisses and the
+ * next open is clean. The popover itself is a plain <div>, not a dialog, and is
+ * unaffected by the migration.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../../src/components/labels/label-form.js", () => ({}));
+
+import { ESPHomeLabelsFilter } from "../../../src/components/labels/labels-filter.js";
+
+async function mount(): Promise<ESPHomeLabelsFilter> {
+  const el = new ESPHomeLabelsFilter();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const createDialog = (el: ESPHomeLabelsFilter): HTMLElement =>
+  el.shadowRoot!.querySelector("esphome-base-dialog.create-dialog")!;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isOpen = (el: ESPHomeLabelsFilter): boolean => (el as any)._createOpen;
+
+describe("labels-filter create-dialog open/close contract", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("binds _createOpen to the wrapper's ?open", async () => {
+    const el = await mount();
+    expect(isOpen(el)).toBe(false);
+    expect(createDialog(el).hasAttribute("open")).toBe(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._openCreateDialog();
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(true);
+    expect(createDialog(el).hasAttribute("open")).toBe(true);
+  });
+
+  it("flips _createOpen to false on request-close", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._createOpen = true;
+    await el.updateComplete;
+    createDialog(el).dispatchEvent(new CustomEvent("request-close"));
+    expect(isOpen(el)).toBe(false);
+  });
+
+  it("flips _createOpen to false on after-hide", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._createOpen = true;
+    await el.updateComplete;
+    createDialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(isOpen(el)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-labels-filter`'s **"Create label" sub-dialog** off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

Note on scope: the labels filter's main UI (the trigger + dropdown) is a plain `<div>` **popover**, not a dialog — and the edit-mode back arrow lives in that popover's body, not in any dialog header. The only `<wa-dialog>` in this component is the small "Create label" dialog, so that's all this migrates. The popover and its back arrow are untouched.

The swap is minimal because the dialog was already reactive: `?open` stays bound to the existing `_createOpen` flag; `request-close` and `after-hide` both mirror the flag back to `false` (so Escape / X / outside-click dismiss cleanly and the next open is fresh); `light-dismiss` is the wrapper default. The dialog's `::part` overrides are **class-based** (`.create-dialog::part(...)`), so they carry over unchanged once the class sits on the wrapper — no style edits needed. Public API (`selected` / `usageCounts` props, `labels-filter-change` / `request-delete-label` events) is unchanged, so the dashboard consumer needs no edits.

Adds the first test for this component, pinning the create-dialog `open` / `request-close` / `after-hide` reactive-flag contract.

**Related issue or feature (if applicable):**

- part of #549 (next unchecked dialog in the list)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
