### PR TITLE
Hydrate action catalog in script and api-action editors

### DIFF
--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -45,7 +45,7 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import { loadAvailableFor } from "./hydrate-available-bodies.js";
+import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -115,6 +115,11 @@ export class ESPHomeApiActionEditor extends LitElement {
   private _applyInFlight = false;
   private _applyDirty = false;
   private _lastSelfWrittenYaml: string | null = null;
+
+  /** Catalog loader; owns the concurrency guard so overlapping loads
+   *  (connectedCallback + updated both reaching ``_loadAvailable``)
+   *  can't clobber ``_available`` or double-fire the toast. */
+  private readonly _catalogLoad = new CatalogLoadController(this);
 
   /** Brief-window dirty flag covering the 200ms debounce gap so the
    *  global save button activates as soon as the user types. */
@@ -327,7 +332,8 @@ export class ESPHomeApiActionEditor extends LitElement {
     // Hydrates config_entries (the slim catalog omits them); without
     // it every action renders fieldless since the node bails on an
     // empty config_entries list.
-    const { available, error } = await loadAvailableFor(
+    this._error = "";
+    const { available, error } = await this._catalogLoad.load(
       this._api,
       this.configuration,
       this._localize

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -45,6 +45,7 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
+import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -324,10 +325,26 @@ export class ESPHomeApiActionEditor extends LitElement {
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
-    try {
-      this._available = await this._api.getAvailableAutomations(this.configuration);
-    } catch (err) {
-      this._error = err instanceof Error ? err.message : String(err);
+    // Hydrate config_entries (the slim catalog omits them); without
+    // this every action renders fieldless since the node bails on an
+    // empty config_entries list.
+    const outcome = await loadAndHydrateAvailable(this._api, this.configuration);
+    if (outcome.status === "stale") return;
+    if (outcome.status === "error") {
+      this._error =
+        outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+      return;
+    }
+    this._available = outcome.available;
+    const { missingBody, missingField, rejected } = outcome.hydration;
+    const failures = missingBody + missingField + rejected;
+    if (failures > 0) {
+      toast.error(
+        this._localize("device.automation_partial_hydration", {
+          count: String(failures),
+        }),
+        { richColors: true }
+      );
     }
   }
 

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -45,7 +45,7 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
+import { loadAvailableFor } from "./hydrate-available-bodies.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -324,28 +324,16 @@ export class ESPHomeApiActionEditor extends LitElement {
   }
 
   private async _loadAvailable() {
-    if (!this._api || !this.configuration) return;
-    // Hydrate config_entries (the slim catalog omits them); without
-    // this every action renders fieldless since the node bails on an
+    // Hydrates config_entries (the slim catalog omits them); without
+    // it every action renders fieldless since the node bails on an
     // empty config_entries list.
-    const outcome = await loadAndHydrateAvailable(this._api, this.configuration);
-    if (outcome.status === "stale") return;
-    if (outcome.status === "error") {
-      this._error =
-        outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
-      return;
-    }
-    this._available = outcome.available;
-    const { missingBody, missingField, rejected } = outcome.hydration;
-    const failures = missingBody + missingField + rejected;
-    if (failures > 0) {
-      toast.error(
-        this._localize("device.automation_partial_hydration", {
-          count: String(failures),
-        }),
-        { richColors: true }
-      );
-    }
+    const { available, error } = await loadAvailableFor(
+      this._api,
+      this.configuration,
+      this._localize
+    );
+    if (error !== undefined) this._error = error;
+    if (available) this._available = available;
   }
 
   private async _hydrateFromBackend() {

--- a/src/components/device/automation-editor/catalog-load-controller.ts
+++ b/src/components/device/automation-editor/catalog-load-controller.ts
@@ -36,8 +36,11 @@ export class CatalogLoadController implements ReactiveController {
   ): Promise<{ available?: AvailableAutomations; error?: string }> {
     if (!api || !configuration) return {};
     const seq = ++this._seq;
+    // Trigger-less editors render actions + conditions only; skipping
+    // trigger-body hydration avoids needless get_bodies work on mount.
     const outcome = await loadAndHydrateAvailable(api, configuration, {
       isStale: () => seq !== this._seq,
+      lists: ["actions", "conditions"],
     });
     // Re-check after the await: a later load (or disconnect) bumped the
     // token, so this result is stale — drop it before it can toast or

--- a/src/components/device/automation-editor/catalog-load-controller.ts
+++ b/src/components/device/automation-editor/catalog-load-controller.ts
@@ -1,0 +1,48 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+import type { ESPHomeAPI } from "../../../api/index.js";
+import type { AvailableAutomations } from "../../../api/types/automations.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import {
+  loadAndHydrateAvailable,
+  resolveLoadedAvailable,
+} from "./hydrate-available-bodies.js";
+
+/**
+ * Owns the concurrency guard for a trigger-less editor's catalog load
+ * (script, api-action). The sequence token lives here, not on the
+ * editor, so a load cannot be issued without it: load() is the only
+ * entry point and always discards a result superseded by a later load
+ * or by host disconnect, so an overlapping load can never clobber the
+ * editor's state or double-fire the partial-hydration toast. The
+ * editor just assigns the returned fields to its own reactive state.
+ */
+export class CatalogLoadController implements ReactiveController {
+  private _seq = 0;
+
+  constructor(host: ReactiveControllerHost) {
+    host.addController(this);
+  }
+
+  /** A load resolving after the host detaches must not assign. */
+  hostDisconnected(): void {
+    this._seq++;
+  }
+
+  async load(
+    api: ESPHomeAPI | undefined,
+    configuration: string,
+    localize: LocalizeFunc
+  ): Promise<{ available?: AvailableAutomations; error?: string }> {
+    if (!api || !configuration) return {};
+    const seq = ++this._seq;
+    const outcome = await loadAndHydrateAvailable(api, configuration, {
+      isStale: () => seq !== this._seq,
+    });
+    // Re-check after the await: a later load (or disconnect) bumped the
+    // token, so this result is stale — drop it before it can toast or
+    // assign.
+    if (seq !== this._seq) return {};
+    return resolveLoadedAvailable(outcome, localize);
+  }
+}

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -117,28 +117,12 @@ export async function loadAndHydrateAvailable(
   }
 }
 
-/** Load + hydrate the catalog for an editor and return the
- *  ``_available`` / ``_error`` it should assign. Used by the two
- *  trigger-less editors (script, api-action), which differ only in
- *  which reactive fields they write; the automation editor keeps its
- *  bespoke paint+staleness orchestration. Returns an empty object
- *  (assign nothing) when there's no api or configuration yet. */
-export async function loadAvailableFor(
-  api: ESPHomeAPI | undefined,
-  configuration: string,
-  localize: LocalizeFunc
-): Promise<{ available?: AvailableAutomations; error?: string }> {
-  if (!api || !configuration) return {};
-  return resolveLoadedAvailable(
-    await loadAndHydrateAvailable(api, configuration),
-    localize
-  );
-}
-
 /** Map a :func:`loadAndHydrateAvailable` outcome to the
  *  ``_available`` / ``_error`` an editor assigns, surfacing partial
  *  hydration as a non-blocking toast. A ``stale`` outcome yields
- *  neither field so an overlapping load wins. */
+ *  neither field so an overlapping load wins. The concurrency token
+ *  that makes the ``stale`` branch reachable is owned by
+ *  ``CatalogLoadController`` — editors never call this unguarded. */
 export function resolveLoadedAvailable(
   outcome: LoadAndHydrateOutcome,
   localize: LocalizeFunc

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -16,11 +16,17 @@ import {
   type HydrationResult,
 } from "../../../util/automation-body-hydration.js";
 
-type _AutomationListType = "triggers" | "actions" | "conditions";
+/** Which catalog lists to hydrate bodies for. A consumer that renders
+ *  only some of them (the trigger-less editors never show triggers)
+ *  passes a subset to skip the unused ``get_bodies`` work. */
+export type HydrateList = "triggers" | "actions" | "conditions";
 type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationCondition;
 
+const _ALL_LISTS: readonly HydrateList[] = ["triggers", "actions", "conditions"];
+
 /** Hydrate ``config_entries`` for every entry in *available* via the
- *  shared per-entry helper. ``allSettled`` so a single rejection
+ *  shared per-entry helper. *lists* selects which catalog lists to
+ *  hydrate (default all three). ``allSettled`` so a single rejection
  *  doesn't abort the rest; the returned aggregate lets the caller
  *  surface partial-failure UI (the body cache's
  *  ``cacheMisses: false`` lets a re-mount retry contract-violation
@@ -28,11 +34,12 @@ type _AutomationEntry = AutomationTrigger | AutomationAction | AutomationConditi
 export async function hydrateAvailableBodies(
   api: ESPHomeAPI,
   available: AvailableAutomations,
-  fetchBody?: AutomationBodyFetcher
+  fetchBody?: AutomationBodyFetcher,
+  lists: readonly HydrateList[] = _ALL_LISTS
 ): Promise<HydrationResult> {
   const result = emptyHydrationResult();
   const jobs: Promise<unknown>[] = [];
-  const merge = (type: _AutomationListType, list: _AutomationEntry[]): void => {
+  const merge = (type: HydrateList, list: _AutomationEntry[]): void => {
     for (const entry of list) {
       jobs.push(
         hydrateEntryConfigEntries(api, type, entry, fetchBody).then((outcome) => {
@@ -41,9 +48,9 @@ export async function hydrateAvailableBodies(
       );
     }
   };
-  merge("triggers", available.triggers);
-  merge("actions", available.actions);
-  merge("conditions", available.conditions);
+  if (lists.includes("triggers")) merge("triggers", available.triggers);
+  if (lists.includes("actions")) merge("actions", available.actions);
+  if (lists.includes("conditions")) merge("conditions", available.conditions);
   const settled = await Promise.allSettled(jobs);
   for (const r of settled) {
     if (r.status === "rejected") {
@@ -82,6 +89,7 @@ export async function loadAndHydrateAvailable(
   options?: {
     onPaint?: (available: AvailableAutomations) => void;
     isStale?: () => boolean;
+    lists?: readonly HydrateList[];
   }
 ): Promise<LoadAndHydrateOutcome> {
   try {
@@ -99,7 +107,12 @@ export async function loadAndHydrateAvailable(
       conditions: slim.conditions.map((e) => ({ ...e })),
     };
     options?.onPaint?.(available);
-    const hydration = await hydrateAvailableBodies(api, available);
+    const hydration = await hydrateAvailableBodies(
+      api,
+      available,
+      undefined,
+      options?.lists
+    );
     if (options?.isStale?.()) return { status: "stale" };
     // Fresh array refs so identity-based ``hasChanged`` consumers
     // re-render with the hydrated entries (entries' object identity

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -1,3 +1,5 @@
+import toast from "sonner-js";
+
 import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationAction,
@@ -5,6 +7,7 @@ import type {
   AutomationTrigger,
   AvailableAutomations,
 } from "../../../api/types/automations.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
 import {
   emptyHydrationResult,
   hydrateEntryConfigEntries,
@@ -112,4 +115,48 @@ export async function loadAndHydrateAvailable(
     if (options?.isStale?.()) return { status: "stale" };
     return { status: "error", error };
   }
+}
+
+/** Load + hydrate the catalog for an editor and return the
+ *  ``_available`` / ``_error`` it should assign. Used by the two
+ *  trigger-less editors (script, api-action), which differ only in
+ *  which reactive fields they write; the automation editor keeps its
+ *  bespoke paint+staleness orchestration. Returns an empty object
+ *  (assign nothing) when there's no api or configuration yet. */
+export async function loadAvailableFor(
+  api: ESPHomeAPI | undefined,
+  configuration: string,
+  localize: LocalizeFunc
+): Promise<{ available?: AvailableAutomations; error?: string }> {
+  if (!api || !configuration) return {};
+  return resolveLoadedAvailable(
+    await loadAndHydrateAvailable(api, configuration),
+    localize
+  );
+}
+
+/** Map a :func:`loadAndHydrateAvailable` outcome to the
+ *  ``_available`` / ``_error`` an editor assigns, surfacing partial
+ *  hydration as a non-blocking toast. A ``stale`` outcome yields
+ *  neither field so an overlapping load wins. */
+export function resolveLoadedAvailable(
+  outcome: LoadAndHydrateOutcome,
+  localize: LocalizeFunc
+): { available?: AvailableAutomations; error?: string } {
+  if (outcome.status === "stale") return {};
+  if (outcome.status === "error") {
+    return {
+      error:
+        outcome.error instanceof Error ? outcome.error.message : String(outcome.error),
+    };
+  }
+  const { missingBody, missingField, rejected } = outcome.hydration;
+  const failures = missingBody + missingField + rejected;
+  if (failures > 0) {
+    toast.error(
+      localize("device.automation_partial_hydration", { count: String(failures) }),
+      { richColors: true }
+    );
+  }
+  return { available: outcome.available };
 }

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -54,6 +54,7 @@ import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
+import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -236,10 +237,26 @@ export class ESPHomeScriptEditor extends LitElement {
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
-    try {
-      this._available = await this._api.getAvailableAutomations(this.configuration);
-    } catch (err) {
-      this._error = err instanceof Error ? err.message : String(err);
+    // Hydrate config_entries (the slim catalog omits them); without
+    // this every action renders fieldless since the node bails on an
+    // empty config_entries list.
+    const outcome = await loadAndHydrateAvailable(this._api, this.configuration);
+    if (outcome.status === "stale") return;
+    if (outcome.status === "error") {
+      this._error =
+        outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+      return;
+    }
+    this._available = outcome.available;
+    const { missingBody, missingField, rejected } = outcome.hydration;
+    const failures = missingBody + missingField + rejected;
+    if (failures > 0) {
+      toast.error(
+        this._localize("device.automation_partial_hydration", {
+          count: String(failures),
+        }),
+        { richColors: true }
+      );
     }
   }
 

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -54,7 +54,7 @@ import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
+import { loadAvailableFor } from "./hydrate-available-bodies.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -236,28 +236,16 @@ export class ESPHomeScriptEditor extends LitElement {
   }
 
   private async _loadAvailable() {
-    if (!this._api || !this.configuration) return;
-    // Hydrate config_entries (the slim catalog omits them); without
-    // this every action renders fieldless since the node bails on an
+    // Hydrates config_entries (the slim catalog omits them); without
+    // it every action renders fieldless since the node bails on an
     // empty config_entries list.
-    const outcome = await loadAndHydrateAvailable(this._api, this.configuration);
-    if (outcome.status === "stale") return;
-    if (outcome.status === "error") {
-      this._error =
-        outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
-      return;
-    }
-    this._available = outcome.available;
-    const { missingBody, missingField, rejected } = outcome.hydration;
-    const failures = missingBody + missingField + rejected;
-    if (failures > 0) {
-      toast.error(
-        this._localize("device.automation_partial_hydration", {
-          count: String(failures),
-        }),
-        { richColors: true }
-      );
-    }
+    const { available, error } = await loadAvailableFor(
+      this._api,
+      this.configuration,
+      this._localize
+    );
+    if (error !== undefined) this._error = error;
+    if (available) this._available = available;
   }
 
   /** Lazy fetch of the ``script`` component catalog entry. Reuses

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -54,7 +54,7 @@ import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./callable-params-editor.js";
-import { loadAvailableFor } from "./hydrate-available-bodies.js";
+import { CatalogLoadController } from "./catalog-load-controller.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -138,6 +138,11 @@ export class ESPHomeScriptEditor extends LitElement {
   private _applyInFlight = false;
   private _applyDirty = false;
   private _lastSelfWrittenYaml: string | null = null;
+
+  /** Catalog loader; owns the concurrency guard so overlapping loads
+   *  (connectedCallback + updated both reaching ``_loadAvailable``)
+   *  can't clobber ``_available`` or double-fire the toast. */
+  private readonly _catalogLoad = new CatalogLoadController(this);
 
   /** Brief-window dirty flag mirroring the automation editor —
    *  covers the 200ms debounce gap so the page's unsaved-changes
@@ -239,7 +244,8 @@ export class ESPHomeScriptEditor extends LitElement {
     // Hydrates config_entries (the slim catalog omits them); without
     // it every action renders fieldless since the node bails on an
     // empty config_entries list.
-    const { available, error } = await loadAvailableFor(
+    this._error = "";
+    const { available, error } = await this._catalogLoad.load(
       this._api,
       this.configuration,
       this._localize

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -21,6 +21,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
+import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
@@ -61,7 +62,10 @@ async function mountEditor(
 }
 
 describe("api-action-editor action-catalog hydration (#1286)", () => {
-  beforeEach(() => _clearAutomationBodyCache());
+  beforeEach(() => {
+    _clearAutomationBodyCache();
+    vi.mocked(toast.error).mockClear();
+  });
   afterEach(() => {
     document.body.innerHTML = "";
   });
@@ -77,6 +81,8 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actions = (editor as any)._available.actions as AvailableAutomations["actions"];
     expect(actions[0].config_entries.length).toBeGreaterThan(0);
+    // Fully-hydrated catalog -> no partial-hydration toast.
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("does not load without a configuration", async () => {

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Mount test for api-action-editor.ts catalog hydration (#1286). Like
+ * the script editor, actions inside an api action must arrive with
+ * config_entries hydrated or they render fieldless. Heavy children are
+ * no-op mocked so the editor constructs in a happy-dom window.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/callable-params-editor.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
+import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
+import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+
+const slimWithLoggerAction = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [{ id: "logger.log", config_entries: [] }],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+const loggerBodies = () => ({
+  "actions/logger.log": {
+    id: "logger.log",
+    config_entries: [{ key: "format", type: "string", label: "Format", required: true }],
+  },
+});
+
+async function flushPending(times = 30): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountEditor(
+  api: ESPHomeAPI,
+  configuration?: string
+): Promise<ESPHomeApiActionEditor> {
+  const editor = new ESPHomeApiActionEditor();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any)._api = api;
+  if (configuration !== undefined) editor.configuration = configuration;
+  document.body.appendChild(editor);
+  await editor.updateComplete;
+  await flushPending();
+  return editor;
+}
+
+describe("api-action-editor action-catalog hydration (#1286)", () => {
+  beforeEach(() => _clearAutomationBodyCache());
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("hydrates action config_entries so the form renders", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = await mountEditor(api, "device.yaml");
+
+    expect(getAutomationBodies).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const actions = (editor as any)._available.actions as AvailableAutomations["actions"];
+    expect(actions[0].config_entries.length).toBeGreaterThan(0);
+  });
+
+  it("does not load without a configuration", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    await mountEditor(api);
+
+    expect(getAvailableAutomations).not.toHaveBeenCalled();
+    expect(getAutomationBodies).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/automation-editor/catalog-load-controller.test.ts
+++ b/test/components/device/automation-editor/catalog-load-controller.test.ts
@@ -21,10 +21,10 @@ const emptySlim = (): AvailableAutomations =>
     devices: [],
   }) as unknown as AvailableAutomations;
 
-const slimWithTrigger = (): AvailableAutomations =>
+const slimWithAction = (): AvailableAutomations =>
   ({
-    triggers: [{ id: "on_boot", config_entries: [] }],
-    actions: [],
+    triggers: [],
+    actions: [{ id: "logger.log", config_entries: [] }],
     conditions: [],
     scripts: [],
     devices: [],
@@ -79,7 +79,7 @@ describe("CatalogLoadController", () => {
     // Missing body -> failures -> the winning load toasts once; the
     // superseded load must stay silent.
     const api = {
-      getAvailableAutomations: vi.fn().mockResolvedValue(slimWithTrigger()),
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimWithAction()),
       getAutomationBodies: vi.fn().mockResolvedValue({}),
     } as unknown as ESPHomeAPI;
 

--- a/test/components/device/automation-editor/catalog-load-controller.test.ts
+++ b/test/components/device/automation-editor/catalog-load-controller.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ReactiveControllerHost } from "lit";
+import toast from "sonner-js";
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
+import { CatalogLoadController } from "../../../../src/components/device/automation-editor/catalog-load-controller.js";
+import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+
+const localize = ((key: string) => key) as never;
+const stubHost = () => ({ addController: vi.fn() }) as unknown as ReactiveControllerHost;
+
+const emptySlim = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+const slimWithTrigger = (): AvailableAutomations =>
+  ({
+    triggers: [{ id: "on_boot", config_entries: [] }],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+describe("CatalogLoadController", () => {
+  beforeEach(() => {
+    _clearAutomationBodyCache();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it("returns an empty result with no api or configuration", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    expect(await ctrl.load(undefined, "a.yaml", localize)).toEqual({});
+    const getAvailableAutomations = vi.fn();
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+    expect(await ctrl.load(api, "", localize)).toEqual({});
+    expect(getAvailableAutomations).not.toHaveBeenCalled();
+  });
+
+  it("resolves the hydrated available for a single load", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(emptySlim()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    const { available, error } = await ctrl.load(api, "a.yaml", localize);
+
+    expect(error).toBeUndefined();
+    expect(available).toBeDefined();
+  });
+
+  it("discards a load superseded by a later one (structural guard)", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(emptySlim()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    // Second call bumps the token before the first awaits resolve.
+    const first = ctrl.load(api, "a.yaml", localize);
+    const second = ctrl.load(api, "b.yaml", localize);
+    const [r1, r2] = await Promise.all([first, second]);
+
+    expect(r1).toEqual({});
+    expect(r2.available).toBeDefined();
+  });
+
+  it("does not toast for a superseded partial-hydration load", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    // Missing body -> failures -> the winning load toasts once; the
+    // superseded load must stay silent.
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimWithTrigger()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    const first = ctrl.load(api, "dev.yaml", localize);
+    const second = ctrl.load(api, "dev.yaml", localize);
+    await Promise.all([first, second]);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards an in-flight load after the host disconnects", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(emptySlim()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    const p = ctrl.load(api, "a.yaml", localize);
+    ctrl.hostDisconnected();
+
+    expect(await p).toEqual({});
+  });
+});

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type {
   AutomationAction,
@@ -12,6 +16,8 @@ import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
 import {
   hydrateAvailableBodies,
   loadAndHydrateAvailable,
+  resolveLoadedAvailable,
+  type LoadAndHydrateOutcome,
 } from "../../../../src/components/device/automation-editor/hydrate-available-bodies.js";
 
 const configEntry = (key: string): ConfigEntry => ({ key }) as ConfigEntry;
@@ -268,5 +274,49 @@ describe("loadAndHydrateAvailable", () => {
     });
 
     expect(outcome.status).toBe("stale");
+  });
+});
+
+describe("resolveLoadedAvailable", () => {
+  const localize = ((key: string) => key) as never;
+  const okOutcome = (failures = 0): LoadAndHydrateOutcome => ({
+    status: "ok",
+    available: slimAvailable(),
+    hydration: { succeeded: 1, missingBody: failures, missingField: 0, rejected: 0 },
+  });
+
+  it("returns the hydrated available on success", () => {
+    const av = slimAvailable();
+    const { available, error } = resolveLoadedAvailable(
+      {
+        status: "ok",
+        available: av,
+        hydration: { succeeded: 1, missingBody: 0, missingField: 0, rejected: 0 },
+      },
+      localize
+    );
+    expect(available).toBe(av);
+    expect(error).toBeUndefined();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("maps an error outcome to the message and yields no available", () => {
+    const { available, error } = resolveLoadedAvailable(
+      { status: "error", error: new Error("boom") },
+      localize
+    );
+    expect(available).toBeUndefined();
+    expect(error).toBe("boom");
+  });
+
+  it("yields neither field when stale", () => {
+    expect(resolveLoadedAvailable({ status: "stale" }, localize)).toEqual({});
+  });
+
+  it("toasts when some entries failed to hydrate", () => {
+    vi.mocked(toast.error).mockClear();
+    const { available } = resolveLoadedAvailable(okOutcome(2), localize);
+    expect(available).toBeDefined();
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -320,3 +320,17 @@ describe("resolveLoadedAvailable", () => {
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("hydrateAvailableBodies list selection", () => {
+  it("skips lists not requested", async () => {
+    const fetchBody = vi.fn(async () => triggerBody("x", [configEntry("foo")]));
+    const available = slimAvailable(); // triggers only
+    const result = await hydrateAvailableBodies(makeApi(), available, fetchBody, [
+      "actions",
+    ]);
+    // No actions present and triggers not requested -> nothing fetched.
+    expect(fetchBody).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(0);
+    expect(available.triggers[0].config_entries).toEqual([]);
+  });
+});

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Mount test for script-editor.ts catalog hydration (#1286). Actions
+ * inside a script block must arrive with config_entries hydrated, or
+ * every action renders fieldless. Heavy children (config-entry-form ->
+ * CodeMirror, the action list) are no-op mocked so the editor itself
+ * can construct in a happy-dom window.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/callable-params-editor.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
+
+import type { ESPHomeAPI } from "../../../../src/api/index.js";
+import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
+import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
+import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+
+const slimWithLoggerAction = (): AvailableAutomations =>
+  ({
+    triggers: [],
+    actions: [{ id: "logger.log", config_entries: [] }],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
+const loggerBodies = () => ({
+  "actions/logger.log": {
+    id: "logger.log",
+    config_entries: [{ key: "format", type: "string", label: "Format", required: true }],
+  },
+});
+
+async function flushPending(times = 30): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountEditor(
+  api: ESPHomeAPI,
+  configuration?: string
+): Promise<ESPHomeScriptEditor> {
+  const editor = new ESPHomeScriptEditor();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any)._api = api;
+  if (configuration !== undefined) editor.configuration = configuration;
+  document.body.appendChild(editor);
+  await editor.updateComplete;
+  await flushPending();
+  return editor;
+}
+
+describe("script-editor action-catalog hydration (#1286)", () => {
+  beforeEach(() => _clearAutomationBodyCache());
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("hydrates action config_entries so the form renders", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue(loggerBodies());
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    const editor = await mountEditor(api, "device.yaml");
+
+    expect(getAutomationBodies).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const actions = (editor as any)._available.actions as AvailableAutomations["actions"];
+    expect(actions[0].config_entries.length).toBeGreaterThan(0);
+  });
+
+  it("does not load without a configuration", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(slimWithLoggerAction());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = { getAvailableAutomations, getAutomationBodies } as unknown as ESPHomeAPI;
+
+    await mountEditor(api);
+
+    expect(getAvailableAutomations).not.toHaveBeenCalled();
+    expect(getAutomationBodies).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -24,6 +24,7 @@ vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
+import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
@@ -64,7 +65,10 @@ async function mountEditor(
 }
 
 describe("script-editor action-catalog hydration (#1286)", () => {
-  beforeEach(() => _clearAutomationBodyCache());
+  beforeEach(() => {
+    _clearAutomationBodyCache();
+    vi.mocked(toast.error).mockClear();
+  });
   afterEach(() => {
     document.body.innerHTML = "";
   });
@@ -80,6 +84,8 @@ describe("script-editor action-catalog hydration (#1286)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actions = (editor as any)._available.actions as AvailableAutomations["actions"];
     expect(actions[0].config_entries.length).toBeGreaterThan(0);
+    // Fully-hydrated catalog -> no partial-hydration toast.
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("does not load without a configuration", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Actions added inside a `script:` block showed no input field for their values (e.g. `logger.log:` had nowhere to type the text). The same actions under `interval:` worked.

Cause: the action node skips rendering a form when an action has no `config_entries` (`automation-action-node.ts`), and `config_entries` aren't in the slim catalog; they're hydrated on demand via `/automations/get_bodies`. The automation editor hydrates; the script editor and api-action editor loaded only the slim catalog, so their actions arrived with empty `config_entries` and rendered fieldless. The api-action editor had the identical latent bug (it renders the same action list).

What changed:

- Both editors now hydrate the catalog before rendering action forms.
- The shared load + hydrate + outcome-mapping (and the partial-hydration toast) lives in one place; each editor keeps only a thin assign of its own reactive state.
- The load concurrency guard is structural: a `CatalogLoadController` (`ReactiveController`) owns the sequence token and is the only entry point, so an overlapping load (connectedCallback + updated) can't clobber `_available` or double-fire the toast, and the guard can't be omitted by a future caller. It also invalidates on host disconnect.
- Hydration is scoped to the lists an editor actually renders — the trigger-less editors fetch action + condition bodies only, not trigger bodies.

Verified with unit + happy-dom mount + controller tests, and end-to-end in the browser (the `logger.log` field now renders).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1286
- closes #688 (the double-fire / concurrency guard, fixed structurally here)
- follow-up: #689 (migrate the automation editor onto the same controller)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
