### PR TITLE
Read tagged !lambda block scalars in the section editor

### DIFF
--- a/src/util/yaml-block-scalar-value.ts
+++ b/src/util/yaml-block-scalar-value.ts
@@ -5,15 +5,14 @@
  */
 
 import type { LambdaValue } from "../api/types/automations.js";
+import type { BlockScalarHeader } from "./yaml-section-lexer.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 // Only the canonical strip-chomped literal block becomes an editable
 // lambda; folded (>) or keep (|+) markers carry semantics the editor
 // would normalise away, so they stay opaque YamlRawValue blocks.
-export const isEditableLambdaBlock = (header: {
-  tag: string | undefined;
-  marker: string;
-}): boolean => header.tag === "!lambda" && header.marker === "|-";
+export const isEditableLambdaBlock = (header: BlockScalarHeader): boolean =>
+  header.tag === "!lambda" && header.marker === "|-";
 
 // Dedents via YamlRawValue.body and drops only trailing newlines (the
 // |- strip chomp), so trailing spaces on the last line survive.
@@ -25,7 +24,7 @@ export const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
 // Editable LambdaValue for a canonical !lambda |-, else a YamlRawValue
 // carrying the verbatim header so any other tag/marker round-trips.
 export const blockScalarValue = (
-  header: { tag: string | undefined; marker: string },
+  header: BlockScalarHeader,
   rawHeader: string,
   bodyLines: string[]
 ): LambdaValue | YamlRawValue =>

--- a/src/util/yaml-block-scalar-value.ts
+++ b/src/util/yaml-block-scalar-value.ts
@@ -1,0 +1,48 @@
+/**
+ * Turn a parsed block-scalar header (`parseBlockScalarHeader`) plus its
+ * captured body lines into a section-editor form value. Kept out of
+ * yaml-section-reader.ts (already over the file-size cap) so the reader
+ * doesn't keep growing.
+ */
+
+import type { LambdaValue } from "../api/types/automations.js";
+import { YamlRawValue } from "./yaml-serialize.js";
+
+/**
+ * True for the canonical strip-chomped literal block (`|-`) — the only
+ * marker the form's lambda editor (and the serializer) emit. Other
+ * markers (folded `>`, keep `|+`) carry distinct YAML semantics the
+ * editor would silently normalise to `|-`, so they stay opaque
+ * YamlRawValue blocks instead of editable lambdas.
+ */
+export const isEditableLambdaBlock = (header: {
+  tag: string | undefined;
+  marker: string;
+}): boolean => header.tag === "!lambda" && header.marker === "|-";
+
+/**
+ * Build a LambdaValue sentinel from a captured `!lambda |-` block body.
+ * Reuses YamlRawValue.body to strip the block's common indent (so
+ * '          return 0.01;' becomes 'return 0.01;'); only trailing
+ * newlines are dropped (the `|-` strip chomp), not trailing spaces or
+ * tabs on the last line.
+ */
+export const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
+  _lambda: new YamlRawValue(bodyLines).body.replace(/\n+$/, ""),
+  _tag: "!lambda",
+});
+
+/**
+ * Turn a (possibly tagged) block-scalar header + its captured body
+ * lines into a form value: a LambdaValue for a canonical `!lambda |-`
+ * so the value stays editable, a YamlRawValue (carrying the verbatim
+ * header) for any other tag, marker, or a bare `|-` / `>` block.
+ */
+export const blockScalarValue = (
+  header: { tag: string | undefined; marker: string },
+  rawHeader: string,
+  bodyLines: string[]
+): LambdaValue | YamlRawValue =>
+  isEditableLambdaBlock(header)
+    ? lambdaValueFromBlock(bodyLines)
+    : new YamlRawValue(bodyLines, rawHeader);

--- a/src/util/yaml-block-scalar-value.ts
+++ b/src/util/yaml-block-scalar-value.ts
@@ -1,43 +1,29 @@
 /**
- * Turn a parsed block-scalar header (`parseBlockScalarHeader`) plus its
- * captured body lines into a section-editor form value. Kept out of
- * yaml-section-reader.ts (already over the file-size cap) so the reader
- * doesn't keep growing.
+ * Turn a parsed block-scalar header plus its captured body lines into a
+ * section-editor form value. Split out of yaml-section-reader.ts to keep
+ * that file under the size cap.
  */
 
 import type { LambdaValue } from "../api/types/automations.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
-/**
- * True for the canonical strip-chomped literal block (`|-`) — the only
- * marker the form's lambda editor (and the serializer) emit. Other
- * markers (folded `>`, keep `|+`) carry distinct YAML semantics the
- * editor would silently normalise to `|-`, so they stay opaque
- * YamlRawValue blocks instead of editable lambdas.
- */
+// Only the canonical strip-chomped literal block becomes an editable
+// lambda; folded (>) or keep (|+) markers carry semantics the editor
+// would normalise away, so they stay opaque YamlRawValue blocks.
 export const isEditableLambdaBlock = (header: {
   tag: string | undefined;
   marker: string;
 }): boolean => header.tag === "!lambda" && header.marker === "|-";
 
-/**
- * Build a LambdaValue sentinel from a captured `!lambda |-` block body.
- * Reuses YamlRawValue.body to strip the block's common indent (so
- * '          return 0.01;' becomes 'return 0.01;'); only trailing
- * newlines are dropped (the `|-` strip chomp), not trailing spaces or
- * tabs on the last line.
- */
+// Dedents via YamlRawValue.body and drops only trailing newlines (the
+// |- strip chomp), so trailing spaces on the last line survive.
 export const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
   _lambda: new YamlRawValue(bodyLines).body.replace(/\n+$/, ""),
   _tag: "!lambda",
 });
 
-/**
- * Turn a (possibly tagged) block-scalar header + its captured body
- * lines into a form value: a LambdaValue for a canonical `!lambda |-`
- * so the value stays editable, a YamlRawValue (carrying the verbatim
- * header) for any other tag, marker, or a bare `|-` / `>` block.
- */
+// Editable LambdaValue for a canonical !lambda |-, else a YamlRawValue
+// carrying the verbatim header so any other tag/marker round-trips.
 export const blockScalarValue = (
   header: { tag: string | undefined; marker: string },
   rawHeader: string,

--- a/src/util/yaml-scalar.ts
+++ b/src/util/yaml-scalar.ts
@@ -6,6 +6,7 @@
  * keep growing.
  */
 
+import type { LambdaValue } from "../api/types/automations.js";
 import { splitTopLevelCommas } from "./split-top-level-commas.js";
 import { unescapeYamlDoubleQuoted } from "./yaml-escape.js";
 import { parseYamlBoolean } from "./yaml-serialize.js";
@@ -57,6 +58,19 @@ export const splitInlineComment = (raw: string): { value: string; comment: strin
   return { value: raw, comment: "" };
 };
 
+// Inline lambda scalar: ``!lambda return x;`` (and the quoted
+// ``!lambda 'return x;'`` form). Recognised as a ``LambdaValue``
+// so a templatable field shows the lambda editor instead of a
+// string field holding the literal ``!lambda …`` text. The block
+// form (``!lambda |-``) is captured by the reader's block-scalar
+// branch before reaching here.
+const INLINE_LAMBDA_RE = /^!lambda\s+([\s\S]+)$/;
+
+const parseInlineLambda = (scalar: string): LambdaValue | null => {
+  const m = scalar.match(INLINE_LAMBDA_RE);
+  return m ? { _lambda: stripQuotes(m[1].trim()), _tag: "!lambda" } : null;
+};
+
 // Quoting in YAML is the explicit "treat me as a string" signal —
 // ``key: "on"`` must stay the literal ``"on"`` even though ``on`` is
 // a truthy spelling. Detect the quotes BEFORE stripping so we only
@@ -67,6 +81,8 @@ export const parseScalar = (raw: string): unknown => {
   // Strip a trailing inline comment so a boolean/number field coerces
   // and the form value isn't polluted with `# ...` text (#1235).
   const { value: scalar } = splitInlineComment(raw);
+  const lambda = parseInlineLambda(scalar);
+  if (lambda !== null) return lambda;
   const wasQuoted =
     (scalar.startsWith('"') && scalar.endsWith('"')) ||
     (scalar.startsWith("'") && scalar.endsWith("'"));

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -99,9 +99,13 @@ export const BLOCK_SCALAR_RE = /^[^"']*:\s*(?:!\S+\s+)?[|>][-+]?\s*(?:#.*)?$/;
  */
 const BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)\s*(?:#.*)?$/;
 
-export const parseBlockScalarHeader = (
-  raw: string
-): { tag: string | undefined; marker: string } | null => {
+/** A parsed block-scalar header: its optional tag and its `|`/`>` marker. */
+export interface BlockScalarHeader {
+  tag: string | undefined;
+  marker: string;
+}
+
+export const parseBlockScalarHeader = (raw: string): BlockScalarHeader | null => {
   const m = raw.match(BLOCK_SCALAR_INLINE_RE);
   return m ? { tag: m[1], marker: m[2] } : null;
 };

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -95,13 +95,16 @@ export const BLOCK_SCALAR_INLINE_RE = /^[|>][-+]?$/;
 
 /**
  * Tag-aware form of `BLOCK_SCALAR_INLINE_RE`: the post-colon `raw`
- * is an optional YAML tag followed by a `|`/`>` marker. Capture
- * group 1 is the tag (or undefined), group 2 the marker. Used by
- * the reader to recognise `!lambda |-` so a lambda block round-trips
- * as an editable value instead of decaying to the literal string
- * `"!lambda |-"`.
+ * is an optional YAML tag followed by a `|`/`>` marker and an
+ * optional trailing comment. Capture group 1 is the tag (or
+ * undefined), group 2 the marker. Used by the reader to recognise
+ * `!lambda |-` so a lambda block round-trips as an editable value
+ * instead of decaying to the literal string `"!lambda |-"`. The
+ * trailing `\s*(?:#.*)?` mirrors `BLOCK_SCALAR_RE` so a header
+ * comment (`!lambda |- # note`) still reads as a block scalar
+ * rather than falling through to inline-scalar parsing.
  */
-const TAGGED_BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)$/;
+const TAGGED_BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)\s*(?:#.*)?$/;
 
 export const parseBlockScalarHeader = (
   raw: string

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -86,30 +86,23 @@ export const LIST_ITEM_START_RE = /^\s+-(\s|$)/;
 export const BLOCK_SCALAR_RE = /^[^"']*:\s*(?:!\S+\s+)?[|>][-+]?\s*(?:#.*)?$/;
 
 /**
- * Match an inline block-scalar marker — the part AFTER the colon
- * on a `key: |-` line, captured by the parser as `raw`. Used to
- * detect the direct-block-scalar shape (a key whose value is a
- * block scalar header rather than a list of items).
+ * Match the part AFTER the colon on a `key: |-` line (the `raw` value
+ * the parser captures) as a block-scalar header: an optional YAML tag,
+ * the `|`/`>` marker, and an optional trailing comment. Capture group 1
+ * is the tag (or undefined), group 2 the marker.
+ *
+ * The trailing `\s*(?:#.*)?` mirrors `BLOCK_SCALAR_RE` so a header
+ * comment (`!lambda |- # note`) still reads as a block scalar rather
+ * than falling through to inline-scalar parsing. An undefined tag is
+ * the plain `|-`/`>` case; a `!lambda` tag is what the reader turns
+ * into an editable lambda instead of the literal string `"!lambda |-"`.
  */
-export const BLOCK_SCALAR_INLINE_RE = /^[|>][-+]?$/;
-
-/**
- * Tag-aware form of `BLOCK_SCALAR_INLINE_RE`: the post-colon `raw`
- * is an optional YAML tag followed by a `|`/`>` marker and an
- * optional trailing comment. Capture group 1 is the tag (or
- * undefined), group 2 the marker. Used by the reader to recognise
- * `!lambda |-` so a lambda block round-trips as an editable value
- * instead of decaying to the literal string `"!lambda |-"`. The
- * trailing `\s*(?:#.*)?` mirrors `BLOCK_SCALAR_RE` so a header
- * comment (`!lambda |- # note`) still reads as a block scalar
- * rather than falling through to inline-scalar parsing.
- */
-const TAGGED_BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)\s*(?:#.*)?$/;
+const BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)\s*(?:#.*)?$/;
 
 export const parseBlockScalarHeader = (
   raw: string
 ): { tag: string | undefined; marker: string } | null => {
-  const m = raw.match(TAGGED_BLOCK_SCALAR_INLINE_RE);
+  const m = raw.match(BLOCK_SCALAR_INLINE_RE);
   return m ? { tag: m[1], marker: m[2] } : null;
 };
 

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -77,8 +77,13 @@ export const LIST_ITEM_START_RE = /^\s+-(\s|$)/;
  * conservative (they over-trigger raw mode, which is lossless),
  * but the anchor avoids the surprise of raw-mode kicking in on a
  * value the parser could otherwise round-trip.
+ *
+ * An optional YAML tag (`!lambda`, `!secret`) may sit between the
+ * colon and the `|`/`>` marker (`multiply: !lambda |-`); ESPHome's
+ * templatable fields emit that shape, so the tag has to count as a
+ * block-scalar header too.
  */
-export const BLOCK_SCALAR_RE = /^[^"']*:\s*[|>][-+]?\s*(?:#.*)?$/;
+export const BLOCK_SCALAR_RE = /^[^"']*:\s*(?:!\S+\s+)?[|>][-+]?\s*(?:#.*)?$/;
 
 /**
  * Match an inline block-scalar marker — the part AFTER the colon
@@ -87,6 +92,23 @@ export const BLOCK_SCALAR_RE = /^[^"']*:\s*[|>][-+]?\s*(?:#.*)?$/;
  * block scalar header rather than a list of items).
  */
 export const BLOCK_SCALAR_INLINE_RE = /^[|>][-+]?$/;
+
+/**
+ * Tag-aware form of `BLOCK_SCALAR_INLINE_RE`: the post-colon `raw`
+ * is an optional YAML tag followed by a `|`/`>` marker. Capture
+ * group 1 is the tag (or undefined), group 2 the marker. Used by
+ * the reader to recognise `!lambda |-` so a lambda block round-trips
+ * as an editable value instead of decaying to the literal string
+ * `"!lambda |-"`.
+ */
+const TAGGED_BLOCK_SCALAR_INLINE_RE = /^(?:(!\S+)\s+)?([|>][-+]?)$/;
+
+export const parseBlockScalarHeader = (
+  raw: string
+): { tag: string | undefined; marker: string } | null => {
+  const m = raw.match(TAGGED_BLOCK_SCALAR_INLINE_RE);
+  return m ? { tag: m[1], marker: m[2] } : null;
+};
 
 /**
  * Match a bare-dash list item (``    -`` followed by EOL or only

--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -12,12 +12,12 @@ import {
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
-  BLOCK_SCALAR_INLINE_RE,
   BLOCK_SCALAR_RE,
   endsBlockAtIndent,
   isBlankOrCommentLine,
   LIST_ITEM_BARE_DASH_RE,
   LIST_ITEM_DICT_KEY_RE,
+  parseBlockScalarHeader,
 } from "./yaml-section-lexer.js";
 
 export const collectBlockListItems = (
@@ -80,10 +80,12 @@ export const parseFlatMappingField = (
   // so the surrounding parser keeps the block as YamlRawValue
   // and the serializer doesn't quote the dotted key on save.
   if (key.includes(".")) return null;
-  // Block-scalar headers (``key: |-``) stay opaque so the body
-  // round-trips through YamlRawValue; ``parseScalar("|-")`` would
-  // otherwise return the literal string ``"|-"``.
-  if (BLOCK_SCALAR_INLINE_RE.test(raw)) return null;
+  // Block-scalar headers (``key: |-``, ``key: !lambda |-``) stay
+  // opaque here so the multi-line body round-trips: the inline
+  // ``raw`` is only the header, the body sits on following lines
+  // the caller captures. ``parseScalar("|-")`` would otherwise
+  // return the literal string ``"|-"`` (or ``"!lambda |-"``).
+  if (parseBlockScalarHeader(raw)) return null;
   // ``key:`` with no value is structurally ``{key: null}`` in YAML.
   // Recognising it here is what lets list-of-single-key-mappings
   // (light ``effects:``, sensor ``filters:``, any registry-shaped

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -224,6 +224,17 @@ const collectBlockListMappings = (
           at + 1,
           `${dashIndent}${ESPHOME_YAML_INDENT}`
         );
+        // A sibling sub-key after the lambda body would be lost by the
+        // early return; bail to the whole-list YamlRawValue fallback
+        // instead (this helper's conservative contract). Unreachable
+        // with valid ESPHome YAML: filter/effect items are single-key.
+        const peek = _skipBlankAndCommentLines(lines, endIdx);
+        if (
+          peek < lines.length &&
+          _leadingIndent(lines[peek]).length > dashIndent.length
+        ) {
+          return null;
+        }
         item[headerKey] = lambdaValueFromBlock(lines.slice(at + 1, endIdx));
         return { item, endIdx };
       }

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -39,28 +39,42 @@ import { type KeySpan, type ParsedSection } from "./yaml-section-splice.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
- * Build a ``LambdaValue`` sentinel from a captured ``!lambda`` block
+ * True for the canonical strip-chomped literal block (``|-``) — the
+ * only marker the form's lambda editor (and the serializer) emit.
+ * Other markers (folded ``>``, keep ``|+``) carry distinct YAML
+ * semantics the editor would silently normalise to ``|-``, so they
+ * stay opaque ``YamlRawValue`` blocks instead of editable lambdas.
+ */
+const isEditableLambdaBlock = (header: {
+  tag: string | undefined;
+  marker: string;
+}): boolean => header.tag === "!lambda" && header.marker === "|-";
+
+/**
+ * Build a ``LambdaValue`` sentinel from a captured ``!lambda |-`` block
  * body. Reuses ``YamlRawValue.body`` to strip the block's common
  * indent (so ``          return 0.01;`` becomes ``return 0.01;``);
- * the trailing-whitespace trim mirrors the ``|-`` chomp.
+ * only trailing newlines are dropped (the ``|-`` strip chomp), not
+ * trailing spaces/tabs on the last line.
  */
 const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
-  _lambda: new YamlRawValue(bodyLines).body.replace(/[ \t\r\n]+$/, ""),
+  _lambda: new YamlRawValue(bodyLines).body.replace(/\n+$/, ""),
   _tag: "!lambda",
 });
 
 /**
  * Turn a (possibly tagged) block-scalar header + its captured body
- * lines into a form value: a ``LambdaValue`` for ``!lambda`` so the
- * value stays editable, a ``YamlRawValue`` (carrying the verbatim
- * header) for any other tag or a bare ``|-``/``>`` block.
+ * lines into a form value: a ``LambdaValue`` for a canonical
+ * ``!lambda |-`` so the value stays editable, a ``YamlRawValue``
+ * (carrying the verbatim header) for any other tag, marker, or a
+ * bare ``|-``/``>`` block.
  */
 const blockScalarValue = (
-  tag: string | undefined,
+  header: { tag: string | undefined; marker: string },
   rawHeader: string,
   bodyLines: string[]
 ): LambdaValue | YamlRawValue =>
-  tag === "!lambda"
+  isEditableLambdaBlock(header)
     ? lambdaValueFromBlock(bodyLines)
     : new YamlRawValue(bodyLines, rawHeader);
 
@@ -242,7 +256,7 @@ const collectBlockListMappings = (
       // sibling sub-keys.
       const blockHeader = parseBlockScalarHeader(headerRaw);
       if (blockHeader) {
-        if (blockHeader.tag !== "!lambda") return null;
+        if (!isEditableLambdaBlock(blockHeader)) return null;
         const { endIdx } = _scanValueBlock(
           lines,
           at + 1,
@@ -453,7 +467,7 @@ export function parseSectionCore(
     const blockHeader = parseBlockScalarHeader(raw);
     if (blockHeader) {
       const { endIdx } = _scanValueBlock(lines, i + 1, childIndent);
-      values[key] = blockScalarValue(blockHeader.tag, raw, lines.slice(i + 1, endIdx));
+      values[key] = blockScalarValue(blockHeader, raw, lines.slice(i + 1, endIdx));
       recordSpan(key, i, endIdx);
       i = endIdx - 1;
       continue;
@@ -581,11 +595,7 @@ function parseNestedBlock(
     const nestedBlockHeader = parseBlockScalarHeader(raw);
     if (nestedBlockHeader) {
       const { endIdx } = _scanValueBlock(lines, i + 1, indent);
-      values[key] = blockScalarValue(
-        nestedBlockHeader.tag,
-        raw,
-        lines.slice(i + 1, endIdx)
-      );
+      values[key] = blockScalarValue(nestedBlockHeader, raw, lines.slice(i + 1, endIdx));
       i = endIdx;
       continue;
     }

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -6,6 +6,7 @@
  * facade in yaml-section-values.ts.
  */
 
+import type { LambdaValue } from "../api/types/automations.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
@@ -14,7 +15,6 @@ import {
   _detectSectionChildIndent,
   _leadingIndent,
   _skipBlankAndCommentLines,
-  BLOCK_SCALAR_INLINE_RE,
   childRegexFor,
   isBlankOrCommentLine,
   isChildListItemLine,
@@ -25,6 +25,7 @@ import {
   LIST_ITEM_INLINE_KEY_RE,
   LIST_ITEM_START_RE,
   listItemRegexFor,
+  parseBlockScalarHeader,
   TOP_LEVEL_KEY_START_RE,
 } from "./yaml-section-lexer.js";
 import {
@@ -32,9 +33,36 @@ import {
   _matchFlatMappingField,
   _scanValueBlock,
   collectBlockListItems,
+  parseFlatMappingField,
 } from "./yaml-section-list.js";
 import { type KeySpan, type ParsedSection } from "./yaml-section-splice.js";
 import { YamlRawValue } from "./yaml-serialize.js";
+
+/**
+ * Build a ``LambdaValue`` sentinel from a captured ``!lambda`` block
+ * body. Reuses ``YamlRawValue.body`` to strip the block's common
+ * indent (so ``          return 0.01;`` becomes ``return 0.01;``);
+ * the trailing-whitespace trim mirrors the ``|-`` chomp.
+ */
+const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
+  _lambda: new YamlRawValue(bodyLines).body.replace(/[ \t\r\n]+$/, ""),
+  _tag: "!lambda",
+});
+
+/**
+ * Turn a (possibly tagged) block-scalar header + its captured body
+ * lines into a form value: a ``LambdaValue`` for ``!lambda`` so the
+ * value stays editable, a ``YamlRawValue`` (carrying the verbatim
+ * header) for any other tag or a bare ``|-``/``>`` block.
+ */
+const blockScalarValue = (
+  tag: string | undefined,
+  rawHeader: string,
+  bodyLines: string[]
+): LambdaValue | YamlRawValue =>
+  tag === "!lambda"
+    ? lambdaValueFromBlock(bodyLines)
+    : new YamlRawValue(bodyLines, rawHeader);
 
 /**
  * Dispatch a YAML list block (``key:\n  - …``) into the right
@@ -197,7 +225,33 @@ const collectBlockListMappings = (
     const item: Record<string, unknown> = Object.create(null);
     let firstEmptyKey: string | null = null;
     if (!LIST_ITEM_BARE_DASH_RE.test(lines[at])) {
-      const header = _matchFlatMappingField(lines[at], headerRe);
+      const headerMatch = lines[at].match(headerRe);
+      if (!headerMatch) return null;
+      const headerKey = headerMatch[1];
+      const headerRaw = headerMatch[2].trim();
+      // ``- multiply: !lambda |-`` (#1351): the body sits on the
+      // following deeper-indented lines, so capture it here rather
+      // than letting ``parseFlatMappingField`` mis-read the lone
+      // header as a scalar and drop the body. Scoped to the ``!lambda``
+      // tag so the value comes back as an editable ``LambdaValue``;
+      // a bare ``- foo: |-`` (or ``- then:`` automation sequence)
+      // still bails to the whole-list ``YamlRawValue`` fallback. The
+      // body extent is measured against the dash's key column
+      // (``dashIndent + "- "``) — the detected ``childIndent``
+      // collapses onto the body indent when there are no flat
+      // sibling sub-keys.
+      const blockHeader = parseBlockScalarHeader(headerRaw);
+      if (blockHeader) {
+        if (blockHeader.tag !== "!lambda") return null;
+        const { endIdx } = _scanValueBlock(
+          lines,
+          at + 1,
+          `${dashIndent}${ESPHOME_YAML_INDENT}`
+        );
+        item[headerKey] = lambdaValueFromBlock(lines.slice(at + 1, endIdx));
+        return { item, endIdx };
+      }
+      const header = parseFlatMappingField(headerKey, headerRaw);
       if (!header) return null;
       item[header.key] = header.value;
       // ``- effect_id:`` with no value may be a polymorphic single-
@@ -389,16 +443,17 @@ export function parseSectionCore(
     const raw = match[2].trim();
 
     // Direct block scalar: `key: |-` (or `|`, `>`, `>-`, `|+`,
-    // `>+`). The header sits on this line; the body lines are
-    // indented underneath. Without this branch the parser would
-    // store `raw` as a literal string `"|-"` and drop the body —
-    // the serializer would then quote `|-` (it starts with `-`)
-    // and emit `key: "|-"`, corrupting any inline lambda /
-    // multi-line scalar field. Capture the body lines as raw
-    // and replay the inline header on serialize.
-    if (BLOCK_SCALAR_INLINE_RE.test(raw)) {
+    // `>+`), optionally tagged (`key: !lambda |-`). The header sits
+    // on this line; the body lines are indented underneath. Without
+    // this branch the parser would store `raw` as a literal string
+    // `"|-"` / `"!lambda |-"` and drop the body — the serializer
+    // would then quote it and corrupt the field. A `!lambda` tag
+    // becomes an editable `LambdaValue`; anything else round-trips
+    // through `YamlRawValue` (header replayed on serialize).
+    const blockHeader = parseBlockScalarHeader(raw);
+    if (blockHeader) {
       const { endIdx } = _scanValueBlock(lines, i + 1, childIndent);
-      values[key] = new YamlRawValue(lines.slice(i + 1, endIdx), raw);
+      values[key] = blockScalarValue(blockHeader.tag, raw, lines.slice(i + 1, endIdx));
       recordSpan(key, i, endIdx);
       i = endIdx - 1;
       continue;
@@ -519,12 +574,18 @@ function parseNestedBlock(
 
     // Direct block scalar at nested indent (same shape as the
     // top-level parser's branch — see comment there). A nested
-    // field written as `key: |-` followed by indented body has
-    // to round-trip via `YamlRawValue`; otherwise the body is
-    // dropped and `raw` survives as a stray `"|-"` string.
-    if (BLOCK_SCALAR_INLINE_RE.test(raw)) {
+    // field written as `key: |-` (or `key: !lambda |-`) followed by
+    // indented body round-trips via `LambdaValue` / `YamlRawValue`;
+    // otherwise the body is dropped and `raw` survives as a stray
+    // `"|-"` / `"!lambda |-"` string.
+    const nestedBlockHeader = parseBlockScalarHeader(raw);
+    if (nestedBlockHeader) {
       const { endIdx } = _scanValueBlock(lines, i + 1, indent);
-      values[key] = new YamlRawValue(lines.slice(i + 1, endIdx), raw);
+      values[key] = blockScalarValue(
+        nestedBlockHeader.tag,
+        raw,
+        lines.slice(i + 1, endIdx)
+      );
       i = endIdx;
       continue;
     }

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -207,17 +207,15 @@ const collectBlockListMappings = (
       if (!headerMatch) return null;
       const headerKey = headerMatch[1];
       const headerRaw = headerMatch[2].trim();
-      // ``- multiply: !lambda |-`` (#1351): the body sits on the
-      // following deeper-indented lines, so capture it here rather
-      // than letting ``parseFlatMappingField`` mis-read the lone
-      // header as a scalar and drop the body. Scoped to the ``!lambda``
-      // tag so the value comes back as an editable ``LambdaValue``;
-      // a bare ``- foo: |-`` (or ``- then:`` automation sequence)
-      // still bails to the whole-list ``YamlRawValue`` fallback. The
-      // body extent is measured against the dash's key column
-      // (``dashIndent + "- "``) — the detected ``childIndent``
-      // collapses onto the body indent when there are no flat
-      // sibling sub-keys.
+      // ``- multiply: !lambda |-``: the body sits on the following
+      // deeper-indented lines, so capture it here rather than letting
+      // ``parseFlatMappingField`` mis-read the lone header as a scalar
+      // and drop the body. Scoped to ``!lambda``; a bare ``- foo: |-``
+      // (or ``- then:`` sequence) still bails to the whole-list
+      // ``YamlRawValue`` fallback. Body extent is measured against the
+      // dash key column (``dashIndent + "- "``); the detected
+      // ``childIndent`` collapses onto the body indent when there are
+      // no flat sibling sub-keys.
       const blockHeader = parseBlockScalarHeader(headerRaw);
       if (blockHeader) {
         if (!isEditableLambdaBlock(blockHeader)) return null;
@@ -424,7 +422,7 @@ export function parseSectionCore(
     // `>+`), optionally tagged (`key: !lambda |-`). The header sits
     // on this line; the body lines are indented underneath. Without
     // this branch the parser would store `raw` as a literal string
-    // `"|-"` / `"!lambda |-"` and drop the body — the serializer
+    // `"|-"` / `"!lambda |-"` and drop the body; the serializer
     // would then quote it and corrupt the field. A `!lambda` tag
     // becomes an editable `LambdaValue`; anything else round-trips
     // through `YamlRawValue` (header replayed on serialize).

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -6,9 +6,13 @@
  * facade in yaml-section-values.ts.
  */
 
-import type { LambdaValue } from "../api/types/automations.js";
 import { ESPHOME_YAML_INDENT } from "./esphome-yaml-lang.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
+import {
+  blockScalarValue,
+  isEditableLambdaBlock,
+  lambdaValueFromBlock,
+} from "./yaml-block-scalar-value.js";
 import { parseFlowList, parseScalar, splitInlineComment } from "./yaml-scalar.js";
 import {
   _detectListItemChildIndent,
@@ -37,46 +41,6 @@ import {
 } from "./yaml-section-list.js";
 import { type KeySpan, type ParsedSection } from "./yaml-section-splice.js";
 import { YamlRawValue } from "./yaml-serialize.js";
-
-/**
- * True for the canonical strip-chomped literal block (``|-``) — the
- * only marker the form's lambda editor (and the serializer) emit.
- * Other markers (folded ``>``, keep ``|+``) carry distinct YAML
- * semantics the editor would silently normalise to ``|-``, so they
- * stay opaque ``YamlRawValue`` blocks instead of editable lambdas.
- */
-const isEditableLambdaBlock = (header: {
-  tag: string | undefined;
-  marker: string;
-}): boolean => header.tag === "!lambda" && header.marker === "|-";
-
-/**
- * Build a ``LambdaValue`` sentinel from a captured ``!lambda |-`` block
- * body. Reuses ``YamlRawValue.body`` to strip the block's common
- * indent (so ``          return 0.01;`` becomes ``return 0.01;``);
- * only trailing newlines are dropped (the ``|-`` strip chomp), not
- * trailing spaces/tabs on the last line.
- */
-const lambdaValueFromBlock = (bodyLines: string[]): LambdaValue => ({
-  _lambda: new YamlRawValue(bodyLines).body.replace(/\n+$/, ""),
-  _tag: "!lambda",
-});
-
-/**
- * Turn a (possibly tagged) block-scalar header + its captured body
- * lines into a form value: a ``LambdaValue`` for a canonical
- * ``!lambda |-`` so the value stays editable, a ``YamlRawValue``
- * (carrying the verbatim header) for any other tag, marker, or a
- * bare ``|-``/``>`` block.
- */
-const blockScalarValue = (
-  header: { tag: string | undefined; marker: string },
-  rawHeader: string,
-  bodyLines: string[]
-): LambdaValue | YamlRawValue =>
-  isEditableLambdaBlock(header)
-    ? lambdaValueFromBlock(bodyLines)
-    : new YamlRawValue(bodyLines, rawHeader);
 
 /**
  * Dispatch a YAML list block (``key:\n  - …``) into the right

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -958,6 +958,80 @@ ${lambdaBlock}
     // Old body is gone.
     expect(after).not.toContain("return original_body");
   });
+
+  it("reads a tagged-block-scalar filter lambda as an editable LambdaValue (#1351)", () => {
+    // The exact #1351 repro: a templatable filter whose value the
+    // editor wrote as ``!lambda |-``. The tag sat between the colon
+    // and the ``|-`` marker, which the tag-blind block-scalar
+    // detectors missed — the body was dropped and ``!lambda |-``
+    // survived as a literal string, so the editor could no longer
+    // parse the value. It must come back as a ``LambdaValue`` so the
+    // templatable lambda editor renders (not YAML-only).
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    id: sensor_template_1
+    filters:
+      - multiply: !lambda |-
+          return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    const filters = values.filters as Array<Record<string, unknown>>;
+    expect(filters).toHaveLength(1);
+    expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+  });
+
+  it("round-trips a tagged-block-scalar filter lambda through a re-save (#1351)", () => {
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    filters:
+      - multiply: !lambda |-
+          return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    const after = updateSectionInYaml(yaml, "sensor.template", values, 2);
+    expect(after).toContain("- multiply: !lambda |-");
+    expect(after).toContain("          return 0.01;");
+    // No mangled literal-string / sentinel leak.
+    expect(after).not.toContain('"!lambda');
+    expect(after).not.toContain("_lambda:");
+    // Re-parsing the saved YAML yields the same LambdaValue — the
+    // editor's own output is readable on the next focus change.
+    const reparsed = parseYamlSectionValues(after, "sensor.template", 2);
+    const filters = reparsed.filters as Array<Record<string, unknown>>;
+    expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+  });
+
+  it("reads an inline `!lambda` filter value as a LambdaValue (#1351)", () => {
+    // Second #1351 symptom: the inline form was not identified as a
+    // valid lambda. ``parseScalar`` now recognises ``!lambda <body>``.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    filters:
+      - multiply: !lambda return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    const filters = values.filters as Array<Record<string, unknown>>;
+    expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+  });
+
+  it("reads a direct `!lambda |-` field as an editable LambdaValue (#1351)", () => {
+    // A non-list templatable field (e.g. ``lambda:`` on a template
+    // sensor) written with the explicit ``!lambda`` tag.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    lambda: !lambda |-
+      return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.lambda).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+    const after = updateSectionInYaml(yaml, "sensor.template", values, 2);
+    expect(after).toContain("lambda: !lambda |-");
+    expect(after).toContain("      return 0.01;");
+  });
 });
 
 describe("updateSectionInYaml — preserves untouched field byte layout (#1227)", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1017,6 +1017,20 @@ ${lambdaBlock}
     expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
   });
 
+  it("reads a quoted inline `!lambda '<body>'` filter value as a LambdaValue (#1351)", () => {
+    // ``parseInlineLambda`` strips the surrounding quotes, so the
+    // single-quoted inline form lands the same sentinel body.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    filters:
+      - multiply: !lambda 'return 0.01;'
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    const filters = values.filters as Array<Record<string, unknown>>;
+    expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+  });
+
   it("reads a direct `!lambda |-` field as an editable LambdaValue (#1351)", () => {
     // A non-list templatable field (e.g. ``lambda:`` on a template
     // sensor) written with the explicit ``!lambda`` tag.

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -963,8 +963,8 @@ ${lambdaBlock}
     // The exact #1351 repro: a templatable filter whose value the
     // editor wrote as ``!lambda |-``. The tag sat between the colon
     // and the ``|-`` marker, which the tag-blind block-scalar
-    // detectors missed — the body was dropped and ``!lambda |-``
-    // survived as a literal string, so the editor could no longer
+    // detectors missed, so the body was dropped and ``!lambda |-``
+    // survived as a literal string; the editor could no longer
     // parse the value. It must come back as a ``LambdaValue`` so the
     // templatable lambda editor renders (not YAML-only).
     const yaml = `sensor:
@@ -996,7 +996,7 @@ ${lambdaBlock}
     // No mangled literal-string / sentinel leak.
     expect(after).not.toContain('"!lambda');
     expect(after).not.toContain("_lambda:");
-    // Re-parsing the saved YAML yields the same LambdaValue — the
+    // Re-parsing the saved YAML yields the same LambdaValue; the
     // editor's own output is readable on the next focus change.
     const reparsed = parseYamlSectionValues(after, "sensor.template", 2);
     const filters = reparsed.filters as Array<Record<string, unknown>>;

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1032,6 +1032,55 @@ ${lambdaBlock}
     expect(after).toContain("lambda: !lambda |-");
     expect(after).toContain("      return 0.01;");
   });
+
+  it("recognises a tagged block-scalar header carrying a trailing comment (#1351)", () => {
+    // ``!lambda |- # note`` must still read as a block scalar; without
+    // stripping the comment the header fell through to inline parsing,
+    // which read the body as the literal ``|-`` and dropped the real
+    // lambda lines.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    filters:
+      - multiply: !lambda |- # scale factor
+          return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    const filters = values.filters as Array<Record<string, unknown>>;
+    expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
+  });
+
+  it("keeps a non-strip lambda marker (`!lambda >-`) opaque so it round-trips verbatim", () => {
+    // Folded (``>``) / keep (``|+``) markers carry distinct YAML
+    // semantics; coercing them to an editable LambdaValue would
+    // normalise the style to ``!lambda |-`` and change meaning. They
+    // stay YamlRawValue and survive a save byte-for-byte.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    lambda: !lambda >-
+      return 0.01;
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.lambda).toBeInstanceOf(YamlRawValue);
+    const after = updateSectionInYaml(yaml, "sensor.template", values, 2);
+    expect(after).toContain("lambda: !lambda >-");
+    expect(after).toContain("      return 0.01;");
+    expect(after).not.toContain("!lambda |-");
+  });
+
+  it("preserves trailing whitespace on a lambda's last line (|- strips newlines only)", () => {
+    // ``|-`` strips trailing line breaks, not trailing spaces/tabs on
+    // the final content line, so the dedented body must keep them.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    lambda: !lambda |-
+      return 0.01;${"  "}
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.lambda).toEqual({ _lambda: "return 0.01;  ", _tag: "!lambda" });
+  });
 });
 
 describe("updateSectionInYaml — preserves untouched field byte layout (#1227)", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -981,6 +981,26 @@ ${lambdaBlock}
     expect(filters[0].multiply).toEqual({ _lambda: "return 0.01;", _tag: "!lambda" });
   });
 
+  it("bails to YamlRawValue when a sibling sub-key follows the lambda body", () => {
+    // The lambda-capture branch must not silently drop a sub-key that
+    // trails the block body within the same list item; it falls back
+    // to the whole-list raw path so the sibling round-trips verbatim.
+    const yaml = `sensor:
+  - platform: template
+    name: Test Sensor
+    filters:
+      - multiply: !lambda |-
+          return x;
+        unit: y
+`;
+    const values = parseYamlSectionValues(yaml, "sensor.template", 2);
+    expect(values.filters).toBeInstanceOf(YamlRawValue);
+    const after = updateSectionInYaml(yaml, "sensor.template", values, 2);
+    expect(after).toContain("- multiply: !lambda |-");
+    expect(after).toContain("          return x;");
+    expect(after).toContain("        unit: y");
+  });
+
   it("round-trips a tagged-block-scalar filter lambda through a re-save (#1351)", () => {
     const yaml = `sensor:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

In the Visual Editor, a templatable sensor filter written as a lambda
(e.g. `multiply: !lambda |- return 0.01;`) got corrupted: after the
editor serialized it to a tagged block scalar, the section reader could
no longer parse its own output, and the inline `!lambda <body>` form was
never recognised as a lambda at all.

**Root cause.** The section-editor YAML reader only recognised a
block-scalar marker (`|-`, `>`, ...) sitting immediately after the
colon. A YAML tag prefix (`!lambda`) made every detector miss
(`BLOCK_SCALAR_RE`, `BLOCK_SCALAR_INLINE_RE`, and `parseScalar`), so the
body was dropped and `!lambda |-` survived as a literal string.

**Fix.**
- Add a tag-aware `parseBlockScalarHeader` to the lexer; make
  `BLOCK_SCALAR_RE` accept an optional leading tag.
- In the reader (direct field, nested field, and the `filters:` /
  `effects:` list-item path), reconstruct a `LambdaValue`
  (`{_lambda, _tag: "!lambda"}`) for the `!lambda` tag so the value
  round-trips **and** stays editable through the existing templatable
  lambda editor. Bare `|-` block scalars keep their existing
  `YamlRawValue` fallback (automation sequences are unchanged).
- `parseScalar` now recognises the inline `!lambda <body>` /
  `!lambda '<body>'` form.

The serializer already emits `LambdaValue` back to `!lambda |-`, so no
serializer change was needed. `lambdaValueFromBlock` reuses
`YamlRawValue.body` for the dedent instead of duplicating it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1351

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
