### PR TITLE
Migrate the device-labels-editor dialog onto esphome-base-dialog

### DIFF
--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -242,20 +242,25 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   ];
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("device")) {
-      // Reset transient state when the drawer swaps to a different
-      // device; otherwise a half-typed "create" form would persist
-      // into the next device's editor and a still-pending save
-      // chained against the previous device would gate this one's
-      // ``_saving`` indicator until that promise settled.
+    if (!changed.has("device")) return;
+    const prev = changed.get("device") as ConfiguredDevice | undefined;
+    // A same-device prop update — the ``DEVICE_UPDATED`` push that lands
+    // after our own ``set_labels`` — now carries the saved labels, so drop
+    // the optimistic override and trust the prop. Crucially, DON'T close the
+    // dialog: the user is mid-edit and toggling more labels, and each toggle
+    // round-trips through this same push.
+    this._optimisticLabels = null;
+    // Only a real swap to a *different* device tears down the transient edit
+    // state and closes the dialog; otherwise a half-typed "create" form would
+    // persist into the next device's editor and a still-pending save chained
+    // against the previous device would gate this one's ``_saving`` indicator.
+    if (prev !== undefined && prev.configuration !== this.device.configuration) {
       this._open = false;
       this._createForm?.collapse();
-      this._optimisticLabels = null;
       this._saving = false;
       this._saveChain = Promise.resolve();
-      // Drop any in-flight create snapshot so a late
-      // ``label-created`` arriving after the swap is ignored rather
-      // than misapplied to the new device.
+      // Drop any in-flight create snapshot so a late ``label-created``
+      // arriving after the swap is ignored rather than misapplied.
       this._pendingCreateConfig = null;
     }
   }

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -3,9 +3,9 @@
  *
  * In-drawer affordance is intentionally minimal: a chip row with
  * per-chip × buttons plus a single "Edit labels" trigger. The
- * full assignment / create UI lives behind that trigger in a
- * ``<wa-dialog>`` so the drawer stays scannable when a device
- * carries a long list of labels.
+ * full assignment / create UI lives behind that trigger in an
+ * ``<esphome-base-dialog>`` so the drawer stays scannable when a
+ * device carries a long list of labels.
  *
  * The dialog body has three parts: a search input, a catalog list
  * where each row is a checkbox toggling the device's assignment
@@ -44,8 +44,8 @@ import "./label-form.js";
 import type { ESPHomeLabelForm } from "./label-form.js";
 import { labelsListStyles } from "./labels-list-styles.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "../base-dialog.js";
 
 registerMdiIcons({
   check: mdiCheck,
@@ -104,8 +104,8 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
    *  state non-deterministic on overlapping requests. */
   private _saveChain: Promise<unknown> = Promise.resolve();
 
-  @query("wa-dialog")
-  private _dialog?: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   @query("esphome-label-form")
   private _createForm?: ESPHomeLabelForm;
@@ -201,32 +201,28 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
       /* ─── Dialog ──────────────────────────────────────────── */
 
-      wa-dialog {
+      esphome-base-dialog {
         --width: 480px;
       }
 
-      wa-dialog::part(header) {
+      esphome-base-dialog::part(header) {
         padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
       }
 
-      wa-dialog::part(title) {
+      esphome-base-dialog::part(title) {
         font-size: var(--wa-font-size-m);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-normal);
       }
 
-      wa-dialog::part(close-button__base) {
+      esphome-base-dialog::part(close-button__base) {
         background: transparent;
         border: none;
         box-shadow: none;
       }
 
-      wa-dialog::part(body) {
+      esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l) var(--wa-space-l);
-      }
-
-      wa-dialog::part(footer) {
-        display: none;
       }
 
       /* Cap the list height for the in-drawer editor (the bulk
@@ -252,7 +248,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
       // into the next device's editor and a still-pending save
       // chained against the previous device would gate this one's
       // ``_saving`` indicator until that promise settled.
-      if (this._dialog) this._dialog.open = false;
+      this._open = false;
       this._createForm?.collapse();
       this._optimisticLabels = null;
       this._saving = false;
@@ -309,10 +305,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
   private _renderDialog() {
     const assignedSet = new Set(this._currentLabelIds);
     return html`
-      <wa-dialog
-        label=${this._localize("dashboard.labels_dialog_title")}
-        light-dismiss
-        @wa-after-hide=${this._onDialogClose}
+      <esphome-base-dialog
+        ?open=${this._open}
+        .label=${this._localize("dashboard.labels_dialog_title")}
+        @request-close=${this._onRequestClose}
+        @after-hide=${this._onDialogClose}
       >
         <div
           class="options"
@@ -348,7 +345,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
             @label-created=${this._onCreateResolved}
           ></esphome-label-form>
         </div>
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
 
@@ -369,10 +366,17 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
   private _openDialog = () => {
     this._createForm?.collapse();
-    if (this._dialog) this._dialog.open = true;
+    this._open = true;
+  };
+
+  // esphome-base-dialog never flips its own open on a user-driven close
+  // (Escape / X / outside-click); the host owns _open here.
+  private _onRequestClose = () => {
+    this._open = false;
   };
 
   private _onDialogClose = () => {
+    this._open = false;
     this._createForm?.collapse();
   };
 

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the label editor's reactive open/close contract after the migration
+ * onto esphome-base-dialog (#549): the dialog tracks _open via ?open, and
+ * request-close / after-hide both mirror it back to false so a user-driven
+ * close (Escape / X / outside-click) actually dismisses. Saves fire on every
+ * label toggle while the dialog stays open, so it deliberately does NOT bind
+ * ?busy (that would dim/lock the dialog on each toggle).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+// Stub esphome-label-form with the one method the editor calls on its @query
+// ref (_createForm?.collapse()); the real form pulls in heavy deps we don't need.
+vi.mock("../../../src/components/labels/label-form.js", () => {
+  class StubLabelForm extends HTMLElement {
+    collapse(): void {}
+  }
+  if (!customElements.get("esphome-label-form")) {
+    customElements.define("esphome-label-form", StubLabelForm);
+  }
+  return {};
+});
+
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import { ESPHomeDeviceLabelsEditor } from "../../../src/components/labels/device-labels-editor.js";
+
+async function mount(): Promise<ESPHomeDeviceLabelsEditor> {
+  const el = new ESPHomeDeviceLabelsEditor();
+  el.device = { configuration: "kitchen", labels: [] } as unknown as ConfiguredDevice;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const dialog = (el: ESPHomeDeviceLabelsEditor): HTMLElement =>
+  el.shadowRoot!.querySelector("esphome-base-dialog")!;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isOpen = (el: ESPHomeDeviceLabelsEditor): boolean => (el as any)._open;
+
+describe("device-labels-editor open/close contract", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("opens via the Edit-labels trigger", async () => {
+    const el = await mount();
+    expect(isOpen(el)).toBe(false);
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".edit-btn")!.click();
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(true);
+    expect(dialog(el).hasAttribute("open")).toBe(true);
+  });
+
+  it("flips _open to false on request-close", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._open = true;
+    await el.updateComplete;
+    dialog(el).dispatchEvent(new CustomEvent("request-close"));
+    expect(isOpen(el)).toBe(false);
+  });
+
+  it("flips _open to false on after-hide", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._open = true;
+    await el.updateComplete;
+    dialog(el).dispatchEvent(new CustomEvent("after-hide"));
+    expect(isOpen(el)).toBe(false);
+  });
+
+  it("closes when the device prop swaps", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._open = true;
+    await el.updateComplete;
+    el.device = { configuration: "bedroom", labels: [] } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(false);
+  });
+});

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -73,7 +73,7 @@ describe("device-labels-editor open/close contract", () => {
     expect(isOpen(el)).toBe(false);
   });
 
-  it("closes when the device prop swaps", async () => {
+  it("closes when the device prop swaps to a different device", async () => {
     const el = await mount();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._open = true;
@@ -81,5 +81,20 @@ describe("device-labels-editor open/close contract", () => {
     el.device = { configuration: "bedroom", labels: [] } as unknown as ConfiguredDevice;
     await el.updateComplete;
     expect(isOpen(el)).toBe(false);
+  });
+
+  it("stays open on a same-device update (e.g. DEVICE_UPDATED after a toggle)", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._open = true;
+    await el.updateComplete;
+    // Same configuration, new labels (and a new object ref, as the dashboard
+    // hands down after set_labels) — the dialog must NOT close.
+    el.device = {
+      configuration: "kitchen",
+      labels: ["a"],
+    } as unknown as ConfiguredDevice;
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-device-labels-editor` — the in-drawer "Edit labels" dialog (toggle a device's label assignments + an inline "create label" form) — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

Converts the imperative `@query("wa-dialog")` + `_dialog.open = …` to the reactive pattern: a state-driven `_open` flag, a `request-close` handler, and `after-hide` teardown (which also collapses the inline create form). The device-swap cleanup in `willUpdate` now flips `_open` instead of poking the dialog element. The bare `wa-dialog::part(...)` overrides are re-prefixed to `esphome-base-dialog::part(...)`, and the now-redundant `footer { display: none }` is dropped (the wrapper renders no footer slot unless filled).

**Deliberately not wired to the `?busy` gate.** Unlike a one-shot submit dialog, `set_labels` fires on **every label toggle** while this dialog stays open, so gating dismissal on `_saving` would dim/lock the dialog on each toggle. The existing optimistic-update design already makes close-during-save safe, so the behaviour is preserved as-is.

The component is fully self-contained (the parent passes only `.device` and listens for no events), so the consumer needs no edits.

Adds the first test for this component, pinning the `open` / `request-close` / `after-hide` / device-swap reactive-flag contract.

**Related issue or feature (if applicable):**

- part of #549 (next unchecked dialog in the list)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
