### PR TITLE
Don't echo programmatic value syncs as lambda-change

### DIFF
--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -146,9 +146,11 @@ export class ESPHomeLambdaEditor extends LitElement {
           EditorView.updateListener.of((update) => {
             // Skip programmatic ``value``-prop syncs (tagged ``externalSync``);
             // only a real user edit should emit ``lambda-change`` (#1223).
+            // Presence check, not truthiness, so the marker reads as "this is
+            // a sync" regardless of the annotation's payload.
             if (
               update.docChanged &&
-              !update.transactions.some((tr) => tr.annotation(externalSync))
+              !update.transactions.some((tr) => tr.annotation(externalSync) !== undefined)
             ) {
               const value = update.state.doc.toString();
               this.dispatchEvent(

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -8,12 +8,17 @@
  * mixed-language overlay; reusing it here keeps the highlighting
  * consistent between the two surfaces.
  *
- * Emits ``lambda-change`` with ``{ value: string }`` on every doc edit.
+ * Emits ``lambda-change`` with ``{ value: string }`` on every *user* doc
+ * edit. Programmatic ``value``-prop syncs (see ``updated``) are tagged with
+ * the ``externalSync`` annotation and skipped — otherwise re-pointing a
+ * reused editor at a new field's body (e.g. a section switch driven by the
+ * YAML pane's cursor) would echo a spurious ``lambda-change`` and dirty the
+ * form with no user edit (#1223).
  */
 import { indentWithTab } from "@codemirror/commands";
 import { cpp } from "@codemirror/lang-cpp";
 import { indentUnit } from "@codemirror/language";
-import { Compartment, EditorState } from "@codemirror/state";
+import { Annotation, Compartment, EditorState } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { basicSetup, EditorView } from "codemirror";
@@ -22,6 +27,11 @@ import { customElement, property, query, state } from "lit/decorators.js";
 
 import { darkModeContext } from "../../../context/index.js";
 import { vscodeDark, vscodeLight } from "../../../util/yaml-editor-theme.js";
+
+/** Marks the doc change that syncs the external ``value`` prop into the
+ *  view, so the update listener can tell it apart from a user edit and
+ *  not echo it back as a ``lambda-change``. */
+const externalSync = Annotation.define<boolean>();
 
 @customElement("esphome-lambda-editor")
 export class ESPHomeLambdaEditor extends LitElement {
@@ -107,6 +117,7 @@ export class ESPHomeLambdaEditor extends LitElement {
       if (current !== this.value) {
         this._view.dispatch({
           changes: { from: 0, to: current.length, insert: this.value },
+          annotations: externalSync.of(true),
         });
       }
     }
@@ -133,7 +144,12 @@ export class ESPHomeLambdaEditor extends LitElement {
             "&": { height: "100%" },
           }),
           EditorView.updateListener.of((update) => {
-            if (update.docChanged) {
+            // Skip programmatic ``value``-prop syncs (tagged ``externalSync``);
+            // only a real user edit should emit ``lambda-change`` (#1223).
+            if (
+              update.docChanged &&
+              !update.transactions.some((tr) => tr.annotation(externalSync))
+            ) {
               const value = update.state.doc.toString();
               this.dispatchEvent(
                 new CustomEvent("lambda-change", {

--- a/test/components/device/lambda-editor.test.ts
+++ b/test/components/device/lambda-editor.test.ts
@@ -40,6 +40,32 @@ describe("lambda-editor lambda-change emission", () => {
     expect(el["_view"]!.state.doc.toString()).toBe("return 2;");
   });
 
+  it("does not emit while mounting with an initial value", async () => {
+    const el = new ESPHomeLambdaEditor();
+    el.value = "return 1;";
+    const onChange = vi.fn();
+    // Listen *before* the first render so the initial value-sync is observed.
+    el.addEventListener("lambda-change", onChange);
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(el["_view"]!.state.doc.toString()).toBe("return 1;");
+  });
+
+  it("stays silent across repeated programmatic syncs (feedback loop)", async () => {
+    const el = await mount("return 1;");
+    const onChange = vi.fn();
+    el.addEventListener("lambda-change", onChange);
+
+    for (const v of ["return 2;", "return 3;", "return 4;"]) {
+      el.value = v;
+      await el.updateComplete;
+    }
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("emits exactly once on a user edit", async () => {
     const el = await mount("return 1;");
     const onChange = vi.fn();
@@ -54,5 +80,25 @@ describe("lambda-editor lambda-change emission", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0].detail).toEqual({ value: "return 42;" });
+  });
+
+  it("suppresses a programmatic sync that follows a user edit", async () => {
+    const el = await mount("return 1;");
+    const onChange = vi.fn();
+    el.addEventListener("lambda-change", onChange);
+
+    // User types...
+    const view = el["_view"]!;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: "return 42;" },
+    });
+    await el.updateComplete;
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // ...then the owner echoes a fresh value back through the prop: no emit.
+    el.value = "return 99;";
+    await el.updateComplete;
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(view.state.doc.toString()).toBe("return 99;");
   });
 });

--- a/test/components/device/lambda-editor.test.ts
+++ b/test/components/device/lambda-editor.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression test for #1223: the inline lambda editor must emit
+ * `lambda-change` only on a real user edit, never on the programmatic
+ * `value`-prop sync. A reused editor re-pointed at a different field's
+ * body (section switch driven by the YAML pane's cursor) would otherwise
+ * echo a spurious change, dirty the form, and trigger a lossy
+ * re-serialize of the whole section.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ESPHomeLambdaEditor } from "../../../src/components/device/config-entry-renderers/lambda-editor.js";
+
+async function mount(value: string): Promise<ESPHomeLambdaEditor> {
+  const el = new ESPHomeLambdaEditor();
+  el.value = value;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("lambda-editor lambda-change emission", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does not emit on a programmatic value-prop sync", async () => {
+    const el = await mount("return 1;");
+    const onChange = vi.fn();
+    el.addEventListener("lambda-change", onChange);
+
+    // Simulate the section-switch reuse: the form re-points this editor
+    // at a different field's body via the `value` prop.
+    el.value = "return 2;";
+    await el.updateComplete;
+
+    expect(onChange).not.toHaveBeenCalled();
+    // The doc still tracks the new value, it just doesn't echo it back.
+    expect(el["_view"]!.state.doc.toString()).toBe("return 2;");
+  });
+
+  it("emits exactly once on a user edit", async () => {
+    const el = await mount("return 1;");
+    const onChange = vi.fn();
+    el.addEventListener("lambda-change", onChange);
+
+    // A user edit is a doc change with no `externalSync` annotation.
+    const view = el["_view"]!;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: "return 42;" },
+    });
+    await el.updateComplete;
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].detail).toEqual({ value: "return 42;" });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Selecting or scrolling through the YAML of a device with lambda fields silently rewrote the document; lambdas got re-indented, inline-comment scalars got quoted, comments duplicated, and the page warned about unsaved changes even though nothing was typed.

The inline lambda editor emitted `lambda-change` on every doc change, including the programmatic sync of its `value` prop. When the section form reused a lambda editor for a different field during a cursor driven section switch, that sync fired a spurious change, dirtied the form, and triggered a lossy re-serialize of the whole section. This tags the programmatic sync with an annotation and skips it, so only real user edits emit the event.

The residual serializer lossiness on a genuine edit is tracked separately in esphome/device-builder#1227.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1223

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

