### PR TITLE
Declutter the device navigator and unify section icons

### DIFF
--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -1,10 +1,7 @@
 import { consume } from "@lit/context";
 import {
-  mdiArrowDecisionOutline,
   mdiArrowLeft,
   mdiClose,
-  mdiCogOutline,
-  mdiMemory,
   mdiOpenInNew,
   mdiPartyPopper,
   mdiPlusCircleOutline,
@@ -29,6 +26,7 @@ import type { ESPHomeChangeBoardDialog } from "./change-board-dialog.js";
 import { isEmptyToPopulatedYamlChange } from "./device-board-info-helpers.js";
 import { deviceBoardInfoStyles } from "./device-board-info.styles.js";
 import type { ESPHomeDeviceSectionConfig } from "./device-section-config.js";
+import { SECTION_ICON } from "./section-icons.js";
 
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
 import "@home-assistant/webawesome/dist/components/callout/callout.js";
@@ -45,10 +43,7 @@ import "./device-section-config.js";
 
 registerMdiIcons({
   "open-in-new": mdiOpenInNew,
-  memory: mdiMemory,
-  "arrow-decision-outline": mdiArrowDecisionOutline,
   "arrow-left": mdiArrowLeft,
-  "cog-outline": mdiCogOutline,
   close: mdiClose,
   "party-popper": mdiPartyPopper,
   "plus-circle-outline": mdiPlusCircleOutline,
@@ -303,21 +298,21 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
             ${this._renderStepSection({
               title: this._localize("device.step_core"),
               desc: this._localize("device.step_core_desc"),
-              icon: "cog-outline",
+              icon: SECTION_ICON.core,
               action: this._localize("device.show_core_configuration"),
               section: "core",
             })}
             ${this._renderStepSection({
               title: this._localize("device.step_components"),
               desc: this._localize("device.step_components_desc"),
-              icon: "memory",
+              icon: SECTION_ICON.components,
               action: this._localize("device.show_components"),
               section: "components",
             })}
             ${this._renderStepSection({
               title: this._localize("device.step_automations"),
               desc: this._localize("device.step_automations_desc"),
-              icon: "arrow-decision-outline",
+              icon: SECTION_ICON.automations,
               action: this._localize("device.show_automations"),
               section: "automations",
             })}

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -67,7 +67,7 @@ export const deviceEditorStyles = css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    flex-shrink: 0;
+    min-width: 0;
   }
 
   .editor-header-file {
@@ -78,6 +78,9 @@ export const deviceEditorStyles = css`
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
+    /* Yield before the device name when the header is tight; the
+       filename is the secondary half of the title row. */
+    flex-shrink: 2;
   }
 
   .editor-floating-actions {

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -53,6 +53,13 @@ export const deviceEditorStyles = css`
     flex: 1;
   }
 
+  .editor-header-titlerow {
+    display: flex;
+    align-items: baseline;
+    gap: var(--wa-space-xs);
+    min-width: 0;
+  }
+
   .editor-header-title {
     margin: 0;
     font-size: var(--wa-font-size-s);
@@ -60,6 +67,17 @@ export const deviceEditorStyles = css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    flex-shrink: 0;
+  }
+
+  .editor-header-file {
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-normal);
+    color: color-mix(in srgb, var(--esphome-on-primary), transparent 25%);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
   }
 
   .editor-floating-actions {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -210,7 +210,12 @@ export class ESPHomeDeviceEditor extends LitElement {
         <header class="card-header ${compactHeader ? "card-header--compact" : ""}">
           <slot name="header-start"></slot>
           <div class="editor-header-main">
-            <h2 class="editor-header-title">${title}</h2>
+            <div class="editor-header-titlerow">
+              <h2 class="editor-header-title">${title}</h2>
+              ${this.configuration && !compactHeader
+                ? html`<span class="editor-header-file">${this.configuration}</span>`
+                : nothing}
+            </div>
           </div>
           <div class="header-actions">
             ${effectiveLayout !== "left"

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -37,9 +37,8 @@ export const deviceNavigatorStyles = css`
 
   .card-title {
     margin: 0;
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
     line-height: 1;
+    min-width: 0;
   }
 
   .card-title-btn {
@@ -55,6 +54,9 @@ export const deviceNavigatorStyles = css`
     border-radius: var(--wa-border-radius-s);
     min-width: 0;
     line-height: 1;
+    font-family: inherit;
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-bold);
   }
 
   .card-title-btn:hover {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -214,14 +214,21 @@ export const deviceNavigatorStyles = css`
     font-size: var(--wa-font-size-l);
     color: var(--esphome-primary);
     flex-shrink: 0;
-    opacity: 0;
-    transition: opacity 0.1s;
   }
 
-  .nav-item:hover wa-icon,
-  .nav-item--hovered wa-icon,
-  .nav-item--selected wa-icon {
-    opacity: 1;
+  /* Declutter the chevron only where hover exists; on touch (no hover)
+     it stays visible so the "this row navigates" cue isn't lost. */
+  @media (hover: hover) {
+    .nav-item wa-icon {
+      opacity: 0;
+      transition: opacity 0.1s;
+    }
+
+    .nav-item:hover wa-icon,
+    .nav-item--hovered wa-icon,
+    .nav-item--selected wa-icon {
+      opacity: 1;
+    }
   }
 
   .action-item {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -39,6 +39,32 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
+    line-height: 1;
+  }
+
+  .card-title-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    margin-left: calc(-1 * var(--wa-space-xs));
+    border-radius: var(--wa-border-radius-s);
+    min-width: 0;
+    line-height: 1;
+  }
+
+  .card-title-btn:hover {
+    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+  }
+
+  .card-title-btn wa-icon {
+    display: block;
+    font-size: 18px;
+    flex-shrink: 0;
   }
 
   .collapse-btn {
@@ -94,6 +120,13 @@ export const deviceNavigatorStyles = css`
     flex-shrink: 0;
   }
 
+  .nav-content-label {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+    min-width: 0;
+  }
+
   .nav-content:hover p {
     color: var(--esphome-primary);
   }
@@ -104,22 +137,29 @@ export const deviceNavigatorStyles = css`
     font-weight: var(--wa-font-weight-bold);
   }
 
-  .nav-content wa-icon {
+  .nav-content-label wa-icon {
+    font-size: var(--wa-font-size-l);
+    color: var(--esphome-primary);
+    flex-shrink: 0;
+  }
+
+  .nav-content-chevron {
     font-size: var(--wa-font-size-xl);
     color: var(--esphome-primary);
+    flex-shrink: 0;
   }
 
   .nav-items {
     display: flex;
     flex-direction: column;
-    gap: var(--wa-space-2xs);
-    padding: var(--wa-space-xs) var(--wa-space-m);
+    gap: 1px;
+    padding: var(--wa-space-2xs) var(--wa-space-s);
   }
 
   .nav-item {
-    padding: 0 var(--wa-space-2xs);
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    padding: 0 var(--wa-space-xs);
     border-radius: var(--wa-border-radius-m);
+    border-left: 3px solid transparent;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -134,25 +174,24 @@ export const deviceNavigatorStyles = css`
   .nav-item:hover,
   .nav-item--hovered {
     background: var(--esphome-tint);
-    border-color: var(--esphome-primary);
   }
 
   .nav-item--selected {
     background: var(--esphome-tint);
-    border-color: var(--esphome-primary);
+    border-left-color: var(--esphome-primary);
   }
 
   .nav-item-content {
     display: flex;
     flex-direction: column;
     min-width: 0;
-    padding: var(--wa-space-xs) 0;
+    padding: var(--wa-space-2xs) 0;
   }
 
   .nav-item-content p {
     margin: 0;
     font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
+    font-weight: var(--wa-font-weight-semibold);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -170,9 +209,17 @@ export const deviceNavigatorStyles = css`
   }
 
   .nav-item wa-icon {
-    font-size: var(--wa-font-size-xl);
+    font-size: var(--wa-font-size-l);
     color: var(--esphome-primary);
     flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  .nav-item:hover wa-icon,
+  .nav-item--hovered wa-icon,
+  .nav-item--selected wa-icon {
+    opacity: 1;
   }
 
   .action-item {

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -1,12 +1,11 @@
 import { consume } from "@lit/context";
 import {
-  mdiArrowDecisionOutline,
   mdiChevronDown,
   mdiChevronLeft,
   mdiChevronRight,
   mdiChevronUp,
   mdiCog,
-  mdiMemory,
+  mdiHomeOutline,
   mdiPlusCircleOutline,
   mdiScriptTextOutline,
 } from "@mdi/js";
@@ -43,6 +42,7 @@ import "./add-config-dialog.js";
 import type { ESPHomeAddConfigDialog } from "./add-config-dialog.js";
 import "./add-script-dialog.js";
 import type { ESPHomeAddScriptDialog } from "./add-script-dialog.js";
+import { SECTION_ICON } from "./section-icons.js";
 import { TriggerCatalogController } from "./trigger-catalog-controller.js";
 
 registerMdiIcons({
@@ -51,8 +51,7 @@ registerMdiIcons({
   "chevron-up": mdiChevronUp,
   "chevron-right": mdiChevronRight,
   cog: mdiCog,
-  "arrow-decision-outline": mdiArrowDecisionOutline,
-  memory: mdiMemory,
+  "home-outline": mdiHomeOutline,
   "plus-circle-outline": mdiPlusCircleOutline,
   "script-text-outline": mdiScriptTextOutline,
 });
@@ -265,6 +264,9 @@ export class ESPHomeDeviceNavigator extends LitElement {
     interface NavSection {
       label: string;
       desc: string;
+      /** Leading section icon — mirrors the overview pane's step
+       *  buttons (cog / chip / automation) so the two surfaces agree. */
+      icon: string;
       items: YamlSection[];
       category: "core" | "component" | "automation";
       /** A section can carry multiple "+ Add X" affordances —
@@ -276,6 +278,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
       {
         label: this._localize("device.section_core"),
         desc: this._localize("device.section_core_desc"),
+        icon: SECTION_ICON.core,
         items: core,
         category: "core",
         actions: [
@@ -289,12 +292,13 @@ export class ESPHomeDeviceNavigator extends LitElement {
       {
         label: this._localize("device.section_components"),
         desc: this._localize("device.section_components_desc"),
+        icon: SECTION_ICON.components,
         items: components,
         category: "component",
         actions: [
           {
             label: this._localize("device.add_component"),
-            icon: "memory",
+            icon: SECTION_ICON.components,
             onClick: () => this._addComponentDialog.open(),
           },
         ],
@@ -302,12 +306,13 @@ export class ESPHomeDeviceNavigator extends LitElement {
       {
         label: this._localize("device.section_automations"),
         desc: this._localize("device.section_automations_desc"),
+        icon: SECTION_ICON.automations,
         items: automations,
         category: "automation",
         actions: [
           {
             label: this._localize("device.add_automation"),
-            icon: "arrow-decision-outline",
+            icon: SECTION_ICON.automations,
             onClick: () => this._addAutomationDialog.open(),
           },
           {
@@ -350,7 +355,16 @@ export class ESPHomeDeviceNavigator extends LitElement {
           @automation-added=${this._onAutomationAdded}
         ></esphome-add-script-dialog>
         <header class="card-header">
-          <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
+          <button
+            type="button"
+            class="card-title-btn"
+            @click=${this._goToOverview}
+            title=${this._localize("device.navigator_home")}
+            aria-label=${this._localize("device.navigator_home")}
+          >
+            <wa-icon library="mdi" name="home-outline"></wa-icon>
+            <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
+          </button>
           <button
             type="button"
             class="collapse-btn"
@@ -364,12 +378,16 @@ export class ESPHomeDeviceNavigator extends LitElement {
         <div class="card-body">
           <p class="italic">${this._localize("device.navigator_desc")}</p>
           <div class="separator"></div>
-          ${sections.map(({ label, desc, items, category, actions }, i) => {
+          ${sections.map(({ label, desc, icon, items, category, actions }, i) => {
             const open = this.openSections.has(i);
             return html`
               <div class="nav-content" @click=${() => this._toggleSection(i)}>
-                <p>${label}</p>
+                <div class="nav-content-label">
+                  <wa-icon library="mdi" name=${icon}></wa-icon>
+                  <p>${label}</p>
+                </div>
                 <wa-icon
+                  class="nav-content-chevron"
                   library="mdi"
                   name=${open ? "chevron-up" : "chevron-down"}
                 ></wa-icon>
@@ -448,6 +466,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
       })
     );
   }
+
+  /** Clear the current section selection so the editor pane returns to
+   *  the device overview (board image + "Change board"). Mirrors the
+   *  deselect branch of ``_onItemClick`` without a row to toggle. */
+  private _goToOverview = () => {
+    this.selectedKey = null;
+    this._selectedLine = null;
+    this._selectedRange = null;
+    this._hoveredLine = null;
+    this._emitHighlight(null, false);
+    this._emitSectionSelect(null, undefined);
+  };
 
   /** Ask the page to hide the navigator. The page decides between
    *  desktop (set ``_navCollapsed`` + persist) and mobile (close the

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -361,7 +361,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
               class="card-title-btn"
               @click=${this._goToOverview}
               title=${this._localize("device.navigator_home")}
-              aria-label=${this._localize("device.navigator_home")}
             >
               <wa-icon library="mdi" name="home-outline"></wa-icon>
               <span>${this._localize("device.navigator_title")}</span>

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -355,16 +355,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
           @automation-added=${this._onAutomationAdded}
         ></esphome-add-script-dialog>
         <header class="card-header">
-          <button
-            type="button"
-            class="card-title-btn"
-            @click=${this._goToOverview}
-            title=${this._localize("device.navigator_home")}
-            aria-label=${this._localize("device.navigator_home")}
-          >
-            <wa-icon library="mdi" name="home-outline"></wa-icon>
-            <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
-          </button>
+          <h2 class="card-title">
+            <button
+              type="button"
+              class="card-title-btn"
+              @click=${this._goToOverview}
+              title=${this._localize("device.navigator_home")}
+              aria-label=${this._localize("device.navigator_home")}
+            >
+              <wa-icon library="mdi" name="home-outline"></wa-icon>
+              <span>${this._localize("device.navigator_title")}</span>
+            </button>
+          </h2>
           <button
             type="button"
             class="collapse-btn"

--- a/src/components/device/section-icons.ts
+++ b/src/components/device/section-icons.ts
@@ -1,0 +1,19 @@
+import { mdiArrowDecisionOutline, mdiCogOutline, mdiMemory } from "@mdi/js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+/**
+ * Canonical per-section icons, shared by the navigator's section
+ * headers and the overview pane's step buttons so the two surfaces
+ * never drift. Importing this module registers the mdi paths once.
+ */
+export const SECTION_ICON = {
+  core: "cog-outline",
+  components: "memory",
+  automations: "arrow-decision-outline",
+} as const;
+
+registerMdiIcons({
+  [SECTION_ICON.core]: mdiCogOutline,
+  [SECTION_ICON.components]: mdiMemory,
+  [SECTION_ICON.automations]: mdiArrowDecisionOutline,
+});

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -594,6 +594,7 @@
   },
   "device": {
     "navigator_title": "Device navigator",
+    "navigator_home": "Back to device overview",
     "navigator_desc": "Navigate, add and remove options to define your ESP device and its functionality.",
     "section_core": "Core configuration",
     "section_components": "Components",

--- a/test/components/device/device-navigator-overview.test.ts
+++ b/test/components/device/device-navigator-overview.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins two navigator chrome behaviors: each section header carries the
+ * shared per-section icon (so it matches the overview pane), and the
+ * title button clears the selection to return to the device overview.
+ * Dialog children are no-oped so the element constructs in happy-dom;
+ * see ``device-navigator-coalesce.test.ts``.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-config-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-script-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
+import { SECTION_ICON } from "../../../src/components/device/section-icons.js";
+
+async function mountNavigator(): Promise<ESPHomeDeviceNavigator> {
+  const nav = new ESPHomeDeviceNavigator();
+  nav.yaml = "esphome:\n  name: bktest\n";
+  document.body.appendChild(nav);
+  await nav.updateComplete;
+  return nav;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("device-navigator section header icons", () => {
+  it("renders the shared section icons in header order", async () => {
+    const nav = await mountNavigator();
+    const icons = [
+      ...(nav.shadowRoot?.querySelectorAll(".nav-content-label wa-icon") ?? []),
+    ].map((el) => el.getAttribute("name"));
+    expect(icons).toEqual([
+      SECTION_ICON.core,
+      SECTION_ICON.components,
+      SECTION_ICON.automations,
+    ]);
+  });
+});
+
+describe("device-navigator overview button", () => {
+  it("clears the selection when the title is clicked", async () => {
+    const nav = await mountNavigator();
+    const events: Array<{ sectionKey: string | null }> = [];
+    nav.addEventListener("section-select", (e) => events.push((e as CustomEvent).detail));
+    const title = nav.shadowRoot?.querySelector<HTMLButtonElement>(".card-title-btn");
+    expect(title).toBeTruthy();
+    title!.click();
+    expect(events).toHaveLength(1);
+    expect(events[0].sectionKey).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The device navigator left rail gets visually heavy on larger configs, so this is a first pass at calming it down. Rows are now a flat scannable list instead of bordered boxes; the per row chevron only appears on hover or selection; labels are lighter weight with tighter spacing so more fits before scrolling. The section headers gained the same icons the overview pane already uses (cog, chip, automations), so the two surfaces match. The editor header now shows the config filename next to the device name, and clicking "Device navigator" returns you to the device overview where "Change board" lives.

Motivated by Discord feedback that complex configs are hard to navigate; grouping by domain and a search or filter box are natural follow ups.

The section to icon mapping now lives in one module, `section-icons.ts`, consumed by both the navigator and the overview pane so they cannot drift.

**Related issue or feature (if applicable):**

- N/A (Discord feedback) https://ptb.discord.com/channels/429907082951524364/1513031639603871956

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
