### PR TITLE
Migrate automation-editor onto CatalogLoadController

### DIFF
--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -396,17 +396,13 @@ export class ESPHomeAutomationEditor extends LitElement {
       this.configuration,
       this._localize,
       {
-        // Hydrate all three lists — the editor renders the trigger
-        // picker, unlike the trigger-less editors (actions +
-        // conditions only).
+        // All three lists: this editor renders the trigger picker.
         lists: ["triggers", "actions", "conditions"],
-        // Paint the picker with the slim list AND drop the loading
-        // spinner so the dropdowns mount while hydration runs in the
-        // background; the controller guards this against a superseded
-        // load. The post-hydration ``available`` below carries fresh
-        // array refs so identity-based ``hasChanged`` consumers
-        // (trigger picker, condition tree, action node) re-render with
-        // the hydrated ``config_entries``.
+        // Paint the slim list and drop the spinner so the dropdowns
+        // mount while hydration runs; the controller guards this
+        // against a superseded load. The post-hydration ``available``
+        // below carries fresh array refs so identity-based
+        // ``hasChanged`` consumers re-render with the hydrated bodies.
         onPaint: (painted) => {
           this._available = painted;
           this._loading = false;
@@ -415,8 +411,7 @@ export class ESPHomeAutomationEditor extends LitElement {
     );
     // A stale/no-op load returns neither field — leave ``_loading`` to
     // the newer load that superseded this one (the old finally-seq
-    // guard). The partial-hydration toast now fires inside the
-    // controller's ``resolveLoadedAvailable``.
+    // guard). The partial-hydration toast fires inside the controller.
     if (error !== undefined) {
       this._error = error;
       this._loading = false;

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -63,8 +63,8 @@ import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./automation-target-picker.js";
 import "./automation-trigger-picker.js";
+import { CatalogLoadController } from "./catalog-load-controller.js";
 import { componentDomain, instanceName } from "./component-targets.js";
-import { loadAndHydrateAvailable } from "./hydrate-available-bodies.js";
 import { ParseErrorController } from "./parse-error-controller.js";
 import {
   applyYamlDiff,
@@ -130,13 +130,6 @@ export class ESPHomeAutomationEditor extends LitElement {
    *  device's YAML) so the dropdowns only show what's usable. */
   @state() private _available: AvailableAutomations | null = null;
 
-  /** Monotonic generation token for ``_loadAvailable``. Two
-   *  overlapping reconnect-driven loads can otherwise have the
-   *  earlier one's stale assignment land after the later one's
-   *  fresh assignment; this lets each invocation drop its results
-   *  if the seq has moved on while it awaited. */
-  private _loadAvailableSeq = 0;
-
   /** Component catalog entry for the ``interval`` component, lazily
    *  fetched the first time we render an interval automation. Drives
    *  the header (name / description / docs / image) and the inline
@@ -150,6 +143,13 @@ export class ESPHomeAutomationEditor extends LitElement {
   /** Renders read-only + blocks auto-apply for a parse-errored
    *  automation so its empty tree can't overwrite the real YAML. */
   private readonly _parseError = new ParseErrorController(this);
+
+  /** Owns the catalog-load concurrency guard (sequence token +
+   *  host-disconnect invalidation) so an overlapping load can't
+   *  clobber ``_available``, paint a stale slim catalog, or
+   *  double-fire the partial-hydration toast. Shared with the
+   *  trigger-less editors (script, api-action). */
+  private readonly _catalogLoad = new CatalogLoadController(this);
 
   /** "Show advanced settings" toggle state for the params form.
    *  Mirrors ``device-section-config``'s same-named state but
@@ -389,49 +389,41 @@ export class ESPHomeAutomationEditor extends LitElement {
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
-    const seq = ++this._loadAvailableSeq;
     this._loading = true;
     this._error = "";
-    try {
-      const outcome = await loadAndHydrateAvailable(this._api, this.configuration, {
+    const { available, error } = await this._catalogLoad.load(
+      this._api,
+      this.configuration,
+      this._localize,
+      {
+        // Hydrate all three lists — the editor renders the trigger
+        // picker, unlike the trigger-less editors (actions +
+        // conditions only).
+        lists: ["triggers", "actions", "conditions"],
         // Paint the picker with the slim list AND drop the loading
-        // spinner so the dropdowns mount while hydration runs in
-        // the background. The post-hydration ``_available``
-        // reassignment below carries fresh array refs to force a
-        // re-render with the hydrated ``config_entries``.
+        // spinner so the dropdowns mount while hydration runs in the
+        // background; the controller guards this against a superseded
+        // load. The post-hydration ``available`` below carries fresh
+        // array refs so identity-based ``hasChanged`` consumers
+        // (trigger picker, condition tree, action node) re-render with
+        // the hydrated ``config_entries``.
         onPaint: (painted) => {
-          if (seq !== this._loadAvailableSeq) return;
           this._available = painted;
           this._loading = false;
         },
-        isStale: () => seq !== this._loadAvailableSeq,
-      });
-      if (outcome.status === "stale") return;
-      if (outcome.status === "error") {
-        this._error =
-          outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
-        return;
       }
-      // Fresh array refs so identity-based ``hasChanged`` consumers
-      // (trigger picker, condition tree, action node) re-render
-      // with the hydrated entries.
-      this._available = outcome.available;
-      const { missingBody, missingField, rejected } = outcome.hydration;
-      const failures = missingBody + missingField + rejected;
-      if (failures > 0) {
-        // Soft surface: non-blocking toast. Don't set ``_error``
-        // since the picker is still usable for the entries that
-        // hydrated; ``cacheMisses: false`` lets a re-mount retry
-        // the missing ones.
-        toast.error(
-          this._localize("device.automation_partial_hydration", {
-            count: String(failures),
-          }),
-          { richColors: true }
-        );
-      }
-    } finally {
-      if (seq === this._loadAvailableSeq) this._loading = false;
+    );
+    // A stale/no-op load returns neither field — leave ``_loading`` to
+    // the newer load that superseded this one (the old finally-seq
+    // guard). The partial-hydration toast now fires inside the
+    // controller's ``resolveLoadedAvailable``.
+    if (error !== undefined) {
+      this._error = error;
+      this._loading = false;
+    }
+    if (available) {
+      this._available = available;
+      this._loading = false;
     }
   }
 

--- a/src/components/device/automation-editor/catalog-load-controller.ts
+++ b/src/components/device/automation-editor/catalog-load-controller.ts
@@ -6,16 +6,18 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import {
   loadAndHydrateAvailable,
   resolveLoadedAvailable,
+  type HydrateList,
 } from "./hydrate-available-bodies.js";
 
 /**
- * Owns the concurrency guard for a trigger-less editor's catalog load
- * (script, api-action). The sequence token lives here, not on the
- * editor, so a load cannot be issued without it: load() is the only
- * entry point and always discards a result superseded by a later load
- * or by host disconnect, so an overlapping load can never clobber the
- * editor's state or double-fire the partial-hydration toast. The
- * editor just assigns the returned fields to its own reactive state.
+ * Owns the concurrency guard for a catalog-form editor's catalog load
+ * (script, api-action, automation). The sequence token lives here, not
+ * on the editor, so a load cannot be issued without it: load() is the
+ * only entry point and always discards a result superseded by a later
+ * load or by host disconnect, so an overlapping load can never clobber
+ * the editor's state, paint a stale slim catalog, or double-fire the
+ * partial-hydration toast. The editor just assigns the returned fields
+ * to its own reactive state.
  */
 export class CatalogLoadController implements ReactiveController {
   private _seq = 0;
@@ -32,15 +34,31 @@ export class CatalogLoadController implements ReactiveController {
   async load(
     api: ESPHomeAPI | undefined,
     configuration: string,
-    localize: LocalizeFunc
+    localize: LocalizeFunc,
+    options?: {
+      lists?: readonly HydrateList[];
+      onPaint?: (available: AvailableAutomations) => void;
+    }
   ): Promise<{ available?: AvailableAutomations; error?: string }> {
     if (!api || !configuration) return {};
     const seq = ++this._seq;
-    // Trigger-less editors render actions + conditions only; skipping
-    // trigger-body hydration avoids needless get_bodies work on mount.
+    const onPaint = options?.onPaint;
     const outcome = await loadAndHydrateAvailable(api, configuration, {
       isStale: () => seq !== this._seq,
-      lists: ["actions", "conditions"],
+      // Trigger-less editors (script, api-action) render actions +
+      // conditions only; skipping trigger-body hydration avoids needless
+      // get_bodies work on mount. automation-editor passes all three to
+      // also hydrate the trigger picker.
+      lists: options?.lists ?? ["actions", "conditions"],
+      // Wrap the caller's early paint in the same staleness check so a
+      // superseded load (or a post-disconnect resolve) can't paint a
+      // stale slim catalog over a newer load's result.
+      onPaint: onPaint
+        ? (available) => {
+            if (seq !== this._seq) return;
+            onPaint(available);
+          }
+        : undefined,
     });
     // Re-check after the await: a later load (or disconnect) bumped the
     // token, so this result is stale — drop it before it can toast or

--- a/test/components/device/automation-editor/catalog-load-controller.test.ts
+++ b/test/components/device/automation-editor/catalog-load-controller.test.ts
@@ -30,6 +30,15 @@ const slimWithAction = (): AvailableAutomations =>
     devices: [],
   }) as unknown as AvailableAutomations;
 
+const slimWithTrigger = (): AvailableAutomations =>
+  ({
+    triggers: [{ id: "on_boot", config_entries: [] }],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  }) as unknown as AvailableAutomations;
+
 describe("CatalogLoadController", () => {
   beforeEach(() => {
     _clearAutomationBodyCache();
@@ -101,5 +110,72 @@ describe("CatalogLoadController", () => {
     ctrl.hostDisconnected();
 
     expect(await p).toEqual({});
+  });
+
+  it("does not invoke a superseded load's onPaint (staleness wrap)", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(emptySlim()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    const firstPaint = vi.fn();
+    const secondPaint = vi.fn();
+    // Second call bumps the token before the first awaits resolve, so
+    // the first's early paint must never land.
+    const first = ctrl.load(api, "a.yaml", localize, { onPaint: firstPaint });
+    const second = ctrl.load(api, "b.yaml", localize, { onPaint: secondPaint });
+    await Promise.all([first, second]);
+
+    expect(firstPaint).not.toHaveBeenCalled();
+    expect(secondPaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke onPaint after the host disconnects", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(emptySlim()),
+      getAutomationBodies: vi.fn().mockResolvedValue({}),
+    } as unknown as ESPHomeAPI;
+
+    const onPaint = vi.fn();
+    const p = ctrl.load(api, "a.yaml", localize, { onPaint });
+    ctrl.hostDisconnected();
+    await p;
+
+    expect(onPaint).not.toHaveBeenCalled();
+  });
+
+  it("forwards an explicit lists selector so triggers hydrate too", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimWithTrigger()),
+      getAutomationBodies,
+    } as unknown as ESPHomeAPI;
+
+    await ctrl.load(api, "a.yaml", localize, {
+      lists: ["triggers", "actions", "conditions"],
+    });
+
+    expect(getAutomationBodies).toHaveBeenCalledTimes(1);
+    expect(getAutomationBodies).toHaveBeenCalledWith([
+      { type: "triggers", id: "on_boot" },
+    ]);
+  });
+
+  it("defaults to actions + conditions, skipping trigger hydration", async () => {
+    const ctrl = new CatalogLoadController(stubHost());
+    const getAutomationBodies = vi.fn().mockResolvedValue({});
+    const api = {
+      getAvailableAutomations: vi.fn().mockResolvedValue(slimWithTrigger()),
+      getAutomationBodies,
+    } as unknown as ESPHomeAPI;
+
+    // No options: the trigger-less default scopes hydration to actions
+    // + conditions, so a trigger-only slim fetches no bodies.
+    await ctrl.load(api, "a.yaml", localize);
+
+    expect(getAutomationBodies).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

automation-editor was the last catalog-form editor still rolling its own load-concurrency guard (the hand-rolled `_loadAvailableSeq` token). This moves it onto the shared `CatalogLoadController` from #687, so script-editor, api-action-editor, and automation-editor all share one structural guard.

The controller's `load()` now takes optional `{ lists, onPaint }`; `lists` defaults to actions plus conditions so the trigger-less editors are unchanged, and `onPaint` is wrapped in the controller's sequence token so a superseded early paint can't land. automation-editor passes all three lists since it renders the trigger picker, and keeps owning its own `_loading` lifecycle by driving it off the return shape. As a side effect it now gets host-disconnect invalidation it previously lacked.

Added controller coverage for the onPaint staleness wrap and the lists passthrough; existing automation-editor mount tests stay green.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/689

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
