### PR TITLE
Fix stale doc reference in registry-list helper comment

### DIFF
--- a/src/components/device/config-entry-renderers/registry-list-helpers.ts
+++ b/src/components/device/config-entry-renderers/registry-list-helpers.ts
@@ -34,8 +34,8 @@ export function itemId(item: Record<string, unknown>): string {
 /** True when *item* looks like a registry-list item the renderer can
  *  edit: a plain object with zero or one key. Multi-key items or
  *  non-object entries are preserved verbatim through edits via
- *  ``preserveForeignEntries`` so a click in the visual editor never
- *  drops data the form doesn't understand. */
+ *  ``editableEntries`` / ``spliceEditable`` so a click in the visual
+ *  editor never drops data the form doesn't understand. */
 export function isEditableItem(raw: unknown): raw is Record<string, unknown> {
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return false;
   return Object.keys(raw as Record<string, unknown>).length <= 1;


### PR DESCRIPTION
# What does this implement/fix?

Followup to #681; the `isEditableItem` doc comment referenced `preserveForeignEntries`, a symbol that does not exist anywhere in the tree. The foreign-entry preservation is actually handled by `editableEntries` and `spliceEditable`, so the comment now points at the real functions. Comment only, no behaviour change.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
