### PR TITLE
Give the add-secret dialog's password field an accessible name

### DIFF
--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -211,6 +211,8 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
           <esphome-password-input
             .value=${this._addValue}
             .revealed=${this.revealSensitive}
+            label=${this._localize("secrets.value_placeholder")}
+            placeholder=${this._localize("secrets.value_placeholder")}
             @password-input-change=${(e: CustomEvent<PasswordInputValueChange>) =>
               (this._addValue = e.detail.value)}
           ></esphome-password-input>

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -188,6 +188,17 @@ describe("esphome-secrets-structured-editor", () => {
     expect((pw as unknown as { revealed: boolean }).revealed).toBe(true);
   });
 
+  test("the add dialog's value field carries an accessible name", async () => {
+    // esphome-password-input isn't a labelable control, so the visible
+    // caption can't bind to its inner input; the label prop supplies the
+    // accessible name (forwarded as aria-label).
+    const el = await mount("wifi_ssid: home\n", false);
+    const pw = el.shadowRoot!.querySelector<HTMLElement>(
+      ".add-body esphome-password-input"
+    )!;
+    expect(pw.getAttribute("label")).toBeTruthy();
+  });
+
   async function changeTarget(el: ESPHomeSecretsStructuredEditor, value: string) {
     await el.updateComplete;
     const select = el.shadowRoot!.querySelector<HTMLSelectElement>(".add-select")!;

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -190,13 +190,15 @@ describe("esphome-secrets-structured-editor", () => {
 
   test("the add dialog's value field carries an accessible name", async () => {
     // esphome-password-input isn't a labelable control, so the visible
-    // caption can't bind to its inner input; the label prop supplies the
-    // accessible name (forwarded as aria-label).
+    // caption can't bind to its inner input; the label prop forwards to the
+    // inner input as aria-label. Assert that end state, not the host attr.
     const el = await mount("wifi_ssid: home\n", false);
     const pw = el.shadowRoot!.querySelector<HTMLElement>(
       ".add-body esphome-password-input"
     )!;
-    expect(pw.getAttribute("label")).toBeTruthy();
+    await (pw as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    const input = pw.shadowRoot!.querySelector("input")!;
+    expect(input.getAttribute("aria-label")).toBeTruthy();
   });
 
   async function changeTarget(el: ESPHomeSecretsStructuredEditor, value: string) {


### PR DESCRIPTION
# What does this implement/fix?

Late follow-up to #668. The add-secret dialog wrapped `esphome-password-input` in a `<label>` with an external caption, but that custom element isn't a labelable control, so the inner password input had no accessible name and screen readers announced an unlabeled field. This passes the visible label text through the component's `label` and `placeholder` props, the same way the row renderer already does, so the inner input gets an `aria-label`.

The other late comment (clearing the add error on target change) was on a pre-merge commit; the merged code already recomputes the error conditionally, so nothing to change there.

**Related issue or feature (if applicable):**

- follow-up to #668

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
