### PR TITLE
Add control-flow action param-rendering regression test (#1285)

### DIFF
--- a/test/components/device/automation-editor/automation-action-node-controlflow.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-controlflow.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A control-flow action node renders its params form alongside its
+ * nested action list; children must not suppress the params form.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-condition-tree.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import type {
+  ActionNode,
+  AutomationAction,
+} from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+
+const countEntry = {
+  key: "count",
+  type: "integer",
+  label: "Count",
+  required: true,
+} as unknown as ConfigEntry;
+
+// The two assertions are driven purely by config_entries (params form)
+// and accepts_action_list (nested list); the node reads neither
+// is_control_flow nor any other field.
+const repeatAction: AutomationAction = {
+  id: "repeat",
+  name: "Repeat",
+  description: "",
+  config_entries: [countEntry],
+  accepts_action_list: ["then"],
+} as unknown as AutomationAction;
+
+const repeatNode: ActionNode = {
+  action_id: "repeat",
+  params: {},
+  children: { then: [] },
+} as unknown as ActionNode;
+
+async function mountNode(): Promise<ESPHomeAutomationActionNode> {
+  const el = new ESPHomeAutomationActionNode();
+  el.value = repeatNode;
+  el.catalog = [repeatAction];
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("automation-action-node control-flow rendering (#1285)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the params form for a control-flow action that has nested children", async () => {
+    const el = await mountNode();
+    // Params form must render even though this action has a nested list.
+    expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).not.toBeNull();
+  });
+
+  it("renders the nested action list alongside the params form", async () => {
+    const el = await mountNode();
+    expect(el.shadowRoot!.querySelector("esphome-automation-action-list")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Test-only follow-up for #1285 (no input field for a `repeat` action's required `count`). The root cause was the same slim-catalog hydration gap fixed in #687 — once `config_entries` are hydrated, the action node renders `repeat`'s `count`. This adds the missing regression coverage for control-flow actions.

`repeat` (and `if` / `while`) carry both a scalar param and a nested action list. The node renders the params form independently of the nested list, so a control-flow action must show BOTH. The test mounts a `repeat` node and asserts it renders its config-entry-form (the `count` field) alongside its nested `then` action list, guarding against a future change that suppresses params when children exist.

Verified end-to-end in the browser: with `repeat` inside a `script:`, the `count` input now renders.

**Related issue or feature (if applicable):**

- regression test for https://github.com/esphome/device-builder/issues/1285 (fixed by #687)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
