### PR TITLE
Render a waiting hint for remote_pending compiles

### DIFF
--- a/src/api/types/firmware-jobs.ts
+++ b/src/api/types/firmware-jobs.ts
@@ -39,10 +39,13 @@ export type RemoteBuildSubmitTarget = JobType.COMPILE | JobType.UPLOAD;
  *  receiver ran and the offloader fetched the artifacts from. The
  *  install dialog reads ``FirmwareJob.source_label`` to render a
  *  "Building on {receiver_label}" sub-line when ``source ===
- *  REMOTE``. */
+ *  REMOTE``. ``REMOTE_PENDING`` is the transient before dispatch: a
+ *  compile that will run on a paired server, but whose server is
+ *  chosen when one frees, so ``source_label`` is still empty. */
 export enum JobSource {
   LOCAL = "local",
   REMOTE = "remote",
+  REMOTE_PENDING = "remote_pending",
 }
 
 export interface FirmwareJob {

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -138,7 +138,9 @@ function renderRowAction(
 // doesn't churn if the pairing is later renamed. Symmetric receiver-side
 // rendering: when remote_peer is set, the job was submitted from another
 // dashboard's offloader.
-function renderSourceLine(
+// Exported for unit testing of the per-source row line (building-on /
+// waiting-for-server / submitted-by).
+export function renderSourceLine(
   host: ESPHomeFirmwareJobsDialog,
   job: FirmwareJob
 ): TemplateResult | typeof nothing {

--- a/src/components/firmware-jobs-dialog/renderers.ts
+++ b/src/components/firmware-jobs-dialog/renderers.ts
@@ -154,6 +154,14 @@ function renderSourceLine(
       </div>
     `;
   }
+  // No server bound yet: the compile is waiting for one to free up.
+  if (job.source === JobSource.REMOTE_PENDING) {
+    return html`
+      <div class="job-source">
+        ${host._localize("firmware_jobs.waiting_for_build_server")}
+      </div>
+    `;
+  }
   if (job.remote_peer) {
     const peer = job.remote_peer_label || job.remote_peer;
     return html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1252,6 +1252,7 @@
     "time_started": "started {time}",
     "time_finished": "finished {time}",
     "building_on": "Building on {label}",
+    "waiting_for_build_server": "Waiting for a build server",
     "submitted_by": "from {label}"
   }
 }

--- a/test/components/firmware-jobs-dialog/renderers.test.ts
+++ b/test/components/firmware-jobs-dialog/renderers.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+//
+// Tests for renderSourceLine — the per-job "source" line in the firmware-jobs
+// dialog. Mounts the Lit TemplateResult into a happy-dom container (repo idiom)
+// and asserts on the produced DOM.
+
+import { nothing, render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { JobSource } from "../../../src/api/types/firmware-jobs.js";
+import { renderSourceLine } from "../../../src/components/firmware-jobs-dialog/renderers.js";
+import { makeFirmwareJob } from "../../_make-firmware-job.js";
+
+// renderSourceLine only reads host._localize; a key-echoing stub lets us assert
+// which localization key the branch picked.
+function host(): { _localize: (key: string) => string } {
+  return { _localize: (key: string) => key };
+}
+
+function renderInto(value: unknown): HTMLElement {
+  const container = document.createElement("div");
+  render(value, container);
+  return container;
+}
+
+describe("renderSourceLine", () => {
+  it("renders the waiting hint for a REMOTE_PENDING compile", () => {
+    const job = makeFirmwareJob({ source: JobSource.REMOTE_PENDING });
+    const el = renderInto(renderSourceLine(host() as never, job));
+    expect(el.textContent).toContain("firmware_jobs.waiting_for_build_server");
+  });
+
+  it("renders 'building on' once a REMOTE compile is bound to a server", () => {
+    const job = makeFirmwareJob({
+      source: JobSource.REMOTE,
+      source_label: "desktop",
+    });
+    const el = renderInto(renderSourceLine(host() as never, job));
+    expect(el.textContent).toContain("firmware_jobs.building_on");
+    expect(el.textContent).not.toContain("waiting_for_build_server");
+  });
+
+  it("renders nothing for a plain LOCAL compile", () => {
+    const job = makeFirmwareJob({ source: JobSource.LOCAL });
+    expect(renderSourceLine(host() as never, job)).toBe(nothing);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds the backend's new remote_pending JobSource value to the mirrored enum so the type stays accurate, and shows a "Waiting for a build server" hint on a job row while a remote compile waits for a paired server to free up. Nothing was broken without it; a queued remote compile just showed no source line, so this is the visible explanation.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder#1229

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
