### PR TITLE
Splice only changed fields when saving a section form

### DIFF
--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -1,0 +1,108 @@
+/**
+ * Diff-and-splice support for `updateSectionInYaml` (#1227).
+ *
+ * Holds the per-key source-span model, structural value equality, and
+ * the body assembler that copies untouched keys back byte-for-byte
+ * while re-serializing only the keys the form changed. Kept apart from
+ * the parser/update file so that already-oversized module doesn't grow
+ * with this concern.
+ */
+
+import { isPlainObject } from "./nested-values.js";
+import {
+  serializeYamlValues,
+  YamlRawValue,
+  type SerializeYamlOptions,
+} from "./yaml-serialize.js";
+
+/**
+ * A top-level key's source-line span within a section body. Both
+ * fields are 0-indexed into the section's lines array; ``[start, end)``
+ * is half-open. ``leadStart <= start`` extends over the contiguous
+ * blank / standalone-comment run that visually precedes the key, so a
+ * verbatim copy carries that key's own comments with it.
+ */
+export interface KeySpan {
+  start: number;
+  end: number;
+  leadStart: number;
+}
+
+export interface ParsedSection {
+  values: Record<string, unknown>;
+  // One span per top-level key, in file order. The inline-on-dash key
+  // (list items) is intentionally absent — it lives on the section
+  // header line, which `updateSectionInYaml` owns directly.
+  spans: Map<string, KeySpan>;
+  childIndent: string;
+  isListItem: boolean;
+  // 0-indexed section header / leading-dash line.
+  startIdx: number;
+}
+
+/**
+ * Structural equality for the value shapes the section parser emits —
+ * primitives, null, null-prototype mappings, ``string[]`` / ``Record[]``
+ * arrays, and ``YamlRawValue`` (compared by header + body lines so an
+ * untouched lambda stays verbatim). Not a general deep-equal; the
+ * exotic shapes (Map / Set / Date / function) never reach here.
+ */
+export function yamlValueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof YamlRawValue || b instanceof YamlRawValue) {
+    return (
+      a instanceof YamlRawValue &&
+      b instanceof YamlRawValue &&
+      a.inlineHeader === b.inlineHeader &&
+      a.lines.length === b.lines.length &&
+      a.lines.every((line, i) => line === b.lines[i])
+    );
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, i) => yamlValueEqual(item, b[i]))
+    );
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    if (ak.length !== Object.keys(b).length) return false;
+    return ak.every(
+      (k) => Object.prototype.hasOwnProperty.call(b, k) && yamlValueEqual(a[k], b[k])
+    );
+  }
+  return false;
+}
+
+/**
+ * Build the spliced section body: each form key the value of which
+ * matches the on-disk parse keeps its source lines verbatim; the rest
+ * (and added keys) re-serialize through the normal path. `inlineKeys`
+ * are the list-item dash keys the caller already represents on the
+ * header line, so they're skipped here (#1227).
+ */
+export function buildSplicedBody(
+  lines: string[],
+  parsed: ParsedSection,
+  values: Record<string, unknown>,
+  inlineKeys: Set<string>,
+  childIndent: string,
+  serializeOptions: SerializeYamlOptions
+): string[] {
+  const bodyLines: string[] = [];
+  for (const [key, val] of Object.entries(values)) {
+    if (inlineKeys.has(key)) continue;
+    const span = parsed.spans.get(key);
+    if (span && yamlValueEqual(val, parsed.values[key])) {
+      bodyLines.push(...lines.slice(span.leadStart, span.end));
+      continue;
+    }
+    // Changed / added key. Keep any standalone-comment run that led the
+    // original key — the value line below reformats, the comment stays.
+    if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
+    bodyLines.push(...serializeYamlValues({ [key]: val }, childIndent, serializeOptions));
+  }
+  return bodyLines;
+}

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -8,8 +8,13 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
-import { isPlainObject } from "./nested-values.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
+import {
+  buildSplicedBody,
+  yamlValueEqual,
+  type KeySpan,
+  type ParsedSection,
+} from "./yaml-section-splice.js";
 import {
   formatYamlScalar,
   parseYamlBoolean,
@@ -728,31 +733,6 @@ export function parseYamlSectionValues(
 }
 
 /**
- * A top-level key's source-line span within a section body. Both
- * fields are 0-indexed into the section's lines array; ``[start, end)``
- * is half-open. ``leadStart <= start`` extends over the contiguous
- * blank / standalone-comment run that visually precedes the key, so a
- * verbatim copy carries that key's own comments with it.
- */
-interface KeySpan {
-  start: number;
-  end: number;
-  leadStart: number;
-}
-
-interface ParsedSection {
-  values: Record<string, unknown>;
-  // One span per top-level key, in file order. The inline-on-dash key
-  // (list items) is intentionally absent — it lives on the section
-  // header line, which `updateSectionInYaml` owns directly.
-  spans: Map<string, KeySpan>;
-  childIndent: string;
-  isListItem: boolean;
-  // 0-indexed section header / leading-dash line.
-  startIdx: number;
-}
-
-/**
  * Parse a section into values plus each top-level key's source-line
  * span, so `updateSectionInYaml` can copy untouched keys back verbatim
  * rather than re-serialize the whole section (#1227). Spans are built
@@ -1234,59 +1214,12 @@ export function updateSectionInYaml(
 
   // Splice only what changed (#1227): untouched keys keep their source
   // lines byte-for-byte; the rest re-serialize through the normal path.
-  const bodyLines: string[] = [];
-  for (const [key, val] of Object.entries(values)) {
-    if (inlineKeys.has(key)) continue;
-    const span = parsed.spans.get(key);
-    if (span && yamlValueEqual(val, parsed.values[key])) {
-      bodyLines.push(...lines.slice(span.leadStart, span.end));
-      continue;
-    }
-    // Changed / added key. Keep any standalone-comment run that led the
-    // original key — the value line below reformats, the comment stays.
-    if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
-    bodyLines.push(...serializeYamlValues({ [key]: val }, childIndent, serializeOptions));
-  }
-
-  const newLines = [dashLine, ...bodyLines];
+  const newLines = [
+    dashLine,
+    ...buildSplicedBody(lines, parsed, values, inlineKeys, childIndent, serializeOptions),
+  ];
   lines.splice(start, spliceEnd - start, ...newLines);
   return lines.join("\n");
-}
-
-/**
- * Structural equality for the value shapes the section parser emits —
- * primitives, null, null-prototype mappings, ``string[]`` / ``Record[]``
- * arrays, and ``YamlRawValue`` (compared by header + body lines so an
- * untouched lambda stays verbatim). Not a general deep-equal; the
- * exotic shapes (Map / Set / Date / function) never reach here.
- */
-function yamlValueEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a instanceof YamlRawValue || b instanceof YamlRawValue) {
-    return (
-      a instanceof YamlRawValue &&
-      b instanceof YamlRawValue &&
-      a.inlineHeader === b.inlineHeader &&
-      a.lines.length === b.lines.length &&
-      a.lines.every((line, i) => line === b.lines[i])
-    );
-  }
-  if (Array.isArray(a) || Array.isArray(b)) {
-    return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((item, i) => yamlValueEqual(item, b[i]))
-    );
-  }
-  if (isPlainObject(a) && isPlainObject(b)) {
-    const ak = Object.keys(a);
-    if (ak.length !== Object.keys(b).length) return false;
-    return ak.every(
-      (k) => Object.prototype.hasOwnProperty.call(b, k) && yamlValueEqual(a[k], b[k])
-    );
-  }
-  return false;
 }
 
 /**

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -8,6 +8,7 @@
  */
 
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
+import { isPlainObject } from "./nested-values.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import {
   formatYamlScalar,
@@ -723,7 +724,45 @@ export function parseYamlSectionValues(
   sectionKey: string,
   fromLine?: number
 ): Record<string, unknown> {
-  const lines = yaml.split("\n");
+  return parseSectionCore(yaml.split("\n"), sectionKey, fromLine).values;
+}
+
+/**
+ * A top-level key's source-line span within a section body. Both
+ * fields are 0-indexed into the section's lines array; ``[start, end)``
+ * is half-open. ``leadStart <= start`` extends over the contiguous
+ * blank / standalone-comment run that visually precedes the key, so a
+ * verbatim copy carries that key's own comments with it.
+ */
+interface KeySpan {
+  start: number;
+  end: number;
+  leadStart: number;
+}
+
+interface ParsedSection {
+  values: Record<string, unknown>;
+  // One span per top-level key, in file order. The inline-on-dash key
+  // (list items) is intentionally absent — it lives on the section
+  // header line, which `updateSectionInYaml` owns directly.
+  spans: Map<string, KeySpan>;
+  childIndent: string;
+  isListItem: boolean;
+  // 0-indexed section header / leading-dash line.
+  startIdx: number;
+}
+
+/**
+ * Parse a section into values plus each top-level key's source-line
+ * span, so `updateSectionInYaml` can copy untouched keys back verbatim
+ * rather than re-serialize the whole section (#1227). Spans are built
+ * in the value-parse walk so the two can't drift.
+ */
+function parseSectionCore(
+  lines: string[],
+  sectionKey: string,
+  fromLine?: number
+): ParsedSection {
   // Null-prototype map so a YAML key like `__proto__` /
   // `constructor` / `prototype` lands as a normal own property
   // instead of mutating the inherited prototype chain — defends
@@ -738,8 +777,15 @@ export function parseYamlSectionValues(
   // would now throw. Use `Object.prototype.hasOwnProperty.call` if
   // you need that check on a downstream consumer.
   const values: Record<string, unknown> = Object.create(null);
+  const spans = new Map<string, KeySpan>();
+  // leadStart is finalised by the post-loop pass below.
+  const recordSpan = (key: string, start: number, end: number): void => {
+    spans.set(key, { start, end, leadStart: start });
+  };
   const startIdx = findSectionStart(lines, sectionKey, fromLine);
-  if (startIdx < 0) return values;
+  if (startIdx < 0) {
+    return { values, spans, childIndent: "", isListItem: false, startIdx };
+  }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
   // Detect the indent the user actually picked for this
@@ -756,12 +802,15 @@ export function parseYamlSectionValues(
     const peek = _skipBlankAndCommentLines(lines, startIdx + 1);
     if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
       values[sectionKey] = parseListBlock(lines, startIdx + 1, childIndent).value;
-      return values;
+      // No per-key spans — `updateSectionInYaml` re-emits this whole
+      // list through its dedicated LIST_SECTIONS branch.
+      return { values, spans, childIndent, isListItem, startIdx };
     }
   }
 
   // List-item form: the first child key may sit on the same line as
-  // the leading dash (e.g. `  - platform: gpio\n    pin: 4`).
+  // the leading dash (e.g. `  - platform: gpio\n    pin: 4`). No span
+  // is recorded — it rides on the dash line.
   if (isListItem) {
     const firstMatch = lines[startIdx].match(LIST_ITEM_INLINE_KEY_RE);
     if (firstMatch) {
@@ -808,6 +857,7 @@ export function parseYamlSectionValues(
     if (BLOCK_SCALAR_INLINE_RE.test(raw)) {
       const { endIdx } = _scanValueBlock(lines, i + 1, childIndent);
       values[key] = new YamlRawValue(lines.slice(i + 1, endIdx), raw);
+      recordSpan(key, i, endIdx);
       i = endIdx - 1;
       continue;
     }
@@ -825,6 +875,7 @@ export function parseYamlSectionValues(
         );
         if (!isEmptyScalarList) {
           values[key] = value;
+          recordSpan(key, i, endIdx);
           i = endIdx - 1;
         }
         continue;
@@ -837,6 +888,7 @@ export function parseYamlSectionValues(
         const result = parseNestedBlock(lines, i + 1, peekLead);
         if (Object.keys(result.values).length > 0) {
           values[key] = result.values;
+          recordSpan(key, i, result.endIdx);
         }
         i = result.endIdx - 1;
       }
@@ -845,12 +897,50 @@ export function parseYamlSectionValues(
 
     if (raw.startsWith("[") && raw.endsWith("]")) {
       values[key] = parseFlowList(raw);
+      recordSpan(key, i, i + 1);
       continue;
     }
     values[key] = parseScalar(raw);
+    recordSpan(key, i, i + 1);
   }
 
-  return values;
+  // A multi-line value's scanners skip trailing blank / sibling-level
+  // comment lines, so the recorded `end` can swallow a comment that
+  // really leads the NEXT key — and editing this key would then drop
+  // it. Pull the trailing run off the span so it folds into the next
+  // key's leadStart below. Only when the run actually holds a comment:
+  // a pure-blank run (the file's trailing newline, a `|+` keep) stays
+  // with the value so byte-identical no-op saves don't lose it. The
+  // indent guard keeps deeper block-scalar literal text in the value
+  // (#1227).
+  for (const span of spans.values()) {
+    const low = span.start + 1;
+    let runStart = span.end;
+    let hasComment = false;
+    while (
+      runStart > low &&
+      isBlankOrCommentLine(lines[runStart - 1]) &&
+      _leadingIndent(lines[runStart - 1]).length <= childIndent.length
+    ) {
+      runStart--;
+      if (isCommentLine(lines[runStart])) hasComment = true;
+    }
+    if (hasComment) span.end = runStart;
+  }
+
+  // Extend each span back over the blank/comment run directly above it
+  // (bounded by the previous key's trimmed end), so leadStart/end
+  // partition the body — a verbatim copy then neither drops nor
+  // double-counts an inter-key comment.
+  let prevEnd = startIdx + 1;
+  for (const span of spans.values()) {
+    let lead = span.start;
+    while (lead > prevEnd && isBlankOrCommentLine(lines[lead - 1])) lead--;
+    span.leadStart = lead;
+    prevEnd = span.end;
+  }
+
+  return { values, spans, childIndent, isListItem, startIdx };
 }
 
 /** Recursively parse a nested YAML block at the given indent. */
@@ -1046,11 +1136,17 @@ export function updateSectionInYaml(
     return lines.join("\n");
   }
 
+  // Re-parse the original to recover each key's source-line span and
+  // on-disk value — the diff below needs both.
+  const parsed = parseSectionCore(lines, sectionKey, fromLine);
+
   // `childIndent` (detected above) also matches the user's existing
   // indent step on save, so 4-space (or other consistent) YAML isn't
   // re-emitted with a mixed 2-space slice.
-  let toSerialize = values;
   let dashLine = lines[start];
+  // Keys carried inline on the list-item dash are represented by
+  // `dashLine`, not the body — the per-key loop skips them.
+  const inlineKeys = new Set<string>();
   if (isListItem) {
     // List items can carry a key/value inline with the dash
     // (`- platform: esphome`). `parseYamlSectionValues` reads
@@ -1068,11 +1164,11 @@ export function updateSectionInYaml(
     //   1. inline key absent from form: dash kept as-is, body
     //      emitted normally. Original behaviour.
     //   2. form value is an inline-able scalar (string / number
-    //      / boolean): rewrite the dash to carry the form's
-    //      value, drop the key from the body. Handles the
-    //      empty-inline (`- platform:`), stale-inline (form
-    //      picked a different value), and trailing-comment
-    //      (`- platform: # ...`) cases uniformly.
+    //      / boolean): the dash carries it (skipped from the
+    //      body). Unchanged → kept byte-for-byte so a trailing
+    //      `# comment` survives; changed → rewritten from the
+    //      form's value. Also handles the empty-inline
+    //      (`- platform:`) and stale-inline cases.
     //   3. form value is non-scalar (object / array / null /
     //      undefined): collapse the dash to bare `-` and let
     //      the body serializer emit the inline key at the
@@ -1098,28 +1194,25 @@ export function updateSectionInYaml(
       // inline content. (`Object.prototype.hasOwnProperty.call`
       // rather than `Object.hasOwn` for tsconfig-target reach.)
       if (Object.prototype.hasOwnProperty.call(values, inlineKey)) {
-        // Single regex captures both the indentation up to the
-        // dash and the trailing whitespace before the inline
-        // key — `dashPrefix` (with the trailing space) is what
-        // the rewrite path needs, and the indent alone is what
-        // the bare-dash path needs.
-        //
-        // The match always succeeds in this branch: we entered
-        // it via `LIST_ITEM_INLINE_KEY_RE`, which requires `\s+`
-        // both before and after the dash, so `\s+-\s+` is
-        // already true of `dashLine`. The non-null assertion
-        // makes that invariant local.
-        const dashPrefixMatch = dashLine.match(/^(\s+)-(\s+)/)!;
-        const dashIndent = dashPrefixMatch[1];
-        const dashPrefix = `${dashIndent}-${dashPrefixMatch[2]}`;
         if (_isInlinableScalar(values[inlineKey])) {
-          dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}`;
-          const { [inlineKey]: _omit, ...rest } = values;
-          toSerialize = rest;
+          inlineKeys.add(inlineKey);
+          // Only rewrite the dash when the form changed the inline
+          // value; an unchanged value stays byte-for-byte so its
+          // trailing comment / original quoting survive.
+          if (!yamlValueEqual(values[inlineKey], parsed.values[inlineKey])) {
+            // The match always succeeds here: we entered via
+            // `LIST_ITEM_INLINE_KEY_RE`, which requires `\s+` both
+            // before and after the dash. The non-null assertion
+            // makes that invariant local.
+            const dashPrefixMatch = dashLine.match(/^(\s+)-(\s+)/)!;
+            const dashPrefix = `${dashPrefixMatch[1]}-${dashPrefixMatch[2]}`;
+            dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}`;
+          }
         } else {
           // Non-scalar form value: drop the inline key from the
           // dash and let the body serializer emit everything,
           // including the now-non-inline key.
+          const dashIndent = (dashLine.match(/^(\s+)-/) ?? ["", ""])[1];
           dashLine = `${dashIndent}-`;
         }
       }
@@ -1137,15 +1230,63 @@ export function updateSectionInYaml(
   // valid-and-readable even when the surrounding file uses a
   // different step elsewhere.
   const detectedStep = !isListItem && childIndent ? childIndent : ESPHOME_YAML_INDENT;
-  const newLines = [
-    dashLine,
-    ...serializeYamlValues(toSerialize, childIndent, {
-      ...options,
-      indentStep: options.indentStep ?? detectedStep,
-    }),
-  ];
+  const serializeOptions = { ...options, indentStep: options.indentStep ?? detectedStep };
+
+  // Splice only what changed (#1227): untouched keys keep their source
+  // lines byte-for-byte; the rest re-serialize through the normal path.
+  const bodyLines: string[] = [];
+  for (const [key, val] of Object.entries(values)) {
+    if (inlineKeys.has(key)) continue;
+    const span = parsed.spans.get(key);
+    if (span && yamlValueEqual(val, parsed.values[key])) {
+      bodyLines.push(...lines.slice(span.leadStart, span.end));
+      continue;
+    }
+    // Changed / added key. Keep any standalone-comment run that led the
+    // original key — the value line below reformats, the comment stays.
+    if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
+    bodyLines.push(...serializeYamlValues({ [key]: val }, childIndent, serializeOptions));
+  }
+
+  const newLines = [dashLine, ...bodyLines];
   lines.splice(start, spliceEnd - start, ...newLines);
   return lines.join("\n");
+}
+
+/**
+ * Structural equality for the value shapes the section parser emits —
+ * primitives, null, null-prototype mappings, ``string[]`` / ``Record[]``
+ * arrays, and ``YamlRawValue`` (compared by header + body lines so an
+ * untouched lambda stays verbatim). Not a general deep-equal; the
+ * exotic shapes (Map / Set / Date / function) never reach here.
+ */
+function yamlValueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof YamlRawValue || b instanceof YamlRawValue) {
+    return (
+      a instanceof YamlRawValue &&
+      b instanceof YamlRawValue &&
+      a.inlineHeader === b.inlineHeader &&
+      a.lines.length === b.lines.length &&
+      a.lines.every((line, i) => line === b.lines[i])
+    );
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, i) => yamlValueEqual(item, b[i]))
+    );
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    if (ak.length !== Object.keys(b).length) return false;
+    return ak.every(
+      (k) => Object.prototype.hasOwnProperty.call(b, k) && yamlValueEqual(a[k], b[k])
+    );
+  }
+  return false;
 }
 
 /**

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1095,6 +1095,27 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
     expect(after).toContain("new_code();");
     expect(after).not.toContain("old_code();");
   });
+
+  it("appends a form-added key without disturbing commented siblings", () => {
+    // Exercises the added-key arm of the splice loop (no source span →
+    // serialize fresh): the new key appends while every existing
+    // commented sibling stays byte-identical.
+    const before = [
+      "wifi:",
+      "  ssid: home #primary",
+      "  password: secret #wpa2",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.fast_connect = true;
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("  ssid: home #primary\n");
+    expect(after).toContain("  password: secret #wpa2\n");
+    expect(after).not.toContain('"home #primary"');
+    expect(after).not.toContain('"secret #wpa2"');
+    expect(after).toContain("fast_connect: true");
+  });
 });
 
 describe("serializeYamlValues — single-key null-value list items", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -905,6 +905,198 @@ ${lambdaBlock}
   });
 });
 
+describe("updateSectionInYaml — preserves untouched field byte layout (#1227)", () => {
+  // A single-field edit re-serialized the WHOLE section, so untouched
+  // siblings lost their byte layout: inline-comment scalars got quoted,
+  // standalone comments shifted, lambda bodies re-indented. The
+  // diff-and-splice writer copies unchanged keys' lines verbatim and
+  // only re-serializes the keys the form actually changed.
+
+  it("keeps a sibling's inline-comment scalar byte-identical", () => {
+    // Headline repro: `internal: true #hides from list` must NOT become
+    // `internal: "true #hides from list"` when an unrelated field edits.
+    const before = [
+      "wifi:",
+      "  ssid: home",
+      "  internal: true #hides from list",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.ssid = "office";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("\n  internal: true #hides from list\n");
+    expect(after).not.toContain('internal: "true #hides from list"');
+    expect(after).toContain("ssid: office");
+  });
+
+  it("keeps a sibling lambda block byte-identical and un-duplicated", () => {
+    const before = [
+      "display:",
+      "  lambda: |-",
+      '    it.printf(0, 0, "hello");',
+      "  update_interval: 1s",
+      "sensor:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    values.update_interval = "5s";
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain('  lambda: |-\n    it.printf(0, 0, "hello");\n');
+    expect(after.match(/lambda:/g)).toHaveLength(1);
+    expect(after).toContain("update_interval: 5s");
+  });
+
+  it("keeps a standalone comment between siblings in place", () => {
+    const before = [
+      "wifi:",
+      "  ssid: home",
+      "  # keep me",
+      "  password: secret",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.ssid = "office";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("\n  # keep me\n  password: secret\n");
+  });
+
+  it("reformats only the edited field, keeping a standalone comment above it", () => {
+    const before = [
+      "wifi:",
+      "  ssid: home",
+      "  # toggles list visibility",
+      "  internal: true #hides from list",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    // Edit the commented field itself: the value line is allowed to
+    // reformat (its trailing comment drops), but the standalone comment
+    // above it and the untouched sibling survive.
+    values.internal = false;
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("  # toggles list visibility\n  internal: false");
+    expect(after).toContain("\n  ssid: home\n");
+  });
+
+  it("interleaves a changed key between two unchanged keys correctly", () => {
+    const before = [
+      "wifi:",
+      "  ssid: home #primary",
+      "  power_save_mode: none",
+      "  fast_connect: true #saves boot time",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.power_save_mode = "light";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    // Both commented siblings stay byte-identical; the middle key changed.
+    expect(after).toContain("  ssid: home #primary\n");
+    expect(after).toContain("  fast_connect: true #saves boot time\n");
+    expect(after).toContain("power_save_mode: light");
+    expect(after).not.toContain('"home #primary"');
+    expect(after).not.toContain('"true #saves boot time"');
+  });
+
+  it("is stable across repeated saves on a commented section", () => {
+    const before = [
+      "wifi:",
+      "  ssid: home",
+      "  internal: true #hides from list",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.ssid = "office";
+    const once = updateSectionInYaml(before, "wifi", values, 1);
+    const twiceValues = parseYamlSectionValues(once, "wifi", 1);
+    const twice = updateSectionInYaml(once, "wifi", twiceValues, 1);
+    expect(twice).toBe(once);
+  });
+
+  it("keeps a list item's commented inline dash key byte-identical", () => {
+    const before = [
+      "ota:",
+      "  - platform: esphome #default backend",
+      "    password: oldpass",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "ota.esphome", 2);
+    values.password = "newpass";
+    const after = updateSectionInYaml(before, "ota.esphome", values, 2);
+    expect(after).toContain("  - platform: esphome #default backend\n");
+    expect(after).not.toContain('"esphome #default backend"');
+    expect(after).toContain("password: newpass");
+    expect(after.match(/platform:/g)).toHaveLength(1);
+  });
+
+  it("keeps an unchanged nested-mapping sibling byte-identical", () => {
+    // Exercises the deep-equal object branch on the verbatim path: an
+    // untouched nested map (with its own deep inline comment) survives
+    // a sibling scalar edit.
+    const before = [
+      "api:",
+      "  reboot_timeout: 0s",
+      "  encryption:",
+      "    key: abc123 #shared with HA",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "api", 1);
+    values.reboot_timeout = "30s";
+    const after = updateSectionInYaml(before, "api", values, 1);
+    expect(after).toContain("  encryption:\n    key: abc123 #shared with HA\n");
+    expect(after).not.toContain('"abc123 #shared with HA"');
+    expect(after).toContain("reboot_timeout: 30s");
+  });
+
+  it("keeps an unchanged list sibling with a commented item byte-identical", () => {
+    // Exercises the array-equality branch on the verbatim path, and
+    // guards a regression: re-serializing the list would quote the
+    // commented item (`- homenet #primary` → `- "homenet #primary"`).
+    const before = [
+      "wifi:",
+      "  ssid: home",
+      "  networks:",
+      "    - homenet #primary",
+      "    - guestnet",
+      "logger:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "wifi", 1);
+    values.ssid = "office";
+    const after = updateSectionInYaml(before, "wifi", values, 1);
+    expect(after).toContain("  networks:\n    - homenet #primary\n    - guestnet\n");
+    expect(after).not.toContain('"homenet #primary"');
+    expect(after).toContain("ssid: office");
+  });
+
+  it("keeps an inter-key comment when editing the multi-line value above it", () => {
+    // Copilot review: a block scalar's span absorbs the trailing
+    // sibling-level comment the scanner skipped, so editing that key
+    // used to drop the comment. The span-trim folds it into the next
+    // key's leadStart instead.
+    const before = [
+      "display:",
+      "  lambda: |-",
+      "    old_code();",
+      "  # between siblings",
+      "  update_interval: 5s",
+      "sensor:",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "display", 1);
+    values.lambda = { _lambda: "new_code();" };
+    const after = updateSectionInYaml(before, "display", values, 1);
+    expect(after).toContain("  # between siblings\n  update_interval: 5s\n");
+    expect(after).toContain("new_code();");
+    expect(after).not.toContain("old_code();");
+  });
+});
+
 describe("serializeYamlValues — single-key null-value list items", () => {
   // The polymorphic carve-out in serializeListItem is in the
   // shared helper, so it affects every list-of-mapping consumer,


### PR DESCRIPTION
# What does this implement/fix?

When a user edits **one field** in a structured section form, the draft
flush re-serialized the **entire section** body from the parsed values
object. The custom regex parser/serializer doesn't carry byte layout, so
untouched sibling fields were corrupted:

- Inline-comment scalars got quoted:
  `internal: true #hides from list` → `internal: "true #hides from list"`.
- Standalone comments between fields shifted.
- `lambda: |-` block bodies re-indented.

This switches `updateSectionInYaml` to **diff-and-splice**: each
top-level key's source-line span is recorded during the parse, and on
save an unchanged key's lines are copied back **byte-for-byte** (inline
comments, standalone comments, and lambda indentation preserved). Only
keys the form actually changed or added re-serialize through the
existing path. Equality is compared structurally over the parser's value
shapes (primitives, mappings, arrays, `YamlRawValue`).

Span tracking lives inside the existing parse walk (not a parallel
scanner) so it can't drift from the value parse. The list-item dash /
inline-key branch additionally keeps an **unchanged** inline value
byte-for-byte instead of rewriting it.

**Scope:** this fixes corruption of *untouched* commented fields. The
separate parse-side behaviour — `parseScalar` folding an inline comment
into the form's displayed value (`true #hides...` shown in the field) —
is independent and is intentionally left out of this PR.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1227

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
