### PR TITLE
Consolidate shared CodeMirror scaffolding between the editors

### DIFF
--- a/src/components/codemirror-editor-element.ts
+++ b/src/components/codemirror-editor-element.ts
@@ -16,8 +16,11 @@ export abstract class CodeMirrorEditorElement extends LitElement {
 
   protected _view: EditorView | null = null;
 
-  /** Build the view into ``.cm-wrap`` with the subclass's extensions. */
-  protected _mountView(doc: string, extensions: Extension[]): void {
+  /** Build the view into ``.cm-wrap`` with the subclass's extensions;
+   *  tears down any existing view first so the single-handle contract
+   *  holds even if a subclass mounts twice. */
+  protected _mountView(doc: string, extensions: Extension): void {
+    this._destroyView();
     this._view = new EditorView({
       state: EditorState.create({ doc, extensions }),
       parent: this._container,

--- a/src/components/codemirror-editor-element.ts
+++ b/src/components/codemirror-editor-element.ts
@@ -1,0 +1,37 @@
+import { EditorState, type Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { LitElement } from "lit";
+import { query } from "lit/decorators.js";
+
+/**
+ * Shared CodeMirror host scaffolding for the YAML and lambda editors.
+ *
+ * Owns only the genuinely identical lifecycle — the ``.cm-wrap`` host
+ * lookup, the single ``EditorView`` handle, and its mount/teardown.
+ * Subclasses keep their own styles, extensions, change events, and
+ * theme/reconfigure strategy; the base never touches those.
+ */
+export abstract class CodeMirrorEditorElement extends LitElement {
+  @query(".cm-wrap") protected _container!: HTMLDivElement;
+
+  protected _view: EditorView | null = null;
+
+  /** Build the view into ``.cm-wrap`` with the subclass's extensions. */
+  protected _mountView(doc: string, extensions: Extension[]): void {
+    this._view = new EditorView({
+      state: EditorState.create({ doc, extensions }),
+      parent: this._container,
+    });
+  }
+
+  /** Destroy the view and drop the handle. */
+  protected _destroyView(): void {
+    this._view?.destroy();
+    this._view = null;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._destroyView();
+  }
+}

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -18,17 +18,18 @@
 import { indentWithTab } from "@codemirror/commands";
 import { cpp } from "@codemirror/lang-cpp";
 import { indentUnit } from "@codemirror/language";
-import { Annotation, Compartment, EditorState } from "@codemirror/state";
+import { Annotation, Compartment } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { basicSetup, EditorView } from "codemirror";
-import { css, html, LitElement } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { css, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { darkModeContext, localizeContext } from "../../../context/index.js";
 import { editorSearchPhrases } from "../../../util/editor-search-phrases.js";
-import { vscodeDark, vscodeLight } from "../../../util/yaml-editor-theme.js";
+import { editorHeightTheme, selectEditorTheme } from "../../../util/yaml-editor-theme.js";
+import { CodeMirrorEditorElement } from "../../codemirror-editor-element.js";
 
 /** Marks the doc change that syncs the external ``value`` prop into the
  *  view, so the update listener can tell it apart from a user edit and
@@ -36,7 +37,7 @@ import { vscodeDark, vscodeLight } from "../../../util/yaml-editor-theme.js";
 const externalSync = Annotation.define<boolean>();
 
 @customElement("esphome-lambda-editor")
-export class ESPHomeLambdaEditor extends LitElement {
+export class ESPHomeLambdaEditor extends CodeMirrorEditorElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
   private _darkMode = false;
@@ -58,9 +59,6 @@ export class ESPHomeLambdaEditor extends LitElement {
 
   @property() placeholder = "";
 
-  @query(".cm-wrap") private _container!: HTMLDivElement;
-
-  private _view: EditorView | null = null;
   private _themeCompartment = new Compartment();
   private _editableCompartment = new Compartment();
 
@@ -107,9 +105,7 @@ export class ESPHomeLambdaEditor extends LitElement {
     if (!this._view) return;
     if (changed.has("_darkMode")) {
       this._view.dispatch({
-        effects: this._themeCompartment.reconfigure(
-          this._darkMode ? vscodeDark : vscodeLight
-        ),
+        effects: this._themeCompartment.reconfigure(selectEditorTheme(this._darkMode)),
       });
     }
     if (changed.has("disabled")) {
@@ -130,50 +126,36 @@ export class ESPHomeLambdaEditor extends LitElement {
     }
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._view?.destroy();
-    this._view = null;
-  }
-
   private _mountEditor() {
-    this._view = new EditorView({
-      state: EditorState.create({
-        doc: this.value,
-        extensions: [
-          basicSetup,
-          editorSearchPhrases(this._localize),
-          cpp(),
-          indentUnit.of("  "),
-          keymap.of([indentWithTab]),
-          this._editableCompartment.of(EditorView.editable.of(!this.disabled)),
-          this._themeCompartment.of(this._darkMode ? vscodeDark : vscodeLight),
-          EditorView.theme({
-            "&": { height: "100%" },
-          }),
-          EditorView.updateListener.of((update) => {
-            // Skip programmatic ``value``-prop syncs (tagged ``externalSync``);
-            // only a real user edit should emit ``lambda-change`` (#1223).
-            // Presence check, not truthiness, so the marker reads as "this is
-            // a sync" regardless of the annotation's payload.
-            if (
-              update.docChanged &&
-              !update.transactions.some((tr) => tr.annotation(externalSync) !== undefined)
-            ) {
-              const value = update.state.doc.toString();
-              this.dispatchEvent(
-                new CustomEvent("lambda-change", {
-                  detail: { value },
-                  bubbles: true,
-                  composed: true,
-                })
-              );
-            }
-          }),
-        ],
+    this._mountView(this.value, [
+      basicSetup,
+      editorSearchPhrases(this._localize),
+      cpp(),
+      indentUnit.of("  "),
+      keymap.of([indentWithTab]),
+      this._editableCompartment.of(EditorView.editable.of(!this.disabled)),
+      this._themeCompartment.of(selectEditorTheme(this._darkMode)),
+      editorHeightTheme,
+      EditorView.updateListener.of((update) => {
+        // Skip programmatic ``value``-prop syncs (tagged ``externalSync``);
+        // only a real user edit should emit ``lambda-change`` (#1223).
+        // Presence check, not truthiness, so the marker reads as "this is
+        // a sync" regardless of the annotation's payload.
+        if (
+          update.docChanged &&
+          !update.transactions.some((tr) => tr.annotation(externalSync) !== undefined)
+        ) {
+          const value = update.state.doc.toString();
+          this.dispatchEvent(
+            new CustomEvent("lambda-change", {
+              detail: { value },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
       }),
-      parent: this._container,
-    });
+    ]);
   }
 }
 

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -27,8 +27,8 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { darkModeContext, localizeContext } from "../../../context/index.js";
+import { editorHeightTheme, selectEditorTheme } from "../../../util/codemirror-theme.js";
 import { editorSearchPhrases } from "../../../util/editor-search-phrases.js";
-import { editorHeightTheme, selectEditorTheme } from "../../../util/yaml-editor-theme.js";
 import { CodeMirrorEditorElement } from "../../codemirror-editor-element.js";
 
 /** Marks the doc change that syncs the external ``value`` prop into the

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -11,10 +11,6 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
-import { editorSearchPhrases } from "../util/editor-search-phrases.js";
-import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
-import { getKeyPath } from "../util/yaml-ast.js";
-import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import {
   darkHighlight,
   EDITOR_BG_DARK,
@@ -25,7 +21,11 @@ import {
   INDENT_GUIDE_COLORS,
   lightHighlight,
   selectEditorTheme,
-} from "../util/yaml-editor-theme.js";
+} from "../util/codemirror-theme.js";
+import { editorSearchPhrases } from "../util/editor-search-phrases.js";
+import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { getKeyPath } from "../util/yaml-ast.js";
+import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import {
   createBackendYamlLinter,

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,13 +1,13 @@
 import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
-import { EditorState, StateEffect, StateField } from "@codemirror/state";
+import { StateEffect, StateField } from "@codemirror/state";
 import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { basicSetup, EditorView } from "codemirror";
-import { css, html, LitElement } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { css, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
@@ -21,10 +21,10 @@ import {
   EDITOR_BG_LIGHT,
   EDITOR_FONT_FAMILY,
   EDITOR_FONT_SIZE,
+  editorHeightTheme,
   INDENT_GUIDE_COLORS,
   lightHighlight,
-  vscodeDark,
-  vscodeLight,
+  selectEditorTheme,
 } from "../util/yaml-editor-theme.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import {
@@ -37,6 +37,7 @@ import {
   setRevealSensitiveEffect,
 } from "../util/yaml-sensitive-mask.js";
 import { yamlStickyScroll } from "../util/yaml-sticky-scroll.js";
+import { CodeMirrorEditorElement } from "./codemirror-editor-element.js";
 
 export type HighlightRange = Pick<YamlSection, "fromLine" | "toLine">;
 
@@ -84,7 +85,7 @@ const highlightField = StateField.define<DecorationSet>({
 });
 
 @customElement("esphome-yaml-editor")
-export class ESPHomeYamlEditor extends LitElement {
+export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
   private _darkMode = false;
@@ -124,10 +125,6 @@ export class ESPHomeYamlEditor extends LitElement {
    *  extension-construction time; runtime changes trigger an
    *  editor remount via `updated()` (same path dark-mode uses). */
   @property({ type: Boolean }) maskAllValues = false;
-
-  @query(".cm-wrap") private _container!: HTMLDivElement;
-
-  private _view: EditorView | null = null;
 
   /** Last 1-indexed cursor line we emitted as `yaml-cursor-line`.
    *  We only emit on line transitions so a horizontal mouse / arrow
@@ -181,8 +178,8 @@ export class ESPHomeYamlEditor extends LitElement {
         jumpToLineLabel: (line) =>
           this._localize("yaml_editor.sticky_jump_to_line", { line: String(line) }),
       }),
+      editorHeightTheme,
       EditorView.theme({
-        "&": { height: "100%" },
         ".cm-scroller": {
           overflow: "auto",
           fontFamily: EDITOR_FONT_FAMILY,
@@ -421,7 +418,7 @@ export class ESPHomeYamlEditor extends LitElement {
           }
         }
       }),
-      this._darkMode ? vscodeDark : vscodeLight,
+      selectEditorTheme(this._darkMode),
     ];
 
     if (this._api && this.configuration) {
@@ -462,13 +459,7 @@ export class ESPHomeYamlEditor extends LitElement {
   }
 
   private _mountEditor() {
-    this._view = new EditorView({
-      state: EditorState.create({
-        doc: this.value,
-        extensions: this._buildExtensions(),
-      }),
-      parent: this._container,
-    });
+    this._mountView(this.value, this._buildExtensions());
 
     // Remount paths in updated() return before the highlightRange
     // branch, so re-apply a pending highlight (+ scroll) here.
@@ -504,7 +495,7 @@ export class ESPHomeYamlEditor extends LitElement {
    * field outliving the destroyed view).
    */
   private _remountEditor() {
-    this._view!.destroy();
+    this._destroyView();
     this._container.innerHTML = "";
     this._lastReportedCursorLine = 0;
     this._mountEditor();
@@ -640,12 +631,6 @@ export class ESPHomeYamlEditor extends LitElement {
         effects: setRevealSensitiveEffect.of(this.revealSensitive),
       });
     }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._view?.destroy();
-    this._view = null;
   }
 }
 

--- a/src/util/codemirror-theme.ts
+++ b/src/util/codemirror-theme.ts
@@ -4,7 +4,7 @@ import { EditorView } from "@codemirror/view";
 import { tags as t } from "@lezer/highlight";
 
 /**
- * VSCode-flavored CodeMirror themes for the YAML editor.
+ * VSCode-flavored CodeMirror themes, shared by the YAML and lambda editors.
  *
  * Dark mode mirrors VSCode "Dark+":
  *   keys light-blue, strings peach, comments green italic,

--- a/src/util/yaml-editor-theme.ts
+++ b/src/util/yaml-editor-theme.ts
@@ -186,3 +186,11 @@ const lightBase = EditorView.theme(
 
 export const vscodeDark: Extension = [darkBase, syntaxHighlighting(darkHighlight)];
 export const vscodeLight: Extension = [lightBase, syntaxHighlighting(lightHighlight)];
+
+/** Stretch the editor to fill its host; shared by both CM editors. */
+export const editorHeightTheme = EditorView.theme({ "&": { height: "100%" } });
+
+/** Pick the VSCode-flavored theme for the current colour mode. */
+export function selectEditorTheme(darkMode: boolean): Extension {
+  return darkMode ? vscodeDark : vscodeLight;
+}

--- a/src/util/yaml-sticky-theme.ts
+++ b/src/util/yaml-sticky-theme.ts
@@ -1,6 +1,6 @@
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { EDITOR_FONT_FAMILY, EDITOR_FONT_SIZE } from "./yaml-editor-theme.js";
+import { EDITOR_FONT_FAMILY, EDITOR_FONT_SIZE } from "./codemirror-theme.js";
 
 export function buildStickyTheme(background: string): Extension {
   return EditorView.theme({

--- a/test/components/codemirror-editor-element.test.ts
+++ b/test/components/codemirror-editor-element.test.ts
@@ -33,6 +33,10 @@ class TestCmEditor extends CodeMirrorEditorElement {
   destroyView(): void {
     this._destroyView();
   }
+
+  remount(doc: string): void {
+    this._mountView(doc, []);
+  }
 }
 
 async function mount(): Promise<TestCmEditor> {
@@ -59,6 +63,16 @@ describe("CodeMirrorEditorElement", () => {
     el.destroyView();
     expect(el.view).toBeNull();
     expect(el.container.querySelector(".cm-editor")).toBeNull();
+  });
+
+  it("tears down the prior view when mounted again", async () => {
+    const el = await mount();
+    const first = el.view!;
+    el.remount("again");
+    expect(el.view).not.toBe(first);
+    expect(el.view!.state.doc.toString()).toBe("again");
+    // Old view torn down — only the new editor remains in the host.
+    expect(el.container.querySelectorAll(".cm-editor").length).toBe(1);
   });
 
   it("tears the view down when disconnected", async () => {

--- a/test/components/codemirror-editor-element.test.ts
+++ b/test/components/codemirror-editor-element.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the shared CodeMirror host lifecycle: `_mountView` builds a live
+ * EditorView into `.cm-wrap`, and `_destroyView` / `disconnectedCallback`
+ * tear it down.
+ */
+import type { EditorView } from "@codemirror/view";
+import { html } from "lit";
+import { customElement } from "lit/decorators.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CodeMirrorEditorElement } from "../../src/components/codemirror-editor-element.js";
+
+@customElement("test-cm-editor")
+class TestCmEditor extends CodeMirrorEditorElement {
+  protected render() {
+    return html`<div class="cm-wrap"></div>`;
+  }
+
+  protected firstUpdated() {
+    this._mountView("hello\nworld\n", []);
+  }
+
+  get view(): EditorView | null {
+    return this._view;
+  }
+
+  get container(): HTMLDivElement {
+    return this._container;
+  }
+
+  destroyView(): void {
+    this._destroyView();
+  }
+}
+
+async function mount(): Promise<TestCmEditor> {
+  const el = new TestCmEditor();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("CodeMirrorEditorElement", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("mounts a live EditorView into .cm-wrap", async () => {
+    const el = await mount();
+    expect(el.view).not.toBeNull();
+    expect(el.view!.state.doc.toString()).toBe("hello\nworld\n");
+    expect(el.container.querySelector(".cm-editor")).not.toBeNull();
+  });
+
+  it("destroys the view and drops the handle on _destroyView", async () => {
+    const el = await mount();
+    el.destroyView();
+    expect(el.view).toBeNull();
+    expect(el.container.querySelector(".cm-editor")).toBeNull();
+  });
+
+  it("tears the view down when disconnected", async () => {
+    const el = await mount();
+    el.remove();
+    expect(el.view).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

`yaml-editor.ts` and `lambda-editor.ts` each hand-rolled the same CodeMirror host scaffolding: the `.cm-wrap` container query, the `EditorView` handle, the mount call, the `disconnectedCallback` teardown, the `height: 100%` theme, and the dark/light theme pick. This pulls those genuinely identical bits into an abstract `CodeMirrorEditorElement` base both editors extend, plus an `editorHeightTheme` constant and a `selectEditorTheme(darkMode)` helper in the shared theme module.

Each editor keeps everything that actually differs; yaml-editor still owns its lint, completion, hover, sticky-scroll, masking, highlight ranges, minimal-diff patching, and its remount-on-change strategy, while lambda-editor keeps its Compartment reconfigure path and the externalSync guard. No behaviour change; both files shrank. Surfaced during the #718 DRY audit, not introduced by it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/719

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
