### PR TITLE
Add a domain glyph to navigator subgroup headers

### DIFF
--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -184,6 +184,12 @@ export const deviceNavigatorStyles = css`
     cursor: default;
   }
 
+  .nav-subgroup-icon {
+    font-size: var(--wa-font-size-m);
+    color: var(--wa-color-text-quiet);
+    flex-shrink: 0;
+  }
+
   .nav-subgroup-title {
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-semibold);

--- a/src/components/device/navigator-render.ts
+++ b/src/components/device/navigator-render.ts
@@ -3,6 +3,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import type { YamlSection } from "../../util/yaml-sections.js";
 import type { NavGroup } from "./navigator-groups.js";
 import { type NavRow, prettyDomain } from "./navigator-labels.js";
+import { iconForDomain } from "./navigator-row-icons.js";
 
 /** A "+ Add X" affordance at the foot of a section. */
 export interface NavAction {
@@ -80,6 +81,11 @@ function renderNavGroup(group: NavGroup, v: NavSectionView): TemplateResult {
         }
       }}
     >
+      <wa-icon
+        class="nav-subgroup-icon"
+        library="mdi"
+        name=${iconForDomain(group.key)}
+      ></wa-icon>
       <span class="nav-subgroup-title">${prettyDomain(group.key)}</span>
       <span class="nav-subgroup-count">${group.rows.length}</span>
       ${interactive

--- a/src/components/device/navigator-row-icons.ts
+++ b/src/components/device/navigator-row-icons.ts
@@ -1,0 +1,97 @@
+import {
+  mdiApi,
+  mdiBellOutline,
+  mdiBluetooth,
+  mdiCalendarClock,
+  mdiCameraOutline,
+  mdiCardTextOutline,
+  mdiCheckboxMarkedCircleOutline,
+  mdiChip,
+  mdiClockOutline,
+  mdiCloudUploadOutline,
+  mdiConnection,
+  mdiExportVariant,
+  mdiFan,
+  mdiFormDropdown,
+  mdiFormTextbox,
+  mdiGauge,
+  mdiGestureTapButton,
+  mdiLan,
+  mdiLightbulbOutline,
+  mdiLockOutline,
+  mdiMonitor,
+  mdiNumeric,
+  mdiSerialPort,
+  mdiShapeOutline,
+  mdiShieldHomeOutline,
+  mdiSpeaker,
+  mdiTextBoxOutline,
+  mdiThermostat,
+  mdiToggleSwitchOutline,
+  mdiValve,
+  mdiWeb,
+  mdiWifi,
+  mdiWifiLock,
+  mdiWindowShutter,
+} from "@mdi/js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+/**
+ * Per-domain leading glyph for navigator rows, so a long Core or
+ * Components list can be scanned by shape. Keyed on the YAML domain
+ * (``item.key``); the value is ``[registered mdi name, svg path]`` so
+ * registration derives from this one map and shared glyphs dedupe.
+ */
+const DOMAIN_ICON: Record<string, readonly [string, string]> = {
+  // Core infrastructure
+  esphome: ["chip", mdiChip],
+  wifi: ["wifi", mdiWifi],
+  ethernet: ["lan", mdiLan],
+  mdns: ["lan", mdiLan],
+  api: ["api", mdiApi],
+  ota: ["cloud-upload-outline", mdiCloudUploadOutline],
+  logger: ["card-text-outline", mdiCardTextOutline],
+  web_server: ["web", mdiWeb],
+  captive_portal: ["wifi-lock", mdiWifiLock],
+  time: ["clock-outline", mdiClockOutline],
+  sntp: ["clock-outline", mdiClockOutline],
+  uart: ["serial-port", mdiSerialPort],
+  i2c: ["connection", mdiConnection],
+  spi: ["connection", mdiConnection],
+  esp32_ble: ["bluetooth", mdiBluetooth],
+  esp32_ble_tracker: ["bluetooth", mdiBluetooth],
+  ble: ["bluetooth", mdiBluetooth],
+
+  // Component platforms
+  sensor: ["gauge", mdiGauge],
+  binary_sensor: ["checkbox-marked-circle-outline", mdiCheckboxMarkedCircleOutline],
+  text_sensor: ["text-box-outline", mdiTextBoxOutline],
+  switch: ["toggle-switch-outline", mdiToggleSwitchOutline],
+  light: ["lightbulb-outline", mdiLightbulbOutline],
+  output: ["export-variant", mdiExportVariant],
+  number: ["numeric", mdiNumeric],
+  select: ["form-dropdown", mdiFormDropdown],
+  button: ["gesture-tap-button", mdiGestureTapButton],
+  fan: ["fan", mdiFan],
+  cover: ["window-shutter", mdiWindowShutter],
+  climate: ["thermostat", mdiThermostat],
+  text: ["form-textbox", mdiFormTextbox],
+  lock: ["lock-outline", mdiLockOutline],
+  valve: ["valve", mdiValve],
+  media_player: ["speaker", mdiSpeaker],
+  display: ["monitor", mdiMonitor],
+  datetime: ["calendar-clock", mdiCalendarClock],
+  camera: ["camera-outline", mdiCameraOutline],
+  event: ["bell-outline", mdiBellOutline],
+  alarm_control_panel: ["shield-home-outline", mdiShieldHomeOutline],
+};
+
+/** Neutral glyph for any domain not in {@link DOMAIN_ICON}. */
+const FALLBACK: readonly [string, string] = ["shape-outline", mdiShapeOutline];
+
+registerMdiIcons(Object.fromEntries([...Object.values(DOMAIN_ICON), FALLBACK]));
+
+/** Registered mdi icon name for a row's domain; neutral shape if unmapped. */
+export function iconForDomain(domain: string): string {
+  return (DOMAIN_ICON[domain] ?? FALLBACK)[0];
+}

--- a/test/components/device/navigator-row-icons.test.ts
+++ b/test/components/device/navigator-row-icons.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Loading the module registers an mdi resolver as a side effect; stub the
+// webawesome registry so the import doesn't pull the real icon library.
+vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
+  registerIconLibrary: vi.fn(),
+}));
+
+import { iconForDomain } from "../../../src/components/device/navigator-row-icons.js";
+
+describe("iconForDomain", () => {
+  it("maps known domains to their glyph", () => {
+    expect(iconForDomain("sensor")).toBe("gauge");
+    expect(iconForDomain("switch")).toBe("toggle-switch-outline");
+    expect(iconForDomain("number")).toBe("numeric");
+  });
+
+  it("shares one glyph across related domains", () => {
+    expect(iconForDomain("mdns")).toBe(iconForDomain("ethernet"));
+  });
+
+  it("falls back to a neutral shape for unmapped domains", () => {
+    expect(iconForDomain("totally_unknown")).toBe("shape-outline");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The Components domain subgroups (#716) read as near-identical text rows. This adds a small muted glyph to each subgroup header keyed on the domain (gauge for sensor, a numeric badge for number, a toggle for switch), so the list can be scanned by shape. The glyph lives on the group header rather than every row, so the rows stay clean and the extra visual weight is paid once per domain instead of once per item. Domains without a mapping fall back to a neutral shape; the icon map is a single source that both renders the glyph and registers its mdi path.

Follow-up to the navigator grouping (#716); together with the filter box (#704) they address the Discord feedback that complex configs are hard to navigate.

**Related issue or feature (if applicable):**

- Follow-up to #716 (Discord feedback)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
