### PR TITLE
Write nRF52 pins as P0.x in the pin picker

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -23,12 +23,18 @@ import {
 import { renderNestedField } from "./config-entry-renderers/nested.js";
 import { renderBooleanField } from "./config-entry-renderers/primitives.js";
 
+// Bare int / "GPIOn" form (esp / esp8266 / rp2040 / libretiny).
+const GPIO_PIN_RE = /^\s*(?:GPIO)?(\d+)\s*$/i;
+// nRF52 "P{port}.{pin}" form.
+const NRF52_PIN_RE = /^\s*P(\d+)\.(\d+)\s*$/i;
+
 /**
  * Parse a pin reference into a GPIO number. Used both for the field's
  * current value and for individual `suggestions` entries. Featured
  * manifests write pins as bare ints (`12`), string forms (`"GPIO12"`,
- * `"gpio12"`), or — for fields whose locked preset needs the long-form
- * ESPHome pin block — an object like
+ * `"gpio12"`), nRF52 port.pin notation (`"P0.27"`, `"P1.1"`), or — for
+ * fields whose locked preset needs the long-form ESPHome pin block — an
+ * object like
  * `{ number: 0, mode: { input: true, pullup: true }, inverted: true }`
  * (Sonoff Basic's front-panel button is the canonical example: the pin
  * is occupied + inverted + needs the internal pull-up, all baked into
@@ -38,13 +44,28 @@ import { renderBooleanField } from "./config-entry-renderers/primitives.js";
 export function parsePinGpio(s: unknown): number | null {
   if (typeof s === "number" && Number.isFinite(s)) return s;
   if (typeof s === "string") {
-    const m = s.match(/^\s*(?:GPIO)?(\d+)\s*$/i);
+    const m = s.match(GPIO_PIN_RE);
     if (m) return Number(m[1]);
+    // nRF52 port.pin notation, e.g. "P0.27" -> 27, "P1.1" -> 33. Each port has
+    // 32 pins, so reject pin >= 32 ("P0.33") rather than normalize it to a
+    // different valid-looking pin (which would silently rewrite the YAML).
+    const p = s.match(NRF52_PIN_RE);
+    if (p && Number(p[2]) < 32) return Number(p[1]) * 32 + Number(p[2]);
   }
   if (s !== null && typeof s === "object" && !Array.isArray(s)) {
     return parsePinGpio((s as Record<string, unknown>).number);
   }
   return null;
+}
+
+/**
+ * Format a GPIO number as the pin value ESPHome's platform validator
+ * accepts. ESP/LibreTiny take "GPIOn"; nRF52's validator rejects that
+ * and wants port.pin notation ("P0.27", "P1.1") — port*32 + pin.
+ */
+export function formatPinValue(gpio: number, platform: string | undefined): string {
+  if (platform === "nrf52") return `P${Math.floor(gpio / 32)}.${gpio % 32}`;
+  return `GPIO${gpio}`;
 }
 
 interface PinOptionView {
@@ -70,7 +91,7 @@ function buildPinOption(
   usedPins: Map<number, string>,
   ctx: RenderCtx
 ): PinOptionView {
-  const optValue = `GPIO${pin.gpio}`;
+  const optValue = formatPinValue(pin.gpio, ctx.board?.esphome.platform);
   const primary = pin.label || optValue;
   const occupiedBy = pin.occupied_by || "";
   const usedBy = usedPins.get(pin.gpio) || "";
@@ -193,12 +214,14 @@ export function renderPinField(
     return renderStringField(entry, "text", path, ctx);
   }
 
-  // Pin presets can land as bare ints (`12`), `GPIOn` strings, or the
-  // long-form pin block (`{ number: N, mode: {...}, inverted: ... }`).
-  // The wa-option values are always the `GPIOn` form, so normalise
-  // before comparing or the disabled select renders blank.
+  // Pin presets can land as bare ints (`12`), `GPIOn` / `P0.x` strings, or
+  // the long-form pin block (`{ number: N, mode: {...}, inverted: ... }`).
+  // The wa-option values are the platform's value form (`GPIOn`, or `P0.x`
+  // for nRF52), so normalise before comparing or the disabled select renders
+  // blank.
   const rawValue = ctx.getAt(path);
   const valueGpio = parsePinGpio(rawValue);
+  const platform = ctx.board.esphome.platform;
   // Fallback to ``String(rawValue)`` only when the value is a
   // primitive — js-yaml emits null-prototype maps for partial /
   // mid-edit pin blocks, and ``String(Object.create(null))`` throws
@@ -208,7 +231,7 @@ export function renderPinField(
   // the dropdown stays empty rather than blowing up.
   const value =
     valueGpio !== null
-      ? `GPIO${valueGpio}`
+      ? formatPinValue(valueGpio, platform)
       : isPrimitiveOrNullish(rawValue)
         ? String(rawValue ?? "")
         : "";

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -131,6 +131,24 @@ describe("renderPinField nRF52 pin values", () => {
     expect(option.value).toBe("P0.27");
     expect(option["?selected"]).toBe(true);
   });
+
+  it("writes the P0.x form to path.number on a long-form value", () => {
+    // Long-form pin block on nRF52: the picker must write the P0.x value form
+    // into `number:` (ESPHome's nRF52 validator accepts it; `GPIOn` it rejects).
+    const ctx = makeRenderCtx(
+      { pin: { number: "P0.27", mode: { pullup: true } } },
+      { board: nrf52Board() }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
+    onChange({ target: { value: "P1.1" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "number"], "P1.1");
+  });
 });
 
 describe("renderPinField wa-select binding", () => {

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -4,6 +4,7 @@ import {
   ConfigEntryType,
 } from "../../../src/api/types/config-entries.js";
 import {
+  formatPinValue,
   parsePinGpio,
   renderPinField,
 } from "../../../src/components/device/config-entry-pin-renderer.js";
@@ -11,7 +12,13 @@ import {
   extractAttributeBindings,
   findTemplatesByAnchor,
 } from "../../_lit-template-walker.js";
-import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+import {
+  findElementBindings,
+  makeBoardPin,
+  makeEntry,
+  makeRenderCtx,
+  makeTestBoard,
+} from "./_renderer-fixtures.js";
 
 describe("parsePinGpio", () => {
   it("accepts bare integers", () => {
@@ -28,6 +35,21 @@ describe("parsePinGpio", () => {
   it("accepts plain numeric strings", () => {
     expect(parsePinGpio("7")).toBe(7);
     expect(parsePinGpio("0")).toBe(0);
+  });
+
+  it("accepts nRF52 port.pin notation", () => {
+    // ESPHome's nRF52 validator writes pins as P{port}.{pin} = port*32 + pin.
+    expect(parsePinGpio("P0.27")).toBe(27);
+    expect(parsePinGpio("P1.1")).toBe(33);
+    expect(parsePinGpio("P0.0")).toBe(0);
+    expect(parsePinGpio("p1.16")).toBe(48);
+  });
+
+  it("rejects an out-of-range nRF52 pin part", () => {
+    // Each port has 32 pins (0-31); "P0.33" must not normalize to P1.1 (33) —
+    // that would silently rewrite the YAML to a different valid-looking pin.
+    expect(parsePinGpio("P0.33")).toBeNull();
+    expect(parsePinGpio("P0.32")).toBeNull();
   });
 
   it("extracts the GPIO from a long-form pin block", () => {
@@ -55,6 +77,59 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio({ number: "nope" })).toBeNull();
     expect(parsePinGpio([])).toBeNull();
     expect(parsePinGpio(Number.NaN)).toBeNull();
+  });
+});
+
+describe("formatPinValue", () => {
+  it("uses GPIOn for ESP / LibreTiny", () => {
+    expect(formatPinValue(12, "esp32")).toBe("GPIO12");
+    expect(formatPinValue(5, "bk72xx")).toBe("GPIO5");
+    expect(formatPinValue(0, undefined)).toBe("GPIO0");
+  });
+
+  it("uses P{port}.{pin} for nRF52", () => {
+    expect(formatPinValue(27, "nrf52")).toBe("P0.27");
+    expect(formatPinValue(33, "nrf52")).toBe("P1.1");
+    expect(formatPinValue(48, "nrf52")).toBe("P1.16");
+  });
+});
+
+describe("renderPinField nRF52 pin values", () => {
+  // ESPHome's nRF52 pin validator rejects "GPIO27"; it wants P0.x / integer.
+  // The renderer must emit the P0.x value form for nRF52 boards so the
+  // editor writes valid YAML.
+  const nrf52Board = () =>
+    makeTestBoard({
+      pins: [makeBoardPin(27, { label: "P0.27", features: ["adc"] })],
+      overrides: { esphome: { platform: "nrf52", board: "xiao_ble" } as never },
+    });
+
+  it("writes the P{port}.{pin} value, not GPIOn", () => {
+    const ctx = makeRenderCtx({ pin: undefined }, { board: nrf52Board() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("P0.27");
+
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
+    onChange({ target: { value: "P0.27" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "P0.27");
+  });
+
+  it("matches the active option for a P0.x value", () => {
+    const ctx = makeRenderCtx({ pin: "P0.27" }, { board: nrf52Board() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("P0.27");
+    expect(option["?selected"]).toBe(true);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Makes the Visual Editor pin picker write valid YAML for **nRF52** boards.

ESPHome's nRF52 pin validator (`components/nrf52/gpio.py::_translate_pin`) rejects `"GPIO27"` — it accepts an integer or `P{port}.{pin}` notation (`"P0.27"`, `"P1.1"`). The pin renderer hardcoded the `wa-option` value as `` `GPIO${gpio}` `` (independent of the display label) and `parsePinGpio` only accepted `GPIOn`/bare digits, so selecting a pin on an nRF52 board produced a config that fails `esphome config`.

This adds a platform-aware value formatter `formatPinValue(gpio, platform)` (`P{port}.{pin}` for nRF52, `GPIOn` for everything else), routes `buildPinOption` + the `renderPinField` value normalization through it, and extends `parsePinGpio` to read `P{port}.{pin}` back so existing nRF52 configs round-trip. ESP/ESP8266/RP2040/LibreTiny are unchanged (they still write/read `GPIOn`, which their validators accept).

Companion to the backend PR that generates the nRF52 boards with `P0.x`-labelled pins.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1171

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
