### PR TITLE
Point README translations section to the ESPHome translations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,7 @@ python3 -m build --wheel
 
 ### Contributing translations
 
-Translations are crowd-sourced through Lokalise — **no coding or GitHub account required**. To help translate the dashboard into your language:
-
-1. Open the project's public signup link and join: <https://app.lokalise.com/public/974668436a17ffd6803f51.79180045/>
-2. Pick your language and start translating. Only **native speakers** should submit translations; proofreading existing work is just as valuable, even for a language that looks "complete".
-3. **Don't translate proper nouns** like `ESPHome`, `ESPHome Device Builder`, or `Home Assistant`, and leave `{placeholder}` tokens (e.g. `{count}`) exactly as they are — the words around a token can be reordered, but the token itself must stay verbatim.
-
-Don't see your language? It has to be added to the project once before it shows up — request it in the [Discord language thread](https://discord.com/channels/429907082951524364/1511452603391938705) and someone will add it. Translated strings ship with the next release; any key a translator hasn't filled in yet falls back to English automatically.
+Translations are crowd-sourced through Lokalise — **no coding or GitHub account required**. See the [ESPHome translations guide](https://developers.esphome.io/contributing/translations/) for how to join the project, pick your language, and start translating.
 
 ### How it works
 


### PR DESCRIPTION
# What does this implement/fix?

The README's "Contributing translations" section duplicated the Lokalise signup steps. Replace that inline how-to with a link to the canonical ESPHome translations guide at https://developers.esphome.io/contributing/translations/ so contributor instructions live in one place. The repo-specific "How it works" / build details below it are unchanged.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).