### PR TITLE
Ignore stray top-level YAML so a misplaced config can't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ build/
 !/README.md
 !/CLAUDE.md
 /*.png
+
+# Stray top-level YAML must never be committed: a misplaced device config
+# could leak secrets. Only the tooling config below is tracked; nested
+# YAML is unaffected.
+/*.yaml
+/*.yml
+!/.pre-commit-config.yaml


### PR DESCRIPTION
# What does this implement/fix?

Ignores stray top-level `*.yaml` / `*.yml` so a device config accidentally dropped in the repo root can't be committed (a misplaced config with secrets is a credential-leak risk). Mirrors the existing root-level `/*.md` and `/*.png` rules; `.pre-commit-config.yaml` is negated back, and nested YAML is untouched by the `/` anchor.

Verified with `git check-ignore`: a root `bktest.yaml` is now ignored while `.pre-commit-config.yaml` and `.github/ISSUE_TEMPLATE/config.yml` stay tracked.

## Types of changes

- [x] Maintenance (dependencies, CI, tooling) — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
