### PR TITLE
Skip the empty config screen for option-less components

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiClose, mdiPackageVariantClosed } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
@@ -12,6 +13,7 @@ import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
+import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
 import { chooseExcludeCategories } from "./add-component-dialog-categories.js";
 import {
   matchesDepDomain,
@@ -320,6 +322,23 @@ export class ESPHomeAddComponentDialog extends LitElement {
     }
     this._selected = result.entry;
     this._submitError = "";
+    // Skip the empty form and add directly only when there is genuinely
+    // nothing to show: no config fields AND no missing top-level
+    // dependencies. A configless component can still require other
+    // components (e.g. `captive_portal` needs `wifi`), in which case the
+    // form's deps banner guides the user, so keep showing it. The empty
+    // schema makes the fields payload provably `{}` (no defaults, id, or
+    // pins to seed); on the rare API failure `_submitComponent` toasts
+    // the error (see its catch) since there's no form surface for it.
+    if (result.entry.config_entries.length === 0) {
+      const present = parseTopLevelComponents(this.yaml);
+      const hasMissingDeps = (result.entry.dependencies ?? []).some(
+        (d) => !present.has(d)
+      );
+      if (!hasMissingDeps) {
+        await this._submitComponent({}, /* notify */ true);
+      }
+    }
   }
 
   /**
@@ -402,8 +421,20 @@ export class ESPHomeAddComponentDialog extends LitElement {
     return navigateToDep(this as unknown as DepNavHost, e.detail.domain);
   }
 
-  private async _onFormSubmit(e: CustomEvent<{ fields: Record<string, unknown> }>) {
+  private _onFormSubmit(e: CustomEvent<{ fields: Record<string, unknown> }>) {
     e.stopPropagation();
+    return this._submitComponent(e.detail.fields);
+  }
+
+  /**
+   * Add the selected component with ``fields`` and run the post-add
+   * routing (dep-detour restore, bundle advance, or navigate-and-close).
+   * Shared by the form-submit and configless direct-add paths.
+   *
+   * ``notify`` toasts on a successful close — the configless path has no
+   * form Add-click to confirm the add otherwise.
+   */
+  private async _submitComponent(fields: Record<string, unknown>, notify = false) {
     if (!this._selected || !this.configuration || this._submitting) return;
     this._submitting = true;
     this._submitError = "";
@@ -421,7 +452,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this.configuration,
         {
           component_id: this._selected.id,
-          fields: e.detail.fields,
+          fields,
         },
         this.yaml || undefined
       );
@@ -460,7 +491,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // id when the just-added component matches what the dep-nav
         // asked for (defends against the user picking off-domain in
         // the catalog fallback).
-        const newId = e.detail.fields["id"];
+        const newId = fields["id"];
         if (
           depDomain &&
           typeof newId === "string" &&
@@ -501,7 +532,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // `light.binary` whose `output:` field has to point at it — and
         // without this prefill the user has to re-pick the id they just
         // typed in the previous step from a dropdown.
-        const justAddedId = e.detail.fields["id"];
+        const justAddedId = fields["id"];
         const justAddedDomain = this._selected.category;
         if (typeof justAddedId === "string" && justAddedDomain) {
           this._prefillReference = {
@@ -524,7 +555,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // leave the previous selection alone than navigate somewhere
         // wrong.
         const componentId = this._selected.id;
-        const newId = e.detail.fields["id"];
+        const componentName = this._selected.name;
+        const newId = fields["id"];
         const target = findAddedSection(
           yaml,
           componentId,
@@ -542,10 +574,24 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this._open = false;
         this._selected = null;
         this._resetDetourState();
+        // Configless add skipped the form, so the close is the only
+        // signal the add happened — toast to confirm.
+        if (notify) {
+          toast.success(
+            this._localize("device.component_added", { name: componentName }),
+            { richColors: true }
+          );
+        }
       }
     } catch (err) {
       this._submitError =
         err instanceof Error ? err.message : this._localize("device.add_component_error");
+      // The configless path (notify) has no form fields, so `_submitError`
+      // would land in an otherwise-empty form view where it's easy to
+      // miss — toast it too so the failure can't read as a silent no-op.
+      if (notify) {
+        toast.error(this._submitError, { richColors: true });
+      }
     } finally {
       this._submitting = false;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -646,6 +646,7 @@
     "search_components_placeholder": "Search components…",
     "no_components_found": "No components found",
     "add_component_action": "Add",
+    "component_added": "Added {name}",
     "featured_bundle_badge": "Bundle",
     "field_locked_by_board": "Set by the board",
     "bundle_step_progress": "Step {current} of {total} — Adding {name}",

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A component with no config entries (e.g. Async TCP) has nothing to
+ * configure — the form view would be an empty dead-end. Picking one
+ * must skip the form, add it directly with an empty payload, toast,
+ * and close the dialog. Components that DO have options still open the
+ * form.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import toast from "sonner-js";
+
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+/** Dialog whose API hydrates to `entry` and records `addComponent` calls. */
+function makeDialog(entry: ReturnType<typeof makeComponentEntry>) {
+  const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
+  const getComponentBodies = vi.fn().mockResolvedValue({ [entry.id]: entry });
+  const dialog = new ESPHomeAddComponentDialog();
+  Object.assign(dialog as unknown as Record<string, unknown>, {
+    _api: { addComponent, getComponentBodies },
+    _open: true,
+  });
+  dialog.configuration = "foo.yaml";
+  dialog.yaml = "esphome:\n  name: foo\n";
+  return { dialog, addComponent };
+}
+
+function select(dialog: ESPHomeAddComponentDialog, id: string) {
+  return (
+    dialog as unknown as {
+      _onComponentSelected: (e: CustomEvent) => Promise<void>;
+    }
+  )._onComponentSelected(
+    new CustomEvent("add-component", { detail: { component: { id } } })
+  );
+}
+
+describe("add-component-dialog skips the form for configless components", () => {
+  afterEach(() => {
+    _clearComponentCache();
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("adds a configless component directly, toasts, and closes", async () => {
+    const entry = makeComponentEntry("async_tcp", {
+      name: "Async TCP",
+      config_entries: [],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "async_tcp");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "async_tcp", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect(toast.success).toHaveBeenCalledWith("device.component_added", {
+      richColors: true,
+    });
+    // Form view never opened: dialog closed, selection cleared.
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
+  });
+
+  it("opens the form (no direct add) when the component has options", async () => {
+    const entry = makeComponentEntry("wifi", {
+      name: "WiFi",
+      config_entries: [makeConfigEntry({ key: "ssid" })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "wifi");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    // Form view: the entry is selected, dialog stays open.
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("opens the form for a configless component with a missing dependency", async () => {
+    // `captive_portal` has no options but requires `wifi`; with no wifi
+    // in the yaml the form's deps banner must guide the user, so we must
+    // not fast-path past it.
+    const entry = makeComponentEntry("captive_portal", {
+      name: "Captive Portal",
+      config_entries: [],
+      dependencies: ["wifi"],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "captive_portal");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("fast-paths a configless component once its dependency is present", async () => {
+    const entry = makeComponentEntry("captive_portal", {
+      name: "Captive Portal",
+      config_entries: [],
+      dependencies: ["wifi"],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    dialog.yaml = "wifi:\n  ssid: foo\n";
+
+    await select(dialog, "captive_portal");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "captive_portal", fields: {} },
+      "wifi:\n  ssid: foo\n"
+    );
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+  });
+
+  it("toasts the error and keeps the dialog open when a configless add fails", async () => {
+    const entry = makeComponentEntry("async_tcp", {
+      name: "Async TCP",
+      config_entries: [],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    addComponent.mockRejectedValueOnce(new Error("boom"));
+
+    await select(dialog, "async_tcp");
+
+    // Failure is surfaced as a toast (the empty form view would hide it),
+    // and the dialog stays open as a recovery surface.
+    expect(toast.error).toHaveBeenCalledWith("boom", { richColors: true });
+    expect(toast.success).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+});

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -79,4 +79,42 @@ describe("add-component-dialog preserves the editor draft (#1146)", () => {
       undefined
     );
   });
+
+  it("configless direct-add still merges the draft and closes the dialog", async () => {
+    const dialog = new ESPHomeAddComponentDialog();
+    const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
+    // No `_returnTo` / bundle state → the navigate-and-close branch runs,
+    // exercising the draft-merge of the direct-add path through
+    // `_submitComponent`. `notify` defaults false so this stays a pure
+    // logic test (the toast is covered in -configless.test.ts).
+    Object.assign(dialog as unknown as Record<string, unknown>, {
+      _api: { addComponent },
+      _selected: { id: "async_tcp", name: "Async TCP" },
+      _open: true,
+    });
+    dialog.configuration = "foo.yaml";
+    dialog.yaml = "esphome:\n  name: foo\n";
+
+    const seen: Array<{ type: string }> = [];
+    dialog.addEventListener("yaml-draft", (e) => seen.push({ type: e.type }));
+
+    await (
+      dialog as unknown as {
+        _submitComponent: (
+          fields: Record<string, unknown>,
+          notify?: boolean
+        ) => Promise<void>;
+      }
+    )._submitComponent({});
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "async_tcp", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect(seen).toEqual([{ type: "yaml-draft" }]);
+    // Navigate-and-close branch ran: dialog closed, selection cleared.
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Picking a component with no options to configure (e.g. Async TCP) used to drop you on an empty detail screen with just a YAML preview link and Add/Back, which confused users since there was nothing to do there. Now those components are added directly on click; the dialog shows a success toast and closes, jumping the navigator to the new block. Components that actually have options still open the form as before.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
