### PR TITLE
Migrate the add-automation dialog onto esphome-base-dialog

### DIFF
--- a/src/components/device/add-automation-dialog.styles.ts
+++ b/src/components/device/add-automation-dialog.styles.ts
@@ -8,10 +8,10 @@ import { css } from "lit";
  * ``inputStyles``.
  */
 export const addAutomationDialogStyles = css`
-  wa-dialog {
+  esphome-base-dialog {
     --width: 560px;
   }
-  wa-dialog::part(body) {
+  esphome-base-dialog::part(body) {
     padding: var(--wa-space-l);
   }
   .field {

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -18,9 +18,8 @@
  * new section.
  */
 import { consume } from "@lit/context";
-import { mdiClose } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../api/index.js";
@@ -37,7 +36,6 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { renderMarkdown } from "../../util/markdown.js";
-import { registerMdiIcons } from "../../util/register-icons.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
 import { addAutomationDialogStyles } from "./add-automation-dialog.styles.js";
 import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
@@ -49,13 +47,11 @@ import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/seria
  *  to?" framing doesn't apply to them. */
 export type AddAutomationKind = "device_on" | "component_on" | "interval";
 
-import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/option/option.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
-
-registerMdiIcons({ close: mdiClose });
+import "../base-dialog.js";
 
 type TargetKind = AddAutomationKind;
 
@@ -77,8 +73,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   @property({ attribute: false })
   board: BoardCatalogEntry | null = null;
 
-  @query("wa-dialog")
-  private _dialog!: HTMLElement & { open: boolean };
+  @state() private _open = false;
 
   @state() private _kind: TargetKind = "device_on";
   @state() private _componentId = "";
@@ -129,9 +124,16 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     this._intervalValue = "";
     this._intervalUnit = "s";
     this._error = "";
-    this._dialog.open = true;
+    this._open = true;
     void this._loadAvailable();
   }
+
+  // esphome-base-dialog never flips its own open on a user-driven close
+  // (Escape / X / outside-click); the host owns _open here. The busy gate
+  // (?busy=_saving) blocks dismissal while an upsert is in flight.
+  private _onRequestClose = () => {
+    this._open = false;
+  };
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
@@ -151,13 +153,18 @@ export class ESPHomeAddAutomationDialog extends LitElement {
           name: this.boardName,
         })
       : this._localize("device.add_automation");
-    return html`<wa-dialog light-dismiss label=${title}>
+    return html`<esphome-base-dialog
+      ?open=${this._open}
+      ?busy=${this._saving}
+      .label=${title}
+      @request-close=${this._onRequestClose}
+    >
       ${this._loading && !this._available
         ? html`<div style="text-align: center; padding: 32px;">
             <wa-spinner></wa-spinner>
           </div>`
         : this._renderForm()}
-    </wa-dialog>`;
+    </esphome-base-dialog>`;
   }
 
   private _renderForm() {
@@ -431,7 +438,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         this.yaml
       );
       this._dispatchAdded(location, yaml_diff);
-      this._dialog.open = false;
+      this._open = false;
     } catch (err) {
       const msg =
         err instanceof Error

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -210,3 +210,41 @@ describe("add-automation-dialog list-shaped triggers (#1080)", () => {
     });
   });
 });
+
+// The migration onto esphome-base-dialog swapped the imperative
+// @query _dialog.open for a reactive _open flag. Pin the open / request-close
+// contract — request-close flipping _open is what makes a user-driven close
+// (Escape / X / outside-click) actually dismiss.
+describe("add-automation-dialog open/close contract", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const baseDialog = (d: ESPHomeAddAutomationDialog): HTMLElement =>
+    d.shadowRoot!.querySelector("esphome-base-dialog")!;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isOpen = (d: ESPHomeAddAutomationDialog): boolean => (d as any)._open;
+
+  it("open() flips the reactive flag and binds ?open", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(slimAvailable())),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    expect(isOpen(dialog)).toBe(false);
+    dialog.open();
+    await dialog.updateComplete;
+    expect(isOpen(dialog)).toBe(true);
+    expect(baseDialog(dialog).hasAttribute("open")).toBe(true);
+  });
+
+  it("flips _open to false on request-close", async () => {
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(slimAvailable())),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    dialog.open();
+    await dialog.updateComplete;
+    baseDialog(dialog).dispatchEvent(new CustomEvent("request-close"));
+    expect(isOpen(dialog)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Migrates `esphome-add-automation-dialog` — the "+ Add automation" wizard (pick target kind → component → trigger, then upsert an empty automation and route to its section) — off a directly-rendered `<wa-dialog>` and onto the shared `esphome-base-dialog` wrapper. **This is the last dialog in #549.**

It's the simplest of the series — a plain header (dynamic title, no back button or custom chrome) — so it follows the basic confirm-dialog shape:

- **Reactive open:** the imperative `@query("wa-dialog")` + `_dialog.open = …` becomes a state-driven `_open` flag. The public `open(prefill?)` method (called by all three consumers — device-navigator, device-section-config, device-board-info, with an optional `{ kind, componentId }` prefill) flips it, and the form-submit success path flips it back. A `request-close` handler dismisses on Escape / X / outside-click.
- **Busy gate:** `_saving` (the one-shot automation upsert) is bound to `?busy` so a dismissal can't orphan the in-flight request.
- **Spinner render-gate preserved:** the `_loading && !_available ? spinner : form` gate (the #495 memory-leak fix — keeps the `wa-select`s mounted across reopens) is unchanged and is *separate* from the busy gate.
- **Styles:** the only override (`::part(body)` padding) and `--width: 560px` are re-prefixed to `esphome-base-dialog`. No `header-prefix` slot or fullscreen-mobile needed (no back button, modest 560px width).
- **Cleanup:** drops the now-dead `mdiClose` import + `registerMdiIcons` registration (the close icon was never rendered).

Public API (`open` / the `automation-added` event) is unchanged, so the three consumers need no edits.

Adds the open / request-close reactive-flag contract test; the existing render-gate and trigger-shape suites still pass.

**Related issue or feature (if applicable):**

- closes the last item in #549

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
