### PR TITLE
Always expose the Wi-Fi credentials kebab entry

### DIFF
--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -103,20 +103,21 @@ export interface OnboardingStep {
  * ``src/util/onboarding-gate.ts`` (``shouldAutoShowOnboarding``)
  * with unit-test coverage of every branch.
  *
- * Manual entry via the ``Set up Wi-Fi…`` kebab item bypasses
- * both the version-bump gate and the session-dismiss flag —
- * the click IS the explicit "I want to do this now" signal —
- * but is itself only visible when ``isOnboardingPending`` is
- * true (so the user never sees the entry when there's nothing
- * to do).
+ * Manual entry via the Wi-Fi kebab item bypasses both the
+ * version-bump gate and the session-dismiss flag — the click IS
+ * the explicit "I want to do this now" signal. The entry is
+ * ALWAYS visible so a user can rotate already-configured
+ * credentials without hand-editing ``secrets.yaml``;
+ * ``isOnboardingPending`` only selects its wording (``Set up
+ * Wi-Fi`` when nothing is configured yet vs ``Change Wi-Fi
+ * credentials`` once it is), it no longer gates visibility.
  *
- * Step status also drives the kebab entry's visibility
- * directly. It's computed from live on-disk state on every
+ * That label is computed from live on-disk state on every
  * server-side ``get_state`` call — never persisted — and the
  * dashboard re-fetches on (re)connect AND on every
  * ``secrets-saved`` event, so an in-app save (wizard or
- * Secrets editor) updates the entry in real time and an
- * out-of-band ``secrets.yaml`` edit clears it no later than
+ * Secrets editor) updates the wording in real time and an
+ * out-of-band ``secrets.yaml`` edit flips it no later than
  * the next WS reconnect.
  */
 export interface OnboardingState {

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -71,14 +71,14 @@ export class ESPHomeHeaderActions extends LitElement {
 
   /** True when onboarding still has work to do (currently:
    *  Wi-Fi step pending — data-derived from ``secrets.yaml``).
-   *  Gates a dedicated ``Set up Wi-Fi…`` kebab entry so a user
-   *  who declined the wizard with "I don't use Wi-Fi" — or who
-   *  cleared the credentials by hand from the Secrets editor —
-   *  still has a one-click re-entry into the wizard. The entry
-   *  appears / disappears in real time as ``secrets.yaml``
-   *  changes (the app-shell re-fetches the snapshot on every
-   *  ``secrets-saved`` event). Owned by the app shell, threaded
-   *  via context. */
+   *  The Wi-Fi kebab entry is ALWAYS shown (so a user can rotate
+   *  credentials without hand-editing ``secrets.yaml``); this flag
+   *  only selects the entry's wording — ``Set up Wi-Fi`` when
+   *  nothing is configured yet vs ``Change Wi-Fi credentials`` once
+   *  it is. It tracks ``secrets.yaml`` in real time (the app-shell
+   *  re-fetches the snapshot on every ``secrets-saved`` event), so
+   *  the label flips the moment credentials are saved or cleared.
+   *  Owned by the app shell, threaded via context. */
   @consume({ context: onboardingPendingContext, subscribe: true })
   @state()
   private _onboardingPending = false;
@@ -322,20 +322,20 @@ export class ESPHomeHeaderActions extends LitElement {
                 <wa-icon library="mdi" name="key-variant"></wa-icon>
                 <span class="menu-item-label">${this._localize("layout.secrets")}</span>
               </div>
-              ${this._onboardingPending
-                ? html`<div
-                    class="menu-item"
-                    role="menuitem"
-                    tabindex="0"
-                    @click=${this._openOnboarding}
-                    @keydown=${this._onMenuItemKeydown}
-                  >
-                    <wa-icon library="mdi" name="wifi-cog"></wa-icon>
-                    <span class="menu-item-label"
-                      >${this._localize("onboarding.menu_item_setup_wifi")}</span
-                    >
-                  </div>`
-                : nothing}
+              <div
+                class="menu-item"
+                role="menuitem"
+                tabindex="0"
+                @click=${this._openOnboarding}
+                @keydown=${this._onMenuItemKeydown}
+              >
+                <wa-icon library="mdi" name="wifi-cog"></wa-icon>
+                <span class="menu-item-label"
+                  >${this._onboardingPending
+                    ? this._localize("onboarding.menu_item_setup_wifi")
+                    : this._localize("onboarding.menu_item_change_wifi")}</span
+                >
+              </div>
               <div
                 class="menu-item"
                 role="menuitem"
@@ -463,11 +463,11 @@ export class ESPHomeHeaderActions extends LitElement {
     navigate("/secrets");
   }
 
-  /** Re-launches the onboarding wizard on demand. The kebab item
-   *  is gated on ``_onboardingPending`` (data-derived from
-   *  ``secrets.yaml``), so it appears only when there's actually
-   *  something to onboard — a user who declined "I don't use Wi-Fi"
-   *  earlier sees the entry and can change their mind. */
+  /** Opens the Wi-Fi credentials dialog on demand. The kebab item
+   *  is always present (its label tracks ``_onboardingPending`` —
+   *  setup vs change), so a user can both complete first-run setup
+   *  and rotate already-configured credentials without ever
+   *  hand-editing ``secrets.yaml``. */
   private _openOnboarding() {
     this._close();
     this.dispatchEvent(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -866,6 +866,7 @@
   },
   "onboarding": {
     "menu_item_setup_wifi": "Set up Wi-Fi",
+    "menu_item_change_wifi": "Change Wi-Fi credentials",
     "wifi": {
       "title": "Set up Wi-Fi credentials",
       "intro": "Your devices use these to join your network. They're stored once in secrets.yaml and shared across every config you create.",


### PR DESCRIPTION
# What does this implement/fix?

The "Set up Wi-Fi" entry in the header kebab was hidden once `secrets.yaml` had Wi-Fi credentials, so a user who wanted to rotate their password had no UI path and had to hand edit YAML. This renders the entry unconditionally; the onboarding-pending flag now only picks the wording, "Set up Wi-Fi" when nothing is configured yet, "Change Wi-Fi credentials" once it is.

The dialog is reused as is, and the auto-pop gate (`shouldAutoShowOnboarding`) is untouched, so configured users get a permanent menu entry without the wizard popping up on load.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
