### PR TITLE
Hide Archived Devices in the kebab menu off the dashboard route

### DIFF
--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -13,7 +13,7 @@ import {
   mdiWifiCog,
 } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
 import { JobStatus } from "../api/types/firmware-jobs.js";
@@ -68,6 +68,12 @@ export class ESPHomeHeaderActions extends LitElement {
 
   @state()
   private _open = false;
+
+  /** True on the dashboard route. Dashboard-only menu entries
+   *  (Archived Devices) hide elsewhere; their dialog is hosted on the
+   *  dashboard page, so the entry would no-op anywhere else. */
+  @property({ type: Boolean, attribute: "dashboard-route" })
+  dashboardRoute = false;
 
   /** True when onboarding still has work to do (currently:
    *  Wi-Fi step pending — data-derived from ``secrets.yaml``).
@@ -336,16 +342,18 @@ export class ESPHomeHeaderActions extends LitElement {
                     : this._localize("onboarding.menu_item_change_wifi")}</span
                 >
               </div>
-              <div
-                class="menu-item"
-                role="menuitem"
-                tabindex="0"
-                @click=${this._openArchivedDevices}
-                @keydown=${this._onMenuItemKeydown}
-              >
-                <wa-icon library="mdi" name="archive-outline"></wa-icon>
-                ${this._localize("layout.archived_devices")}
-              </div>
+              ${this.dashboardRoute
+                ? html`<div
+                    class="menu-item"
+                    role="menuitem"
+                    tabindex="0"
+                    @click=${this._openArchivedDevices}
+                    @keydown=${this._onMenuItemKeydown}
+                  >
+                    <wa-icon library="mdi" name="archive-outline"></wa-icon>
+                    ${this._localize("layout.archived_devices")}
+                  </div>`
+                : nothing}
               ${ignoredCount > 0
                 ? html`<div
                     class="menu-item"

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -58,8 +58,12 @@ export class ESPHomeLayout extends LitElement {
     window.removeEventListener("popstate", this._onPopState);
   }
 
+  private get _isDashboard(): boolean {
+    return this._path === "/" || this._path === "";
+  }
+
   private get _showBack(): boolean {
-    return this._path !== "/" && this._path !== "";
+    return !this._isDashboard;
   }
 
   protected updated() {
@@ -337,7 +341,9 @@ export class ESPHomeLayout extends LitElement {
           <p>${this._localize("dashboard.subtitle")}</p>
         </div>
         <div class="header-spacer"></div>
-        <esphome-header-actions></esphome-header-actions>
+        <esphome-header-actions
+          ?dashboard-route=${this._isDashboard}
+        ></esphome-header-actions>
       </div>
       <slot></slot>
       <div class="app-footer">

--- a/test/components/esphome-header-actions-archived.test.ts
+++ b/test/components/esphome-header-actions-archived.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Archived Devices is a dashboard concern; its dialog lives on the dashboard
+ * page, so the kebab entry must only render on the dashboard route and stay
+ * hidden in the editor where it would no-op (#1320).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+
+async function renderOpenMenu(dashboardRoute: boolean): Promise<ESPHomeHeaderActions> {
+  const el = new ESPHomeHeaderActions();
+  el.dashboardRoute = dashboardRoute;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._open = true;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("header-actions Archived Devices visibility", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the Archived Devices entry on the dashboard route", async () => {
+    const el = await renderOpenMenu(true);
+    expect(
+      el.shadowRoot!.querySelector('wa-icon[name="archive-outline"]')
+    ).not.toBeNull();
+  });
+
+  it("hides the Archived Devices entry off the dashboard route", async () => {
+    const el = await renderOpenMenu(false);
+    expect(el.shadowRoot!.querySelector('wa-icon[name="archive-outline"]')).toBeNull();
+  });
+});

--- a/test/components/esphome-layout-back-button.test.ts
+++ b/test/components/esphome-layout-back-button.test.ts
@@ -7,6 +7,7 @@ import { setLeaveGuard } from "../../src/util/navigation.js";
 interface LayoutPrivateView {
   _path: string;
   readonly _showBack: boolean;
+  readonly _isDashboard: boolean;
   _goHome: () => Promise<void>;
 }
 
@@ -25,6 +26,15 @@ describe("esphome-layout header back button visibility", () => {
   test("shown inside a device editor and other non-root routes", () => {
     expect(makeLayout("/device/living-room")._showBack).toBe(true);
     expect(makeLayout("/secrets")._showBack).toBe(true);
+  });
+});
+
+describe("esphome-layout dashboard-route detection", () => {
+  test("true on the device-list root, false elsewhere", () => {
+    expect(makeLayout("/")._isDashboard).toBe(true);
+    expect(makeLayout("")._isDashboard).toBe(true);
+    expect(makeLayout("/device/living-room")._isDashboard).toBe(false);
+    expect(makeLayout("/secrets")._isDashboard).toBe(false);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

From the header kebab menu, "Archived Devices" did nothing while a device was open in the editor; the dialog is hosted on the dashboard page, so the entry had nothing to open from any other route. Rather than wiring the dialog to work everywhere, this just hides the entry where it does not belong; archived devices is a dashboard concern.

The layout already tracks the active route to show or hide the back button, so it now passes an `on-dashboard` flag to the header and the Archived Devices entry renders only on the dashboard. It stays hidden in the editor and on secrets.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1320

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
