### PR TITLE
Add indentation guide lines to the YAML editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@lit/context": "1.1.6",
         "@lit/reactive-element": "2.1.2",
         "@mdi/js": "7.4.47",
+        "@replit/codemirror-indentation-markers": "^6.5.3",
         "@tanstack/lit-table": "^8.21.3",
         "codemirror": "^6.0.2",
         "esptool-js": "^0.6.0",
@@ -371,6 +372,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@replit/codemirror-indentation-markers": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.3.tgz",
+      "integrity": "sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@lit/context": "1.1.6",
     "@lit/reactive-element": "2.1.2",
     "@mdi/js": "7.4.47",
+    "@replit/codemirror-indentation-markers": "^6.5.3",
     "@tanstack/lit-table": "^8.21.3",
     "codemirror": "^6.0.2",
     "esptool-js": "^0.6.0",

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -4,6 +4,7 @@ import { indentUnit } from "@codemirror/language";
 import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
+import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { basicSetup, EditorView } from "codemirror";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
@@ -159,6 +160,19 @@ export class ESPHomeYamlEditor extends LitElement {
       esphomeYaml(),
       indentUnit.of(ESPHOME_YAML_INDENT),
       keymap.of([indentWithTab]),
+      // Vertical indentation guides. The default 'fullScope' markerType
+      // carries the guide through blank lines inside a block, matching the
+      // legacy editor's column lines.
+      indentationMarkers({
+        thickness: 1,
+        highlightActiveBlock: true,
+        colors: {
+          light: "#e3e3e8",
+          activeLight: "#c0c0cc",
+          dark: "#33333b",
+          activeDark: "#50505c",
+        },
+      }),
       highlightField,
       sensitiveValueMaskExtension(this.revealSensitive, this.maskAllValues),
       yamlStickyScroll({

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -20,6 +20,7 @@ import {
   EDITOR_BG_LIGHT,
   EDITOR_FONT_FAMILY,
   EDITOR_FONT_SIZE,
+  INDENT_GUIDE_COLORS,
   lightHighlight,
   vscodeDark,
   vscodeLight,
@@ -160,18 +161,15 @@ export class ESPHomeYamlEditor extends LitElement {
       esphomeYaml(),
       indentUnit.of(ESPHOME_YAML_INDENT),
       keymap.of([indentWithTab]),
-      // Vertical indentation guides. The default 'fullScope' markerType
-      // carries the guide through blank lines inside a block, matching the
-      // legacy editor's column lines.
+      // Vertical indentation guides. 'fullScope' carries the guide through
+      // blank lines inside a block, matching the legacy editor's column
+      // lines; pinned explicitly so a dependency default change can't alter
+      // it.
       indentationMarkers({
         thickness: 1,
         highlightActiveBlock: true,
-        colors: {
-          light: "#e3e3e8",
-          activeLight: "#c0c0cc",
-          dark: "#33333b",
-          activeDark: "#50505c",
-        },
+        markerType: "fullScope",
+        colors: INDENT_GUIDE_COLORS,
       }),
       highlightField,
       sensitiveValueMaskExtension(this.revealSensitive, this.maskAllValues),

--- a/src/util/yaml-editor-theme.ts
+++ b/src/util/yaml-editor-theme.ts
@@ -28,6 +28,16 @@ export const EDITOR_FONT_SIZE = "13px";
 export const EDITOR_BG_DARK = "#1e1e1e";
 export const EDITOR_BG_LIGHT = "#ffffff";
 
+/** Indentation-guide line colours per mode, with a brighter variant for
+ *  the cursor's active block. Subtle hairlines against the editor
+ *  backgrounds above. */
+export const INDENT_GUIDE_COLORS = {
+  light: "#e3e3e8",
+  activeLight: "#c0c0cc",
+  dark: "#33333b",
+  activeDark: "#50505c",
+} as const;
+
 const DARK_BG = EDITOR_BG_DARK;
 const DARK_FG = "#d4d4d4";
 const DARK_GUTTER_FG = "#858585";

--- a/test/components/yaml-editor-indent-guides.test.ts
+++ b/test/components/yaml-editor-indent-guides.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins issue #1231: the editor draws indentation guide lines on
+ * indented rows (the legacy editor's "column lines").
+ */
+import type { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
+
+async function mount(): Promise<ESPHomeYamlEditor> {
+  const el = new ESPHomeYamlEditor();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const viewOf = (el: ESPHomeYamlEditor): EditorView =>
+  (el as unknown as { _view: EditorView })._view;
+
+describe("yaml-editor indentation guides (#1231)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("marks indented lines with the indent-guide decoration", async () => {
+    const el = await mount();
+    el.value = "sensor:\n  - platform: dht\n    pin: D1\n";
+    await el.updateComplete;
+
+    const guided = viewOf(el).dom.querySelectorAll(".cm-line.cm-indent-markers");
+    expect(guided.length).toBeGreaterThan(0);
+  });
+
+  it("does not mark the top-level (unindented) line", async () => {
+    const el = await mount();
+    el.value = "logger:\n  level: DEBUG\n";
+    await el.updateComplete;
+
+    const view = viewOf(el);
+    const lines = view.dom.querySelectorAll(".cm-line");
+    expect(lines[0]?.classList.contains("cm-indent-markers")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The new CodeMirror 6 YAML editor dropped the vertical indentation guide
lines (the "column lines") the legacy editor drew, making it harder to
align indentation in deeply-nested ESPHome configs.

This wires the `@replit/codemirror-indentation-markers` extension into
the editor with theme-aware colors (subtle hairlines against the light
`#ffffff` / dark `#1e1e1e` backgrounds) and active-block highlighting.
CodeMirror's `basicSetup` ships no indent guides, so a dedicated
extension is needed; this is the de-facto CM6 package and its peer deps
are already satisfied by the bundled `codemirror`.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1231

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
