### PR TITLE
Follow-up: reveal and stale-error fixes in the add-secret dialog

### DIFF
--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -8,6 +8,7 @@ import { mdiAlertCircleOutline, mdiClose, mdiPlus } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
+import toast from "sonner-js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { devicesContext, localizeContext } from "../../context/index.js";
@@ -343,9 +344,11 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
 
   // A splice helper returns null when its target line no longer matches
   // (a stale index from a concurrent edit). Re-render so the optimistic
-  // input snaps back to the unchanged buffer rather than diverging from it.
+  // input snaps back to the unchanged buffer, and toast so the dropped
+  // edit is visible rather than a silent no-op.
   private _emit(value: string | null) {
     if (value === null) {
+      toast.error(this._localize("secrets.edit_out_of_sync"), { richColors: true });
       this.requestUpdate();
       return;
     }

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -175,9 +175,10 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
             .value=${live(this._addTarget)}
             @change=${(e: Event) => {
               this._addTarget = (e.target as HTMLSelectElement).value;
-              // The full key includes the ``<device>__`` prefix, so a new
-              // target can resolve a duplicate-key error — clear it.
-              this._addError = null;
+              // A new target can resolve (or re-introduce) a duplicate via the
+              // ``<device>__`` prefix, but can't fix an invalid name; recompute
+              // only when an error is already shown so it isn't blanket-cleared.
+              if (this._addError) this._addError = this._addKeyError();
             }}
           >
             <option value="">${this._localize("secrets.group_shared")}</option>
@@ -325,21 +326,33 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     this._addOpen = false;
   };
 
+  private _addKey(): string {
+    return (this._addTarget ? `${this._addTarget}__` : "") + this._addName.trim();
+  }
+
+  // Validate the dialog's name against the chosen target; null when valid.
+  // The duplicate check depends on the ``<device>__`` prefix, so it can flip
+  // when the target changes — an invalid identifier never can.
+  private _addKeyError(): string | null {
+    if (!isValidSecretKey(this._addName.trim())) {
+      return this._localize("secrets.invalid_key");
+    }
+    if (parseSecretsEntries(this.value).some((entry) => entry.key === this._addKey())) {
+      return this._localize("secrets.duplicate_key");
+    }
+    return null;
+  }
+
   // Create the secret in one shot from the dialog fields, prefixing the key
   // with ``<device>__`` when a device was chosen so it lands in that group.
   private _confirmAdd = () => {
-    const name = this._addName.trim();
-    const key = (this._addTarget ? `${this._addTarget}__` : "") + name;
-    if (!isValidSecretKey(name)) {
-      this._addError = this._localize("secrets.invalid_key");
-      return;
-    }
-    if (parseSecretsEntries(this.value).some((entry) => entry.key === key)) {
-      this._addError = this._localize("secrets.duplicate_key");
+    const error = this._addKeyError();
+    if (error) {
+      this._addError = error;
       return;
     }
     this._addOpen = false;
-    this._emit(addSecret(this.value, key, this._addValue));
+    this._emit(addSecret(this.value, this._addKey(), this._addValue));
   };
 
   // A splice helper returns null when its target line no longer matches

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -172,8 +172,12 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
           <select
             class="add-select"
             .value=${live(this._addTarget)}
-            @change=${(e: Event) =>
-              (this._addTarget = (e.target as HTMLSelectElement).value)}
+            @change=${(e: Event) => {
+              this._addTarget = (e.target as HTMLSelectElement).value;
+              // The full key includes the ``<device>__`` prefix, so a new
+              // target can resolve a duplicate-key error — clear it.
+              this._addError = null;
+            }}
           >
             <option value="">${this._localize("secrets.group_shared")}</option>
             ${this._devices.map(
@@ -204,6 +208,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
           >
           <esphome-password-input
             .value=${this._addValue}
+            .revealed=${this.revealSensitive}
             @password-input-change=${(e: CustomEvent<PasswordInputValueChange>) =>
               (this._addValue = e.detail.value)}
           ></esphome-password-input>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1243,6 +1243,7 @@
     "remove_secret": "Remove secret",
     "group_shared": "Shared",
     "open_device": "Open this device",
+    "edit_out_of_sync": "That change couldn't be applied; the editor was out of sync and has been refreshed.",
     "unsaved_title": "Unsaved secrets",
     "unsaved_message": "You have unsaved changes to your secrets. If you leave without saving, they will be lost.",
     "add_dialog_title": "Add a secret",

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -1,10 +1,15 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import toast from "sonner-js";
+
 // wa-dialog / wa-button run form-validation lifecycle hooks happy-dom doesn't
 // implement; stub them so the add-secret dialog can render in the test.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
 
 import { ESPHomeSecretsStructuredEditor } from "../../../src/components/secrets/secrets-structured-editor.js";
 
@@ -103,6 +108,16 @@ describe("esphome-secrets-structured-editor", () => {
     const captured = onChange(el);
     rows(el)[0].querySelector<HTMLButtonElement>(".icon-btn")!.click();
     expect(captured.value).toBe("api_key: abc\n");
+  });
+
+  test("a null splice (stale index) toasts and emits nothing", async () => {
+    vi.mocked(toast.error).mockClear();
+    const el = await mount("wifi_ssid: home\n");
+    const captured = onChange(el);
+    // Removing an out-of-range line returns null from the splice helper.
+    (el as unknown as { _emit(v: string | null): void })._emit(null);
+    expect(captured.value).toBeNull();
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   interface AddView {

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -188,18 +188,37 @@ describe("esphome-secrets-structured-editor", () => {
     expect((pw as unknown as { revealed: boolean }).revealed).toBe(true);
   });
 
-  test("changing the add target clears a stale key error", async () => {
-    const el = await mount("bw15__api: a\n", false, [
-      { name: "bw15", configuration: "bw15.yaml", friendly_name: "BW15" },
-    ]);
-    const view = el as unknown as AddView & { _addError: string | null };
-    view._openAdd();
-    view._addError = "stale";
+  async function changeTarget(el: ESPHomeSecretsStructuredEditor, value: string) {
     await el.updateComplete;
     const select = el.shadowRoot!.querySelector<HTMLSelectElement>(".add-select")!;
-    select.value = "bw15";
+    select.value = value;
     select.dispatchEvent(new Event("change"));
+  }
+
+  test("switching target clears a duplicate error it resolves", async () => {
+    const el = await mount("api: x\n", false, [
+      { name: "bw15", configuration: "bw15.yaml", friendly_name: "BW15" },
+    ]);
+    const view = el as unknown as AddView;
+    view._openAdd();
+    view._addName = "api";
+    view._confirmAdd(); // shared "api" duplicates the existing key
+    expect(view._addError).not.toBeNull();
+    await changeTarget(el, "bw15"); // bw15__api is unique
     expect(view._addError).toBeNull();
+  });
+
+  test("switching target keeps an invalid-name error it can't fix", async () => {
+    const el = await mount("wifi_ssid: home\n", false, [
+      { name: "bw15", configuration: "bw15.yaml", friendly_name: "BW15" },
+    ]);
+    const view = el as unknown as AddView;
+    view._openAdd();
+    view._addName = "1bad";
+    view._confirmAdd();
+    expect(view._addError).not.toBeNull();
+    await changeTarget(el, "bw15");
+    expect(view._addError).not.toBeNull();
   });
 
   test("a tagged value renders read-only with no value input", async () => {

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -167,6 +167,26 @@ describe("esphome-secrets-structured-editor", () => {
     expect(view._addOpen).toBe(true);
   });
 
+  test("the add dialog's value field honors the page-level reveal", async () => {
+    const el = await mount("wifi_ssid: home\n", true);
+    const pw = el.shadowRoot!.querySelector(".add-body esphome-password-input");
+    expect((pw as unknown as { revealed: boolean }).revealed).toBe(true);
+  });
+
+  test("changing the add target clears a stale key error", async () => {
+    const el = await mount("bw15__api: a\n", false, [
+      { name: "bw15", configuration: "bw15.yaml", friendly_name: "BW15" },
+    ]);
+    const view = el as unknown as AddView & { _addError: string | null };
+    view._openAdd();
+    view._addError = "stale";
+    await el.updateComplete;
+    const select = el.shadowRoot!.querySelector<HTMLSelectElement>(".add-select")!;
+    select.value = "bw15";
+    select.dispatchEvent(new Event("change"));
+    expect(view._addError).toBeNull();
+  });
+
   test("a tagged value renders read-only with no value input", async () => {
     const el = await mount("ssid: !secret real_ssid\n");
     const row = rows(el)[0];


### PR DESCRIPTION
# What does this implement/fix?

Follow-ups to the structured secrets editor (#665), from post-merge review:

- The Add-secret dialog's value field now honors the page-level "Reveal values" toggle (`.revealed=${this.revealSensitive}`), matching the rows (and hiding its per-field eye while reveal-all is on).
- Switching the dialog's target device now **recomputes** the key error via a shared `_addKeyError()` (name validity + `<device>__` duplicate) rather than blanket-clearing: a duplicate that the new target resolves clears, while a name-only `invalid_key` error persists (switching device can't make a bad identifier valid).
- The near-unreachable null-splice path in `_emit` (stale line index) now shows a `toast.error` (`secrets.edit_out_of_sync`) alongside the `requestUpdate()` revert, so a dropped edit is visible instead of a silent no-op.

**Related issue or feature (if applicable):**

- Follow-up to #665.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
