### PR TITLE
Fix navigator section lock-out after YAML cursor reveal

### DIFF
--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -59,6 +59,13 @@ export class NavigatorRevealController implements ReactiveController {
       this._revealedLine = null;
       return;
     }
+    // The selection genuinely moved to a different line: drop the stale latch
+    // so a line whose reveal never scroll-latched (collapsed subgroup) can
+    // reveal again when the user clicks back to it. Same-line re-renders keep
+    // the latch, which is what prevents the toggle lock-out / snap-back.
+    if (this._revealedLine !== null && this._revealedLine !== selectedLine) {
+      this._revealedLine = null;
+    }
     if (selectedLine === this._scrolledLine) return;
     const index = sectionIndexForLine(buckets, selectedLine);
     if (index === -1) {

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -69,8 +69,8 @@ export class NavigatorRevealController implements ReactiveController {
     }
     if (!filtering && !openSections.has(index) && this._revealedLine !== selectedLine) {
       // Ask the page to open it once, then bail; the re-render re-enters with
-      // the row. Latching the line here (not on scroll) keeps a manual re-close
-      // of this section from re-triggering the forced open on the next render.
+      // the row. Latch *before* dispatch (below) so a manual re-close of this
+      // section can't re-trigger the forced open on a later render.
       this._revealedLine = selectedLine;
       this._host.dispatchEvent(
         new CustomEvent("section-reveal", {
@@ -81,6 +81,12 @@ export class NavigatorRevealController implements ReactiveController {
       );
       return;
     }
+    // Past the reveal gate: the section is already open (URL ``open=`` restore,
+    // accordion), we're filtering, or we already asked once. Latch the line
+    // here too — without it a section opened by URL never marks the line
+    // handled, so closing it (by opening another section) re-fires the reveal
+    // and snaps it back open.
+    this._revealedLine = selectedLine;
     // Latch only on a confirmed scroll so the reveal retries when the row
     // becomes scrollable: querySelector misses a row that isn't rendered yet
     // (collapsed Components subgroup), and getClientRects catches one that is

--- a/src/components/device/navigator-reveal-controller.ts
+++ b/src/components/device/navigator-reveal-controller.ts
@@ -38,6 +38,12 @@ export function sectionIndexForLine(buckets: NavigatorBuckets, line: number): nu
  */
 export class NavigatorRevealController implements ReactiveController {
   private _scrolledLine: number | null = null;
+  // Section reveal is one-shot per selected line. The scroll below only
+  // latches once the row is actually visible, and a row inside a collapsed
+  // subgroup (or the hidden desktop nav) never gets there — without this
+  // guard every later render re-fires section-reveal, forcing the cursor's
+  // section back open and locking the user out of toggling any other section.
+  private _revealedLine: number | null = null;
 
   constructor(
     private readonly _host: RevealHost,
@@ -50,6 +56,7 @@ export class NavigatorRevealController implements ReactiveController {
     const { selectedLine, buckets, openSections, filtering } = this._read();
     if (selectedLine === null) {
       this._scrolledLine = null;
+      this._revealedLine = null;
       return;
     }
     if (selectedLine === this._scrolledLine) return;
@@ -60,8 +67,11 @@ export class NavigatorRevealController implements ReactiveController {
       this._scrolledLine = selectedLine;
       return;
     }
-    if (!filtering && !openSections.has(index)) {
-      // Ask the page to open it and bail; the re-render re-enters with the row.
+    if (!filtering && !openSections.has(index) && this._revealedLine !== selectedLine) {
+      // Ask the page to open it once, then bail; the re-render re-enters with
+      // the row. Latching the line here (not on scroll) keeps a manual re-close
+      // of this section from re-triggering the forced open on the next render.
+      this._revealedLine = selectedLine;
       this._host.dispatchEvent(
         new CustomEvent("section-reveal", {
           detail: { index },

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -189,6 +189,32 @@ describe("device-navigator reveal-selected", () => {
     expect(reveals).toEqual([1]);
   });
 
+  // Regression: a row selected while its section was already open (URL
+  // ``?section=&open=1`` restore) must mark the line handled, so closing that
+  // section (by opening another) doesn't re-fire reveal and snap it back open.
+  it("does not re-reveal a section that was already open when selected", async () => {
+    const { nav, reveals } = await mount(new Set([1]));
+    const sensorGroup = () =>
+      [...nav.shadowRoot!.querySelectorAll(".nav-subgroup-header")].find((h) =>
+        h.querySelector(".nav-subgroup-title")?.textContent?.includes("Sensor")
+      ) as HTMLElement;
+
+    // Collapse the Sensor subgroup so the selected row can never scroll-latch.
+    sensorGroup().click();
+    await nav.updateComplete;
+
+    // Select the row while Components is already open: nothing to reveal.
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    expect(reveals).toEqual([]);
+
+    // User opens Core (accordion closes Components). Must not snap back.
+    nav.openSections = new Set([0]);
+    await nav.updateComplete;
+    expect(reveals).toEqual([]);
+  });
+
   // The page renders two navigators (drawer + desktop) sharing one
   // openSections. A toggle would race them open/closed forever and hang the
   // page; section-reveal is an idempotent set, so it converges.

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -215,6 +215,40 @@ describe("device-navigator reveal-selected", () => {
     expect(reveals).toEqual([]);
   });
 
+  // The one-shot latch is per continuous selection, not forever: moving the
+  // cursor away and clicking back to a line whose reveal never scroll-latched
+  // (its section was left closed) must reveal it again.
+  it("re-reveals a line after the selection moves away and returns", async () => {
+    const coreLine = () => {
+      const s = parseYamlTopLevelSections(YAML).find(
+        (sec) => sectionKeyOf(sec) === "wifi"
+      );
+      if (!s) throw new Error("fixture: wifi not found");
+      return s.fromLine;
+    };
+    // Leave everything collapsed so no reveal ever scroll-latches.
+    const { nav, reveals } = await mount(new Set());
+
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    expect(reveals).toEqual([1]);
+
+    // Same-line idle re-render: one-shot, no repeat.
+    nav.requestUpdate();
+    await nav.updateComplete;
+    expect(reveals).toEqual([1]);
+
+    // Move to a core line, then back to the sensor line: each move re-reveals.
+    nav.selectedKey = "wifi";
+    nav.selectedFromLine = coreLine();
+    await nav.updateComplete;
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    expect(reveals).toEqual([1, 0, 1]);
+  });
+
   // The page renders two navigators (drawer + desktop) sharing one
   // openSections. A toggle would race them open/closed forever and hang the
   // page; section-reveal is an idempotent set, so it converges.

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -156,6 +156,39 @@ describe("device-navigator reveal-selected", () => {
     expect(scrollSpy).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: a selected row whose section was revealed but never scrolled
+  // (it lives in a collapsed subgroup) must not re-fire section-reveal when the
+  // user later opens a different section, or the cursor's section is force-
+  // reopened on every render and the user can't toggle anything else.
+  it("does not re-reveal the cursor's section after the user opens another", async () => {
+    const { nav, reveals } = await mount(new Set([1]));
+    const sensorGroup = () =>
+      [...nav.shadowRoot!.querySelectorAll(".nav-subgroup-header")].find((h) =>
+        h.querySelector(".nav-subgroup-title")?.textContent?.includes("Sensor")
+      ) as HTMLElement;
+
+    // Collapse the Sensor subgroup so the selected row can never scroll-latch.
+    sensorGroup().click();
+    await nav.updateComplete;
+    nav.openSections = new Set();
+    await nav.updateComplete;
+
+    // Cursor lands on the hidden sensor row: section reveal fires exactly once.
+    nav.selectedKey = "sensor.template";
+    nav.selectedFromLine = sensorLine();
+    await nav.updateComplete;
+    nav.openSections = new Set([1]);
+    await nav.updateComplete;
+    expect(reveals).toEqual([1]);
+    expect(nav.shadowRoot!.querySelector(".nav-item--selected")).toBeNull();
+
+    // User opens Core (accordion closes Components). The controller must not
+    // re-reveal Components — reveals stays [1], so the toggle sticks.
+    nav.openSections = new Set([0]);
+    await nav.updateComplete;
+    expect(reveals).toEqual([1]);
+  });
+
   // The page renders two navigators (drawer + desktop) sharing one
   // openSections. A toggle would race them open/closed forever and hang the
   // page; section-reveal is an idempotent set, so it converges.

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -17,7 +17,12 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
 import { deriveNavigatorBuckets } from "../../../src/components/device/navigator-buckets.js";
-import { sectionIndexForLine } from "../../../src/components/device/navigator-reveal-controller.js";
+import {
+  NavigatorRevealController,
+  type RevealHost,
+  type RevealState,
+  sectionIndexForLine,
+} from "../../../src/components/device/navigator-reveal-controller.js";
 import {
   parseYamlTopLevelSections,
   sectionKeyOf,
@@ -81,6 +86,49 @@ describe("sectionIndexForLine", () => {
     expect(sectionIndexForLine(buckets, buckets.core[0].fromLine)).toBe(0);
     expect(sectionIndexForLine(buckets, buckets.components[0].fromLine)).toBe(1);
     expect(sectionIndexForLine(buckets, 9999)).toBe(-1);
+  });
+});
+
+// Focused on the controller: an intervening selection that maps to no nav row
+// (index === -1, e.g. an unscoped automation) must not pin the reveal latch, so
+// returning to a still-collapsed section re-reveals it.
+describe("NavigatorRevealController one-shot latch", () => {
+  it("re-reveals after an index===-1 line breaks the selection run", () => {
+    const buckets = deriveNavigatorBuckets(YAML);
+    const sLine = sensorLine();
+    const reveals: number[] = [];
+    const host = {
+      addController() {},
+      removeController() {},
+      requestUpdate() {},
+      updateComplete: Promise.resolve(true),
+      renderRoot: { querySelector: () => null } as unknown as ParentNode,
+      dispatchEvent(e: Event) {
+        reveals.push((e as CustomEvent<{ index: number }>).detail.index);
+        return true;
+      },
+    } as unknown as RevealHost;
+    // Section stays closed and the row never scrolls (querySelector → null), so
+    // only the latch governs whether reveal fires.
+    const state: RevealState = {
+      selectedLine: null,
+      buckets,
+      openSections: new Set(),
+      filtering: false,
+    };
+    const ctrl = new NavigatorRevealController(host, () => state);
+
+    state.selectedLine = sLine; // sensor row, section closed
+    ctrl.hostUpdated();
+    expect(reveals).toEqual([1]);
+
+    state.selectedLine = 9999; // unscoped line: index === -1
+    ctrl.hostUpdated();
+    expect(reveals).toEqual([1]);
+
+    state.selectedLine = sLine; // back to the still-closed sensor row
+    ctrl.hostUpdated();
+    expect(reveals).toEqual([1, 1]);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression from #729 (navigator "reveal selected"): after clicking a line in the YAML editor, the navigator would expand the cursor's section but then refuse to let you open any other section; the clicked section snapped back open on every render.

The reveal controller re-dispatched `section-reveal` on every host update until it confirmed a scroll latch. When the selected row never became visible, a component inside a collapsed subgroup, or the hidden second navigator instance that the page also renders, that latch never set, so the next render, including the one triggered by the user clicking a different section header, re-forced the cursor's section open. The user was locked out of toggling anything else.

The fix makes the `section-reveal` dispatch one-shot per selected line via a separate `_revealedLine` latch, so a manual re-close of that section no longer re-triggers the forced open. The deferred scroll retry is left intact, so a row that becomes scrollable later (collapsed subgroup expanded) still scrolls into view.

Verified empirically with Chrome/CDP against a real device: pre-fix, clicking Core after the cursor revealed Automations did nothing (Automations stayed force-open); post-fix, Core opens and stays open across re-renders.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
