### PR TITLE
Parse rtl87xx/ln882x PA/PB pins and detect non-GPIOn used pins

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -11,6 +11,7 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType, PinFeature, PinMode } from "../../api/types/config-entries.js";
 import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.js";
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
+import { formatPinValue, parsePinGpio } from "../../util/pin-gpio.js";
 import { expandPinModeShorthand } from "../../util/pin-mode.js";
 import {
   effectiveDisabled,
@@ -23,59 +24,11 @@ import {
 import { renderNestedField } from "./config-entry-renderers/nested.js";
 import { renderBooleanField } from "./config-entry-renderers/primitives.js";
 
-// Bare int / "GPIOn" form (esp / esp8266 / rp2040 / ln882x).
-const GPIO_PIN_RE = /^\s*(?:GPIO)?(\d+)\s*$/i;
-// nRF52 "P{port}.{pin}" form.
-const NRF52_PIN_RE = /^\s*P(\d+)\.(\d+)\s*$/i;
-// BK72xx (LibreTiny / Beken) "P{n}" form — bare P + number, no dot.
-const BK72XX_PIN_RE = /^\s*P(\d+)\s*$/i;
-
-/**
- * Parse a pin reference into a GPIO number. Used both for the field's
- * current value and for individual `suggestions` entries. Featured
- * manifests write pins as bare ints (`12`), string forms (`"GPIO12"`,
- * `"gpio12"`), nRF52 port.pin notation (`"P0.27"`, `"P1.1"`), or — for
- * fields whose locked preset needs the long-form ESPHome pin block — an
- * object like
- * `{ number: 0, mode: { input: true, pullup: true }, inverted: true }`
- * (Sonoff Basic's front-panel button is the canonical example: the pin
- * is occupied + inverted + needs the internal pull-up, all baked into
- * the preset). Returns `null` for anything we can't parse — the caller
- * drops those entries rather than letting a typo blank the dropdown.
- */
-export function parsePinGpio(s: unknown): number | null {
-  if (typeof s === "number" && Number.isFinite(s)) return s;
-  if (typeof s === "string") {
-    const m = s.match(GPIO_PIN_RE);
-    if (m) return Number(m[1]);
-    // nRF52 port.pin notation, e.g. "P0.27" -> 27, "P1.1" -> 33. Each port has
-    // 32 pins, so reject pin >= 32 ("P0.33") rather than normalize it to a
-    // different valid-looking pin (which would silently rewrite the YAML).
-    const p = s.match(NRF52_PIN_RE);
-    if (p && Number(p[2]) < 32) return Number(p[1]) * 32 + Number(p[2]);
-    // BK72xx "P{n}" form (e.g. "P23" -> 23). Tried after the nRF52 match so
-    // the dotted "P0.27" form is never swallowed by this no-dot pattern; the
-    // letter-port rtl87xx form ("PA00") won't match either.
-    const bk = s.match(BK72XX_PIN_RE);
-    if (bk) return Number(bk[1]);
-  }
-  if (s !== null && typeof s === "object" && !Array.isArray(s)) {
-    return parsePinGpio((s as Record<string, unknown>).number);
-  }
-  return null;
-}
-
-/**
- * Format a GPIO number as the pin value ESPHome's platform validator
- * accepts. ESP take "GPIOn"; nRF52's validator rejects that and wants
- * port.pin notation ("P0.27", "P1.1") — port*32 + pin; BK72xx wants the
- * bare "P{n}" form ("P23"), where the LibreTiny pin index is the number.
- */
-export function formatPinValue(gpio: number, platform: string | undefined): string {
-  if (platform === "nrf52") return `P${Math.floor(gpio / 32)}.${gpio % 32}`;
-  if (platform === "bk72xx") return `P${gpio}`;
-  return `GPIO${gpio}`;
-}
+// `parsePinGpio` / `formatPinValue` moved to `util/pin-gpio.ts` so the YAML
+// used-pin scanner shares the same platform pin-format rules. Re-exported
+// here to keep this module's long-standing public surface (and its tests)
+// pointing at the renderer.
+export { formatPinValue, parsePinGpio };
 
 interface PinOptionView {
   optValue: string;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -16,6 +16,8 @@
  * collapses the worst case (paste a multi-thousand-line config,
  * type into a field) from O(N) per keystroke to O(1).
  */
+import { scanPinGpios } from "./pin-gpio.js";
+
 /**
  * Single-entry memo for the YAML scans. The hot path is the
  * form re-rendering on every keystroke into the YAML pane:
@@ -99,8 +101,11 @@ const pinKeyEquals = (a: PinKey, b: PinKey) =>
 const pinMemo = createScanMemo<PinKey, Map<number, string>>(pinKeyEquals);
 
 /**
- * Map every `GPIO<n>` reference in the YAML to the top-level
- * domain that owns it (e.g. `{ 4: "switch", 5: "binary_sensor" }`).
+ * Map every pin reference in the YAML to the top-level domain that
+ * owns it (e.g. `{ 4: "switch", 5: "binary_sensor" }`). Pin tokens are
+ * matched across every platform form (`GPIOn`, bk72xx `P{n}`, rtl87xx
+ * `PA{n}`, nRF52 `P{port}.{pin}`) via `scanPinGpios`, so conflict
+ * warnings fire for LibreTiny / nRF52 configs too, not just ESP ones.
  * When `excludeFromLine` / `excludeToLine` are provided the lines
  * in that (inclusive) 1-indexed range are skipped — used by the
  * section editor so a pin selector doesn't flag the user's *own*
@@ -141,11 +146,9 @@ export function findUsedPins(
     ) {
       continue;
     }
-    for (const m of line.matchAll(/GPIO(\d+)/g)) {
-      const num = parseInt(m[1], 10);
-      if (!Number.isNaN(num) && !used.has(num) && currentDomain) {
-        used.set(num, currentDomain);
-      }
+    if (!currentDomain) continue;
+    for (const num of scanPinGpios(line)) {
+      if (!used.has(num)) used.set(num, currentDomain);
     }
   }
   pinMemo.set(probe, used);

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -1,0 +1,142 @@
+/*
+ * Pin string <-> GPIO number primitives, shared by the pin-selector
+ * renderer (current value + suggestions) and the YAML used-pin scanner
+ * (cross-section conflict detection). They live here, free of any Lit /
+ * DOM dependency, so both consumers agree on exactly one set of
+ * platform pin-format rules — a single source of truth, so the picker
+ * and the conflict scanner can't drift apart on what "P23" or "PA02"
+ * means.
+ *
+ * Pin forms across the platforms ESPHome supports:
+ *   - esp / esp8266 / rp2040          : bare int or "GPIOn"
+ *   - bk72xx (LibreTiny / Beken)      : bare "P{n}" (e.g. "P23"), n is the pin
+ *   - rtl87xx (LibreTiny / Realtek)   : "PA{n}" (e.g. "PA02"); rtl87xx is
+ *                                        single-port, so n is the GPIO directly
+ *   - ln882x (LibreTiny / Lightning)  : "PA{n}" (port A, n is the GPIO) and
+ *                                        "PB{n}" (port B = GPIO 16+n, e.g.
+ *                                        "PB03" -> 19; see LN882X_PORT_B_OFFSET)
+ *   - nRF52                           : "P{port}.{pin}" = port*32 + pin
+ *
+ * ESPHome's LibreTiny validator (`_translate_pin`) also accepts "GPIOn"
+ * for bk72xx / rtl87xx / ln882x — it strips the prefix to the numeric pin
+ * and looks it up — so the board manifest labels those pins "GPIO{n}" and
+ * `formatPinValue` writes the "GPIOn" form for rtl87xx / ln882x. bk72xx
+ * keeps the bare "P{n}" form it's conventionally written in; nRF52's
+ * validator rejects "GPIOn" outright and needs the port.pin form.
+ *
+ * Every form is globally unambiguous, so parsing doesn't need the platform:
+ * bare "P{n}" is bk72xx only, "PA{n}" is port A (rtl87xx + ln882x, same
+ * trailing -> GPIO rule), "PB{n}" is ln882x only, "P{p}.{p}" is nRF52 only.
+ * That's why the platform key in the YAML (mandatory — a platformless config
+ * is invalid) doesn't need to be threaded in here.
+ */
+
+// ln882x splits its GPIOs into two ports of 16: port A is GPIO 0-15, port B is
+// GPIO 16-31, so "PB{n}" resolves to 16 + n (verified constant across every
+// ln882x board's pin map; no other platform uses a "PB" form).
+const LN882X_PORT_B_OFFSET = 16;
+
+// Bare int / "GPIOn" form (esp / esp8266 / rp2040 / ln882x / libretiny GPIO).
+const GPIO_PIN_RE = /^\s*(?:GPIO)?(\d+)\s*$/i;
+// nRF52 "P{port}.{pin}" form.
+const NRF52_PIN_RE = /^\s*P(\d+)\.(\d+)\s*$/i;
+// BK72xx (LibreTiny / Beken) "P{n}" form — bare P + number, no dot.
+const BK72XX_PIN_RE = /^\s*P(\d+)\s*$/i;
+// LibreTiny port-A "PA{n}" form (rtl87xx, ln882x). Port A maps trailing-number
+// -> GPIO on every family ("PA02" -> 2, padding cosmetic).
+const PORT_A_PIN_RE = /^\s*PA(\d+)\s*$/i;
+// LibreTiny port-B "PB{n}" form (ln882x only) -> 16 + n.
+const PORT_B_PIN_RE = /^\s*PB(\d+)\s*$/i;
+
+/**
+ * Parse a pin reference into a GPIO number. Used both for the field's
+ * current value and for individual `suggestions` entries. Featured
+ * manifests write pins as bare ints (`12`), string forms (`"GPIO12"`,
+ * `"gpio12"`), nRF52 port.pin notation (`"P0.27"`, `"P1.1"`), LibreTiny
+ * forms (`"P23"` bk72xx, `"PA02"` rtl87xx), or — for fields whose locked
+ * preset needs the long-form ESPHome pin block — an object like
+ * `{ number: 0, mode: { input: true, pullup: true }, inverted: true }`
+ * (Sonoff Basic's front-panel button is the canonical example: the pin
+ * is occupied + inverted + needs the internal pull-up, all baked into
+ * the preset). Returns `null` for anything we can't parse — the caller
+ * drops those entries rather than letting a typo blank the dropdown.
+ */
+export function parsePinGpio(s: unknown): number | null {
+  if (typeof s === "number" && Number.isFinite(s)) return s;
+  if (typeof s === "string") {
+    const m = s.match(GPIO_PIN_RE);
+    if (m) return Number(m[1]);
+    // nRF52 port.pin notation, e.g. "P0.27" -> 27, "P1.1" -> 33. Each port has
+    // 32 pins, so reject pin >= 32 ("P0.33") rather than normalize it to a
+    // different valid-looking pin (which would silently rewrite the YAML).
+    const p = s.match(NRF52_PIN_RE);
+    if (p && Number(p[2]) < 32) return Number(p[1]) * 32 + Number(p[2]);
+    // LibreTiny port-A "PA{n}" form (rtl87xx / ln882x; e.g. "PA02" -> 2) and
+    // port-B "PB{n}" form (ln882x; e.g. "PB03" -> 19). Tried before the bare-P
+    // bk72xx pattern since the leading "PA"/"PB" letter would otherwise fail it.
+    const portA = s.match(PORT_A_PIN_RE);
+    if (portA) return Number(portA[1]);
+    const portB = s.match(PORT_B_PIN_RE);
+    if (portB) return LN882X_PORT_B_OFFSET + Number(portB[1]);
+    // BK72xx "P{n}" form (e.g. "P23" -> 23). Tried after the nRF52 and port
+    // matches so the dotted "P0.27" and letter-port "PA02"/"PB03" forms are
+    // never swallowed by this no-dot, no-letter pattern.
+    const bk = s.match(BK72XX_PIN_RE);
+    if (bk) return Number(bk[1]);
+  }
+  if (s !== null && typeof s === "object" && !Array.isArray(s)) {
+    return parsePinGpio((s as Record<string, unknown>).number);
+  }
+  return null;
+}
+
+/**
+ * Format a GPIO number as the pin value ESPHome's platform validator
+ * accepts. ESP / rtl87xx take "GPIOn"; nRF52's validator rejects that and
+ * wants port.pin notation ("P0.27", "P1.1") — port*32 + pin; BK72xx wants
+ * the bare "P{n}" form ("P23"), where the LibreTiny pin index is the
+ * number.
+ */
+export function formatPinValue(gpio: number, platform: string | undefined): string {
+  if (platform === "nrf52") return `P${Math.floor(gpio / 32)}.${gpio % 32}`;
+  if (platform === "bk72xx") return `P${gpio}`;
+  return `GPIO${gpio}`;
+}
+
+// "GPIOn" anywhere in a line. The "GPIO" prefix is distinctive enough to scan
+// unbounded (its own tokens can't collide with ordinary words).
+const GPIO_TOKEN_RE = /GPIO(\d+)/gi;
+// The LibreTiny / nRF52 "P…" pin forms anywhere in a line: port-A "PA{n}",
+// port-B "PB{n}", nRF52 "P{port}.{pin}", bk72xx "P{n}". `\b` word boundaries
+// keep a bare "P5" from matching inside words like "STEP5" / "PUMP5" /
+// "relay_p7" — and from matching the "P" inside "GPIO5", "esp32", or "RP2040".
+// The dotted nRF52 alternative is listed before the bare one so "P0.27" reads
+// as 27, not 0.
+const P_PIN_TOKEN_RE = /\bP(?:A(\d+)|B(\d+)|(\d+)\.(\d+)|(\d+))\b/gi;
+
+/**
+ * Every GPIO number referenced by *line*, across all pin string forms
+ * (GPIOn / P{n} / PA{n} / PB{n} / P{port}.{pin}). Used by the YAML used-pin
+ * scan so cross-section conflict warnings fire for LibreTiny and nRF52
+ * configs, not just ESP "GPIOn" ones. Each form is unique to one platform (or
+ * platforms that share its numbering), so scanning every form on one pass
+ * can't cross-wire pins between platforms.
+ */
+export function scanPinGpios(line: string): number[] {
+  const out: number[] = [];
+  for (const m of line.matchAll(GPIO_TOKEN_RE)) out.push(Number(m[1]));
+  for (const m of line.matchAll(P_PIN_TOKEN_RE)) {
+    if (m[1] !== undefined) {
+      out.push(Number(m[1])); // port-A "PA{n}" (rtl87xx / ln882x)
+    } else if (m[2] !== undefined) {
+      out.push(LN882X_PORT_B_OFFSET + Number(m[2])); // port-B "PB{n}" (ln882x)
+    } else if (m[3] !== undefined && m[4] !== undefined) {
+      // nRF52 "P{port}.{pin}" — reject pin >= 32 (mirrors parsePinGpio).
+      const pin = Number(m[4]);
+      if (pin < 32) out.push(Number(m[3]) * 32 + pin);
+    } else if (m[5] !== undefined) {
+      out.push(Number(m[5])); // bk72xx "P{n}"
+    }
+  }
+  return out;
+}

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -26,7 +26,7 @@
  *
  * Every form is globally unambiguous, so parsing doesn't need the platform:
  * bare "P{n}" is bk72xx only, "PA{n}" is port A (rtl87xx + ln882x, same
- * trailing -> GPIO rule), "PB{n}" is ln882x only, "P{p}.{p}" is nRF52 only.
+ * trailing -> GPIO rule), "PB{n}" is ln882x only, "P{port}.{pin}" is nRF52 only.
  * That's why the platform key in the YAML (mandatory — a platformless config
  * is invalid) doesn't need to be threaded in here.
  */
@@ -92,10 +92,11 @@ export function parsePinGpio(s: unknown): number | null {
 
 /**
  * Format a GPIO number as the pin value ESPHome's platform validator
- * accepts. ESP / rtl87xx take "GPIOn"; nRF52's validator rejects that and
- * wants port.pin notation ("P0.27", "P1.1") — port*32 + pin; BK72xx wants
- * the bare "P{n}" form ("P23"), where the LibreTiny pin index is the
- * number.
+ * accepts. "GPIOn" is the default — taken by esp / esp8266 / rp2040 /
+ * rtl87xx / ln882x (their validators all accept it). Two exceptions:
+ * nRF52's validator rejects "GPIOn" and wants port.pin notation ("P0.27",
+ * "P1.1") — port*32 + pin; BK72xx writes the bare "P{n}" form ("P23"), the
+ * convention its configs use, where the LibreTiny pin index is the number.
  */
 export function formatPinValue(gpio: number, platform: string | undefined): string {
   if (platform === "nrf52") return `P${Math.floor(gpio / 32)}.${gpio % 32}`;

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -52,8 +52,26 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio("P6")).toBe(6);
     expect(parsePinGpio("  p7 ")).toBe(7);
     expect(parsePinGpio("P0")).toBe(0);
-    // A letter-port rtl87xx pin must not parse as a BK72xx pin.
-    expect(parsePinGpio("PA0")).toBeNull();
+  });
+
+  it("accepts LibreTiny port-A PA{n} notation", () => {
+    // rtl87xx (single-port) and ln882x port A both map "PA{n}" -> n; "PA02" ->
+    // 2, padding cosmetic.
+    expect(parsePinGpio("PA02")).toBe(2);
+    expect(parsePinGpio("PA18")).toBe(18);
+    expect(parsePinGpio("PA0")).toBe(0);
+    expect(parsePinGpio("  pa3 ")).toBe(3);
+    // A bk72xx "P{n}" pin (no port letter) still parses on its own branch.
+    expect(parsePinGpio("P23")).toBe(23);
+  });
+
+  it("accepts ln882x port-B PB{n} notation (GPIO 16+n)", () => {
+    // ln882x splits GPIOs into two ports of 16: port A is 0-15, port B is
+    // 16-31, so "PB03" -> 19. No other platform uses a "PB" form.
+    expect(parsePinGpio("PB03")).toBe(19);
+    expect(parsePinGpio("PB9")).toBe(25);
+    expect(parsePinGpio("PB0")).toBe(16);
+    expect(parsePinGpio("  pb5 ")).toBe(21);
   });
 
   it("rejects an out-of-range nRF52 pin part", () => {
@@ -109,6 +127,14 @@ describe("formatPinValue", () => {
     expect(formatPinValue(27, "nrf52")).toBe("P0.27");
     expect(formatPinValue(33, "nrf52")).toBe("P1.1");
     expect(formatPinValue(48, "nrf52")).toBe("P1.16");
+  });
+
+  it("uses GPIOn for rtl87xx", () => {
+    // ESPHome's rtl87xx validator accepts "GPIOn" (strips to the numeric pin),
+    // and the board manifest labels rtl87xx pins "GPIOn", so the picker writes
+    // that form even though the user may have typed "PA02".
+    expect(formatPinValue(2, "rtl87xx")).toBe("GPIO2");
+    expect(formatPinValue(18, "rtl87xx")).toBe("GPIO18");
   });
 });
 
@@ -224,6 +250,47 @@ describe("renderPinField BK72xx pin values", () => {
     const option = findElementBindings(result, "wa-option")[0];
     expect(option.value).toBe("P23");
     expect(option["?selected"]).toBe(true);
+  });
+});
+
+describe("renderPinField rtl87xx pin values", () => {
+  // ESPHome's rtl87xx (LibreTiny / Realtek) pins are written "PA{n}". The
+  // renderer must parse that form (or the dropdown renders blank); rtl87xx's
+  // validator accepts "GPIOn" too, and the board manifest labels its pins
+  // "GPIOn", so the picker keeps writing that form.
+  const rtl87xxBoard = () =>
+    makeTestBoard({
+      pins: [makeBoardPin(2, { label: "GPIO2", features: ["input"] })],
+      overrides: {
+        esphome: { platform: "rtl87xx", board: "generic-rtl8720cf-2mb-992k" } as never,
+      },
+    });
+
+  it("matches the active option for a PA{n} value", () => {
+    // The reported bug: an output with `pin: PA02` rendered a blank Pin
+    // dropdown because "PA02" failed to parse.
+    const ctx = makeRenderCtx({ pin: "PA02" }, { board: rtl87xxBoard() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("GPIO2");
+    expect(option["?selected"]).toBe(true);
+  });
+
+  it("writes the GPIOn value for rtl87xx", () => {
+    const ctx = makeRenderCtx({ pin: undefined }, { board: rtl87xxBoard() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", required: true, pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    const select = findTemplatesByAnchor(result, "<wa-select")[0];
+    const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
+    onChange({ target: { value: "GPIO2" } } as never);
+    expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "GPIO2");
   });
 });
 

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -40,6 +40,49 @@ describe("findUsedPins", () => {
     expect(map.has(5)).toBe(false);
   });
 
+  it("detects non-GPIOn pin forms (bk72xx, rtl87xx, ln882x, nRF52)", () => {
+    // Conflict warnings must fire for LibreTiny / nRF52 configs, whose pins
+    // aren't written "GPIOn": bk72xx "P{n}", port-A "PA{n}", ln882x port-B
+    // "PB{n}" (16+n), nRF52 "P{port}.{pin}".
+    const config = [
+      "switch:",
+      "  - platform: gpio",
+      "    pin: P23", // bk72xx -> 23
+      "light:",
+      "  - platform: status_led",
+      "    pin:",
+      "      number: PA02", // port A -> 2
+      "output:",
+      "  - platform: gpio",
+      "    pin: PB03", // ln882x port B -> 19
+      "sensor:",
+      "  - platform: gpio",
+      "    pin: P1.1", // nRF52 -> 33
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.get(23)).toBe("switch");
+    expect(map.get(2)).toBe("light");
+    expect(map.get(19)).toBe("output");
+    expect(map.get(33)).toBe("sensor");
+  });
+
+  it("does not mistake P-prefixed words for bare P{n} pins", () => {
+    // `\b` boundaries keep "P5" inside ordinary identifiers / words from
+    // registering as a used pin — only standalone pin tokens count.
+    const config = [
+      "sensor:",
+      "  - platform: adc",
+      "    name: STEP5 PUMP7 voltage", // not pins
+      "    id: relay_p9", // not a pin
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.has(5)).toBe(false);
+    expect(map.has(7)).toBe(false);
+    expect(map.has(9)).toBe(false);
+  });
+
   it("returns an empty map for empty yaml", () => {
     expect(findUsedPins("").size).toBe(0);
   });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #610. The Pin selector rendered blank for rtl87xx pins written `PA02`; LibreTiny port-A pins map the trailing number straight to the GPIO, so `PA02` is GPIO 2, but the picker only parsed bare ints, `GPIOn`, bk72xx `P{n}`, and nRF52 `P{port}.{pin}`. This adds port-A `PA{n}` parsing (rtl87xx and ln882x) plus ln882x port-B `PB{n}` (port A is GPIO 0 to 15, port B is 16 to 31, so `PB03` is GPIO 19); rtl87xx and ln882x both keep writing the `GPIOn` form, which their validators accept and which the board manifest already labels them with.

It also addresses Copilot's review note on #610; `findUsedPins` only scanned `GPIOn` tokens, so a pin used elsewhere as `P23`, `PA02`, `PB03`, or `P0.27` wasn't detected and the picker didn't warn about the conflict. The pin string to GPIO logic moves into `src/util/pin-gpio.ts` so the picker and the used-pin scanner share one set of platform rules, and the scanner now recognises every form with word boundary guards so a bare `P5` inside a word like `STEP5` doesn't false match.

**Related issue or feature (if applicable):**

- follow-up to #610, covering its Copilot review comment about `findUsedPins` and the rtl87xx / ln882x pin forms

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
