### PR TITLE
Run the vitest suite on the threads pool

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     environment: "node",
     globals: false,
     silent: true,
+    // Threads start far cheaper than the default forked processes. The suite's
+    // wall time is dominated by per-file worker/environment startup and module
+    // re-imports (happy-dom + lit/webawesome/codemirror), not by the assertions
+    // themselves, so a lighter worker model is a direct win on the CI runner.
+    pool: "threads",
   },
   resolve: {
     extensions: [".ts", ".js"],


### PR DESCRIPTION
# What does this implement/fix?

Switches the vitest suite to the `threads` pool to cut CI wall time.

The "Test and Lint" job is dominated by the Test step (~39s of a ~68s
run), but the suite's own breakdown shows the assertions are not the
cost:

```
Duration 38.41s (transform 7.02s, import 36.71s, tests 6.71s,
                 environment 29.49s)
```

The actual test logic runs in 6.71s. The rest is per-file worker and
happy-dom startup plus re-importing the heavy module graph (lit,
webawesome, codemirror) into a freshly **forked** process for each of
the 242 test files. On the 4-core CI runner there's little parallelism
to hide that fixed per-file overhead, and it grows linearly as files
are added — which is why it's been creeping up. This is a test-infra
cost, not a production/runtime performance problem.

Threads start far cheaper than forked processes, so this is a drop-in
win with no test changes. All 242 files / 2567 tests still pass;
locally (full suite, `--maxWorkers=4` to mimic CI) Duration drops from
9.02s to 7.40s.

A follow-up PR (stacked on this branch) will pursue the larger win
(`isolate: false`), which needs a test-hygiene pass first and so ships
separately.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
