### PR TITLE
Title the browser tab ESPHome Device Builder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss: data: https://schema.esphome.io; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
-    <title>ESPHome</title>
+    <title>ESPHome Device Builder</title>
     <!-- Backend rewrites ``__ESPHOME_BASE_HREF__`` per-request to
          the deployment prefix; values MUST end with a trailing
          slash so a relative URL like ``app.HASH.js`` resolves


### PR DESCRIPTION
# What does this implement/fix?

The browser tab read just "ESPHome", which is inconsistent with the in-app header and the project name. The static `<title>` in the HTML template is now "ESPHome Device Builder" so the window is identifiable and matches the header shown right below the tab.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1329

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
