### PR TITLE
Document and pin comma-safety of the CSV / list splits

### DIFF
--- a/src/components/labels/label-form.ts
+++ b/src/components/labels/label-form.ts
@@ -236,6 +236,9 @@ export class ESPHomeLabelForm extends LitElement {
     const raw = this._localize("dashboard.labels_suggestions");
     if (!raw || raw === "dashboard.labels_suggestions") return [];
     const taken = new Set(this.existingNames.map((n) => n.toLowerCase()));
+    // The translation is a comma-separated list of suggested label names;
+    // the comma is the format's separator, so a name can't contain one. A
+    // plain ``split(",")`` is correct here (#650).
     return raw
       .split(",")
       .map((s) => s.trim())

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1357,6 +1357,10 @@ export class ESPHomePageDevice extends LitElement {
   private _readUrlSections(): number[] {
     const raw = new URLSearchParams(window.location.search).get("open");
     if (!raw) return [];
+    // Section indices are numeric, so a value can never contain a comma —
+    // ``split(",")`` is safe. ``map(Number)`` then ``filter(!isNaN)``
+    // discards non-numeric fragments; an empty fragment coerces to ``0``
+    // (a valid index), not ``NaN`` (#650).
     return raw
       .split(",")
       .map(Number)

--- a/src/util/dashboard-url.ts
+++ b/src/util/dashboard-url.ts
@@ -62,6 +62,9 @@ function fromCsv(raw: string | null): string[] | undefined {
 
 function toCsv(arr: readonly string[] | undefined): string | undefined {
   if (!arr || arr.length === 0) return undefined;
+  // ``encodeURIComponent`` escapes a comma to ``%2C``, so the ``,`` join
+  // separator is unambiguous and ``fromCsv``'s ``split(",")`` is safe even
+  // for a label/filter value that itself contains a comma (#650).
   return arr.map((s) => encodeURIComponent(s)).join(",");
 }
 

--- a/test/util/dashboard-url.test.ts
+++ b/test/util/dashboard-url.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The dashboard filter state round-trips through the URL as
+ * ``encodeURIComponent``-encoded, comma-joined lists. ``encodeURIComponent``
+ * escapes a comma to ``%2C``, so the ``,`` separator is unambiguous even
+ * for a label/filter value that itself contains a comma — this pins that
+ * invariant so a future switch to a non-encoding join would fail loudly
+ * (audit #650).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { readDashboardUrl, writeDashboardUrl } from "../../src/util/dashboard-url.js";
+
+type Globals = Record<string, unknown>;
+
+// Back the stubbed ``window.location`` / ``history`` with a single mutable
+// href so ``writeDashboardUrl``'s ``replaceState`` is visible to a
+// following ``readDashboardUrl``.
+let href = "";
+function installUrl(initial = "http://localhost/dashboard"): void {
+  href = initial;
+  const g = globalThis as Globals;
+  g.window = {
+    location: {
+      get href() {
+        return href;
+      },
+      get search() {
+        return new URL(href).search;
+      },
+    },
+  };
+  g.history = {
+    state: null,
+    replaceState: (_s: unknown, _t: string, next: string) => {
+      href = new URL(next, href).href;
+    },
+  };
+}
+
+afterEach(() => {
+  const g = globalThis as Globals;
+  delete g.window;
+  delete g.history;
+});
+
+describe("dashboard-url comma round-trip", () => {
+  it("preserves a comma inside a label value", () => {
+    installUrl();
+    writeDashboardUrl({ labels: ["a,b", "c"] });
+    expect(readDashboardUrl().labels).toEqual(["a,b", "c"]);
+  });
+
+  it("round-trips multiple filter lists", () => {
+    installUrl();
+    writeDashboardUrl({ labels: ["x,y"], areas: ["Kitchen, Bath"], search: "q,r" });
+    const back = readDashboardUrl();
+    expect(back.labels).toEqual(["x,y"]);
+    expect(back.areas).toEqual(["Kitchen, Bath"]);
+    expect(back.search).toBe("q,r");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Audit of the naive comma splits flagged in #650. All three sites are safe; this documents why and pins the one non-trivial invariant with a test.

`dashboard-url.ts` encodes each value with `encodeURIComponent`, which escapes a comma to `%2C`, so the `,` join separator is unambiguous and a label or filter value containing a comma round-trips correctly. `label-form.ts` splits a localized list of suggested names where the comma is the format separator, so a name cannot contain one. `device.ts` splits numeric section indices, where a comma can never appear.

Adds a round-trip test pinning the dashboard-url invariant so a future switch to a non-encoding join fails loudly, plus a clarifying comment at each site.

**Related issue or feature (if applicable):**

- closes https://github.com/esphome/device-builder-frontend/issues/650

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
