### PR TITLE
Parse ESPHome's Ohm spelling in the float-with-unit picker

### DIFF
--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -16,6 +16,16 @@ export interface FloatWithUnit {
   unit: string;
 }
 
+// ESPHome accepts a textual spelling for some units whose unit_options carry a
+// non-ASCII symbol (resistance: 'Ohm' / 'OHM' for Ω). Keyed by the canonical
+// base symbol (unit_options[0]); the matched spelling is folded onto that
+// symbol before matching, so '5.6kOhm' lands on the kΩ option. Only the symbol
+// units a user cannot easily type need an entry. ESPHome rejects plural forms
+// ('Ohms'), so the patterns are anchored to the singular.
+const UNIT_SPELLING_ALIASES: Record<string, RegExp> = {
+  Ω: /ohm$/i,
+};
+
 /**
  * Parse a raw value into number + unit.
  *
@@ -51,9 +61,13 @@ export function parseFloatWithUnit(
   // function only deals with strings. NaN/Infinity numbers stringify
   // to "NaN"/"Infinity" which `Number()` round-trips back to non-finite
   // — caught by the final `Number.isFinite` guard.
-  const text = raw === null || raw === undefined ? "" : String(raw).trim();
-  if (text === "") return { value: null, unit: fallbackUnit };
+  const trimmed = raw === null || raw === undefined ? "" : String(raw).trim();
+  if (trimmed === "") return { value: null, unit: fallbackUnit };
 
+  // Fold a textual unit spelling onto its symbol when this picker uses one,
+  // so '5.6kOhm' matches the kΩ option (see UNIT_SPELLING_ALIASES).
+  const aliasPattern = UNIT_SPELLING_ALIASES[fallbackUnit];
+  const text = aliasPattern ? trimmed.replace(aliasPattern, fallbackUnit) : trimmed;
   const lowerText = text.toLowerCase();
   let match: string | undefined;
   let bestScore = -1;

--- a/test/util/float-with-unit.test.ts
+++ b/test/util/float-with-unit.test.ts
@@ -10,6 +10,7 @@ import {
 
 const FREQUENCY_UNITS = ["Hz", "mHz", "kHz", "MHz", "GHz"] as const;
 const TEMPERATURE_UNITS = ["°C", "°F", "K"] as const;
+const RESISTANCE_UNITS = ["Ω", "nΩ", "µΩ", "mΩ", "kΩ", "MΩ", "GΩ"] as const;
 
 describe("parseFloatWithUnit", () => {
   it("splits the canonical case", () => {
@@ -203,30 +204,31 @@ describe("parseFloatWithUnit", () => {
       });
     });
 
-    it("handles case-variant resistance suffixes", () => {
-      // Scope check: the bug is in ``cv.float_with_unit`` itself,
-      // not specific to ``cv.frequency``. Pin that resistance
-      // (which takes ``Ω|ohm|Ohm|OHM`` and various SI prefixes in
-      // its ESPHome regex) gets the same case-insensitive
-      // treatment for the BASE unit. The user can type the base
-      // in any case (``ohm``, ``Ohm``, ``OHM``) and the parser
-      // picks the right SI-prefixed option, normalising to the
-      // canonical-cased option on round-trip.
-      const resistanceUnits = ["Ohm", "kOhm", "MOhm"] as const;
-      // All-lowercase: ``k`` matches case (score 1) > ``Ohm``'s
-      // ``o`` ≠ ``O`` (score 0). Length tie-break would also pick
-      // ``kOhm`` over the bare ``Ohm`` if scores tied.
-      expect(parseFloatWithUnit("4.7kohm", resistanceUnits)).toEqual({
+    it("folds ESPHome's textual Ohm spelling onto the Ω options", () => {
+      // The catalog emits the Ω symbol, but ESPHome accepts and the
+      // docs use the textual 'Ohm' / 'OHM' spelling (e.g. '4.7kOhm').
+      // Fold the spelling so the prefixed value lands on the matching
+      // symbol option; an already-symbol value is unaffected. Issue #1299.
+      expect(parseFloatWithUnit("4.7kohm", RESISTANCE_UNITS)).toEqual({
         value: 4.7,
-        unit: "kOhm",
+        unit: "kΩ",
       });
-      // Lowercase prefix + uppercase base: ``kOhm`` scores 2
-      // (k=k, O=O) vs ``Ohm``'s 1 (O=O, h≠H), so the SI prefix
-      // is preserved correctly even though the user uppercased
-      // the base.
-      expect(parseFloatWithUnit("4.7kOHM", resistanceUnits)).toEqual({
+      expect(parseFloatWithUnit("4.7kOHM", RESISTANCE_UNITS)).toEqual({
         value: 4.7,
-        unit: "kOhm",
+        unit: "kΩ",
+      });
+      expect(parseFloatWithUnit("10Ohm", RESISTANCE_UNITS)).toEqual({
+        value: 10,
+        unit: "Ω",
+      });
+      expect(parseFloatWithUnit("4.7kΩ", RESISTANCE_UNITS)).toEqual({
+        value: 4.7,
+        unit: "kΩ",
+      });
+      // ESPHome rejects the plural 'Ohms', so it is not folded.
+      expect(parseFloatWithUnit("4.7kOhms", RESISTANCE_UNITS)).toEqual({
+        value: null,
+        unit: "Ω",
       });
     });
 


### PR DESCRIPTION
# What does this implement/fix?

Opening a `resistance` sensor in the Visual Editor dropped the `resistor` value: a config of `resistor: 5.6kOhm` rendered with an empty number input and the unit stuck on `Ω`. The catalog emits the canonical `Ω` symbol in `unit_options`, but ESPHome's docs and values use the textual `Ohm` spelling, so `parseFloatWithUnit` could not match `"5.6kohm"` against `kΩ` and fell back to `{value: null, unit: "Ω"}`. `reference_voltage` (`3.3 V`) worked only because `V` matches directly.

This folds ESPHome's textual `Ohm` / `OHM` spelling onto the `Ω` symbol before matching, so `5.6kOhm` parses to `{5.6, kΩ}`. A value already written with the symbol (`5.6kΩ`) is unaffected, and saving normalises to the canonical `5.6kΩ`.

Scope: resistance is the only unit where a metric symbol is both non-ASCII and commonly typed as a word, so the fold is intentionally limited to ohm. Non-metric units (angle, decibel) already include their textual spellings as options, and ASCII-symbol units (V, A) are typed as the symbol.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1299

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
