### PR TITLE
Reveal the selected component in the navigator

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -38,6 +38,7 @@ import { type NavigatorBuckets, deriveNavigatorBuckets } from "./navigator-bucke
 import { groupRowsByDomain } from "./navigator-groups.js";
 import { type NavRow, resolveBucketLabels } from "./navigator-labels.js";
 import { type NavAction, renderNavSection } from "./navigator-render.js";
+import { NavigatorRevealController } from "./navigator-reveal-controller.js";
 import { navItemMatches } from "./navigator-search-match.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -89,6 +90,13 @@ export class ESPHomeDeviceNavigator extends LitElement {
     api: this._api,
     platform: this.platform || undefined,
     boardId: this.board?.id,
+  }));
+
+  private readonly _reveal = new NavigatorRevealController(this, () => ({
+    selectedLine: this._selectedLine,
+    buckets: this._deriveBuckets(this.yaml),
+    openSections: this.openSections,
+    filtering: this._query.trim().length > 0,
   }));
 
   @property({ attribute: false })

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -71,20 +71,14 @@ export class NavigatorRevealController implements ReactiveController {
       );
       return;
     }
-    // Latch only on a confirmed scroll, so the reveal retries when the row
-    // becomes scrollable. querySelector finds a row that isn't yet rendered
-    // (collapsed Components subgroup) or whose nav is display:none (collapsed
-    // desktop nav), and scrolling either is a silent no-op; checkVisibility
-    // screens both out (and is absent in older engines, so we fall through).
+    // Latch only on a confirmed scroll so the reveal retries when the row
+    // becomes scrollable: querySelector misses a row that isn't rendered yet
+    // (collapsed Components subgroup), and getClientRects catches one that is
+    // rendered but has no layout box (display:none collapsed desktop nav).
     const row = this._host.renderRoot.querySelector(".nav-item--selected");
-    if (row && isVisible(row)) {
+    if (row && row.getClientRects().length > 0) {
       row.scrollIntoView({ block: "nearest" });
       this._scrolledLine = selectedLine;
     }
   }
-}
-
-function isVisible(el: Element): boolean {
-  const check = (el as { checkVisibility?: () => boolean }).checkVisibility;
-  return check ? check.call(el) : true;
 }

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -65,9 +65,13 @@ export class NavigatorRevealController implements ReactiveController {
       );
       return;
     }
-    this._host.renderRoot
-      .querySelector(".nav-item--selected")
-      ?.scrollIntoView({ block: "nearest" });
-    this._scrolledLine = selectedLine;
+    // Latch only on a confirmed scroll: a row inside a collapsed Components
+    // subgroup isn't rendered yet, so leave the line unlatched to retry once
+    // it mounts.
+    const row = this._host.renderRoot.querySelector(".nav-item--selected");
+    if (row) {
+      row.scrollIntoView({ block: "nearest" });
+      this._scrolledLine = selectedLine;
+    }
   }
 }

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -65,13 +65,20 @@ export class NavigatorRevealController implements ReactiveController {
       );
       return;
     }
-    // Latch only on a confirmed scroll: a row inside a collapsed Components
-    // subgroup isn't rendered yet, so leave the line unlatched to retry once
-    // it mounts.
+    // Latch only on a confirmed scroll, so the reveal retries when the row
+    // becomes scrollable. querySelector finds a row that isn't yet rendered
+    // (collapsed Components subgroup) or whose nav is display:none (collapsed
+    // desktop nav), and scrolling either is a silent no-op; checkVisibility
+    // screens both out (and is absent in older engines, so we fall through).
     const row = this._host.renderRoot.querySelector(".nav-item--selected");
-    if (row) {
+    if (row && isVisible(row)) {
       row.scrollIntoView({ block: "nearest" });
       this._scrolledLine = selectedLine;
     }
   }
+}
+
+function isVisible(el: Element): boolean {
+  const check = (el as { checkVisibility?: () => boolean }).checkVisibility;
+  return check ? check.call(el) : true;
 }

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -54,7 +54,13 @@ export class NavigatorRevealController implements ReactiveController {
     }
     if (selectedLine === this._scrolledLine) return;
     const index = sectionIndexForLine(buckets, selectedLine);
-    if (index !== -1 && !filtering && !openSections.has(index)) {
+    if (index === -1) {
+      // No navigator row for this line (e.g. an unscoped automation); latch so
+      // we don't re-scan the buckets on every later update.
+      this._scrolledLine = selectedLine;
+      return;
+    }
+    if (!filtering && !openSections.has(index)) {
       // Ask the page to open it and bail; the re-render re-enters with the row.
       this._host.dispatchEvent(
         new CustomEvent("section-reveal", {

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -1,0 +1,73 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { NavigatorBuckets } from "./navigator-buckets.js";
+
+/** What the section list looks like at one host update. */
+export interface RevealState {
+  /** YAML line of the selected section, or null when nothing is selected. */
+  selectedLine: number | null;
+  buckets: NavigatorBuckets;
+  /** Indices (0 core / 1 components / 2 automations) currently expanded. */
+  openSections: Set<number>;
+  /** A search query is active (sections force-open); don't toggle them. */
+  filtering: boolean;
+}
+
+/** Host surface the controller drives: render root, event dispatch, plumbing. */
+export interface RevealHost extends ReactiveControllerHost {
+  renderRoot: ParentNode;
+  dispatchEvent(event: Event): boolean;
+}
+
+/** Section index (0 core / 1 components / 2 automations) whose bucket holds a
+ *  section starting at *line*, or -1 (e.g. an unscoped automation, no nav row). */
+export function sectionIndexForLine(buckets: NavigatorBuckets, line: number): number {
+  if (buckets.core.some((s) => s.fromLine === line)) return 0;
+  if (buckets.components.some((s) => s.fromLine === line)) return 1;
+  if (buckets.automations.some((s) => s.fromLine === line)) return 2;
+  return -1;
+}
+
+/**
+ * Reveal the externally-selected nav row (YAML cursor / URL restore):
+ * expand its collapsed section, then scroll it into view on the next render.
+ * Latches the scrolled line so idle re-renders (hover, search) don't re-scroll.
+ *
+ * Opening fires the idempotent 'section-reveal' (a set, not a toggle); two
+ * navigator instances share one openSections, so a toggle would race and
+ * oscillate the section open/closed forever.
+ */
+export class NavigatorRevealController implements ReactiveController {
+  private _scrolledLine: number | null = null;
+
+  constructor(
+    private readonly _host: RevealHost,
+    private readonly _read: () => RevealState
+  ) {
+    _host.addController(this);
+  }
+
+  hostUpdated(): void {
+    const { selectedLine, buckets, openSections, filtering } = this._read();
+    if (selectedLine === null) {
+      this._scrolledLine = null;
+      return;
+    }
+    if (selectedLine === this._scrolledLine) return;
+    const index = sectionIndexForLine(buckets, selectedLine);
+    if (index !== -1 && !filtering && !openSections.has(index)) {
+      // Ask the page to open it and bail; the re-render re-enters with the row.
+      this._host.dispatchEvent(
+        new CustomEvent("section-reveal", {
+          detail: { index },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      return;
+    }
+    this._host.renderRoot
+      .querySelector(".nav-item--selected")
+      ?.scrollIntoView({ block: "nearest" });
+    this._scrolledLine = selectedLine;
+  }
+}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -869,6 +869,7 @@ export class ESPHomePageDevice extends LitElement {
       <div
         class="drawer ${this._drawerOpen ? "drawer--open" : ""}"
         @section-toggle=${this._onSectionToggle}
+        @section-reveal=${this._onSectionReveal}
         @section-select=${this._onSectionSelect}
         @yaml-highlight=${this._onYamlHighlight}
         @yaml-updated=${this._onYamlUpdated}
@@ -882,6 +883,7 @@ export class ESPHomePageDevice extends LitElement {
         <div
           class="layout-grid ${this._navCollapsed ? "nav-collapsed" : ""}"
           @section-toggle=${this._onSectionToggle}
+          @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}
           @yaml-change=${this._onYamlChange}
           @yaml-cursor-line=${this._onYamlCursorLine}
@@ -1044,6 +1046,16 @@ export class ESPHomePageDevice extends LitElement {
       next.add(index);
     }
     this._openSections = next;
+    this._updateUrl();
+  }
+
+  /** Idempotently open the section holding an externally-selected row.
+   *  A set, not a toggle: two navigators fire this and a toggle would
+   *  race them into oscillating the section open/closed. */
+  private _onSectionReveal(e: CustomEvent<{ index: number }>) {
+    const { index } = e.detail;
+    if (this._openSections.has(index)) return;
+    this._openSections = new Set([index]);
     this._updateUrl();
   }
 

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -164,33 +164,43 @@ describe("device-navigator reveal-selected", () => {
     let reveals = 0;
     const navs: ESPHomeDeviceNavigator[] = [];
     // Mimic the page handler: idempotent open, applied to both navigators.
-    document.addEventListener("section-reveal", (e) => {
-      reveals++;
-      if (reveals > 30) return; // safety net: a regression would loop here
-      const idx = (e as CustomEvent<{ index: number }>).detail.index;
-      if (shared.has(idx)) return;
-      shared = new Set([idx]);
-      for (const n of navs) n.openSections = shared;
-    });
+    // Scoped to an AbortController so the document listener doesn't leak.
+    const controller = new AbortController();
+    document.addEventListener(
+      "section-reveal",
+      (e) => {
+        reveals++;
+        if (reveals > 30) return; // safety net: a regression would loop here
+        const idx = (e as CustomEvent<{ index: number }>).detail.index;
+        if (shared.has(idx)) return;
+        shared = new Set([idx]);
+        for (const n of navs) n.openSections = shared;
+      },
+      { signal: controller.signal }
+    );
 
-    for (let i = 0; i < 2; i++) {
-      const n = new ESPHomeDeviceNavigator();
-      n.yaml = YAML;
-      n.openSections = shared;
-      document.body.appendChild(n);
-      navs.push(n);
+    try {
+      for (let i = 0; i < 2; i++) {
+        const n = new ESPHomeDeviceNavigator();
+        n.yaml = YAML;
+        n.openSections = shared;
+        document.body.appendChild(n);
+        navs.push(n);
+      }
+      await Promise.all(navs.map((n) => n.updateComplete));
+
+      for (const n of navs) {
+        n.selectedKey = "sensor.template";
+        n.selectedFromLine = sensorLine();
+      }
+      // Let the open → re-render → scroll settle across both instances.
+      for (let i = 0; i < 5; i++) await Promise.all(navs.map((n) => n.updateComplete));
+
+      expect(reveals).toBeLessThan(10); // converged, nowhere near the safety net
+      expect(shared.has(1)).toBe(true); // Components ended open
+      expect(scrollSpy).toHaveBeenCalled();
+    } finally {
+      controller.abort();
     }
-    await Promise.all(navs.map((n) => n.updateComplete));
-
-    for (const n of navs) {
-      n.selectedKey = "sensor.template";
-      n.selectedFromLine = sensorLine();
-    }
-    // Let the open → re-render → scroll settle across both instances.
-    for (let i = 0; i < 5; i++) await Promise.all(navs.map((n) => n.updateComplete));
-
-    expect(reveals).toBeLessThan(10); // converged, nowhere near the safety net
-    expect(shared.has(1)).toBe(true); // Components ended open
-    expect(scrollSpy).toHaveBeenCalled();
   });
 });

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -44,8 +44,10 @@ const sensorLine = () => {
 };
 
 let scrollSpy: ReturnType<typeof vi.fn>;
+let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
 
 beforeEach(() => {
+  originalScrollIntoView = Element.prototype.scrollIntoView;
   scrollSpy = vi.fn();
   // happy-dom doesn't implement scrollIntoView; install a spy to assert on.
   Element.prototype.scrollIntoView = scrollSpy as typeof Element.prototype.scrollIntoView;
@@ -53,7 +55,8 @@ beforeEach(() => {
 
 afterEach(() => {
   document.body.innerHTML = "";
-  vi.restoreAllMocks();
+  // Direct prototype assignment isn't a vi.spyOn, so restore it explicitly.
+  Element.prototype.scrollIntoView = originalScrollIntoView;
 });
 
 async function mount(openSections: Set<number>): Promise<{
@@ -124,6 +127,32 @@ describe("device-navigator reveal-selected", () => {
     // A re-render that doesn't change the selection (e.g. hover) must not rescroll.
     nav.requestUpdate();
     await nav.updateComplete;
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // A Components row inside a collapsed domain subgroup isn't rendered even
+  // when its section is open; the controller must not latch on that empty
+  // render, so it retries once the subgroup expands and the row mounts.
+  it("retries the scroll after a collapsed subgroup is expanded", async () => {
+    const { nav } = await mount(new Set([1]));
+    const sensorGroup = () =>
+      [...nav.shadowRoot!.querySelectorAll(".nav-subgroup-header")].find((h) =>
+        h.querySelector(".nav-subgroup-title")?.textContent?.includes("Sensor")
+      ) as HTMLElement;
+
+    // Collapse the Sensor subgroup, then select the sensor row it hides.
+    sensorGroup().click();
+    await nav.updateComplete;
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    expect(nav.shadowRoot!.querySelector(".nav-item--selected")).toBeNull();
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    // Expand it: the row mounts and the deferred scroll fires.
+    sensorGroup().click();
+    await nav.updateComplete;
+    expect(nav.shadowRoot!.querySelector(".nav-item--selected")).toBeTruthy();
     expect(scrollSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the navigator "reveal selected" behavior: an externally-driven
+ * selection (YAML cursor) expands the collapsed section that holds the row
+ * and scrolls the row into view, without re-scrolling on idle re-renders.
+ * Dialog children are no-oped so the element constructs in happy-dom; see
+ * device-navigator-filter.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-config-dialog.js", () => ({}));
+vi.mock("../../../src/components/device/add-script-dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
+import { deriveNavigatorBuckets } from "../../../src/components/device/navigator-buckets.js";
+import { sectionIndexForLine } from "../../../src/components/device/navigator-reveal-controller.js";
+import {
+  parseYamlTopLevelSections,
+  sectionKeyOf,
+} from "../../../src/util/yaml-sections.js";
+
+const YAML = [
+  "esphome:",
+  "  name: t",
+  "wifi:",
+  "sensor:",
+  "  - platform: template",
+  '    name: "Living Temp"',
+  "    id: living_temp",
+  "",
+].join("\n");
+
+/** fromLine of the sensor.template row (lives in the Components section). */
+const sensorLine = () => {
+  const s = parseYamlTopLevelSections(YAML).find(
+    (sec) => sectionKeyOf(sec) === "sensor.template"
+  );
+  if (!s) throw new Error("fixture: sensor.template not found");
+  return s.fromLine;
+};
+
+let scrollSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  scrollSpy = vi.fn();
+  // happy-dom doesn't implement scrollIntoView; install a spy to assert on.
+  Element.prototype.scrollIntoView = scrollSpy as typeof Element.prototype.scrollIntoView;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+async function mount(openSections: Set<number>): Promise<{
+  nav: ESPHomeDeviceNavigator;
+  reveals: number[];
+}> {
+  const nav = new ESPHomeDeviceNavigator();
+  nav.yaml = YAML;
+  nav.openSections = openSections;
+  const reveals: number[] = [];
+  nav.addEventListener("section-reveal", (e) => {
+    reveals.push((e as CustomEvent<{ index: number }>).detail.index);
+  });
+  document.body.appendChild(nav);
+  await nav.updateComplete;
+  return { nav, reveals };
+}
+
+describe("sectionIndexForLine", () => {
+  it("maps a line to its bucket (core/components/automations)", () => {
+    const buckets = deriveNavigatorBuckets(YAML);
+    expect(sectionIndexForLine(buckets, buckets.core[0].fromLine)).toBe(0);
+    expect(sectionIndexForLine(buckets, buckets.components[0].fromLine)).toBe(1);
+    expect(sectionIndexForLine(buckets, 9999)).toBe(-1);
+  });
+});
+
+describe("device-navigator reveal-selected", () => {
+  it("expands the collapsed section, then scrolls the row into view", async () => {
+    const { nav, reveals } = await mount(new Set());
+
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+
+    // Components is section index 1; collapsed, so it asks the page to open it.
+    expect(reveals).toEqual([1]);
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    // Page opens it (accordion). Now the row mounts and we scroll to it.
+    nav.openSections = new Set([1]);
+    await nav.updateComplete;
+
+    const row = nav.shadowRoot!.querySelector(".nav-item--selected");
+    expect(row).toBeTruthy();
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy.mock.instances[0]).toBe(row);
+  });
+
+  it("scrolls without asking to open when the section is already open", async () => {
+    const { nav, reveals } = await mount(new Set([1]));
+
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+
+    expect(reveals).toEqual([]);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-scroll on an idle re-render", async () => {
+    const { nav } = await mount(new Set([1]));
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    // A re-render that doesn't change the selection (e.g. hover) must not rescroll.
+    nav.requestUpdate();
+    await nav.updateComplete;
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // The page renders two navigators (drawer + desktop) sharing one
+  // openSections. A toggle would race them open/closed forever and hang the
+  // page; section-reveal is an idempotent set, so it converges.
+  it("converges with two navigators sharing openSections (no oscillation)", async () => {
+    let shared = new Set<number>();
+    let reveals = 0;
+    const navs: ESPHomeDeviceNavigator[] = [];
+    // Mimic the page handler: idempotent open, applied to both navigators.
+    document.addEventListener("section-reveal", (e) => {
+      reveals++;
+      if (reveals > 30) return; // safety net: a regression would loop here
+      const idx = (e as CustomEvent<{ index: number }>).detail.index;
+      if (shared.has(idx)) return;
+      shared = new Set([idx]);
+      for (const n of navs) n.openSections = shared;
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const n = new ESPHomeDeviceNavigator();
+      n.yaml = YAML;
+      n.openSections = shared;
+      document.body.appendChild(n);
+      navs.push(n);
+    }
+    await Promise.all(navs.map((n) => n.updateComplete));
+
+    for (const n of navs) {
+      n.selectedKey = "sensor.template";
+      n.selectedFromLine = sensorLine();
+    }
+    // Let the open → re-render → scroll settle across both instances.
+    for (let i = 0; i < 5; i++) await Promise.all(navs.map((n) => n.updateComplete));
+
+    expect(reveals).toBeLessThan(10); // converged, nowhere near the safety net
+    expect(shared.has(1)).toBe(true); // Components ended open
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Clicking a line in the YAML pane flips the structured editor to the matching
component, but the left Device navigator only highlighted the row; it left the
containing section (Core configuration / Components / Automations) collapsed
and never scrolled the row into view, so the selection stayed hidden until you
expanded the section by hand.

This expands the section that holds the externally-selected row and scrolls it
into view. The reveal logic lives in a small `NavigatorRevealController`
(mirrors `FieldScrollController`): on each host update it finds the bucket that
owns the selected line, asks the page to open that section through the existing
`section-toggle` event (so `openSections` ownership and the accordion stay put),
then scrolls the row in once it mounts. A latched line keeps idle re-renders
(hover, search typing) from re-scrolling. Direct navigator clicks are a no-op
here since their section is already open.

**Related issue or feature (if applicable):**

- Navigator did not follow the YAML-cursor selection into a collapsed section.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
