### PR TITLE
Align sticky-scroll line numbers with the editor gutter

### DIFF
--- a/src/util/yaml-sticky-render.ts
+++ b/src/util/yaml-sticky-render.ts
@@ -4,6 +4,17 @@ import type { Tree } from "@lezer/common";
 import { highlightTree } from "@lezer/highlight";
 import type { StickyScopeLine } from "./yaml-sticky-scope.js";
 
+/** Right inset that lands the full-gutters-wide num span's glyph on the
+ *  line-number column's right edge: past the fold gutter, plus CM's 3px
+ *  cell inset (gutter cells use padding 0 3px 0 5px). */
+export function stickyNumPaddingRight(
+  gutterWidth: number,
+  lineNumberWidth: number
+): number {
+  if (gutterWidth <= 0 || lineNumberWidth <= 0) return 8; // pre-measure fallback
+  return gutterWidth - lineNumberWidth + 3;
+}
+
 export function createStickyRow(): HTMLDivElement {
   const row = document.createElement("div");
   row.className = "cm-esphome-sticky-line";
@@ -25,6 +36,7 @@ export function patchStickyRow(
   row: HTMLDivElement,
   sticky: StickyScopeLine,
   gutterWidth: number,
+  lineNumberWidth: number,
   tree: Tree,
   state: EditorState,
   highlightStyle: HighlightStyle,
@@ -43,6 +55,8 @@ export function patchStickyRow(
   const num = row.firstElementChild as HTMLSpanElement;
   const widthStr = gutterWidth > 0 ? `${gutterWidth}px` : "";
   if (num.style.width !== widthStr) num.style.width = widthStr;
+  const padRightStr = `${stickyNumPaddingRight(gutterWidth, lineNumberWidth)}px`;
+  if (num.style.paddingRight !== padRightStr) num.style.paddingRight = padRightStr;
   if (num.textContent !== lineStr) num.textContent = lineStr;
 
   // Re-run the (relatively costly) syntax highlighting only when the row

--- a/src/util/yaml-sticky-render.ts
+++ b/src/util/yaml-sticky-render.ts
@@ -4,15 +4,26 @@ import type { Tree } from "@lezer/common";
 import { highlightTree } from "@lezer/highlight";
 import type { StickyScopeLine } from "./yaml-sticky-scope.js";
 
+/** Live measurements of the editor's line-number gutter, read from the real
+ *  DOM in the plugin's measure phase so the overlay tracks whatever inset CM
+ *  (or a custom theme) actually renders, rather than a hard-coded constant. */
+export interface GutterMetrics {
+  /** Full ``.cm-gutters`` width (line numbers + the fold gutter basicSetup
+   *  mounts to their right). */
+  width: number;
+  /** Line-number column width alone, narrower than ``width``. */
+  lineNumberWidth: number;
+  /** Computed left/right padding of a real line-number gutter cell. */
+  padLeft: number;
+  padRight: number;
+}
+
 /** Right inset that lands the full-gutters-wide num span's glyph on the
- *  line-number column's right edge: past the fold gutter, plus CM's 3px
- *  cell inset (gutter cells use padding 0 3px 0 5px). */
-export function stickyNumPaddingRight(
-  gutterWidth: number,
-  lineNumberWidth: number
-): number {
-  if (gutterWidth <= 0 || lineNumberWidth <= 0) return 8; // pre-measure fallback
-  return gutterWidth - lineNumberWidth + 3;
+ *  line-number column's right edge: past the fold gutter, plus the gutter
+ *  cell's own right padding (measured, so a CM/theme change can't drift it). */
+export function stickyNumPaddingRight(m: GutterMetrics): number {
+  if (m.width <= 0 || m.lineNumberWidth <= 0) return 8; // pre-measure fallback
+  return m.width - m.lineNumberWidth + m.padRight;
 }
 
 export function createStickyRow(): HTMLDivElement {
@@ -35,8 +46,7 @@ export function createStickyRow(): HTMLDivElement {
 export function patchStickyRow(
   row: HTMLDivElement,
   sticky: StickyScopeLine,
-  gutterWidth: number,
-  lineNumberWidth: number,
+  gutter: GutterMetrics,
   tree: Tree,
   state: EditorState,
   highlightStyle: HighlightStyle,
@@ -53,10 +63,14 @@ export function patchStickyRow(
   }
 
   const num = row.firstElementChild as HTMLSpanElement;
-  const widthStr = gutterWidth > 0 ? `${gutterWidth}px` : "";
+  const widthStr = gutter.width > 0 ? `${gutter.width}px` : "";
   if (num.style.width !== widthStr) num.style.width = widthStr;
-  const padRightStr = `${stickyNumPaddingRight(gutterWidth, lineNumberWidth)}px`;
+  const padRightStr = `${stickyNumPaddingRight(gutter)}px`;
   if (num.style.paddingRight !== padRightStr) num.style.paddingRight = padRightStr;
+  // Mirror the gutter cell's measured left inset; empty before the first
+  // measure leaves the theme's fallback in place.
+  const padLeftStr = gutter.padLeft > 0 ? `${gutter.padLeft}px` : "";
+  if (num.style.paddingLeft !== padLeftStr) num.style.paddingLeft = padLeftStr;
   if (num.textContent !== lineStr) num.textContent = lineStr;
 
   // Re-run the (relatively costly) syntax highlighting only when the row

--- a/src/util/yaml-sticky-scroll.ts
+++ b/src/util/yaml-sticky-scroll.ts
@@ -43,7 +43,11 @@ import {
   type PluginValue,
   type ViewUpdate,
 } from "@codemirror/view";
-import { createStickyRow, patchStickyRow } from "./yaml-sticky-render.js";
+import {
+  createStickyRow,
+  patchStickyRow,
+  type GutterMetrics,
+} from "./yaml-sticky-render.js";
 import {
   computeStickyScope,
   findScopeExitLine,
@@ -69,10 +73,7 @@ interface MeasureResult {
   /** Offset (<= 0) applied to the bottom row so it slides out as its
    *  scope ends — Monaco's ``lastLineRelativePosition``. */
   lastLineRelativePosition: number;
-  gutterWidth: number;
-  /** Line-number column width; narrower than ``gutterWidth`` (fold gutter to
-   *  its right). Right-aligns the pinned number to the real gutter. */
-  lineNumberWidth: number;
+  gutter: GutterMetrics;
   rowHeight: number;
 }
 
@@ -105,15 +106,18 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
       // the doc instance changes (i.e. an edit landed).
       private _lines: string[] = [];
       private _linesDoc: Text | null = null;
-      // Gutter width is a layout read (offsetWidth); cache it and only
-      // re-measure on the requestMeasure path (geometry/viewport changes),
-      // so the synchronous scroll handler never forces layout. The gutter
-      // only resizes on those same events (e.g. line-number digit count),
-      // so the cached value is current between refreshes.
-      private _gutterWidth = 0;
-      // Line-number column width alone (narrower than _gutterWidth: the fold
-      // gutter sits to its right). The pinned number aligns to this edge.
-      private _lineNumberWidth = 0;
+      // Gutter geometry is a layout read (offsetWidth / getComputedStyle);
+      // cache it and only re-measure on the requestMeasure path
+      // (geometry/viewport changes), so the synchronous scroll handler never
+      // forces layout. The gutter only resizes on those same events (e.g.
+      // line-number digit count), so the cached value is current between
+      // refreshes.
+      private _gutter: GutterMetrics = {
+        width: 0,
+        lineNumberWidth: 0,
+        padLeft: 0,
+        padRight: 0,
+      };
 
       constructor(readonly view: EditorView) {
         this.overlay = document.createElement("div");
@@ -175,9 +179,18 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
             // geometry/viewport/doc changes, which is when the gutter can
             // resize. The scroll handler then reuses the cached width.
             const gutterEl = view.dom.querySelector<HTMLElement>(".cm-gutters");
-            this._gutterWidth = gutterEl ? gutterEl.offsetWidth : 0;
             const lnEl = view.dom.querySelector<HTMLElement>(".cm-lineNumbers");
-            this._lineNumberWidth = lnEl ? lnEl.offsetWidth : 0;
+            // Read the cell's actual padding rather than hard-coding CM's
+            // ``0 3px 0 5px`` default, so a CM bump or custom gutter theme
+            // can't drift the pinned number off the real gutter.
+            const cell = lnEl?.querySelector<HTMLElement>(".cm-gutterElement");
+            const cs = cell ? getComputedStyle(cell) : null;
+            this._gutter = {
+              width: gutterEl ? gutterEl.offsetWidth : 0,
+              lineNumberWidth: lnEl ? lnEl.offsetWidth : 0,
+              padLeft: cs ? parseFloat(cs.paddingLeft) || 0 : 0,
+              padRight: cs ? parseFloat(cs.paddingRight) || 0 : 0,
+            };
             return this.measure(view);
           },
           write: (measured, view) => this.applyMeasured(measured, view),
@@ -247,8 +260,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
         return {
           scope,
           lastLineRelativePosition,
-          gutterWidth: this._gutterWidth,
-          lineNumberWidth: this._lineNumberWidth,
+          gutter: this._gutter,
           rowHeight,
         };
       }
@@ -258,20 +270,15 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
           this.setEmpty();
           return;
         }
-        const {
-          scope,
-          lastLineRelativePosition,
-          gutterWidth,
-          lineNumberWidth,
-          rowHeight,
-        } = measured;
+        const { scope, lastLineRelativePosition, gutter, rowHeight } = measured;
 
-        const scopeKey = `${gutterWidth}|${lineNumberWidth}|${scope
+        const { width, lineNumberWidth, padLeft, padRight } = gutter;
+        const scopeKey = `${width}|${lineNumberWidth}|${padLeft}|${padRight}|${scope
           .map((l) => `${l.lineNumber}:${l.text}`)
           .join("\n")}`;
         if (scopeKey !== this._renderedKey) {
           this._renderedKey = scopeKey;
-          this.render(scope, gutterWidth, lineNumberWidth, view);
+          this.render(scope, gutter, view);
         }
 
         // Each row is absolutely positioned at ``i*rowHeight``; the last
@@ -323,8 +330,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
 
       private render(
         scope: StickyScopeLine[],
-        gutterWidth: number,
-        lineNumberWidth: number,
+        gutter: GutterMetrics,
         view: EditorView
       ): void {
         const tree = syntaxTree(view.state);
@@ -338,8 +344,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
           patchStickyRow(
             row,
             sticky,
-            gutterWidth,
-            lineNumberWidth,
+            gutter,
             tree,
             view.state,
             highlightStyle,

--- a/src/util/yaml-sticky-scroll.ts
+++ b/src/util/yaml-sticky-scroll.ts
@@ -70,6 +70,9 @@ interface MeasureResult {
    *  scope ends — Monaco's ``lastLineRelativePosition``. */
   lastLineRelativePosition: number;
   gutterWidth: number;
+  /** Line-number column width; narrower than ``gutterWidth`` (fold gutter to
+   *  its right). Right-aligns the pinned number to the real gutter. */
+  lineNumberWidth: number;
   rowHeight: number;
 }
 
@@ -108,6 +111,9 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
       // only resizes on those same events (e.g. line-number digit count),
       // so the cached value is current between refreshes.
       private _gutterWidth = 0;
+      // Line-number column width alone (narrower than _gutterWidth: the fold
+      // gutter sits to its right). The pinned number aligns to this edge.
+      private _lineNumberWidth = 0;
 
       constructor(readonly view: EditorView) {
         this.overlay = document.createElement("div");
@@ -170,6 +176,8 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
             // resize. The scroll handler then reuses the cached width.
             const gutterEl = view.dom.querySelector<HTMLElement>(".cm-gutters");
             this._gutterWidth = gutterEl ? gutterEl.offsetWidth : 0;
+            const lnEl = view.dom.querySelector<HTMLElement>(".cm-lineNumbers");
+            this._lineNumberWidth = lnEl ? lnEl.offsetWidth : 0;
             return this.measure(view);
           },
           write: (measured, view) => this.applyMeasured(measured, view),
@@ -240,6 +248,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
           scope,
           lastLineRelativePosition,
           gutterWidth: this._gutterWidth,
+          lineNumberWidth: this._lineNumberWidth,
           rowHeight,
         };
       }
@@ -249,14 +258,20 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
           this.setEmpty();
           return;
         }
-        const { scope, lastLineRelativePosition, gutterWidth, rowHeight } = measured;
+        const {
+          scope,
+          lastLineRelativePosition,
+          gutterWidth,
+          lineNumberWidth,
+          rowHeight,
+        } = measured;
 
-        const scopeKey = `${gutterWidth}|${scope
+        const scopeKey = `${gutterWidth}|${lineNumberWidth}|${scope
           .map((l) => `${l.lineNumber}:${l.text}`)
           .join("\n")}`;
         if (scopeKey !== this._renderedKey) {
           this._renderedKey = scopeKey;
-          this.render(scope, gutterWidth, view);
+          this.render(scope, gutterWidth, lineNumberWidth, view);
         }
 
         // Each row is absolutely positioned at ``i*rowHeight``; the last
@@ -309,6 +324,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
       private render(
         scope: StickyScopeLine[],
         gutterWidth: number,
+        lineNumberWidth: number,
         view: EditorView
       ): void {
         const tree = syntaxTree(view.state);
@@ -323,6 +339,7 @@ export function yamlStickyScroll(options: StickyScrollOptions): Extension {
             row,
             sticky,
             gutterWidth,
+            lineNumberWidth,
             tree,
             view.state,
             highlightStyle,

--- a/src/util/yaml-sticky-theme.ts
+++ b/src/util/yaml-sticky-theme.ts
@@ -53,8 +53,9 @@ export function buildStickyTheme(background: string): Extension {
       flex: "0 0 auto",
       boxSizing: "border-box",
       textAlign: "right",
-      // paddingRight is per-row inline (yaml-sticky-render); paddingLeft
-      // mirrors CM's gutter cell inset (padding 0 3px 0 5px).
+      // Both paddings are set per-row inline (yaml-sticky-render) from the
+      // gutter cell's measured inset; this 5px is only the pre-measure
+      // fallback for the first paint.
       paddingLeft: "5px",
       opacity: "0.65",
       userSelect: "none",

--- a/src/util/yaml-sticky-theme.ts
+++ b/src/util/yaml-sticky-theme.ts
@@ -19,7 +19,7 @@ export function buildStickyTheme(background: string): Extension {
       fontFamily: EDITOR_FONT_FAMILY,
       fontSize: EDITOR_FONT_SIZE,
       background,
-      boxShadow: "0 1px 0 rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.08)",
+      boxShadow: "0 2px 0 rgba(0, 0, 0, 0.25), 0 2px 4px rgba(0, 0, 0, 0.08)",
       overflow: "hidden",
       "&:empty": {
         display: "none",
@@ -53,8 +53,9 @@ export function buildStickyTheme(background: string): Extension {
       flex: "0 0 auto",
       boxSizing: "border-box",
       textAlign: "right",
-      paddingRight: "8px",
-      paddingLeft: "8px",
+      // paddingRight is per-row inline (yaml-sticky-render); paddingLeft
+      // mirrors CM's gutter cell inset (padding 0 3px 0 5px).
+      paddingLeft: "5px",
       opacity: "0.65",
       userSelect: "none",
     },

--- a/test/util/yaml-sticky-render.test.ts
+++ b/test/util/yaml-sticky-render.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { stickyNumPaddingRight } from "../../src/util/yaml-sticky-render.js";
+
+/**
+ * The pinned line-number span spans the full ``.cm-gutters`` width so the
+ * sticky content stays aligned with the editor body. basicSetup also mounts
+ * a fold gutter to the right of the line numbers, so right-aligning the glyph
+ * against the full width drops it past the real gutter column. The right
+ * inset pushes it back: fold-gutter width (gutters − lineNumbers) plus CM's
+ * own 3px cell inset, landing the glyph on the line-number column's edge.
+ *
+ * jsdom has no layout engine (``offsetWidth`` is 0), so the pixel math is
+ * only exercisable through this pure helper.
+ */
+describe("stickyNumPaddingRight", () => {
+  it("offsets the glyph past the fold gutter plus CM's 3px inset", () => {
+    // gutters 50, line numbers 34 → fold gutter 16, + 3 = 19.
+    expect(stickyNumPaddingRight(50, 34)).toBe(19);
+  });
+
+  it("collapses to CM's 3px inset when there is no fold gutter", () => {
+    expect(stickyNumPaddingRight(34, 34)).toBe(3);
+  });
+
+  it("falls back to 8 before either width is measured", () => {
+    expect(stickyNumPaddingRight(0, 0)).toBe(8);
+    expect(stickyNumPaddingRight(50, 0)).toBe(8);
+    expect(stickyNumPaddingRight(0, 34)).toBe(8);
+  });
+});

--- a/test/util/yaml-sticky-render.test.ts
+++ b/test/util/yaml-sticky-render.test.ts
@@ -1,30 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { stickyNumPaddingRight } from "../../src/util/yaml-sticky-render.js";
+import {
+  stickyNumPaddingRight,
+  type GutterMetrics,
+} from "../../src/util/yaml-sticky-render.js";
 
 /**
  * The pinned line-number span spans the full ``.cm-gutters`` width so the
  * sticky content stays aligned with the editor body. basicSetup also mounts
  * a fold gutter to the right of the line numbers, so right-aligning the glyph
  * against the full width drops it past the real gutter column. The right
- * inset pushes it back: fold-gutter width (gutters − lineNumbers) plus CM's
- * own 3px cell inset, landing the glyph on the line-number column's edge.
+ * inset pushes it back: fold-gutter width (gutters − lineNumbers) plus the
+ * gutter cell's measured right padding, landing the glyph on the line-number
+ * column's edge.
  *
  * jsdom has no layout engine (``offsetWidth`` is 0), so the pixel math is
- * only exercisable through this pure helper.
+ * only exercisable through this pure helper; the padding is measured live in
+ * the plugin, so the helper takes it as input rather than hard-coding it.
  */
+function metrics(over: Partial<GutterMetrics> = {}): GutterMetrics {
+  return { width: 50, lineNumberWidth: 34, padLeft: 5, padRight: 3, ...over };
+}
+
 describe("stickyNumPaddingRight", () => {
-  it("offsets the glyph past the fold gutter plus CM's 3px inset", () => {
+  it("offsets the glyph past the fold gutter plus the cell's right padding", () => {
     // gutters 50, line numbers 34 → fold gutter 16, + 3 = 19.
-    expect(stickyNumPaddingRight(50, 34)).toBe(19);
+    expect(stickyNumPaddingRight(metrics())).toBe(19);
   });
 
-  it("collapses to CM's 3px inset when there is no fold gutter", () => {
-    expect(stickyNumPaddingRight(34, 34)).toBe(3);
+  it("uses the measured padding rather than a hard-coded constant", () => {
+    // A theme with a 6px cell inset shifts the result to match.
+    expect(stickyNumPaddingRight(metrics({ padRight: 6 }))).toBe(22);
+  });
+
+  it("collapses to the cell's right padding when there is no fold gutter", () => {
+    expect(stickyNumPaddingRight(metrics({ width: 34 }))).toBe(3);
   });
 
   it("falls back to 8 before either width is measured", () => {
-    expect(stickyNumPaddingRight(0, 0)).toBe(8);
-    expect(stickyNumPaddingRight(50, 0)).toBe(8);
-    expect(stickyNumPaddingRight(0, 34)).toBe(8);
+    expect(stickyNumPaddingRight(metrics({ width: 0, lineNumberWidth: 0 }))).toBe(8);
+    expect(stickyNumPaddingRight(metrics({ lineNumberWidth: 0 }))).toBe(8);
+    expect(stickyNumPaddingRight(metrics({ width: 0 }))).toBe(8);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The sticky scroll header line numbers were offset from the editor gutter; they measured the full `.cm-gutters` width, which includes the fold gutter that `basicSetup` mounts to the right of the line numbers, so the right aligned number landed past the real line number column. This measures the `.cm-lineNumbers` column on its own and pushes the pinned number back onto its right edge, so the sticky numbers line up as one continuous column with the gutter below. The divider under the sticky header is also a touch taller and darker while I was in there.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/626

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
