### PR TITLE
Use the normal UI font for terminal dialog titles and buttons

### DIFF
--- a/src/components/command-dialog/styles.ts
+++ b/src/components/command-dialog/styles.ts
@@ -27,7 +27,6 @@ export const commandDialogStyles = css`
     color: var(--esphome-on-primary);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
   }
   esphome-base-dialog::part(body) {
     padding: 0;
@@ -49,7 +48,7 @@ export const commandDialogStyles = css`
     gap: 16px;
     padding: 24px;
     text-align: center;
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+    font-family: var(--term-mono-font);
     color: var(--term-fg);
     z-index: 1;
   }
@@ -91,7 +90,7 @@ export const commandDialogStyles = css`
     gap: 8px;
     padding: 8px 20px;
     border-bottom: 1px solid var(--term-border);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+    font-family: var(--term-mono-font);
     font-size: 12px;
     color: var(--wa-color-text-quiet, #888);
   }
@@ -133,7 +132,7 @@ export const commandDialogStyles = css`
     padding: 10px 20px;
     border-top: 1px solid var(--term-border);
     background: var(--term-bg-alt);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+    font-family: var(--term-mono-font);
     font-size: 12px;
     line-height: 1.5;
     color: var(--term-fg-muted);

--- a/src/components/logs-dialog.styles.ts
+++ b/src/components/logs-dialog.styles.ts
@@ -13,11 +13,6 @@ import { fillTerminal } from "./process-terminal/process-terminal.styles.js";
  * from the shared termTokens / termButtonStyles in the component's styles.
  */
 export const logsDialogStyles = css`
-  :host {
-    /* Shared by the title part and the chip so the two can't drift. */
-    --logs-mono-font: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
-  }
-
   esphome-base-dialog {
     /* Width history: 900 wrapped, 1100 still ~100px short, 1200 still wrapped
        on retina / HiDPI screens where ESPHome's ANSI-coloured output reads at
@@ -30,12 +25,10 @@ export const logsDialogStyles = css`
   }
 
   /* The primary header bar + title colour/size come from the shared
-     primaryDialogHeaderStyles; the log title is the only monospace one.
-     The title ellipsis + close-button-clearance now live in base-dialog,
-     so a long /dev/cu… path can't overflow the header here either. */
-  esphome-base-dialog::part(title) {
-    font-family: var(--logs-mono-font);
-  }
+     primaryDialogHeaderStyles; the title uses the normal UI font (the
+     monospace transport chip carries the technical detail). The title
+     ellipsis + close-button-clearance live in base-dialog, so a long
+     /dev/cu… path can't overflow the header here either. */
   esphome-base-dialog::part(body) {
     padding: 0;
     background: var(--term-bg);
@@ -55,7 +48,7 @@ export const logsDialogStyles = css`
     text-overflow: ellipsis;
     padding: 1px 8px;
     border-radius: 999px;
-    font-family: var(--logs-mono-font);
+    font-family: var(--term-mono-font);
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-normal);
     color: var(--esphome-on-primary);

--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -21,6 +21,9 @@ export const termTokens = css`
     --term-accent: #4ec9b0;
     --term-error: #f44747;
     --term-success: #6a9955;
+    /* One monospace stack for every terminal-body element (status banner,
+       queued overlay, transport chip, sub-lines) across the driver dialogs. */
+    --term-mono-font: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
   }
 
   :host([light]) {
@@ -54,7 +57,6 @@ export const termButtonStyles = css`
     border-radius: 4px;
     font-size: 12px;
     font-weight: 600;
-    font-family: "SF Mono", "Fira Code", monospace;
     cursor: pointer;
     border: 1px solid var(--term-border);
     transition:
@@ -170,7 +172,7 @@ export const processTerminalStyles = css`
     gap: 12px;
     padding: 14px 20px;
     border-top: 1px solid var(--term-border);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", "Cascadia Code", monospace;
+    font-family: var(--term-mono-font);
     font-size: 14px;
     font-weight: 600;
   }


### PR DESCRIPTION
# What does this implement/fix?

The Logs and Install dialogs rendered their title bar and the terminal toolbar buttons in a monospace font. Monospace is right for the log output, but on the title and buttons it looked out of place against the rest of the UI. This keeps monospace for the log content only; the title and the toolbar buttons now inherit the normal UI body font.

While here, the monospace font stack was duplicated across five rules; it is now a single `--term-mono-font` token in the shared terminal tokens, referenced by the status banner, queued overlay, sub-lines, and the logs transport chip.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1327

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
