### PR TITLE
Honor BACKEND_PORT in the dev server proxy

### DIFF
--- a/build-scripts/dev-server.cjs
+++ b/build-scripts/dev-server.cjs
@@ -1,4 +1,4 @@
-const { createRspackConfig } = require("./rspack.cjs");
+const { createRspackConfig, BACKEND_PORT } = require("./rspack.cjs");
 const { RspackDevServer } = require("@rspack/dev-server");
 const rspack = require("@rspack/core");
 
@@ -20,10 +20,8 @@ if (Number.isFinite(envPort) && envPort > 0) {
 const compiler = rspack.rspack(config);
 const server = new RspackDevServer(config.devServer, compiler);
 
-const backendPort = process.env.BACKEND_PORT || 6052;
-
 server.start().then(() => {
   console.log(`\n  ESPHome Frontend dev server running at:\n`);
   console.log(`  > Local:   http://localhost:${config.devServer.port}/\n`);
-  console.log(`  API proxy target: http://localhost:${backendPort}\n`);
+  console.log(`  API proxy target: http://localhost:${BACKEND_PORT}\n`);
 });

--- a/build-scripts/dev-server.cjs
+++ b/build-scripts/dev-server.cjs
@@ -20,8 +20,10 @@ if (Number.isFinite(envPort) && envPort > 0) {
 const compiler = rspack.rspack(config);
 const server = new RspackDevServer(config.devServer, compiler);
 
+const backendPort = process.env.BACKEND_PORT || 6052;
+
 server.start().then(() => {
   console.log(`\n  ESPHome Frontend dev server running at:\n`);
   console.log(`  > Local:   http://localhost:${config.devServer.port}/\n`);
-  console.log(`  API proxy target: http://localhost:6052\n`);
+  console.log(`  API proxy target: http://localhost:${backendPort}\n`);
 });

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -187,30 +187,33 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
       },
     },
     historyApiFallback: { disableDotRule: true },
+    // Honor BACKEND_PORT so a dev server can point at a backend on a
+    // non-default port; lets two backends run side by side (testing
+    // multiple checkouts) without editing this file. Defaults to 6052.
     proxy: [
       {
         // All communication goes through the single /ws WebSocket endpoint
         context: ["/ws"],
-        target: "ws://localhost:6052",
+        target: `ws://localhost:${process.env.BACKEND_PORT || 6052}`,
         ws: true,
       },
       {
         // Backend-served static files (board images, etc.)
         context: ["/boards"],
-        target: "http://localhost:6052",
+        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
         changeOrigin: true,
       },
       {
         // REST endpoints, incl. the firmware artifact download
         // (GET /api/firmware/download — too large for the WS).
         context: ["/api"],
-        target: "http://localhost:6052",
+        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
         changeOrigin: true,
       },
       {
         // Legacy REST endpoints (for backward compat if needed)
         context: ["/devices", "/json-config", "/compile", "/upload"],
-        target: "http://localhost:6052",
+        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
         changeOrigin: true,
       },
     ],

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -13,6 +13,16 @@ const SRC_DIR = path.resolve(ROOT_DIR, "src");
 const OUTPUT_DIR = path.resolve(ROOT_DIR, "esphome_device_builder_frontend");
 const PUBLIC_DIR = path.resolve(ROOT_DIR, "public");
 
+// Backend port the dev proxy targets. Honors BACKEND_PORT so two
+// checkouts can run side by side without editing this file; validated
+// like PORT in dev-server.cjs so a typo (BACKEND_PORT=abc) can't
+// produce an invalid proxy URL. Falls back to 6052.
+const parsedBackendPort = parseInt(process.env.BACKEND_PORT, 10);
+const BACKEND_PORT =
+  Number.isFinite(parsedBackendPort) && parsedBackendPort > 0
+    ? parsedBackendPort
+    : 6052;
+
 /**
  * Create the rspack configuration for the ESPHome frontend.
  */
@@ -187,37 +197,34 @@ const createRspackConfig = ({ isProdBuild = false } = {}) => ({
       },
     },
     historyApiFallback: { disableDotRule: true },
-    // Honor BACKEND_PORT so a dev server can point at a backend on a
-    // non-default port; lets two backends run side by side (testing
-    // multiple checkouts) without editing this file. Defaults to 6052.
     proxy: [
       {
         // All communication goes through the single /ws WebSocket endpoint
         context: ["/ws"],
-        target: `ws://localhost:${process.env.BACKEND_PORT || 6052}`,
+        target: `ws://localhost:${BACKEND_PORT}`,
         ws: true,
       },
       {
         // Backend-served static files (board images, etc.)
         context: ["/boards"],
-        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
+        target: `http://localhost:${BACKEND_PORT}`,
         changeOrigin: true,
       },
       {
         // REST endpoints, incl. the firmware artifact download
         // (GET /api/firmware/download — too large for the WS).
         context: ["/api"],
-        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
+        target: `http://localhost:${BACKEND_PORT}`,
         changeOrigin: true,
       },
       {
         // Legacy REST endpoints (for backward compat if needed)
         context: ["/devices", "/json-config", "/compile", "/upload"],
-        target: `http://localhost:${process.env.BACKEND_PORT || 6052}`,
+        target: `http://localhost:${BACKEND_PORT}`,
         changeOrigin: true,
       },
     ],
   },
 });
 
-module.exports = { createRspackConfig };
+module.exports = { createRspackConfig, BACKEND_PORT };


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The dev server proxy target was hardcoded to `localhost:6052`, so testing a frontend against a backend on any other port meant editing `rspack.cjs` by hand. This honors a `BACKEND_PORT` env var (defaulting to 6052) for the `/ws`, `/api`, `/boards`, and legacy REST proxies, mirroring how `dev-server.cjs` already honors `PORT` for the frontend port. With both, two checkouts can run side by side; `PORT=5175 BACKEND_PORT=6060 npm run dev` points a second dev server at a second backend without touching tracked files. The startup banner now prints the resolved target instead of the literal 6052.

**Related issue or feature (if applicable):**

- N/A (dev tooling)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
