### PR TITLE
Truncate navigator card titles so long names don't overlap the chevron

### DIFF
--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -123,6 +123,7 @@ export const deviceNavigatorStyles = css`
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: var(--wa-space-2xs);
     cursor: pointer;
     user-select: none;
     transition:
@@ -152,6 +153,9 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .nav-item-subtitle {
@@ -160,11 +164,15 @@ export const deviceNavigatorStyles = css`
     font-weight: normal;
     margin: 0;
     line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .nav-item wa-icon {
     font-size: var(--wa-font-size-xl);
     color: var(--esphome-primary);
+    flex-shrink: 0;
   }
 
   .action-item {


### PR DESCRIPTION
# What does this implement/fix?

Long navigator card titles overflowed their box and ran under the chevron icon on the right; the fallback raw id like `text_sensor.state_machine` collided with the `>`. The title now truncates with an ellipsis, the subtitle truncates the same way, and the chevron keeps its size so it never gets squeezed; a small gap separates the text from the icon. The `.nav-item-content` already carried `min-width: 0`, so the flex child shrinks and the ellipsis engages.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/695

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
