### PR TITLE
Reword pairing-requests section description

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1153,7 +1153,7 @@
     "remote_build_rotate_already_in_progress": "Another rotation is already running on this dashboard. Wait for it to finish before retrying.",
     "remote_build_rotate_failed": "Could not rotate the identity.",
     "build_server_pairing_requests_heading": "Pairing requests",
-    "build_server_pairing_requests_desc": "Senders that have asked to pair with this dashboard. Open Review to compare the fingerprint with what the sending dashboard shows and decide.",
+    "build_server_pairing_requests_desc": "Senders that have asked to pair with this dashboard. Open Review to compare the fingerprint shown on the sending dashboard, then accept or reject.",
     "build_server_pairing_requests_loading": "Loading pairing requests…",
     "build_server_pairing_requests_empty": "No pairing requests yet.",
     "build_server_pairing_window_open": "Open",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1153,7 +1153,7 @@
     "remote_build_rotate_already_in_progress": "Another rotation is already running on this dashboard. Wait for it to finish before retrying.",
     "remote_build_rotate_failed": "Could not rotate the identity.",
     "build_server_pairing_requests_heading": "Pairing requests",
-    "build_server_pairing_requests_desc": "Senders that have asked to pair with this dashboard. Open Review to compare the fingerprint shown on the sending dashboard, then accept or reject.",
+    "build_server_pairing_requests_desc": "Senders that have asked to pair with this dashboard. Open Review to compare the fingerprint shown there with the one on the sending dashboard, then accept or reject.",
     "build_server_pairing_requests_loading": "Loading pairing requests…",
     "build_server_pairing_requests_empty": "No pairing requests yet.",
     "build_server_pairing_window_open": "Open",


### PR DESCRIPTION
# What does this implement/fix?

The pairing requests section description ended on a dangling "and decide" with no object, which reads as unfinished English. Reworded it so the sentence compares the fingerprint, then accepts or rejects, matching the buttons the Review dialog actually shows.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1217

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
