### PR TITLE
Surface the backend error detail in the secrets save toast

### DIFF
--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -3,6 +3,7 @@ import { mdiContentSave, mdiEye, mdiEyeOff } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import toast from "sonner-js";
+import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
@@ -307,7 +308,9 @@ export class ESPHomePageSecrets extends LitElement {
     // sequence the device editor fixed under issue #436.
     let saved = true;
     // Backend rejection detail (e.g. the secrets.yaml parse error with
-    // line/column) so the failure toast can name what's wrong.
+    // line/column) so the failure toast can name what's wrong. Read the
+    // structured APIError.details, not Error.message, which is prefixed
+    // with the internal error_code.
     let errorDetail = "";
     try {
       await this._api.updateConfig(SECRETS_FILE, this._yaml);
@@ -320,7 +323,7 @@ export class ESPHomePageSecrets extends LitElement {
       if (!msg.includes("timed out")) {
         saved = false;
         this._savedYaml = previousSaved;
-        errorDetail = msg;
+        errorDetail = apiErrorDetails(e);
       }
     } finally {
       this._saving = false;

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -306,6 +306,9 @@ export class ESPHomePageSecrets extends LitElement {
     // save secrets" on a real backend rejection — the misleading
     // sequence the device editor fixed under issue #436.
     let saved = true;
+    // Backend rejection detail (e.g. the secrets.yaml parse error with
+    // line/column) so the failure toast can name what's wrong.
+    let errorDetail = "";
     try {
       await this._api.updateConfig(SECRETS_FILE, this._yaml);
     } catch (e) {
@@ -317,6 +320,7 @@ export class ESPHomePageSecrets extends LitElement {
       if (!msg.includes("timed out")) {
         saved = false;
         this._savedYaml = previousSaved;
+        errorDetail = msg;
       }
     } finally {
       this._saving = false;
@@ -331,9 +335,14 @@ export class ESPHomePageSecrets extends LitElement {
         new CustomEvent("secrets-saved", { detail: { source: this } })
       );
     }
-    const message = saved ? "secrets.saved" : "secrets.save_error";
-    const variant = saved ? toast.success : toast.error;
-    variant(this._localize(message), { richColors: true });
+    if (saved) {
+      toast.success(this._localize("secrets.saved"), { richColors: true });
+      return;
+    }
+    const base = this._localize("secrets.save_error");
+    toast.error(errorDetail ? `${base}: ${errorDetail}` : base, {
+      richColors: true,
+    });
   }
 }
 

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -164,6 +164,27 @@ describe("esphome-page-secrets save toast ordering", () => {
     expect(page._savedYaml).toBe("wifi_password: old\n");
   });
 
+  test("_save() surfaces the backend rejection message in the error toast", async () => {
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    const page = makePage({
+      _loaded: true,
+      _yaml: "wifi_ssid: home\nxx:xxx\n",
+      _savedYaml: "wifi_ssid: old\n",
+    });
+    const detail =
+      "refusing to save invalid secrets.yaml: could not find expected ':' at line 2, column 1";
+    page._api = {
+      updateConfig: vi.fn().mockRejectedValue(new Error(detail)),
+    } as unknown as ESPHomeAPI;
+
+    await page._save();
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    const [message] = vi.mocked(toast.error).mock.calls[0];
+    expect(message).toContain(detail);
+  });
+
   test("_save() toasts success and fires secrets-saved only after the write resolves", async () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import toast from "sonner-js";
 
+import { APIError } from "../../src/api/api-error.js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { ESPHomePageSecrets } from "../../src/pages/secrets.js";
 import {
@@ -164,7 +165,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     expect(page._savedYaml).toBe("wifi_password: old\n");
   });
 
-  test("_save() surfaces the backend rejection message in the error toast", async () => {
+  test("_save() surfaces the backend rejection detail without the error_code prefix", async () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
     const page = makePage({
@@ -174,8 +175,10 @@ describe("esphome-page-secrets save toast ordering", () => {
     });
     const detail =
       "refusing to save invalid secrets.yaml: could not find expected ':' at line 2, column 1";
+    // Real updateConfig() failures are APIError, whose user-facing text
+    // lives in .details while .message carries the internal error_code.
     page._api = {
-      updateConfig: vi.fn().mockRejectedValue(new Error(detail)),
+      updateConfig: vi.fn().mockRejectedValue(new APIError("invalid_request", detail)),
     } as unknown as ESPHomeAPI;
 
     await page._save();
@@ -183,6 +186,7 @@ describe("esphome-page-secrets save toast ordering", () => {
     expect(toast.error).toHaveBeenCalledTimes(1);
     const [message] = vi.mocked(toast.error).mock.calls[0];
     expect(message).toContain(detail);
+    expect(message).not.toContain("invalid_request");
   });
 
   test("_save() toasts success and fires secrets-saved only after the write resolves", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When saving the Secrets editor fails, the toast showed a fixed "Failed to save secrets" string and dropped the reason. The backend now rejects an invalid `secrets.yaml` with a specific message (the parser error with line and column), so this surfaces that message in the error toast instead of the generic one. The reason is captured from the rejection in `_save`, and a real failure shows `<localized error>: <backend detail>`; a timeout is still treated as success and the success path is unchanged.

Pairs with the backend guard in esphome/device-builder#1253.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1252

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
