### PR TITLE
Don't offer WiFi secrets on non-WiFi fields in the secret picker

### DIFF
--- a/src/components/device/secret-picker.ts
+++ b/src/components/device/secret-picker.ts
@@ -24,10 +24,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
 import { navigate } from "../../util/navigation.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import {
-  secretValueFromYaml,
-  withoutForeignDeviceSecrets,
-} from "../../util/secret-eligibility.js";
+import { secretValueFromYaml, visibleSecretKeys } from "../../util/secret-eligibility.js";
 import {
   fetchSecretKeys,
   getCachedSecretKeys,
@@ -283,10 +280,12 @@ export class ESPHomeSecretPicker extends LitElement {
 
   protected render() {
     const selected = this.selectedKey !== "";
-    // Hide per-device secrets that belong to other devices (migrate/_keys
-    // membership still use the full unfiltered list).
-    const keys = withoutForeignDeviceSecrets(
+    // Hide other devices' per-device secrets and field-bound shared secrets
+    // (wifi_*) not meant for this field. Migrate / _keys membership still use
+    // the full unfiltered list.
+    const keys = visibleSecretKeys(
       this._keys,
+      [...this.recommendedKeys, this.selectedKey],
       this.deviceName,
       this._devices.map((d) => d.name)
     );
@@ -325,7 +324,7 @@ export class ESPHomeSecretPicker extends LitElement {
           : nothing}
         ${recommended.length
           ? html`<small class="group-label" aria-hidden="true"
-                >${this._localize("device.secret_picker_recommended")}</small
+                >${this._localize("device.secret_picker_related")}</small
               >
               ${recommended.map((k) => this._renderKeyItem(k))}
               ${others.length

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -690,7 +690,7 @@
     "secret_picker_aria": "Pick a stored secret for {field}",
     "secret_picker_create": "Create new secret…",
     "secret_picker_empty": "No secrets yet",
-    "secret_picker_recommended": "Recommended",
+    "secret_picker_related": "Related",
     "secret_picker_shared": "Shared secrets",
     "secret_picker_manual": "Enter a value manually",
     "secret_picker_manual_error": "Couldn't read the stored secret",

--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -12,6 +12,12 @@ const SHARED: Readonly<Record<string, Readonly<Record<string, string>>>> = {
   wifi: { ssid: "wifi_ssid", password: "wifi_password" },
 };
 
+/** Field-bound shared secret names (``wifi_ssid``, ``wifi_password``) — each
+ *  belongs to one specific field and shouldn't be offered on the others. */
+const FIELD_BOUND_SHARED = new Set(
+  Object.values(SHARED).flatMap((m) => Object.values(m))
+);
+
 /** Per-device base names for the well-known credential fields, joined to the
  *  hostname as ``<hostname>__<base>``. Keyed by ``sectionKey`` then key. */
 const DEVICE_BASE: Readonly<Record<string, Readonly<Record<string, string>>>> = {
@@ -57,6 +63,35 @@ export function withoutForeignDeviceSecrets(
     const i = k.indexOf("__");
     return i <= 0 || !others.has(k.slice(0, i));
   });
+}
+
+/**
+ * The secrets to show in a field's picker. Drops other devices' per-device
+ * secrets (via :func:`withoutForeignDeviceSecrets`) and field-bound shared
+ * secrets (``wifi_ssid`` / ``wifi_password``) that aren't relevant to *this*
+ * field — so a WiFi SSID field still offers ``wifi_ssid`` but an OTA password
+ * or encryption-key field doesn't.
+ *
+ * *keep* is the set that's never field-filtered: the field's recommendations
+ * plus its currently-selected key (so the active value is always listed).
+ */
+export function visibleSecretKeys(
+  keys: readonly string[],
+  keep: readonly string[],
+  currentHostname: string,
+  allDeviceNames: readonly string[]
+): string[] {
+  const kept = new Set(keep.filter(Boolean));
+  // `kept` is exempt from BOTH filters (foreign-device and field-bound), so the
+  // currently-selected value is always listed even in the (unreachable-via-UI)
+  // case where it's another device's per-device secret. Filter the original
+  // list so order is preserved.
+  const afterForeign = new Set(
+    withoutForeignDeviceSecrets(keys, currentHostname, allDeviceNames)
+  );
+  return keys.filter(
+    (k) => kept.has(k) || (afterForeign.has(k) && !FIELD_BOUND_SHARED.has(k))
+  );
 }
 
 /** Per-device key forms, most-preferred first. A double underscore joins the

--- a/test/components/device/secret-picker.test.ts
+++ b/test/components/device/secret-picker.test.ts
@@ -70,10 +70,10 @@ afterEach(() => {
 
 describe("esphome-secret-picker", () => {
   it("renders one item per cached key plus the create action", async () => {
-    const el = await mount(["wifi_ssid", "wifi_password"]);
+    const el = await mount(["secret_a", "secret_b"]);
     const values = items(el).map((i) => i.getAttribute("value"));
-    expect(values).toContain("wifi_ssid");
-    expect(values).toContain("wifi_password");
+    expect(values).toContain("secret_a");
+    expect(values).toContain("secret_b");
     // The last item is the create action.
     expect(el.shadowRoot!.querySelector(".create")).not.toBeNull();
   });
@@ -150,7 +150,7 @@ describe("esphome-secret-picker", () => {
     const el = await mount([
       "kitchen__encryption_key",
       "porch__encryption_key",
-      "wifi_ssid",
+      "x_secret",
     ]);
     (el as unknown as { _devices: { name: string }[] })._devices = [
       { name: "kitchen" },
@@ -161,8 +161,28 @@ describe("esphome-secret-picker", () => {
 
     const values = items(el).map((i) => i.getAttribute("value"));
     expect(values).toContain("kitchen__encryption_key");
-    expect(values).toContain("wifi_ssid");
+    expect(values).toContain("x_secret");
     expect(values).not.toContain("porch__encryption_key");
+  });
+
+  it("hides wifi_* secrets on a non-WiFi field, shows them on a WiFi field", async () => {
+    const el = await mount(["wifi_ssid", "wifi_password", "kitchen__encryption_key"]);
+    el.deviceName = "kitchen";
+
+    // Non-WiFi field (encryption key recommended) → no wifi_* offered.
+    el.recommendedKeys = ["kitchen__encryption_key"];
+    await el.updateComplete;
+    let values = items(el).map((i) => i.getAttribute("value"));
+    expect(values).not.toContain("wifi_ssid");
+    expect(values).not.toContain("wifi_password");
+    expect(values).toContain("kitchen__encryption_key");
+
+    // WiFi SSID field → wifi_ssid offered (recommended), wifi_password not.
+    el.recommendedKeys = ["wifi_ssid"];
+    await el.updateComplete;
+    values = items(el).map((i) => i.getAttribute("value"));
+    expect(values).toContain("wifi_ssid");
+    expect(values).not.toContain("wifi_password");
   });
 
   it("groups recommended keys above the rest", async () => {
@@ -174,7 +194,7 @@ describe("esphome-secret-picker", () => {
       l.textContent!.trim()
     );
     expect(labels).toEqual([
-      "device.secret_picker_recommended",
+      "device.secret_picker_related",
       "device.secret_picker_shared",
     ]);
   });

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -3,6 +3,7 @@ import {
   isSecretEligible,
   recommendedSecretKeys,
   secretValueFromYaml,
+  visibleSecretKeys,
   withoutForeignDeviceSecrets,
 } from "../../src/util/secret-eligibility.js";
 import { formatYamlScalar } from "../../src/util/yaml-serialize.js";
@@ -109,6 +110,63 @@ describe("withoutForeignDeviceSecrets", () => {
     expect(withoutForeignDeviceSecrets(["myapp__token"], "kitchen", devices)).toEqual([
       "myapp__token",
     ]);
+  });
+});
+
+describe("visibleSecretKeys", () => {
+  const keys = [
+    "wifi_ssid",
+    "wifi_password",
+    "kitchen__encryption_key",
+    "kitchen__ota_password",
+    "porch__encryption_key",
+    "x_secret",
+  ];
+
+  it("drops wifi_* on a non-WiFi field, keeps the device's own + unscoped", () => {
+    expect(
+      visibleSecretKeys(keys, ["kitchen__encryption_key"], "kitchen", [
+        "kitchen",
+        "porch",
+      ])
+    ).toEqual(["kitchen__encryption_key", "kitchen__ota_password", "x_secret"]);
+  });
+
+  it("keeps wifi_ssid on the WiFi SSID field but not wifi_password", () => {
+    expect(
+      visibleSecretKeys(keys, ["wifi_ssid"], "kitchen", ["kitchen", "porch"])
+    ).toEqual([
+      "wifi_ssid",
+      "kitchen__encryption_key",
+      "kitchen__ota_password",
+      "x_secret",
+    ]);
+  });
+
+  it("still hides other devices' per-device secrets", () => {
+    expect(
+      visibleSecretKeys(keys, ["wifi_ssid"], "kitchen", ["kitchen", "porch"])
+    ).not.toContain("porch__encryption_key");
+  });
+
+  it("keeps a kept key (e.g. the selected value) even if field-bound", () => {
+    // The picker passes recommended + selectedKey as `keep`, so the currently
+    // referenced secret stays listed even on a field it's not recommended for.
+    expect(
+      visibleSecretKeys(["wifi_password", "x"], ["wifi_password"], "kitchen", ["kitchen"])
+    ).toContain("wifi_password");
+  });
+
+  it("keeps a kept key even if it's another device's per-device secret", () => {
+    // The selected value is always listed, even past the foreign-device filter.
+    expect(
+      visibleSecretKeys(
+        ["porch__encryption_key", "x"],
+        ["porch__encryption_key"],
+        "kitchen",
+        ["kitchen", "porch"]
+      )
+    ).toContain("porch__encryption_key");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The secret picker listed wifi_ssid and wifi_password on every secret-eligible field, so the OTA password and API encryption key pickers offered the WiFi credentials, which never makes sense (you would not point an OTA password at the WiFi SSID).

Adds visibleSecretKeys, which composes the existing other-device filter with a field-bound rule: a shared secret (a value in the SHARED map, i.e. wifi_ssid or wifi_password) is hidden unless it is one of the field's recommendations or its currently selected value. So the WiFi SSID field still offers wifi_ssid, the WiFi password field offers wifi_password, and non-WiFi fields offer neither. The currently selected secret always stays listed so the active value and its checkmark do not vanish.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
