### PR TITLE
Write secrets through the atomic config/set_secret command

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -100,6 +100,7 @@ function redactForLog(payload: unknown): unknown {
   // all of them should have their secrets redacted before logging.
   const containsSecret =
     (command !== null && command.startsWith("auth")) ||
+    command === "config/set_secret" ||
     "token" in obj ||
     "password" in obj ||
     (result !== null && ("token" in result || "password" in result));
@@ -112,6 +113,10 @@ function redactForLog(payload: unknown): unknown {
     const safeArgs: Record<string, unknown> = { ...args };
     if ("token" in safeArgs) safeArgs.token = "<redacted>";
     if ("password" in safeArgs) safeArgs.password = "<redacted>";
+    // config/set_secret carries the secret in ``value``.
+    if (command === "config/set_secret" && "value" in safeArgs) {
+      safeArgs.value = "<redacted>";
+    }
     clone.args = safeArgs;
   }
   if (result !== null) {
@@ -1683,6 +1688,24 @@ export class ESPHomeAPI {
   /** Get secret key names. */
   async getSecretKeys(): Promise<string[]> {
     return this.sendCommand<string[]>("config/get_secrets");
+  }
+
+  /**
+   * Atomically set one secret in secrets.yaml; returns whether it was newly
+   * created. The backend serialises the read-modify-write under a lock so
+   * concurrent per-key writes don't lose each other (issue #1334).
+   * ``overwrite=false`` leaves an existing key untouched (create-if-absent).
+   */
+  async setSecret(
+    key: string,
+    value: string,
+    overwrite = true
+  ): Promise<{ created: boolean }> {
+    return this.sendCommand<{ created: boolean }>("config/set_secret", {
+      key,
+      value,
+      overwrite,
+    });
   }
 
   /**

--- a/src/util/secrets-write.ts
+++ b/src/util/secrets-write.ts
@@ -1,58 +1,24 @@
 import type { ESPHomeAPI } from "../api/esphome-api.js";
-import { secretValueFromYaml } from "./secret-eligibility.js";
-import { splitInlineComment } from "./yaml-scalar.js";
-import { formatYamlScalar } from "./yaml-serialize.js";
-
-const SECRETS_FILE = "secrets.yaml";
-
-/** Append ``key: value`` after the file's content, normalising trailing space. */
-function appendSecret(content: string, key: string, value: string): string {
-  const body = content.replace(/\s+$/, "");
-  return `${body ? `${body}\n` : ""}${key}: ${formatYamlScalar(value)}\n`;
-}
-
-/** Replace the top-level ``key``'s value in *content* (preserving any inline
- *  comment), or append it when the key is absent. */
-function replaceOrAppendSecret(content: string, key: string, value: string): string {
-  const lines = content.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Top-level `key: value` only — skip indentation, blanks, and comments.
-    if (!line || line[0] === " " || line[0] === "\t" || line[0] === "#") continue;
-    const colon = line.search(/:(\s|$)/);
-    if (colon < 0 || line.slice(0, colon).trim() !== key) continue;
-    // `comment` keeps its leading whitespace ("" when none), so re-append it raw.
-    const { comment } = splitInlineComment(line.slice(colon + 1));
-    lines[i] = `${key}: ${formatYamlScalar(value)}${comment}`;
-    return lines.join("\n");
-  }
-  return appendSecret(content, key, value);
-}
 
 /**
  * Ensure `key: value` exists in `secrets.yaml`, returning whether it was newly
  * created.
  *
- * Reads the file first and does NOT swallow a read failure: writing just the
- * new key after a transient read error would wipe every other secret, so a
- * failed read rejects (the caller aborts). If the key already exists its value
- * is left untouched and `{ created: false }` is returned — the existing value
- * may differ from *value*, and overwriting a shared/other-tab secret is worse
- * than reusing it. Otherwise the key is appended and a window `secrets-saved`
- * event is dispatched so every secret picker's cache refreshes.
+ * Delegates to the atomic `config/set_secret` command with `overwrite=false`,
+ * so the existence-check-and-write happens under the backend's lock rather than
+ * as a racy read-then-write here: if the key already exists its value is left
+ * untouched (`{ created: false }`) because clobbering a shared/other-tab secret
+ * is worse than reusing it. On a create, a window `secrets-saved` event is
+ * dispatched so every secret picker's cache refreshes.
  */
 export async function ensureSecretInYaml(
   api: ESPHomeAPI,
   key: string,
   value: string
 ): Promise<{ created: boolean }> {
-  const current = await api.getConfig(SECRETS_FILE); // throws → caller aborts
-  if (secretValueFromYaml(current, key) !== null) {
-    return { created: false };
-  }
-  await api.updateConfig(SECRETS_FILE, appendSecret(current, key, value));
-  window.dispatchEvent(new CustomEvent("secrets-saved"));
-  return { created: true };
+  const { created } = await api.setSecret(key, value, false);
+  if (created) window.dispatchEvent(new CustomEvent("secrets-saved"));
+  return { created };
 }
 
 /**
@@ -66,7 +32,6 @@ export async function setSecretInYaml(
   key: string,
   value: string
 ): Promise<void> {
-  const current = await api.getConfig(SECRETS_FILE);
-  await api.updateConfig(SECRETS_FILE, replaceOrAppendSecret(current, key, value));
+  await api.setSecret(key, value, true);
   window.dispatchEvent(new CustomEvent("secrets-saved"));
 }

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -2146,4 +2146,22 @@ describe("ESPHomeAPI — console-debug redaction", () => {
     expect(text).toContain("bar");
     expect(text).not.toContain("<redacted>");
   });
+
+  it("redacts the value of a config/set_secret frame (but sends it on the wire)", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+
+    const pending = api.setSecret("api_key", "topsecretvalue", false);
+    const sent = ws.sentAs<{ args: { value: string }; message_id: string }>(0);
+    ws.receive({ message_id: sent.message_id, result: { created: true } });
+    await pending;
+
+    // The real value must reach the backend on the wire...
+    expect(sent.args.value).toBe("topsecretvalue");
+    // ...but never appear in the debug log.
+    const text = debugText(debugSpy);
+    expect(text).not.toContain("topsecretvalue");
+    expect(text).toContain("<redacted>");
+  });
 });

--- a/test/components/device/secret-picker.test.ts
+++ b/test/components/device/secret-picker.test.ts
@@ -301,8 +301,7 @@ describe("esphome-secret-picker", () => {
   it("migrates an inline value into the preferred (double-underscore) secret", async () => {
     const el = await mount([]); // neither recommended form on disk yet
     const api = {
-      getConfig: vi.fn(async () => "wifi_ssid: x\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: true })),
       getSecretKeys: vi.fn(async () => []),
     } as unknown as ESPHomeAPI;
     (el as unknown as { _api: ESPHomeAPI })._api = api;
@@ -319,13 +318,12 @@ describe("esphome-secret-picker", () => {
     fireSelectItem(el, ".migrate");
     await new Promise((r) => setTimeout(r, 0)); // let the async write settle
 
-    expect(api.updateConfig).toHaveBeenCalledTimes(1);
-    const [file, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(file).toBe("secrets.yaml");
-    // The double-underscore form is created, never the back-compat alias.
-    expect(content).toContain("kitchen__ota_password: plaintextpw");
-    expect(content).not.toContain("kitchen_ota_password: plaintextpw");
-    expect(content).toContain("wifi_ssid: x");
+    // The double-underscore form is created (create-if-absent), never the alias.
+    expect(api.setSecret).toHaveBeenCalledWith(
+      "kitchen__ota_password",
+      "plaintextpw",
+      false
+    );
     expect(saved).toHaveBeenCalled();
     expect((onSelected.mock.calls[0][0] as CustomEvent).detail.value).toBe(
       "!secret kitchen__ota_password"
@@ -333,13 +331,12 @@ describe("esphome-secret-picker", () => {
     window.removeEventListener("secrets-saved", saved as EventListener);
   });
 
-  it("aborts the migration (no write, no field change) when the read fails", async () => {
+  it("aborts the migration (no field change) when the write fails", async () => {
     const el = await mount([]);
     const api = {
-      getConfig: vi.fn(async () => {
+      setSecret: vi.fn(async () => {
         throw new Error("ws blip");
       }),
-      updateConfig: vi.fn(async () => {}),
       getSecretKeys: vi.fn(async () => []),
     } as unknown as ESPHomeAPI;
     (el as unknown as { _api: ESPHomeAPI })._api = api;
@@ -353,17 +350,15 @@ describe("esphome-secret-picker", () => {
     fireSelectItem(el, ".migrate");
     await new Promise((r) => setTimeout(r, 0));
 
-    // A read failure must never lead to a write that could clobber secrets.yaml.
-    expect(api.updateConfig).not.toHaveBeenCalled();
+    // A failed write must never change the field to a !secret ref.
     expect(onSelected).not.toHaveBeenCalled();
   });
 
-  it("points at the existing key instead of appending a duplicate (stale cache)", async () => {
-    // Cache says empty, but the freshly-read file already defines the key.
+  it("points at the existing key instead of appending a duplicate", async () => {
+    // The backend reports the key already existed (create-if-absent left it).
     const el = await mount([]);
     const api = {
-      getConfig: vi.fn(async () => "kitchen__ota_password: alreadythere\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: false })),
       getSecretKeys: vi.fn(async () => []),
     } as unknown as ESPHomeAPI;
     (el as unknown as { _api: ESPHomeAPI })._api = api;
@@ -377,9 +372,13 @@ describe("esphome-secret-picker", () => {
     fireSelectItem(el, ".migrate");
     await new Promise((r) => setTimeout(r, 0));
 
-    // No duplicate write; just reference the existing key, with a distinct
+    // create-if-absent left the existing value; reference the key with a distinct
     // "linked" toast (its value may differ from what the user typed).
-    expect(api.updateConfig).not.toHaveBeenCalled();
+    expect(api.setSecret).toHaveBeenCalledWith(
+      "kitchen__ota_password",
+      "plaintextpw",
+      false
+    );
     expect(toast.info).toHaveBeenCalled();
     expect((onSelected.mock.calls[0][0] as CustomEvent).detail.value).toBe(
       "!secret kitchen__ota_password"

--- a/test/components/device/secret-value.test.ts
+++ b/test/components/device/secret-value.test.ts
@@ -76,7 +76,7 @@ describe("esphome-secret-value", () => {
   it("warns and creates the secret inline when the key is missing", async () => {
     const api = {
       getConfig: vi.fn(async () => "other: x\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: true })),
       getSecretKeys: vi.fn(async () => ["other", "api_key"]),
     } as unknown as ESPHomeAPI;
     const el = await mount(api, "api_key", false);
@@ -87,9 +87,8 @@ describe("esphome-secret-value", () => {
     await typeValue(el, "base64key==");
     await click(el, ".save");
 
-    const [file, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(file).toBe("secrets.yaml");
-    expect(content).toContain("api_key: base64key==");
+    // Create path is create-if-absent (overwrite=false).
+    expect(api.setSecret).toHaveBeenCalledWith("api_key", "base64key==", false);
     expect(toast.success).toHaveBeenCalled();
     expect(api.getSecretKeys).toHaveBeenCalled(); // cache refreshed
   });
@@ -145,7 +144,7 @@ describe("esphome-secret-value", () => {
     // Device-specific key so the save isn't gated by the shared-secret confirm.
     const api = {
       getConfig: vi.fn(async () => "kitchen__api_key: oldvalue\nother: y\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: false })),
       getSecretKeys: vi.fn(async () => ["kitchen__api_key", "other"]),
     } as unknown as ESPHomeAPI;
     const el = await mount(api, "kitchen__api_key", true, "kitchen");
@@ -158,10 +157,8 @@ describe("esphome-secret-value", () => {
 
     await click(el, ".save");
 
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("kitchen__api_key: newvalue");
-    expect(content).toContain("other: y"); // other secrets preserved
-    expect(content).not.toContain("oldvalue");
+    // Edit path always overwrites (overwrite=true).
+    expect(api.setSecret).toHaveBeenCalledWith("kitchen__api_key", "newvalue", true);
     expect(toast.success).toHaveBeenCalled();
     // Saved value is now the baseline → Save disabled again.
     expect((el.shadowRoot!.querySelector(".save") as HTMLButtonElement).disabled).toBe(
@@ -172,7 +169,7 @@ describe("esphome-secret-value", () => {
   it("confirms before overwriting a shared secret, then writes on confirm", async () => {
     const api = {
       getConfig: vi.fn(async () => "wifi_password: old\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: false })),
       getSecretKeys: vi.fn(async () => ["wifi_password"]),
     } as unknown as ESPHomeAPI;
     // wifi_password is shared (not this device's `<host>__` namespace).
@@ -181,7 +178,7 @@ describe("esphome-secret-value", () => {
     await typeValue(el, "newpass");
     await click(el, ".save");
     // Write is deferred until the user confirms.
-    expect(api.updateConfig).not.toHaveBeenCalled();
+    expect(api.setSecret).not.toHaveBeenCalled();
 
     el.shadowRoot!.querySelector("esphome-confirm-dialog")!.dispatchEvent(
       new CustomEvent("confirm")
@@ -189,14 +186,13 @@ describe("esphome-secret-value", () => {
     await new Promise((r) => setTimeout(r, 0));
     await el.updateComplete;
 
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("wifi_password: newpass");
+    expect(api.setSecret).toHaveBeenCalledWith("wifi_password", "newpass", true);
   });
 
   it("saves a device-specific secret without confirmation", async () => {
     const api = {
       getConfig: vi.fn(async () => "kitchen__encryption_key: old\n"),
-      updateConfig: vi.fn(async () => {}),
+      setSecret: vi.fn(async () => ({ created: false })),
       getSecretKeys: vi.fn(async () => ["kitchen__encryption_key"]),
     } as unknown as ESPHomeAPI;
     const el = await mount(api, "kitchen__encryption_key", true, "kitchen");
@@ -205,8 +201,7 @@ describe("esphome-secret-value", () => {
     await click(el, ".save");
 
     // This device's own secret → no prompt, write goes straight through.
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("kitchen__encryption_key: newkey");
+    expect(api.setSecret).toHaveBeenCalledWith("kitchen__encryption_key", "newkey", true);
   });
 
   it("disables the field while the stored value is loading", async () => {
@@ -298,12 +293,12 @@ describe("esphome-secret-value", () => {
     let n = 0;
     const api = {
       getConfig: vi.fn(async () => ""), // both keys absent → create path
-      updateConfig: vi.fn(
+      setSecret: vi.fn(
         () =>
-          new Promise<void>((r) => {
+          new Promise<{ created: boolean }>((r) => {
             n += 1;
-            if (n === 1) resolveA = r;
-            else resolveB = r;
+            if (n === 1) resolveA = () => r({ created: true });
+            else resolveB = () => r({ created: true });
           })
       ),
       getSecretKeys: vi.fn(async () => []),
@@ -332,7 +327,7 @@ describe("esphome-secret-value", () => {
     resolveB();
     await new Promise((r) => setTimeout(r, 0));
     await el.updateComplete;
-    expect((api.updateConfig as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+    expect((api.setSecret as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
   });
 
   it("reloads the value and resets the draft when present flips", async () => {

--- a/test/components/device/security-notice.test.ts
+++ b/test/components/device/security-notice.test.ts
@@ -143,65 +143,63 @@ describe("security-notice — generate", () => {
     sectionKey: string,
     yaml: string,
     fromLine: number,
-    getConfig: () => Promise<string>,
+    setSecretImpl: (
+      key: string,
+      value: string,
+      overwrite: boolean
+    ) => Promise<{ created: boolean }> = async () => ({ created: true }),
     devices = [{ name: "kitchen" }]
   ) {
-    const updateConfig = vi.fn().mockResolvedValue(undefined);
+    const setSecret = vi.fn(setSecretImpl);
     const { el, inner } = make(sectionKey, yaml, fromLine);
-    inner._api = { getConfig: vi.fn(getConfig), updateConfig } as Partial<ESPHomeAPI>;
+    inner._api = { setSecret } as Partial<ESPHomeAPI>;
     inner._devices = devices.map((d) => ({ ...d, configuration: "device.yaml" }));
     const applied: { path: string[]; value: string }[][] = [];
     el.addEventListener("apply-security-secrets", (e) =>
       applied.push((e as CustomEvent).detail.secrets)
     );
-    return { el, inner, updateConfig, applied };
+    return { el, inner, setSecret, applied };
   }
 
   it("api: writes the encryption key and references encryption.key", async () => {
-    const { inner, updateConfig, applied } = setup(
-      "api",
-      "api:\n  id: api_server\n",
-      1,
-      async () => "wifi_ssid: x\n"
-    );
+    const { inner, setSecret, applied } = setup("api", "api:\n  id: api_server\n", 1);
     await inner._onGenerate();
-    const [file, content] = updateConfig.mock.calls[0];
-    expect(file).toBe("secrets.yaml");
-    expect(content).toMatch(/kitchen__encryption_key: [A-Za-z0-9+/]{43}=/);
+    const [key, value, overwrite] = setSecret.mock.calls[0];
+    expect(key).toBe("kitchen__encryption_key");
+    expect(value).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+    expect(overwrite).toBe(false); // create-if-absent
     expect(applied[0]).toEqual([
       { path: ["encryption", "key"], value: "!secret kitchen__encryption_key" },
     ]);
   });
 
   it("ota: writes a passphrase and references password", async () => {
-    const { inner, updateConfig, applied } = setup(
+    const { inner, setSecret, applied } = setup(
       "ota.esphome",
       "ota:\n  - platform: esphome\n",
-      2,
-      async () => ""
+      2
     );
     await inner._onGenerate();
-    const [, content] = updateConfig.mock.calls[0];
-    expect(content).toMatch(/kitchen__ota_password: [a-z]+(-[a-z]+){3}\n/);
+    const [key, value] = setSecret.mock.calls[0];
+    expect(key).toBe("kitchen__ota_password");
+    expect(value).toMatch(/^[a-z]+(-[a-z]+){3}$/);
     expect(applied[0]).toEqual([
       { path: ["password"], value: "!secret kitchen__ota_password" },
     ]);
   });
 
   it("web_server: inlines a single-word username, stores only the password", async () => {
-    const { inner, updateConfig, applied } = setup(
+    const { inner, setSecret, applied } = setup(
       "web_server",
       "web_server:\n  port: 80\n",
-      1,
-      async () => ""
+      1
     );
     await inner._onGenerate();
     // Only the password is written to secrets.yaml (username is inline).
-    expect(updateConfig).toHaveBeenCalledTimes(1);
-    expect(updateConfig.mock.calls[0][1]).toMatch(
-      /kitchen__web_password: [a-z]+(-[a-z]+){3}\n/
-    );
-    expect(updateConfig.mock.calls[0][1]).not.toContain("web_username");
+    expect(setSecret).toHaveBeenCalledTimes(1);
+    const [key, value] = setSecret.mock.calls[0];
+    expect(key).toBe("kitchen__web_password");
+    expect(value).toMatch(/^[a-z]+(-[a-z]+){3}$/);
 
     const [user, pass] = applied[0];
     expect(user.path).toEqual(["auth", "username"]);
@@ -213,14 +211,19 @@ describe("security-notice — generate", () => {
   });
 
   it("reuses an existing secret (no overwrite) and still references it", async () => {
-    const { inner, updateConfig, applied } = setup(
+    const { inner, setSecret, applied } = setup(
       "ota.esphome",
       "ota:\n  - platform: esphome\n",
       2,
-      async () => "kitchen__ota_password: existing\n" // key already present → reused
+      async () => ({ created: false }) // key already present → reused, not overwritten
     );
     await inner._onGenerate();
-    expect(updateConfig).not.toHaveBeenCalled();
+    // The write is create-if-absent, so the existing value is left intact server-side.
+    expect(setSecret).toHaveBeenCalledWith(
+      "kitchen__ota_password",
+      expect.any(String),
+      false
+    );
     expect(applied[0]).toEqual([
       { path: ["password"], value: "!secret kitchen__ota_password" },
     ]);
@@ -228,28 +231,22 @@ describe("security-notice — generate", () => {
   });
 
   it("does nothing when the device name can't resolve", async () => {
-    const { inner, updateConfig } = setup(
+    const { inner, setSecret } = setup(
       "api",
       "api:\n  id: api_server\n",
       1,
-      async () => "",
+      async () => ({ created: true }),
       []
     );
     await inner._onGenerate();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(setSecret).not.toHaveBeenCalled();
   });
 
-  it("aborts on a secrets read failure without emitting", async () => {
-    const { inner, updateConfig, applied } = setup(
-      "api",
-      "api:\n  id: api_server\n",
-      1,
-      async () => {
-        throw new Error("ws blip");
-      }
-    );
+  it("aborts on a secrets write failure without emitting", async () => {
+    const { inner, applied } = setup("api", "api:\n  id: api_server\n", 1, async () => {
+      throw new Error("ws blip");
+    });
     await inner._onGenerate();
-    expect(updateConfig).not.toHaveBeenCalled();
     expect(applied).toHaveLength(0);
     expect(toast.error).toHaveBeenCalled();
   });

--- a/test/util/ensure-secret-with-toast.test.ts
+++ b/test/util/ensure-secret-with-toast.test.ts
@@ -3,6 +3,7 @@
  *
  * Pins ensureSecretWithToast: created → success toast + createdKey, existing →
  * info toast + the shared "linked" key, failure → error toast + false return.
+ * The write goes through the atomic ``config/set_secret`` command (issue #1334).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -26,6 +27,14 @@ const messages = {
 };
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
+/** Stub API whose ``setSecret`` reports the given create/overwrite outcome. */
+function apiWith(created: boolean, keys: string[]) {
+  return {
+    setSecret: vi.fn(async () => ({ created })),
+    getSecretKeys: vi.fn(async () => keys),
+  } as unknown as ESPHomeAPI;
+}
+
 afterEach(() => {
   document.body.innerHTML = "";
   _resetSecretKeysCache();
@@ -35,48 +44,36 @@ afterEach(() => {
 });
 
 describe("ensureSecretWithToast", () => {
-  it("appends a new key, toasts success, refreshes the cache, and returns true", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "other: x\n"),
-      updateConfig: vi.fn(async () => {}),
-      getSecretKeys: vi.fn(async () => ["other", "k"]),
-    } as unknown as ESPHomeAPI;
+  it("creates a new key, toasts success, refreshes the cache, and returns true", async () => {
+    const api = apiWith(true, ["other", "k"]);
 
     const ok = await ensureSecretWithToast(api, "k", "v", localize, messages);
     await flush();
 
     expect(ok).toBe(true);
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("k: v");
+    expect(api.setSecret).toHaveBeenCalledWith("k", "v", false);
     expect(toast.success).toHaveBeenCalledWith("device.created", { richColors: true });
     expect(api.getSecretKeys).toHaveBeenCalled();
   });
 
-  it("links to an existing key (no write), toasts info, and still refreshes the cache", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "k: existing\n"),
-      updateConfig: vi.fn(async () => {}),
-      getSecretKeys: vi.fn(async () => ["k"]),
-    } as unknown as ESPHomeAPI;
+  it("links to an existing key, toasts info, and still refreshes the cache", async () => {
+    const api = apiWith(false, ["k"]);
 
     const ok = await ensureSecretWithToast(api, "k", "v", localize, messages);
     await flush();
 
     expect(ok).toBe(true);
-    expect(api.updateConfig).not.toHaveBeenCalled();
     expect(toast.info).toHaveBeenCalledWith("device.secret_picker_linked", {
       richColors: true,
     });
-    // The linked path doesn't fire secrets-saved, so the cache is refreshed here.
     expect(api.getSecretKeys).toHaveBeenCalled();
   });
 
-  it("toasts an error, returns false, and skips the refresh when the read fails", async () => {
+  it("toasts an error, returns false, and skips the refresh when the write fails", async () => {
     const api = {
-      getConfig: vi.fn(async () => {
+      setSecret: vi.fn(async () => {
         throw new Error("ws blip");
       }),
-      updateConfig: vi.fn(async () => {}),
       getSecretKeys: vi.fn(async () => []),
     } as unknown as ESPHomeAPI;
 
@@ -84,7 +81,6 @@ describe("ensureSecretWithToast", () => {
     await flush();
 
     expect(ok).toBe(false);
-    expect(api.updateConfig).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith("device.error", { richColors: true });
     expect(api.getSecretKeys).not.toHaveBeenCalled();
   });
@@ -98,28 +94,22 @@ describe("setSecretWithToast", () => {
   };
 
   it("overwrites the value, toasts success, and refreshes the cache", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "k: old\n"),
-      updateConfig: vi.fn(async () => {}),
-      getSecretKeys: vi.fn(async () => ["k"]),
-    } as unknown as ESPHomeAPI;
+    const api = apiWith(false, ["k"]);
 
     const ok = await setSecretWithToast(api, "k", "new", localize, setMessages);
     await flush();
 
     expect(ok).toBe(true);
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("k: new");
+    expect(api.setSecret).toHaveBeenCalledWith("k", "new", true);
     expect(toast.success).toHaveBeenCalledWith("device.saved", { richColors: true });
     expect(api.getSecretKeys).toHaveBeenCalled();
   });
 
   it("toasts an error, returns false, and skips the refresh on failure", async () => {
     const api = {
-      getConfig: vi.fn(async () => {
+      setSecret: vi.fn(async () => {
         throw new Error("ws blip");
       }),
-      updateConfig: vi.fn(async () => {}),
       getSecretKeys: vi.fn(async () => []),
     } as unknown as ESPHomeAPI;
 
@@ -127,7 +117,6 @@ describe("setSecretWithToast", () => {
     await flush();
 
     expect(ok).toBe(false);
-    expect(api.updateConfig).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith("device.error", { richColors: true });
     expect(api.getSecretKeys).not.toHaveBeenCalled();
   });

--- a/test/util/secrets-write.test.ts
+++ b/test/util/secrets-write.test.ts
@@ -1,5 +1,11 @@
 /**
  * @vitest-environment happy-dom
+ *
+ * The per-key writers delegate to the atomic ``config/set_secret`` command
+ * (issue #1334); the line-based YAML manipulation now lives on the backend.
+ * These pin the call contract: ensure passes ``overwrite=false`` and only
+ * announces ``secrets-saved`` when the backend reports a create, set passes
+ * ``overwrite=true`` and always announces.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
@@ -11,107 +17,62 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
+function apiWith(created: boolean) {
+  return {
+    setSecret: vi.fn(async () => ({ created })),
+  } as unknown as ESPHomeAPI;
+}
+
 describe("ensureSecretInYaml", () => {
-  it("appends a new key and dispatches secrets-saved", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "wifi_ssid: x\n"),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
+  it("calls config/set_secret with overwrite=false and announces a create", async () => {
+    const api = apiWith(true);
     const saved = vi.fn();
     window.addEventListener("secrets-saved", saved as EventListener);
 
     const result = await ensureSecretInYaml(api, "kitchen__encryption_key", "oQ3==");
 
     expect(result).toEqual({ created: true });
-    const [file, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(file).toBe("secrets.yaml");
-    expect(content).toContain("wifi_ssid: x");
-    expect(content).toContain("kitchen__encryption_key: oQ3==");
+    expect(api.setSecret).toHaveBeenCalledWith("kitchen__encryption_key", "oQ3==", false);
     await tick();
     expect(saved).toHaveBeenCalled();
     window.removeEventListener("secrets-saved", saved as EventListener);
   });
 
-  it("leaves an existing key untouched and writes nothing", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "kitchen__encryption_key: existing\n"),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
+  it("does not announce secrets-saved when the key already existed", async () => {
+    const api = apiWith(false);
+    const saved = vi.fn();
+    window.addEventListener("secrets-saved", saved as EventListener);
 
     const result = await ensureSecretInYaml(api, "kitchen__encryption_key", "new");
 
     expect(result).toEqual({ created: false });
-    expect(api.updateConfig).not.toHaveBeenCalled();
+    await tick();
+    expect(saved).not.toHaveBeenCalled();
+    window.removeEventListener("secrets-saved", saved as EventListener);
   });
 
-  it("rejects and never writes when the read fails", async () => {
+  it("rejects when the command rejects", async () => {
     const api = {
-      getConfig: vi.fn(async () => {
+      setSecret: vi.fn(async () => {
         throw new Error("ws blip");
       }),
-      updateConfig: vi.fn(async () => {}),
     } as unknown as ESPHomeAPI;
 
     await expect(ensureSecretInYaml(api, "k", "v")).rejects.toThrow();
-    expect(api.updateConfig).not.toHaveBeenCalled();
-  });
-
-  it("quotes a value that needs quoting via formatYamlScalar", async () => {
-    const api = {
-      getConfig: vi.fn(async () => ""),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
-
-    await ensureSecretInYaml(api, "k", "a: b # c");
-
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toBe('k: "a: b # c"\n');
   });
 });
 
 describe("setSecretInYaml", () => {
-  it("overwrites an existing key's value, preserving other secrets", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "a: 1\nkitchen__encryption_key: old\nb: 2\n"),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
+  it("calls config/set_secret with overwrite=true and announces secrets-saved", async () => {
+    const api = apiWith(false);
     const saved = vi.fn();
     window.addEventListener("secrets-saved", saved as EventListener);
 
     await setSecretInYaml(api, "kitchen__encryption_key", "new");
 
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("kitchen__encryption_key: new");
-    expect(content).not.toContain("old");
-    expect(content).toContain("a: 1");
-    expect(content).toContain("b: 2");
+    expect(api.setSecret).toHaveBeenCalledWith("kitchen__encryption_key", "new", true);
     await tick();
     expect(saved).toHaveBeenCalled();
     window.removeEventListener("secrets-saved", saved as EventListener);
-  });
-
-  it("preserves an inline comment on the rewritten line", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "k: old  # keep me\n"),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
-
-    await setSecretInYaml(api, "k", "new");
-
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toBe("k: new  # keep me\n");
-  });
-
-  it("appends when the key is absent", async () => {
-    const api = {
-      getConfig: vi.fn(async () => "other: x\n"),
-      updateConfig: vi.fn(async () => {}),
-    } as unknown as ESPHomeAPI;
-
-    await setSecretInYaml(api, "k", "v");
-
-    const [, content] = (api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(content).toContain("other: x");
-    expect(content).toContain("k: v");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

`ensureSecretInYaml` / `setSecretInYaml` wrote one secret by reading the whole `secrets.yaml` over `devices/get_config`, mutating one key in JS, and writing the whole file back over `devices/update_config`. Two overlapping per-key writes (two tabs, the device editor racing `/secrets`, two quick saves) each read the same base and wrote back their own full version, so the last write silently dropped the other key.

Both helpers now go through the backend's atomic `config/set_secret(key, value, overwrite)` command, which does the read-modify-write under a lock; `ensure` passes `overwrite=false` so the create-if-absent existence check happens server-side instead of as a racy check-then-set here, and keeps the `{created}` result that drives the created-vs-linked toast. Drops the now-dead JS YAML mutation helpers, and masks the secret `value` in the debug `[SENDING]` log. The whole-file `/secrets` editor still uses `getConfig`/`updateConfig`; only per-key writes move.

Needs the companion backend change that adds the command (it ships prebuilt in the wheel).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1334

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
