### PR TITLE
Round-trip unicode escape sequences in font glyph fields

### DIFF
--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
+import { escapeForInput, unescapeForInput } from "../../../util/yaml-escape.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -82,13 +83,21 @@ export function renderMultiValueField(
   path: string[],
   ctx: RenderCtx
 ) {
-  const items: string[] = readArrayAt(ctx, path).map((v) => String(v));
+  // Show escape-worthy code points (control / Private-Use, e.g. MDI font
+  // glyphs) as ``\U…`` so an otherwise-invisible value is editable, and
+  // decode on input (device-builder#1232). Escaping is unconditional so
+  // display and input stay a true inverse: a value that merely looks like
+  // an escape (``C:\x41bc``) shows with its backslash doubled and decodes
+  // back unchanged, rather than being rewritten on a no-op edit. Decoding
+  // must stay unconditional too — a freshly added row is empty, so a typed
+  // ``\U…`` has to decode without a prior escape-worthy value to gate on.
+  const items: string[] = readArrayAt(ctx, path).map((v) => escapeForInput(String(v)));
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");
   const updateAt = (idx: number, value: string) => {
     const current = [...readArrayAt(ctx, path)];
-    current[idx] = value;
+    current[idx] = unescapeForInput(value);
     ctx.emitChange(path, current);
   };
 

--- a/src/util/split-top-level-commas.ts
+++ b/src/util/split-top-level-commas.ts
@@ -1,0 +1,32 @@
+/**
+ * Split *s* on top-level commas, ignoring commas inside single- or
+ * double-quoted spans (``\"`` escapes are honored inside double quotes).
+ * Returns the raw segments between delimiters — callers trim / unquote.
+ *
+ * A quote-unaware ``split(",")`` fractures a quoted element that itself
+ * contains a comma (e.g. a YAML flow list ``["a,b", "c"]``); this keeps
+ * such elements intact.
+ */
+export function splitTopLevelCommas(s: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let quote: string | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      buf += c;
+      if (quote === '"' && c === "\\" && i + 1 < s.length) buf += s[++i];
+      else if (c === quote) quote = null;
+    } else if (c === '"' || c === "'") {
+      quote = c;
+      buf += c;
+    } else if (c === ",") {
+      out.push(buf);
+      buf = "";
+    } else {
+      buf += c;
+    }
+  }
+  out.push(buf);
+  return out;
+}

--- a/src/util/yaml-escape.ts
+++ b/src/util/yaml-escape.ts
@@ -1,0 +1,160 @@
+/**
+ * Escape helpers for unicode code points that are invisible in a text
+ * field — control characters and Private-Use-Area glyphs (e.g. Material
+ * Design Icon glyphs at ``\U000F058F``). Ordinary printable text
+ * (letters, accents, emoji) is kept raw so a ``friendly_name`` like
+ * ``Café`` survives unchanged. The escape *format* follows PyYAML's
+ * emitter (uppercase hex; ``\x`` / ``\u`` / ``\U`` chosen by width).
+ *
+ * Two layers share the predicate below:
+ *   - ``escapeYamlDoubleQuoted`` / ``unescapeYamlDoubleQuoted`` model a
+ *     YAML double-quoted *scalar* — the short escapes the serializer emits
+ *     (``\\`` ``\"`` ``\n`` ``\r`` ``\t``) plus numeric escapes; used by
+ *     the serializer and section-value parser. It is not a full YAML
+ *     escape set (no ``\0`` / ``\a`` / ``\f`` / ``\N`` etc.).
+ *   - ``escapeForInput`` / ``unescapeForInput`` are a *narrower* pair for
+ *     form inputs: only numeric (``\x`` / ``\u`` / ``\U``) escapes and the
+ *     backslash, so editing a non-glyph multi_value field never rewrites
+ *     a literal ``\t`` / quote / path the user typed.
+ */
+
+/** True for control / Private-Use code points that are written as escapes. */
+export function isEscapeWorthy(cp: number): boolean {
+  return (
+    cp < 0x20 ||
+    cp === 0x7f ||
+    (cp >= 0x80 && cp <= 0x9f) ||
+    (cp >= 0xe000 && cp <= 0xf8ff) ||
+    (cp >= 0xf0000 && cp <= 0xffffd) ||
+    (cp >= 0x100000 && cp <= 0x10fffd)
+  );
+}
+
+/** True when any code point in *s* is escape-worthy. */
+export function hasEscapeWorthyChar(s: string): boolean {
+  for (const ch of s) {
+    if (isEscapeWorthy(ch.codePointAt(0)!)) return true;
+  }
+  return false;
+}
+
+/** Render a code point as ``\xXX`` / ``\uXXXX`` / ``\UXXXXXXXX`` (uppercase hex). */
+function escapeCodePoint(cp: number): string {
+  if (cp <= 0xff) return `\\x${cp.toString(16).toUpperCase().padStart(2, "0")}`;
+  if (cp <= 0xffff) return `\\u${cp.toString(16).toUpperCase().padStart(4, "0")}`;
+  return `\\U${cp.toString(16).toUpperCase().padStart(8, "0")}`;
+}
+
+/**
+ * Decode a ``\x`` / ``\u`` / ``\U`` numeric escape whose indicator is at
+ * *idx*. Returns ``[char, charsConsumedAfterBackslash]``, or ``null`` for
+ * a non-numeric, malformed, out-of-range, or lone-surrogate sequence.
+ */
+function decodeNumeric(s: string, idx: number): [string, number] | null {
+  const esc = s[idx];
+  const width = esc === "x" ? 2 : esc === "u" ? 4 : esc === "U" ? 8 : 0;
+  if (!width) return null;
+  const hex = s.slice(idx + 1, idx + 1 + width);
+  if (hex.length !== width || !/^[0-9a-fA-F]+$/.test(hex)) return null;
+  const cp = parseInt(hex, 16);
+  if (cp > 0x10ffff || (cp >= 0xd800 && cp <= 0xdfff)) return null;
+  return [String.fromCodePoint(cp), 1 + width];
+}
+
+// Per-character short escapes the *escape* side emits, keyed by the raw
+// character; the YAML scalar form carries these, the form-input form
+// carries none (control chars fall through to a numeric escape).
+const NO_SHORT_ESCAPE: Record<string, string> = {};
+const YAML_SHORT_ESCAPE: Record<string, string> = {
+  '"': '\\"',
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+};
+
+// Short escapes the *unescape* side decodes, keyed by the indicator
+// character after the backslash. The form-input form only collapses
+// ``\\`` so a typed ``\t`` / path stays literal.
+const BACKSLASH_ONLY_UNESCAPE: Record<string, string> = { "\\": "\\" };
+const YAML_SHORT_UNESCAPE: Record<string, string> = {
+  "\\": "\\",
+  '"': '"',
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
+
+// Always double a literal backslash so escape/unescape are invertible.
+function escapeBody(s: string, short: Record<string, string>): string {
+  let out = "";
+  for (const ch of s) {
+    const cp = ch.codePointAt(0)!;
+    if (ch === "\\") out += "\\\\";
+    else if (short[ch] !== undefined) out += short[ch];
+    else if (isEscapeWorthy(cp)) out += escapeCodePoint(cp);
+    else out += ch;
+  }
+  return out;
+}
+
+// Decode numeric escapes plus *short*; any other backslash sequence keeps
+// the backslash literal (so an unrecognized ``\Users`` isn't dropped).
+function unescapeBody(s: string, short: Record<string, string>): string {
+  if (!s.includes("\\")) return s;
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] !== "\\" || i + 1 >= s.length) {
+      out += s[i];
+      continue;
+    }
+    const num = decodeNumeric(s, i + 1);
+    if (num) {
+      out += num[0];
+      i += num[1];
+      continue;
+    }
+    const mapped = short[s[i + 1]];
+    if (mapped !== undefined) {
+      out += mapped;
+      i += 1;
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}
+
+/**
+ * Escape the body of a double-quoted YAML scalar (caller adds the
+ * surrounding quotes): ``\`` / ``"`` / the short control forms, and
+ * escape-worthy code points numerically so an MDI glyph becomes
+ * ``\U000F058F`` instead of a bare invalid char.
+ */
+export function escapeYamlDoubleQuoted(s: string): string {
+  return escapeBody(s, YAML_SHORT_ESCAPE);
+}
+
+/** Inverse of :func:`escapeYamlDoubleQuoted` — decode a double-quoted scalar body. */
+export function unescapeYamlDoubleQuoted(s: string): string {
+  return unescapeBody(s, YAML_SHORT_UNESCAPE);
+}
+
+/**
+ * Show a stored value in a form input: double ``\`` and render
+ * escape-worthy code points as ``\x`` / ``\u`` / ``\U`` so an invisible
+ * glyph is editable. Unlike the YAML variant it leaves quotes and short
+ * control forms alone — paired with :func:`unescapeForInput` it only
+ * round-trips numeric escapes, so non-glyph list values are untouched.
+ */
+export function escapeForInput(s: string): string {
+  return escapeBody(s, NO_SHORT_ESCAPE);
+}
+
+/**
+ * Inverse of :func:`escapeForInput`. Decodes ``\\`` and numeric escapes
+ * only; any other backslash sequence (``\t``, ``\Users``) is kept literal
+ * so a path or regex typed into a multi_value field is not rewritten.
+ */
+export function unescapeForInput(s: string): string {
+  return unescapeBody(s, BACKSLASH_ONLY_UNESCAPE);
+}

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -6,11 +6,17 @@
  * keep growing.
  */
 
+import { splitTopLevelCommas } from "./split-top-level-commas.js";
+import { unescapeYamlDoubleQuoted } from "./yaml-escape.js";
 import { parseYamlBoolean } from "./yaml-serialize.js";
 
 export const stripQuotes = (s: string): string => {
-  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+  if (s.startsWith('"') && s.endsWith('"')) {
     return s.slice(1, -1);
+  }
+  if (s.startsWith("'") && s.endsWith("'")) {
+    // YAML single-quote escape: a doubled `''` is a literal `'`.
+    return s.slice(1, -1).replace(/''/g, "'");
   }
   return s;
 };
@@ -75,5 +81,15 @@ export const parseScalar = (raw: string): unknown => {
 export const parseFlowList = (raw: string): string[] => {
   const inner = raw.slice(1, -1).trim();
   if (inner === "") return [];
-  return inner.split(",").map((p) => stripQuotes(p.trim()));
+  // Quote-aware split: a quoted element may itself contain a comma (the
+  // serializer quotes such scalars), which a plain ``split(",")`` would
+  // fracture into extra items. Double-quoted elements are unescaped so a
+  // font glyph like ``\U000F058F`` becomes the real code point, not the
+  // literal backslash text (device-builder#1232).
+  return splitTopLevelCommas(inner).map((p) => {
+    const t = p.trim();
+    return t.length >= 2 && t.startsWith('"') && t.endsWith('"')
+      ? unescapeYamlDoubleQuoted(t.slice(1, -1))
+      : stripQuotes(t);
+  });
 };

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -447,6 +447,14 @@ const parseFlatMappingField = (
   // field) round-trip through the section editor instead of
   // falling back to YamlRawValue. #941.
   if (raw === "") return { key, value: null };
+  // Flow list inside a list-item mapping (``extras[].glyphs:
+  // ["\U000F058F", ...]``). Strip a trailing comment first so the
+  // ``[...]`` test fires; without this the array reads as a scalar string
+  // and the multi_value field renders empty (device-builder#1232).
+  const { value: scalar } = splitInlineComment(raw);
+  if (scalar.startsWith("[") && scalar.endsWith("]")) {
+    return { key, value: parseFlowList(scalar) };
+  }
   return { key, value: parseScalar(raw) };
 };
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -16,6 +16,7 @@
 import { isLambdaValue } from "../api/types/automations.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isPlainObject } from "./nested-values.js";
+import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
 
 /**
  * Wrap a ``LambdaValue`` sentinel (``{_lambda: "<body>"}``) as a
@@ -257,6 +258,28 @@ function serializeListItem(
         lines.push(...emitYamlRawValueLines(k, prefix, raw));
         return;
       }
+      if (Array.isArray(v)) {
+        // A list nested inside a list item (e.g. ``extras[].glyphs``).
+        // Without this branch the array falls through to the scalar
+        // tail and ``String(array)`` collapses it to a bare,
+        // comma-joined value (device-builder#1232). Scalar lists emit
+        // flow-style ``[a, b]`` — a block list under a list-item key
+        // makes the structured parser (``_parseItemSubKeys``) bail to an
+        // opaque ``YamlRawValue``, so the field would stop round-tripping.
+        if (v.length === 0) return;
+        const scalarItems = v.every(
+          (it) => !isPlainObject(it) && !Array.isArray(it) && !isLambdaValue(it)
+        );
+        if (scalarItems) {
+          lines.push(`${prefix}${k}: [${v.map(formatYamlFlowScalar).join(", ")}]`);
+          return;
+        }
+        lines.push(`${prefix}${k}:`);
+        for (const sub of v) {
+          lines.push(...serializeListItem(sub, childIndent, options));
+        }
+        return;
+      }
       if (isPlainObject(v)) {
         // Polymorphic single-key item with nested params (effects
         // with overrides, filters with overrides — #941). Emit the
@@ -466,6 +489,7 @@ function yamlNeedsQuoting(s: string): boolean {
     /^[-\s'"]/.test(s) ||
     /\s$/.test(s) ||
     /[\n\r\t]/.test(s) ||
+    hasEscapeWorthyChar(s) ||
     YAML_BOOL.test(s) ||
     YAML_INT.test(s) ||
     YAML_FLOAT.test(s) ||
@@ -474,15 +498,13 @@ function yamlNeedsQuoting(s: string): boolean {
   );
 }
 
-/** Wrap *s* in double quotes, escaping backslashes and control chars. */
+/**
+ * Wrap *s* in double quotes, escaping backslashes, control chars, and
+ * escape-worthy code points (control / Private-Use) so an MDI glyph
+ * round-trips as ``"\U000F058F"`` instead of a bare invalid backslash.
+ */
 function yamlDoubleQuote(s: string): string {
-  const escaped = s
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, "\\n")
-    .replace(/\r/g, "\\r")
-    .replace(/\t/g, "\\t");
-  return `"${escaped}"`;
+  return `"${escapeYamlDoubleQuoted(s)}"`;
 }
 
 /** Format a single scalar value, quoting when needed. */
@@ -491,6 +513,16 @@ export function formatYamlScalar(v: unknown): string {
   if (typeof v === "number") return String(v);
   const s = String(v);
   return yamlNeedsQuoting(s) ? yamlDoubleQuote(s) : s;
+}
+
+/**
+ * Format a scalar for inside a ``[ ... ]`` flow list. A flow indicator
+ * (``,`` ``[`` ``]`` ``{`` ``}``) must be quoted on top of
+ * ``formatYamlScalar``'s rules, or the list mis-splits.
+ */
+function formatYamlFlowScalar(v: unknown): string {
+  if (typeof v === "string" && /[,[\]{}]/.test(v)) return yamlDoubleQuote(v);
+  return formatYamlScalar(v);
 }
 
 // ESPHome's YAML loader accepts the YAML 1.1 truthy/falsy spellings

--- a/test/util/split-top-level-commas.test.ts
+++ b/test/util/split-top-level-commas.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { splitTopLevelCommas } from "../../src/util/split-top-level-commas.js";
+
+describe("splitTopLevelCommas", () => {
+  it("splits plain comma-separated values", () => {
+    expect(splitTopLevelCommas("a, b, c")).toEqual(["a", " b", " c"]);
+  });
+
+  it("keeps commas inside double-quoted spans", () => {
+    expect(splitTopLevelCommas('"a,b", c')).toEqual(['"a,b"', " c"]);
+  });
+
+  it("keeps commas inside single-quoted spans", () => {
+    expect(splitTopLevelCommas("'x,y', z")).toEqual(["'x,y'", " z"]);
+  });
+
+  it("honors an escaped quote inside a double-quoted span", () => {
+    expect(splitTopLevelCommas('"a\\",b", c')).toEqual(['"a\\",b"', " c"]);
+  });
+
+  it("returns a single segment when there are no top-level commas", () => {
+    expect(splitTopLevelCommas('"a,b,c"')).toEqual(['"a,b,c"']);
+  });
+});

--- a/test/util/yaml-escape.test.ts
+++ b/test/util/yaml-escape.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeForInput,
+  escapeYamlDoubleQuoted,
+  hasEscapeWorthyChar,
+  isEscapeWorthy,
+  unescapeForInput,
+  unescapeYamlDoubleQuoted,
+} from "../../src/util/yaml-escape.js";
+
+// A Material Design Icon glyph (Plane-15 Private Use Area) — the value
+// the font editor must round-trip as ``\U000F058F`` (device-builder#1232).
+const MDI = String.fromCodePoint(0xf058f);
+
+describe("isEscapeWorthy", () => {
+  it("flags control and Private-Use code points", () => {
+    expect(isEscapeWorthy(0x09)).toBe(true); // tab
+    expect(isEscapeWorthy(0x7f)).toBe(true); // DEL
+    expect(isEscapeWorthy(0xe000)).toBe(true); // BMP PUA
+    expect(isEscapeWorthy(0xf058f)).toBe(true); // Plane-15 PUA-A
+  });
+
+  it("keeps ordinary printable text raw", () => {
+    expect(isEscapeWorthy(0x41)).toBe(false); // A
+    expect(isEscapeWorthy(0xe9)).toBe(false); // é
+    expect(isEscapeWorthy(0x1f600)).toBe(false); // 😀 emoji
+  });
+});
+
+describe("hasEscapeWorthyChar", () => {
+  it("is true for a PUA glyph, false for a plain identifier", () => {
+    expect(hasEscapeWorthyChar(MDI)).toBe(true);
+    expect(hasEscapeWorthyChar("GPIO4")).toBe(false);
+  });
+});
+
+describe("escapeYamlDoubleQuoted / unescapeYamlDoubleQuoted", () => {
+  it("escapes a PUA glyph as \\U with uppercase hex", () => {
+    expect(escapeYamlDoubleQuoted(MDI)).toBe("\\U000F058F");
+  });
+
+  it("escapes backslash and double quote", () => {
+    expect(escapeYamlDoubleQuoted('a\\b"c')).toBe('a\\\\b\\"c');
+  });
+
+  it("decodes \\U / \\u / \\x and the short forms", () => {
+    expect(unescapeYamlDoubleQuoted("\\U000F058F")).toBe(MDI);
+    expect(unescapeYamlDoubleQuoted("\\u0041")).toBe("A");
+    expect(unescapeYamlDoubleQuoted("\\x41")).toBe("A");
+    expect(unescapeYamlDoubleQuoted("a\\nb")).toBe("a\nb");
+    expect(unescapeYamlDoubleQuoted("a\\\\b")).toBe("a\\b");
+  });
+
+  it("keeps a malformed or lone-surrogate escape literal", () => {
+    // \uD800 alone would yield ill-formed UTF-16; an incomplete \U is
+    // not an escape. Both keep the backslash rather than dropping it.
+    expect(unescapeYamlDoubleQuoted("\\Uzzzz")).toBe("\\Uzzzz");
+    expect(unescapeYamlDoubleQuoted("\\uD800")).toBe("\\uD800");
+  });
+
+  it("preserves a raw-typed backslash that is not a recognized escape", () => {
+    // A user typing ``C:\Users`` in any multi_value field keeps the
+    // backslash; only valid escapes (``\U…``) are decoded.
+    expect(unescapeYamlDoubleQuoted("C:\\Users")).toBe("C:\\Users");
+  });
+
+  it("is invertible, including for stored literal backslash-escape text", () => {
+    // Doubling the backslash on escape is what stops a no-op edit of a
+    // value like ``C:\x41bc`` from re-decoding ``\x41`` to ``A``.
+    for (const s of ["C:\\x41bc", "a\\U0001F600b", "\\u0041", "plain", MDI]) {
+      expect(unescapeYamlDoubleQuoted(escapeYamlDoubleQuoted(s))).toBe(s);
+    }
+  });
+});
+
+describe("escapeForInput / unescapeForInput (form input)", () => {
+  it("shows a glyph as an editable escape and decodes it back", () => {
+    expect(escapeForInput(MDI)).toBe("\\U000F058F");
+    expect(unescapeForInput("\\U000F058F")).toBe(MDI);
+  });
+
+  it("leaves a literal path / regex untouched — only numeric escapes decode", () => {
+    // The narrowing the renderer relies on: a value typed into any
+    // multi_value field keeps ``\t`` as two chars (not a tab), so paths
+    // and regexes are not silently rewritten.
+    expect(unescapeForInput("C:\\temp")).toBe("C:\\temp");
+    expect(unescapeForInput("\\d+")).toBe("\\d+");
+  });
+
+  it("does not escape quotes or short control forms on display", () => {
+    expect(escapeForInput('a"b')).toBe('a"b');
+  });
+
+  it("is invertible — the renderer escapes on display and decodes on edit", () => {
+    // The renderer applies escapeForInput unconditionally, so a no-op edit
+    // of a value that merely looks like an escape (``C:\x41bc``) must round
+    // back unchanged rather than decoding ``\x41`` to ``A`` (#647 review).
+    for (const s of ["C:\\x41bc", "plain", MDI, "\\Users", "a\\b", "\\U0001"]) {
+      expect(unescapeForInput(escapeForInput(s))).toBe(s);
+    }
+  });
+});

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -97,6 +97,59 @@ describe("parseYamlSectionValues — permissive key alphabet", () => {
   });
 });
 
+describe("parseYamlSectionValues — font glyph unicode escapes", () => {
+  // device-builder#1232: ``extras[].glyphs`` is a flow list of
+  // double-quoted unicode escapes (Material Design Icon glyphs). It must
+  // load as an array of the real code points — not a scalar string — and
+  // round-trip back to the same quoted flow list.
+  const MDI_A = String.fromCodePoint(0xf058f);
+  const MDI_B = String.fromCodePoint(0xf0f19);
+  const fontYaml = [
+    "font:",
+    '  - file: "gfonts://Roboto"',
+    "    id: roboto",
+    '    size: "30"',
+    "    extras:",
+    "      - file: fonts/materialdesignicons-webfont.ttf",
+    '        glyphs: ["\\U000F058F","\\U000F0F19"]',
+    "",
+  ].join("\n");
+
+  it("parses the nested flow list into decoded glyph code points", () => {
+    const values = parseYamlSectionValues(
+      fontYaml,
+      "font",
+      firstListItemLine(fontYaml, "font")
+    );
+    expect(values.extras).toEqual([
+      {
+        file: "fonts/materialdesignicons-webfont.ttf",
+        glyphs: [MDI_A, MDI_B],
+      },
+    ]);
+  });
+
+  it("round-trips through serialize back to the quoted flow list", () => {
+    const values = parseYamlSectionValues(
+      fontYaml,
+      "font",
+      firstListItemLine(fontYaml, "font")
+    );
+    const itemLines = serializeYamlValues(values, "");
+    expect(itemLines.join("\n")).toContain('glyphs: ["\\U000F058F", "\\U000F0F19"]');
+    // Re-wrap the serialized fields as a font list item and re-parse:
+    // the glyphs survive as the same code points.
+    const wrapped =
+      "font:\n" + itemLines.map((l, i) => (i === 0 ? `  - ${l}` : `    ${l}`)).join("\n");
+    const reparsed = parseYamlSectionValues(
+      wrapped,
+      "font",
+      firstListItemLine(wrapped, "font")
+    );
+    expect((reparsed.extras as { glyphs: string[] }[])[0].glyphs).toEqual([MDI_A, MDI_B]);
+  });
+});
+
 describe("parseYamlSectionValues — prototype pollution defense", () => {
   // YAML keys like `__proto__` / `constructor` / `prototype`
   // would otherwise hit the corresponding setter on
@@ -1160,6 +1213,12 @@ describe("inline comments on scalar values (#1235)", () => {
     const yaml = ["wifi:", '  ssid: "a \\" # b"', ""].join("\n");
     const v = parseYamlSectionValues(yaml, "wifi", 1);
     expect(v.ssid).toBe('a \\" # b');
+  });
+
+  it("decodes the YAML single-quote escape ('' -> ')", () => {
+    const yaml = ["wifi:", "  ssid: 'a''b'", ""].join("\n");
+    const v = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(v.ssid).toBe("a'b");
   });
 
   it("re-appends the inline comment when the field is edited", () => {
@@ -2247,5 +2306,21 @@ describe("LIST_SECTIONS is membership-driven, not hardcoded to globals", () => {
   it("parses as a flat mapping (no item array) when NOT a member", () => {
     const parsed = parseYamlSectionValues(FIXTURE, KEY);
     expect(parsed[KEY]).toBeUndefined();
+  });
+});
+
+describe("parseYamlSectionValues — flow list with comma-containing items", () => {
+  it("reads a quoted element that contains a comma as one item", () => {
+    const yaml = 'x:\n  items: ["a,b", c]\n';
+    const values = parseYamlSectionValues(yaml, "x");
+    expect(values.items).toEqual(["a,b", "c"]);
+  });
+
+  it("parses a flow list followed by a trailing comment", () => {
+    // ``glyphs: [...] # note`` is valid YAML; without comment tolerance it
+    // reads as a scalar and the multi_value field renders empty (#647).
+    const yaml = 'x:\n  items: ["a", "b"] # keep these\n';
+    const values = parseYamlSectionValues(yaml, "x");
+    expect(values.items).toEqual(["a", "b"]);
   });
 });

--- a/test/util/yaml-serialize-escaping.test.ts
+++ b/test/util/yaml-serialize-escaping.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatYamlScalar } from "../../src/util/yaml-serialize.js";
+import { formatYamlScalar, serializeYamlValues } from "../../src/util/yaml-serialize.js";
+
+// A Material Design Icon glyph (Plane-15 Private Use Area).
+const MDI_A = String.fromCodePoint(0xf058f);
+const MDI_B = String.fromCodePoint(0xf0f19);
 
 // When formatYamlScalar quotes a value it must escape backslashes and
 // control characters the same way the backend _quote helper does, so a
@@ -73,5 +77,56 @@ describe("formatYamlScalar quotes values a YAML loader would re-type", () => {
     "0.0.0.0",
   ])("leaves %j bare", (value) => {
     expect(formatYamlScalar(value)).toBe(value);
+  });
+});
+
+describe("formatYamlScalar escapes Private-Use glyphs", () => {
+  it("quotes and \\U-escapes an MDI glyph", () => {
+    expect(formatYamlScalar(MDI_A)).toBe('"\\U000F058F"');
+  });
+
+  it("keeps an ordinary accented string bare", () => {
+    expect(formatYamlScalar("Café")).toBe("Café");
+  });
+});
+
+describe("serializeYamlValues — array nested in a list item", () => {
+  it("emits a scalar array as a flow list, not a bare scalar", () => {
+    // ``extras[].glyphs`` — without the list-item Array branch the array
+    // collapses to a bare ``glyphs: \U000F058F`` (device-builder#1232).
+    const out = serializeYamlValues(
+      { extras: [{ file: "icons.ttf", glyphs: [MDI_A, MDI_B] }] },
+      ""
+    ).join("\n");
+    expect(out).toContain('glyphs: ["\\U000F058F", "\\U000F0F19"]');
+    expect(out).not.toContain("glyphs: \\U000F058F");
+  });
+
+  it("skips an empty nested array", () => {
+    const out = serializeYamlValues(
+      { extras: [{ file: "icons.ttf", glyphs: [] }] },
+      ""
+    ).join("\n");
+    expect(out).not.toContain("glyphs");
+  });
+
+  it("quotes a comma-containing item in a nested flow list", () => {
+    // formatYamlFlowScalar quotes flow indicators; the quote-aware parser
+    // reads it back as one element (device-builder#647 review).
+    const out = serializeYamlValues({ extras: [{ items: ["a,b", "c"] }] }, "").join("\n");
+    expect(out).toContain('items: ["a,b", c]');
+  });
+
+  it("emits an array of objects nested in a list item as a block list", () => {
+    // Non-scalar nested arrays use the block fallback (the structured
+    // parser reads this back as an opaque block; the form never produces
+    // this shape, so it is best-effort emission, not a round-trip path).
+    const out = serializeYamlValues(
+      { outer: [{ name: "x", items: [{ a: 1 }, { b: 2 }] }] },
+      ""
+    ).join("\n");
+    expect(out).toBe(
+      ["outer:", "  - name: x", "    items:", "      - a: 1", "      - b: 2"].join("\n")
+    );
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The visual editor could not round-trip unicode escape sequences in font glyph fields. A flow list such as `glyphs: ["\U000F058F","\U000F0F19"]` loaded as an empty field, and a typed glyph was emitted as a bare unquoted scalar that ESPHome then read character by character.

The form parser now decodes double quoted escapes, a list nested inside a list item serializes as a flow list instead of collapsing to a scalar, and Private Use and control code points are quoted on emit and shown as editable escapes in the input.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1232

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
