### PR TITLE
Open Archived Devices from any route, including the editor

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -80,6 +80,8 @@ import {
 } from "./app-shell/settings-actions.js";
 
 import "../pages/dashboard.js";
+import "./archived-devices-dialog.js";
+import type { ESPHomeArchivedDevicesDialog } from "./archived-devices-dialog.js";
 import "./command-palette.js";
 import "./esphome-layout.js";
 import "./esphome-login.js";
@@ -174,6 +176,8 @@ export class ESPHomeApp extends LitElement {
 
   private _router = createRouter(this);
 
+  @query("esphome-archived-devices-dialog")
+  private _archivedDialog?: ESPHomeArchivedDevicesDialog;
   @query("esphome-settings-dialog") private _settingsDialog!: ESPHomeSettingsDialog;
   @query("esphome-firmware-jobs-dialog")
   private _firmwareJobsDialog!: ESPHomeFirmwareJobsDialog;
@@ -500,6 +504,7 @@ export class ESPHomeApp extends LitElement {
         @set-yaml-diff-button=${(e: CustomEvent<boolean>) => onSetYamlDiffButton(this, e)}
         @set-language=${(e: CustomEvent<Parameters<typeof onSetLanguage>[1]["detail"]>) =>
           onSetLanguage(this, e as Parameters<typeof onSetLanguage>[1])}
+        @open-archived-devices=${() => this._archivedDialog?.open()}
         @open-settings=${() => this._settingsDialog?.open()}
         @open-firmware-jobs=${() => this._firmwareJobsDialog?.open()}
         @open-reset-build-env=${() => this._firmwareJobsDialog?.openResetBuildEnv()}
@@ -550,6 +555,7 @@ export class ESPHomeApp extends LitElement {
         @onboarding-acknowledged=${this._onOnboardingAcknowledged}
         @onboarding-dismissed-session=${this._onOnboardingDismissedSession}
       ></esphome-onboarding-wifi-dialog>
+      <esphome-archived-devices-dialog></esphome-archived-devices-dialog>
     `;
   }
 

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { mdiArchiveArrowUpOutline, mdiArchiveOutline, mdiTrashCanOutline } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ArchivedDevice } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -9,9 +9,16 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import type { ESPHomeConfirmDialog } from "./confirm-dialog.js";
+import {
+  archivedDeviceName,
+  deleteArchivedDevice,
+  unarchiveDevice,
+} from "./dashboard/actions.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./base-dialog.js";
+import "./confirm-dialog.js";
 
 registerMdiIcons({
   "archive-arrow-up-outline": mdiArchiveArrowUpOutline,
@@ -32,12 +39,12 @@ registerMdiIcons({
  *   * Pull the list off ``devices/list_archived`` on every open.
  *     The archive directory is on-disk state, not WS-event-driven,
  *     so this is the cheapest way to keep the dialog fresh.
- *   * Per-row Unarchive button — fires ``unarchive`` event with the
- *     ArchivedDevice. Caller restores via the WS API and signals
- *     us back to refresh / close.
- *   * Per-row Delete-permanently button — fires ``delete-archived``
- *     event so the dashboard can route through its existing
- *     confirm-dialog instance (we don't duplicate the dialog here).
+ *   * Per-row Unarchive button restores via the WS API, then
+ *     refreshes the list in place.
+ *   * Per-row Delete-permanently button opens a nested confirm, then
+ *     deletes via the WS API and refreshes. Self-contained (rather
+ *     than delegating to the dashboard) so the dialog works from any
+ *     route — the header opens it over the editor too (#1320).
  *   * Empty state when no archives — same dialog opens but tells
  *     the user there's nothing to restore. Keeps the menu entry
  *     always-visible without forcing a count-bridge plumbing.
@@ -56,6 +63,9 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   @state() private _loading = false;
   @state() private _error: string | null = null;
   @state() private _open = false;
+  @state() private _pendingDelete: ArchivedDevice | null = null;
+
+  @query("esphome-confirm-dialog") private _confirmDialog?: ESPHomeConfirmDialog;
 
   static styles = [
     espHomeStyles,
@@ -288,6 +298,18 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
           </button>
         </div>
       </esphome-base-dialog>
+      <esphome-confirm-dialog
+        destructive
+        heading=${this._localize("dashboard.delete_archived_title")}
+        message=${this._pendingDelete
+          ? this._localize("dashboard.delete_archived_desc", {
+              name: archivedDeviceName(this._pendingDelete),
+            })
+          : ""}
+        confirm-label=${this._localize("dashboard.action_delete_permanently")}
+        @confirm=${this._onDeleteConfirm}
+        @cancel=${this._onDeleteCancel}
+      ></esphome-confirm-dialog>
     `;
   }
 
@@ -340,25 +362,30 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
     `;
   }
 
-  private _unarchive(device: ArchivedDevice) {
-    this.dispatchEvent(
-      new CustomEvent("unarchive", {
-        detail: device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+  private async _unarchive(device: ArchivedDevice) {
+    if (!this._api) return;
+    if (await unarchiveDevice(device, this._api, this._localize)) {
+      await this.refresh();
+    }
   }
 
   private _deletePermanently(device: ArchivedDevice) {
-    this.dispatchEvent(
-      new CustomEvent("delete-archived", {
-        detail: device,
-        bubbles: true,
-        composed: true,
-      })
-    );
+    this._pendingDelete = device;
+    this._confirmDialog?.open();
   }
+
+  private _onDeleteConfirm = async (): Promise<void> => {
+    const device = this._pendingDelete;
+    this._pendingDelete = null;
+    if (!device || !this._api) return;
+    if (await deleteArchivedDevice(device, this._api, this._localize)) {
+      await this.refresh();
+    }
+  };
+
+  private _onDeleteCancel = (): void => {
+    this._pendingDelete = null;
+  };
 }
 
 declare global {

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -58,6 +58,11 @@ export async function archiveDevice(
   return true;
 }
 
+/** Display label for an archived device: friendly name, else node name, else filename. */
+export function archivedDeviceName(device: ArchivedDevice): string {
+  return device.friendly_name || device.name || device.configuration;
+}
+
 /**
  * Restore an archived YAML back into the active config dir.
  *
@@ -76,7 +81,7 @@ export async function unarchiveDevice(
   api: ESPHomeAPI,
   localize: LocalizeFunc
 ): Promise<boolean> {
-  const name = device.friendly_name || device.name || device.configuration;
+  const name = archivedDeviceName(device);
   try {
     await api.unarchiveDevice(device.configuration);
   } catch (err) {
@@ -103,7 +108,7 @@ export async function deleteArchivedDevice(
   api: ESPHomeAPI,
   localize: LocalizeFunc
 ): Promise<boolean> {
-  const name = device.friendly_name || device.name || device.configuration;
+  const name = archivedDeviceName(device);
   try {
     await api.deleteArchivedDevice(device.configuration);
   } catch (err) {

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -1,7 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import type { ConfiguredDevice, Label } from "../../api/types/devices.js";
 import { DeviceState } from "../../api/types/devices.js";
-import type { ArchivedDevice } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { computeLabelUsage, deleteConfirmKey } from "../../util/label-usage.js";
@@ -9,7 +8,6 @@ import { archiveBulkDevices, deleteBulkDevices, deleteDevice } from "./actions.j
 
 export type PendingConfirm =
   | { kind: "delete-single"; device: ConfiguredDevice }
-  | { kind: "delete-archived"; device: ArchivedDevice }
   | { kind: "delete-bulk" }
   | { kind: "archive-single"; device: ConfiguredDevice }
   | { kind: "archive-bulk" }
@@ -51,18 +49,6 @@ export function confirmDialogCopy(
         heading: t("dashboard.delete_single_title"),
         message: t("dashboard.delete_single_desc", { name }),
         confirm: t("dashboard.delete_selected_confirm"),
-        destructive: true,
-      };
-    }
-    case "delete-archived": {
-      const name =
-        pending.device.friendly_name ||
-        pending.device.name ||
-        pending.device.configuration;
-      return {
-        heading: t("dashboard.delete_archived_title"),
-        message: t("dashboard.delete_archived_desc", { name }),
-        confirm: t("dashboard.action_delete_permanently"),
         destructive: true,
       };
     }
@@ -131,9 +117,6 @@ export function executeConfirm(
     case "delete-single":
       void deleteDevice(pending.device, host._api, host._localize);
       return;
-    case "delete-archived":
-      void host._deleteArchivedDevice(pending.device);
-      return;
     case "archive-single":
       void host._archiveDevice(pending.device);
       return;
@@ -196,10 +179,5 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
       }}
       @select-method=${host._onInstallMethodSelect}
     ></esphome-install-method-dialog>
-    <esphome-archived-devices-dialog
-      @unarchive=${(e: CustomEvent<ArchivedDevice>) => host._unarchiveDevice(e.detail)}
-      @delete-archived=${(e: CustomEvent<ArchivedDevice>) =>
-        host._confirmDeleteArchived(e.detail)}
-    ></esphome-archived-devices-dialog>
   `;
 }

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -442,10 +442,13 @@ export class ESPHomeHeaderActions extends LitElement {
   };
 
   private _openArchivedDevices = () => {
-    /* Dashboard hosts the dialog instance and listens for this
-       window event to open it. */
     this._close();
-    window.dispatchEvent(new Event("esphome-show-archived-dialog"));
+    this.dispatchEvent(
+      new CustomEvent("open-archived-devices", {
+        bubbles: true,
+        composed: true,
+      })
+    );
   };
 
   private _toggleShowIgnoredDiscoveries = () => {

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -22,7 +22,6 @@ import type { AdoptableDevice, ConfiguredDevice, Label } from "../api/types/devi
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import { ErrorCode } from "../api/types/protocol.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
-import type { ArchivedDevice } from "../api/types/system.js";
 import { DashboardView } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
@@ -35,10 +34,8 @@ import {
 } from "../components/dashboard/actions-ui.js";
 import {
   archiveDevice,
-  deleteArchivedDevice,
   detectAndOpenWizard,
   fetchApiKey,
-  unarchiveDevice,
 } from "../components/dashboard/actions.js";
 import {
   onInstallMethodSelect,
@@ -109,8 +106,6 @@ import "../components/adopt-dialog.js";
 import type { ESPHomeAdoptDialog } from "../components/adopt-dialog.js";
 import "../components/api-key-dialog.js";
 import type { ESPHomeApiKeyDialog } from "../components/api-key-dialog.js";
-import "../components/archived-devices-dialog.js";
-import type { ESPHomeArchivedDevicesDialog } from "../components/archived-devices-dialog.js";
 import "../components/clone-device-dialog.js";
 import type { ESPHomeCloneDeviceDialog } from "../components/clone-device-dialog.js";
 import "../components/command-dialog.js";
@@ -254,8 +249,6 @@ export class ESPHomePageDashboard extends LitElement {
   );
 
   @query("esphome-api-key-dialog") _apiKeyDialog!: ESPHomeApiKeyDialog;
-  @query("esphome-archived-devices-dialog")
-  _archivedDialog?: ESPHomeArchivedDevicesDialog;
   @query("esphome-confirm-dialog") _confirmDialog!: ESPHomeConfirmDialog;
   @query("esphome-create-config-dialog") _createDialog!: ESPHomeCreateConfigDialog;
   @query("esphome-clone-device-dialog") _cloneDialog!: ESPHomeCloneDeviceDialog;
@@ -308,7 +301,6 @@ export class ESPHomePageDashboard extends LitElement {
     if (!this._showIgnored) this._showDiscovered = true;
     this._toggleShowIgnored();
   };
-  private _onShowArchivedDialog = () => this._archivedDialog?.open();
 
   _onEnterSelectMode = (configuration?: string) => {
     this._selectMode = true;
@@ -331,7 +323,6 @@ export class ESPHomePageDashboard extends LitElement {
       "esphome-show-ignored-from-menu",
       this._onShowIgnoredFromMenu
     );
-    window.addEventListener("esphome-show-archived-dialog", this._onShowArchivedDialog);
     const pending = consumePendingHighlight();
     if (pending !== null) {
       this._highlightFreshDevice(pending);
@@ -433,10 +424,6 @@ export class ESPHomePageDashboard extends LitElement {
     window.removeEventListener(
       "esphome-show-ignored-from-menu",
       this._onShowIgnoredFromMenu
-    );
-    window.removeEventListener(
-      "esphome-show-archived-dialog",
-      this._onShowArchivedDialog
     );
     if (this._adoptHighlightTimer !== null) {
       clearTimeout(this._adoptHighlightTimer);
@@ -898,8 +885,6 @@ export class ESPHomePageDashboard extends LitElement {
 
   _confirmDeleteSingle = (device: ConfiguredDevice) =>
     this._openConfirm({ kind: "delete-single", device });
-  _confirmDeleteArchived = (device: ArchivedDevice) =>
-    this._openConfirm({ kind: "delete-archived", device });
   _confirmArchive = (device: ConfiguredDevice) =>
     this._openConfirm({ kind: "archive-single", device });
 
@@ -912,16 +897,6 @@ export class ESPHomePageDashboard extends LitElement {
 
   _archiveDevice = (device: ConfiguredDevice) =>
     archiveDevice(device, this._api, this._localize);
-  _unarchiveDevice = async (device: ArchivedDevice) => {
-    if (await unarchiveDevice(device, this._api, this._localize)) {
-      await this._archivedDialog?.refresh();
-    }
-  };
-  _deleteArchivedDevice = async (device: ArchivedDevice) => {
-    if (await deleteArchivedDevice(device, this._api, this._localize)) {
-      await this._archivedDialog?.refresh();
-    }
-  };
   _deleteLabel = (label: Label) => deleteLabel(this, label);
   _toggleIgnore = (device: AdoptableDevice) => void toggleIgnore(this, device);
 }

--- a/test/components/archived-devices-dialog.test.ts
+++ b/test/components/archived-devices-dialog.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the self-contained archived-devices-dialog actions (#1320): unarchive
+ * and confirmed-delete call the WS API and refresh the list in place, and the
+ * delete is gated behind the nested confirm. Self-containment is what lets the
+ * dialog open over the editor, where no dashboard parent handles its actions.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+import type { ArchivedDevice } from "../../src/api/types/system.js";
+import { ESPHomeArchivedDevicesDialog } from "../../src/components/archived-devices-dialog.js";
+
+const DEVICE = {
+  name: "foo-1234",
+  friendly_name: "Foo",
+  configuration: "foo.yaml",
+} as unknown as ArchivedDevice;
+
+function makeDialog(api: Record<string, unknown>) {
+  const el = new ESPHomeArchivedDevicesDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const priv = el as any;
+  priv._api = api;
+  return priv;
+}
+
+describe("archived-devices-dialog self-contained actions", () => {
+  it("unarchive calls the WS API and refreshes the list", async () => {
+    const unarchiveDevice = vi.fn().mockResolvedValue(undefined);
+    const listArchivedDevices = vi.fn().mockResolvedValue([]);
+    const priv = makeDialog({ unarchiveDevice, listArchivedDevices });
+
+    await priv._unarchive(DEVICE);
+
+    expect(unarchiveDevice).toHaveBeenCalledWith("foo.yaml");
+    expect(listArchivedDevices).toHaveBeenCalledTimes(1);
+  });
+
+  it("delete stages the pending device without touching the WS API (gated behind confirm)", () => {
+    const deleteArchivedDevice = vi.fn();
+    const priv = makeDialog({ deleteArchivedDevice });
+
+    priv._deletePermanently(DEVICE);
+
+    expect(priv._pendingDelete).toBe(DEVICE);
+    expect(deleteArchivedDevice).not.toHaveBeenCalled();
+  });
+
+  it("confirming the delete calls the WS API, refreshes, and clears the pending device", async () => {
+    const deleteArchivedDevice = vi.fn().mockResolvedValue(undefined);
+    const listArchivedDevices = vi.fn().mockResolvedValue([]);
+    const priv = makeDialog({ deleteArchivedDevice, listArchivedDevices });
+
+    priv._deletePermanently(DEVICE);
+    await priv._onDeleteConfirm();
+
+    expect(deleteArchivedDevice).toHaveBeenCalledWith("foo.yaml");
+    expect(listArchivedDevices).toHaveBeenCalledTimes(1);
+    expect(priv._pendingDelete).toBeNull();
+  });
+
+  it("cancelling the delete clears the pending device and skips the WS call", () => {
+    const deleteArchivedDevice = vi.fn();
+    const priv = makeDialog({ deleteArchivedDevice });
+
+    priv._deletePermanently(DEVICE);
+    priv._onDeleteCancel();
+
+    expect(priv._pendingDelete).toBeNull();
+    expect(deleteArchivedDevice).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/esphome-header-actions-archived.test.ts
+++ b/test/components/esphome-header-actions-archived.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the kebab "Archived devices" item fires a bubbling, composed
+ * ``open-archived-devices`` event (#1320). The app shell hosts the dialog at
+ * the root and listens for this, so it opens on any route — including over the
+ * editor, unlike the old dashboard-scoped window event.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+
+describe("header-actions archived-devices trigger", () => {
+  it("dispatches a bubbling, composed open-archived-devices event", () => {
+    const el = new ESPHomeHeaderActions();
+    const onEvent = vi.fn();
+    el.addEventListener("open-archived-devices", onEvent);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._openArchivedDevices();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const event = onEvent.mock.calls[0][0] as CustomEvent;
+    expect(event.bubbles).toBe(true);
+    expect(event.composed).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

From the hamburger menu, "Archived Devices" did nothing while a device was open in the editor; every other item worked. The dialog was rendered inside the dashboard page and opened via a window event only the dashboard listened for, so once the editor route swapped the dashboard out, the trigger and the dialog were both gone.

This moves the archived-devices dialog to the app root and opens it with a bubbling `open-archived-devices` event, the same pattern the Settings, Firmware Jobs, and Feedback dialogs already use, so it works on every route. The dialog is now self-contained; it runs unarchive and delete (behind its own nested confirm) directly instead of delegating to the dashboard, so the dead dashboard wiring is removed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1320

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
