### PR TITLE
Drop stale YAML highlight that outlived a doc-shrinking update

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -54,6 +54,10 @@ const highlightField = StateField.define<DecorationSet>({
         const { fromLine, toLine } = effect.value;
         const doc = tr.state.doc;
         const lo = Math.max(1, fromLine);
+        // A doc-shrinking `value` update can land in the same render cycle as
+        // this highlight; if its start line no longer exists, drop it instead
+        // of letting `doc.line()` throw on the stale number.
+        if (lo > doc.lines) return Decoration.none;
         const hi = Math.min(doc.lines, toLine);
         // Single-line field highlight: a line decoration covers the whole line
         // regardless of content, so it doesn't lag behind text typed into the

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -80,4 +80,20 @@ describe("yaml-editor undo baseline (#1150)", () => {
     expect(viewOf(el).state.doc.toString()).toBe("a\nb\nc\nd\ne\n");
     expect(spy).toHaveBeenCalled();
   });
+
+  it("drops a highlight whose start line outlives a doc-shrinking value update", async () => {
+    const el = await mount();
+    el.value = "a\nb\nc\nd\ne\nf\ng\n";
+    el.highlightRange = { fromLine: 7, toLine: 7 };
+    await el.updateComplete;
+    const view = viewOf(el);
+
+    // Doc shrinks below the highlighted line and a (now stale) highlight
+    // re-applies in the same cycle — must not throw "Invalid line number".
+    el.value = "a\nb\n";
+    el.highlightRange = { fromLine: 7, toLine: 7 };
+    await el.updateComplete;
+
+    expect(view.state.doc.toString()).toBe("a\nb\n");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The YAML editor crashed with a CodeMirror `RangeError: Invalid line number N in M-line document` when a stale highlight outlived a doc-shrinking value update.

The `highlightField` StateField clamped only the end line into range; the start line was floored at 1 but never capped at the doc length. When a doc-shrinking `value` update and a stale `highlightRange` land in the same render cycle, `updated()` shrinks the doc first, then re-applies the highlight, so `doc.line()` is handed a line past the end and throws. Now we drop the highlight when its start line no longer exists; the next render with a fresh range repaints it.

Added a regression test that reproduces the exact RangeError without the fix.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
