### PR TITLE
Show completion popover for falsy config defaults

### DIFF
--- a/src/util/yaml-completion-items.ts
+++ b/src/util/yaml-completion-items.ts
@@ -39,7 +39,8 @@ const RE_LEADING_WHITESPACE = /^( *)/;
  */
 function buildEntryInfo(entry: ConfigEntry): () => HTMLElement | null {
   return () => {
-    if (!entry.description && !entry.default_value && !entry.range) return null;
+    const hasDefault = entry.default_value !== null && entry.default_value !== undefined;
+    if (!entry.description && !hasDefault && !entry.range) return null;
     const dom = document.createElement("div");
     dom.className = "cm-esphome-info";
     if (entry.description) {
@@ -47,7 +48,7 @@ function buildEntryInfo(entry: ConfigEntry): () => HTMLElement | null {
       p.textContent = entry.description;
       dom.appendChild(p);
     }
-    if (entry.default_value !== null && entry.default_value !== undefined) {
+    if (hasDefault) {
       const def = document.createElement("div");
       def.className = "cm-esphome-info-meta";
       def.textContent = `Default: ${String(entry.default_value)}`;

--- a/test/util/yaml-completion-entry-info.test.ts
+++ b/test/util/yaml-completion-entry-info.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import { entryToCompletion } from "../../src/util/yaml-completion-items.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+// The `info` callback renders the hover popover for a config entry. The
+// guard that decides whether to render at all must treat `default_value`
+// as present whenever it is anything other than null/undefined — a falsy
+// `0` / `false` default is still a default worth showing.
+describe("entryToCompletion info popover", () => {
+  const renderInfo = (entry: Parameters<typeof entryToCompletion>[0]) => {
+    const { info } = entryToCompletion(entry);
+    expect(typeof info).toBe("function");
+    return (info as () => HTMLElement | null)();
+  };
+
+  it("renders the Default line for a falsy 0 default", () => {
+    const dom = renderInfo(
+      makeConfigEntry({
+        key: "update_interval",
+        description: null,
+        range: null,
+        default_value: 0,
+      })
+    );
+    expect(dom).not.toBeNull();
+    expect(dom!.textContent).toContain("Default: 0");
+  });
+
+  it("renders the Default line for a falsy false default", () => {
+    const dom = renderInfo(
+      makeConfigEntry({
+        key: "internal",
+        description: null,
+        range: null,
+        default_value: false,
+      })
+    );
+    expect(dom).not.toBeNull();
+    expect(dom!.textContent).toContain("Default: false");
+  });
+
+  it("renders nothing when there is no description, default, or range", () => {
+    const dom = renderInfo(
+      makeConfigEntry({
+        key: "name",
+        description: null,
+        range: null,
+        default_value: null,
+      })
+    );
+    expect(dom).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The config entry hover popover in YAML autocompletion skipped rendering when an entry's only metadata was a falsy default; `default_value: 0` or `default_value: false` hit the `!entry.default_value` guard and returned null, so no popover showed at all. The guard now treats only null/undefined as a missing default, matching the check the Default line itself already uses, so a `0` or `false` default renders its popover.

This was flagged by Copilot on #621 and deferred to a follow up; this is that follow up.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
