### PR TITLE
Support list-form device triggers (on_boot priorities)

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -31,9 +31,10 @@ export interface AutomationTrigger {
    *  components are configured. */
   applies_to: string[];
   is_device_level: boolean;
-  /** True for a component trigger the wizard can stack: it stays
-   *  offerable past the first handler and appends an indexed entry. */
-  repeatable: boolean;
+  /** True when ESPHome accepts a list of handlers (single=False): the
+   *  trigger stays offerable past the first handler and appends an indexed
+   *  entry. Deterministic replacement for the old 'repeatable' heuristic. */
+  supports_list: boolean;
   /** Parameter schema (e.g. ``on_click`` has ``min_length`` /
    *  ``max_length`` time-period fields). */
   config_entries: ConfigEntry[];
@@ -143,7 +144,7 @@ export type AutomationLocation =
   | { kind: "interval"; index: number }
   | { kind: "component_on"; component_id: string; trigger: string; index?: number }
   | { kind: "component_action"; component_id: string; field: string }
-  | { kind: "device_on"; trigger: string }
+  | { kind: "device_on"; trigger: string; index?: number }
   | { kind: "light_effect"; component_id: string; index: number }
   | { kind: "api_action"; action_name: string };
 

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -346,19 +346,21 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   private _filteredTriggers(): AutomationTrigger[] {
     const all = this._available?.triggers ?? [];
     if (this._kind === "device_on") {
-      // Device-level handlers are offered once; the catalog never marks
-      // them repeatable (only component triggers stack by index), so a
-      // second is grown inline rather than added as another block.
+      // Device-level handlers fire once unless ESPHome accepts a list
+      // (supports_list, e.g. multiple on_boot priorities); list-capable ones
+      // stay offerable past the first and append an indexed entry.
       const takenDeviceTriggers = this._existingDeviceTriggers();
-      return all.filter((t) => t.is_device_level && !takenDeviceTriggers.has(t.id));
+      return all.filter(
+        (t) => t.is_device_level && (!takenDeviceTriggers.has(t.id) || t.supports_list)
+      );
     }
     if (this._kind === "component_on") {
       const device = this._available?.devices.find((d) => d.id === this._componentId);
       // A component's inline ``on_*:`` fires once, so hide triggers that
-      // already have a handler here; repeatable ones stay offerable.
+      // already have a handler here; list-capable ones stay offerable.
       const takenComponentTriggers = this._existingComponentTriggers(this._componentId);
       return triggersForComponent(all, device).filter(
-        (t) => !takenComponentTriggers.has(this._bareTrigger(t.id)) || t.repeatable
+        (t) => !takenComponentTriggers.has(this._bareTrigger(t.id)) || t.supports_list
       );
     }
     return [];
@@ -471,6 +473,16 @@ export class ESPHomeAddAutomationDialog extends LitElement {
 
   private _buildLocation(): AutomationLocation {
     if (this._kind === "device_on") {
+      // List-capable device triggers (supports_list, e.g. on_boot) append a
+      // new indexed entry; the index is the existing handler count, so the
+      // first lands at 0 (a one-item list) and later ones append.
+      const trigger = this._available?.triggers.find((t) => t.id === this._triggerId);
+      if (trigger?.supports_list) {
+        const index = parseYamlAutomations(this.yaml).filter(
+          (s) => s.parentKey === "esphome" && s.eventKey === this._triggerId
+        ).length;
+        return { kind: "device_on", trigger: this._triggerId!, index };
+      }
       return { kind: "device_on", trigger: this._triggerId! };
     }
     if (this._kind === "component_on") {
@@ -480,11 +492,11 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       // triggers.
       const dotIdx = this._triggerId!.indexOf(".");
       const bare = dotIdx >= 0 ? this._triggerId!.slice(dotIdx + 1) : this._triggerId!;
-      // Repeatable triggers append a new indexed entry; an un-indexed
+      // List-capable triggers append a new indexed entry; an un-indexed
       // location would overwrite the block. Index = existing entry
       // count on this instance (mirrors the interval path).
       const trigger = this._available?.triggers.find((t) => t.id === this._triggerId);
-      if (trigger?.repeatable) {
+      if (trigger?.supports_list) {
         const index = parseYamlAutomations(this.yaml).filter(
           (s) => s.id === this._componentId && s.eventKey === bare
         ).length;

--- a/src/components/device/automation-editor/serialise.ts
+++ b/src/components/device/automation-editor/serialise.ts
@@ -101,6 +101,16 @@ export function swap<T>(arr: T[], i: number, j: number): T[] {
 }
 
 /**
+ * Parse a section-key segment as a list index: a non-negative integer only.
+ * Returns null for empty (Number('') is 0 in JS), signed, fractional, or
+ * non-numeric segments so a malformed key is rejected rather than routed to
+ * the wrong entry.
+ */
+function parseListIndex(part: string): number | null {
+  return /^\d+$/.test(part) ? Number(part) : null;
+}
+
+/**
  * Convert an ``AutomationLocation`` into the stable section key the
  * navigator emits (and the page consumes to route a click into the
  * automation editor). Mirrors the construction in
@@ -109,7 +119,9 @@ export function swap<T>(arr: T[], i: number, j: number): T[] {
 export function sectionKeyFromLocation(loc: AutomationLocation): string {
   switch (loc.kind) {
     case "device_on":
-      return `automation:device_on:${loc.trigger}`;
+      return loc.index === undefined
+        ? `automation:device_on:${loc.trigger}`
+        : `automation:device_on:${loc.trigger}:${loc.index}`;
     case "component_on":
       return loc.index === undefined
         ? `automation:component_on:${loc.component_id}:${loc.trigger}`
@@ -178,24 +190,32 @@ export function locationFromSectionKey(key: string): AutomationLocation | null {
   const parts = key.split(":");
   // parts[0] = "automation"
   switch (parts[1]) {
-    case "device_on":
-      return parts[2] ? { kind: "device_on", trigger: parts[2] } : null;
-    case "component_on": {
-      if (parts.length < 4) return null;
-      // A 5th part marks one entry of a list-shaped trigger (time.on_time).
-      // The index is a list position, so only a non-negative integer is valid.
-      if (parts.length >= 5) {
-        const idx = Number(parts[4]);
-        return Number.isInteger(idx) && idx >= 0
-          ? {
-              kind: "component_on",
-              component_id: parts[2],
-              trigger: parts[3],
-              index: idx,
-            }
-          : null;
+    case "device_on": {
+      if (!parts[2]) return null;
+      // A 4th part marks one entry of a list-form device handler (multiple
+      // on_boot priorities); exactly 4 parts, index a non-negative integer.
+      // Extra trailing parts or a non-index 4th part are rejected.
+      if (parts.length === 3) return { kind: "device_on", trigger: parts[2] };
+      if (parts.length === 4) {
+        const index = parseListIndex(parts[3]);
+        return index === null ? null : { kind: "device_on", trigger: parts[2], index };
       }
-      return { kind: "component_on", component_id: parts[2], trigger: parts[3] };
+      return null;
+    }
+    case "component_on": {
+      if (!parts[2] || !parts[3]) return null;
+      // A 5th part marks one entry of a list-shaped trigger (time.on_time);
+      // exactly 5 parts, index a non-negative integer.
+      if (parts.length === 4) {
+        return { kind: "component_on", component_id: parts[2], trigger: parts[3] };
+      }
+      if (parts.length === 5) {
+        const index = parseListIndex(parts[4]);
+        return index === null
+          ? null
+          : { kind: "component_on", component_id: parts[2], trigger: parts[3], index };
+      }
+      return null;
     }
     case "component_action":
       // `automation:component_action:<component_id>:<field>` — exactly 4

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -77,18 +77,31 @@ export function parseYamlAutomations(yaml: string): YamlSection[] {
     const host = smallestContainingSection(sections, fromLine);
 
     if (host && host.parentKey === undefined && host.key === "esphome") {
-      automations.push({
-        key: `automation:device_on:${eventName}`,
-        // ``displayLabel`` is the legacy "Esphome → on_boot" label;
-        // the navigator now prefers catalog-resolved labels but
-        // keeps ``displayLabel`` as a graceful fallback for
-        // pre-catalog renders.
-        displayLabel: `esphome → ${eventName}`,
-        fromLine,
-        toLine,
-        parentKey: "esphome",
-        eventKey: eventName,
-      });
+      // ``displayLabel`` is the legacy "esphome → on_boot" fallback; the
+      // navigator prefers catalog-resolved labels.
+      const deviceBase = { parentKey: "esphome", eventKey: eventName };
+      // List-form device handler (multiple on_boot priorities): one row per
+      // entry, keyed with its index to match the backend's per-entry location.
+      const entries = _listTriggerEntries(lines, fromLine, toLine);
+      if (entries) {
+        entries.forEach((entry, idx) => {
+          automations.push({
+            ...deviceBase,
+            key: `automation:device_on:${eventName}:${idx}`,
+            displayLabel: `esphome → ${eventName} #${idx + 1}`,
+            fromLine: entry.fromLine,
+            toLine: entry.toLine,
+          });
+        });
+      } else {
+        automations.push({
+          ...deviceBase,
+          key: `automation:device_on:${eventName}`,
+          displayLabel: `esphome → ${eventName}`,
+          fromLine,
+          toLine,
+        });
+      }
       continue;
     }
 

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -137,14 +137,14 @@ const timeAvailable = (): AvailableAutomations =>
         id: "time.on_time",
         name: "On time",
         applies_to: ["time"],
-        repeatable: true,
+        supports_list: true,
         config_entries: [],
       },
       {
         id: "time.on_time_sync",
         name: "On time sync",
         applies_to: ["time"],
-        repeatable: false,
+        supports_list: false,
         config_entries: [],
       },
     ],
@@ -211,6 +211,77 @@ describe("add-automation-dialog list-shaped triggers (#1080)", () => {
   });
 });
 
+const ON_BOOT_LIST_YAML = `esphome:
+  name: x
+  on_boot:
+    - priority: -300
+      then:
+        - logger.log: late
+`;
+
+const deviceAvailable = (): AvailableAutomations =>
+  ({
+    triggers: [
+      {
+        id: "on_boot",
+        name: "On Boot",
+        applies_to: [],
+        is_device_level: true,
+        supports_list: true,
+        config_entries: [],
+      },
+      {
+        id: "on_shutdown",
+        name: "On Shutdown",
+        applies_to: [],
+        is_device_level: true,
+        supports_list: false,
+        config_entries: [],
+      },
+    ],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+describe("add-automation-dialog device-level list triggers (#1283)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  async function mountForDevice(): Promise<ESPHomeAddAutomationDialog> {
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(deviceAvailable())),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    dialog.open();
+    await dialog.updateComplete;
+    await flushPending();
+    dialog.yaml = ON_BOOT_LIST_YAML;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._kind = "device_on";
+    await dialog.updateComplete;
+    return dialog;
+  }
+
+  it("still offers on_boot when one already exists (supports_list)", async () => {
+    const dialog = await mountForDevice();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const offered = (dialog as any)._filteredTriggers() as Array<{ id: string }>;
+    expect(offered.map((t) => t.id)).toContain("on_boot");
+  });
+
+  it("appends a second on_boot as an indexed device_on entry", async () => {
+    const dialog = await mountForDevice();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog as any)._triggerId = "on_boot";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const loc = (dialog as any)._buildLocation();
+    expect(loc).toEqual({ kind: "device_on", trigger: "on_boot", index: 1 });
+  });
+});
+
 const ahtAvailable = (): AvailableAutomations =>
   ({
     triggers: [
@@ -219,7 +290,7 @@ const ahtAvailable = (): AvailableAutomations =>
         name: "On Value Range",
         applies_to: ["sensor"],
         is_device_level: false,
-        repeatable: false,
+        supports_list: false,
         config_entries: [],
       },
     ],

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -35,7 +35,7 @@ const trigger = (over: Partial<AutomationTrigger> & { id: string }): AutomationT
     name: over.id,
     applies_to: [],
     is_device_level: false,
-    repeatable: false,
+    supports_list: false,
     config_entries: [],
     ...over,
   }) as AutomationTrigger;

--- a/test/components/device/automation-editor/section-key.test.ts
+++ b/test/components/device/automation-editor/section-key.test.ts
@@ -17,6 +17,12 @@ describe("sectionKeyFromLocation", () => {
       "automation:device_on:on_boot"
     );
     expect(
+      sectionKeyFromLocation({ kind: "device_on", trigger: "on_boot", index: 0 })
+    ).toBe("automation:device_on:on_boot:0");
+    expect(
+      sectionKeyFromLocation({ kind: "device_on", trigger: "on_boot", index: 1 })
+    ).toBe("automation:device_on:on_boot:1");
+    expect(
       sectionKeyFromLocation({
         kind: "component_on",
         component_id: "my_button",
@@ -102,10 +108,32 @@ describe("locationFromSectionKey", () => {
     expect(
       locationFromSectionKey("automation:component_on:my_time:on_time:x")
     ).toBeNull();
+    // Empty index (Number("") is 0 in JS) and extra trailing segments.
+    expect(locationFromSectionKey("automation:component_on:my_time:on_time:")).toBeNull();
+    expect(
+      locationFromSectionKey("automation:component_on:my_time:on_time:0:extra")
+    ).toBeNull();
+  });
+
+  it("rejects a device_on index that is not a non-negative integer", () => {
+    expect(locationFromSectionKey("automation:device_on:on_boot:-1")).toBeNull();
+    expect(locationFromSectionKey("automation:device_on:on_boot:1.5")).toBeNull();
+    expect(locationFromSectionKey("automation:device_on:on_boot:x")).toBeNull();
+    // Empty index (Number("") is 0 in JS) and extra trailing segments.
+    expect(locationFromSectionKey("automation:device_on:on_boot:")).toBeNull();
+    expect(locationFromSectionKey("automation:device_on:on_boot:0:extra")).toBeNull();
   });
 
   const cases: [string, AutomationLocation][] = [
     ["automation:device_on:on_boot", { kind: "device_on", trigger: "on_boot" }],
+    [
+      "automation:device_on:on_boot:0",
+      { kind: "device_on", trigger: "on_boot", index: 0 },
+    ],
+    [
+      "automation:device_on:on_boot:1",
+      { kind: "device_on", trigger: "on_boot", index: 1 },
+    ],
     [
       "automation:component_on:my_button:on_press",
       { kind: "component_on", component_id: "my_button", trigger: "on_press" },

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -25,7 +25,7 @@ const trigger = (id: string, name: string): AutomationTrigger => ({
   docs_url: "",
   applies_to: [],
   is_device_level: true,
-  repeatable: false,
+  supports_list: false,
   config_entries: [],
 });
 

--- a/test/util/automation-catalog-cache.test.ts
+++ b/test/util/automation-catalog-cache.test.ts
@@ -31,7 +31,7 @@ const trigger = (id: string): AutomationTrigger => ({
   docs_url: "",
   applies_to: [],
   is_device_level: true,
-  repeatable: false,
+  supports_list: false,
   config_entries: [],
 });
 

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -590,6 +590,29 @@ describe("parseYamlAutomations", () => {
     expect(entry.displayLabel).toBe("esphome → on_boot");
   });
 
+  it("splits a list-form on_boot into indexed device_on rows", () => {
+    const yaml = `esphome:
+  on_boot:
+    - priority: -300
+      then:
+        - logger.log: "late"
+    - priority: 200
+      then:
+        - logger.log: "early"
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:device_on:")
+    );
+    expect(items.map((s) => s.key)).toEqual([
+      "automation:device_on:on_boot:0",
+      "automation:device_on:on_boot:1",
+    ]);
+    expect(items.map((s) => s.displayLabel)).toEqual([
+      "esphome → on_boot #1",
+      "esphome → on_boot #2",
+    ]);
+  });
+
   it("enumerates top-level script: list items by their id", () => {
     const yaml = `script:
   - id: my_alarm


### PR DESCRIPTION
# What does this implement/fix?

Companion frontend change for list-form device triggers (`esphome.on_boot` / `on_loop` / `on_shutdown` written as a list of `priority`/`then` handlers).

- Replace the trigger `repeatable` heuristic with the backend's deterministic `supports_list` (ESPHome's `validate_automation(single=False)`), which both under-counted (`on_press`, `on_boot`) and over-counted (single triggers carrying params).
- Add an optional `index` to the `device_on` automation location, mirroring `component_on`, so multiple `on_boot` priorities each render and round-trip.
- The navigator emits one row per list entry for `device_on`; the section-key round-trip carries the `device_on` index; the add-automation dialog keeps a list-capable device or component trigger offerable past its first handler, appending an indexed entry.
- Harden `locationFromSectionKey` index parsing for `device_on` and `component_on`: a strict non-negative-integer check rejects empty (`Number("")` is `0` in JS) and extra trailing segments instead of routing to the wrong entry.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1283
- Companion to esphome/device-builder#1290

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
