### PR TITLE
Render a lambda delay value in the editor instead of 0 Seconds

### DIFF
--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -31,7 +31,9 @@ import type {
   AvailableComponentInstance,
   AvailableScript,
   ConditionNode,
+  LambdaValue,
 } from "../../../api/types/automations.js";
+import { isLambdaValue } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
@@ -43,6 +45,8 @@ import { registerMdiIcons } from "../../../util/register-icons.js";
 import { renderAdvancedToggle } from "../advanced-toggle.js";
 import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
+import "../config-entry-renderers/lambda-editor.js";
+import { lambdaBodyOf } from "../config-entry-renderers/lambda.js";
 import "./automation-condition-tree.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./catalog-picker-dialog.js";
@@ -143,6 +147,11 @@ export class ESPHomeAutomationActionNode extends LitElement {
   /** "Show advanced settings" gate for the action params form. */
   @state() private _showAdvanced = false;
 
+  /** Last lambda body typed for the Delay action, kept so flipping the
+   *  literal/lambda toggle back and forth doesn't discard the user's
+   *  C++ before they return to it. Reset when the action kind changes. */
+  @state() private _delayLambdaStash = "";
+
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
   /**
@@ -159,6 +168,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     if (previous && previous.action_id !== this.value.action_id) {
       this._collapsed = false;
       this._showAdvanced = false;
+      this._delayLambdaStash = "";
     }
   }
 
@@ -411,8 +421,46 @@ export class ESPHomeAutomationActionNode extends LitElement {
    * backend's shortcut writer lands as ``params.id = "2s"`` —
    * fall back to that key as a last resort so we don't lose
    * historic shortcut values when the user opens the editor.
+   *
+   * Delay is also templatable: ``delay: !lambda "..."`` lands as a
+   * lambda sentinel under ``params.id``. A literal/lambda toggle
+   * (matching the templatable field UX) swaps the number + unit pair
+   * for the C++ editor so the lambda is visible and round-trips.
    */
   private _renderDelayParams() {
+    const lambda = this._delayLambda();
+    return html`<div class="ae-delay">
+      <div
+        class="templatable-toggle"
+        role="tablist"
+        aria-label=${this._localize("device.automation_literal")}
+      >
+        <button
+          type="button"
+          role="tab"
+          class=${lambda ? "" : "active"}
+          aria-selected=${lambda === null}
+          ?disabled=${this.disabled}
+          @click=${() => this._toggleDelayLambda(false)}
+        >
+          ${this._localize("device.automation_literal")}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          class=${lambda ? "active" : ""}
+          aria-selected=${lambda !== null}
+          ?disabled=${this.disabled}
+          @click=${() => this._toggleDelayLambda(true)}
+        >
+          ${this._localize("device.automation_lambda")}
+        </button>
+      </div>
+      ${lambda ? this._renderDelayLambda(lambda) : this._renderDelayLiteral()}
+    </div>`;
+  }
+
+  private _renderDelayLiteral() {
     const { value: numericValue, unit } = this._readDelay();
     return html`<div class="ae-delay-row">
       <div class="ae-delay-value">
@@ -454,6 +502,36 @@ export class ESPHomeAutomationActionNode extends LitElement {
     </div>`;
   }
 
+  private _renderDelayLambda(lambda: LambdaValue) {
+    return html`<esphome-lambda-editor
+      .value=${lambdaBodyOf(lambda)}
+      ?disabled=${this.disabled}
+      @lambda-change=${(e: CustomEvent<{ value: string }>) =>
+        this._writeDelayLambda(e.detail.value)}
+    ></esphome-lambda-editor>`;
+  }
+
+  /** The Delay value when it is a ``!lambda`` (the templatable form),
+   *  else null. The backend lands a scalar delay under ``params.id``. */
+  private _delayLambda(): LambdaValue | null {
+    const id = (this.value.params ?? {}).id;
+    return isLambdaValue(id) ? id : null;
+  }
+
+  /** Flip the Delay action between its literal (value + unit) and
+   *  ``!lambda`` forms, stashing the other side's body so an accidental
+   *  toggle doesn't discard the user's work before they flip back. */
+  private _toggleDelayLambda(toLambda: boolean) {
+    const isLambda = this._delayLambda() !== null;
+    if (toLambda === isLambda) return;
+    if (toLambda) {
+      this._writeDelayLambda(this._delayLambdaStash);
+    } else {
+      this._delayLambdaStash = lambdaBodyOf(this._delayLambda());
+      this._writeDelay("", "s");
+    }
+  }
+
   /** Pick a (numeric value, unit) pair out of the delay action's
    *  params dict. Falls back to seconds when no field is set. */
   private _readDelay(): { value: string; unit: DelayUnit } {
@@ -491,6 +569,18 @@ export class ESPHomeAutomationActionNode extends LitElement {
     for (const u of DELAY_UNITS) delete next[DELAY_UNIT_TO_KEY[u]];
     delete next.id;
     if (trimmed) next[DELAY_UNIT_TO_KEY[unit]] = trimmed;
+    this._emit({ ...this.value, params: next });
+  }
+
+  /** Write a ``!lambda`` body into the delay action's scalar ``id``
+   *  slot, clearing the six unit fields so the literal and lambda
+   *  forms never coexist. The explicit ``!lambda`` tag is what makes
+   *  the backend re-emit a lambda rather than a string literal. */
+  private _writeDelayLambda(body: string) {
+    this._delayLambdaStash = body;
+    const next: Record<string, unknown> = { ...(this.value.params ?? {}) };
+    for (const u of DELAY_UNITS) delete next[DELAY_UNIT_TO_KEY[u]];
+    next.id = { _lambda: body, _tag: "!lambda" };
     this._emit({ ...this.value, params: next });
   }
 

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -47,6 +47,10 @@ import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
 import "../config-entry-renderers/lambda-editor.js";
 import { lambdaBodyOf } from "../config-entry-renderers/lambda.js";
+import {
+  literalLambdaToggleStyles,
+  renderLiteralLambdaToggle,
+} from "../config-entry-renderers/literal-lambda-toggle.js";
 import "./automation-condition-tree.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
 import "./catalog-picker-dialog.js";
@@ -147,12 +151,19 @@ export class ESPHomeAutomationActionNode extends LitElement {
   /** "Show advanced settings" gate for the action params form. */
   @state() private _showAdvanced = false;
 
-  /** Last lambda body typed for the Delay action, kept so flipping the
-   *  literal/lambda toggle back and forth doesn't discard the user's
-   *  C++ before they return to it. Reset when the action kind changes. */
+  /** Stashed other-side values for the Delay literal/lambda toggle, so
+   *  flipping back and forth doesn't discard the user's work before they
+   *  return to it: the C++ body for the lambda side, the value + unit for
+   *  the literal side. Both reset when the action kind changes. */
   @state() private _delayLambdaStash = "";
+  @state() private _delayLiteralStash: { value: string; unit: DelayUnit } | null = null;
 
-  static styles = [espHomeStyles, inputStyles, automationEditorStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    automationEditorStyles,
+    literalLambdaToggleStyles,
+  ];
 
   /**
    * The list reuses nodes by DOM position (plain actions.map, no keyed
@@ -169,6 +180,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
       this._collapsed = false;
       this._showAdvanced = false;
       this._delayLambdaStash = "";
+      this._delayLiteralStash = null;
     }
   }
 
@@ -430,32 +442,12 @@ export class ESPHomeAutomationActionNode extends LitElement {
   private _renderDelayParams() {
     const lambda = this._delayLambda();
     return html`<div class="ae-delay">
-      <div
-        class="templatable-toggle"
-        role="tablist"
-        aria-label=${this._localize("device.automation_literal")}
-      >
-        <button
-          type="button"
-          role="tab"
-          class=${lambda ? "" : "active"}
-          aria-selected=${lambda === null}
-          ?disabled=${this.disabled}
-          @click=${() => this._toggleDelayLambda(false)}
-        >
-          ${this._localize("device.automation_literal")}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          class=${lambda ? "active" : ""}
-          aria-selected=${lambda !== null}
-          ?disabled=${this.disabled}
-          @click=${() => this._toggleDelayLambda(true)}
-        >
-          ${this._localize("device.automation_lambda")}
-        </button>
-      </div>
+      ${renderLiteralLambdaToggle({
+        isLambda: lambda !== null,
+        disabled: this.disabled,
+        localize: this._localize,
+        onSwitch: (toLambda) => this._toggleDelayLambda(toLambda),
+      })}
       ${lambda ? this._renderDelayLambda(lambda) : this._renderDelayLiteral()}
     </div>`;
   }
@@ -519,16 +511,18 @@ export class ESPHomeAutomationActionNode extends LitElement {
   }
 
   /** Flip the Delay action between its literal (value + unit) and
-   *  ``!lambda`` forms, stashing the other side's body so an accidental
+   *  ``!lambda`` forms, stashing the side being left so an accidental
    *  toggle doesn't discard the user's work before they flip back. */
   private _toggleDelayLambda(toLambda: boolean) {
     const isLambda = this._delayLambda() !== null;
     if (toLambda === isLambda) return;
     if (toLambda) {
+      this._delayLiteralStash = this._readDelay();
       this._writeDelayLambda(this._delayLambdaStash);
     } else {
       this._delayLambdaStash = lambdaBodyOf(this._delayLambda());
-      this._writeDelay("", "s");
+      const { value, unit } = this._delayLiteralStash ?? { value: "", unit: "s" };
+      this._writeDelay(value, unit);
     }
   }
 
@@ -557,29 +551,32 @@ export class ESPHomeAutomationActionNode extends LitElement {
     return { value: "", unit: "s" };
   }
 
-  /** Write a (numeric value, unit) pair into the delay action's
-   *  params dict. Clears every other delay field so we never end
-   *  up with two competing values; also drops the legacy ``id``
-   *  shortcut slot so the next round-trip uses the canonical
-   *  ``<unit>: <value>`` form. */
-  private _writeDelay(value: string, unit: DelayUnit) {
-    const trimmed = value.trim();
+  /** A copy of the params with every delay slot removed — the six unit
+   *  fields and the ``id`` scalar shorthand — so a writer can set
+   *  exactly one form (value + unit, or lambda) without the others
+   *  lingering as a competing value. */
+  private _clearedDelayParams(): Record<string, unknown> {
     const next: Record<string, unknown> = { ...(this.value.params ?? {}) };
-    // Clear all six fields + the shortcut slot before re-setting.
     for (const u of DELAY_UNITS) delete next[DELAY_UNIT_TO_KEY[u]];
     delete next.id;
+    return next;
+  }
+
+  /** Write a (numeric value, unit) pair into the delay action's params,
+   *  using the canonical ``<unit>: <value>`` form. */
+  private _writeDelay(value: string, unit: DelayUnit) {
+    const trimmed = value.trim();
+    const next = this._clearedDelayParams();
     if (trimmed) next[DELAY_UNIT_TO_KEY[unit]] = trimmed;
     this._emit({ ...this.value, params: next });
   }
 
   /** Write a ``!lambda`` body into the delay action's scalar ``id``
-   *  slot, clearing the six unit fields so the literal and lambda
-   *  forms never coexist. The explicit ``!lambda`` tag is what makes
-   *  the backend re-emit a lambda rather than a string literal. */
+   *  slot. The explicit ``!lambda`` tag is what makes the backend
+   *  re-emit a lambda rather than a string literal. */
   private _writeDelayLambda(body: string) {
     this._delayLambdaStash = body;
-    const next: Record<string, unknown> = { ...(this.value.params ?? {}) };
-    for (const u of DELAY_UNITS) delete next[DELAY_UNIT_TO_KEY[u]];
+    const next = this._clearedDelayParams();
     next.id = { _lambda: body, _tag: "!lambda" };
     this._emit({ ...this.value, params: next });
   }

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -482,35 +482,6 @@ export const automationEditorStyles = css`
     flex-direction: column;
     gap: var(--wa-space-s);
   }
-  /* Literal/lambda toggle, matching the templatable-field toggle the
-     catalog-driven forms render (config-entry-form-extra.styles). */
-  .ae-delay .templatable-toggle {
-    display: inline-flex;
-    align-self: flex-start;
-    border-radius: var(--wa-border-radius-s);
-    background: var(--wa-color-surface-lowered);
-    padding: 2px;
-  }
-  .ae-delay .templatable-toggle button {
-    appearance: none;
-    border: none;
-    background: transparent;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-2xs);
-    font-weight: var(--wa-font-weight-semibold);
-    padding: 4px 10px;
-    border-radius: var(--wa-border-radius-s);
-    cursor: pointer;
-  }
-  .ae-delay .templatable-toggle button.active {
-    background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-normal);
-    box-shadow: var(--wa-shadow-xs);
-  }
-  .ae-delay .templatable-toggle button:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
   .ae-delay-row {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -477,6 +477,40 @@ export const automationEditorStyles = css`
      its six separate time-component string inputs. Keeps the user
      in the same "one knob" mental model as the interval form
      (which is a single time_period string). */
+  .ae-delay {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-s);
+  }
+  /* Literal/lambda toggle, matching the templatable-field toggle the
+     catalog-driven forms render (config-entry-form-extra.styles). */
+  .ae-delay .templatable-toggle {
+    display: inline-flex;
+    align-self: flex-start;
+    border-radius: var(--wa-border-radius-s);
+    background: var(--wa-color-surface-lowered);
+    padding: 2px;
+  }
+  .ae-delay .templatable-toggle button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-semibold);
+    padding: 4px 10px;
+    border-radius: var(--wa-border-radius-s);
+    cursor: pointer;
+  }
+  .ae-delay .templatable-toggle button.active {
+    background: var(--wa-color-surface-default);
+    color: var(--wa-color-text-normal);
+    box-shadow: var(--wa-shadow-xs);
+  }
+  .ae-delay .templatable-toggle button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
   .ae-delay-row {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/components/device/config-entry-form-extra.styles.ts
+++ b/src/components/device/config-entry-form-extra.styles.ts
@@ -293,45 +293,13 @@ export const configEntryFormExtraStyles = css`
     font-size: var(--wa-font-size-s);
   }
 
-  /* Templatable field wrapper — small literal/lambda tab strip
-     above the active body. The toggle is a pair of buttons rather
-     than a wa-tab-group to keep the markup leaf-cheap and the
-     keyboard story explicit. */
+  /* Templatable field wrapper — column holding the literal/lambda tab
+     strip (styled by literalLambdaToggleStyles) above the active
+     body. */
   .templatable-field {
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-2xs);
-  }
-
-  .templatable-toggle {
-    display: inline-flex;
-    align-self: flex-start;
-    border-radius: var(--wa-border-radius-s);
-    background: var(--wa-color-surface-lowered);
-    padding: 2px;
-  }
-
-  .templatable-toggle button {
-    appearance: none;
-    border: none;
-    background: transparent;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-2xs);
-    font-weight: var(--wa-font-weight-semibold);
-    padding: 4px 10px;
-    border-radius: var(--wa-border-radius-s);
-    cursor: pointer;
-  }
-
-  .templatable-toggle button.active {
-    background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-normal);
-    box-shadow: var(--wa-shadow-xs);
-  }
-
-  .templatable-toggle button:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
   }
 
   /* TRIGGER (action-list) field — a button that opens the automation

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -26,6 +26,7 @@ import {
 import { configEntryFormExtraStyles } from "./config-entry-form-extra.styles.js";
 import { configEntryFormStyles } from "./config-entry-form.styles.js";
 import { filterRenderable, renderFilterOptions } from "./config-entry-render-filter.js";
+import { literalLambdaToggleStyles } from "./config-entry-renderers/literal-lambda-toggle.js";
 import { fieldHighlightStyles } from "./field-highlight.styles.js";
 import type { PasswordInputValueChange } from "./password-input.js";
 // Type-only — the `<esphome-secret-picker>` element is registered by the
@@ -43,6 +44,7 @@ export const fieldRendererStyles = [
   inputStyles,
   configEntryFormStyles,
   configEntryFormExtraStyles,
+  literalLambdaToggleStyles,
   fieldHighlightStyles,
 ];
 

--- a/src/components/device/config-entry-renderers/literal-lambda-toggle.ts
+++ b/src/components/device/config-entry-renderers/literal-lambda-toggle.ts
@@ -1,0 +1,87 @@
+/**
+ * Literal/lambda toggle — the two-button tab strip that swaps a field
+ * between its literal value and a ``!lambda`` body. Shared by the
+ * templatable config-entry wrapper and the bespoke Delay action
+ * renderer so the markup and styling live in one place. The toggle is
+ * a pair of buttons rather than a wa-tab-group to keep the markup
+ * leaf-cheap and the keyboard story explicit.
+ */
+import { css, html } from "lit";
+
+import type { LocalizeFunc } from "../../../common/localize.js";
+
+export const literalLambdaToggleStyles = css`
+  .templatable-toggle {
+    display: inline-flex;
+    align-self: flex-start;
+    border-radius: var(--wa-border-radius-s);
+    background: var(--wa-color-surface-lowered);
+    padding: 2px;
+  }
+
+  .templatable-toggle button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-semibold);
+    padding: 4px 10px;
+    border-radius: var(--wa-border-radius-s);
+    cursor: pointer;
+  }
+
+  .templatable-toggle button.active {
+    background: var(--wa-color-surface-default);
+    color: var(--wa-color-text-normal);
+    box-shadow: var(--wa-shadow-xs);
+  }
+
+  .templatable-toggle button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+`;
+
+interface LiteralLambdaToggleOptions {
+  isLambda: boolean;
+  disabled: boolean;
+  localize: LocalizeFunc;
+  onSwitch: (toLambda: boolean) => void;
+}
+
+export function renderLiteralLambdaToggle({
+  isLambda,
+  disabled,
+  localize,
+  onSwitch,
+}: LiteralLambdaToggleOptions) {
+  return html`
+    <div
+      class="templatable-toggle"
+      role="tablist"
+      aria-label=${localize("device.automation_literal")}
+    >
+      <button
+        type="button"
+        role="tab"
+        class=${!isLambda ? "active" : ""}
+        aria-selected=${!isLambda}
+        ?disabled=${disabled}
+        @click=${() => onSwitch(false)}
+      >
+        ${localize("device.automation_literal")}
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class=${isLambda ? "active" : ""}
+        aria-selected=${isLambda}
+        ?disabled=${disabled}
+        @click=${() => onSwitch(true)}
+      >
+        ${localize("device.automation_lambda")}
+      </button>
+    </div>
+  `;
+}

--- a/src/components/device/config-entry-renderers/templatable.ts
+++ b/src/components/device/config-entry-renderers/templatable.ts
@@ -24,6 +24,7 @@ import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { fieldKeyAttr, type RenderCtx } from "../config-entry-renderers-shared.js";
 import { renderLambdaField } from "./lambda.js";
+import { renderLiteralLambdaToggle } from "./literal-lambda-toggle.js";
 
 interface StashEntry {
   /** Last literal value the user typed before flipping to lambda. */
@@ -96,32 +97,12 @@ export function renderTemplatableField(
 
   return html`
     <div class="templatable-field" data-field-key=${fieldKey}>
-      <div
-        class="templatable-toggle"
-        role="tablist"
-        aria-label=${ctx.localize("device.automation_literal")}
-      >
-        <button
-          type="button"
-          role="tab"
-          class=${!isLambda ? "active" : ""}
-          aria-selected=${!isLambda}
-          ?disabled=${ctx.disabled}
-          @click=${() => switchTo(false)}
-        >
-          ${ctx.localize("device.automation_literal")}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          class=${isLambda ? "active" : ""}
-          aria-selected=${isLambda}
-          ?disabled=${ctx.disabled}
-          @click=${() => switchTo(true)}
-        >
-          ${ctx.localize("device.automation_lambda")}
-        </button>
-      </div>
+      ${renderLiteralLambdaToggle({
+        isLambda,
+        disabled: ctx.disabled,
+        localize: ctx.localize,
+        onSwitch: switchTo,
+      })}
       ${isLambda ? renderLambdaField(entry, path, ctx) : innerRender()}
     </div>
   `;

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -152,6 +152,20 @@ describe("automation-action-node delay lambda", () => {
     expect((lambdaEditor(el) as unknown as { value: string }).value).toBe("return 7;");
   });
 
+  it("keeps the value + unit when toggling to lambda and back", async () => {
+    const { el } = await mountDelay({ seconds: "5" });
+    const [literalBtn, lambdaBtn] = toggleButtons(el);
+
+    lambdaBtn.click();
+    await el.updateComplete;
+    expect(lambdaEditor(el)).not.toBeNull();
+
+    literalBtn.click();
+    await el.updateComplete;
+    expect(valueInput(el)!.value).toBe("5");
+    expect(selectedUnit(el)).toBe("s");
+  });
+
   it("still renders a plain string shorthand as value + unit", async () => {
     const { el } = await mountDelay({ id: "2s" });
     expect(lambdaEditor(el)).toBeNull();

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The Delay action is templatable: ``delay: !lambda "..."`` arrives as a
+ * lambda sentinel under ``params.id``. The bespoke delay renderer must
+ * surface it in the C++ editor (not coerce it to "0 Seconds") and round-trip
+ * the ``!lambda`` tag, while still rendering a plain ``delay: 2s`` as the
+ * value + unit widget. Pins #1335.
+ *
+ * The node imports ``lambda-editor`` (CodeMirror) directly; ``vi.mock``
+ * no-ops it and the other heavy children so the node constructs in happy-dom.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/config-entry-renderers/lambda-editor.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-condition-tree.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import type {
+  ActionNode,
+  AutomationAction,
+} from "../../../../src/api/types/automations.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+
+const DELAY_FIELDS = [
+  "days",
+  "hours",
+  "microseconds",
+  "milliseconds",
+  "minutes",
+  "seconds",
+] as const;
+
+const DELAY_ACTION: AutomationAction = {
+  id: "delay",
+  name: "Delay",
+  description: "",
+  config_entries: DELAY_FIELDS.map((key) => ({
+    key,
+    advanced: true,
+    type: "string",
+    label: key,
+    required: false,
+  })),
+  accepts_action_list: [],
+} as unknown as AutomationAction;
+
+async function mountDelay(
+  params: Record<string, unknown>
+): Promise<{ el: ESPHomeAutomationActionNode; emitted: ActionNode[] }> {
+  const el = new ESPHomeAutomationActionNode();
+  el.value = { action_id: "delay", params };
+  el.catalog = [DELAY_ACTION];
+  // The node is presentational: it emits a fresh ActionNode and the parent
+  // owns ``value``. Mirror that here so toggles see the updated state.
+  const emitted: ActionNode[] = [];
+  el.addEventListener("action-change", (e) => {
+    const next = (e as CustomEvent<{ value: ActionNode }>).detail.value;
+    emitted.push(next);
+    el.value = next;
+  });
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return { el, emitted };
+}
+
+function lambdaEditor(el: ESPHomeAutomationActionNode): HTMLElement | null {
+  return el.shadowRoot!.querySelector<HTMLElement>("esphome-lambda-editor");
+}
+
+function valueInput(el: ESPHomeAutomationActionNode): HTMLInputElement | null {
+  return el.shadowRoot!.querySelector<HTMLInputElement>("#ae-delay-value-input");
+}
+
+/** The unit the renderer marked ``selected`` (read the attribute Lit's
+ *  ``?selected`` binding sets; happy-dom's ``select.value`` ignores it). */
+function selectedUnit(el: ESPHomeAutomationActionNode): string | null {
+  return (
+    el
+      .shadowRoot!.querySelector("#ae-delay-unit-select option[selected]")
+      ?.getAttribute("value") ?? null
+  );
+}
+
+function toggleButtons(el: ESPHomeAutomationActionNode): HTMLButtonElement[] {
+  return [
+    ...el.shadowRoot!.querySelectorAll<HTMLButtonElement>(".templatable-toggle button"),
+  ];
+}
+
+describe("automation-action-node delay lambda", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the lambda body in the editor, not a 0/Seconds default", async () => {
+    const { el } = await mountDelay({
+      id: { _lambda: "return 0;", _tag: "!lambda" },
+    });
+
+    const editor = lambdaEditor(el);
+    expect(editor).not.toBeNull();
+    expect((editor as unknown as { value: string }).value).toBe("return 0;");
+    // Literal value + unit widget is hidden while in lambda mode.
+    expect(valueInput(el)).toBeNull();
+    // The lambda tab is the active one.
+    const [, lambdaBtn] = toggleButtons(el);
+    expect(lambdaBtn.classList.contains("active")).toBe(true);
+  });
+
+  it("preserves the !lambda tag when the body is edited", async () => {
+    const { el, emitted } = await mountDelay({
+      id: { _lambda: "return 0;", _tag: "!lambda" },
+    });
+
+    lambdaEditor(el)!.dispatchEvent(
+      new CustomEvent("lambda-change", { detail: { value: "return 1;" } })
+    );
+
+    expect(emitted[emitted.length - 1].params).toEqual({
+      id: { _lambda: "return 1;", _tag: "!lambda" },
+    });
+  });
+
+  it("keeps the lambda body when toggling to literal and back", async () => {
+    const { el } = await mountDelay({
+      id: { _lambda: "return 7;", _tag: "!lambda" },
+    });
+    const [literalBtn, lambdaBtn] = toggleButtons(el);
+
+    literalBtn.click();
+    await el.updateComplete;
+    // Now in literal mode: editor gone, blank value/unit widget shown.
+    expect(lambdaEditor(el)).toBeNull();
+    expect(valueInput(el)!.value).toBe("");
+
+    lambdaBtn.click();
+    await el.updateComplete;
+    expect((lambdaEditor(el) as unknown as { value: string }).value).toBe("return 7;");
+  });
+
+  it("still renders a plain string shorthand as value + unit", async () => {
+    const { el } = await mountDelay({ id: "2s" });
+    expect(lambdaEditor(el)).toBeNull();
+    expect(valueInput(el)!.value).toBe("2");
+    expect(selectedUnit(el)).toBe("s");
+  });
+
+  it("still renders a canonical unit field as value + unit", async () => {
+    const { el } = await mountDelay({ seconds: "5" });
+    expect(valueInput(el)!.value).toBe("5");
+    expect(selectedUnit(el)).toBe("s");
+  });
+});

--- a/test/components/device/config-entry-templatable-renderer.test.ts
+++ b/test/components/device/config-entry-templatable-renderer.test.ts
@@ -14,27 +14,28 @@ import { describe, expect, it, vi } from "vitest";
 import type { LambdaValue } from "../../../src/api/types/automations.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderTemplatableField } from "../../../src/components/device/config-entry-renderers/templatable.js";
-import { isTemplateResult } from "../../_lit-template-walker.js";
+import { isTemplateResult, visitTemplates } from "../../_lit-template-walker.js";
 import { makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 /**
- * Extract every ``@click`` handler from a template in declaration
- * order. The wrapper emits two buttons in literal-then-lambda order
- * inside a single template, so the two click handlers in ``values``
- * line up with that order too.
+ * Extract every ``@click`` handler from a template tree in document
+ * order. The two buttons live in the nested literal/lambda toggle
+ * template, so recurse through ``visitTemplates``; the literal button
+ * precedes the lambda one, so the handlers come out in that order.
  */
 function clickHandlers(template: unknown): Array<(e: Event) => void> {
   if (!isTemplateResult(template)) {
     throw new Error("Expected a Lit TemplateResult");
   }
-  const t = template as TemplateResult;
   const out: Array<(e: Event) => void> = [];
-  for (let i = 0; i < t.values.length; i++) {
-    const prefix = t.strings[i];
-    if (/@click\s*=\s*"?\s*$/.test(prefix) && typeof t.values[i] === "function") {
-      out.push(t.values[i] as (e: Event) => void);
+  visitTemplates(template, (t: TemplateResult) => {
+    for (let i = 0; i < t.values.length; i++) {
+      const prefix = t.strings[i];
+      if (/@click\s*=\s*"?\s*$/.test(prefix) && typeof t.values[i] === "function") {
+        out.push(t.values[i] as (e: Event) => void);
+      }
     }
-  }
+  });
   return out;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

The Delay automation action is templatable, so `delay: !lambda "return ...;"` is valid, but the Visual Editor rendered it as `Value: 0` / `Unit: Seconds` and dropped the lambda the moment you touched the field. The bespoke delay renderer only ever drew the number + unit widget; a lambda arrives under `params.id` as a sentinel object, so the string-only shortcut path fell through to the empty default.

This adds a literal/lambda toggle to the delay renderer, matching the toggle the catalog-driven templatable fields already use. When the value is a lambda it shows the C++ editor with the body and round-trips the `!lambda` tag; a plain `delay: 2s` still renders as value + unit. Switching forms stashes the other side's body so an accidental toggle does not discard your work. Backend already parses and re-emits the tag, so this is editor-only.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1335

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
