### PR TITLE
Ignore editor swap and backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ build/
 /*.yaml
 /*.yml
 !/.pre-commit-config.yaml
+
+# Editor swap/backup files — a vim swap of a secrets file would leak
+# credentials, and `.swp` slips past the `*.yaml` rule above.
+*.swp
+*.swo
+*~


### PR DESCRIPTION
# What does this implement/fix?

A vim swap of a secrets file is named like .secrets.yaml.swp; it ends in .swp, so it slips past the existing /*.yaml rule and can be committed, which would leak credentials. This ignores *.swp, *.swo, and *~ so editor swap and backup files can never be committed.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
