### PR TITLE
Re-lint the open YAML editor on a secrets save

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,6 +1,7 @@
 import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
+import { forceLinting } from "@codemirror/lint";
 import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
@@ -30,6 +31,7 @@ import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
+  relintEffect,
 } from "../util/yaml-lint-backend.js";
 import type { YamlSection } from "../util/yaml-sections.js";
 import {
@@ -642,11 +644,28 @@ export class ESPHomeYamlEditor extends LitElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("secrets-saved", this._onSecretsSaved);
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback();
+    window.removeEventListener("secrets-saved", this._onSecretsSaved);
     this._view?.destroy();
     this._view = null;
   }
+
+  // A secrets.yaml write doesn't change the editor doc, so the backend lint
+  // result for the open device is stale (its squiggle outlives the now-defined
+  // !secret). Force a re-validate; the relintEffect schedules the lint so
+  // forceLinting can run it immediately on unchanged content.
+  private _onSecretsSaved = () => {
+    const view = this._view;
+    if (!view) return;
+    view.dispatch({ effects: relintEffect.of(null) });
+    forceLinting(view);
+  };
 }
 
 declare global {

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -13,6 +13,7 @@
 import { forEachDiagnostic, linter, type Diagnostic } from "@codemirror/lint";
 import {
   RangeSetBuilder,
+  StateEffect,
   StateField,
   type EditorState,
   type Extension,
@@ -304,9 +305,19 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
       // Don't auto-open the panel — we only want the inline wavy underlines
       // and hover tooltip.
       autoPanel: false,
+      // Re-run for unchanged content when a relintEffect is dispatched. A
+      // secrets.yaml write doesn't touch the editor doc, so without this the
+      // lint plugin has nothing scheduled and forceLinting() is a no-op.
+      needsRefresh: (update) =>
+        update.transactions.some((tr) => tr.effects.some((e) => e.is(relintEffect))),
     }
   );
 }
+
+// Dispatch on the editor view to make the backend linter re-validate the
+// current (unchanged) content, e.g. after a secrets.yaml write the doc can't
+// see. Pair with forceLinting(view) to run it immediately.
+export const relintEffect = StateEffect.define<null>();
 
 /** Tags a line so its line-number gutter cell renders the error icon. */
 const errorLineMarker = new (class extends GutterMarker {

--- a/test/util/yaml-lint-relint.test.ts
+++ b/test/util/yaml-lint-relint.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The backend linter must re-validate UNCHANGED content when a
+ * `relintEffect` is dispatched (e.g. after a secrets.yaml write the editor
+ * doc can't see). Without the `needsRefresh` wiring the lint plugin has
+ * nothing scheduled and `forceLinting` is a no-op, so the stale squiggle
+ * would linger. Issue device-builder#1332.
+ */
+import { forceLinting } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
+import {
+  createBackendYamlLinter,
+  relintEffect,
+} from "../../src/util/yaml-lint-backend.js";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function mountView(validateYaml: ESPHomeAPI["validateYaml"]): EditorView {
+  const api = { validateYaml } as unknown as ESPHomeAPI;
+  return new EditorView({
+    state: EditorState.create({
+      doc: "esphome:\n  name: x\n",
+      extensions: [createBackendYamlLinter({ api, getConfiguration: () => "x.yaml" })],
+    }),
+    parent: document.body,
+  });
+}
+
+describe("backend linter relint on relintEffect", () => {
+  it("re-validates the same content when relintEffect is dispatched", async () => {
+    const calls: string[] = [];
+    const validateYaml = vi.fn(async (_cfg: string, content: string) => {
+      calls.push(content);
+      return { yaml_errors: [], validation_errors: [] };
+    }) as unknown as ESPHomeAPI["validateYaml"];
+
+    const view = mountView(validateYaml);
+    try {
+      forceLinting(view); // run the initial lint
+      await flush();
+      expect(calls).toHaveLength(1);
+
+      // No doc change; the dispatched effect is what lets forceLinting re-run.
+      view.dispatch({ effects: relintEffect.of(null) });
+      forceLinting(view);
+      await flush();
+
+      expect(calls).toEqual(["esphome:\n  name: x\n", "esphome:\n  name: x\n"]);
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("does not re-validate on an unrelated dispatch", async () => {
+    const calls: string[] = [];
+    const validateYaml = vi.fn(async (_cfg: string, content: string) => {
+      calls.push(content);
+      return { yaml_errors: [], validation_errors: [] };
+    }) as unknown as ESPHomeAPI["validateYaml"];
+
+    const view = mountView(validateYaml);
+    try {
+      forceLinting(view);
+      await flush();
+      expect(calls).toHaveLength(1);
+
+      // A no-op selection dispatch must not schedule a relint.
+      view.dispatch({ selection: { anchor: 0 } });
+      forceLinting(view);
+      await flush();
+
+      expect(calls).toHaveLength(1);
+    } finally {
+      view.destroy();
+    }
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

After a secret is written while the YAML editor is open (secret picker inline create, secrets editor), the code editor kept the stale `Secret '<name>' not defined` squiggle until the lint cache expired. A secrets.yaml write doesn't change the editor doc, so the lint plugin has nothing scheduled and `forceLinting(view)` alone is a no-op. This adds a `relintEffect` plus a `needsRefresh` hook on the backend linter; on the `secrets-saved` window event the editor dispatches that effect and forces a re-lint, so the now-invalidated backend result is recomputed promptly instead of on the next keystroke.

Pairs with the backend cache invalidation that makes the recomputed result fresh.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1332

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
