### PR TITLE
Extract a shared fetch-once session-blob cache helper

### DIFF
--- a/src/util/automation-catalog-cache.ts
+++ b/src/util/automation-catalog-cache.ts
@@ -14,6 +14,7 @@ import {
   tallyOutcome,
   type HydrationResult,
 } from "./automation-body-hydration.js";
+import { createSessionBlobCache, type SessionBlobCache } from "./session-blob-cache.js";
 
 /**
  * Session-scoped cache of the five slim automation catalogues
@@ -44,80 +45,49 @@ type CatalogValue = {
   filters: Filter[];
 };
 
-const _cache: {
-  [K in CatalogKind]: Map<string, CatalogValue[K]>;
-} = {
-  triggers: new Map(),
-  actions: new Map(),
-  conditions: new Map(),
-  light_effects: new Map(),
-  filters: new Map(),
-};
-
-const _inflight: {
-  [K in CatalogKind]: Map<string, Promise<CatalogValue[K]>>;
-} = {
-  triggers: new Map(),
-  actions: new Map(),
-  conditions: new Map(),
-  light_effects: new Map(),
-  filters: new Map(),
-};
-
-const _listeners = new Set<() => void>();
-
 function _key(platform?: string, boardId?: string): string {
   return `${platform ?? ""}|${boardId ?? ""}`;
 }
 
-function _notify(): void {
-  // Isolate each listener so a throwing subscriber doesn't reject
-  // the fetch promise (the cache is already populated at this
-  // point, so the rejection would be misleading) or skip later
-  // listeners. Same isolation as ``component-name-cache.ts``.
-  for (const listener of _listeners) {
-    try {
-      listener();
-    } catch (err) {
-      console.error("automation-catalog-cache listener threw", err);
-    }
-  }
-}
-
-function _fetch<K extends CatalogKind>(
-  kind: K,
-  fetcher: (platform?: string, boardId?: string) => Promise<CatalogValue[K]>,
-  platform: string | undefined,
-  boardId: string | undefined
-): Promise<CatalogValue[K]> {
-  const key = _key(platform, boardId);
-  const cached = _cache[kind].get(key);
-  if (cached !== undefined) return Promise.resolve(cached);
-
-  const existing = _inflight[kind].get(key);
-  if (existing) return existing;
-
-  const promise = fetcher(platform, boardId)
-    .then((entries) => {
-      _cache[kind].set(key, entries);
-      _inflight[kind].delete(key);
-      _notify();
-      return entries;
-    })
-    .catch((err) => {
-      _inflight[kind].delete(key);
-      throw err;
-    });
-
-  _inflight[kind].set(key, promise);
-  return promise;
-}
+// One session-blob cache per catalogue kind, all keyed by
+// ``platform|boardId``. No ``fallback`` — a failed list fetch rethrows
+// and isn't cached, so the next call retries; ``light_effects`` /
+// ``filters`` add a hydration pass below via each cache's ``update``.
+const _caches: {
+  [K in CatalogKind]: SessionBlobCache<CatalogValue[K], [string?, string?]>;
+} = {
+  triggers: createSessionBlobCache<AutomationTrigger[], [string?, string?]>({
+    name: "automation-catalog-cache:triggers",
+    key: _key,
+    fetch: (api, p, b) => api.getAutomationTriggers(p, b),
+  }),
+  actions: createSessionBlobCache<AutomationAction[], [string?, string?]>({
+    name: "automation-catalog-cache:actions",
+    key: _key,
+    fetch: (api, p, b) => api.getAutomationActions(p, b),
+  }),
+  conditions: createSessionBlobCache<AutomationCondition[], [string?, string?]>({
+    name: "automation-catalog-cache:conditions",
+    key: _key,
+    fetch: (api, p, b) => api.getAutomationConditions(p, b),
+  }),
+  light_effects: createSessionBlobCache<LightEffect[], [string?, string?]>({
+    name: "automation-catalog-cache:light_effects",
+    key: _key,
+    fetch: (api, p, b) => api.getLightEffects(p, b),
+  }),
+  filters: createSessionBlobCache<Filter[], [string?, string?]>({
+    name: "automation-catalog-cache:filters",
+    key: _key,
+    fetch: (api, p, b) => api.getFilters(p, b),
+  }),
+};
 
 export function getCachedAutomationTriggers(
   platform?: string,
   boardId?: string
 ): AutomationTrigger[] | undefined {
-  return _cache.triggers.get(_key(platform, boardId));
+  return _caches.triggers.getCached(platform, boardId);
 }
 
 export function fetchAutomationTriggers(
@@ -125,14 +95,14 @@ export function fetchAutomationTriggers(
   platform?: string,
   boardId?: string
 ): Promise<AutomationTrigger[]> {
-  return _fetch("triggers", (p, b) => api.getAutomationTriggers(p, b), platform, boardId);
+  return _caches.triggers.fetch(api, platform, boardId);
 }
 
 export function getCachedAutomationActions(
   platform?: string,
   boardId?: string
 ): AutomationAction[] | undefined {
-  return _cache.actions.get(_key(platform, boardId));
+  return _caches.actions.getCached(platform, boardId);
 }
 
 export function fetchAutomationActions(
@@ -140,14 +110,14 @@ export function fetchAutomationActions(
   platform?: string,
   boardId?: string
 ): Promise<AutomationAction[]> {
-  return _fetch("actions", (p, b) => api.getAutomationActions(p, b), platform, boardId);
+  return _caches.actions.fetch(api, platform, boardId);
 }
 
 export function getCachedAutomationConditions(
   platform?: string,
   boardId?: string
 ): AutomationCondition[] | undefined {
-  return _cache.conditions.get(_key(platform, boardId));
+  return _caches.conditions.getCached(platform, boardId);
 }
 
 export function fetchAutomationConditions(
@@ -155,19 +125,14 @@ export function fetchAutomationConditions(
   platform?: string,
   boardId?: string
 ): Promise<AutomationCondition[]> {
-  return _fetch(
-    "conditions",
-    (p, b) => api.getAutomationConditions(p, b),
-    platform,
-    boardId
-  );
+  return _caches.conditions.fetch(api, platform, boardId);
 }
 
 export function getCachedLightEffects(
   platform?: string,
   boardId?: string
 ): LightEffect[] | undefined {
-  return _cache.light_effects.get(_key(platform, boardId));
+  return _caches.light_effects.getCached(platform, boardId);
 }
 
 export async function fetchLightEffects(
@@ -175,13 +140,8 @@ export async function fetchLightEffects(
   platform?: string,
   boardId?: string
 ): Promise<LightEffect[]> {
-  const list = await _fetch(
-    "light_effects",
-    (p, b) => api.getLightEffects(p, b),
-    platform,
-    boardId
-  );
-  // Hydration runs OUTSIDE ``_fetch`` so cache hits also retry
+  const list = await _caches.light_effects.fetch(api, platform, boardId);
+  // Hydration runs OUTSIDE the cache fetch so cache hits also retry
   // any entries whose body fetch previously failed —
   // ``_hydratedEntries`` short-circuits already-done ones, so the
   // happy path pays a no-op filter.
@@ -194,7 +154,7 @@ export function getCachedFilters(
   platform?: string,
   boardId?: string
 ): Filter[] | undefined {
-  return _cache.filters.get(_key(platform, boardId));
+  return _caches.filters.getCached(platform, boardId);
 }
 
 export async function fetchFilters(
@@ -202,19 +162,19 @@ export async function fetchFilters(
   platform?: string,
   boardId?: string
 ): Promise<Filter[]> {
-  const list = await _fetch("filters", (p, b) => api.getFilters(p, b), platform, boardId);
+  const list = await _caches.filters.fetch(api, platform, boardId);
   return _postHydrate("filters", platform, boardId, list, (l) =>
     _hydrateRegistryConfigEntries(api, "filters", l)
   );
 }
 
-/** After ``_fetch`` notifies subscribers with the slim list, hydrate
- *  ``config_entries`` and — if any entry actually changed — replace
- *  the cached array with a fresh identity and notify again so
- *  identity-checking consumers (registry-list's
+/** After the cache fetch notifies subscribers with the slim list,
+ *  hydrate ``config_entries`` and — if any entry actually changed —
+ *  ``update`` the cache with a fresh array identity (which notifies
+ *  again) so identity-checking consumers (registry-list's
  *  ``subscribeAutomationCatalogCache`` reread of ``cache()``) repaint
  *  with the hydrated entries. Without the second notify + identity
- *  swap, the slim entries the first ``_notify`` painted would never
+ *  swap, the slim entries the first notify painted would never
  *  refresh: in-place mutation of ``config_entries`` doesn't bump the
  *  array reference Lit's ``hasChanged`` compares against. */
 async function _postHydrate<K extends "light_effects" | "filters">(
@@ -227,8 +187,7 @@ async function _postHydrate<K extends "light_effects" | "filters">(
   const result = await hydrate(list);
   if (result.succeeded === 0) return list;
   const fresh = [...list] as CatalogValue[K];
-  _cache[kind].set(_key(platform, boardId), fresh);
-  _notify();
+  _caches[kind].update(fresh, platform, boardId);
   return fresh;
 }
 
@@ -294,22 +253,17 @@ async function _hydrateRegistryConfigEntries(
 }
 
 /** Subscribe to cache updates. Returns an unsubscribe function.
- *  Listeners fire once per fresh entry (across any of the four
- *  catalogues); failed fetches do not fire. */
+ *  Listeners fire once per fresh entry (across any of the five
+ *  catalogues); failed fetches do not fire. Fanned across every
+ *  per-kind cache so one subscription covers them all. */
 export function subscribeAutomationCatalogCache(listener: () => void): () => void {
-  _listeners.add(listener);
+  const unsubs = Object.values(_caches).map((c) => c.subscribe(listener));
   return () => {
-    _listeners.delete(listener);
+    for (const unsub of unsubs) unsub();
   };
 }
 
-/** Test-only: drop all cached entries and pending promises. */
+/** Test-only: drop all cached entries, pending promises, and listeners. */
 export function _clearAutomationCatalogCache(): void {
-  // Derive the kinds from `_cache` so new registries (filters,
-  // ...) don't have to remember to update this list separately.
-  for (const kind of Object.keys(_cache) as CatalogKind[]) {
-    _cache[kind].clear();
-    _inflight[kind].clear();
-  }
-  _listeners.clear();
+  for (const cache of Object.values(_caches)) cache.reset();
 }

--- a/src/util/pin-registry-modes-cache.ts
+++ b/src/util/pin-registry-modes-cache.ts
@@ -1,4 +1,5 @@
 import type { ESPHomeAPI } from "../api/esphome-api.js";
+import { createSessionBlobCache } from "./session-blob-cache.js";
 
 /**
  * Session cache of the ``{provider_key: [allowed_mode_flags]}`` map
@@ -6,57 +7,35 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
  * renderers. A failed fetch caches ``{}`` so renders don't retry-storm.
  */
 
-let _cache: Record<string, string[]> | undefined;
-let _inflight: Promise<Record<string, string[]>> | undefined;
-const _listeners = new Set<() => void>();
+const _cache = createSessionBlobCache<Record<string, string[]>>({
+  name: "pin-registry-modes",
+  fetch: (api) => api.getPinRegistryModes(),
+  fallback: (err) => {
+    // Cache an empty map so renders don't retry-storm; log so the lost
+    // scoping shows. Null-prototype to match the populated map's shape.
+    console.warn("pin-registry-modes fetch failed; Mode flags unscoped", err);
+    return Object.create(null) as Record<string, string[]>;
+  },
+});
 
 /** Read the cached map; ``undefined`` until the first fetch resolves. */
 export function getCachedPinRegistryModes(): Record<string, string[]> | undefined {
-  return _cache;
+  return _cache.getCached();
 }
 
 /** Subscribe to cache population; returns an unsubscribe function. */
 export function subscribePinRegistryModes(cb: () => void): () => void {
-  _listeners.add(cb);
-  return () => {
-    _listeners.delete(cb);
-  };
+  return _cache.subscribe(cb);
 }
 
 /** Fetch once per session; concurrent callers share the in-flight promise. */
 export function fetchPinRegistryModes(
   api: ESPHomeAPI
 ): Promise<Record<string, string[]>> {
-  if (_cache) return Promise.resolve(_cache);
-  if (!_inflight) {
-    _inflight = api
-      .getPinRegistryModes()
-      .catch((err) => {
-        // Cache an empty map so renders don't retry-storm; log so the lost
-        // scoping shows. Null-prototype to match the populated map's shape.
-        console.warn("pin-registry-modes fetch failed; Mode flags unscoped", err);
-        return Object.create(null) as Record<string, string[]>;
-      })
-      .then((modes) => {
-        _cache = modes;
-        _inflight = undefined;
-        // Isolate listeners so one throw can't break others or reject this promise.
-        for (const cb of _listeners) {
-          try {
-            cb();
-          } catch (err) {
-            console.error("pin-registry-modes listener threw", err);
-          }
-        }
-        return modes;
-      });
-  }
-  return _inflight;
+  return _cache.fetch(api);
 }
 
 /** Test-only: reset the cached map, in-flight fetch, and listeners. */
 export function _resetPinRegistryModesCache(): void {
-  _cache = undefined;
-  _inflight = undefined;
-  _listeners.clear();
+  _cache.reset();
 }

--- a/src/util/session-blob-cache.ts
+++ b/src/util/session-blob-cache.ts
@@ -1,0 +1,116 @@
+import type { ESPHomeAPI } from "../api/index.js";
+
+/**
+ * A fetch-once session cache for a whole immutable payload, keyed by a
+ * string derived from the fetch arguments. Concurrent callers for the
+ * same key share one in-flight promise; the resolved value is held for
+ * the session. Single-global caches are just the keyed case with one
+ * fixed ``""`` key (omit ``key``).
+ *
+ * This is distinct from :class:`BatchedCache` (`batched-cache.ts`),
+ * which is per-key / microtask-batched / consumer-driven — the wrong
+ * shape for "read one whole list/map at once". Both
+ * ``pin-registry-modes-cache`` and ``automation-catalog-cache`` are
+ * built on this.
+ *
+ * Failure policy is the ``fallback`` option:
+ * - present → the rejection is swallowed, ``fallback(err)`` is cached
+ *   and broadcast, and ``fetch`` resolves to it (so renders don't
+ *   retry-storm; the callback owns any logging).
+ * - absent → the rejection propagates and nothing is cached, so the
+ *   next call retries.
+ */
+export interface SessionBlobCache<T, A extends unknown[]> {
+  /** Cached value for these args, or ``undefined`` until first resolve. */
+  getCached(...args: A): T | undefined;
+  /** Fetch once per key; concurrent callers share the in-flight promise. */
+  fetch(api: ESPHomeAPI, ...args: A): Promise<T>;
+  /** Overwrite a key's cached value and notify subscribers — for an
+   *  external mutation (e.g. post-fetch hydration swapping identity). */
+  update(value: T, ...args: A): void;
+  /** Subscribe to cache updates; returns an unsubscribe function. */
+  subscribe(cb: () => void): () => void;
+  /** Test-only: drop cached values, in-flight fetches, and listeners. */
+  reset(): void;
+}
+
+export interface SessionBlobCacheOptions<T, A extends unknown[]> {
+  /** Label used in the listener-threw log line. */
+  name: string;
+  fetch: (api: ESPHomeAPI, ...args: A) => Promise<T>;
+  /** Cache key from the fetch args. Defaults to a single ``""`` key. */
+  key?: (...args: A) => string;
+  /** Failure fallback — see the interface doc. Omit to rethrow. */
+  fallback?: (err: unknown) => T;
+}
+
+export function createSessionBlobCache<T, A extends unknown[] = []>(
+  opts: SessionBlobCacheOptions<T, A>
+): SessionBlobCache<T, A> {
+  const keyOf = opts.key ?? (() => "");
+  const cache = new Map<string, T>();
+  const inflight = new Map<string, Promise<T>>();
+  const listeners = new Set<() => void>();
+
+  // Isolate each listener so a throwing subscriber can't reject the fetch
+  // promise (the cache is already populated here) or skip later listeners.
+  const notify = (): void => {
+    for (const listener of listeners) {
+      try {
+        listener();
+      } catch (err) {
+        console.error(`${opts.name} listener threw`, err);
+      }
+    }
+  };
+
+  return {
+    getCached(...args: A): T | undefined {
+      return cache.get(keyOf(...args));
+    },
+
+    fetch(api: ESPHomeAPI, ...args: A): Promise<T> {
+      const key = keyOf(...args);
+      if (cache.has(key)) return Promise.resolve(cache.get(key) as T);
+      const existing = inflight.get(key);
+      if (existing) return existing;
+
+      const promise = opts
+        .fetch(api, ...args)
+        .then((value) => {
+          cache.set(key, value);
+          inflight.delete(key);
+          notify();
+          return value;
+        })
+        .catch((err: unknown) => {
+          inflight.delete(key);
+          if (opts.fallback === undefined) throw err;
+          const value = opts.fallback(err);
+          cache.set(key, value);
+          notify();
+          return value;
+        });
+      inflight.set(key, promise);
+      return promise;
+    },
+
+    update(value: T, ...args: A): void {
+      cache.set(keyOf(...args), value);
+      notify();
+    },
+
+    subscribe(cb: () => void): () => void {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+
+    reset(): void {
+      cache.clear();
+      inflight.clear();
+      listeners.clear();
+    },
+  };
+}

--- a/src/util/session-blob-cache.ts
+++ b/src/util/session-blob-cache.ts
@@ -1,4 +1,4 @@
-import type { ESPHomeAPI } from "../api/index.js";
+import type { ESPHomeAPI } from "../api/esphome-api.js";
 
 /**
  * A fetch-once session cache for a whole immutable payload, keyed by a
@@ -51,6 +51,11 @@ export function createSessionBlobCache<T, A extends unknown[] = []>(
   const cache = new Map<string, T>();
   const inflight = new Map<string, Promise<T>>();
   const listeners = new Set<() => void>();
+  // Bumped by reset(); a fetch captures it at call time so a stale
+  // promise that resolves after a reset no-ops its cache write / notify
+  // (it still resolves the original callers) instead of repopulating a
+  // reset cache or notifying listeners added since.
+  let generation = 0;
 
   // Isolate each listener so a throwing subscriber can't reject the fetch
   // promise (the cache is already populated here) or skip later listeners.
@@ -75,20 +80,25 @@ export function createSessionBlobCache<T, A extends unknown[] = []>(
       const existing = inflight.get(key);
       if (existing) return existing;
 
+      const gen = generation;
       const promise = opts
         .fetch(api, ...args)
         .then((value) => {
-          cache.set(key, value);
-          inflight.delete(key);
-          notify();
+          if (gen === generation) {
+            cache.set(key, value);
+            inflight.delete(key);
+            notify();
+          }
           return value;
         })
         .catch((err: unknown) => {
-          inflight.delete(key);
+          if (gen === generation) inflight.delete(key);
           if (opts.fallback === undefined) throw err;
           const value = opts.fallback(err);
-          cache.set(key, value);
-          notify();
+          if (gen === generation) {
+            cache.set(key, value);
+            notify();
+          }
           return value;
         });
       inflight.set(key, promise);
@@ -108,6 +118,7 @@ export function createSessionBlobCache<T, A extends unknown[] = []>(
     },
 
     reset(): void {
+      generation += 1;
       cache.clear();
       inflight.clear();
       listeners.clear();

--- a/src/util/session-blob-cache.ts
+++ b/src/util/session-blob-cache.ts
@@ -81,8 +81,17 @@ export function createSessionBlobCache<T, A extends unknown[] = []>(
       if (existing) return existing;
 
       const gen = generation;
-      const promise = opts
-        .fetch(api, ...args)
+      // Call the fetcher eagerly (callers rely on the request firing
+      // synchronously), but funnel a synchronous throw into a rejection so
+      // it flows through the fallback / rethrow path below rather than
+      // escaping fetch() directly.
+      let started: Promise<T>;
+      try {
+        started = opts.fetch(api, ...args);
+      } catch (err) {
+        started = Promise.reject(err);
+      }
+      const promise = started
         .then((value) => {
           if (gen === generation) {
             cache.set(key, value);

--- a/test/util/session-blob-cache.test.ts
+++ b/test/util/session-blob-cache.test.ts
@@ -120,4 +120,26 @@ describe("createSessionBlobCache", () => {
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(onNotify).toHaveBeenCalledTimes(1); // only the pre-reset fetch
   });
+
+  it("a fetch resolving after reset() no-ops its cache write and notify", async () => {
+    let release!: (v: string[]) => void;
+    const fetch = vi.fn(
+      () =>
+        new Promise<string[]>((resolve) => {
+          release = resolve;
+        })
+    );
+    const cache = createSessionBlobCache<string[]>({ name: "t", fetch });
+
+    const pending = cache.fetch(API); // in-flight
+    cache.reset();
+    const lateListener = vi.fn();
+    cache.subscribe(lateListener); // subscribed after the reset
+
+    release(["stale"]);
+    await expect(pending).resolves.toEqual(["stale"]); // caller still resolves
+    // ...but the post-reset cache stays empty and the late listener is untouched.
+    expect(cache.getCached()).toBeUndefined();
+    expect(lateListener).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/session-blob-cache.test.ts
+++ b/test/util/session-blob-cache.test.ts
@@ -77,6 +77,29 @@ describe("createSessionBlobCache", () => {
     expect(onNotify).toHaveBeenCalledTimes(1);
   });
 
+  it("normalizes a synchronous throw in the fetcher into the failure path", async () => {
+    // no fallback → rejects (not a sync throw out of fetch())
+    const cache = createSessionBlobCache<string[]>({
+      name: "t",
+      fetch: () => {
+        throw new Error("sync boom");
+      },
+    });
+    await expect(cache.fetch(API)).rejects.toThrow("sync boom");
+    expect(cache.getCached()).toBeUndefined();
+
+    // with fallback → the sync throw is caught and the fallback is cached
+    const withFallback = createSessionBlobCache<string[]>({
+      name: "t",
+      fetch: () => {
+        throw new Error("sync boom");
+      },
+      fallback: () => ["fallback"],
+    });
+    await expect(withFallback.fetch(API)).resolves.toEqual(["fallback"]);
+    expect(withFallback.getCached()).toEqual(["fallback"]);
+  });
+
   it("isolates a throwing listener from others and from the fetch promise", async () => {
     const fetch = vi.fn(async () => ["a"]);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/test/util/session-blob-cache.test.ts
+++ b/test/util/session-blob-cache.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import { createSessionBlobCache } from "../../src/util/session-blob-cache.js";
+
+// The helper only forwards ``api`` to ``opts.fetch``; tests that don't
+// exercise a real client pass this stand-in.
+const API = {} as ESPHomeAPI;
+
+describe("createSessionBlobCache", () => {
+  it("fetches once per key and shares the in-flight promise", async () => {
+    const fetch = vi.fn(async () => ["a"]);
+    const cache = createSessionBlobCache<string[]>({ name: "t", fetch });
+
+    const [a, b] = await Promise.all([cache.fetch(API), cache.fetch(API)]);
+    expect(a).toEqual(["a"]);
+    expect(b).toBe(a);
+    await cache.fetch(API);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(cache.getCached()).toBe(a);
+  });
+
+  it("buckets by the derived key", async () => {
+    const fetch = vi.fn(async (_api: ESPHomeAPI, p?: string) => [p ?? "none"]);
+    const cache = createSessionBlobCache<string[], [string?]>({
+      name: "t",
+      key: (p) => p ?? "",
+      fetch,
+    });
+
+    expect(await cache.fetch(API, "x")).toEqual(["x"]);
+    expect(await cache.fetch(API, "y")).toEqual(["y"]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(cache.getCached("x")).toEqual(["x"]);
+    expect(cache.getCached("y")).toEqual(["y"]);
+    expect(cache.getCached("z")).toBeUndefined();
+  });
+
+  it("with a fallback: caches it, notifies, and resolves (no retry-storm)", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const onNotify = vi.fn();
+    const cache = createSessionBlobCache<Record<string, string[]>>({
+      name: "t",
+      fetch,
+      fallback: () => Object.create(null) as Record<string, string[]>,
+    });
+    cache.subscribe(onNotify);
+
+    const value = await cache.fetch(API);
+    expect(value).toEqual({});
+    expect(onNotify).toHaveBeenCalledTimes(1);
+    // Cached → no second fetch.
+    await cache.fetch(API);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(cache.getCached()).toBe(value);
+  });
+
+  it("without a fallback: rejects, doesn't cache, and retries next call", async () => {
+    let attempt = 0;
+    const fetch = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("transient");
+      return ["ok"];
+    });
+    const onNotify = vi.fn();
+    const cache = createSessionBlobCache<string[]>({ name: "t", fetch });
+    cache.subscribe(onNotify);
+
+    await expect(cache.fetch(API)).rejects.toThrow("transient");
+    expect(cache.getCached()).toBeUndefined();
+    expect(onNotify).not.toHaveBeenCalled(); // failed fetch doesn't notify
+    // Retry succeeds and caches.
+    expect(await cache.fetch(API)).toEqual(["ok"]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(onNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates a throwing listener from others and from the fetch promise", async () => {
+    const fetch = vi.fn(async () => ["a"]);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cache = createSessionBlobCache<string[]>({ name: "t", fetch });
+    const good = vi.fn();
+    cache.subscribe(() => {
+      throw new Error("listener boom");
+    });
+    cache.subscribe(good);
+
+    await expect(cache.fetch(API)).resolves.toEqual(["a"]);
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalledWith("t listener threw", expect.any(Error));
+    errSpy.mockRestore();
+  });
+
+  it("update() overwrites the cached value and notifies", () => {
+    const cache = createSessionBlobCache<string[]>({
+      name: "t",
+      fetch: async () => ["a"],
+    });
+    const onNotify = vi.fn();
+    cache.subscribe(onNotify);
+
+    cache.update(["b"]);
+    expect(cache.getCached()).toEqual(["b"]);
+    expect(onNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset() clears the cache, in-flight fetch, and listeners", async () => {
+    const fetch = vi.fn(async () => ["a"]);
+    const cache = createSessionBlobCache<string[]>({ name: "t", fetch });
+    const onNotify = vi.fn();
+    cache.subscribe(onNotify);
+
+    await cache.fetch(API);
+    cache.reset();
+    expect(cache.getCached()).toBeUndefined();
+    // Listener was dropped; a fresh fetch re-runs and doesn't notify it.
+    await cache.fetch(API);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(onNotify).toHaveBeenCalledTimes(1); // only the pre-reset fetch
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Closes #592. Two session caches hand-rolled the same "fetch one immutable blob once, share the in-flight promise, notify subscribers" boilerplate: `pin-registry-modes-cache.ts` (single global) and `automation-catalog-cache.ts` (keyed by platform|boardId, five kinds). `BatchedCache` is the wrong shape for whole-payload reads, so both were written by hand.

This extracts `createSessionBlobCache<T, A>` (`src/util/session-blob-cache.ts`): a keyed single-flight blob cache that owns the in-flight dedup, isolated listener notification, an `update()` for external-mutation broadcast, and `reset()`. A single-global cache is just the keyed case with one fixed key.

No behaviour change; each caller's failure semantics are preserved via the `fallback` option:

- pin caches `{}` and warns on failure (no retry-storm).
- the automation catalogues omit `fallback`, so a failed list fetch rethrows and isn't cached, and the next call retries.

Typing is fully preserved: the variadic `A` carries the key args through `fetch` / `getCached` / `update`, so call sites stay typed; no `any`. Both modules keep their exact public APIs, so consumers (`trigger-catalog-controller`, `registry-list`, pin renderers) and their tests need no edits. `automation-catalog-cache` uses one instance per kind with a fanned-out subscription so the shared-listener semantics are unchanged, and `_postHydrate` broadcasts the hydrated identity swap via `update()`.

The existing cache tests pass unchanged as the behaviour guard; a new `session-blob-cache.test.ts` pins the primitive directly.

**Related issue or feature (if applicable):**

- Closes #592

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
