### PR TITLE
Consolidate board image fallback onto board-image.ts

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -16,7 +16,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { actionFieldLabel } from "../../util/action-field-label.js";
-import { withBase } from "../../util/base-path.js";
+import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.js";
 import { anyAdvancedEntry } from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -267,14 +267,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     );
   }
 
-  private _onImageError(e: Event) {
-    const img = e.target as HTMLImageElement;
-    const fallback = withBase("/assets/board/default.svg");
-    if (img.src !== window.location.origin + fallback && !img.src.endsWith(fallback)) {
-      img.src = fallback;
-    }
-  }
-
   private _onShowYamlEditor() {
     this.dispatchEvent(
       new CustomEvent("show-yaml-editor", { bubbles: true, composed: true })
@@ -344,10 +336,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
           ? nothing
           : html`<div class="section-image">
               <img
-                src=${this._config.image_url || withBase("/assets/board/default.svg")}
+                src=${this._config.image_url || defaultBoardImageUrl()}
                 alt=${this._config.title}
                 referrerpolicy="no-referrer"
-                @error=${this._onImageError}
+                @error=${onBoardImageError}
               />
             </div>`}
       </div>

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -17,7 +17,7 @@ import type { SerialPort } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { withBase } from "../../util/base-path.js";
+import { boardImageUrl } from "../../util/board-image.js";
 import { debounce } from "../../util/debounce.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../../util/environment.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -277,8 +277,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   }
 
   private _renderFeatured(board: BoardCatalogEntry) {
-    const imageUrl =
-      board.images.length > 0 ? board.images[0] : withBase("/assets/board/default.svg");
+    const imageUrl = boardImageUrl(board);
     return html`
       <div class="featured-card">
         <img class="featured-image" src=${imageUrl} alt=${board.name} />
@@ -317,8 +316,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   }
 
   private _renderBoardCard(board: BoardCatalogEntry, expanded: boolean) {
-    const imageUrl =
-      board.images.length > 0 ? board.images[0] : withBase("/assets/board/default.svg");
+    const imageUrl = boardImageUrl(board);
     return html`
       <article class="board-card ${expanded ? "board-card--expanded" : ""}">
         <div class="board-card-header">

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -7,7 +7,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { withBase } from "../../util/base-path.js";
+import { boardImageUrl } from "../../util/board-image.js";
 import { EnterController } from "../../util/enter-controller.js";
 
 @customElement("esphome-wizard-step-setup")
@@ -255,9 +255,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
         ${board
           ? html`<img
               class="board-image"
-              src=${board.images.length > 0
-                ? board.images[0]
-                : withBase("/assets/board/default.svg")}
+              src=${boardImageUrl(board)}
               alt=${board.name}
             />`
           : null}

--- a/src/util/board-image.ts
+++ b/src/util/board-image.ts
@@ -3,16 +3,21 @@ import { withBase } from "./base-path.js";
 
 const DEFAULT_BOARD_IMAGE = "/assets/board/default.svg";
 
+/** URL of the bundled board placeholder image. */
+export function defaultBoardImageUrl(): string {
+  return withBase(DEFAULT_BOARD_IMAGE);
+}
+
 /** First catalog image for a board, or the bundled placeholder. */
 export function boardImageUrl(board: BoardCatalogEntry): string {
   if (board.images.length > 0) return board.images[0];
-  return withBase(DEFAULT_BOARD_IMAGE);
+  return defaultBoardImageUrl();
 }
 
 /** `@error` handler that swaps a broken board image for the placeholder. */
 export function onBoardImageError(e: Event): void {
   const img = e.target as HTMLImageElement;
-  const fallback = withBase(DEFAULT_BOARD_IMAGE);
+  const fallback = defaultBoardImageUrl();
   if (img.src !== window.location.origin + fallback && !img.src.endsWith(fallback)) {
     img.src = fallback;
   }

--- a/test/util/board-image.test.ts
+++ b/test/util/board-image.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
+import {
+  boardImageUrl,
+  defaultBoardImageUrl,
+  onBoardImageError,
+} from "../../src/util/board-image.js";
+
+const board = (images: string[]): BoardCatalogEntry =>
+  ({ id: "b", name: "B", images }) as BoardCatalogEntry;
+
+describe("boardImageUrl", () => {
+  it("returns the first catalog image when present", () => {
+    expect(boardImageUrl(board(["https://example.com/a.png", "b.png"]))).toBe(
+      "https://example.com/a.png"
+    );
+  });
+
+  it("falls back to the bundled placeholder when there are no images", () => {
+    expect(boardImageUrl(board([]))).toBe(defaultBoardImageUrl());
+  });
+});
+
+describe("defaultBoardImageUrl", () => {
+  it("points at the bundled board placeholder asset", () => {
+    expect(defaultBoardImageUrl().endsWith("/assets/board/default.svg")).toBe(true);
+  });
+});
+
+describe("onBoardImageError", () => {
+  it("rewrites a broken image src to the placeholder", () => {
+    const img = { src: "https://example.com/missing.png" };
+    onBoardImageError({ target: img } as unknown as Event);
+    expect(img.src).toBe(defaultBoardImageUrl());
+  });
+
+  it("leaves the src alone when it is already the placeholder", () => {
+    const img = { src: defaultBoardImageUrl() };
+    onBoardImageError({ target: img } as unknown as Event);
+    expect(img.src).toBe(defaultBoardImageUrl());
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #629; finishes consolidating the board image fallback onto `src/util/board-image.ts`. The wizard board picker, the wizard setup step, and the device section editor each inlined their own `board.images[0]` or `default.svg` fallback (and the section editor had a verbatim copy of the image-error handler); they now use the shared helper. Adds `defaultBoardImageUrl` for the section image, which falls back from `config.image_url` rather than from a board. Pure refactor, no behavior change; adds a unit test for the helper.

**Related issue or feature (if applicable):**

- fixes #631

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
