### PR TITLE
Consolidate duplicated dialog header/close styles (DRY)

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -5,6 +5,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
@@ -41,27 +42,15 @@ export class ESPHomeAdoptDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
       }
 
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      esphome-base-dialog::part(footer) {
-        display: none;
       }
 
       .description {

--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -35,27 +36,15 @@ export class ESPHomeApiKeyDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     css`
       esphome-base-dialog {
         --width: 480px;
       }
 
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      esphome-base-dialog::part(footer) {
-        display: none;
       }
 
       .content {

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
@@ -50,25 +51,12 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
+    quietCloseButtonStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
-      }
-
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
-      esphome-base-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
       }
 
       esphome-base-dialog::part(body) {

--- a/src/components/device/add-component-dialog.styles.ts
+++ b/src/components/device/add-component-dialog.styles.ts
@@ -9,60 +9,10 @@ export const addComponentDialogStyles = css`
     --width: 480px;
   }
 
-  esphome-base-dialog::part(header) {
-    background: var(--esphome-primary);
-    /* Right padding is 0 so the close button sits flush with the
-       dialog's corner — the button is explicitly sized to a 40x40
-       square below to give the X a comfortable hit target right
-       where the user reaches for it. */
-    padding: 0 0 0 var(--wa-space-m);
-    height: 40px;
-    box-sizing: border-box;
-  }
-
-  /* Title text lives in base-dialog's title-text span; colour/weight
-     cascade in from the forwarded title part. */
-  esphome-base-dialog::part(title) {
-    color: var(--esphome-on-primary);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-  }
-
-  esphome-base-dialog::part(close-button__base) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    /* Square 40x40 button matching the header height so the X has a
-       comfortable click/tap target instead of just the icon's
-       ~14px footprint. */
-    padding: 0;
-    width: 40px;
-    height: 40px;
-    min-width: unset;
-    min-height: unset;
-    color: var(--esphome-on-primary);
-    cursor: pointer;
-  }
-
+  /* Primary header + 40x40 close + .back-button come from
+     primaryHeaderDialogStyles (dialog-chrome.ts). */
   esphome-base-dialog::part(body) {
     padding: var(--wa-space-l);
-  }
-
-  .back-button {
-    display: inline-flex;
-    align-items: center;
-    border: none;
-    background: none;
-    padding: 2px;
-    margin-right: var(--wa-space-2xs);
-    color: var(--esphome-on-primary);
-    cursor: pointer;
-    border-radius: 4px;
-    opacity: 0.85;
-  }
-
-  .back-button:hover {
-    opacity: 1;
   }
 
   /* Breadcrumb that shows up while the user is detoured into

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -7,6 +7,7 @@ import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.j
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -150,6 +151,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
   static styles = [
     espHomeStyles,
     fullscreenMobileDialog("esphome-base-dialog"),
+    // Shared primary header + back button (also used by create-config and the
+    // command dialog) — see dialog-chrome.ts.
+    primaryHeaderDialogStyles,
     addComponentDialogStyles,
   ];
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -151,8 +151,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
   static styles = [
     espHomeStyles,
     fullscreenMobileDialog("esphome-base-dialog"),
-    // Shared primary header + back button (also used by create-config and the
-    // command dialog) — see dialog-chrome.ts.
+    // Shared primary header + back button (also used by create-config) —
+    // see dialog-chrome.ts.
     primaryHeaderDialogStyles,
     addComponentDialogStyles,
   ];

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -11,6 +11,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext, serverVersionContext } from "../context/index.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -86,28 +87,16 @@ export class ESPHomeFeedbackDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
       }
 
-      /* Close-button styling comes from esphome-base-dialog (dialogCloseButtonStyles). */
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
+      /* Extra bottom padding here (the link list has no actions row). */
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l) var(--wa-space-l);
-      }
-
-      esphome-base-dialog::part(footer) {
-        display: none;
       }
 
       .description {

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
@@ -55,27 +56,15 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
       }
 
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      esphome-base-dialog::part(footer) {
-        display: none;
       }
 
       .field {

--- a/src/components/labels/bulk-labels-dialog.ts
+++ b/src/components/labels/bulk-labels-dialog.ts
@@ -35,6 +35,7 @@ import {
   localizeContext,
 } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
+import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { labelChipStyles, renderLabelChip } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -276,6 +277,8 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
     labelChipStyles,
     labelsListStyles,
     dialogActionButtonStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     css`
       :host {
         display: contents;
@@ -285,16 +288,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
         --width: min(480px, 92vw);
       }
 
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
+      /* Bottom padding is --wa-space-m here (vs --wa-space-l elsewhere) — see #600. */
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l) var(--wa-space-m);
       }

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -32,6 +32,10 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { ConfiguredDevice, Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, labelsContext, localizeContext } from "../../context/index.js";
+import {
+  dialogChromeStyles,
+  quietCloseButtonStyles,
+} from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import {
   labelChipStyles,
@@ -114,6 +118,9 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     espHomeStyles,
     labelChipStyles,
     labelsListStyles,
+    // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
+    quietCloseButtonStyles,
     css`
       :host {
         display: block;
@@ -205,22 +212,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         --width: 480px;
       }
 
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
-      esphome-base-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
+      /* Neutral header + title + quiet close come from dialog-chrome.ts. */
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l) var(--wa-space-l);
       }

--- a/src/components/labels/labels-filter.styles.ts
+++ b/src/components/labels/labels-filter.styles.ts
@@ -220,27 +220,11 @@ export const labelsFilterStyles = css`
     --width: 460px;
   }
 
-  .create-dialog::part(header) {
-    padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-  }
-
-  .create-dialog::part(title) {
-    font-size: var(--wa-font-size-m);
-    font-weight: var(--wa-font-weight-bold);
-    color: var(--wa-color-text-normal);
-  }
-
-  .create-dialog::part(close-button__base) {
-    background: transparent;
-    border: none;
-    box-shadow: none;
-  }
-
+  /* Neutral header + title + footer + quiet close come from dialogChromeStyles
+     and quietCloseButtonStyles (added in labels-filter.ts's static styles).
+     There's a single esphome-base-dialog in this component, so their unscoped
+     ::part selectors land on the create dialog. */
   .create-dialog::part(body) {
     padding: 0 var(--wa-space-l) var(--wa-space-l);
-  }
-
-  .create-dialog::part(footer) {
-    display: none;
   }
 `;

--- a/src/components/labels/labels-filter.ts
+++ b/src/components/labels/labels-filter.ts
@@ -32,6 +32,10 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
+import {
+  dialogChromeStyles,
+  quietCloseButtonStyles,
+} from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { labelChipStyles } from "../../util/label-chip-template.js";
@@ -107,7 +111,15 @@ export class ESPHomeLabelsFilter extends LitElement {
     this._close();
   });
 
-  static styles = [espHomeStyles, facetStyles, labelChipStyles, labelsFilterStyles];
+  static styles = [
+    espHomeStyles,
+    facetStyles,
+    labelChipStyles,
+    // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
+    quietCloseButtonStyles,
+    labelsFilterStyles,
+  ];
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._escape.set(this._open);

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -11,6 +11,7 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -84,6 +85,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     inputStyles,
     pinHexStyles,
     dialogActionButtonStyles,
+    // Neutral header + title + footer (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
     pairBuildServerDialogStyles,
   ];
 

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -5,22 +5,10 @@ export const pairBuildServerDialogStyles = css`
     --width: 500px;
   }
 
-  esphome-base-dialog::part(header) {
-    padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-  }
-
-  esphome-base-dialog::part(title) {
-    font-size: var(--wa-font-size-m);
-    font-weight: var(--wa-font-weight-bold);
-    color: var(--wa-color-text-normal);
-  }
-
+  /* Neutral header + title + footer come from dialogChromeStyles
+     (added in pair-build-server-dialog.ts's static styles). */
   esphome-base-dialog::part(body) {
     padding: 0 var(--wa-space-l);
-  }
-
-  esphome-base-dialog::part(footer) {
-    display: none;
   }
 
   .description {

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
@@ -29,25 +30,12 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
+    dialogChromeStyles,
+    quietCloseButtonStyles,
     css`
       esphome-base-dialog {
         --width: 420px;
-      }
-
-      esphome-base-dialog::part(header) {
-        padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-      }
-
-      esphome-base-dialog::part(title) {
-        font-size: var(--wa-font-size-m);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-normal);
-      }
-
-      esphome-base-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
       }
 
       esphome-base-dialog::part(body) {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -92,8 +92,8 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   static styles = [
     espHomeStyles,
     fullscreenMobileDialog("esphome-base-dialog"),
-    // Shared primary header + back button (also used by add-component and the
-    // command dialog) — see dialog-chrome.ts.
+    // Shared primary header + back button (also used by add-component) —
+    // see dialog-chrome.ts.
     primaryHeaderDialogStyles,
     css`
       esphome-base-dialog {

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -7,6 +7,7 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
@@ -91,6 +92,9 @@ export class ESPHomeCreateConfigDialog extends LitElement {
   static styles = [
     espHomeStyles,
     fullscreenMobileDialog("esphome-base-dialog"),
+    // Shared primary header + back button (also used by add-component and the
+    // command dialog) — see dialog-chrome.ts.
+    primaryHeaderDialogStyles,
     css`
       esphome-base-dialog {
         --width: 520px;
@@ -102,58 +106,6 @@ export class ESPHomeCreateConfigDialog extends LitElement {
 
       /* Mobile full-screen comes from fullscreenMobileDialog in the static
          styles so the board picker isn't boxed into a 520px column. #41 */
-
-      esphome-base-dialog::part(header) {
-        background: var(--esphome-primary);
-        /* Right padding is 0 so the close button sits flush with the
-           dialog's corner — the button is explicitly sized to a 40x40
-           square below to give the X a comfortable hit target right
-           where the user reaches for it. */
-        padding: 0 0 0 var(--wa-space-m);
-        height: 40px;
-        box-sizing: border-box;
-      }
-
-      /* Title text lives in base-dialog's title-text span; colour/weight
-         cascade in from the forwarded title part. */
-      esphome-base-dialog::part(title) {
-        color: var(--esphome-on-primary);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-      }
-
-      .back-button {
-        display: inline-flex;
-        align-items: center;
-        border: none;
-        background: none;
-        padding: 2px;
-        margin-right: var(--wa-space-2xs);
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-        border-radius: 4px;
-        opacity: 0.85;
-      }
-
-      .back-button:hover {
-        opacity: 1;
-      }
-
-      esphome-base-dialog::part(close-button__base) {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-        /* Square 40x40 button matching the header height so the X has a
-           comfortable click/tap target instead of just the icon's
-           ~14px footprint. */
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        min-width: unset;
-        min-height: unset;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-      }
 
       esphome-base-dialog::part(body) {
         padding: var(--wa-space-l) var(--wa-space-xl);

--- a/src/styles/dialog-chrome.ts
+++ b/src/styles/dialog-chrome.ts
@@ -1,0 +1,117 @@
+import { css } from "lit";
+
+/**
+ * Shared dialog header / close-button chrome (#549 follow-up).
+ *
+ * The app's dialogs had three style blocks copied verbatim across many
+ * components. These fragments are the single source of truth; drop the
+ * relevant one(s) into a dialog's ``static styles`` array (after
+ * ``espHomeStyles``) and add only the per-dialog deltas — ``--width``, body
+ * padding, banners — alongside.
+ *
+ * Dual ``wa-dialog`` + ``esphome-base-dialog`` selectors cover both the raw
+ * dialogs and the ones migrated onto the shared wrapper (its parts are
+ * re-exported under the same names).
+ */
+
+/**
+ * Neutral modal header: standard header padding, title typography, hidden
+ * footer. The canonical default dialog chrome — ``modalDialogStyles``
+ * composes it, and the form / picker dialogs that don't need the confirm
+ * body layout use it directly. Body padding is intentionally NOT here: it
+ * varies per dialog (``0 var(--wa-space-l)`` vs a bottom-padded variant).
+ */
+export const dialogChromeStyles = css`
+  wa-dialog::part(header),
+  esphome-base-dialog::part(header) {
+    padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
+  }
+
+  wa-dialog::part(title),
+  esphome-base-dialog::part(title) {
+    font-size: var(--wa-font-size-m);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
+  }
+
+  wa-dialog::part(footer),
+  esphome-base-dialog::part(footer) {
+    display: none;
+  }
+`;
+
+/**
+ * Quiet close (X): strip wa-dialog's default button chrome so the X reads as
+ * a plain icon. Shared by the neutral form dialogs that want a flat close
+ * button (the primary-header fragment below carries its own, sized variant).
+ */
+export const quietCloseButtonStyles = css`
+  wa-dialog::part(close-button__base),
+  esphome-base-dialog::part(close-button__base) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+  }
+`;
+
+/**
+ * Branded "wizard" header: a compact primary-colored bar, a flush 40×40
+ * close button, and a back button slotted into ``esphome-base-dialog``'s
+ * ``header-prefix``. Shared by the create-config wizard, the add-component
+ * dialog, and the command dialog. The back button is a plain
+ * ``<button class="back-button" slot="header-prefix">`` in the consumer's
+ * own light DOM, so the ``.back-button`` rule styles it directly.
+ */
+export const primaryHeaderDialogStyles = css`
+  esphome-base-dialog::part(header) {
+    background: var(--esphome-primary);
+    /* Right padding is 0 so the close button sits flush with the
+       dialog's corner — the button is explicitly sized to a 40x40
+       square below to give the X a comfortable hit target right
+       where the user reaches for it. */
+    padding: 0 0 0 var(--wa-space-m);
+    height: 40px;
+    box-sizing: border-box;
+  }
+
+  /* Title text lives in base-dialog's title-text span; colour/weight
+     cascade in from the forwarded title part. */
+  esphome-base-dialog::part(title) {
+    color: var(--esphome-on-primary);
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-bold);
+  }
+
+  esphome-base-dialog::part(close-button__base) {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    /* Square 40x40 button matching the header height so the X has a
+       comfortable click/tap target instead of just the icon's
+       ~14px footprint. */
+    padding: 0;
+    width: 40px;
+    height: 40px;
+    min-width: unset;
+    min-height: unset;
+    color: var(--esphome-on-primary);
+    cursor: pointer;
+  }
+
+  .back-button {
+    display: inline-flex;
+    align-items: center;
+    border: none;
+    background: none;
+    padding: 2px;
+    margin-right: var(--wa-space-2xs);
+    color: var(--esphome-on-primary);
+    cursor: pointer;
+    border-radius: 4px;
+    opacity: 0.85;
+  }
+
+  .back-button:hover {
+    opacity: 1;
+  }
+`;

--- a/src/styles/dialog-chrome.ts
+++ b/src/styles/dialog-chrome.ts
@@ -57,8 +57,10 @@ export const quietCloseButtonStyles = css`
 /**
  * Branded "wizard" header: a compact primary-colored bar, a flush 40×40
  * close button, and a back button slotted into ``esphome-base-dialog``'s
- * ``header-prefix``. Shared by the create-config wizard, the add-component
- * dialog, and the command dialog. The back button is a plain
+ * ``header-prefix``. Shared by the create-config wizard and the add-component
+ * dialog. (The process-terminal dialogs — command / firmware-install / logs —
+ * have a similar bar but a monospace title and a terminal body, so they're
+ * intentionally not folded in here; see #600.) The back button is a plain
  * ``<button class="back-button" slot="header-prefix">`` in the consumer's
  * own light DOM, so the ``.back-button`` rule styles it directly.
  */

--- a/src/styles/modal-dialog.ts
+++ b/src/styles/modal-dialog.ts
@@ -46,30 +46,17 @@
  */
 import { css } from "lit";
 
-export const modalDialogStyles = css`
-  /* Dual selectors so this one shared fragment styles both the raw
-     <wa-dialog> modals and the ones migrated onto <esphome-base-dialog>
-     (its parts are re-exported under the same names). #39 */
-  wa-dialog::part(header),
-  esphome-base-dialog::part(header) {
-    padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
-  }
+import { dialogChromeStyles } from "./dialog-chrome.js";
 
-  wa-dialog::part(title),
-  esphome-base-dialog::part(title) {
-    font-size: var(--wa-font-size-m);
-    font-weight: var(--wa-font-weight-bold);
-    color: var(--wa-color-text-normal);
-  }
+export const modalDialogStyles = css`
+  /* The neutral header / title / footer chrome is shared with the form and
+     picker dialogs via dialogChromeStyles; this fragment adds the
+     confirm-style body padding + icon/text/actions/button layout on top. */
+  ${dialogChromeStyles}
 
   wa-dialog::part(body),
   esphome-base-dialog::part(body) {
     padding: 0 var(--wa-space-l);
-  }
-
-  wa-dialog::part(footer),
-  esphome-base-dialog::part(footer) {
-    display: none;
   }
 
   .body {


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up to the #549 dialog migrations. Auditing the dialogs afterward surfaced three style blocks copied near-verbatim across many components. This hoists them into a single source of truth — `src/styles/dialog-chrome.ts` — and routes every consumer onto it.

### New shared fragments (`src/styles/dialog-chrome.ts`)

- **`primaryHeaderDialogStyles`** — the branded primary-colored header bar + flush 40×40 on-primary close button + `header-prefix` back button. Was duplicated byte-for-byte in **create-config** and **add-component**.
- **`dialogChromeStyles`** — the neutral header padding + title typography + hidden footer. This is exactly what the existing `modalDialogStyles` already encoded, yet ~10 dialogs hand-rolled their own copy. `modalDialogStyles` now **composes** `dialogChromeStyles` (so confirm / yaml-validation are unchanged), and the form/picker dialogs use it directly: **clone-device, rename-device, api-key, friendly-name, adopt, feedback, bulk-labels, pair-build-server, device-labels-editor, labels-filter**.
- **`quietCloseButtonStyles`** — the flat (transparent) close-button reset shared by **clone, rename, device-labels-editor, labels-filter**.

### Why it's safe

Pure refactor: every rule is **relocated unchanged**. Per-dialog deltas (`--width`, body padding, banners) stay local. Within any single dialog the shared fragment's selectors don't overlap the local rules, so the cascade is identical. Verified by `npm run build` + the full suite (**2059 tests**). 17 files, −273 duplicated lines (the 117-line shared module is the only real addition).

### Not force-fit (see #600)

A few dialogs *nearly* match but differ — the process-terminal dialogs' monospace title (command/firmware/logs), and a couple of body-padding variants (e.g. bulk-labels' `--wa-space-m` bottom). Rather than bend them to fit, those are catalogued in #600 for a separate "unintended drift vs intentional" decision.

**Related issue or feature (if applicable):**

- follow-up to #549; drift triage tracked in #600

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
