### PR TITLE
Split label, bucket, and section-render logic out of the navigator

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -34,6 +34,13 @@ import {
 import type { HighlightRange } from "../yaml-editor.js";
 import { CacheTickController } from "./cache-tick-controller.js";
 import { deviceNavigatorStyles } from "./device-navigator.styles.js";
+import { type NavigatorBuckets, deriveNavigatorBuckets } from "./navigator-buckets.js";
+import {
+  type LabelContext,
+  type NavRow,
+  resolveNavItemLabels,
+} from "./navigator-labels.js";
+import { type NavAction, renderNavSection } from "./navigator-render.js";
 import { navItemMatches } from "./navigator-search-match.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -59,12 +66,6 @@ registerMdiIcons({
   "plus-circle-outline": mdiPlusCircleOutline,
   "script-text-outline": mdiScriptTextOutline,
 });
-
-/** A nav row paired with its resolved display labels. */
-interface NavRow {
-  item: YamlSection;
-  labels: { primary: string; secondary?: string };
-}
 
 @customElement("esphome-device-navigator")
 export class ESPHomeDeviceNavigator extends LitElement {
@@ -99,39 +100,9 @@ export class ESPHomeDeviceNavigator extends LitElement {
   @property({ attribute: false })
   yaml = "";
 
-  /** Derive the three navigator buckets (core, components,
-   *  automations) from the YAML string. Memoised on the YAML
-   *  source so the parse + categorize + filter + sort pipeline
-   *  runs once per YAML edit, not per render. Two parser passes
-   *  and three list traversals collapse into a single cached
-   *  result. The render path destructures from this object. */
-  private _deriveBuckets = memoizeOne((yaml: string) => {
-    const {
-      core,
-      components,
-      automations: topLevelAutomations,
-    } = categorizeSections(parseYamlTopLevelSections(yaml));
-    // ``parseYamlAutomations`` enumerates individual ``script:`` /
-    // ``interval:`` list items as stable-keyed entries; drop the
-    // bare top-level blocks so each automation shows up exactly
-    // once.
-    const detailed = parseYamlAutomations(yaml);
-    const filteredTopLevel = topLevelAutomations.filter(
-      (s) => s.key !== "script" && s.key !== "interval"
-    );
-    // Drop ``light_effect`` (managed via the parent light's section
-    // editor) and ``unscoped`` entries (inline ``on_*:`` handlers
-    // on id-less components that the structured editor can't
-    // address).
-    const automations = [...filteredTopLevel, ...detailed]
-      .filter(
-        (s) =>
-          !s.key.startsWith("automation:light_effect:") &&
-          !s.key.startsWith("automation:unscoped:")
-      )
-      .sort((a, b) => a.fromLine - b.fromLine);
-    return { core, components, automations };
-  });
+  /** Memoised on the YAML source so the parse pipeline runs once per
+   *  edit, not per render. See {@link deriveNavigatorBuckets}. */
+  private _deriveBuckets = memoizeOne(deriveNavigatorBuckets);
 
   /** Resolve every row's labels, indexed [core, components, automations]
    *  to match the section order. Memoised on the parsed buckets plus the
@@ -141,26 +112,33 @@ export class ESPHomeDeviceNavigator extends LitElement {
    *  args exist solely to invalidate the memo. */
   private _resolveLabels = memoizeOne(
     (
-      buckets: {
-        core: YamlSection[];
-        components: YamlSection[];
-        automations: YamlSection[];
-      },
+      buckets: NavigatorBuckets,
       _tick: number,
-      _platform: string,
-      _deviceName: string,
-      _localize: LocalizeFunc
-    ): NavRow[][] => [
-      buckets.core.map((item) => ({ item, labels: this._navItemLabels(item, "core") })),
-      buckets.components.map((item) => ({
-        item,
-        labels: this._navItemLabels(item, "component"),
-      })),
-      buckets.automations.map((item) => ({
-        item,
-        labels: this._navItemLabels(item, "automation"),
-      })),
-    ]
+      platform: string,
+      deviceName: string,
+      localize: LocalizeFunc
+    ): NavRow[][] => {
+      const ctx: LabelContext = {
+        triggerCatalog: this._triggerCatalog,
+        platform,
+        deviceName,
+        localize,
+      };
+      return [
+        buckets.core.map((item) => ({
+          item,
+          labels: resolveNavItemLabels(item, "core", ctx),
+        })),
+        buckets.components.map((item) => ({
+          item,
+          labels: resolveNavItemLabels(item, "component", ctx),
+        })),
+        buckets.automations.map((item) => ({
+          item,
+          labels: resolveNavItemLabels(item, "automation", ctx),
+        })),
+      ];
+    }
   );
 
   /** Optional board metadata; forwarded to the add-component dialog so
@@ -285,11 +263,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
     const buckets = this._deriveBuckets(this.yaml);
     const { core, components, automations } = buckets;
 
-    interface NavAction {
-      label: string;
-      icon: string;
-      onClick: () => void;
-    }
     interface NavSection {
       label: string;
       desc: string;
@@ -448,97 +421,30 @@ export class ESPHomeDeviceNavigator extends LitElement {
             ? html`<p class="nav-empty" role="status">
                 ${this._localize("device.navigator_search_none")}
               </p>`
-            : sections.map(({ label, desc, icon, actions }, i) => {
-                const open = filtering ? true : this.openSections.has(i);
-                // Filtered rows come from the pre-pass; otherwise the
-                // section's full (memoised) row set.
-                const rows = matches?.[i] ?? resolved[i];
-                // While filtering, drop sections with no matches entirely.
-                if (filtering && rows.length === 0) return nothing;
-                return html`
-                  <div
-                    class="nav-content"
-                    @click=${() => {
-                      if (!filtering) this._toggleSection(i);
-                    }}
-                  >
-                    <div class="nav-content-label">
-                      <wa-icon library="mdi" name=${icon}></wa-icon>
-                      <p>${label}</p>
-                    </div>
-                    ${filtering
-                      ? nothing
-                      : html`<wa-icon
-                          class="nav-content-chevron"
-                          library="mdi"
-                          name=${open ? "chevron-up" : "chevron-down"}
-                        ></wa-icon>`}
-                  </div>
-                  ${open
-                    ? html`
-                        <div class="separator"></div>
-                        ${filtering ? nothing : html`<p class="italic">${desc}</p>`}
-                        ${rows.length > 0
-                          ? html`<div class="nav-items">
-                              ${rows.map(({ item, labels }) =>
-                                this._renderNavItem(item, labels)
-                              )}
-                            </div>`
-                          : nothing}
-                        ${filtering
-                          ? nothing
-                          : html`<div class="nav-items">
-                              ${actions.map((action) => this._renderActionItem(action))}
-                            </div>`}
-                      `
-                    : nothing}
-                  <div class="separator"></div>
-                `;
-              })}
+            : sections.map(({ label, desc, icon, actions }, i) =>
+                renderNavSection({
+                  label,
+                  desc,
+                  icon,
+                  actions,
+                  // Filtered rows from the pre-pass; else the full set.
+                  rows: matches?.[i] ?? resolved[i],
+                  open: filtering ? true : this.openSections.has(i),
+                  filtering,
+                  selectedLine: this._selectedLine,
+                  hoveredLine: this._hoveredLine,
+                  onToggle: () => {
+                    if (!filtering) this._toggleSection(i);
+                  },
+                  onItemEnter: (item) =>
+                    this._onItemHover(item.fromLine, item.fromLine, item.toLine),
+                  onItemLeave: () => this._onItemLeave(),
+                  onItemClick: (item) => this._onItemClick(item),
+                })
+              )}
         </div>
       </section>
     `;
-  }
-
-  /** One navigator row; shared by the filtered and unfiltered paths. */
-  private _renderNavItem(
-    item: YamlSection,
-    labels: { primary: string; secondary?: string }
-  ) {
-    const { primary, secondary } = labels;
-    return html`
-      <div
-        class="nav-item ${this._selectedLine === item.fromLine
-          ? "nav-item--selected"
-          : ""} ${this._hoveredLine === item.fromLine ? "nav-item--hovered" : ""}"
-        @mouseenter=${() => this._onItemHover(item.fromLine, item.fromLine, item.toLine)}
-        @mouseleave=${() => this._onItemLeave()}
-        @click=${() => this._onItemClick(item)}
-      >
-        <div class="nav-item-content">
-          <p>${primary}</p>
-          ${secondary
-            ? html`<span class="nav-item-subtitle">${secondary}</span>`
-            : nothing}
-        </div>
-        <wa-icon library="mdi" name="chevron-right"></wa-icon>
-      </div>
-    `;
-  }
-
-  /** One "+ Add X" affordance at the foot of a section. */
-  private _renderActionItem(action: {
-    label: string;
-    icon: string;
-    onClick: () => void;
-  }) {
-    return html`<div class="action-item" @click=${() => action.onClick()}>
-      <div>
-        <wa-icon library="mdi" name=${action.icon}></wa-icon>
-        <p>${action.label}</p>
-      </div>
-      <wa-icon library="mdi" name="plus-circle-outline"></wa-icon>
-    </div>`;
   }
 
   private _onSearchChange = (e: CustomEvent<{ value: string }>) => {
@@ -604,119 +510,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
     // "Switch → On Turn On" instead of the raw YAML key. The
     // controller re-renders the host when the fetch lands.
     this._triggerCatalog.ensure();
-  }
-
-  /**
-   * Decide what to show on the two lines of a nav item.
-   *
-   *   line 1 (primary)   the catalog's friendly name (e.g.
-   *                      "GPIO Binary Sensor") once resolved.
-   *                      Falls back to <domain>.<platform> (or just
-   *                      the domain for core keys like `wifi`) until
-   *                      the cache is populated, or when no catalog
-   *                      entry exists (typically: automations).
-   *   line 2 (secondary) the user-supplied `name:` if present, else
-   *                      the `id:`. Hidden when neither is set or
-   *                      when it's identical to the primary.
-   */
-  private _navItemLabels(
-    item: YamlSection,
-    category: "core" | "component" | "automation"
-  ): { primary: string; secondary?: string } {
-    const raw = sectionKeyOf(item);
-
-    if (category === "automation") {
-      return this._automationLabels(item, raw);
-    }
-
-    let primary = raw;
-    const cached = getCachedComponent(raw, this.platform || undefined);
-    if (cached?.name) primary = cached.name;
-
-    // Prefer the backend-resolved node name for the esphome core
-    // section so a `name: $devicename` substitution shows the
-    // expanded hostname, not the raw scalar. Falls back to the raw
-    // YAML value for a new/unsaved device not yet in the devices list.
-    const named =
-      category === "core" && item.key === "esphome" && this.deviceName
-        ? this.deviceName
-        : item.name || item.id;
-    const secondary = named && named !== primary ? named : undefined;
-
-    return { primary, secondary };
-  }
-
-  /**
-   * Two-line layout for automation entries — keeps the navigator
-   * consistent with how components render (catalog name on top,
-   * instance name/id below):
-   *
-   *   on_*: under a component  →  "Switch → Turn on" / instance name+id
-   *   script entry             →  "Script"           / id
-   *   interval entry           →  "Interval"         / "Every 60s"
-   *
-   * The catalog-derived "Switch" / "Turn on" pair comes from the
-   * automation triggers catalog. While the catalog is still loading
-   * we render a graceful fallback ("Switch → on_turn_on") so the
-   * navigator never blanks out on first paint.
-   */
-  private _automationLabels(
-    item: YamlSection,
-    raw: string
-  ): { primary: string; secondary?: string } {
-    // Script: line 1 = "Script", line 2 = id.
-    if (item.parentKey === "script") {
-      const primary = this._localize("device.script_header_title_static");
-      const secondary = item.id ?? raw;
-      return { primary, secondary: secondary !== primary ? secondary : undefined };
-    }
-    // Interval: line 1 = "Interval", line 2 = the time if known.
-    // Uses the bare "automation_interval_label" key (not the
-    // longer-form "On an interval" used by the kind picker) so the
-    // nav row stays scannable.
-    if (item.parentKey === "interval") {
-      const primary = this._localize("device.automation_interval_label");
-      const every = item.meta?.every;
-      const secondary = every
-        ? this._localize("device.automation_interval_every_n", { time: every })
-        : undefined;
-      return { primary, secondary };
-    }
-    // Device-level (``esphome → on_boot``) — no instance to show on
-    // line 2; keep line 2 empty since the trigger name already
-    // identifies the automation uniquely.
-    if (item.parentKey === "esphome" && item.eventKey) {
-      const primary = this._triggerCatalog.resolveName(
-        "esphome",
-        item.eventKey,
-        `${this._prettyDomain("esphome")} → ${item.eventKey}`
-      );
-      return { primary };
-    }
-    // Component-bound (``Switch → On Turn On`` resolved from the
-    // catalog; "Warmtepomp" on line 2).
-    if (item.parentKey && item.eventKey) {
-      const fallback = `${this._prettyDomain(item.parentKey)} → ${item.eventKey}`;
-      const primary = this._triggerCatalog.resolveName(
-        item.parentKey,
-        item.eventKey,
-        fallback
-      );
-      const named = item.name || item.id;
-      const secondary = named && named !== primary ? named : undefined;
-      return { primary, secondary };
-    }
-    // Unscoped / unrecognised — fall back to displayLabel.
-    return { primary: item.displayLabel || raw };
-  }
-
-  /** Capitalize a YAML domain key for display (``binary_sensor`` →
-   *  ``Binary sensor``). Used only for the pre-catalog fallback
-   *  label so the navigator never shows a raw lowercase domain
-   *  while the trigger fetch is still in flight. */
-  private _prettyDomain(domain: string): string {
-    const spaced = domain.replace(/_/g, " ");
-    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
   }
 
   private _onItemHover(line: number, fromLine: number, toLine: number) {

--- a/src/components/device/navigator-buckets.ts
+++ b/src/components/device/navigator-buckets.ts
@@ -1,0 +1,43 @@
+import {
+  type YamlSection,
+  categorizeSections,
+  parseYamlAutomations,
+  parseYamlTopLevelSections,
+} from "../../util/yaml-sections.js";
+
+export interface NavigatorBuckets {
+  core: YamlSection[];
+  components: YamlSection[];
+  automations: YamlSection[];
+}
+
+/**
+ * Parse + categorize + filter + sort the YAML into the three navigator
+ * buckets. Two parser passes and three list traversals collapse into a
+ * single result; the navigator memoises it on the YAML source.
+ */
+export function deriveNavigatorBuckets(yaml: string): NavigatorBuckets {
+  const {
+    core,
+    components,
+    automations: topLevelAutomations,
+  } = categorizeSections(parseYamlTopLevelSections(yaml));
+  // ``parseYamlAutomations`` enumerates individual ``script:`` /
+  // ``interval:`` list items as stable-keyed entries; drop the bare
+  // top-level blocks so each automation shows up exactly once.
+  const detailed = parseYamlAutomations(yaml);
+  const filteredTopLevel = topLevelAutomations.filter(
+    (s) => s.key !== "script" && s.key !== "interval"
+  );
+  // Drop ``light_effect`` (managed via the parent light's section
+  // editor) and ``unscoped`` entries (inline ``on_*:`` handlers on
+  // id-less components that the structured editor can't address).
+  const automations = [...filteredTopLevel, ...detailed]
+    .filter(
+      (s) =>
+        !s.key.startsWith("automation:light_effect:") &&
+        !s.key.startsWith("automation:unscoped:")
+    )
+    .sort((a, b) => a.fromLine - b.fromLine);
+  return { core, components, automations };
+}

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -1,0 +1,137 @@
+import type { LocalizeFunc } from "../../common/localize.js";
+import { getCachedComponent } from "../../util/component-name-cache.js";
+import { type YamlSection, sectionKeyOf } from "../../util/yaml-sections.js";
+import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
+
+export type NavCategory = "core" | "component" | "automation";
+
+export interface NavItemLabels {
+  primary: string;
+  secondary?: string;
+}
+
+/** A nav row paired with its resolved display labels. */
+export interface NavRow {
+  item: YamlSection;
+  labels: NavItemLabels;
+}
+
+/** Inputs label resolution reads, gathered from the navigator host. */
+export interface LabelContext {
+  triggerCatalog: TriggerCatalogController;
+  platform: string;
+  deviceName: string;
+  localize: LocalizeFunc;
+}
+
+/**
+ * Decide what to show on the two lines of a nav item.
+ *
+ *   line 1 (primary)   the catalog's friendly name (e.g. "GPIO Binary
+ *                      Sensor") once resolved. Falls back to the raw
+ *                      <domain>.<platform> (or just the domain for core
+ *                      keys like `wifi`) until the cache is populated,
+ *                      or when no catalog entry exists (automations).
+ *   line 2 (secondary) the user-supplied `name:` if present, else the
+ *                      `id:`. Hidden when neither is set or when it's
+ *                      identical to the primary.
+ */
+export function resolveNavItemLabels(
+  item: YamlSection,
+  category: NavCategory,
+  ctx: LabelContext
+): NavItemLabels {
+  const raw = sectionKeyOf(item);
+
+  if (category === "automation") {
+    return automationLabels(item, raw, ctx);
+  }
+
+  let primary = raw;
+  const cached = getCachedComponent(raw, ctx.platform || undefined);
+  if (cached?.name) primary = cached.name;
+
+  // Prefer the backend-resolved node name for the esphome core section
+  // so a `name: $devicename` substitution shows the expanded hostname,
+  // not the raw scalar. Falls back to the raw YAML value for a
+  // new/unsaved device not yet in the devices list.
+  const named =
+    category === "core" && item.key === "esphome" && ctx.deviceName
+      ? ctx.deviceName
+      : item.name || item.id;
+  const secondary = named && named !== primary ? named : undefined;
+
+  return { primary, secondary };
+}
+
+/**
+ * Two-line layout for automation entries — keeps the navigator
+ * consistent with how components render (catalog name on top, instance
+ * name/id below):
+ *
+ *   on_*: under a component  →  "Switch → Turn on" / instance name+id
+ *   script entry             →  "Script"           / id
+ *   interval entry           →  "Interval"         / "Every 60s"
+ *
+ * The catalog-derived "Switch" / "Turn on" pair comes from the
+ * automation triggers catalog. While the catalog is still loading we
+ * render a graceful fallback ("Switch → on_turn_on") so the navigator
+ * never blanks out on first paint.
+ */
+function automationLabels(
+  item: YamlSection,
+  raw: string,
+  ctx: LabelContext
+): NavItemLabels {
+  // Script: line 1 = "Script", line 2 = id.
+  if (item.parentKey === "script") {
+    const primary = ctx.localize("device.script_header_title_static");
+    const secondary = item.id ?? raw;
+    return { primary, secondary: secondary !== primary ? secondary : undefined };
+  }
+  // Interval: line 1 = "Interval", line 2 = the time if known. Uses the
+  // bare "automation_interval_label" key (not the longer-form "On an
+  // interval" used by the kind picker) so the nav row stays scannable.
+  if (item.parentKey === "interval") {
+    const primary = ctx.localize("device.automation_interval_label");
+    const every = item.meta?.every;
+    const secondary = every
+      ? ctx.localize("device.automation_interval_every_n", { time: every })
+      : undefined;
+    return { primary, secondary };
+  }
+  // Device-level (``esphome → on_boot``) — no instance to show on line 2;
+  // the trigger name already identifies the automation uniquely.
+  if (item.parentKey === "esphome" && item.eventKey) {
+    const primary = ctx.triggerCatalog.resolveName(
+      "esphome",
+      item.eventKey,
+      `${prettyDomain("esphome")} → ${item.eventKey}`
+    );
+    return { primary };
+  }
+  // Component-bound (``Switch → On Turn On`` resolved from the catalog;
+  // "Warmtepomp" on line 2).
+  if (item.parentKey && item.eventKey) {
+    const fallback = `${prettyDomain(item.parentKey)} → ${item.eventKey}`;
+    const primary = ctx.triggerCatalog.resolveName(
+      item.parentKey,
+      item.eventKey,
+      fallback
+    );
+    const named = item.name || item.id;
+    const secondary = named && named !== primary ? named : undefined;
+    return { primary, secondary };
+  }
+  // Unscoped / unrecognised — fall back to displayLabel.
+  return { primary: item.displayLabel || raw };
+}
+
+/** Capitalize a YAML domain key for display (``binary_sensor`` →
+ *  ``Binary sensor``). Used only for the pre-catalog fallback label so
+ *  the navigator never shows a raw lowercase domain while the trigger
+ *  fetch is still in flight. */
+function prettyDomain(domain: string): string {
+  const spaced = domain.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -1,0 +1,100 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { YamlSection } from "../../util/yaml-sections.js";
+import type { NavRow } from "./navigator-labels.js";
+
+/** A "+ Add X" affordance at the foot of a section. */
+export interface NavAction {
+  label: string;
+  icon: string;
+  onClick: () => void;
+}
+
+/** Everything one section block needs to render itself. */
+export interface NavSectionView {
+  label: string;
+  icon: string;
+  desc: string;
+  actions: NavAction[];
+  rows: NavRow[];
+  open: boolean;
+  filtering: boolean;
+  selectedLine: number | null;
+  hoveredLine: number | null;
+  onToggle: () => void;
+  onItemEnter: (item: YamlSection) => void;
+  onItemLeave: () => void;
+  onItemClick: (item: YamlSection) => void;
+}
+
+/** One navigator row; shared by the filtered and unfiltered paths. */
+function renderNavRow(row: NavRow, v: NavSectionView): TemplateResult {
+  const { item, labels } = row;
+  const { primary, secondary } = labels;
+  return html`
+    <div
+      class="nav-item ${v.selectedLine === item.fromLine
+        ? "nav-item--selected"
+        : ""} ${v.hoveredLine === item.fromLine ? "nav-item--hovered" : ""}"
+      @mouseenter=${() => v.onItemEnter(item)}
+      @mouseleave=${() => v.onItemLeave()}
+      @click=${() => v.onItemClick(item)}
+    >
+      <div class="nav-item-content">
+        <p>${primary}</p>
+        ${secondary ? html`<span class="nav-item-subtitle">${secondary}</span>` : nothing}
+      </div>
+      <wa-icon library="mdi" name="chevron-right"></wa-icon>
+    </div>
+  `;
+}
+
+function renderNavAction(action: NavAction): TemplateResult {
+  return html`<div class="action-item" @click=${() => action.onClick()}>
+    <div>
+      <wa-icon library="mdi" name=${action.icon}></wa-icon>
+      <p>${action.label}</p>
+    </div>
+    <wa-icon library="mdi" name="plus-circle-outline"></wa-icon>
+  </div>`;
+}
+
+/**
+ * One section block: header (collapsible when not filtering), its rows,
+ * and the "+ Add X" actions. Returns ``nothing`` while filtering when the
+ * section has no matches so it drops out of the list entirely.
+ */
+export function renderNavSection(v: NavSectionView): TemplateResult | typeof nothing {
+  if (v.filtering && v.rows.length === 0) return nothing;
+  return html`
+    <div class="nav-content" @click=${() => v.onToggle()}>
+      <div class="nav-content-label">
+        <wa-icon library="mdi" name=${v.icon}></wa-icon>
+        <p>${v.label}</p>
+      </div>
+      ${v.filtering
+        ? nothing
+        : html`<wa-icon
+            class="nav-content-chevron"
+            library="mdi"
+            name=${v.open ? "chevron-up" : "chevron-down"}
+          ></wa-icon>`}
+    </div>
+    ${v.open
+      ? html`
+          <div class="separator"></div>
+          ${v.filtering ? nothing : html`<p class="italic">${v.desc}</p>`}
+          ${v.rows.length > 0
+            ? html`<div class="nav-items">
+                ${v.rows.map((row) => renderNavRow(row, v))}
+              </div>`
+            : nothing}
+          ${v.filtering
+            ? nothing
+            : html`<div class="nav-items">
+                ${v.actions.map((action) => renderNavAction(action))}
+              </div>`}
+        `
+      : nothing}
+    <div class="separator"></div>
+  `;
+}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Behaviour-free split of `device-navigator.ts`, the deferred follow-up to the navigator filter box (#704). The file was over the repo's 500 to 600 line cap, so this extracts three cohesive concerns into sibling modules and leaves the component owning state, events, and orchestration. No behaviour change; output is identical and the existing navigator tests cover it.

- `navigator-labels.ts`: pure label resolution (`resolveNavItemLabels`, the automation/interval/script cases, the domain prettifier) plus the `NavRow` / `LabelContext` types.
- `navigator-buckets.ts`: `deriveNavigatorBuckets`, the parse plus categorize plus sort pipeline the component memoises.
- `navigator-render.ts`: the presentational `renderNavSection` (header, rows, add actions) and its row/action helpers, driven by a plain view object with callbacks.

`device-navigator.ts` drops from 793 to 586 lines, back under the cap.

**Related issue or feature (if applicable):**

- Follow-up to #704

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
