### PR TITLE
Trim float-with-unit pickers to the field's value range

### DIFF
--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -4,9 +4,11 @@ import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import {
   chooseDisplayUnit,
+  defaultUnitForFloatWithUnit,
   parseFloatWithUnit,
   placeholderForFloatWithUnit,
   serializeFloatWithUnit,
+  visibleUnitOptions,
 } from "../../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
@@ -297,6 +299,13 @@ export function renderFloatWithUnitField(
     ctx.getPendingUnit(path),
     unitOptions
   );
+  // Narrow the picker to the field's scale; keep canonical/default/in-use so a
+  // trimmed unit a value uses is never hidden (parsing uses the full list).
+  const pickerUnitOptions = visibleUnitOptions(unitOptions, entry.range, [
+    canonicalUnit,
+    defaultUnitForFloatWithUnit(entry.default_value, unitOptions),
+    unit,
+  ]);
   const placeholder = placeholderForFloatWithUnit(entry.default_value, unitOptions);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
@@ -329,7 +338,7 @@ export function renderFloatWithUnitField(
           }}
           @blur=${() => ctx.clearEditingMagnitude(path)}
         />
-        ${unitOptions.length > 1
+        ${pickerUnitOptions.length > 1
           ? html`
               <wa-select
                 data-no-value-sync
@@ -345,7 +354,7 @@ export function renderFloatWithUnitField(
                   }
                 }}
               >
-                ${unitOptions.map(
+                ${pickerUnitOptions.map(
                   (option) =>
                     html`<wa-option value=${option} ?selected=${option === unit}
                       >${option}</wa-option

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -174,3 +174,51 @@ export function chooseDisplayUnit(
   }
   return pendingUnit ?? defaultUnitForFloatWithUnit(defaultValue, unitOptions);
 }
+
+// SI prefixes the metric pickers use, with multipliers, for judging which
+// prefixed options sit at a field's scale. 'µ' is the canonical micro form.
+const METRIC_PREFIX_MULTIPLIERS: Record<string, number> = {
+  "": 1,
+  n: 1e-9,
+  µ: 1e-6,
+  m: 1e-3,
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+};
+
+/**
+ * Narrow `unitOptions` to prefixes at the field's `range` scale, always keeping
+ * `mustKeep` units. Only metric-prefixed lists are trimmed; fixed lists and
+ * rangeless fields pass through. Display-only: callers parse against the full
+ * list, so a trimmed unit a value already uses is never stranded.
+ */
+export function visibleUnitOptions(
+  unitOptions: readonly string[],
+  range: readonly [number, number] | null,
+  mustKeep: readonly string[]
+): string[] {
+  const all = [...unitOptions];
+  if (!range || all.length <= 1) return all;
+  const base = all[0];
+  const prefixOf = (option: string): string | null => {
+    if (option === base) return "";
+    if (!option.endsWith(base)) return null;
+    const prefix = option.slice(0, option.length - base.length);
+    // own-key check, not `in`, so inherited keys (toString/constructor) can't
+    // masquerade as a known prefix and mis-trim a non-metric unit.
+    return Object.prototype.hasOwnProperty.call(METRIC_PREFIX_MULTIPLIERS, prefix)
+      ? prefix
+      : null;
+  };
+  // Only trim genuinely metric-prefixed lists.
+  if (!all.every((option) => prefixOf(option) !== null)) return all;
+  const [min, max] = range;
+  const keep = new Set(mustKeep);
+  const result = all.filter((option) => {
+    if (keep.has(option)) return true;
+    const mult = METRIC_PREFIX_MULTIPLIERS[prefixOf(option) as string];
+    return 0.1 * mult <= max && 1000 * mult >= min;
+  });
+  return result.length ? result : all;
+}

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -5,6 +5,7 @@ import {
   parseFloatWithUnit,
   placeholderForFloatWithUnit,
   serializeFloatWithUnit,
+  visibleUnitOptions,
 } from "../../src/util/float-with-unit.js";
 
 const FREQUENCY_UNITS = ["Hz", "mHz", "kHz", "MHz", "GHz"] as const;
@@ -334,5 +335,49 @@ describe("serializeFloatWithUnit", () => {
   it("round-trips through parse", () => {
     const parsed = parseFloatWithUnit("3.3V", ["V", "mV", "kV"]);
     expect(serializeFloatWithUnit(parsed)).toBe("3.3V");
+  });
+});
+
+describe("visibleUnitOptions", () => {
+  const VOLTS = ["V", "nV", "µV", "mV", "kV", "MV", "GV"];
+
+  it("keeps the full list when there is no range", () => {
+    expect(visibleUnitOptions(VOLTS, null, ["V"])).toEqual(VOLTS);
+  });
+
+  it("drops prefixes above a small max", () => {
+    // 0-32 V field: kV/MV/GV are out of scale, sub-volt prefixes stay.
+    expect(visibleUnitOptions(VOLTS, [0, 32], ["V"])).toEqual(["V", "nV", "µV", "mV"]);
+  });
+
+  it("keeps high prefixes when the max needs them", () => {
+    // 0-65535 m: km is in scale, Mm/Gm are not.
+    const metres = ["m", "nm", "µm", "mm", "km", "Mm", "Gm"];
+    expect(visibleUnitOptions(metres, [0, 65535], ["m"])).toEqual([
+      "m",
+      "nm",
+      "µm",
+      "mm",
+      "km",
+    ]);
+  });
+
+  it("never drops a mustKeep unit even if out of range", () => {
+    // The value already uses kV; trimming must not strand it.
+    expect(visibleUnitOptions(VOLTS, [0, 32], ["V", "kV"])).toContain("kV");
+  });
+
+  it("leaves fixed-unit lists untouched", () => {
+    const fixed = ["FPS", "Hz"];
+    expect(visibleUnitOptions(fixed, [0, 1], ["FPS"])).toEqual(fixed);
+    const db = ["dB", "dBm"];
+    expect(visibleUnitOptions(db, [0, 1], ["dB"])).toEqual(db);
+  });
+
+  it("does not treat inherited Object keys as metric prefixes", () => {
+    // A unit whose 'prefix' is an inherited key (constructor/toString) must
+    // be read as non-metric and left untouched, not coerced and mis-trimmed.
+    const tricky = ["X", "constructorX", "toStringX"];
+    expect(visibleUnitOptions(tricky, [0, 1], ["X"])).toEqual(tricky);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the backend float_with_unit work (esphome/device-builder#1299). Metric unit pickers offered the full SI-prefix superset, so a field that maxes at 32V still listed `kV`/`MV`/`GV` and a current sensor showed `MA`/`GA`. This narrows the *displayed* options to prefixes whose natural magnitude window overlaps the field's `range`, so the dropdown matches the field's scale.

Safety first: it always keeps the canonical, default, and currently-used unit, and parsing still runs against the full `unit_options` list. So a value that uses a trimmed unit (even one our range guess got wrong) is still accepted, shown, and round-trips. Fixed-unit lists (`FPS`/`Hz`, `dB`/`dBm`) and fields without a range are left untouched.

Verified in the browser: an INA219 `max_voltage` (range 0-32V) picker drops `MV`/`GV`; a config with `max_voltage: 5kV` still shows and selects `kV`.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder#1299

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
