### PR TITLE
Localize the component-catalog result counter

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -209,10 +209,12 @@ export class ESPHomeComponentCatalog extends LitElement {
         />
         ${!this._loading
           ? html`<span class="result-count"
-              >${visible.length + bundles.length} of ${this._total + bundles.length}
-              components</span
+              >${this._localize("device.components_count", {
+                visible: visible.length + bundles.length,
+                total: this._total + bundles.length,
+              })}</span
             >`
-          : ""}
+          : nothing}
         <div class="grid-scroll">
           <div class="components-grid">
             ${this._loading

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -642,6 +642,7 @@
     "component_category_featured": "Recommended",
     "search_components_placeholder": "Search components…",
     "no_components_found": "No components found",
+    "components_count": "{visible} of {total} components",
     "add_component_action": "Add",
     "component_added": "Added {name}",
     "featured_bundle_badge": "Bundle",


### PR DESCRIPTION
# What does this implement/fix?

The component catalog's result counter ("12 of 340 components") was hardcoded
English with no translation key, so it couldn't be localized (reported in the
issue).

Add a `device.components_count` key (`"{visible} of {total} components"`) and
render the counter through the existing localizer (the component already
consumes `localizeContext` → `this._localize`, used for the neighbouring
`device.loading_components` / `search_components_placeholder` /
`no_components_found` strings). Mirrors the existing placeholder pattern
(e.g. `dashboard.pagination_page_of`). Also swaps the empty-string branch for
`nothing`.

English source only — other locales are synced from Lokalise (`en.json` is the
sole source of truth; the runtime falls back to English per-key). No
singular/plural variants: the i18n layer is flat `{placeholder}` substitution
with no plural support, and the original text was always plural.

## Verification

- `tsc` + `npm run lint` clean; full suite (2241) green (incl.
  `translation-key-coverage`).
- Confirmed the key interpolates: `{visible:12, total:340}` →
  `"12 of 340 components"`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1233

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
