### PR TITLE
Split list-form triggers whose entries sit at the key's indent

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -274,6 +274,13 @@ export function renderYamlOnlyFallbackIfNonPrimitive(
   raw: unknown
 ) {
   if (isPrimitiveOrNullish(raw)) return null;
+  return renderYamlOnlyField(entry, path, ctx);
+}
+
+/** The "this value can only be edited in YAML" field shell — shown when a
+ *  value's shape (a mapping, or a list whose items are mappings) can't be
+ *  driven by the scalar/multi-value inputs. */
+export function renderYamlOnlyField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}

--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -9,6 +9,7 @@ import {
   labelFor,
   renderFieldError,
   renderLabel,
+  renderYamlOnlyField,
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
@@ -83,6 +84,14 @@ export function renderMultiValueField(
   path: string[],
   ctx: RenderCtx
 ) {
+  const raw = readArrayAt(ctx, path);
+  // A list whose items are mappings (a backend list-of-dicts the schema
+  // bundle couldn't type as nested, e.g. a light's ``segments``) can't be
+  // driven by scalar rows — ``String({…})`` would render "[object Object]"
+  // and a save would clobber the data. Edit those in the YAML pane.
+  if (raw.some((v) => !isPrimitiveOrNullish(v))) {
+    return renderYamlOnlyField(entry, path, ctx);
+  }
   // Show escape-worthy code points (control / Private-Use, e.g. MDI font
   // glyphs) as ``\U…`` so an otherwise-invisible value is editable, and
   // decode on input (device-builder#1232). Escaping is unconditional so
@@ -91,7 +100,7 @@ export function renderMultiValueField(
   // back unchanged, rather than being rewritten on a no-op edit. Decoding
   // must stay unconditional too — a freshly added row is empty, so a typed
   // ``\U…`` has to decode without a prior escape-worthy value to gate on.
-  const items: string[] = readArrayAt(ctx, path).map((v) => escapeForInput(String(v)));
+  const items: string[] = raw.map((v) => escapeForInput(String(v)));
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   const { addItem, removeAt } = arrayItemHandlers(ctx, path, () => "");

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -246,13 +246,18 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
   return automations;
 }
 
-/** First non-empty line at indent ≤ ``indent`` after ``startIdx``,
- *  or end-of-file. */
+/** First line that closes the block opened at ``startIdx``, or
+ *  end-of-file. Blank and comment lines never close a block. A
+ *  block-sequence value may sit at its key's own indent (``on_*:``
+ *  with the ``- `` items un-indented), so a same-indent list dash
+ *  continues the block; only a same-indent non-dash line closes it. */
 function _findBlockEnd(lines: string[], startIdx: number, indent: number): number {
   for (let j = startIdx + 1; j < lines.length; j++) {
-    if (lines[j].trim() === "") continue;
+    const trimmed = lines[j].trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
     const lineIndent = (lines[j].match(/^(\s*)/) ?? ["", ""])[1].length;
-    if (lineIndent <= indent) return j;
+    if (lineIndent < indent) return j;
+    if (lineIndent === indent && !/^\s*-\s/.test(lines[j])) return j;
   }
   return lines.length;
 }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -5,6 +5,7 @@
  * unaffected; import from there or from here directly.
  */
 
+import { endsBlockAtIndent } from "./yaml-section-lexer.js";
 import {
   instanceComponentId,
   listItemChildIndent,
@@ -246,20 +247,14 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
   return automations;
 }
 
-/** First line that closes the block opened at ``startIdx``, or
- *  end-of-file. Blank and comment lines never close a block. A
- *  block-sequence value may sit at its key's own indent (``on_*:``
- *  with the ``- `` items un-indented), so a same-indent list dash
- *  continues the block; only a same-indent non-dash line closes it. */
+/** Index of the first line past the block opened at ``startIdx`` (its key
+ *  at ``indent`` columns), or ``lines.length`` at EOF. Read as a 1-indexed
+ *  line number this is the block's last content line, so callers use it
+ *  directly as a section's ``toLine``. The same-indent-sequence and comment
+ *  rules live in ``endsBlockAtIndent``. */
 function _findBlockEnd(lines: string[], startIdx: number, indent: number): number {
   for (let j = startIdx + 1; j < lines.length; j++) {
-    const trimmed = lines[j].trim();
-    if (trimmed === "" || trimmed.startsWith("#")) continue;
-    const lineIndent = (lines[j].match(/^(\s*)/) ?? ["", ""])[1].length;
-    if (lineIndent < indent) return j;
-    // A bare ``-`` (value on the next line) is still a list item, so
-    // match end-of-line too — mirrors ``LIST_ITEM_START_RE``.
-    if (lineIndent === indent && !/^\s*-(\s|$)/.test(lines[j])) return j;
+    if (endsBlockAtIndent(lines[j], indent)) return j;
   }
   return lines.length;
 }

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -257,7 +257,9 @@ function _findBlockEnd(lines: string[], startIdx: number, indent: number): numbe
     if (trimmed === "" || trimmed.startsWith("#")) continue;
     const lineIndent = (lines[j].match(/^(\s*)/) ?? ["", ""])[1].length;
     if (lineIndent < indent) return j;
-    if (lineIndent === indent && !/^\s*-\s/.test(lines[j])) return j;
+    // A bare ``-`` (value on the next line) is still a list item, so
+    // match end-of-line too — mirrors ``LIST_ITEM_START_RE``.
+    if (lineIndent === indent && !/^\s*-(\s|$)/.test(lines[j])) return j;
   }
   return lines.length;
 }

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -277,3 +277,23 @@ export const isChildListItemLine = (line: string, parentIndent: string): boolean
   const tail = line.slice(lead.length);
   return tail === "-" || tail.startsWith("- ");
 };
+
+/**
+ * The one rule for "where does a block end". True when *line* terminates a
+ * block whose opener key sits at *openerIndent* columns. Blank and
+ * comment-only lines never terminate (they belong to the block); a line
+ * indented deeper is the block's body; a *same-indent* compact
+ * block-sequence dash (``calibration:\n- a\n- b``, bare ``-`` or ``- x``)
+ * continues the block; any other same-indent or shallower line ends it.
+ *
+ * Every block-boundary scan funnels through here so the same-indent-
+ * sequence and comment cases are handled in one place instead of being
+ * relearned (and mis-learned) per call site.
+ */
+export const endsBlockAtIndent = (line: string, openerIndent: number): boolean => {
+  if (isBlankOrCommentLine(line)) return false;
+  const lineIndent = _leadingIndent(line).length;
+  if (lineIndent < openerIndent) return true;
+  if (lineIndent > openerIndent) return false;
+  return !isChildListItemLine(line, line.slice(0, lineIndent));
+};

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -14,6 +14,7 @@ import {
 import {
   BLOCK_SCALAR_INLINE_RE,
   BLOCK_SCALAR_RE,
+  endsBlockAtIndent,
   isBlankOrCommentLine,
   LIST_ITEM_BARE_DASH_RE,
   LIST_ITEM_DICT_KEY_RE,
@@ -160,16 +161,9 @@ export const _scanValueBlock = (
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i];
     if (isBlankOrCommentLine(line)) continue;
-    const lead = line.match(/^ */)![0];
-    if (lead.length < keyIndent.length) return { endIdx: i, isComplex };
-    if (lead.length === keyIndent.length) {
-      // YAML's compact block-sequence form allows a child list to
-      // share the parent key's indent (``calibration:\n- a\n- b``).
-      // Same-indent dash lines stay in the block; any other shape
-      // at this indent terminates as before.
-      const tail = line.slice(lead.length);
-      if (tail !== "-" && !tail.startsWith("- ")) return { endIdx: i, isComplex };
-    }
+    // Same-indent compact block-sequence + comment rules live in
+    // ``endsBlockAtIndent`` (see the lexer).
+    if (endsBlockAtIndent(line, keyIndent.length)) return { endIdx: i, isComplex };
     if (!isComplex) {
       if (
         BLOCK_SCALAR_RE.test(line) ||

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -13,6 +13,7 @@
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { indentOf, RE_PAIR_LINE, stripComment } from "./yaml-line-walker.js";
+import { endsBlockAtIndent } from "./yaml-section-lexer.js";
 
 /** A YAML list-item line: leading indent, a dash, then a space or EOL. */
 const RE_LIST_ITEM = /^\s*-(\s|$)/;
@@ -401,8 +402,9 @@ export function findFieldLine(
       if (rest.length === 0) return i + 1;
       let blockHi = hi;
       for (let j = i + 1; j <= hi; j++) {
-        const cs = stripComment(lines[j]);
-        if (cs.trim() && indentOf(cs) <= baseIndent) {
+        // Shared block-end rule: a same-indent compact block-sequence
+        // value (``key:\n- a\n- b``) stays in the block; comments don't end it.
+        if (endsBlockAtIndent(lines[j], baseIndent)) {
           blockHi = j - 1;
           break;
         }

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../src/api/types/config-entries.js";
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderMultiValueField } from "../../../src/components/device/config-entry-renderers/lists.js";
 import {
   renderBooleanField,
   renderFloatWithUnitField,
@@ -208,6 +209,36 @@ describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primi
     const tpl = renderFloatWithUnitField(entry, ["frequency"], ctx);
     const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
     expect(rendersBailBranch(json)).toBe(false);
+  });
+});
+
+// A backend list-of-dicts the schema bundle couldn't type as nested can
+// arrive as multi_value=true with scalar type (a light's ``segments``).
+// The scalar-row editor would render "[object Object]" per item and a
+// save would clobber the dicts, so it bails to the YAML-only notice.
+describe("renderMultiValueField — bail when items are mappings", () => {
+  const entry = (): ConfigEntry =>
+    makeConfigEntry({
+      key: "segments",
+      type: ConfigEntryType.STRING,
+      label: "Segments",
+      multi_value: true,
+    });
+
+  it("renders editable rows for a list of scalars", () => {
+    const { ctx } = makeCtx({ segments: ["ON for 1s", "OFF for 500ms"] });
+    const tpl = renderMultiValueField(entry(), ["segments"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(false);
+    expect(json).toContain("multi-input");
+  });
+
+  it("bails when an item is a mapping", () => {
+    const { ctx } = makeCtx({ segments: [{ id: "a", from: 0, to: 10 }] });
+    const tpl = renderMultiValueField(entry(), ["segments"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(rendersBailBranch(json)).toBe(true);
+    expect(json).not.toContain("multi-input");
   });
 });
 

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -84,6 +84,23 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["areas", "0", "name_add_mac"])).toBeNull();
   });
 
+  it("descends a same-indent compact block-sequence value", () => {
+    // ``items:`` carries its list at the key's own indent (YAML's compact
+    // block-sequence form). The block-end scan must keep those dashes in
+    // the block or descending into ``items.0`` fails and returns null.
+    const yaml = [
+      "wifi:",
+      "  group:",
+      "    items:",
+      "    - ssid: a",
+      "    - ssid: b",
+      "",
+    ].join("\n");
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["group", "items", "0", "ssid"])).toBe(4);
+    expect(findFieldLine(yaml, section, ["group", "items", "1", "ssid"])).toBe(5);
+  });
+
   it("resolves a numeric mapping key instead of reading it as a list index", () => {
     const yaml = ["substitutions:", "  0: zero", "  name: x", ""].join("\n");
     const section = sectionAt(yaml, 1);

--- a/test/util/yaml-section-lexer.test.ts
+++ b/test/util/yaml-section-lexer.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { endsBlockAtIndent } from "../../src/util/yaml-section-lexer.js";
+
+describe("endsBlockAtIndent", () => {
+  // The single source of truth for "where does a block end", shared by
+  // every block-boundary scan (_findBlockEnd, _scanValueBlock, findFieldLine).
+  const OPENER = 2; // a key at two columns, e.g. ``  areas:``
+
+  it("never ends on blank or comment-only lines", () => {
+    expect(endsBlockAtIndent("", OPENER)).toBe(false);
+    expect(endsBlockAtIndent("   ", OPENER)).toBe(false);
+    expect(endsBlockAtIndent("# banner", OPENER)).toBe(false);
+    expect(endsBlockAtIndent("    # indented note", OPENER)).toBe(false);
+  });
+
+  it("keeps deeper-indented body lines in the block", () => {
+    expect(endsBlockAtIndent("      number: 33", OPENER)).toBe(false);
+  });
+
+  it("ends on a shallower line (back-out) or a same-indent sibling key", () => {
+    expect(endsBlockAtIndent("name: x", OPENER)).toBe(true); // shallower
+    expect(endsBlockAtIndent("  id: x", OPENER)).toBe(true); // same-indent non-dash
+  });
+
+  it("continues on a same-indent compact block-sequence dash, bare or with content", () => {
+    expect(endsBlockAtIndent("  - name: zombie", OPENER)).toBe(false);
+    expect(endsBlockAtIndent("  -", OPENER)).toBe(false);
+  });
+
+  it("ends on a same-indent line that only looks like a dash (e.g. -name)", () => {
+    expect(endsBlockAtIndent("  -name: x", OPENER)).toBe(true);
+  });
+});

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -611,6 +611,40 @@ describe("parseYamlAutomations", () => {
     ]);
   });
 
+  it("splits an on_multi_click whose entries sit at the key indent with comments", () => {
+    // The ``- timing:`` items align with ``on_multi_click:`` (a valid
+    // block-sequence value at the key's own indent) and ``# S`` / ``# L``
+    // comments sit between them; the block scan must look past both or the
+    // list collapses to one un-indexed row that never matches the backend.
+    const yaml = `binary_sensor:
+  - platform: gpio
+    id: button_main
+    on_multi_click:
+    # S
+    - timing:
+        - ON for 50ms to 500ms
+        - OFF for at least 500ms
+      then:
+        - switch.toggle: usb
+    # L
+    - timing:
+        - ON for 1s to 3s
+        - OFF for at least 500ms
+      then:
+        - switch.turn_on: socket_1
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:button_main:on_multi_click")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:button_main:on_multi_click:0",
+      "automation:component_on:button_main:on_multi_click:1",
+    ]);
+    expect(items[0].displayLabel).toBe("button_main → on_multi_click #1");
+    expect(items[0].fromLine).toBe(6); // first ``- timing:``
+    expect(items[1].fromLine).toBe(12); // second ``- timing:``
+  });
+
   it("does not split a bare action list into per-action rows", () => {
     const yaml = `binary_sensor:
   - platform: gpio

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -645,6 +645,29 @@ describe("parseYamlAutomations", () => {
     expect(items[1].fromLine).toBe(12); // second ``- timing:``
   });
 
+  it("keeps splitting when a bare-dash placeholder row sits among the entries", () => {
+    // A bare ``-`` (no value yet, mid-edit) at the key indent must not
+    // close the block — otherwise the real entry after it collapses to one
+    // un-indexed row. The dash test matches end-of-line, like the lexer's
+    // ``LIST_ITEM_START_RE``.
+    const yaml = `binary_sensor:
+  - platform: gpio
+    id: button_main
+    on_multi_click:
+    -
+    - timing:
+        - ON for 1s to 3s
+      then:
+        - switch.toggle: usb
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:button_main:on_multi_click")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:component_on:button_main:on_multi_click:0",
+    ]);
+  });
+
   it("does not split a bare action list into per-action rows", () => {
     const yaml = `binary_sensor:
   - platform: gpio


### PR DESCRIPTION
# What does this implement/fix?

In the Visual Editor, a binary_sensor on_multi_click written with its `- timing:` items aligned to the `on_multi_click:` key (a valid block-sequence value at the key's own indent), with `# S` / `# L` comments between the entries, showed a blank Timing field and "No actions defined yet." The backend parses that YAML correctly; the navigator's synchronous block scan stopped at the first comment and never saw the list, so it emitted one un-indexed row whose key did not match the backend's per-entry location, and the editor hydrated an empty tree.

The root issue is that "where does a block end" (same-indent compact block-sequence values stay in the block; comments and blanks do not end it; a bare `-` is still a list item) was being relearned per call site, and not every site got it right. This adds a single `endsBlockAtIndent` helper in the lexer as the source of truth (reusing `isBlankOrCommentLine` and `isChildListItemLine`) and routes every block-boundary scan through it: `_findBlockEnd` (the on_multi_click fix), `_scanValueBlock`, and `findFieldLine`, the last of which had the same latent flaw and would cut a same-indent list value short. Tests cover the helper directly plus regressions for the multi_click split, a bare-dash placeholder row, and a same-indent field descent.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1250

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
