### PR TITLE
Localize the CodeMirror search/replace panel

### DIFF
--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -25,7 +25,9 @@ import { basicSetup, EditorView } from "codemirror";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
-import { darkModeContext } from "../../../context/index.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { darkModeContext, localizeContext } from "../../../context/index.js";
+import { editorSearchPhrases } from "../../../util/editor-search-phrases.js";
 import { vscodeDark, vscodeLight } from "../../../util/yaml-editor-theme.js";
 
 /** Marks the doc change that syncs the external ``value`` prop into the
@@ -38,6 +40,10 @@ export class ESPHomeLambdaEditor extends LitElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
   private _darkMode = false;
+
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
 
   @property() value = "";
 
@@ -135,6 +141,7 @@ export class ESPHomeLambdaEditor extends LitElement {
         doc: this.value,
         extensions: [
           basicSetup,
+          editorSearchPhrases(this._localize),
           cpp(),
           indentUnit.of("  "),
           keymap.of([indentWithTab]),

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -41,7 +41,8 @@ export class ESPHomeLambdaEditor extends LitElement {
   @state()
   private _darkMode = false;
 
-  @consume({ context: localizeContext, subscribe: true })
+  // Not subscribed: phrases are captured at mount, so the panel localizes at mount only.
+  @consume({ context: localizeContext })
   @state()
   private _localize: LocalizeFunc = (key) => key;
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -11,6 +11,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
+import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { getKeyPath } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
@@ -158,6 +159,7 @@ export class ESPHomeYamlEditor extends LitElement {
   private _buildExtensions() {
     const extensions = [
       basicSetup,
+      editorSearchPhrases(this._localize),
       esphomeYaml(),
       indentUnit.of(ESPHOME_YAML_INDENT),
       keymap.of([indentWithTab]),
@@ -518,17 +520,21 @@ export class ESPHomeYamlEditor extends LitElement {
     // would dispatch a stale-cursor preservation against the
     // freshly-mounted view.
 
-    // Theme / API / maskAllValues changes require a full editor
-    // rebuild — CodeMirror extensions are static once the state is
-    // built, and the mask-all flag is captured at extension
-    // construction time. The user may have unsaved edits in the
+    // Theme / API / maskAllValues / locale changes require a full
+    // editor rebuild — CodeMirror extensions are static once the state
+    // is built, so the mask-all flag and the search-panel phrases facet
+    // are captured at extension construction time. The user may have
+    // unsaved edits in the
     // view that the parent's `value` prop doesn't yet reflect (the
     // parent only learns about edits via `yaml-change`, which it
     // loops back as `value`), so preserve the current view content
     // across the rebuild by writing it back into `this.value`
     // before remounting.
     if (
-      (changed.has("_darkMode") || changed.has("_api") || changed.has("maskAllValues")) &&
+      (changed.has("_darkMode") ||
+        changed.has("_api") ||
+        changed.has("maskAllValues") ||
+        changed.has("_localize")) &&
       this._view
     ) {
       this.value = this._view.state.doc.toString();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1009,6 +1009,25 @@
   "yaml_editor": {
     "sticky_jump_to_line": "Jump to line {line}"
   },
+  "editor_search": {
+    "find": "Find",
+    "replace_placeholder": "Replace",
+    "next": "next",
+    "previous": "previous",
+    "all": "all",
+    "match_case": "match case",
+    "by_word": "by word",
+    "regexp": "regexp",
+    "replace": "replace",
+    "replace_all": "replace all",
+    "close": "close",
+    "go_to_line": "Go to line",
+    "go": "go",
+    "current_match": "current match",
+    "on_line": "on line",
+    "replaced_matches": "replaced $ matches",
+    "replaced_match_on_line": "replaced match on line $"
+  },
   "settings": {
     "title": "Settings",
     "appearance": "Appearance",

--- a/src/util/editor-search-phrases.ts
+++ b/src/util/editor-search-phrases.ts
@@ -5,9 +5,8 @@ import type { LocalizeFunc } from "../common/localize.js";
 /**
  * Localize CodeMirror's search / goto-line panel via the `phrases` facet.
  *
- * Keys MUST be the verbatim English source strings `@codemirror/search`
- * passes to `state.phrase(...)`. `$` is CodeMirror's positional arg slot,
- * substituted after lookup, so it stays in the value untouched.
+ * Keys are the verbatim source strings `@codemirror/search` looks up; keep
+ * the `$` positional slot, which CodeMirror substitutes after lookup.
  */
 export function editorSearchPhrases(localize: LocalizeFunc): Extension {
   return EditorState.phrases.of({

--- a/src/util/editor-search-phrases.ts
+++ b/src/util/editor-search-phrases.ts
@@ -1,0 +1,32 @@
+import { EditorState, type Extension } from "@codemirror/state";
+
+import type { LocalizeFunc } from "../common/localize.js";
+
+/**
+ * Localize CodeMirror's search / goto-line panel via the `phrases` facet.
+ *
+ * Keys MUST be the verbatim English source strings `@codemirror/search`
+ * passes to `state.phrase(...)`. `$` is CodeMirror's positional arg slot,
+ * substituted after lookup, so it stays in the value untouched.
+ */
+export function editorSearchPhrases(localize: LocalizeFunc): Extension {
+  return EditorState.phrases.of({
+    Find: localize("editor_search.find"),
+    Replace: localize("editor_search.replace_placeholder"),
+    next: localize("editor_search.next"),
+    previous: localize("editor_search.previous"),
+    all: localize("editor_search.all"),
+    "match case": localize("editor_search.match_case"),
+    "by word": localize("editor_search.by_word"),
+    regexp: localize("editor_search.regexp"),
+    replace: localize("editor_search.replace"),
+    "replace all": localize("editor_search.replace_all"),
+    close: localize("editor_search.close"),
+    "Go to line": localize("editor_search.go_to_line"),
+    go: localize("editor_search.go"),
+    "current match": localize("editor_search.current_match"),
+    "on line": localize("editor_search.on_line"),
+    "replaced $ matches": localize("editor_search.replaced_matches"),
+    "replaced match on line $": localize("editor_search.replaced_match_on_line"),
+  });
+}

--- a/test/util/editor-search-phrases.test.ts
+++ b/test/util/editor-search-phrases.test.ts
@@ -1,0 +1,48 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+
+import type { LocalizeFunc } from "../../src/common/localize.js";
+import { editorSearchPhrases } from "../../src/util/editor-search-phrases.js";
+
+/** Echoes the key so each phrase resolves to its own translation key. */
+const echo: LocalizeFunc = (key) => key;
+
+function phraseState(localize: LocalizeFunc): EditorState {
+  return EditorState.create({ extensions: [editorSearchPhrases(localize)] });
+}
+
+describe("editorSearchPhrases", () => {
+  it("maps every CodeMirror search source string to a translation", () => {
+    const state = phraseState(echo);
+    expect(state.phrase("Find")).toBe("editor_search.find");
+    expect(state.phrase("Replace")).toBe("editor_search.replace_placeholder");
+    expect(state.phrase("next")).toBe("editor_search.next");
+    expect(state.phrase("previous")).toBe("editor_search.previous");
+    expect(state.phrase("all")).toBe("editor_search.all");
+    expect(state.phrase("match case")).toBe("editor_search.match_case");
+    expect(state.phrase("by word")).toBe("editor_search.by_word");
+    expect(state.phrase("regexp")).toBe("editor_search.regexp");
+    expect(state.phrase("replace")).toBe("editor_search.replace");
+    expect(state.phrase("replace all")).toBe("editor_search.replace_all");
+    expect(state.phrase("close")).toBe("editor_search.close");
+    expect(state.phrase("Go to line")).toBe("editor_search.go_to_line");
+    expect(state.phrase("go")).toBe("editor_search.go");
+    expect(state.phrase("current match")).toBe("editor_search.current_match");
+    expect(state.phrase("on line")).toBe("editor_search.on_line");
+  });
+
+  it("keeps CodeMirror's $ positional slot so announcements interpolate", () => {
+    // CodeMirror substitutes $ with the passed argument after lookup, so the
+    // translated value must still contain $. A localize that returns the
+    // English source proves the slot survives our facet.
+    const state = phraseState((key) =>
+      key === "editor_search.replaced_matches" ? "replaced $ matches" : key
+    );
+    expect(state.phrase("replaced $ matches", 3)).toBe("replaced 3 matches");
+  });
+
+  it("returns the localized value, not the source string", () => {
+    const state = phraseState((key) => key.replace("editor_search.", "x-"));
+    expect(state.phrase("next")).toBe("x-next");
+  });
+});

--- a/test/util/editor-search-phrases.test.ts
+++ b/test/util/editor-search-phrases.test.ts
@@ -32,9 +32,7 @@ describe("editorSearchPhrases", () => {
   });
 
   it("keeps CodeMirror's $ positional slot so announcements interpolate", () => {
-    // CodeMirror substitutes $ with the passed argument after lookup, so the
-    // translated value must still contain $. A localize that returns the
-    // English source proves the slot survives our facet.
+    // CM substitutes $ after lookup, so the value must keep its $.
     const state = phraseState((key) =>
       key === "editor_search.replaced_matches" ? "replaced $ matches" : key
     );


### PR DESCRIPTION
# What does this implement/fix?

The code editor's CTRL-F search/replace panel (and the goto-line dialog) showed hardcoded English with no translation keys, so it could not be localized via Lokalise like the rest of the UI.

CodeMirror's search panel routes every label through `state.phrase(...)`, which reads the `EditorState.phrases` facet; that is the intended localization hook. A new `editorSearchPhrases(localize)` helper maps each phrase to a key under a new `editor_search` block in `en.json`, and both editors that mount `basicSetup` (the YAML editor and the C++ lambda editor) now register it. The English values are unchanged so the panel looks identical; the win is the keys now exist for translators.

The YAML editor rebuilds on a locale change so the panel re-localizes (the phrases facet is captured at extension-construction time, like dark mode and mask-all).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1336

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
