### PR TITLE
Stack Secrets header on mobile to remove dead space

### DIFF
--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -22,7 +22,6 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
-import "@home-assistant/webawesome/dist/components/divider/divider.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../components/secrets/secrets-structured-editor.js";
@@ -515,7 +514,6 @@ export class ESPHomePageSecrets extends LitElement {
             ${revealLabel}
           </button>
         </div>
-        <wa-divider></wa-divider>
         <div class="editor-card">
           ${this._loaded
             ? html`

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -432,6 +432,12 @@ export class ESPHomePageSecrets extends LitElement {
          in JS (matching the device editor), so no layout rules are
          duplicated here. */
       @media (max-width: 900px) {
+        .page-header {
+          flex-wrap: wrap;
+        }
+        .page-title {
+          flex-basis: 100%;
+        }
         .layout-toggle .split-btn {
           display: none;
         }

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -240,7 +240,7 @@ export class ESPHomePageSecrets extends LitElement {
         flex: 1;
         display: flex;
         flex-direction: column;
-        padding: var(--wa-space-l);
+        padding: var(--wa-space-l) var(--content-gutter);
         gap: var(--wa-space-m);
         overflow: hidden;
       }
@@ -432,6 +432,9 @@ export class ESPHomePageSecrets extends LitElement {
          in JS (matching the device editor), so no layout rules are
          duplicated here. */
       @media (max-width: 900px) {
+        .page {
+          padding-block: var(--wa-space-s);
+        }
         .page-header {
           flex-wrap: wrap;
         }


### PR DESCRIPTION
# What does this implement/fix?

On mobile the Secrets page header kept the title, description, and toolbar on one flex row, so the description got squeezed into a narrow column and wrapped down many lines while the toggle and Reveal values button left a lot of empty space beside it.

Below the 900px breakpoint the header now wraps; the title and description take the full width and the controls drop onto the row beneath them. Desktop is unchanged.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
