### PR TITLE
Link the board wizard help to the new boards guide

### DIFF
--- a/src/common/docs.ts
+++ b/src/common/docs.ts
@@ -1,0 +1,2 @@
+/** Origin of the ESPHome documentation site; build doc links from this. */
+export const ESPHOME_DOCS_BASE = "https://esphome.io";

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -34,6 +34,7 @@ import type {
   AvailableAutomations,
 } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
@@ -59,7 +60,7 @@ registerMdiIcons({
 /** ESPHome's docs page for the api component (which hosts
  *  ``api.actions:``). Linked from the header so the user lands on
  *  the right docs page from a single click. */
-const API_DOCS_URL = "https://esphome.io/components/api.html";
+const API_DOCS_URL = `${ESPHOME_DOCS_BASE}/components/api.html`;
 
 /** ``AutomationLocation`` variant for ``api.actions:`` entries —
  *  pulled out as a local alias because the api-action editor only

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -35,6 +35,7 @@ import type {
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
+import { ESPHOME_DOCS_BASE } from "../../../common/docs.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
@@ -382,7 +383,7 @@ export class ESPHomeScriptEditor extends LitElement {
     const title = comp?.name ?? this._localize("device.script_header_title_static");
     const descText =
       comp?.description ?? this._localize("device.script_header_description");
-    const docsUrl = comp?.docs_url ?? "https://esphome.io/components/script.html";
+    const docsUrl = comp?.docs_url ?? `${ESPHOME_DOCS_BASE}/components/script.html`;
     const imageUrl = comp?.image_url ?? "";
     return html`<div class="ae-header">
       <div class="ae-header-text">

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -14,6 +14,7 @@ import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { SerialPort } from "../../api/types/system.js";
+import { ESPHOME_DOCS_BASE } from "../../common/docs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
@@ -48,6 +49,9 @@ registerMdiIcons({
   plus: mdiPlus,
   "usb-port": mdiUsbPort,
 });
+
+// "I don't know what board I have" guide on the docs site (device-builder-frontend#114).
+const UNDERSTANDING_BOARDS_DOCS_URL = `${ESPHOME_DOCS_BASE}/guides/understanding_boards/`;
 
 @customElement("esphome-wizard-step-board")
 export class ESPHomeWizardStepBoard extends LitElement {
@@ -241,9 +245,14 @@ export class ESPHomeWizardStepBoard extends LitElement {
                 <wa-icon library="mdi" name="usb-port"></wa-icon>
                 ${this._localize("wizard.connect_your_board")}
               </button>
-              <button class="helper-link" type="button">
+              <a
+                class="helper-link"
+                href=${UNDERSTANDING_BOARDS_DOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 ${this._localize("wizard.dont_know_board")}
-              </button>
+              </a>
             </div>
           `}
 


### PR DESCRIPTION
# What does this implement/fix?

Wires the "I don't know what board I have" link on the board wizard step to the new boards guide; it was a no-op `<button>` before. It now opens `https://esphome.io/guides/understanding_boards/` in a new tab. While here, adds a shared `ESPHOME_DOCS_BASE` constant and builds the existing api and script doc links from it too, so the docs origin lives in one place.

The guide page itself is esphome/esphome.io#6744; merge that first so the link is not a 404.

**Related issue or feature (if applicable):**

- fixes #114

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
