### PR TITLE
Ignore editor swap & backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,4 @@ build/
 
 # Editor swap/backup files — a vim swap of a secrets file would leak
 # credentials, and `.swp` slips past the `*.yaml` rule above.
-*.swp
 *.swo
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 # swap such as .secrets.yaml.swp can hold unsaved buffer contents,
 # including secrets, so the whole range must be ignored.
 *.sw[a-p]
+*.swo
 *~
 .claude/*
 !.claude/skills/
@@ -40,6 +41,4 @@ build/
 /*.yml
 !/.pre-commit-config.yaml
 
-# Editor swap/backup files — a vim swap of a secrets file would leak
-# credentials, and `.swp` slips past the `*.yaml` rule above.
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ build/
 # from src/translations/*.json by build-scripts/gen-language-manifest.cjs.
 /src/generated/
 .DS_Store
+# Editor swap & backup files. Vim rotates .swp/.swo/.swn/.swm/... and a
+# swap such as .secrets.yaml.swp can hold unsaved buffer contents,
+# including secrets, so the whole range must be ignored.
+*.sw[a-p]
+*~
 .claude/*
 !.claude/skills/
 # Stray notes / screenshots dropped at the repo root during development.

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ build/
 /*.yml
 !/.pre-commit-config.yaml
 
-*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ build/
 /*.yaml
 /*.yml
 !/.pre-commit-config.yaml
-


### PR DESCRIPTION
# What does this implement/fix?

Editors like vim drop swap files (for example `.secrets.yaml.swp`) next to the file being edited, and those buffers can hold live secrets before they ever hit disk. This repo did not ignore any of them. This adds `*.sw[a-p]` (the full vim swap rotation, `.swp`/`.swo`/`.swn`/...) plus `*~` backups so an editor swap or backup file can never be committed.

Nothing is being removed; no swap file was ever committed here, this is purely preventive. Companion change in esphome/device-builder#1254.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
