### PR TITLE
Resolve cross-domain id references through component providers

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1374,6 +1374,10 @@ export class ESPHomeAPI {
     exclude_category?: string | string[];
     platform?: string;
     board_id?: string;
+    /** Filter to components that can be referenced *as* this interface
+     *  (e.g. ``voltage_sampler`` returns the ADC-family sensors), matching
+     *  ``ComponentCatalogEntry.provides``. */
+    provides?: string;
     offset?: number;
     limit?: number;
   }): Promise<PagedComponentsResponse> {

--- a/src/api/types/components.ts
+++ b/src/api/types/components.ts
@@ -105,6 +105,9 @@ export interface ComponentCatalogEntry {
   multi_conf: boolean;
   /** Empty list = works on every target platform. Non-empty = restricted to those. */
   supported_platforms: string[];
+  /** Interfaces this component can be referenced *as* beyond its own domain
+   *  (an `adc` sensor provides `voltage_sampler`). */
+  provides?: string[];
   /** The component's configuration schema. May contain `nested` entries
    *  (`type === "nested"`) whose `config_entries` recurse. */
   config_entries: ConfigEntry[];

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -6,6 +6,7 @@ import type {
   AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
+import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
 
 /** The instance's display label: its ``name:`` when set, else its id. */
 export function instanceName(device: AvailableComponentInstance): string {
@@ -14,7 +15,7 @@ export function instanceName(device: AvailableComponentInstance): string {
 
 /** Bare domain of a ``component_id`` (``sensor.aht10`` → ``sensor``). */
 export function componentDomain(componentId: string): string {
-  return componentId.split(".")[0];
+  return parseCatalogId(componentId).domain;
 }
 
 /** The parenthetical context shown beside an instance's label: its domain,

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -76,6 +76,9 @@ export class ESPHomeComponentCatalog extends LitElement {
   @state() _initialLoad = true;
   @state() _search = "";
   @state() _category = "all";
+  // Interface to probe via the ``provides`` filter (set by ``filterByDomain``
+  // for a non-category reference domain); cleared on user-driven browsing.
+  @state() _provides = "";
   @state() _expandedId: string | null = null;
 
   // Per-id tracking — a single broken image_url shouldn't pull every other
@@ -90,6 +93,7 @@ export class ESPHomeComponentCatalog extends LitElement {
   // open, and (b) race the device-page's async board load — the first
   // request would go out with empty platform / board_id.
   public load() {
+    this._provides = "";
     // Auto-select "Featured" when the board has any recommendations; reset
     // away from it when reopening against a board without any.
     const featuredCount =
@@ -105,18 +109,21 @@ export class ESPHomeComponentCatalog extends LitElement {
     this._fetchComponents();
   }
 
-  // Filter to a specific component domain. If the domain matches a known
-  // ComponentCategory we use the category filter (exact match against
-  // output.gpio, output.ledc, …); otherwise fall back to the search query.
+  // Filter to a specific component domain. A known ComponentCategory uses the
+  // category filter (output.gpio, output.ledc, …); anything else may be a
+  // component id/stem OR a homeless interface (voltage_sampler), so we probe
+  // ``provides`` and fall back to a search when it yields nothing.
   public filterByDomain(domain: string) {
     const isCategory = Object.values(ComponentCategory).includes(
       domain as ComponentCategory
     );
     if (isCategory) {
       this._search = "";
+      this._provides = "";
       this._category = domain;
     } else {
       this._search = domain;
+      this._provides = domain;
       this._category = "all";
     }
     this._fetchComponents();
@@ -136,14 +143,25 @@ export class ESPHomeComponentCatalog extends LitElement {
           : undefined;
       const exclude_category: string[] | undefined =
         !locked && this.excludeCategories.length > 0 ? this.excludeCategories : undefined;
-      const response = await this._api.getComponents({
-        query,
+      const base = {
         category,
         exclude_category,
         platform: this.platform || undefined,
         board_id: this.boardId || undefined,
         limit: 50,
-      });
+      };
+      // Interface probe first; a homeless interface (voltage_sampler) has no
+      // matching id/name, so an empty result means it was a plain domain and
+      // we retry as a search (an i2c dependency still resolves). Clear
+      // ``_provides`` on that empty branch so a later fetch (board/platform
+      // prop change) goes straight to search instead of re-probing.
+      let response = this._provides
+        ? await this._api.getComponents({ ...base, provides: this._provides })
+        : await this._api.getComponents({ ...base, query });
+      if (this._provides && response.components.length === 0) {
+        this._provides = "";
+        response = await this._api.getComponents({ ...base, query });
+      }
       this._components = response.components;
       this._categories = response.categories;
       this._total = response.total;
@@ -187,6 +205,7 @@ export class ESPHomeComponentCatalog extends LitElement {
                   type="button"
                   @click=${() => {
                     this._category = id;
+                    this._provides = "";
                     this._fetchComponents();
                   }}
                 >
@@ -254,6 +273,7 @@ export class ESPHomeComponentCatalog extends LitElement {
 
   private _onSearchInput = (ev: Event) => {
     this._search = (ev.target as HTMLInputElement).value;
+    this._provides = "";
     this._debouncedSearch();
   };
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -31,6 +31,10 @@ import { ConfigEntryType } from "../../api/types/config-entries.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
+import {
+  parseCatalogId,
+  type ComponentProvider,
+} from "../../util/config-entry-yaml-scan.js";
 import { type ValidationError } from "../../util/config-validation.js";
 import { resolveDeviceName } from "../../util/device-name.js";
 import { getIn, isPrimitiveOrNullish } from "../../util/nested-values.js";
@@ -194,6 +198,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
   /** Keys already default-opened by ``_seedNestedOpen`` so the seed fires
    *  once and a later user collapse isn't re-overridden. */
   private _seededNestedOpen: Set<string> = new Set();
+
+  /** Resolved providers per interface name, and the in-flight set, for the
+   *  id-reference dropdown's cross-domain lookup. */
+  private _interfaceProviders: Map<string, ComponentProvider[]> = new Map();
+  private _interfaceProvidersPending: Set<string> = new Set();
 
   /** Scrolls the YAML-cursor-selected field into view (the structured side
    *  of the field sync); driven from ``updated``. */
@@ -614,6 +623,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
       toggleNested: (key) => this._toggleNested(key),
       seedNestedOpen: (key) => this._seedNestedOpen(key),
       requestAddComponent: (domain) => this._requestAddComponent(domain),
+      resolveInterfaceProviders: (interfaceName) =>
+        this._resolveInterfaceProviders(interfaceName),
       scopeValues: (path) => this._scopeValues(path),
       filterRenderable: this._filterRenderable,
       getPendingUnit: (path) => this._pendingUnits.get(path.join(".")),
@@ -732,6 +743,49 @@ export class ESPHomeConfigEntryForm extends LitElement {
         composed: true,
       })
     );
+  }
+
+  /**
+   * Providers of an interface reference, from a per-form cache.
+   *
+   * A miss fetches the catalog by ``provides`` once and re-renders on
+   * resolve; an empty *success* caches ``[]`` (a same-domain reference has
+   * no extra providers). A *failure* is logged and left uncached so a later
+   * render retries rather than permanently dropping candidates.
+   */
+  private _resolveInterfaceProviders(
+    interfaceName: string
+  ): readonly ComponentProvider[] {
+    if (!interfaceName) return [];
+    const cached = this._interfaceProviders.get(interfaceName);
+    if (cached) return cached;
+    if (this._api && !this._interfaceProvidersPending.has(interfaceName)) {
+      this._interfaceProvidersPending.add(interfaceName);
+      // ``limit: 200`` captures every provider of the interface in one shot
+      // (interfaces have at most a couple dozen); this is the full dropdown
+      // candidate set, distinct from the Add-component picker's paginated grid.
+      this._api
+        .getComponents({ provides: interfaceName, limit: 200 })
+        .then((resp) => {
+          this._interfaceProviders.set(
+            interfaceName,
+            resp.components.map((c) => parseCatalogId(c.id))
+          );
+          this.requestUpdate();
+        })
+        .catch((err) =>
+          // Warn (not debug) so the dropped-candidate path is observable, and
+          // don't cache [] — that's indistinguishable from "no providers" and
+          // would silently omit candidates for the form's lifetime.
+          console.warn(
+            "[config-entry-form] provider fetch failed for",
+            interfaceName,
+            err
+          )
+        )
+        .finally(() => this._interfaceProvidersPending.delete(interfaceName));
+    }
+    return [];
   }
 }
 

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -7,7 +7,7 @@
 
 import { html } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
-import { findReferencedComponents } from "../../util/config-entry-yaml-scan.js";
+import { findReferenceCandidates } from "../../util/config-entry-yaml-scan.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -25,7 +25,11 @@ export function renderIdReferenceField(
   ctx: RenderCtx
 ) {
   const domain = entry.references_component || "";
-  const candidates = findReferencedComponents(ctx.yaml, domain);
+  const candidates = findReferenceCandidates(
+    ctx.yaml,
+    domain,
+    ctx.resolveInterfaceProviders(domain)
+  );
   const raw = ctx.getAt(path);
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -13,6 +13,7 @@ import { ConfigEntryType } from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import type { ComponentProvider } from "../../util/config-entry-yaml-scan.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { isPrimitiveOrNullish } from "../../util/nested-values.js";
@@ -136,6 +137,12 @@ export interface RenderCtx {
    *  values), without overriding a later explicit user collapse. */
   seedNestedOpen: (key: string) => void;
   requestAddComponent: (domain: string) => void;
+  /**
+   * Providers of a cross-domain interface reference. Returns synchronously
+   * from a per-form cache; a miss kicks an async catalog fetch and
+   * re-renders. Empty until loaded, and ``[]`` for a same-domain reference.
+   */
+  resolveInterfaceProviders: (interfaceName: string) => ReadonlyArray<ComponentProvider>;
   scopeValues: (path: string[]) => Record<string, unknown>;
   filterRenderable: (
     entries: ConfigEntry[],

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,6 +17,7 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import { scanPinGpios } from "./pin-gpio.js";
+import { parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
 /**
  * Single-entry memo for the YAML scans. The hot path is the
@@ -233,60 +234,97 @@ export function sectionEndLine(yaml: string, fromLine?: number): number | undefi
   return lines.length;
 }
 
-/**
- * Walk the YAML and return every `id:` (with its sibling `name:`) found
- * inside the given top-level domain. Block-list items reset the cursor
- * so each list element produces its own `{ id, name }` record.
- */
-interface RefKey {
-  yaml: string;
+/** One provider of an interface: a catalog domain and optional platform
+ *  stem. ``{sensor, adc}`` matches a ``sensor:`` item with ``platform: adc``;
+ *  an empty stem matches every id in the ``domain:`` block. */
+export interface ComponentProvider {
   domain: string;
+  stem: string;
 }
-const refKeyEquals = (a: RefKey, b: RefKey) => a.yaml === b.yaml && a.domain === b.domain;
-const refMemo = createScanMemo<RefKey, Array<{ id: string; name: string }>>(refKeyEquals);
 
-export function findReferencedComponents(
+/** Split a catalog id into a provider: ``"sensor.adc"`` → ``{sensor, adc}``;
+ *  a bare ``"ble_nus"`` → ``{ble_nus, ""}`` (a top-level component). */
+export function parseCatalogId(id: string): ComponentProvider {
+  const dot = id.indexOf(".");
+  return dot === -1
+    ? { domain: id, stem: "" }
+    : { domain: id.slice(0, dot), stem: id.slice(dot + 1) };
+}
+
+interface ProviderKey {
+  yaml: string;
+  signature: string;
+}
+const providerKeyEquals = (a: ProviderKey, b: ProviderKey) =>
+  a.yaml === b.yaml && a.signature === b.signature;
+const providerMemo = createScanMemo<ProviderKey, Array<{ id: string; name: string }>>(
+  providerKeyEquals
+);
+
+/**
+ * Configured components matching a set of providers.
+ *
+ * For each provider, keeps a configured instance under its ``domain:`` block
+ * whose ``platform`` matches the provider stem (or every id when the stem is
+ * empty, e.g. a top-level component like a ``uart``-providing ``ble_nus:``).
+ * Delegates the YAML structure to {@link parseYamlTopLevelSections} so nested
+ * lists (``filters:``) and sub-mappings don't break item boundaries. The
+ * building block under {@link findReferenceCandidates}.
+ */
+export function findComponentsByProviders(
   yaml: string,
-  domain: string
+  providers: ReadonlyArray<ComponentProvider>
 ): Array<{ id: string; name: string }> {
-  if (!domain) return [];
-  const probe: RefKey = { yaml, domain };
-  const cached = refMemo.get(probe);
+  if (!providers.length) return [];
+  const signature = providers
+    .map((p) => `${p.domain}.${p.stem}`)
+    .sort()
+    .join(",");
+  const probe: ProviderKey = { yaml, signature };
+  const cached = providerMemo.get(probe);
   if (cached) return cached;
-  const lines = yaml.split("\n");
+
+  // ``stem === ""`` for any provider in a domain means "match every id".
+  const stemsByDomain = new Map<string, Set<string>>();
+  for (const p of providers) {
+    const stems = stemsByDomain.get(p.domain) ?? new Set<string>();
+    stems.add(p.stem);
+    stemsByDomain.set(p.domain, stems);
+  }
+
   const result: Array<{ id: string; name: string }> = [];
-  let inSection = false;
-  let currentId = "";
-  let currentName = "";
-
-  const flush = () => {
-    if (currentId) result.push({ id: currentId, name: currentName });
-    currentId = "";
-    currentName = "";
-  };
-
-  for (const line of lines) {
-    const topMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
-    if (topMatch) {
-      flush();
-      inSection = topMatch[1] === domain;
-      continue;
-    }
-    if (!inSection) continue;
-    if (/^\s*-\s/.test(line)) flush();
-    const idMatch = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
-    if (idMatch) {
-      currentId = idMatch[1];
-      continue;
-    }
-    const nameMatch = line.match(/^\s+(?:-\s+)?name:\s*["']?(.+?)["']?\s*$/);
-    if (nameMatch) {
-      currentName = nameMatch[1];
+  const seen = new Set<string>();
+  for (const section of parseYamlTopLevelSections(yaml)) {
+    if (!section.id || seen.has(section.id)) continue;
+    const stems = stemsByDomain.get(section.parentKey ?? section.key);
+    if (!stems) continue;
+    if (
+      stems.has("") ||
+      (section.platform !== undefined && stems.has(section.platform))
+    ) {
+      seen.add(section.id);
+      result.push({ id: section.id, name: section.name ?? "" });
     }
   }
-  flush();
-  refMemo.set(probe, result);
+  providerMemo.set(probe, result);
   return result;
+}
+
+/**
+ * Configured components that satisfy a reference, via its providers.
+ *
+ * The reference's own domain is an implicit provider (empty stem ⇒ every id
+ * in that ``<domain>:`` block), so same-domain (``i2c``) and cross-domain
+ * (``voltage_sampler`` → ADC sensors under ``sensor:``) references resolve
+ * through one scan. Shared by the visual editor and the YAML autocomplete.
+ */
+export function findReferenceCandidates(
+  yaml: string,
+  domain: string,
+  providers: ReadonlyArray<ComponentProvider>
+): Array<{ id: string; name: string }> {
+  if (!domain) return [];
+  return findComponentsByProviders(yaml, [{ domain, stem: "" }, ...providers]);
 }
 
 /**
@@ -298,5 +336,5 @@ export function findReferencedComponents(
  */
 export function _clearScanMemos(): void {
   pinMemo.clear();
-  refMemo.clear();
+  providerMemo.clear();
 }

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,3 +1,5 @@
+import { readInstanceScalar } from "./yaml-sections-core.js";
+
 /**
  * Auto-generate a default `id:` value for a component being added
  * via the catalog. Used by `esphome-add-component-form` to seed the
@@ -42,16 +44,18 @@ export function generateDefaultComponentId(
 
 /**
  * Scan the YAML for every `id:` line and return the set of values.
- * Best-effort regex match — same approach the ID-reference picker
- * uses, deliberately simple (we only need a uniqueness check, not
- * a full parse).
+ * Best-effort line scan via the shared `readInstanceScalar`, deliberately
+ * simple (we only need a uniqueness check, not a full parse).
  */
 export function collectExistingIds(yaml: string): Set<string> {
   const ids = new Set<string>();
   if (!yaml) return ids;
   for (const line of yaml.split("\n")) {
-    const m = line.match(/^\s+(?:-\s+)?id:\s*["']?(\S+?)["']?\s*$/);
-    if (m) ids.add(m[1]);
+    // A real component id is always indented under a block; `readInstanceScalar`
+    // leaves indent-gating to callers, so skip a column-0 `id:`.
+    if (!/^\s/.test(line)) continue;
+    const id = readInstanceScalar(line, "id");
+    if (id !== null) ids.add(id);
   }
   return ids;
 }

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -29,7 +29,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
-import { findReferencedComponents } from "./config-entry-yaml-scan.js";
+import { findReferenceCandidates, parseCatalogId } from "./config-entry-yaml-scan.js";
 import {
   getActions,
   getConfigVarKeys,
@@ -458,17 +458,22 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       const entry = entries.find((e) => e.key === key);
 
       // ID-reference field (``i2c_id:``, ``output:``, …) → suggest the
-      // IDs declared in the referenced domain. Mirrors the visual
-      // form's ``renderIdReferenceField`` so both editors offer the
-      // same candidate set. Declaring ``id:`` fields carry a null
-      // ``references_component`` and fall through untouched.
+      // IDs declared in the referenced domain plus any cross-domain
+      // providers (``voltage_sampler`` → ADC sensors under ``sensor:``).
+      // Mirrors the visual form's ``renderIdReferenceField`` so both
+      // editors offer the same candidate set. Declaring ``id:`` fields
+      // carry a null ``references_component`` and fall through untouched.
       if (entry?.type === ConfigEntryType.ID && entry.references_component) {
-        const candidates = findReferencedComponents(
+        const domain = entry.references_component;
+        const providers = catalog.components
+          .filter((c) => c.provides?.includes(domain))
+          .map((c) => parseCatalogId(c.id));
+        const candidates = findReferenceCandidates(
           state.doc.toString(),
-          entry.references_component
+          domain,
+          providers
         );
         if (candidates.length > 0) {
-          const domain = entry.references_component;
           return {
             from: valueFrom,
             options: candidates.map((c) => ({

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -343,14 +343,18 @@ const _INSTANCE_SCALAR_RE = new Map<string, RegExp>();
  * Value of a ``<key>: value`` line (surrounding quotes peeled), or ``null``.
  *
  * Allows an optional leading ``- `` list dash; ``id`` / ``platform`` take a
- * bare token, other keys (``name``) the rest of the line. Callers gate the
- * line's indent — this only peels the key + value.
+ * bare token, other keys (``name``) the rest of the line. For bare tokens a
+ * trailing inline comment is tolerated, but only when ``#`` is whitespace-
+ * preceded (YAML's rule) — ``id: a#b`` keeps ``a#b``, ``id: a  # b`` keeps
+ * ``a``. Callers gate the line's indent — this only peels the key + value.
  */
 export function readInstanceScalar(line: string, key: string): string | null {
   let re = _INSTANCE_SCALAR_RE.get(key);
   if (re === undefined) {
-    const value = key === "id" || key === "platform" ? "(\\S+?)" : "(.+?)";
-    re = new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*["']?${value}["']?\\s*$`);
+    const bareToken = key === "id" || key === "platform";
+    const value = bareToken ? "(\\S+?)" : "(.+?)";
+    const tail = bareToken ? "(?:\\s+#.*)?\\s*" : "\\s*";
+    re = new RegExp(`^\\s*(?:-\\s+)?${key}:\\s*["']?${value}["']?${tail}$`);
     _INSTANCE_SCALAR_RE.set(key, re);
   }
   return line.match(re)?.[1] ?? null;

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -104,6 +104,7 @@ export function makeRenderCtx(
     toggleNested: vi.fn(),
     seedNestedOpen: vi.fn(),
     requestAddComponent: vi.fn(),
+    resolveInterfaceProviders: () => [],
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,
     renderEntry: vi.fn(),

--- a/test/components/device/component-catalog-provides.test.ts
+++ b/test/components/device/component-catalog-provides.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * ``filterByDomain`` routes a cross-domain reference (ct_clamp's
+ * ``voltage_sampler``) through the ``provides`` filter so the Add
+ * component picker lists the interface's providers, falling back to a
+ * search only when the domain isn't a homeless interface (issue #1275).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeComponentCatalog } from "../../../src/components/device/component-catalog.js";
+
+function emptyResponse() {
+  return { components: [], categories: [], total: 0, offset: 0, limit: 50 };
+}
+
+function response(ids: string[]) {
+  return {
+    components: ids.map((id) => ({ id }) as ComponentCatalogEntry),
+    categories: [],
+    total: ids.length,
+    offset: 0,
+    limit: 50,
+  };
+}
+
+describe("component-catalog filterByDomain provides routing", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("probes the provides filter for an interface domain", async () => {
+    const el = new ESPHomeComponentCatalog();
+    const getComponents = vi
+      .fn()
+      .mockResolvedValue(response(["sensor.adc", "sensor.ads1115"]));
+    Object.assign(el as unknown as Record<string, unknown>, { _api: { getComponents } });
+
+    el.filterByDomain("voltage_sampler");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(getComponents.mock.calls[0][0]).toMatchObject({ provides: "voltage_sampler" });
+    expect(getComponents.mock.calls[0][0].query).toBeUndefined();
+    expect(el._components.map((c) => c.id)).toEqual(["sensor.adc", "sensor.ads1115"]);
+  });
+
+  it("falls back to a search when the provides probe is empty", async () => {
+    const el = new ESPHomeComponentCatalog();
+    const getComponents = vi
+      .fn()
+      .mockResolvedValueOnce(emptyResponse()) // provides probe: not an interface
+      .mockResolvedValueOnce(response(["i2c"])); // search fallback
+    Object.assign(el as unknown as Record<string, unknown>, { _api: { getComponents } });
+
+    el.filterByDomain("i2c");
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getComponents).toHaveBeenCalledTimes(2);
+    expect(getComponents.mock.calls[0][0]).toMatchObject({ provides: "i2c" });
+    expect(getComponents.mock.calls[1][0]).toMatchObject({ query: "i2c" });
+    expect(getComponents.mock.calls[1][0].provides).toBeUndefined();
+    expect(el._components.map((c) => c.id)).toEqual(["i2c"]);
+  });
+
+  it("uses the category filter, not provides, for a real category", async () => {
+    const el = new ESPHomeComponentCatalog();
+    const getComponents = vi.fn().mockResolvedValue(response(["sensor.dht"]));
+    Object.assign(el as unknown as Record<string, unknown>, { _api: { getComponents } });
+
+    el.filterByDomain("sensor");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(getComponents.mock.calls[0][0]).toMatchObject({ category: "sensor" });
+    expect(getComponents.mock.calls[0][0].provides).toBeUndefined();
+  });
+});

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * ``_resolveInterfaceProviders`` backs the id-reference dropdown's
+ * cross-domain lookup: a per-form cache fed by one ``provides`` fetch,
+ * deduped while in flight, and — crucially — NOT poisoned with ``[]`` on a
+ * failed fetch so a later render can retry.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+import type { ComponentProvider } from "../../../src/util/config-entry-yaml-scan.js";
+
+const resolve = (
+  form: ESPHomeConfigEntryForm,
+  name: string
+): readonly ComponentProvider[] =>
+  (
+    form as unknown as {
+      _resolveInterfaceProviders(n: string): readonly ComponentProvider[];
+    }
+  )._resolveInterfaceProviders(name);
+
+const flush = async () => {
+  // Let the getComponents promise's then/catch/finally chain settle.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function withApi(getComponents: ReturnType<typeof vi.fn>): ESPHomeConfigEntryForm {
+  const form = new ESPHomeConfigEntryForm();
+  Object.assign(form as unknown as Record<string, unknown>, { _api: { getComponents } });
+  return form;
+}
+
+function response(ids: string[]) {
+  return {
+    components: ids.map((id) => ({ id }) as ComponentCatalogEntry),
+    categories: [],
+    total: ids.length,
+    offset: 0,
+    limit: 200,
+  };
+}
+
+describe("config-entry-form _resolveInterfaceProviders", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns [] on the first miss, then the fetched providers, fetching once", async () => {
+    const getComponents = vi
+      .fn()
+      .mockResolvedValue(response(["sensor.adc", "sensor.ads1115"]));
+    const form = withApi(getComponents);
+
+    // First miss: synchronous empty, fetch kicked off.
+    expect(resolve(form, "voltage_sampler")).toEqual([]);
+    // A second call while in flight must not fire a duplicate fetch.
+    resolve(form, "voltage_sampler");
+    await flush();
+
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(getComponents.mock.calls[0][0]).toMatchObject({ provides: "voltage_sampler" });
+    // Resolved cache, returned synchronously, mapped through parseCatalogId.
+    expect(resolve(form, "voltage_sampler")).toEqual([
+      { domain: "sensor", stem: "adc" },
+      { domain: "sensor", stem: "ads1115" },
+    ]);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches [] for an empty success (a same-domain reference)", async () => {
+    const getComponents = vi.fn().mockResolvedValue(response([]));
+    const form = withApi(getComponents);
+    resolve(form, "i2c");
+    await flush();
+    expect(resolve(form, "i2c")).toEqual([]);
+    // Cached: no refetch.
+    expect(getComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache [] on a failed fetch, so a later render retries", async () => {
+    const getComponents = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ws down"))
+      .mockResolvedValueOnce(response(["sensor.adc"]));
+    const form = withApi(getComponents);
+
+    resolve(form, "voltage_sampler");
+    await flush();
+    // Failure left the cache unset — the next call retries rather than
+    // returning a poisoned empty list forever.
+    expect(resolve(form, "voltage_sampler")).toEqual([]);
+    await flush();
+    expect(getComponents).toHaveBeenCalledTimes(2);
+    expect(resolve(form, "voltage_sampler")).toEqual([{ domain: "sensor", stem: "adc" }]);
+  });
+});

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   _clearScanMemos,
-  findReferencedComponents,
+  findComponentsByProviders,
+  findReferenceCandidates,
   findUsedPins,
 } from "../../src/util/config-entry-yaml-scan.js";
 
@@ -198,7 +199,7 @@ describe("findUsedPins", () => {
   });
 });
 
-describe("findReferencedComponents", () => {
+describe("findReferenceCandidates (same-domain base case)", () => {
   const yaml = [
     "i2c:",
     "  - id: bus_a",
@@ -208,41 +209,115 @@ describe("findReferencedComponents", () => {
     "",
   ].join("\n");
 
-  it("returns id/name pairs for the given domain", () => {
-    expect(findReferencedComponents(yaml, "i2c")).toEqual([
+  it("returns id/name pairs for the reference's own domain", () => {
+    expect(findReferenceCandidates(yaml, "i2c", [])).toEqual([
       { id: "bus_a", name: "" },
       { id: "bus_b", name: "" },
     ]);
   });
 
   it("returns an empty array for an unknown domain", () => {
-    expect(findReferencedComponents(yaml, "uart")).toEqual([]);
+    expect(findReferenceCandidates(yaml, "uart", [])).toEqual([]);
   });
 
   it("returns an empty array for an empty domain string", () => {
-    expect(findReferencedComponents(yaml, "")).toEqual([]);
+    expect(findReferenceCandidates(yaml, "", [])).toEqual([]);
   });
 
-  it("returns the same array reference on repeated calls (memoised)", () => {
-    const a = findReferencedComponents(yaml, "i2c");
-    const b = findReferencedComponents(yaml, "i2c");
-    expect(a).toBe(b);
+  it("unions the own-domain ids with cross-domain providers", () => {
+    const config = [yaml, "sensor:", "  - platform: adc", "    id: adc_a", ""].join("\n");
+    expect(
+      findReferenceCandidates(config, "i2c", [{ domain: "sensor", stem: "adc" }])
+    ).toEqual([
+      { id: "bus_a", name: "" },
+      { id: "bus_b", name: "" },
+      { id: "adc_a", name: "" },
+    ]);
+  });
+});
+
+describe("findComponentsByProviders", () => {
+  const yaml = [
+    "sensor:",
+    "  - platform: adc",
+    "    id: adc_a",
+    "    pin: GPIO34",
+    "  - platform: dht",
+    "    id: temp_a",
+    "  - platform: ads1115",
+    "    id: adc_b",
+    "ble_nus:",
+    "  id: nus_link",
+    "",
+  ].join("\n");
+
+  it("matches list items by provider platform", () => {
+    const providers = [
+      { domain: "sensor", stem: "adc" },
+      { domain: "sensor", stem: "ads1115" },
+    ];
+    expect(findComponentsByProviders(yaml, providers)).toEqual([
+      { id: "adc_a", name: "" },
+      { id: "adc_b", name: "" },
+    ]);
   });
 
-  it("invalidates the memo when yaml changes", () => {
-    // Single-entry semantics: round-trip back to the original
-    // yaml re-scans, not returns the original array. Pinning
-    // for the same reason as the pin memo's equivalent test.
-    const a = findReferencedComponents(yaml, "i2c");
-    const otherYaml = "i2c:\n  - id: bus_z\n";
-    const b = findReferencedComponents(otherYaml, "i2c");
-    expect(a).not.toBe(b);
-    expect(b).toEqual([{ id: "bus_z", name: "" }]);
+  it("matches a platform value carrying a trailing inline comment", () => {
+    const commented = [
+      "sensor:",
+      "  - platform: adc  # current clamp",
+      "    id: adc_c",
+      "",
+    ].join("\n");
+    expect(
+      findComponentsByProviders(commented, [{ domain: "sensor", stem: "adc" }])
+    ).toEqual([{ id: "adc_c", name: "" }]);
   });
 
-  it("invalidates the memo when domain changes", () => {
-    const a = findReferencedComponents(yaml, "i2c");
-    const b = findReferencedComponents(yaml, "uart");
-    expect(a).not.toBe(b);
+  it("keeps the item across a nested list (filters) before its id/name", () => {
+    // A nested `filters:` list must not end the component scan — the
+    // platform/id/name still belong to the outer sensor item.
+    const nested = [
+      "sensor:",
+      "  - platform: adc",
+      "    filters:",
+      "      - offset: 0.1",
+      "      - multiply: 2.0",
+      "    id: adc_nested",
+      '    name: "Nested ADC"',
+      "",
+    ].join("\n");
+    expect(
+      findComponentsByProviders(nested, [{ domain: "sensor", stem: "adc" }])
+    ).toEqual([{ id: "adc_nested", name: "Nested ADC" }]);
+  });
+
+  it("excludes platforms that do not provide the interface", () => {
+    const ids = findComponentsByProviders(yaml, [{ domain: "sensor", stem: "adc" }]).map(
+      (c) => c.id
+    );
+    expect(ids).toEqual(["adc_a"]);
+    expect(ids).not.toContain("temp_a");
+  });
+
+  it("an empty stem matches every id in the block (top-level provider)", () => {
+    expect(findComponentsByProviders(yaml, [{ domain: "ble_nus", stem: "" }])).toEqual([
+      { id: "nus_link", name: "" },
+    ]);
+  });
+
+  it("returns an empty array when no providers are given", () => {
+    expect(findComponentsByProviders(yaml, [])).toEqual([]);
+  });
+
+  it("memoises on (yaml, providers) and invalidates on change", () => {
+    const providers = [{ domain: "sensor", stem: "adc" }];
+    expect(findComponentsByProviders(yaml, providers)).toBe(
+      findComponentsByProviders(yaml, providers)
+    );
+    const other = findComponentsByProviders(yaml, [
+      { domain: "sensor", stem: "ads1115" },
+    ]);
+    expect(other).toEqual([{ id: "adc_b", name: "" }]);
   });
 });

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -3,8 +3,36 @@ import {
   _clearYamlSectionsMemo,
   findFieldLine,
   parseYamlTopLevelSections,
+  readInstanceScalar,
   type YamlSection,
 } from "../../src/util/yaml-sections-core.js";
+
+describe("readInstanceScalar", () => {
+  it("peels a bare token and surrounding quotes", () => {
+    expect(readInstanceScalar("  - platform: adc", "platform")).toBe("adc");
+    expect(readInstanceScalar('    id: "bus_a"', "id")).toBe("bus_a");
+    expect(readInstanceScalar("    name: My Sensor", "name")).toBe("My Sensor");
+  });
+
+  it("strips a whitespace-preceded inline comment from a bare token", () => {
+    expect(readInstanceScalar("  - platform: adc  # current clamp", "platform")).toBe(
+      "adc"
+    );
+    expect(readInstanceScalar("    id: adc_a # note", "id")).toBe("adc_a");
+  });
+
+  it("keeps a `#` that is not preceded by whitespace (not a YAML comment)", () => {
+    expect(readInstanceScalar("    id: foo#bar", "id")).toBe("foo#bar");
+  });
+
+  it("keeps `#` literal in a free-text name value", () => {
+    expect(readInstanceScalar("    name: Sensor #3", "name")).toBe("Sensor #3");
+  });
+
+  it("returns null when the key doesn't match", () => {
+    expect(readInstanceScalar("    id: adc_a", "name")).toBeNull();
+  });
+});
 
 function sectionAt(yaml: string, fromLine: number): YamlSection {
   _clearYamlSectionsMemo();


### PR DESCRIPTION
# What does this implement/fix?

Adding a ct_clamp sensor needs a voltage_sampler reference, but the picker found nothing even with an ADC sensor configured; the providers live under `sensor:`, not a `voltage_sampler:` block, so the old top level scan never matched them.

This consumes the backend's new `ComponentCatalogEntry.provides` so a reference resolves through its providers. The id-reference dropdown treats the reference's own domain as one implicit provider (every id in that block) and unions it with the cross-domain providers, so a same-domain reference (i2c) and a cross-domain one (voltage_sampler, provided by ADC sensors under sensor:) flow through one authoritative scan. The providers for an interface are fetched once via `getComponents({ provides })` and cached per form. The Add component picker probes the same `provides` filter first, falling back to a search only when the domain is a plain component rather than an interface, so an i2c dependency still resolves.

Needs the companion backend PR (esphome/device-builder#1276) for the `provides` catalog data and the `get_components` filter.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1275

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
