### PR TITLE
Parse and write BK72xx P{n} pins in the pin picker

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -23,10 +23,12 @@ import {
 import { renderNestedField } from "./config-entry-renderers/nested.js";
 import { renderBooleanField } from "./config-entry-renderers/primitives.js";
 
-// Bare int / "GPIOn" form (esp / esp8266 / rp2040 / libretiny).
+// Bare int / "GPIOn" form (esp / esp8266 / rp2040 / ln882x).
 const GPIO_PIN_RE = /^\s*(?:GPIO)?(\d+)\s*$/i;
 // nRF52 "P{port}.{pin}" form.
 const NRF52_PIN_RE = /^\s*P(\d+)\.(\d+)\s*$/i;
+// BK72xx (LibreTiny / Beken) "P{n}" form — bare P + number, no dot.
+const BK72XX_PIN_RE = /^\s*P(\d+)\s*$/i;
 
 /**
  * Parse a pin reference into a GPIO number. Used both for the field's
@@ -51,6 +53,11 @@ export function parsePinGpio(s: unknown): number | null {
     // different valid-looking pin (which would silently rewrite the YAML).
     const p = s.match(NRF52_PIN_RE);
     if (p && Number(p[2]) < 32) return Number(p[1]) * 32 + Number(p[2]);
+    // BK72xx "P{n}" form (e.g. "P23" -> 23). Tried after the nRF52 match so
+    // the dotted "P0.27" form is never swallowed by this no-dot pattern; the
+    // letter-port rtl87xx form ("PA00") won't match either.
+    const bk = s.match(BK72XX_PIN_RE);
+    if (bk) return Number(bk[1]);
   }
   if (s !== null && typeof s === "object" && !Array.isArray(s)) {
     return parsePinGpio((s as Record<string, unknown>).number);
@@ -60,11 +67,13 @@ export function parsePinGpio(s: unknown): number | null {
 
 /**
  * Format a GPIO number as the pin value ESPHome's platform validator
- * accepts. ESP/LibreTiny take "GPIOn"; nRF52's validator rejects that
- * and wants port.pin notation ("P0.27", "P1.1") — port*32 + pin.
+ * accepts. ESP take "GPIOn"; nRF52's validator rejects that and wants
+ * port.pin notation ("P0.27", "P1.1") — port*32 + pin; BK72xx wants the
+ * bare "P{n}" form ("P23"), where the LibreTiny pin index is the number.
  */
 export function formatPinValue(gpio: number, platform: string | undefined): string {
   if (platform === "nrf52") return `P${Math.floor(gpio / 32)}.${gpio % 32}`;
+  if (platform === "bk72xx") return `P${gpio}`;
   return `GPIO${gpio}`;
 }
 

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -45,6 +45,17 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio("p1.16")).toBe(48);
   });
 
+  it("accepts BK72xx P{n} notation", () => {
+    // ESPHome's BK72xx (LibreTiny) validator writes pins as bare "P{n}",
+    // where the number is the LibreTiny pin index — "P23" -> 23.
+    expect(parsePinGpio("P23")).toBe(23);
+    expect(parsePinGpio("P6")).toBe(6);
+    expect(parsePinGpio("  p7 ")).toBe(7);
+    expect(parsePinGpio("P0")).toBe(0);
+    // A letter-port rtl87xx pin must not parse as a BK72xx pin.
+    expect(parsePinGpio("PA0")).toBeNull();
+  });
+
   it("rejects an out-of-range nRF52 pin part", () => {
     // Each port has 32 pins (0-31); "P0.33" must not normalize to P1.1 (33) —
     // that would silently rewrite the YAML to a different valid-looking pin.
@@ -81,10 +92,17 @@ describe("parsePinGpio", () => {
 });
 
 describe("formatPinValue", () => {
-  it("uses GPIOn for ESP / LibreTiny", () => {
+  it("uses GPIOn for ESP", () => {
     expect(formatPinValue(12, "esp32")).toBe("GPIO12");
-    expect(formatPinValue(5, "bk72xx")).toBe("GPIO5");
+    expect(formatPinValue(5, "esp8266")).toBe("GPIO5");
     expect(formatPinValue(0, undefined)).toBe("GPIO0");
+  });
+
+  it("uses P{n} for BK72xx", () => {
+    // ESPHome's BK72xx validator wants the bare "P{n}" form, not "GPIOn".
+    expect(formatPinValue(5, "bk72xx")).toBe("P5");
+    expect(formatPinValue(23, "bk72xx")).toBe("P23");
+    expect(formatPinValue(0, "bk72xx")).toBe("P0");
   });
 
   it("uses P{port}.{pin} for nRF52", () => {
@@ -148,6 +166,64 @@ describe("renderPinField nRF52 pin values", () => {
     const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
     onChange({ target: { value: "P1.1" } } as never);
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin", "number"], "P1.1");
+  });
+});
+
+describe("renderPinField BK72xx pin values", () => {
+  // ESPHome's BK72xx (LibreTiny) pins are written as bare "P{n}". The
+  // renderer must parse that form (or the dropdown renders blank) and emit
+  // it back so the editor writes valid YAML.
+  const bk72xxBoard = () =>
+    makeTestBoard({
+      pins: [makeBoardPin(23, { label: "P23", features: ["input"] })],
+      overrides: {
+        esphome: { platform: "bk72xx", board: "generic-bk7231n-qfn32-tuya" } as never,
+      },
+    });
+
+  it("writes the P{n} value, not GPIOn", () => {
+    const ctx = makeRenderCtx({ pin: undefined }, { board: bk72xxBoard() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("P23");
+
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
+    onChange({ target: { value: "P23" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "P23");
+  });
+
+  it("matches the active option for a P{n} value", () => {
+    const ctx = makeRenderCtx({ pin: "P23" }, { board: bk72xxBoard() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("P23");
+    expect(option["?selected"]).toBe(true);
+  });
+
+  it("matches the active option for a long-form P{n} value", () => {
+    // The reported bug: a binary_sensor with `pin: { number: P23 }` rendered
+    // a blank Pin dropdown because the long-form `P23` failed to parse.
+    const ctx = makeRenderCtx(
+      { pin: { number: "P23", inverted: true } },
+      { board: bk72xxBoard() }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("P23");
+    expect(option["?selected"]).toBe(true);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

On BK72xx (LibreTiny) boards ESPHome writes GPIO pins as bare `P{n}`, like `P23`; the visual editor's Pin selector only parsed bare ints, `GPIOn`, and nRF52 `P{port}.{pin}`, so a `P23` value failed to parse and the dropdown rendered blank. This parses the `P{n}` form into its GPIO number and writes it back as `P{n}` for BK72xx, so the right pin shows as selected and picking a pin produces valid LibreTiny YAML; nRF52 and ESP forms are unchanged, rtl87xx `PA00` stays unmatched.

**Related issue or feature (if applicable):**

- no separate issue; surfaced by a generic-bk7231n config whose `binary_sensor` pin `P23` rendered an empty Pin selector

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
