### PR TITLE
Trim the redundant Component suffix from core navigator rows

### DIFF
--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -50,6 +50,11 @@ export function resolveNavItemLabels(
   let primary = raw;
   const cached = getCachedComponent(raw, ctx.platform || undefined);
   if (cached?.name) primary = cached.name;
+  if (category === "core") {
+    // Core infrastructure names carry a redundant " Component" suffix
+    // ("Native API Component", "Logger Component"); trim it for the nav.
+    primary = primary.replace(/ Component$/, "") || primary;
+  }
 
   // Prefer the backend-resolved node name for the esphome core section
   // so a `name: $devicename` substitution shows the expanded hostname,

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -1,6 +1,4 @@
 /**
- * @vitest-environment happy-dom
- *
  * Pins the core-row " Component" suffix trim in resolveNavItemLabels.
  */
 import { describe, expect, it, vi } from "vitest";

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the core-row " Component" suffix trim in resolveNavItemLabels.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/util/component-name-cache.js", () => ({
+  getCachedComponent: vi.fn(),
+}));
+
+import {
+  type LabelContext,
+  resolveNavItemLabels,
+} from "../../../src/components/device/navigator-labels.js";
+import { getCachedComponent } from "../../../src/util/component-name-cache.js";
+import type { YamlSection } from "../../../src/util/yaml-sections.js";
+
+const mockGetCached = vi.mocked(getCachedComponent);
+const named = (name: string) =>
+  ({ name }) as unknown as ReturnType<typeof getCachedComponent>;
+
+const ctx: LabelContext = {
+  triggerCatalog: {
+    resolveName: () => "",
+  } as unknown as LabelContext["triggerCatalog"],
+  platform: "",
+  deviceName: "",
+  localize: (key) => key,
+};
+
+const item = (key: string): YamlSection => ({ key }) as unknown as YamlSection;
+
+describe("resolveNavItemLabels core suffix", () => {
+  it("strips a redundant ' Component' suffix on core rows", () => {
+    mockGetCached.mockReturnValue(named("Native API Component"));
+    expect(resolveNavItemLabels(item("api"), "core", ctx).primary).toBe("Native API");
+  });
+
+  it("keeps the full name on component rows", () => {
+    mockGetCached.mockReturnValue(named("Custom Component"));
+    expect(resolveNavItemLabels(item("custom"), "component", ctx).primary).toBe(
+      "Custom Component"
+    );
+  });
+
+  it("leaves a bare 'Component' name intact", () => {
+    mockGetCached.mockReturnValue(named("Component"));
+    expect(resolveNavItemLabels(item("x"), "core", ctx).primary).toBe("Component");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The core configuration rows in the device navigator read "Native API Component", "Logger Component", "WiFi Component"; the trailing "Component" repeats down the column and adds nothing. This trims a trailing " Component" from the resolved catalog name on core rows only, so they read "Native API", "Logger", "WiFi". Scoped to the core category so a legitimately named component (for example "Custom Component") in the Components section keeps its full name, and a name that is just "Component" is left intact.

**Related issue or feature (if applicable):**

- Follow-up to #704

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
