### PR TITLE
Confirm form dialogs on Enter via a shared base-dialog opt-in

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -141,7 +141,12 @@ export class ESPHomeBaseDialog extends LitElement {
    *  :class:`EnterController` already skips Enter on
    *  buttons/links/textareas/selects and mid-IME composition. The callback
    *  must self-guard against repeat/invalid — a held Enter can re-fire until
-   *  ``open`` flips false. */
+   *  ``open`` flips false.
+   *
+   *  Don't set this on a dialog that opens a *nested* dialog while it stays
+   *  open: the listener is window-level and the controllers claim Enter in
+   *  open order, not z-order, so a stacked inner dialog wouldn't reliably win
+   *  the Enter (see :class:`EnterController`). */
   @property({ attribute: false }) confirmOnEnter?: () => void;
 
   /** Whether a consumer has slotted footer content. Gates the

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -1,10 +1,12 @@
 import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 
+import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import { dialogCloseButtonStyles } from "../styles/dialog-close-button.js";
 import { centeredMobileDialog } from "../styles/dialog-mobile.js";
+import { EnterController } from "../util/enter-controller.js";
 
 /**
  * Thin shared wrapper around ``<wa-dialog>``.
@@ -132,9 +134,24 @@ export class ESPHomeBaseDialog extends LitElement {
    *  close button. */
   @property({ type: Boolean, reflect: true }) busy = false;
 
+  /** Opt-in Enter-to-confirm. When set, a plain Enter while the dialog is
+   *  open invokes this callback — so a form dialog gets the keyboard submit
+   *  for free instead of re-wiring an :class:`EnterController` itself (the
+   *  boilerplate the add-secret dialog originally forgot, issue #1269).
+   *  :class:`EnterController` already skips Enter on
+   *  buttons/links/textareas/selects and mid-IME composition. The callback
+   *  must self-guard against repeat/invalid — a held Enter can re-fire until
+   *  ``open`` flips false. */
+  @property({ attribute: false }) confirmOnEnter?: () => void;
+
   /** Whether a consumer has slotted footer content. Gates the
    *  forwarding ``<slot name="footer">`` — see ``willUpdate``. */
   @state() private _hasFooter = false;
+
+  // Reads the live ``confirmOnEnter`` at fire time, so a fresh arrow each
+  // render is fine; toggled from ``willUpdate`` and torn down by the
+  // controller's ``hostDisconnected``.
+  private _enter = new EnterController(this, () => this.confirmOnEnter?.());
 
   // wa-dialog turns its footer chrome (border-top + padding) on by
   // testing for a direct ``[slot="footer"]`` child element, not for
@@ -142,8 +159,14 @@ export class ESPHomeBaseDialog extends LitElement {
   // such a child, so it would draw an empty footer bar on every
   // footer-less consumer. Mirror that same presence test against our
   // own light DOM and only forward when a consumer fills the footer.
-  protected willUpdate(): void {
+  protected willUpdate(changed: PropertyValues): void {
     this._hasFooter = this.querySelector(':scope > [slot="footer"]') !== null;
+    // Listen only while open and a callback is set. Detaching the instant
+    // ``open`` flips false (not at after-hide) means a held-Enter's next
+    // keydown can't re-fire during the hide animation.
+    if (changed.has("open") || changed.has("confirmOnEnter")) {
+      this._enter.set(this.open && this.confirmOnEnter !== undefined);
+    }
   }
 
   private _onWaHide = (e: Event): void => {

--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -174,6 +174,7 @@ export class ESPHomeAddApiActionDialog extends LitElement {
       ?open=${this._open}
       ?busy=${this._saving}
       .label=${title}
+      .confirmOnEnter=${this._onContinue}
       @request-close=${this._onRequestClose}
     >
       <p class="intro">

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -157,6 +157,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       ?open=${this._open}
       ?busy=${this._saving}
       .label=${title}
+      .confirmOnEnter=${this._onContinue}
       @request-close=${this._onRequestClose}
     >
       ${this._loading && !this._available

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -192,6 +192,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
       ?open=${this._open}
       ?busy=${this._saving}
       .label=${title}
+      .confirmOnEnter=${this._onContinue}
       @request-close=${this._onRequestClose}
     >
       <p class="intro">

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -162,6 +162,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
     return html`<esphome-base-dialog
       ?open=${this._addOpen}
       .label=${this._localize("secrets.add_dialog_title")}
+      .confirmOnEnter=${this._confirmAdd}
       @request-close=${this._closeAdd}
       @after-hide=${this._closeAdd}
     >

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -349,6 +349,11 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
   // Create the secret in one shot from the dialog fields, prefixing the key
   // with ``<device>__`` when a device was chosen so it lands in that group.
   private _confirmAdd = () => {
+    // One-shot: honor confirmOnEnter's "self-guard against repeat" contract.
+    // On success _addOpen flips false, so a synchronous second dispatch bails
+    // here before it can double-add against the still-stale this.value. The
+    // error path leaves _addOpen true so the user can resubmit after fixing.
+    if (!this._addOpen) return;
     const error = this._addKeyError();
     if (error) {
       this._addError = error;

--- a/test/components/base-dialog.test.ts
+++ b/test/components/base-dialog.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+//
+// Pins the wrapper-owned Enter-to-confirm (issue #1269): a plain Enter fires
+// confirmOnEnter only while open and only when a callback is set, inherits
+// EnterController's focus-target skip rules, and detaches when open flips false.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// wa-dialog runs form-validation lifecycle hooks happy-dom doesn't implement;
+// stub the import so the wrapper can render in the test.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+async function mount(props: Partial<ESPHomeBaseDialog>): Promise<ESPHomeBaseDialog> {
+  const el = new ESPHomeBaseDialog();
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+// Dispatch a bubbling+composed Enter from `from`, which becomes
+// composedPath()[0] (the element the controller treats as focused) and reaches
+// the window listener the wrapper binds.
+function pressEnter(from: Element): void {
+  from.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
+  );
+}
+
+describe("esphome-base-dialog confirmOnEnter", () => {
+  it("fires the callback on Enter while open", async () => {
+    const confirmOnEnter = vi.fn();
+    await mount({ open: true, confirmOnEnter });
+    pressEnter(document.body);
+    expect(confirmOnEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire while closed", async () => {
+    const confirmOnEnter = vi.fn();
+    await mount({ open: false, confirmOnEnter });
+    pressEnter(document.body);
+    expect(confirmOnEnter).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when no callback is set", async () => {
+    const el = await mount({ open: true });
+    // Nothing to assert beyond "no throw"; a stray listener would also leak
+    // EnterController's preventDefault, so confirm the event isn't claimed.
+    const ev = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+    document.body.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+    expect(el.confirmOnEnter).toBeUndefined();
+  });
+
+  it("fires from a focused text input but not a button or select", async () => {
+    const confirmOnEnter = vi.fn();
+    await mount({ open: true, confirmOnEnter });
+
+    const input = document.createElement("input");
+    const button = document.createElement("button");
+    const select = document.createElement("select");
+    document.body.append(input, button, select);
+
+    pressEnter(input);
+    expect(confirmOnEnter).toHaveBeenCalledTimes(1);
+
+    pressEnter(button);
+    pressEnter(select);
+    expect(confirmOnEnter).toHaveBeenCalledTimes(1); // still 1 — both skipped
+  });
+
+  it("detaches the listener when open flips false", async () => {
+    const confirmOnEnter = vi.fn();
+    const el = await mount({ open: true, confirmOnEnter });
+
+    el.open = false;
+    await el.updateComplete;
+
+    pressEnter(document.body);
+    expect(confirmOnEnter).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/add-dialogs-enter.test.ts
+++ b/test/components/device/add-dialogs-enter.test.ts
@@ -28,7 +28,12 @@ afterEach(() => {
 
 function pressEnter(): void {
   document.body.dispatchEvent(
-    new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+    new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    })
   );
 }
 

--- a/test/components/device/add-dialogs-enter.test.ts
+++ b/test/components/device/add-dialogs-enter.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "+ Add" wizard dialogs (api-action / script / automation) submit on a
+ * plain Enter via the shared base-dialog's confirmOnEnter (issue #1269). These
+ * use the REAL esphome-base-dialog (only the wa primitives are stubbed) so the
+ * wrapper's EnterController actually runs: Enter while open invokes _onContinue,
+ * Enter while closed does not.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import { LitElement } from "lit";
+import { ESPHomeAddApiActionDialog } from "../../../src/components/device/add-api-action-dialog.js";
+import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
+import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-script-dialog.js";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+function pressEnter(): void {
+  document.body.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+  );
+}
+
+// Each dialog binds .confirmOnEnter=${this._onContinue}; swap _onContinue for a
+// spy before the first render so the wrapper picks up the spy.
+async function mount<T extends LitElement>(
+  ctor: new () => T
+): Promise<{ dialog: T; onContinue: ReturnType<typeof vi.fn> }> {
+  const dialog = new ctor();
+  const onContinue = vi.fn();
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (dialog as any)._localize = (key: string) => key; // no context provider here
+  (dialog as any)._onContinue = onContinue;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  return { dialog, onContinue };
+}
+
+describe.each([
+  ["add-api-action", ESPHomeAddApiActionDialog],
+  ["add-script", ESPHomeAddScriptDialog],
+  ["add-automation", ESPHomeAddAutomationDialog],
+])("%s dialog Enter-to-confirm (issue #1269)", (_name, ctor) => {
+  it("Enter while open invokes _onContinue", async () => {
+    const { dialog, onContinue } = await mount(ctor as new () => LitElement);
+    (dialog as unknown as { open: () => void }).open();
+    await dialog.updateComplete;
+    pressEnter();
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter while closed does nothing", async () => {
+    const { onContinue } = await mount(ctor as new () => LitElement);
+    pressEnter();
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+
+  it("stops firing once the dialog closes", async () => {
+    const { dialog, onContinue } = await mount(ctor as new () => LitElement);
+    const view = dialog as unknown as { open: () => void; _onRequestClose: () => void };
+    view.open();
+    await dialog.updateComplete;
+    view._onRequestClose(); // flips _open false (Escape / X / backdrop path)
+    await dialog.updateComplete;
+    pressEnter();
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -144,6 +144,42 @@ describe("esphome-secrets-structured-editor", () => {
     expect(captured.value).toBe("wifi_ssid: home\napi_key: abc\n");
   });
 
+  test("Enter in the add dialog confirms (issue #1269)", async () => {
+    const el = await mount("wifi_ssid: home\n");
+    const captured = onChange(el);
+    const view = el as unknown as AddView;
+    view._openAdd();
+    await el.updateComplete;
+    // The wrapper toggles its EnterController in willUpdate once it sees open.
+    const dialog = el.shadowRoot!.querySelector("esphome-base-dialog")!;
+    await (dialog as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    view._addName = "api_key";
+    view._addValue = "abc";
+    // A plain Enter from a neutral element bubbles to the window listener.
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+    );
+    expect(captured.value).toBe("wifi_ssid: home\napi_key: abc\n");
+    expect(view._addOpen).toBe(false);
+  });
+
+  test("Enter with a duplicate name shows the error and adds nothing", async () => {
+    const el = await mount("wifi_ssid: home\n");
+    const captured = onChange(el);
+    const view = el as unknown as AddView;
+    view._openAdd();
+    await el.updateComplete;
+    const dialog = el.shadowRoot!.querySelector("esphome-base-dialog")!;
+    await (dialog as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    view._addName = "wifi_ssid";
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+    );
+    expect(captured.value).toBeNull();
+    expect(view._addOpen).toBe(true);
+    expect(view._addError).not.toBeNull();
+  });
+
   test("a device target prefixes the new secret with <device>__", async () => {
     const el = await mount("wifi_ssid: home\n", false, [
       { name: "bw15", configuration: "bw15.yaml", friendly_name: "BW15" },

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -157,7 +157,12 @@ describe("esphome-secrets-structured-editor", () => {
     view._addValue = "abc";
     // A plain Enter from a neutral element bubbles to the window listener.
     document.body.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      })
     );
     expect(captured.value).toBe("wifi_ssid: home\napi_key: abc\n");
     expect(view._addOpen).toBe(false);
@@ -173,7 +178,12 @@ describe("esphome-secrets-structured-editor", () => {
     await (dialog as unknown as { updateComplete: Promise<unknown> }).updateComplete;
     view._addName = "wifi_ssid";
     document.body.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      })
     );
     expect(captured.value).toBeNull();
     expect(view._addOpen).toBe(true);

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -168,6 +168,21 @@ describe("esphome-secrets-structured-editor", () => {
     expect(view._addOpen).toBe(false);
   });
 
+  test("a synchronous double confirm adds the secret only once", async () => {
+    const el = await mount("wifi_ssid: home\n");
+    const view = el as unknown as AddView;
+    const seen: string[] = [];
+    el.addEventListener("yaml-change", (e) =>
+      seen.push((e as CustomEvent<{ value: string }>).detail.value)
+    );
+    view._openAdd();
+    view._addName = "api_key";
+    view._addValue = "abc";
+    view._confirmAdd();
+    view._confirmAdd(); // second sync dispatch must bail on the one-shot guard
+    expect(seen).toEqual(["wifi_ssid: home\napi_key: abc\n"]);
+  });
+
   test("Enter with a duplicate name shows the error and adds nothing", async () => {
     const el = await mount("wifi_ssid: home\n");
     const captured = onChange(el);


### PR DESCRIPTION
# What does this implement/fix?

The add-secret dialog ignored the **Enter** key — a user could fill in
target / name / value and press Enter, and nothing happened. It was the
only input dialog in the app that never wired up the shared
`EnterController`; the other ~10 input dialogs each hand-roll it
(instantiate, `set(true)` on open, `set(false)` on after-hide).

Rather than copy that boilerplate into one more dialog — the exact thing
that got forgotten here — this moves the capability into the shared
`esphome-base-dialog` wrapper that **every** dialog already renders
through. A new opt-in property `confirmOnEnter?: () => void` lets the
wrapper own the `EnterController` lifecycle: attach the listener while
`open`, detach it the instant `open` flips false. A form dialog now gets
keyboard submit for free with a single property, so a future dialog can't
silently forget it.

It then uses the new opt-in to:

- **Fix** the add-secret dialog (`esphome-secrets-structured-editor`).
- **Fold in** the three other input dialogs that had the same latent gap:
  `add-api-action`, `add-script`, and `add-automation`. Each already has
  a self-guarding `_onContinue` (bails on repeat / invalid / saving), which
  matches the `confirmOnEnter` contract exactly.

`EnterController` already skips Enter on buttons / links / textareas /
selects and during IME composition, and only the first active controller
claims a given Enter — so this is purely additive: the dialogs that wire
their own controller are untouched and there's no double-handling.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1269

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

## Testing

- New `test/components/base-dialog.test.ts` pins the wrapper's
  `confirmOnEnter`: fires on Enter while open, not while closed, not when
  no callback is set, inherits the focus-target skip rules (input yes;
  button / select no), and detaches when `open` flips false.
- New `test/components/device/add-dialogs-enter.test.ts` drives the three
  add-* dialogs through the **real** wrapper and asserts Enter routes to
  `_onContinue` only while open.
- Extended the secrets-editor test with an end-to-end Enter-confirms case
  (and a duplicate-name Enter that shows the inline error instead of
  adding).
- Drove the live dev server with Chrome + Puppeteer: opened Add-secret,
  typed name + value, pressed a real Enter → secret row added and dialog
  closed.

No backend or translation changes; frontend-only, no companion backend PR.