### PR TITLE
Render UNKNOWN config fields as YAML-only

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -51,7 +51,11 @@ import {
   filterRenderable,
   renderFilterOptions,
 } from "./config-entry-render-filter.js";
-import { fieldKeyAttr, parseFieldKey } from "./config-entry-renderers-shared.js";
+import {
+  fieldKeyAttr,
+  parseFieldKey,
+  renderYamlOnlyField,
+} from "./config-entry-renderers-shared.js";
 import { FieldFocusController } from "./field-focus-controller.js";
 import { FieldScrollController } from "./field-scroll-controller.js";
 
@@ -582,6 +586,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
             ${ctx.localize("device.automation_action_field_edit")}
           </button>
         </div>`;
+      case ConfigEntryType.UNKNOWN:
+        // A mapping-or-list union the backend can't model; the YAML pane
+        // holds it where a single input can't.
+        return renderYamlOnlyField(entry, path, ctx);
       default:
         return renderStringField(entry, "text", path, ctx);
     }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -116,7 +116,10 @@ export function getDeviceNameWarning(name: string): ValidationError | null {
 }
 
 export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError | null {
-  if (entry.hidden) return null;
+  // UNKNOWN renders as the YAML-only notice (a mapping-or-list union the
+  // form can't edit), so there is nothing to validate; a required one must
+  // not block the wizard with an error the user can't clear in the form.
+  if (entry.hidden || entry.type === ConfigEntryType.UNKNOWN) return null;
 
   const isEmpty =
     raw === undefined ||

--- a/test/components/device/config-entry-unknown-renderer.test.ts
+++ b/test/components/device/config-entry-unknown-renderer.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * An UNKNOWN config entry (a mapping-or-list union like the ntc sensor's
+ * 'calibration' the backend can't model) renders the YAML-only notice
+ * instead of an input, so the wizard no longer shows a broken control.
+ * Issue #1328.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+
+describe("config-entry-form UNKNOWN field", () => {
+  it("renders the YAML-only notice and no editable control", async () => {
+    const form = new ESPHomeConfigEntryForm();
+    form.entries = [
+      makeConfigEntry({
+        key: "calibration",
+        type: ConfigEntryType.UNKNOWN,
+        required: true,
+      }),
+    ];
+    form.values = {};
+    document.body.append(form);
+    await form.updateComplete;
+
+    const root = form.shadowRoot!;
+    const field = root.querySelector("[data-field-key]");
+    expect(field).not.toBeNull();
+    // No control the user could type a value into.
+    expect(root.querySelector("input, textarea, wa-select")).toBeNull();
+    // The YAML-only notice is shown instead (the test localizer echoes keys).
+    expect(field?.textContent).toContain("value_yaml_only");
+  });
+});

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -73,6 +73,13 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "")).toBeNull();
   });
 
+  it("ignores UNKNOWN (YAML-only) fields even when required", () => {
+    // A mapping-or-list union the form renders as the YAML-only notice;
+    // it must not block the wizard with an unclearable required error.
+    const entry = makeEntry({ required: true, type: ConfigEntryType.UNKNOWN });
+    expect(validateEntry(entry, "")).toBeNull();
+  });
+
   it("allows empty optional fields", () => {
     expect(validateEntry(makeEntry({ required: false }), "")).toBeNull();
   });


### PR DESCRIPTION
# What does this implement/fix?

The backend emits `type: unknown` for a field it cannot model as a single control (a mapping or list union like the ntc sensor's `calibration`). The form dispatch sent `unknown` to the string input default, so the wizard showed a broken required text box. This routes `ConfigEntryType.UNKNOWN` to the existing YAML-only notice so the user edits it in the YAML pane, and skips its validation so a required one does not block the wizard with an error that cannot be cleared in the form.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1328

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
