### PR TITLE
Keep an id-reference value defined outside the scanned YAML

### DIFF
--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -5,7 +5,7 @@
  * literal sentinel as a config value.
  */
 
-import { html } from "lit";
+import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { findReferenceCandidates } from "../../util/config-entry-yaml-scan.js";
 import {
@@ -35,7 +35,31 @@ export function renderIdReferenceField(
   if (bail) return bail;
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
-  const empty = candidates.length === 0;
+
+  const idOption = (optValue: string, primary: string, secondary: string) => html`
+    <wa-option
+      class="id-option"
+      value=${optValue}
+      .label=${primary}
+      ?selected=${optValue === value}
+    >
+      <span class="id-option-stack">
+        <span class="id-option-primary">${primary}</span>
+        <span class="id-option-secondary">${secondary}</span>
+      </span>
+    </wa-option>
+  `;
+
+  // The current id may not be a local candidate: defined in a `packages:`
+  // include / another file the scan can't see, or a dangling reference (typo,
+  // deleted id). We can't tell which, so surface it as a selected option with
+  // provenance-neutral copy rather than dropping it on save.
+  const hasOrphanValue = value !== "" && !candidates.some((c) => c.id === value);
+  const orphanOption = hasOrphanValue
+    ? idOption(value, value, ctx.localize("device.id_reference_unresolved", { domain }))
+    : nothing;
+  // Solo "Add new" CTA only when there's genuinely nothing to show.
+  const empty = candidates.length === 0 && !hasOrphanValue;
 
   const onChange = (e: Event) => {
     const select = e.target as HTMLSelectElement;
@@ -93,21 +117,9 @@ export function renderIdReferenceField(
         ?disabled=${effectiveDisabled(entry, ctx)}
         @change=${onChange}
       >
-        ${candidates.map(
-          (c) =>
-            html`<wa-option
-              class="id-option"
-              value=${c.id}
-              .label=${c.name || c.id}
-              ?selected=${c.id === value}
-            >
-              <span class="id-option-stack">
-                <span class="id-option-primary">${c.name || c.id}</span>
-                <span class="id-option-secondary"
-                  >${c.name ? `${c.id} · ${domain}` : domain}</span
-                >
-              </span>
-            </wa-option>`
+        ${orphanOption}
+        ${candidates.map((c) =>
+          idOption(c.id, c.name || c.id, c.name ? `${c.id} · ${domain}` : domain)
         )}
         ${addOption}
       </wa-select>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -870,6 +870,7 @@
     "missing_dependencies_add": "Add {domain}",
     "id_reference_empty": "No {domain} configured yet",
     "id_reference_add": "Add {domain}",
+    "id_reference_unresolved": "{domain} not defined in this file",
     "return_to_after_dep_prefix": "Adding a dependency. We'll bring you back to",
     "return_to_after_dep_suffix": "after.",
     "add_automation_error": "Failed to add automation",

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for ``renderIdReferenceField`` (#1312). An id-reference field's
+ * value can point at a component defined outside the scanned YAML (a
+ * ``packages:`` include / another file); the picker must still surface it as
+ * a selected option so it displays and round-trips instead of vanishing.
+ */
+import { describe, expect, it } from "vitest";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderIdReferenceField } from "../../../src/components/device/config-entry-id-reference-renderer.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+const LOCAL_SCRIPT_YAML = "script:\n  - id: local_script\n";
+
+function renderFor(yaml: string, value: string) {
+  const entry = makeEntry(ConfigEntryType.STRING, { references_component: "script" });
+  return renderIdReferenceField(
+    entry,
+    ["id"],
+    makeRenderCtx({ id: value }, { overrides: { yaml } })
+  );
+}
+
+describe("renderIdReferenceField — value defined outside the scanned YAML (#1312)", () => {
+  it("keeps a referenced id that isn't a local candidate (e.g. from a package)", () => {
+    const opts = findElementBindings(
+      renderFor(LOCAL_SCRIPT_YAML, "pkg_script"),
+      "wa-option"
+    );
+    const byValue = Object.fromEntries(opts.map((o) => [o.value, o]));
+    // The package id is present AND selected, so it displays + round-trips.
+    expect(byValue["pkg_script"]).toBeDefined();
+    expect(byValue["pkg_script"]["?selected"]).toBe(true);
+    // The local candidate is still offered.
+    expect(byValue["local_script"]).toBeDefined();
+  });
+
+  it("renders the orphan value even when there are no local candidates", () => {
+    const values = findElementBindings(renderFor("", "pkg_script"), "wa-option").map(
+      (o) => o.value
+    );
+    expect(values).toContain("pkg_script");
+  });
+
+  it("does not duplicate an id that is already a local candidate", () => {
+    const values = findElementBindings(
+      renderFor(LOCAL_SCRIPT_YAML, "local_script"),
+      "wa-option"
+    ).map((o) => o.value);
+    expect(values.filter((v) => v === "local_script")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A `script.execute` action (and any id-reference field) showed an empty ID dropdown when the referenced id was defined in a `packages:` include or another file the editor's YAML scan can't see, even though the value was present in the YAML. The picker built its options only from locally-scanned ids and rendered `?selected` per option, so a value with no matching option displayed nothing and risked being dropped on save.

This surfaces the current value as a selected option whenever it isn't a local candidate (mirroring the registry-list "unknown id" fallback), so a package/external id displays and round-trips. A shared `idOption` helper renders both the candidates and the orphan value. No package expansion needed; the value already flows through from the backend parse.

Verified in the browser (Chrome+CDP): a `script.execute: pkg_script` whose script isn't defined locally now shows `pkg_script` selected in the ID dropdown alongside the local scripts.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1312

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
