### PR TITLE
Fix seedBoardPinDefaults missing uart pins (strip _pin/_gpio role suffix)

### DIFF
--- a/src/util/board-pin-defaults.ts
+++ b/src/util/board-pin-defaults.ts
@@ -3,23 +3,28 @@
  * feature tags.
  *
  * Catalog component entries (e.g. i2c's ``scl`` / ``sda``, uart's
- * ``rx`` / ``tx``) carry symbolic defaults like ``"SCL"`` / ``"SDA"``
- * that ESPHome resolves at compile time. On variants without those
- * aliases (ESP32-C3, ESP32-S3, ...) the resolution either fails
+ * ``tx_pin`` / ``rx_pin``) carry symbolic defaults like ``"SCL"`` /
+ * ``"SDA"`` that ESPHome resolves at compile time. On variants without
+ * those aliases (ESP32-C3, ESP32-S3, ...) the resolution either fails
  * outright or produces a pin that doesn't physically exist — invalid
  * YAML the user can't see until they hit compile.
  *
  * Board manifests tag pins with peripheral features (``i2c_scl``,
- * ``i2c_sda``, ``uart_rx``, ``uart_tx``) — when an entry's key
+ * ``i2c_sda``, ``uart_rx``, ``uart_tx``) — when an entry's pin role
  * matches a feature tag the board exposes, pre-fill the entry with
- * that pin's GPIO number so the YAML is correct out of the box.
+ * that pin's GPIO number so the YAML is correct out of the box. The
+ * role is the entry key with a trailing ``_pin`` / ``_gpio`` stripped,
+ * so uart's ``tx_pin`` / ``rx_pin`` map to ``uart_tx`` / ``uart_rx``
+ * (i2c's ``sda`` / ``scl`` have no suffix and are unchanged). This
+ * mirrors the backend's ``_pin_feature_from_name`` normalization
+ * (device-builder#1012 / #1165) so both sides agree on the tag.
  *
  * Bus-like components only: ``audio_adc.es7210`` and other
  * platform-qualified ids (with a ``.`` in the id) are skipped because
  * their pins aren't peripheral defaults — they're entity-specific
  * I/O wiring the user has to choose. Bus entries are bare ids like
  * ``i2c``, ``uart``, ``spi`` so the feature tag is unambiguously
- * ``<componentId>_<entryKey>``.
+ * ``<componentId>_<role>``.
  *
  * Lives in its own module so the validator-tier tests can pin the
  * board-pin seeding rules without rendering a Lit component.
@@ -44,7 +49,12 @@ export function seedBoardPinDefaults(
   for (const entry of configEntries) {
     if (entry.type !== ConfigEntryType.PIN) continue;
     if (next[entry.key] !== undefined) continue;
-    const featureTag = `${componentId}_${entry.key.toLowerCase()}`;
+    // Strip a trailing ``_pin`` / ``_gpio`` so the entry's role matches
+    // the manifest's feature name: uart's ``tx_pin`` → ``uart_tx``
+    // (i2c's ``sda`` is already role-shaped). Mirrors the backend's
+    // ``_pin_feature_from_name`` (device-builder#1012 / #1165).
+    const role = entry.key.toLowerCase().replace(/_(pin|gpio)$/, "");
+    const featureTag = `${componentId}_${role}`;
     const matchingPin = board.pins.find((p) => p.features.includes(featureTag));
     if (!matchingPin) continue;
     next = { ...next, [entry.key]: matchingPin.gpio };

--- a/test/util/board-pin-defaults.test.ts
+++ b/test/util/board-pin-defaults.test.ts
@@ -166,9 +166,11 @@ describe("seedBoardPinDefaults", () => {
     expect(result).toEqual({});
   });
 
-  it("seeds uart rx/tx the same way as i2c scl/sda", () => {
-    // The mechanism is component-agnostic: any bus-like bare id
-    // composes ``<componentId>_<entryKey>`` and looks it up.
+  it("seeds uart tx_pin/rx_pin by stripping the _pin suffix (issue #601)", () => {
+    // Real uart entries are ``tx_pin`` / ``rx_pin``; board manifests
+    // tag pins ``uart_tx`` / ``uart_rx``. The role normalization (strip
+    // a trailing ``_pin`` / ``_gpio``) bridges the two, so the defaults
+    // seed instead of silently falling through.
     const board = makeBoard([
       makePin({ gpio: 20, features: ["uart_rx"] }),
       makePin({ gpio: 21, features: ["uart_tx"] }),
@@ -178,16 +180,30 @@ describe("seedBoardPinDefaults", () => {
       [
         makeEntry({ key: "rx_pin", default_value: "GPIO3" }),
         makeEntry({ key: "tx_pin", default_value: "GPIO1" }),
-        makeEntry({ key: "rx", default_value: "GPIO3" }),
-        makeEntry({ key: "tx", default_value: "GPIO1" }),
       ],
       board,
       {}
     );
-    // Only entries whose key matches the suffix after ``uart_`` get
-    // seeded — ``rx`` and ``tx``. Mismatched keys (``rx_pin``,
-    // ``tx_pin``) fall through.
-    expect(result).toEqual({ rx: 20, tx: 21 });
+    expect(result).toEqual({ rx_pin: 20, tx_pin: 21 });
+  });
+
+  it("matches a bare role key and a _gpio suffix too", () => {
+    // ``sda``/``scl`` (no suffix) and ``*_gpio`` both normalize to the
+    // same role-shaped tag the manifest uses.
+    const board = makeBoard([
+      makePin({ gpio: 20, features: ["uart_rx"] }),
+      makePin({ gpio: 21, features: ["uart_tx"] }),
+    ]);
+    const result = seedBoardPinDefaults(
+      "uart",
+      [
+        makeEntry({ key: "rx", default_value: "GPIO3" }), // bare role
+        makeEntry({ key: "tx_gpio", default_value: "GPIO1" }), // _gpio suffix
+      ],
+      board,
+      {}
+    );
+    expect(result).toEqual({ rx: 20, tx_gpio: 21 });
   });
 
   it("uses the FIRST matching pin when multiple are tagged", () => {


### PR DESCRIPTION
# What does this implement/fix?

Closes #601. `seedBoardPinDefaults` pre-fills a bus component's pin entries from the board manifest's pin-feature tags by composing `${componentId}_${entry.key}`. uart's entry keys carry a `_pin` suffix (`tx_pin` / `rx_pin`), so the composed tag was `uart_tx_pin` / `uart_rx_pin` — but board manifests tag pins `uart_tx` / `uart_rx`. The lookup never matched, so uart pin defaults were silently not pre-filled (the exact symbolic-default case the module exists to fix, e.g. `"TX"` / `"RX"` on ESP32-C3/S3). i2c was unaffected only because `sda` / `scl` have no suffix.

Fix: strip a trailing `_pin` / `_gpio` from the key to get the pin role before composing the tag, so it matches the manifest. This mirrors the backend's `_pin_feature_from_name` (esphome/device-builder#1012 / #1165), which derives `pin_features` from the same `{component}_{role}` convention — the two sides now share the normalization.

The existing uart test had encoded the buggy fall-through (asserting `tx_pin`/`rx_pin` don't seed); rewrote it to assert they now seed, and added a case covering a bare-role key and a `_gpio` suffix.

**Related issue or feature (if applicable):**

- Closes #601

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
