### PR TITLE
Suggest declared IDs at reference fields in the YAML editor

### DIFF
--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -242,41 +242,55 @@ export async function resolveAvailableEntries(
   platformValue: string | null,
   topLevelKey: string | null
 ): Promise<ConfigEntry[]> {
-  // Special case: cursor is nested under a list-item header
-  // (``- platform: template`` → parentKey="platform"). The form
-  // fields the user wants live on the dotted catalog id
-  // ``<domain>.<platformValue>`` (e.g. ``binary_sensor.template``).
-  // Short-circuit either way — even on a miss, falling through
-  // would call ``fetchComponent(api, "platform")`` which 404s
-  // and poisons the session-scoped cache for the lifetime of
-  // the page (unlikely to matter today, but the failure mode
-  // would be silent if a real ``platform`` component ever
-  // shipped).
+  // The slim ``getComponents`` index carries no ``config_entries``
+  // (those hydrate lazily through ``components/get_component_bodies``),
+  // so the catalog tells us only *which* ids exist — never their
+  // fields. Hydrate the body for an id known to the index; return
+  // ``[]`` for unknown ids so we never fetch ``platform`` (or any
+  // non-component key) and poison the session cache with a 404.
+  // Tolerate fetch failures silently: ``BatchedCache`` rejects on a
+  // transport error or a mid-flight ``_clearComponentCache()``, and the
+  // completion source isn't wrapped — an unguarded throw here would drop
+  // the whole popup instead of degrading to no suggestions.
+  const entriesFor = async (id: string): Promise<ConfigEntry[]> => {
+    if (!catalog.byId.has(id)) return [];
+    try {
+      const body = await fetchComponent(api, id);
+      return body?.config_entries ?? [];
+    } catch {
+      return [];
+    }
+  };
+
+  // Cursor nested under a list-item header (``- platform: template``
+  // → parentKey="platform"). The form fields live on the dotted
+  // catalog id ``<domain>.<platformValue>`` (``binary_sensor.template``).
   if (parentKey === "platform") {
     if (!topLevelKey || !platformValue) return [];
-    const dotted = catalog.byId.get(`${topLevelKey}.${platformValue}`);
-    return dotted ? dotted.config_entries : [];
+    return entriesFor(`${topLevelKey}.${platformValue}`);
   }
-  const directHit = catalog.byId.get(parentKey);
-  if (directHit) {
-    // We have a top-level component directly. If it categorizes platforms
-    // (i.e. its sub_entries describe a platform-style mapping) and a
-    // platform value is set, merge platform fields in.
+  if (catalog.byId.has(parentKey)) {
+    // Top-level component directly. If a platform value is set, merge
+    // the platform implementation's fields in (the catalog keys
+    // per-platform entries as ``<domain>.<stem>``). Resolve the merge
+    // id up front so both bodies register before the microtask flush
+    // and batch into a single ``get_component_bodies`` round trip.
+    let mergeId: string | null = null;
     if (platformValue) {
-      const platformComp = catalog.byId.get(platformValue);
-      if (platformComp) {
-        return [...directHit.config_entries, ...platformComp.config_entries];
-      }
-      // Try the dotted lookup — the catalog keys per-platform
-      // entries as ``<domain>.<stem>``.
-      if (topLevelKey) {
-        const dotted = catalog.byId.get(`${topLevelKey}.${platformValue}`);
-        if (dotted) {
-          return [...directHit.config_entries, ...dotted.config_entries];
-        }
+      if (catalog.byId.has(platformValue)) {
+        mergeId = platformValue;
+      } else if (topLevelKey && catalog.byId.has(`${topLevelKey}.${platformValue}`)) {
+        mergeId = `${topLevelKey}.${platformValue}`;
       }
     }
-    return directHit.config_entries;
+    if (mergeId) {
+      const [own, extra] = await Promise.all([
+        entriesFor(parentKey),
+        entriesFor(mergeId),
+      ]);
+      return [...own, ...extra];
+    }
+    return entriesFor(parentKey);
   }
   // No direct hit — try fetching the component (handles aliases the
   // catalog list call doesn't return). Routes through the session-
@@ -285,7 +299,7 @@ export async function resolveAvailableEntries(
   // silently.
   try {
     const comp = await fetchComponent(api, parentKey);
-    if (comp) return comp.config_entries;
+    if (comp) return comp.config_entries ?? [];
   } catch {
     /* ignore */
   }

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -29,6 +29,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
+import { findReferencedComponents } from "./config-entry-yaml-scan.js";
 import {
   getActions,
   getConfigVarKeys,
@@ -455,6 +456,30 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         completionCtx.topLevelKey
       );
       const entry = entries.find((e) => e.key === key);
+
+      // ID-reference field (``i2c_id:``, ``output:``, …) → suggest the
+      // IDs declared in the referenced domain. Mirrors the visual
+      // form's ``renderIdReferenceField`` so both editors offer the
+      // same candidate set. Declaring ``id:`` fields carry a null
+      // ``references_component`` and fall through untouched.
+      if (entry?.type === ConfigEntryType.ID && entry.references_component) {
+        const candidates = findReferencedComponents(
+          state.doc.toString(),
+          entry.references_component
+        );
+        if (candidates.length > 0) {
+          const domain = entry.references_component;
+          return {
+            from: valueFrom,
+            options: candidates.map((c) => ({
+              label: c.id,
+              type: "variable",
+              detail: c.name || domain,
+            })),
+            validFor: RE_KEY,
+          };
+        }
+      }
 
       if (entry?.type === ConfigEntryType.BOOLEAN) {
         return {

--- a/test/util/yaml-completion-id-reference.test.ts
+++ b/test/util/yaml-completion-id-reference.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { CompletionContext } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ComponentCategory } from "../../src/api/types/components.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+// A component carrying an ID-reference field (``ref_field`` points at the
+// ``i2c`` domain) and a plain declaring ``id`` field (no
+// ``references_component``). The completion source should suggest declared
+// i2c IDs for the former and leave the latter untouched.
+//
+// The slim ``getComponents`` index lists the component but carries no
+// ``config_entries``; the field tree hydrates through
+// ``getComponentBodies`` — mirror that split here.
+const componentBody = makeComponentEntry("my_comp", {
+  category: ComponentCategory.MISC,
+  config_entries: [
+    makeConfigEntry({
+      key: "ref_field",
+      type: ConfigEntryType.ID,
+      references_component: "i2c",
+    }),
+    makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
+  ],
+});
+const catalogComponent = makeComponentEntry("my_comp", {
+  category: ComponentCategory.MISC,
+});
+
+const fakeApi = {
+  getComponents: async () => ({ components: [catalogComponent] }),
+  getComponentBodies: async (ids: string[]) =>
+    Object.fromEntries(
+      ids.filter((id) => id === "my_comp").map((id) => [id, componentBody])
+    ),
+  getVersion: async () => ({ server_version: "0.0.0", esphome_version: "2026.5.0" }),
+  getComponent: async () => null,
+} as unknown as ESPHomeAPI;
+
+async function complete(yaml: string) {
+  const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
+  const source = createYamlCompletionSource(fakeApi);
+  const ctx = new CompletionContext(state, yaml.length, false);
+  return source(ctx);
+}
+
+describe("createYamlCompletionSource (ID-reference completion)", () => {
+  beforeEach(() => {
+    _clearComponentCache();
+    _resetSchemaCacheForTests();
+    // Schema-bundle fallback (the path declaring-``id`` falls through to)
+    // must not hit the network — return an empty bundle so it yields no
+    // enum values and the source resolves to null.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("suggests declared IDs of the referenced domain", async () => {
+    const yaml = [
+      "i2c:",
+      "  - id: bus_a",
+      "  - id: bus_b",
+      "my_comp:",
+      "  ref_field: ",
+    ].join("\n");
+    const result = await complete(yaml);
+    expect(result).not.toBeNull();
+    const labels = (result?.options ?? []).map((o) => o.label).sort();
+    expect(labels).toEqual(["bus_a", "bus_b"]);
+  });
+
+  it("keeps returning the candidate list as a partial is typed", async () => {
+    const yaml = ["i2c:", "  - id: bus_a", "my_comp:", "  ref_field: bus_"].join("\n");
+    const result = await complete(yaml);
+    expect(result).not.toBeNull();
+    const labels = (result?.options ?? []).map((o) => o.label);
+    expect(labels).toContain("bus_a");
+  });
+
+  it("does not suggest IDs for a declaring ``id:`` field", async () => {
+    const yaml = ["i2c:", "  - id: bus_a", "my_comp:", "  id: "].join("\n");
+    const result = await complete(yaml);
+    const labels = (result?.options ?? []).map((o) => o.label);
+    expect(labels).not.toContain("bus_a");
+  });
+
+  it("falls through when the referenced domain declares no IDs", async () => {
+    const yaml = ["my_comp:", "  ref_field: "].join("\n");
+    const result = await complete(yaml);
+    expect(result).toBeNull();
+  });
+});

--- a/test/util/yaml-completion-id-reference.test.ts
+++ b/test/util/yaml-completion-id-reference.test.ts
@@ -7,6 +7,7 @@ import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ComponentCategory } from "../../src/api/types/components.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { _clearScanMemos } from "../../src/util/config-entry-yaml-scan.js";
 import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
@@ -56,6 +57,7 @@ async function complete(yaml: string) {
 describe("createYamlCompletionSource (ID-reference completion)", () => {
   beforeEach(() => {
     _clearComponentCache();
+    _clearScanMemos();
     _resetSchemaCacheForTests();
     // Schema-bundle fallback (the path declaring-``id`` falls through to)
     // must not hit the network — return an empty bundle so it yields no

--- a/test/util/yaml-completion-top-level.test.ts
+++ b/test/util/yaml-completion-top-level.test.ts
@@ -5,6 +5,7 @@ import {
   type ComponentCatalogEntry,
   ComponentCategory,
 } from "../../src/api/types/components.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
 import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import {
@@ -15,6 +16,7 @@ import {
   platformValueCompletion,
 } from "../../src/util/yaml-completion.js";
 import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
 
 type CatalogIndex = Parameters<typeof buildTopLevelCompletions>[0];
 
@@ -145,8 +147,10 @@ describe("platform-list fallback", () => {
 });
 
 describe("resolveAvailableEntries (platform-merged)", () => {
-  // Re-import here so the test is self-contained when this file
-  // is read in isolation.
+  // The component-body cache is module-global and caches misses, so a
+  // resolved/missed id leaks between tests without this.
+  beforeEach(() => _clearComponentCache());
+
   it("looks up the dotted id when parentKey is the literal 'platform' keyword", async () => {
     // User scenario: cursor is at ``    nam`` under
     // ``binary_sensor:\n  - platform: template\n``. The indent
@@ -178,8 +182,17 @@ describe("resolveAvailableEntries (platform-merged)", () => {
       ],
     };
     const c = catalog([platformEntry]);
+    // ``resolveAvailableEntries`` hydrates ``config_entries`` through
+    // ``getComponentBodies`` (the slim index carries none); serve the
+    // body for the dotted id the lookup resolves to.
     const fakeApi = {
       getComponent: async () => null,
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(
+          ids
+            .filter((id) => id === "binary_sensor.template")
+            .map((id) => [id, platformEntry])
+        ),
     } as never;
     const out = await (resolveAvailableEntries as unknown as Function)(
       fakeApi,
@@ -189,6 +202,33 @@ describe("resolveAvailableEntries (platform-merged)", () => {
       "binary_sensor" // topLevelKey from AST
     );
     expect(out.map((e: { key: string }) => e.key)).toContain("name");
+  });
+
+  it("hydrates config_entries via getComponentBodies when the index is slim", async () => {
+    // The production ``getComponents`` index carries no
+    // ``config_entries`` — they hydrate lazily through
+    // ``getComponentBodies``. ``resolveAvailableEntries`` must use that
+    // path, not read ``config_entries`` off the slim catalog entry
+    // (which is ``undefined`` and threw on ``.filter`` / ``.find``).
+    const { resolveAvailableEntries } = await import("../../src/util/yaml-completion.js");
+    const slim = entry("wifi", ComponentCategory.CORE); // no config_entries
+    const body = {
+      ...slim,
+      config_entries: [makeConfigEntry({ key: "ssid" })],
+    };
+    const c = catalog([slim]);
+    const fakeApi = {
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(ids.filter((id) => id === "wifi").map((id) => [id, body])),
+    } as never;
+    const out = await (resolveAvailableEntries as unknown as Function)(
+      fakeApi,
+      c,
+      "wifi",
+      null,
+      null
+    );
+    expect(out.map((e: { key: string }) => e.key)).toContain("ssid");
   });
 });
 
@@ -275,6 +315,7 @@ describe("createYamlCompletionSource (auto-fire at value position)", () => {
   // even when ``explicit === false``, so CodeMirror's
   // implicit-completion path opens the popup automatically.
   beforeEach(() => {
+    _clearComponentCache();
     _resetSchemaCacheForTests();
     vi.stubGlobal(
       "fetch",
@@ -365,6 +406,14 @@ describe("createYamlCompletionSource (auto-fire at value position)", () => {
           },
         ],
       }),
+      // Body hydration returns empty ``config_entries`` so the
+      // schema-bundle fallback (the mocked fetch) supplies the enum.
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(
+          ids
+            .filter((id) => id === "sensor.uptime")
+            .map((id) => [id, { id, config_entries: [] }])
+        ),
       getVersion: async () => ({
         server_version: "0.0.0",
         esphome_version: "2026.5.0",


### PR DESCRIPTION
# What does this implement/fix?

The old dashboard editor suggested matching IDs when you typed at a field that references another component (for example `i2c_id:`); the new CodeMirror editor only did this in the visual form, not in the raw YAML. This wires the same lookup into the YAML editor's value completion, so typing at an id reference field offers the IDs declared in the referenced domain.

It reuses the form's existing `findReferencedComponents` scan and the entry's `references_component`, so both editors show the same candidates. Declaring `id:` fields are left untouched. The candidate list is memoized so repeated completion passes do not reallocate.

Out of scope for now: `id(...)` references inside `!lambda` blocks, and IDs from other files or packages.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1230

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
