### PR TITLE
Render the value input + lambda toggle for scalar filters

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -100,6 +100,9 @@ export interface RegistryCatalogEntry {
    *  inline input at the polymorphic value position instead of an
    *  empty sub-form. */
   value_type?: RegistryValueType | null;
+  /** The scalar value accepts a lambda (``multiply: !lambda``); the
+   *  renderer offers a literal/lambda toggle on the inline input. */
+  templatable?: boolean;
 }
 
 /** A light effect (``pulse``, ``flicker``, ``addressable_lambda``…).

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -393,7 +393,13 @@ export class ESPHomeRegistryList extends LitElement {
           </wa-select>
           ${renderListRemoveButton(this.ctx, disabled, () => this._removeAt(index))}
         </div>
-        ${this._renderSubForm(index, currentId, scalarConfigType, childEntries)}
+        ${this._renderSubForm(
+          index,
+          currentId,
+          scalarConfigType,
+          childEntries,
+          catalogEntry?.templatable ?? false
+        )}
       </div>
     `;
   }
@@ -445,11 +451,13 @@ export class ESPHomeRegistryList extends LitElement {
     index: number,
     currentId: string,
     scalarConfigType: ConfigEntryType | null,
-    childEntries: ConfigEntry[]
+    childEntries: ConfigEntry[],
+    templatable: boolean
   ) {
     if (scalarConfigType !== null) {
+      // templatable adds the literal/lambda toggle on the value (multiply: !lambda).
       return html`<div class="registry-list-sub-form">
-        ${this.ctx.renderEntry(makeConfigEntry({ type: scalarConfigType }), [
+        ${this.ctx.renderEntry(makeConfigEntry({ type: scalarConfigType, templatable }), [
           ...this.path,
           String(index),
           currentId,

--- a/test/components/device/config-entry-registry-list-renderer.test.ts
+++ b/test/components/device/config-entry-registry-list-renderer.test.ts
@@ -602,6 +602,43 @@ describe("renderRegistryListField — per-row params sub-form", () => {
     });
   });
 
+  it("marks a templatable scalar filter so the row gets a lambda toggle", async () => {
+    // multiply takes a float OR a lambda; the synthetic scalar entry must carry
+    // templatable so renderEntry wraps it with the literal/lambda toggle.
+    const renderEntry = vi.fn();
+    const catalog = [
+      {
+        id: "multiply",
+        name: "Multiply",
+        config_entries: [],
+        applies_to: [],
+        value_type: "float",
+        templatable: true,
+      },
+    ];
+    const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;
+    el.entry = makeEntry(ConfigEntryType.REGISTRY_LIST, {
+      key: "filters",
+      registry: "filter",
+      multi_value: true,
+    });
+    el.path = ["filters"];
+    el.ctx = makeRenderCtx(
+      { filters: [{ multiply: 0.01 }] },
+      { overrides: { renderEntry } }
+    );
+    document.body.append(el);
+    (el as unknown as { _catalog: typeof catalog })._catalog = catalog;
+    el.requestUpdate();
+    await el.updateComplete;
+    const synthetic = renderEntry.mock.calls.map(
+      (c) => c[0] as { type: string; templatable?: boolean }
+    );
+    expect(synthetic).toContainEqual(
+      expect.objectContaining({ type: ConfigEntryType.FLOAT, templatable: true })
+    );
+  });
+
   it("renders no sub-form on an empty / unselected row", async () => {
     const renderEntry = vi.fn();
     const el = document.createElement("esphome-registry-list") as ESPHomeRegistryList;


### PR DESCRIPTION
# What does this implement/fix?

Pairs with esphome/device-builder#1308. A scalar sensor filter (`multiply`, `offset`) showed its type dropdown but no field to set the value. With the backend now tagging those filters `value_type` + `templatable`, this threads `templatable` through the registry-list sub-form so the synthetic scalar `ConfigEntry` carries it; `renderEntry` then wraps the inline input with the literal/lambda toggle. The user can set `multiply: 0.01` or `multiply: !lambda return 0.01;`. Fixed-unit and non-templatable filters are unaffected.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1304

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
