### PR TITLE
Modernize makeRenderCtx fixture and retire inline RenderCtx literals

### DIFF
--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -78,7 +78,7 @@ export function makeRenderCtx(
   } = {}
 ): RenderCtx {
   return {
-    localize: ((k: string) => k) as never,
+    localize: (k: string) => k,
     disabled: false,
     yaml: "",
     fromLine: 0,
@@ -109,8 +109,9 @@ export function makeRenderCtx(
     renderEntry: vi.fn(),
     getPendingUnit: () => undefined,
     setPendingUnit: vi.fn(),
-    getPendingNumeric: () => undefined,
-    setPendingNumeric: vi.fn(),
+    getEditingMagnitude: () => undefined,
+    setEditingMagnitude: vi.fn(),
+    clearEditingMagnitude: vi.fn(),
     // Stable per-fixture stash owner — tests that exercise the
     // templatable stash WeakMap (literal/lambda recovery) need a
     // single object identity across calls into the renderer. A
@@ -118,7 +119,7 @@ export function makeRenderCtx(
     // production form's "one stashOwner per host element" contract.
     stashOwner: {},
     ...(options.overrides ?? {}),
-  } as never;
+  };
 }
 
 /** Build a minimal ``ConfigEntry`` of *type* with sensible

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -83,7 +83,7 @@ export function makeRenderCtx(
     yaml: "",
     fromLine: 0,
     sectionKey: "",
-    board: options.board ?? makeTestBoard(),
+    board: "board" in options ? (options.board ?? null) : makeTestBoard(),
     requiredOnly: false,
     showAdvanced: false,
     presentComponents: new Set<string>(),

--- a/test/components/device/render-map-field.test.ts
+++ b/test/components/device/render-map-field.test.ts
@@ -27,6 +27,7 @@ import {
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { renderMapField } from "../../../src/components/device/config-entry-renderers.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeMapEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -63,42 +64,22 @@ function collectHandlers(values: unknown[]): Array<(...args: unknown[]) => unkno
 function makeCtx(values: Record<string, unknown>): CtxStub {
   const renderEntry = vi.fn(() => "<rendered>");
   const emitChange = vi.fn();
-  const ctx: RenderCtx = {
-    localize: (key) => key,
-    disabled: false,
-    yaml: "",
-    fromLine: undefined,
-    sectionKey: "",
-    board: null,
-    requiredOnly: false,
-    showAdvanced: false,
-    presentComponents: new Set(),
-    nestedOpenSections: new Set(),
-    getAt: (path: string[]) => {
-      let cur: unknown = values;
-      for (const k of path) {
-        if (cur === null || typeof cur !== "object" || Array.isArray(cur)) {
-          return undefined;
-        }
-        cur = (cur as Record<string, unknown>)[k];
+  // Array-rejecting getAt: a map binds to mappings only, so a list
+  // landing at the path must read as absent, not be indexed into.
+  const getAt = (path: string[]) => {
+    let cur: unknown = values;
+    for (const k of path) {
+      if (cur === null || typeof cur !== "object" || Array.isArray(cur)) {
+        return undefined;
       }
-      return cur;
-    },
-    errorAt: () => null,
-    emitChange: emitChange,
-    toggleNested: () => {},
-    seedNestedOpen: () => {},
-    requestAddComponent: () => {},
-    scopeValues: () => ({}),
-    filterRenderable: (entries) => entries,
-    renderEntry: renderEntry,
-    getPendingUnit: () => undefined,
-    setPendingUnit: () => {},
-    getEditingMagnitude: () => undefined,
-    setEditingMagnitude: () => {},
-    clearEditingMagnitude: () => {},
-    stashOwner: {},
+      cur = (cur as Record<string, unknown>)[k];
+    }
+    return cur;
   };
+  const ctx = makeRenderCtx(values, {
+    board: null,
+    overrides: { emitChange, renderEntry, getAt },
+  });
   return { ctx, renderEntry, emitChange };
 }
 

--- a/test/components/device/render-nested-list-field.test.ts
+++ b/test/components/device/render-nested-list-field.test.ts
@@ -26,8 +26,8 @@ import {
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { renderNestedListField } from "../../../src/components/device/config-entry-renderers.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { getIn } from "../../../src/util/nested-values.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeListEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -68,33 +68,10 @@ function makeCtx(values: Record<string, unknown>): CtxStub {
   const renderEntry = vi.fn(() => "<rendered>");
   const emitChange = vi.fn();
   const filterRenderable = vi.fn((entries: ConfigEntry[]) => entries);
-  const ctx: RenderCtx = {
-    localize: (key) => key,
-    disabled: false,
-    yaml: "",
-    fromLine: undefined,
-    sectionKey: "",
+  const ctx = makeRenderCtx(values, {
     board: null,
-    requiredOnly: false,
-    showAdvanced: false,
-    presentComponents: new Set(),
-    nestedOpenSections: new Set(),
-    getAt: (path: string[]) => getIn(values, path),
-    errorAt: () => null,
-    emitChange,
-    toggleNested: () => {},
-    seedNestedOpen: () => {},
-    requestAddComponent: () => {},
-    scopeValues: () => ({}),
-    filterRenderable,
-    renderEntry,
-    getPendingUnit: () => undefined,
-    setPendingUnit: () => {},
-    getEditingMagnitude: () => undefined,
-    setEditingMagnitude: () => {},
-    clearEditingMagnitude: () => {},
-    stashOwner: {},
-  };
+    overrides: { emitChange, renderEntry, filterRenderable },
+  });
   return { ctx, renderEntry, emitChange, filterRenderable };
 }
 

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -22,8 +22,8 @@ import {
   renderTimePeriodField,
 } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { getIn } from "../../../src/util/nested-values.js";
 import { YamlRawValue } from "../../../src/util/yaml-serialize.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeStringEntry(): ConfigEntry {
   return makeConfigEntry({
@@ -38,33 +38,10 @@ function makeCtx(values: Record<string, unknown>): {
   emitChange: ReturnType<typeof vi.fn>;
 } {
   const emitChange = vi.fn();
-  const ctx: RenderCtx = {
-    localize: (key) => key,
-    disabled: false,
-    yaml: "",
-    fromLine: undefined,
-    sectionKey: "",
+  const ctx = makeRenderCtx(values, {
     board: null,
-    requiredOnly: false,
-    showAdvanced: false,
-    presentComponents: new Set(),
-    nestedOpenSections: new Set(),
-    getAt: (path: string[]) => getIn(values, path),
-    errorAt: () => null,
-    emitChange,
-    toggleNested: () => {},
-    seedNestedOpen: () => {},
-    requestAddComponent: () => {},
-    scopeValues: () => ({}),
-    filterRenderable: (entries) => entries,
-    renderEntry: () => "<rendered>",
-    getPendingUnit: () => undefined,
-    setPendingUnit: () => {},
-    getEditingMagnitude: () => undefined,
-    setEditingMagnitude: () => {},
-    clearEditingMagnitude: () => {},
-    stashOwner: {},
-  };
+    overrides: { emitChange, renderEntry: () => "<rendered>" },
+  });
   return { ctx, emitChange };
 }
 

--- a/test/components/device/render-string-field-secret-picker.test.ts
+++ b/test/components/device/render-string-field-secret-picker.test.ts
@@ -12,7 +12,7 @@ import {
 import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
 import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
-import { getIn } from "../../../src/util/nested-values.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
 
 function makeEntry(key: string): ConfigEntry {
   return makeConfigEntry({ key, type: ConfigEntryType.STRING, label: key });
@@ -23,33 +23,10 @@ function makeCtx(
   values: Record<string, unknown> = {}
 ): { ctx: RenderCtx; emitChange: ReturnType<typeof vi.fn> } {
   const emitChange = vi.fn();
-  const ctx: RenderCtx = {
-    localize: (key) => key,
-    disabled: false,
-    yaml: "",
-    fromLine: undefined,
-    sectionKey,
+  const ctx = makeRenderCtx(values, {
     board: null,
-    requiredOnly: false,
-    showAdvanced: false,
-    presentComponents: new Set(),
-    nestedOpenSections: new Set(),
-    getAt: (path) => getIn(values, path),
-    errorAt: () => null,
-    emitChange,
-    toggleNested: () => {},
-    seedNestedOpen: () => {},
-    requestAddComponent: () => {},
-    scopeValues: () => ({}),
-    filterRenderable: (entries) => entries,
-    renderEntry: () => "<rendered>",
-    getPendingUnit: () => undefined,
-    setPendingUnit: () => {},
-    getEditingMagnitude: () => undefined,
-    setEditingMagnitude: () => {},
-    clearEditingMagnitude: () => {},
-    stashOwner: {},
-  };
+    overrides: { sectionKey, emitChange, renderEntry: () => "<rendered>" },
+  });
   return { ctx, emitChange };
 }
 


### PR DESCRIPTION
# What does this implement/fix?

The shared `makeRenderCtx` test fixture had drifted from the `RenderCtx` interface and only compiled behind an `as never` cast; it still carried the removed `getPendingNumeric` / `setPendingNumeric` and was missing the editing-magnitude callbacks, so a fixture-using test of a FLOAT_WITH_UNIT or TIME_PERIOD renderer would have hit `undefined` at runtime. This drops the stale fields, adds `getEditingMagnitude` / `setEditingMagnitude` / `clearEditingMagnitude`, and removes the cast so the fixture is type-checked against `RenderCtx` and cannot silently drift again.

Four renderer tests hand-rolled their own ~26-field `RenderCtx` literal to dodge the stale fixture, which meant every new `RenderCtx` field had to be added in five places at once; they now build on the fixture, keeping their spies and the map test's array-rejecting `getAt` as overrides. No production code changes; net 87 fewer lines.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/674

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
