### PR TITLE
Migrate the add-component dialog onto esphome-base-dialog

### DIFF
--- a/src/components/device/add-component-dialog.styles.ts
+++ b/src/components/device/add-component-dialog.styles.ts
@@ -1,15 +1,15 @@
 import { css } from "lit";
 
 export const addComponentDialogStyles = css`
-  wa-dialog {
+  esphome-base-dialog {
     --width: 900px;
   }
 
-  wa-dialog.form-view {
+  esphome-base-dialog.form-view {
     --width: 480px;
   }
 
-  wa-dialog::part(header) {
+  esphome-base-dialog::part(header) {
     background: var(--esphome-primary);
     /* Right padding is 0 so the close button sits flush with the
        dialog's corner — the button is explicitly sized to a 40x40
@@ -20,13 +20,15 @@ export const addComponentDialogStyles = css`
     box-sizing: border-box;
   }
 
-  wa-dialog::part(title) {
+  /* Title text lives in base-dialog's title-text span; colour/weight
+     cascade in from the forwarded title part. */
+  esphome-base-dialog::part(title) {
     color: var(--esphome-on-primary);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
   }
 
-  wa-dialog::part(close-button__base) {
+  esphome-base-dialog::part(close-button__base) {
     background: transparent;
     border: none;
     box-shadow: none;
@@ -42,21 +44,8 @@ export const addComponentDialogStyles = css`
     cursor: pointer;
   }
 
-  wa-dialog::part(body) {
+  esphome-base-dialog::part(body) {
     padding: var(--wa-space-l);
-  }
-
-  wa-dialog::part(footer) {
-    display: none;
-  }
-
-  .dialog-label {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-xs);
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
   }
 
   .back-button {

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -7,6 +7,7 @@ import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.j
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
@@ -143,7 +144,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
    *  resolve time discards its result. */
   private _selectionSeq = 0;
 
-  static styles = [espHomeStyles, addComponentDialogStyles];
+  // Full-screen on mobile (overrides base-dialog's centered default): the
+  // catalog is a wide, content-heavy view that needs the whole viewport on a
+  // phone rather than being boxed into a centered column.
+  static styles = [
+    espHomeStyles,
+    fullscreenMobileDialog("esphome-base-dialog"),
+    addComponentDialogStyles,
+  ];
 
   public open() {
     this._resetDetourState();

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -22,9 +22,9 @@ import {
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+import "../base-dialog.js";
 import "./add-component-form.js";
 import "./component-catalog.js";
 import type { ESPHomeComponentCatalog } from "./component-catalog.js";
@@ -78,8 +78,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @property({ attribute: false })
   lockedCategories: string[] = [];
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state()
+  private _open = false;
 
   @query("esphome-component-catalog")
   private _catalog!: ESPHomeComponentCatalog;
@@ -150,7 +150,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
-    this._dialog.open = true;
+    this._open = true;
     this.updateComplete.then(() => this._catalog?.load());
   }
 
@@ -166,7 +166,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
-    this._dialog.open = true;
+    this._open = true;
     this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
   }
 
@@ -203,10 +203,18 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // position, expanded card) survives the round trip into the form view —
     // hide it with `hidden` rather than swapping it out of the DOM. The form
     // is fine to mount/unmount on demand since each selection starts fresh.
+    const title = isForm
+      ? this._selected!.name
+      : this.boardName
+        ? this._localize(headerKey, { name: this.boardName })
+        : this._localize(headerKey);
     return html`
-      <wa-dialog
+      <esphome-base-dialog
         class=${isForm ? "form-view" : ""}
-        light-dismiss
+        ?open=${this._open}
+        ?busy=${this._submitting}
+        .label=${title}
+        @request-close=${this._onRequestClose}
         @add-component=${this._onComponentSelected}
         @add-bundle=${this._onBundleSelected}
         @form-cancel=${this._onBack}
@@ -214,18 +222,17 @@ export class ESPHomeAddComponentDialog extends LitElement {
         @navigate-to-dep=${this._onNavigateToDep}
         @request-add-component=${this._onNavigateToDep}
       >
-        <span slot="label" class="dialog-label">
-          ${isForm
-            ? html`<button class="back-button" @click=${this._onBack}>
-                <wa-icon library="mdi" name="arrow-left"></wa-icon>
-              </button>`
-            : nothing}
-          ${isForm
-            ? this._selected!.name
-            : this.boardName
-              ? this._localize(headerKey, { name: this.boardName })
-              : this._localize(headerKey)}
-        </span>
+        ${isForm
+          ? html`<button
+              slot="header-prefix"
+              class="back-button"
+              title=${this._localize("layout.back")}
+              aria-label=${this._localize("layout.back")}
+              @click=${this._onBack}
+            >
+              <wa-icon library="mdi" name="arrow-left"></wa-icon>
+            </button>`
+          : nothing}
         ${this._returnTo
           ? html`<div class="return-banner">
               ${this._localize("device.return_to_after_dep_prefix")}
@@ -270,9 +277,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
               .submitError=${this._submitError}
             ></esphome-add-component-form>`
           : nothing}
-      </wa-dialog>
+      </esphome-base-dialog>
     `;
   }
+
+  // esphome-base-dialog never flips its own open on a user-driven close
+  // (Escape / X / outside-click); the host owns _open here. The busy gate
+  // (?busy=_submitting) blocks dismissal while an add is in flight.
+  private _onRequestClose = () => {
+    this._open = false;
+  };
 
   private async _onComponentSelected(
     e: CustomEvent<{ component: ComponentCatalogEntry }>
@@ -513,7 +527,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
             })
           );
         }
-        this._dialog.open = false;
+        this._open = false;
         this._selected = null;
         this._resetDetourState();
       }

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -129,10 +129,12 @@ export const componentCatalogStyles = css`
   /* Below the shared phone breakpoint (modal viewport on phones) collapse sidebar into a
      horizontal chip row above the grid. */
   @media (max-width: ${MOBILE_BREAKPOINT}px) {
+    /* The dialog hosting the catalog goes full-screen on phones, so fill the
+       available height (the body's flex track) rather than capping at 70vh,
+       which would leave the bottom of the screen empty. */
     :host {
       flex-direction: column;
-      height: auto;
-      max-height: 70vh;
+      height: 100%;
     }
 
     .sidebar {
@@ -160,6 +162,14 @@ export const componentCatalogStyles = css`
     .main {
       padding-left: 0;
       padding-right: 0;
+    }
+
+    /* Drop the desktop 340px column floor: in the full-screen mobile dialog
+       the body is narrower than 340px on small phones (e.g. 375px − padding),
+       and minmax(340px, …) would force a track wider than the viewport and
+       clip the cards. A single minmax(0, 1fr) column shrinks to fit. */
+    .components-grid {
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 

--- a/test/components/device/add-component-dialog-open-close.test.ts
+++ b/test/components/device/add-component-dialog-open-close.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the add-component dialog's reactive open/close contract after the
+ * migration onto esphome-base-dialog (#549): the imperative open() /
+ * openWithSearch() entry points (which the three consumers call) flip the
+ * reactive _open flag, request-close mirrors it back to false, and the
+ * form-view back button renders in the wrapper's header-prefix slot and
+ * returns to the catalog.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+// Stub the catalog with the two methods open()/openWithSearch() call on it.
+vi.mock("../../../src/components/device/component-catalog.js", () => {
+  class StubCatalog extends HTMLElement {
+    load(): void {}
+    filterByDomain(): void {}
+  }
+  if (!customElements.get("esphome-component-catalog")) {
+    customElements.define("esphome-component-catalog", StubCatalog);
+  }
+  return {};
+});
+
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+
+async function mount(): Promise<ESPHomeAddComponentDialog> {
+  const el = new ESPHomeAddComponentDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const dialog = (el: ESPHomeAddComponentDialog): HTMLElement =>
+  el.shadowRoot!.querySelector("esphome-base-dialog")!;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isOpen = (el: ESPHomeAddComponentDialog): boolean => (el as any)._open;
+
+describe("add-component-dialog open/close contract", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("open() flips the reactive open flag and binds ?open", async () => {
+    const el = await mount();
+    expect(isOpen(el)).toBe(false);
+    el.open();
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(true);
+    expect(dialog(el).hasAttribute("open")).toBe(true);
+  });
+
+  it("openWithSearch() also opens", async () => {
+    const el = await mount();
+    el.openWithSearch("output");
+    await el.updateComplete;
+    expect(isOpen(el)).toBe(true);
+  });
+
+  it("flips _open to false on request-close", async () => {
+    const el = await mount();
+    el.open();
+    await el.updateComplete;
+    dialog(el).dispatchEvent(new CustomEvent("request-close"));
+    expect(isOpen(el)).toBe(false);
+  });
+
+  it("renders the back button in header-prefix in form view and returns to the catalog", async () => {
+    const el = await mount();
+    el.open();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._selected = { name: "GPIO Switch" };
+    await el.updateComplete;
+    const back = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button.back-button[slot="header-prefix"]'
+    );
+    expect(back).toBeTruthy();
+    back!.click();
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._selected).toBeNull();
+    // back in catalog view -> no back button.
+    expect(
+      el.shadowRoot!.querySelector('button.back-button[slot="header-prefix"]')
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-add-component-dialog` — the component picker (catalog ↔ per-component form, plus the dependency-detour and bundle flows) — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper.

This is the most involved dialog in the #549 series, but it maps cleanly onto the create-config wizard pattern:

- **Reactive open:** the imperative `@query("wa-dialog")` + `_dialog.open = …` becomes a state-driven `_open` flag. The public `open()` / `openWithSearch(domain)` methods (called by all three consumers — add-config-dialog, device-board-info, device-navigator) flip it, and the deep form-submit close path flips it back. A `request-close` handler dismisses on Escape / X / outside-click.
- **Back button → `header-prefix` slot:** the left-of-title back button (shown in form view) moves into the wrapper's `header-prefix` slot (added for the wizard) and gains an accessible name + tooltip via `layout.back`.
- **Busy gate:** `_submitting` is bound to `?busy` so a dismissal can't orphan an in-flight add. This is a one-shot terminal submit (each add commits + closes or advances the bundle queue), the same shape as the wizard.
- **Styles:** the `wa-dialog::part(...)` overrides (primary-colored header, 40×40 close button, 900px catalog / 480px form-view width) are re-prefixed to `esphome-base-dialog::part(...)`; the now-dead `.dialog-label` and `footer { display: none }` are dropped.

Public API (`open` / `openWithSearch` + the child-step event handlers) is unchanged, so the three consumers need no edits. The catalog stays mounted-but-hidden across the catalog↔form round trip exactly as before.

### Mobile layout

Moving onto the wrapper gave the dialog `esphome-base-dialog`'s *centered* mobile default, which boxed the wide catalog into a column narrower than its content and clipped the cards (the dialog previously had no mobile handling — it was just 900px). Fixed:

- Opt the dialog into **`fullscreenMobileDialog`** (like the wizard's board picker) so the catalog gets the whole viewport on phones.
- The catalog grid used `minmax(340px, 1fr)`; on a 375px phone the full-screen body is `< 340px`, forcing a track wider than the viewport. Drop to **`minmax(0, 1fr)`** below the phone breakpoint so the single column shrinks to fit.
- The catalog capped itself at **`max-height: 70vh`** (a leftover from the old centered-modal-on-phone), leaving the bottom of the full-screen dialog empty — fill the available height instead.

Verified end-to-end on iPhone SE (375px) and Pro Max 14 (430px): full-screen, no horizontal overflow, cards fully visible, list fills the height.

Adds an open / openWithSearch / request-close / form-view-back contract test; the existing helper-function suites (dep-nav, categories, draft, selection) still pass.

**Related issue or feature (if applicable):**

- part of #549 (last component dialog before add-automation)

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

### DRY follow-up

The add-component dialog and the create-config wizard (#589) had a **byte-identical** copy of the "primary-colored header + flush 40×40 close button + `header-prefix` back button" block. Hoisted it into a shared `primaryHeaderDialogStyles` fragment (`src/styles/dialog-primary-header.ts`) consumed by both, so the branded wizard-dialog header lives in one place. Pure refactor — rules relocated unchanged, no selector overlaps the per-dialog `--width`/body/banner rules, so the cascade is identical. (This is why the PR also touches `create-config-dialog.ts`.)
