### PR TITLE
Pass the unsaved draft yaml to automations/get_available

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1551,7 +1551,10 @@ export class ESPHomeAPI {
   ): Promise<AvailableAutomations> {
     const raw = await this.sendCommand<AvailableAutomations>(
       "automations/get_available",
-      { configuration, ...(yaml !== undefined ? { yaml } : {}) }
+      // Empty string is the uninitialized-draft sentinel (a load that
+      // races the page's YAML fetch); omit it so the backend falls back
+      // to disk rather than scoping off an empty document.
+      { configuration, ...(yaml ? { yaml } : {}) }
     );
     // Backend ships slim ``*Index`` shapes that drop ``config_entries``
     // entirely. Renderers (``automation-action-node``,

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1542,12 +1542,16 @@ export class ESPHomeAPI {
    *
    * Unlike the static catalog commands, the result depends on YAML
    * contents — callers should re-fetch on each YAML change rather
-   * than caching across edits.
+   * than caching across edits. Pass ``yaml`` to scope off the unsaved
+   * draft so a wizard-added component's triggers surface pre-save.
    */
-  async getAvailableAutomations(configuration: string): Promise<AvailableAutomations> {
+  async getAvailableAutomations(
+    configuration: string,
+    yaml?: string
+  ): Promise<AvailableAutomations> {
     const raw = await this.sendCommand<AvailableAutomations>(
       "automations/get_available",
-      { configuration }
+      { configuration, ...(yaml !== undefined ? { yaml } : {}) }
     );
     // Backend ships slim ``*Index`` shapes that drop ``config_entries``
     // entirely. Renderers (``automation-action-node``,

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -152,7 +152,10 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     if (!this._api || !this.configuration) return;
     this._loading = true;
     try {
-      this._available = await this._api.getAvailableAutomations(this.configuration);
+      this._available = await this._api.getAvailableAutomations(
+        this.configuration,
+        this.yaml
+      );
       // A per-section shortcut on a multi-entity container prefills the
       // container id, which has no triggers of its own; land on its first
       // sub-entity so the user sees a real target instead of an empty list.

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -177,7 +177,10 @@ export class ESPHomeAddScriptDialog extends LitElement {
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
     try {
-      this._available = await this._api.getAvailableAutomations(this.configuration);
+      this._available = await this._api.getAvailableAutomations(
+        this.configuration,
+        this.yaml
+      );
     } catch (err) {
       this._error = getErrorMessage(err);
     }

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -398,6 +398,9 @@ export class ESPHomeAutomationEditor extends LitElement {
       {
         // All three lists: this editor renders the trigger picker.
         lists: ["triggers", "actions", "conditions"],
+        // Scope off the draft so a just-added component's triggers
+        // surface while re-editing before the global save (#1348).
+        yaml: this.yaml,
         // Paint the slim list and drop the spinner so the dropdowns
         // mount while hydration runs; the controller guards this
         // against a superseded load. The post-hydration ``available``

--- a/src/components/device/automation-editor/catalog-load-controller.ts
+++ b/src/components/device/automation-editor/catalog-load-controller.ts
@@ -38,6 +38,7 @@ export class CatalogLoadController implements ReactiveController {
     options?: {
       lists?: readonly HydrateList[];
       onPaint?: (available: AvailableAutomations) => void;
+      yaml?: string;
     }
   ): Promise<{ available?: AvailableAutomations; error?: string }> {
     if (!api || !configuration) return {};
@@ -45,6 +46,7 @@ export class CatalogLoadController implements ReactiveController {
     const onPaint = options?.onPaint;
     const outcome = await loadAndHydrateAvailable(api, configuration, {
       isStale: () => seq !== this._seq,
+      yaml: options?.yaml,
       // Trigger-less editors (script, api-action) render actions +
       // conditions only; skipping trigger-body hydration avoids needless
       // get_bodies work on mount. automation-editor passes all three to

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -91,10 +91,11 @@ export async function loadAndHydrateAvailable(
     onPaint?: (available: AvailableAutomations) => void;
     isStale?: () => boolean;
     lists?: readonly HydrateList[];
+    yaml?: string;
   }
 ): Promise<LoadAndHydrateOutcome> {
   try {
-    const slim = await api.getAvailableAutomations(configuration);
+    const slim = await api.getAvailableAutomations(configuration, options?.yaml);
     if (options?.isStale?.()) return { status: "stale" };
     // Shallow-clone each entry so ``hydrateAvailableBodies``
     // mutates ``available``'s copies, not the api-client object

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -215,6 +215,45 @@ describe("ESPHomeAPI — sendCommand", () => {
   });
 });
 
+describe("ESPHomeAPI — getAvailableAutomations", () => {
+  beforeEach(() => {
+    installMockWebSocket();
+  });
+  afterEach(() => {
+    uninstallMockWebSocket();
+  });
+
+  const emptyResult = {
+    triggers: [],
+    actions: [],
+    conditions: [],
+    scripts: [],
+    devices: [],
+  };
+
+  it("omits the yaml arg when the draft is empty so the backend reads disk (#1348)", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const pending = api.getAvailableAutomations("device.yaml", "");
+    const sent = ws.sentAs<{ command: string; message_id: string; args: unknown }>(0);
+    expect(sent.command).toBe("automations/get_available");
+    expect(sent.args).toEqual({ configuration: "device.yaml" });
+    ws.receive({ message_id: sent.message_id, result: emptyResult });
+    await pending;
+  });
+
+  it("forwards a non-empty draft so the backend scopes off it (#1348)", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const draft = "esphome:\n  name: d\n";
+    const pending = api.getAvailableAutomations("device.yaml", draft);
+    const sent = ws.sentAs<{ message_id: string; args: unknown }>(0);
+    expect(sent.args).toEqual({ configuration: "device.yaml", yaml: draft });
+    ws.receive({ message_id: sent.message_id, result: emptyResult });
+    await pending;
+  });
+});
+
 describe("ESPHomeAPI — cloneDevice", () => {
   beforeEach(() => {
     installMockWebSocket();

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -119,6 +119,22 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     second.resolve(slimAvailable());
     await flushPending();
   });
+
+  it("scopes available automations off the unsaved draft yaml (#1348)", async () => {
+    const getAvailableAutomations = vi.fn(() => Promise.resolve(slimAvailable()));
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    const dialog = await mountDialog(api);
+    dialog.yaml = "esphome:\n  name: drafty\n";
+    dialog.open();
+    await dialog.updateComplete;
+    await flushPending();
+
+    expect(getAvailableAutomations).toHaveBeenCalledWith(
+      "device.yaml",
+      "esphome:\n  name: drafty\n"
+    );
+  });
 });
 
 const ON_TIME_YAML = `time:

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -75,7 +75,9 @@ describe("automation-editor mount-time load (behavioral)", () => {
     await mountEditor(api, "device.yaml");
 
     expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
-    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml");
+    // Second arg is the editor's draft yaml (empty here), forwarded so a
+    // wizard-added component's triggers scope off the draft (#1348).
+    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml", "");
   });
 
   it("editor mounted without configuration does not call getAvailableAutomations", async () => {

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -164,8 +164,17 @@ describe("loadAndHydrateAvailable", () => {
     const outcome = await loadAndHydrateAvailable(api, "device.yaml");
 
     expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
-    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml");
+    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml", undefined);
     expect(outcome.status).toBe("ok");
+  });
+
+  it("forwards the draft yaml override to getAvailableAutomations (#1348)", async () => {
+    const getAvailableAutomations = vi.fn().mockResolvedValue(emptySlim());
+    const api = { getAvailableAutomations } as unknown as ESPHomeAPI;
+
+    await loadAndHydrateAvailable(api, "device.yaml", { yaml: "draft: true\n" });
+
+    expect(getAvailableAutomations).toHaveBeenCalledWith("device.yaml", "draft: true\n");
   });
 
   it("returns fresh array refs in the hydrated outcome", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When a component is added through the wizard but not yet saved, it lives in the editor's in-memory draft yaml. The Add automation wizard (and the Add script wizard and the inline automation editor) scoped their catalog by calling `automations/get_available` with only the configuration name, so the backend read the on-disk config and the new component's triggers were missing until the first global save.

This forwards the draft yaml every caller already holds through `getAvailableAutomations`, so the backend scopes off what the user sees. Pairs with the backend PR that adds the `yaml=` override.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1348
- backend: esphome/device-builder#1352

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
