### PR TITLE
Pin dropdown groups: accurate warning comment + aria-hidden headers

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -133,10 +133,16 @@ function renderPinOptions(
   // it's one flat list (no false "this is special" framing).
   const splitByCapability = supported.length > 0 && other.length > 0;
   const features = (entry.pin_features ?? []).map((f) => f.toUpperCase()).join(", ");
+  // The group label + divider are a sighted-only contrast cue. ``wa-select``
+  // only navigates ``<wa-option>`` children, so a screen reader would
+  // otherwise announce these as stray, contextless text mid-list (there's no
+  // wa-optgroup to carry real grouping). Hide them from the a11y tree; each
+  // option still conveys its own state (reserved → ``disabled``, in-use /
+  // conflict → ``title``), so no per-option context is lost.
   const header = (key: string, withDivider: boolean) =>
     html`${withDivider
-        ? html`<wa-divider class="pin-group-divider"></wa-divider>`
-        : nothing} <small class="pin-group-label">${key}</small>`;
+        ? html`<wa-divider class="pin-group-divider" aria-hidden="true"></wa-divider>`
+        : nothing} <small class="pin-group-label" aria-hidden="true">${key}</small>`;
   return html`
     ${splitByCapability && features
       ? header(ctx.localize("device.pin_group_supports", { features }), false)
@@ -209,7 +215,9 @@ export function renderPinField(
   const invalid = ctx.errorAt(path) !== null;
   // Show every board pin; a pin that doesn't match the field's required
   // features (or direction) isn't hidden — it's grouped under "Other pins"
-  // with a warning, and stays selectable (issue #1012). Hiding it is too
+  // and stays selectable (issue #1012). Only a direction conflict
+  // (input-only pin on an output field) or an in-use pin is warned; a
+  // merely-missing capability is grouped, not warned. Hiding it is too
   // harsh for unusual boards and "I know what I'm doing" workflows.
   let visible = ctx.board.pins;
   // A featured-component preset can narrow the pin set further — e.g.

--- a/test/components/device/config-entry-pin-renderer-a11y.test.ts
+++ b/test/components/device/config-entry-pin-renderer-a11y.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The Supports / Other / Reserved group labels and dividers inside the
+ * pin ``<wa-select>`` are a sighted-only contrast cue (there's no
+ * wa-optgroup to carry real grouping). They must be ``aria-hidden`` so a
+ * screen reader doesn't announce them as stray, contextless text mid-list.
+ */
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { ConfigEntryType, PinFeature } from "../../../src/api/types/config-entries.js";
+import { renderPinField } from "../../../src/components/device/config-entry-pin-renderer.js";
+import {
+  makeBoardPin,
+  makeEntry,
+  makeRenderCtx,
+  makeTestBoard,
+} from "./_renderer-fixtures.js";
+
+// GPIO32 has ADC (Supports), GPIO25 doesn't (Other), GPIO6 is
+// board-unavailable (Reserved) — forces all three groups + dividers.
+const board = () =>
+  makeTestBoard({
+    pins: [
+      makeBoardPin(32, { features: ["input", "output", "adc"] }),
+      makeBoardPin(25, { features: ["input", "output"] }),
+      makeBoardPin(6, { features: ["input", "output"], available: false }),
+    ],
+  });
+
+describe("renderPinField — group header a11y", () => {
+  it("marks the group labels and dividers aria-hidden", () => {
+    const entry = makeEntry(ConfigEntryType.PIN, {
+      key: "pin",
+      required: true,
+      pin_features: [PinFeature.ADC],
+    });
+    const container = document.createElement("div");
+    render(
+      renderPinField(entry, ["pin"], makeRenderCtx({}, { board: board() })),
+      container
+    );
+
+    const labels = [...container.querySelectorAll(".pin-group-label")];
+    const dividers = [...container.querySelectorAll(".pin-group-divider")];
+    expect(labels.length).toBeGreaterThan(0);
+    expect(dividers.length).toBeGreaterThan(0);
+    for (const el of [...labels, ...dividers]) {
+      expect(el.getAttribute("aria-hidden")).toBe("true");
+    }
+    // The options themselves stay in the a11y tree (not hidden).
+    for (const opt of container.querySelectorAll("wa-option")) {
+      expect(opt.getAttribute("aria-hidden")).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #597, addressing its late Kōan review (two non-blocking suggestions).

1. Doc accuracy: the `renderPinField` comment said a feature-mismatch pin is grouped under "Other pins" "with a warning". It isn't — `warn = inUse || inputOnlyConflict`, so only a direction conflict (input-only pin on an output field) or an in-use pin raises the ⚠. A merely-missing capability is grouped, not warned (the "untagged != incapable" rationale). Reworded to match.

2. Accessibility: the Supports / Other / Reserved group labels (`<small class="pin-group-label">`) and `<wa-divider>`s inside the pin `<wa-select>` are a sighted-only contrast cue. WebAwesome has no option-group construct, and `wa-select` only navigates `<wa-option>` children, so a screen reader would announce these as stray, contextless text mid-list. They're now `aria-hidden`, so AT gets a clean option list; each option still conveys its own state (reserved -> `disabled`, in-use/conflict -> `title`), so no per-option context is lost.

Added a happy-dom test asserting the labels and dividers are `aria-hidden="true"` while the options are not.

**Related issue or feature (if applicable):**

- Follow-up to #597

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
