### PR TITLE
Show the resolved node name in the navigator core subtitle

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -135,6 +135,13 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property()
   configuration = "";
 
+  /** Backend-resolved node name (esphome.name with substitutions
+   *  expanded). Preferred over the raw YAML scalar for the esphome
+   *  core section's subtitle so a `name: $devicename` doesn't leak
+   *  the unexpanded `$devicename` into the navigator. */
+  @property()
+  deviceName = "";
+
   /** Device's target platform — forwarded to add-component / add-config
    * dialogs so the backend can resolve per-platform default values. */
   @property()
@@ -508,7 +515,14 @@ export class ESPHomeDeviceNavigator extends LitElement {
     const cached = getCachedComponent(raw, this.platform || undefined);
     if (cached?.name) primary = cached.name;
 
-    const named = item.name || item.id;
+    // Prefer the backend-resolved node name for the esphome core
+    // section so a `name: $devicename` substitution shows the
+    // expanded hostname, not the raw scalar. Falls back to the raw
+    // YAML value for a new/unsaved device not yet in the devices list.
+    const named =
+      category === "core" && item.key === "esphome" && this.deviceName
+        ? this.deviceName
+        : item.name || item.id;
     const secondary = named && named !== primary ? named : undefined;
 
     return { primary, secondary };

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1091,6 +1091,7 @@ export class ESPHomePageDevice extends LitElement {
       .board=${this._board}
       .boardName=${this._board?.name ?? ""}
       .configuration=${this.id}
+      .deviceName=${this._device?.name ?? ""}
       .platform=${this._board?.esphome.platform ?? ""}
       .platformReady=${this._platformReady}
       .selectedKey=${this._selectedSection}

--- a/test/components/device/device-navigator-labels.test.ts
+++ b/test/components/device/device-navigator-labels.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Behavioral tests for ``device-navigator``'s core-section subtitle.
+ * The esphome row must show the backend-resolved node name (so a
+ * ``name: $devicename`` substitution renders the expanded hostname),
+ * falling back to the raw YAML scalar when no resolved name is known.
+ * The dialog children are no-oped so the element constructs in
+ * happy-dom; see ``device-navigator-coalesce.test.ts``.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-config-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-script-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+
+async function mountNavigator(
+  props: Partial<{ yaml: string; deviceName: string }> = {}
+): Promise<ESPHomeDeviceNavigator> {
+  const nav = new ESPHomeDeviceNavigator();
+  if (props.yaml !== undefined) nav.yaml = props.yaml;
+  if (props.deviceName !== undefined) nav.deviceName = props.deviceName;
+  // Core is the first section; open it so its items render.
+  nav.openSections = new Set([0]);
+  document.body.appendChild(nav);
+  await nav.updateComplete;
+  return nav;
+}
+
+/** Subtitle text of the (single) rendered core nav item. */
+function coreSubtitle(nav: ESPHomeDeviceNavigator): string | undefined {
+  return nav.shadowRoot
+    ?.querySelector(".nav-item .nav-item-subtitle")
+    ?.textContent?.trim();
+}
+
+describe("device-navigator core subtitle", () => {
+  // Clear the shared component-name cache around each test so a
+  // resolved ``esphome`` entry from another test can't shift the
+  // primary label and make these assertions order-dependent.
+  beforeEach(() => {
+    _clearComponentCache();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    _clearComponentCache();
+  });
+
+  it("shows the resolved node name for a $var substitution", async () => {
+    const nav = await mountNavigator({
+      yaml: "esphome:\n  name: $devicename\n",
+      deviceName: "acfloatmonitor32",
+    });
+    expect(coreSubtitle(nav)).toBe("acfloatmonitor32");
+  });
+
+  it("falls back to the raw scalar when no resolved name is known", async () => {
+    const nav = await mountNavigator({
+      yaml: "esphome:\n  name: $devicename\n",
+      deviceName: "",
+    });
+    expect(coreSubtitle(nav)).toBe("$devicename");
+  });
+
+  it("prefers the resolved name even over a plain literal name", async () => {
+    // The backend-resolved name is canonical; with a device in the
+    // list we always show it for the esphome row.
+    const nav = await mountNavigator({
+      yaml: "esphome:\n  name: my_device\n",
+      deviceName: "my_device",
+    });
+    expect(coreSubtitle(nav)).toBe("my_device");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The device editor's left navigator showed the raw `esphome: name:` scalar as the ESPHome Core Configuration subtitle, so a `name: $devicename` substitution displayed the literal `$devicename` instead of the resolved hostname.

This threads the backend-resolved `ConfiguredDevice.name` (already in scope on the device page) into the navigator and prefers it for the esphome core section subtitle; it falls back to the raw scalar for a device not yet in the devices list, so a new or unsaved device does not blank out. Scope is limited to the esphome section's name, no backend roundtrip is needed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1256
- fixes https://github.com/esphome/device-builder/issues/1248

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

