### PR TITLE
Strip inline comments from section form values and preserve them on edit

### DIFF
--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -1,0 +1,79 @@
+/**
+ * Scalar-value parsing primitives for the section editor's minimal YAML
+ * reader: quote stripping, inline-comment splitting, scalar/boolean
+ * coercion, and flow-list (`[a, b]`) parsing. Kept separate from the
+ * section parser/update logic so that already-oversized module doesn't
+ * keep growing.
+ */
+
+import { parseYamlBoolean } from "./yaml-serialize.js";
+
+export const stripQuotes = (s: string): string => {
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+};
+
+/**
+ * Split a scalar's raw text into its value and a trailing inline
+ * comment (``true #hides`` → ``{ value: "true", comment: " #hides" }``).
+ * A ``#`` only starts a comment when it's whitespace-preceded and
+ * outside quotes — ``Bedroom#2`` and ``"a # b"`` keep the ``#`` in the
+ * value. ``comment`` retains its leading whitespace (``""`` when none)
+ * so the serializer can re-append it verbatim.
+ */
+export const splitInlineComment = (raw: string): { value: string; comment: string } => {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    // Backslash escapes the next char inside a double-quoted scalar
+    // (`"a \" # b"`), so it can't desync the quote tracker. Single
+    // quotes escape via `''`, which the toggle already handles.
+    if (c === "\\" && inDouble) {
+      i++;
+      continue;
+    }
+    if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (
+      c === "#" &&
+      !inSingle &&
+      !inDouble &&
+      (raw[i - 1] === " " || raw[i - 1] === "\t")
+    ) {
+      let ws = i;
+      while (ws > 0 && (raw[ws - 1] === " " || raw[ws - 1] === "\t")) ws--;
+      return { value: raw.slice(0, ws), comment: raw.slice(ws) };
+    }
+  }
+  return { value: raw, comment: "" };
+};
+
+// Quoting in YAML is the explicit "treat me as a string" signal —
+// ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
+// a truthy spelling. Detect the quotes BEFORE stripping so we only
+// run the boolean coercion on plain scalars; otherwise a string
+// field that happens to hold ``"on"`` / ``"yes"`` would silently
+// flip to boolean ``true`` on round-trip.
+export const parseScalar = (raw: string): unknown => {
+  // Strip a trailing inline comment so a boolean/number field coerces
+  // and the form value isn't polluted with `# ...` text (#1235).
+  const { value: scalar } = splitInlineComment(raw);
+  const wasQuoted =
+    (scalar.startsWith('"') && scalar.endsWith('"')) ||
+    (scalar.startsWith("'") && scalar.endsWith("'"));
+  const v = stripQuotes(scalar);
+  if (!wasQuoted) {
+    const bool = parseYamlBoolean(v);
+    if (bool !== null) return bool;
+  }
+  return v;
+};
+
+export const parseFlowList = (raw: string): string[] => {
+  const inner = raw.slice(1, -1).trim();
+  if (inner === "") return [];
+  return inner.split(",").map((p) => stripQuotes(p.trim()));
+};

--- a/src/util/yaml-section-splice.ts
+++ b/src/util/yaml-section-splice.ts
@@ -34,6 +34,10 @@ export interface ParsedSection {
   // (list items) is intentionally absent — it lives on the section
   // header line, which `updateSectionInYaml` owns directly.
   spans: Map<string, KeySpan>;
+  // Trailing inline comment (with its leading whitespace, e.g.
+  // ` #hides`) per scalar key that had one, so a re-serialized edit can
+  // re-append it instead of dropping it (#1235).
+  comments: Map<string, string>;
   childIndent: string;
   isListItem: boolean;
   // 0-indexed section header / leading-dash line.
@@ -102,7 +106,12 @@ export function buildSplicedBody(
     // Changed / added key. Keep any standalone-comment run that led the
     // original key — the value line below reformats, the comment stays.
     if (span) bodyLines.push(...lines.slice(span.leadStart, span.start));
-    bodyLines.push(...serializeYamlValues({ [key]: val }, childIndent, serializeOptions));
+    const fresh = serializeYamlValues({ [key]: val }, childIndent, serializeOptions);
+    // Re-append the field's trailing inline comment when it still
+    // serializes to a single scalar line, so an edit keeps it (#1235).
+    const comment = parsed.comments.get(key);
+    if (comment && fresh.length === 1) fresh[0] += comment;
+    bodyLines.push(...fresh);
   }
   return bodyLines;
 }

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -10,6 +10,12 @@
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import {
+  parseFlowList,
+  parseScalar,
+  splitInlineComment,
+  stripQuotes,
+} from "./yaml-scalar.js";
+import {
   buildSplicedBody,
   yamlValueEqual,
   type KeySpan,
@@ -17,7 +23,6 @@ import {
 } from "./yaml-section-splice.js";
 import {
   formatYamlScalar,
-  parseYamlBoolean,
   serializeYamlValues,
   YamlRawValue,
   type SerializeYamlOptions,
@@ -291,76 +296,6 @@ const isChildListItemLine = (line: string, parentIndent: string): boolean => {
   if (lead.length < parentIndent.length) return false;
   const tail = line.slice(lead.length);
   return tail === "-" || tail.startsWith("- ");
-};
-
-const stripQuotes = (s: string): string => {
-  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
-    return s.slice(1, -1);
-  }
-  return s;
-};
-
-/**
- * Split a scalar's raw text into its value and a trailing inline
- * comment (``true #hides`` → ``{ value: "true", comment: " #hides" }``).
- * A ``#`` only starts a comment when it's whitespace-preceded and
- * outside quotes — ``Bedroom#2`` and ``"a # b"`` keep the ``#`` in the
- * value. ``comment`` retains its leading whitespace (``""`` when none)
- * so the serializer can re-append it verbatim.
- */
-const splitInlineComment = (raw: string): { value: string; comment: string } => {
-  let inSingle = false;
-  let inDouble = false;
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw[i];
-    // Backslash escapes the next char inside a double-quoted scalar
-    // (`"a \" # b"`), so it can't desync the quote tracker. Single
-    // quotes escape via `''`, which the toggle already handles.
-    if (c === "\\" && inDouble) {
-      i++;
-      continue;
-    }
-    if (c === '"' && !inSingle) inDouble = !inDouble;
-    else if (c === "'" && !inDouble) inSingle = !inSingle;
-    else if (
-      c === "#" &&
-      !inSingle &&
-      !inDouble &&
-      (raw[i - 1] === " " || raw[i - 1] === "\t")
-    ) {
-      let ws = i;
-      while (ws > 0 && (raw[ws - 1] === " " || raw[ws - 1] === "\t")) ws--;
-      return { value: raw.slice(0, ws), comment: raw.slice(ws) };
-    }
-  }
-  return { value: raw, comment: "" };
-};
-
-// Quoting in YAML is the explicit "treat me as a string" signal —
-// ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
-// a truthy spelling. Detect the quotes BEFORE stripping so we only
-// run the boolean coercion on plain scalars; otherwise a string
-// field that happens to hold ``"on"`` / ``"yes"`` would silently
-// flip to boolean ``true`` on round-trip.
-const parseScalar = (raw: string): unknown => {
-  // Strip a trailing inline comment so a boolean/number field coerces
-  // and the form value isn't polluted with `# ...` text (#1235).
-  const { value: scalar } = splitInlineComment(raw);
-  const wasQuoted =
-    (scalar.startsWith('"') && scalar.endsWith('"')) ||
-    (scalar.startsWith("'") && scalar.endsWith("'"));
-  const v = stripQuotes(scalar);
-  if (!wasQuoted) {
-    const bool = parseYamlBoolean(v);
-    if (bool !== null) return bool;
-  }
-  return v;
-};
-
-const parseFlowList = (raw: string): string[] => {
-  const inner = raw.slice(1, -1).trim();
-  if (inner === "") return [];
-  return inner.split(",").map((p) => stripQuotes(p.trim()));
 };
 
 const collectBlockListItems = (

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -313,6 +313,13 @@ const splitInlineComment = (raw: string): { value: string; comment: string } => 
   let inDouble = false;
   for (let i = 0; i < raw.length; i++) {
     const c = raw[i];
+    // Backslash escapes the next char inside a double-quoted scalar
+    // (`"a \" # b"`), so it can't desync the quote tracker. Single
+    // quotes escape via `''`, which the toggle already handles.
+    if (c === "\\" && inDouble) {
+      i++;
+      continue;
+    }
     if (c === '"' && !inSingle) inDouble = !inDouble;
     else if (c === "'" && !inDouble) inSingle = !inSingle;
     else if (

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -300,6 +300,35 @@ const stripQuotes = (s: string): string => {
   return s;
 };
 
+/**
+ * Split a scalar's raw text into its value and a trailing inline
+ * comment (``true #hides`` → ``{ value: "true", comment: " #hides" }``).
+ * A ``#`` only starts a comment when it's whitespace-preceded and
+ * outside quotes — ``Bedroom#2`` and ``"a # b"`` keep the ``#`` in the
+ * value. ``comment`` retains its leading whitespace (``""`` when none)
+ * so the serializer can re-append it verbatim.
+ */
+const splitInlineComment = (raw: string): { value: string; comment: string } => {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (
+      c === "#" &&
+      !inSingle &&
+      !inDouble &&
+      (raw[i - 1] === " " || raw[i - 1] === "\t")
+    ) {
+      let ws = i;
+      while (ws > 0 && (raw[ws - 1] === " " || raw[ws - 1] === "\t")) ws--;
+      return { value: raw.slice(0, ws), comment: raw.slice(ws) };
+    }
+  }
+  return { value: raw, comment: "" };
+};
+
 // Quoting in YAML is the explicit "treat me as a string" signal —
 // ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
 // a truthy spelling. Detect the quotes BEFORE stripping so we only
@@ -307,10 +336,13 @@ const stripQuotes = (s: string): string => {
 // field that happens to hold ``"on"`` / ``"yes"`` would silently
 // flip to boolean ``true`` on round-trip.
 const parseScalar = (raw: string): unknown => {
+  // Strip a trailing inline comment so a boolean/number field coerces
+  // and the form value isn't polluted with `# ...` text (#1235).
+  const { value: scalar } = splitInlineComment(raw);
   const wasQuoted =
-    (raw.startsWith('"') && raw.endsWith('"')) ||
-    (raw.startsWith("'") && raw.endsWith("'"));
-  const v = stripQuotes(raw);
+    (scalar.startsWith('"') && scalar.endsWith('"')) ||
+    (scalar.startsWith("'") && scalar.endsWith("'"));
+  const v = stripQuotes(scalar);
   if (!wasQuoted) {
     const bool = parseYamlBoolean(v);
     if (bool !== null) return bool;
@@ -758,13 +790,14 @@ function parseSectionCore(
   // you need that check on a downstream consumer.
   const values: Record<string, unknown> = Object.create(null);
   const spans = new Map<string, KeySpan>();
+  const comments = new Map<string, string>();
   // leadStart is finalised by the post-loop pass below.
   const recordSpan = (key: string, start: number, end: number): void => {
     spans.set(key, { start, end, leadStart: start });
   };
   const startIdx = findSectionStart(lines, sectionKey, fromLine);
   if (startIdx < 0) {
-    return { values, spans, childIndent: "", isListItem: false, startIdx };
+    return { values, spans, comments, childIndent: "", isListItem: false, startIdx };
   }
 
   const isListItem = LIST_ITEM_START_RE.test(lines[startIdx]);
@@ -784,7 +817,7 @@ function parseSectionCore(
       values[sectionKey] = parseListBlock(lines, startIdx + 1, childIndent).value;
       // No per-key spans — `updateSectionInYaml` re-emits this whole
       // list through its dedicated LIST_SECTIONS branch.
-      return { values, spans, childIndent, isListItem, startIdx };
+      return { values, spans, comments, childIndent, isListItem, startIdx };
     }
   }
 
@@ -795,7 +828,11 @@ function parseSectionCore(
     const firstMatch = lines[startIdx].match(LIST_ITEM_INLINE_KEY_RE);
     if (firstMatch) {
       const raw = firstMatch[2].trim();
-      if (raw !== "") values[firstMatch[1]] = parseScalar(raw);
+      if (raw !== "") {
+        const { comment } = splitInlineComment(raw);
+        if (comment) comments.set(firstMatch[1], comment);
+        values[firstMatch[1]] = parseScalar(raw);
+      }
     }
   }
 
@@ -875,12 +912,17 @@ function parseSectionCore(
       continue;
     }
 
-    if (raw.startsWith("[") && raw.endsWith("]")) {
-      values[key] = parseFlowList(raw);
+    // Split a trailing inline comment off before the flow-list test
+    // (`[a, b] # c` doesn't end with `]`) and before scalar parsing,
+    // and record it so an edit can re-append it (#1235).
+    const { value: scalar, comment } = splitInlineComment(raw);
+    if (comment) comments.set(key, comment);
+    if (scalar.startsWith("[") && scalar.endsWith("]")) {
+      values[key] = parseFlowList(scalar);
       recordSpan(key, i, i + 1);
       continue;
     }
-    values[key] = parseScalar(raw);
+    values[key] = parseScalar(scalar);
     recordSpan(key, i, i + 1);
   }
 
@@ -920,7 +962,7 @@ function parseSectionCore(
     prevEnd = span.end;
   }
 
-  return { values, spans, childIndent, isListItem, startIdx };
+  return { values, spans, comments, childIndent, isListItem, startIdx };
 }
 
 /** Recursively parse a nested YAML block at the given indent. */
@@ -1186,7 +1228,8 @@ export function updateSectionInYaml(
             // makes that invariant local.
             const dashPrefixMatch = dashLine.match(/^(\s+)-(\s+)/)!;
             const dashPrefix = `${dashPrefixMatch[1]}-${dashPrefixMatch[2]}`;
-            dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}`;
+            const comment = parsed.comments.get(inlineKey) ?? "";
+            dashLine = `${dashPrefix}${inlineKey}: ${formatYamlScalar(values[inlineKey])}${comment}`;
           }
         } else {
           // Non-scalar form value: drop the inline key from the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1118,6 +1118,85 @@ describe("updateSectionInYaml — preserves untouched field byte layout (#1227)"
   });
 });
 
+describe("inline comments on scalar values (#1235)", () => {
+  // The parser used to fold a trailing `# comment` into the scalar's
+  // form value, breaking boolean coercion and showing comment text in
+  // the field. Strip it at parse, and re-append it when the field is
+  // edited so the comment survives.
+
+  it("strips the inline comment from the form value", () => {
+    const yaml = [
+      "sensor:",
+      "  - platform: template",
+      "    name: T",
+      "    internal: true #hides from list",
+      "    update_interval: never  # update via trigger",
+      "",
+    ].join("\n");
+    const v = parseYamlSectionValues(yaml, "sensor.template", 2);
+    // Boolean field coerces (was the string "true #hides from list").
+    expect(v.internal).toBe(true);
+    expect(v.update_interval).toBe("never");
+    expect(v.name).toBe("T");
+  });
+
+  it("keeps a `#` that is not a comment (no preceding space / quoted)", () => {
+    const yaml = [
+      "wifi:",
+      "  ssid: Bedroom#2",
+      '  password: "a # b"',
+      '  domain: "x" # real comment',
+      "",
+    ].join("\n");
+    const v = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(v.ssid).toBe("Bedroom#2");
+    expect(v.password).toBe("a # b");
+    expect(v.domain).toBe("x");
+  });
+
+  it("re-appends the inline comment when the field is edited", () => {
+    const before = [
+      "sensor:",
+      "  - platform: template",
+      "    internal: true #hides from list",
+      "    update_interval: never  # update via trigger",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "sensor.template", 2);
+    values.internal = false;
+    values.update_interval = "60s";
+    const after = updateSectionInYaml(before, "sensor.template", values, 2);
+    expect(after).toContain("    internal: false #hides from list\n");
+    // Original 2-space separator before the comment is preserved.
+    expect(after).toContain("    update_interval: 60s  # update via trigger");
+  });
+
+  it("keeps the inline comment on an unchanged field (verbatim)", () => {
+    const before = [
+      "sensor:",
+      "  - platform: template",
+      "    name: Old",
+      "    internal: true #hides from list",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(before, "sensor.template", 2);
+    values.name = "New";
+    const after = updateSectionInYaml(before, "sensor.template", values, 2);
+    expect(after).toContain("    internal: true #hides from list");
+    expect(after).not.toContain('"true #hides from list"');
+    expect(after).toContain("name: New");
+  });
+
+  it("re-appends the inline comment on a changed list-item dash key", () => {
+    const before = ["ota:", "  - platform: esphome #default backend", ""].join("\n");
+    const values = parseYamlSectionValues(before, "ota.esphome", 2);
+    expect(values.platform).toBe("esphome");
+    values.platform = "http_request";
+    const after = updateSectionInYaml(before, "ota.esphome", values, 2);
+    expect(after).toContain("  - platform: http_request #default backend");
+  });
+});
+
 describe("serializeYamlValues — single-key null-value list items", () => {
   // The polymorphic carve-out in serializeListItem is in the
   // shared helper, so it affects every list-of-mapping consumer,

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1154,6 +1154,14 @@ describe("inline comments on scalar values (#1235)", () => {
     expect(v.domain).toBe("x");
   });
 
+  it("does not desync on an escaped quote inside a double-quoted scalar", () => {
+    // `\"` must not flip the in-quote tracker, or the following `#`
+    // would be wrongly split off as a comment.
+    const yaml = ["wifi:", '  ssid: "a \\" # b"', ""].join("\n");
+    const v = parseYamlSectionValues(yaml, "wifi", 1);
+    expect(v.ssid).toBe('a \\" # b');
+  });
+
   it("re-appends the inline comment when the field is edited", () => {
     const before = [
       "sensor:",


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #643 (#1227). That fix made section saves preserve *untouched*
fields byte-for-byte. This closes the residual parse-side defect: the section
parser folded a trailing `# comment` into a scalar's **form value**, so:

- a boolean field received the string `"true #hides from list"` → the toggle
  rendered wrong, and
- editing the field **dropped its inline comment** (the value line
  re-serialized from the polluted value).

Verified: `internal: true #hides from list` parsed to the string
`"true #hides from list"`; `update_interval: never  # update via trigger` →
`"never  # update via trigger"`.

## Fix

- **Strip at parse** — a quote-aware `splitInlineComment` splits the value from
  a trailing inline comment; `parseScalar` parses only the value, so the form
  gets a clean `true` / `never` at every scalar parse site. A `#` counts as a
  comment only when whitespace-preceded and outside quotes, so `Bedroom#2`,
  `"a # b"` keep the `#`.
- **Preserve on edit** — the comment is recorded per key (`ParsedSection.comments`)
  and re-appended when a changed scalar re-serializes to a single line
  (`buildSplicedBody`), plus on the list-item dash-key rewrite. Composes with the
  #1227 verbatim splice: an untouched commented field still copies back
  byte-for-byte; a changed one re-emits the clean value + the original comment
  (separator whitespace preserved).

## Scope

Covers scalar **map-field** values (`key: value #comment`) — exactly the issue's
shape — for display (all sites) and edit-preservation (top-level + dash keys).
Out of scope (noted for follow-up): scalar **list items** (`- a #c`, parsed via
a different path) still show the comment in the form; nested-mapping scalar
fields aren't comment-preserved when the parent key is edited (consistent with
#1227); ambiguous `key: #comment` / unquoted `color: #ff0000` keep current
behavior.

## Verification

- New tests in `test/util/yaml-section-values.test.ts` (parse-cleans-value,
  keeps non-comment `#`, edit-re-appends, unchanged-verbatim, dash-key).
- Full suite (2236) green; `tsc` clean; prettier.
- Ran the compiled source in real Chrome via CDP/Puppeteer: clean boolean form
  value, comment survives edit, untouched field byte-identical.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1235

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
