### PR TITLE
Preserve the !lambda tag through the lambda value sentinel

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -224,10 +224,13 @@ export interface YamlDiff {
  *  ``!lambda |- ...`` block from a literal string. Used wherever a
  *  ``ConfigEntry`` has ``templatable: true`` and the user picked the
  *  lambda branch of the literal/lambda toggle. The backend writer
- *  emits this as a ruamel ``LiteralScalarString`` with ``|-`` style;
- *  the parser inverts. */
+ *  emits an untagged ``_lambda`` as a bare ``|-`` block; ``_tag:
+ *  "!lambda"`` re-emits the explicit tag, which a templatable value
+ *  field (``uart.write:``, ``delay:``) needs to compile as a lambda
+ *  rather than a string literal. Echo it back unchanged on save. */
 export interface LambdaValue {
   _lambda: string;
+  _tag?: "!lambda";
 }
 
 /** Type guard for ``LambdaValue``. */

--- a/src/components/device/config-entry-renderers/lambda.ts
+++ b/src/components/device/config-entry-renderers/lambda.ts
@@ -47,6 +47,10 @@ export function renderLambdaField(entry: ConfigEntry, path: string[], ctx: Rende
   const value = lambdaBodyOf(raw);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
+  // Carry an existing ``!lambda`` tag forward across body edits so a
+  // tagged value (set by the templatable toggle, or parsed from a
+  // ``!lambda``-tagged field) doesn't decay to a bare ``|-`` block.
+  const tag = isLambdaValue(raw) ? raw._tag : undefined;
   return renderFieldShell(
     entry,
     path,
@@ -57,7 +61,10 @@ export function renderLambdaField(entry: ConfigEntry, path: string[], ctx: Rende
       ?disabled=${disabled}
       placeholder=${String(entry.default_value ?? "")}
       @lambda-change=${(e: CustomEvent<{ value: string }>) =>
-        ctx.emitChange(path, { _lambda: e.detail.value })}
+        ctx.emitChange(
+          path,
+          tag ? { _lambda: e.detail.value, _tag: tag } : { _lambda: e.detail.value }
+        )}
     ></esphome-lambda-editor>`
   );
 }

--- a/src/components/device/config-entry-renderers/templatable.ts
+++ b/src/components/device/config-entry-renderers/templatable.ts
@@ -86,8 +86,11 @@ export function renderTemplatableField(
       ctx.emitChange(path, stash.literal ?? "");
     } else {
       // Currently literal → going to lambda. Capture literal, restore lambda body.
+      // A templatable field also accepts a literal of the same type, so the
+      // lambda form needs the explicit ``!lambda`` tag — a bare ``|-`` block
+      // would parse as that literal, not a lambda.
       stash.literal = raw;
-      ctx.emitChange(path, { _lambda: stash.lambda ?? "" });
+      ctx.emitChange(path, { _lambda: stash.lambda ?? "", _tag: "!lambda" });
     }
   };
 

--- a/src/util/yaml-serialize.ts
+++ b/src/util/yaml-serialize.ts
@@ -13,7 +13,7 @@
  * dependency checks against the user's current configuration.
  */
 
-import { isLambdaValue } from "../api/types/automations.js";
+import { isLambdaValue, type LambdaValue } from "../api/types/automations.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { isPlainObject } from "./nested-values.js";
 import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
@@ -21,9 +21,11 @@ import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
 /**
  * Wrap a ``LambdaValue`` sentinel (``{_lambda: "<body>"}``) as a
  * ``YamlRawValue`` so the serializer's existing block-scalar path
- * handles the emission. Bare ``|-`` (no ``!lambda`` tag) mirrors
- * the backend's ``controllers/automations/emitter.encode_value``
- * convention; the ESPHome parser accepts both forms.
+ * handles the emission. ``_tag: "!lambda"`` emits ``!lambda |-`` so a
+ * templatable value field (``uart.write:``) compiles as a lambda;
+ * untagged stays a bare ``|-`` block, the shape ESPHome auto-detects
+ * on ``lambda:``-keyed fields. Both mirror the backend's
+ * ``controllers/automations/emitter.encode_value`` convention.
  *
  * Without this conversion the form serializer falls through the
  * generic ``typeof val === "object"`` recursion and emits the
@@ -33,11 +35,12 @@ import { escapeYamlDoubleQuoted, hasEscapeWorthyChar } from "./yaml-escape.js";
  * save; each keystroke then appends a fresh copy alongside the
  * malformed one. #940.
  */
-function lambdaToRawValue(body: string, bodyIndent: string): YamlRawValue {
-  const lines = body
+function lambdaToRawValue(value: LambdaValue, bodyIndent: string): YamlRawValue {
+  const lines = value._lambda
     .split("\n")
     .map((line) => (line === "" ? "" : `${bodyIndent}${line}`));
-  return new YamlRawValue(lines, "|-");
+  const header = value._tag === "!lambda" ? "!lambda |-" : "|-";
+  return new YamlRawValue(lines, header);
 }
 
 /**
@@ -254,7 +257,7 @@ function serializeListItem(
         return;
       }
       if (isLambdaValue(v)) {
-        const raw = lambdaToRawValue(v._lambda, `${childIndent}${ESPHOME_YAML_INDENT}`);
+        const raw = lambdaToRawValue(v, `${childIndent}${ESPHOME_YAML_INDENT}`);
         lines.push(...emitYamlRawValueLines(k, prefix, raw));
         return;
       }
@@ -363,7 +366,7 @@ export function serializeYamlValues(
       continue;
     }
     if (isLambdaValue(val)) {
-      const raw = lambdaToRawValue(val._lambda, `${indent}${step}`);
+      const raw = lambdaToRawValue(val, `${indent}${step}`);
       lines.push(...emitYamlRawValueLines(key, indent, raw));
       continue;
     }

--- a/test/components/device/config-entry-lambda-renderer.test.ts
+++ b/test/components/device/config-entry-lambda-renderer.test.ts
@@ -91,4 +91,19 @@ describe("renderLambdaField change handler", () => {
     expect(path).toEqual(["field"]);
     expect(value).toEqual({ _lambda: "return 7;" });
   });
+
+  it("carries an existing !lambda tag forward across a body edit", () => {
+    const emit = vi.fn();
+    const ctx = makeRenderCtx(
+      { field: { _lambda: "return 1;", _tag: "!lambda" } },
+      { overrides: { emitChange: emit } }
+    );
+    const entry = makeEntry(ConfigEntryType.LAMBDA, { key: "field" });
+    const template = renderLambdaField(entry, ["field"], ctx);
+    const b = getEditorBindings(template);
+    (b["@lambda-change"] as (e: CustomEvent<{ value: string }>) => void)(
+      new CustomEvent("lambda-change", { detail: { value: "return 7;" } })
+    );
+    expect(emit.mock.calls[0][1]).toEqual({ _lambda: "return 7;", _tag: "!lambda" });
+  });
 });

--- a/test/components/device/config-entry-templatable-renderer.test.ts
+++ b/test/components/device/config-entry-templatable-renderer.test.ts
@@ -72,7 +72,7 @@ describe("renderTemplatableField", () => {
     expect(innerRender).not.toHaveBeenCalled();
   });
 
-  it("toggling literal → lambda emits a LambdaValue sentinel", () => {
+  it("toggling literal → lambda emits a tagged LambdaValue sentinel", () => {
     const emit = vi.fn();
     const ctx = makeRenderCtx({ field: "hello" }, { overrides: { emitChange: emit } });
     const entry = makeEntry(ConfigEntryType.STRING, {
@@ -84,7 +84,9 @@ describe("renderTemplatableField", () => {
     expect(emit).toHaveBeenCalledTimes(1);
     const [path, value] = emit.mock.calls[0];
     expect(path).toEqual(["field"]);
-    expect(value).toEqual({ _lambda: "" } satisfies LambdaValue);
+    // Templatable fields accept a literal too, so the lambda form needs
+    // the explicit ``!lambda`` tag to compile as a lambda.
+    expect(value).toEqual({ _lambda: "", _tag: "!lambda" } satisfies LambdaValue);
   });
 
   it("toggling lambda → literal emits a non-lambda primitive", () => {

--- a/test/util/yaml-serialize-escaping.test.ts
+++ b/test/util/yaml-serialize-escaping.test.ts
@@ -130,3 +130,31 @@ describe("serializeYamlValues — array nested in a list item", () => {
     );
   });
 });
+
+describe("serializeYamlValues — lambda tag", () => {
+  it("emits a tagged lambda as !lambda |- so it compiles as a lambda", () => {
+    // Dropping the tag on a templatable value field (uart.write:)
+    // would compile the body as a string literal, not a lambda.
+    const out = serializeYamlValues(
+      {
+        set_action: [
+          { "uart.write": { _lambda: "uint8_t a = 1;\nreturn {a};", _tag: "!lambda" } },
+        ],
+      },
+      ""
+    ).join("\n");
+    expect(out).toBe(
+      [
+        "set_action:",
+        "  - uart.write: !lambda |-",
+        "      uint8_t a = 1;",
+        "      return {a};",
+      ].join("\n")
+    );
+  });
+
+  it("emits an untagged lambda as a bare |- block (no !lambda injected)", () => {
+    const out = serializeYamlValues({ lambda: { _lambda: "return x;" } }, "").join("\n");
+    expect(out).toBe(["lambda: |-", "  return x;"].join("\n"));
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1310. The backend now carries a `!lambda` tag through the parse to upsert wire sentinel as an optional `_tag` key; this side preserves it so the user-facing edit flow keeps the tag instead of dropping it.

Three places that previously reconstructed a bare `{_lambda}` and lost the tag: the lambda editor now carries an existing `_tag` forward across body edits, the literal/lambda toggle sets `_tag: "!lambda"` (a templatable value field also accepts a literal, so the lambda form needs the explicit tag), and the YAML serializer emits `!lambda |-` when tagged. Untagged `lambda: |-` stays bare, so the common idiom is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1306

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
