### PR TITLE
Accept decimal or hex in integer fields, preserving notation

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -1,12 +1,14 @@
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
+import { coerceIntFieldValue } from "../../util/int-input.js";
 import { parseYamlBoolean } from "../../util/yaml-serialize.js";
 
 /**
  * Coerce raw form values for the WS payload: numbers / booleans to
- * their proper types so the backend sees `5`, not `"5"`. Hex-display
- * integers stay strings; the renderer's canonical `"0x..."` survives
- * to YAML and `cv.hex_int` accepts both forms on parse.
+ * their proper types so the backend sees `5`, not `"5"`. Decimal
+ * integers become numbers; hex (`0x..`, including hex-display fields)
+ * stays a verbatim string so `cv.int_` / `cv.hex_int` parse it rather
+ * than `parseInt(..., 10)` silently truncating `0x1111` to `0`.
  */
 export function coerceFields(
   entries: ConfigEntry[],
@@ -39,8 +41,7 @@ export function coerceFields(
     }
 
     if (entry.type === ConfigEntryType.INTEGER && entry.display_format !== "hex") {
-      const n = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
-      if (!Number.isNaN(n)) out[entry.key] = n;
+      out[entry.key] = coerceIntFieldValue(raw);
     } else if (entry.type === ConfigEntryType.FLOAT) {
       const n = typeof raw === "number" ? raw : Number.parseFloat(String(raw));
       if (!Number.isNaN(n)) out[entry.key] = n;

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -90,15 +90,14 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   );
 }
 
-// ESPHome's cv.int_ accepts decimal OR hex for every integer field, but
-// <input type="number"> rejects 0x… literals. Use a text input that takes
-// either and preserves the user's notation — unlike the hex path, which
-// canonicalizes. ``coerceIntFieldValue`` emits decimal as a number (so YAML
-// stays bare ``4369``; a string would be quoted to keep it a string) and
-// hex/anything else as the raw string (``0x1111`` round-trips bare, junk
-// reaches the validator), shared with the add-component coercer.
+// <input type="number"> rejects the 0x… literals cv.int_ accepts, so render
+// integers as text and commit through the shared ``coerceIntFieldValue``
+// (decimal → number, hex/other → verbatim string). The edit buffer keeps raw
+// keystrokes on screen while typing so the committed value's reformatting
+// (``0042`` → ``42``) doesn't fight the cursor; it clears on blur.
 function renderIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
-  const value = String(ctx.getAt(path) ?? "");
+  const editingText = ctx.getEditingMagnitude(path);
+  const value = editingText ?? String(ctx.getAt(path) ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   return renderFieldShell(
@@ -114,8 +113,11 @@ function renderIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
       ?disabled=${disabled}
       placeholder=${String(entry.default_value ?? "")}
       @input=${(e: Event) => {
-        ctx.emitChange(path, coerceIntFieldValue((e.target as HTMLInputElement).value));
+        const raw = (e.target as HTMLInputElement).value;
+        ctx.setEditingMagnitude(path, raw);
+        ctx.emitChange(path, coerceIntFieldValue(raw));
       }}
+      @blur=${() => ctx.clearEditingMagnitude(path)}
     />`
   );
 }

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -11,6 +11,7 @@ import {
   visibleUnitOptions,
 } from "../../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
+import { coerceIntFieldValue } from "../../../util/int-input.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -89,17 +90,13 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   );
 }
 
-// A bare decimal integer (optionally negative). Such input is emitted as a
-// number so its YAML stays unquoted; hex / anything else stays a string.
-const DECIMAL_INT_RE = /^-?\d+$/;
-
 // ESPHome's cv.int_ accepts decimal OR hex for every integer field, but
 // <input type="number"> rejects 0x… literals. Use a text input that takes
 // either and preserves the user's notation — unlike the hex path, which
-// canonicalizes. Decimal is emitted as a number (so YAML stays bare
-// ``4369``; a string would be quoted to keep it a string), hex/anything
-// else as the raw string (``0x1111`` round-trips bare, junk reaches the
-// validator). Number(String(value)) in the validator accepts both forms.
+// canonicalizes. ``coerceIntFieldValue`` emits decimal as a number (so YAML
+// stays bare ``4369``; a string would be quoted to keep it a string) and
+// hex/anything else as the raw string (``0x1111`` round-trips bare, junk
+// reaches the validator), shared with the add-component coercer.
 function renderIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const value = String(ctx.getAt(path) ?? "");
   const invalid = ctx.errorAt(path) !== null;
@@ -117,8 +114,7 @@ function renderIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
       ?disabled=${disabled}
       placeholder=${String(entry.default_value ?? "")}
       @input=${(e: Event) => {
-        const v = (e.target as HTMLInputElement).value.trim();
-        ctx.emitChange(path, v === "" ? "" : DECIMAL_INT_RE.test(v) ? Number(v) : v);
+        ctx.emitChange(path, coerceIntFieldValue((e.target as HTMLInputElement).value));
       }}
     />`
   );

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -59,6 +59,10 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
   if (entry.display_format === "hex") {
     return renderHexIntField(entry, path, ctx);
   }
+  if (entry.type === ConfigEntryType.INTEGER) {
+    return renderIntField(entry, path, ctx);
+  }
+  // FLOAT keeps the native number spinner — floats don't take 0x… literals.
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
   const min = entry.range ? String(entry.range[0]) : undefined;
@@ -75,11 +79,46 @@ export function renderNumberField(entry: ConfigEntry, path: string[], ctx: Rende
       ?disabled=${disabled}
       min=${min ?? ""}
       max=${max ?? ""}
-      step=${entry.type === ConfigEntryType.FLOAT ? "any" : "1"}
+      step="any"
       placeholder=${String(entry.default_value ?? "")}
       @input=${(e: Event) => {
         const raw = (e.target as HTMLInputElement).value;
         ctx.emitChange(path, raw === "" ? "" : Number(raw));
+      }}
+    />`
+  );
+}
+
+// A bare decimal integer (optionally negative). Such input is emitted as a
+// number so its YAML stays unquoted; hex / anything else stays a string.
+const DECIMAL_INT_RE = /^-?\d+$/;
+
+// ESPHome's cv.int_ accepts decimal OR hex for every integer field, but
+// <input type="number"> rejects 0x… literals. Use a text input that takes
+// either and preserves the user's notation — unlike the hex path, which
+// canonicalizes. Decimal is emitted as a number (so YAML stays bare
+// ``4369``; a string would be quoted to keep it a string), hex/anything
+// else as the raw string (``0x1111`` round-trips bare, junk reaches the
+// validator). Number(String(value)) in the validator accepts both forms.
+function renderIntField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
+  const value = String(ctx.getAt(path) ?? "");
+  const invalid = ctx.errorAt(path) !== null;
+  const disabled = effectiveDisabled(entry, ctx);
+  return renderFieldShell(
+    entry,
+    path,
+    ctx,
+    html`<input
+      type="text"
+      autocomplete="off"
+      spellcheck="false"
+      class=${invalid ? "invalid" : ""}
+      .value=${value}
+      ?disabled=${disabled}
+      placeholder=${String(entry.default_value ?? "")}
+      @input=${(e: Event) => {
+        const v = (e.target as HTMLInputElement).value.trim();
+        ctx.emitChange(path, v === "" ? "" : DECIMAL_INT_RE.test(v) ? Number(v) : v);
       }}
     />`
   );

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -2,6 +2,7 @@ import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
+import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord } from "./nested-values.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
@@ -158,16 +159,33 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
         return { key: entry.key, code: "validation.max", params: { max } };
       }
     }
-  } else if (
-    entry.type === ConfigEntryType.INTEGER ||
-    entry.type === ConfigEntryType.FLOAT
-  ) {
+  } else if (entry.type === ConfigEntryType.INTEGER) {
+    // Accept exactly what cv.int_ does — bare decimal or 0x hex — so the
+    // editor doesn't pass forms (`1e3`) the backend rejects, and range-check
+    // with BigInt so the 64-bit values the renderer keeps as strings compare
+    // precisely. ``1.5`` / ``1e3`` parse as numbers but aren't integer
+    // literals (``not_an_integer``); junk isn't numeric (``not_a_number``).
+    const n = parseIntInput(raw);
+    if (n === null) {
+      const numeric = !Number.isNaN(Number(String(raw).trim()));
+      return {
+        key: entry.key,
+        code: numeric ? "validation.not_an_integer" : "validation.not_a_number",
+      };
+    }
+    if (entry.range) {
+      const [min, max] = entry.range;
+      if (n < BigInt(Math.floor(min))) {
+        return { key: entry.key, code: "validation.min", params: { min } };
+      }
+      if (n > BigInt(Math.ceil(max))) {
+        return { key: entry.key, code: "validation.max", params: { max } };
+      }
+    }
+  } else if (entry.type === ConfigEntryType.FLOAT) {
     const num = typeof raw === "number" ? raw : Number(String(raw));
     if (Number.isNaN(num)) {
       return { key: entry.key, code: "validation.not_a_number" };
-    }
-    if (entry.type === ConfigEntryType.INTEGER && !Number.isInteger(num)) {
-      return { key: entry.key, code: "validation.not_an_integer" };
     }
     if (entry.range) {
       const [min, max] = entry.range;

--- a/src/util/int-input.ts
+++ b/src/util/int-input.ts
@@ -1,8 +1,23 @@
-// A bare decimal integer (optionally negative). Such input is emitted as a
-// number so its YAML / WS form stays numeric (and unquoted on disk); hex
-// (0x..) or anything else stays a verbatim string — ESPHome's cv.int_ parses
-// 0x.. on its own, and the inline validator flags junk.
+// The integer literals ESPHome's cv.int_ accepts: a bare decimal (optionally
+// negative) or non-negative 0x hex. Decimal is emitted as a number so its YAML
+// / WS form stays numeric; hex / anything else stays a verbatim string.
 const DECIMAL_INT_RE = /^-?\d+$/;
+const HEX_INT_RE = /^0x[0-9a-f]+$/i;
+
+/**
+ * BigInt value of a decimal-or-hex integer literal (what `cv.int_` accepts),
+ * or null for any other form. Lets validation reject `1e3` / `1.5` and
+ * range-check 64-bit values precisely, matching `coerceIntFieldValue`.
+ */
+export function parseIntInput(raw: unknown): bigint | null {
+  const v = String(raw ?? "").trim();
+  if (!DECIMAL_INT_RE.test(v) && !HEX_INT_RE.test(v)) return null;
+  try {
+    return BigInt(v);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Normalise a decimal-or-hex integer field value: bare decimal → number,

--- a/src/util/int-input.ts
+++ b/src/util/int-input.ts
@@ -5,16 +5,17 @@
 const DECIMAL_INT_RE = /^-?\d+$/;
 
 /**
- * Normalise a decimal-or-hex integer field value.
- *
- * Bare decimal → number; hex / anything else → the trimmed string verbatim;
- * empty → "". Shared by the integer renderer and the add-component coercer so
- * neither canonicalises hex (``0x1111`` must not become ``4369`` or, via
- * ``parseInt(..., 10)``, ``0``).
+ * Normalise a decimal-or-hex integer field value: bare decimal → number,
+ * hex / anything else → verbatim string, empty → "". Shared by the integer
+ * renderer and the add-component coercer so neither truncates `0x1111` to `0`.
+ * A decimal above 2^53 stays a string to keep 64-bit precision (#378/#944);
+ * leading zeros on a safe int are dropped (`0042` → `42`).
  */
 export function coerceIntFieldValue(raw: unknown): number | string {
   if (typeof raw === "number") return raw;
   const v = String(raw ?? "").trim();
   if (v === "") return "";
-  return DECIMAL_INT_RE.test(v) ? Number(v) : v;
+  if (!DECIMAL_INT_RE.test(v)) return v;
+  const n = Number(v);
+  return Number.isSafeInteger(n) ? n : v;
 }

--- a/src/util/int-input.ts
+++ b/src/util/int-input.ts
@@ -11,12 +11,11 @@ const HEX_INT_RE = /^0x[0-9a-f]+$/i;
  */
 export function parseIntInput(raw: unknown): bigint | null {
   const v = String(raw ?? "").trim();
+  // The regexes admit only ``BigInt``-parseable literals, so call it directly
+  // (mirrors ``parseHexInt``) — a future regex change that breaks that
+  // invariant should throw loudly, not be swallowed into a silent null.
   if (!DECIMAL_INT_RE.test(v) && !HEX_INT_RE.test(v)) return null;
-  try {
-    return BigInt(v);
-  } catch {
-    return null;
-  }
+  return BigInt(v);
 }
 
 /**

--- a/src/util/int-input.ts
+++ b/src/util/int-input.ts
@@ -1,0 +1,20 @@
+// A bare decimal integer (optionally negative). Such input is emitted as a
+// number so its YAML / WS form stays numeric (and unquoted on disk); hex
+// (0x..) or anything else stays a verbatim string — ESPHome's cv.int_ parses
+// 0x.. on its own, and the inline validator flags junk.
+const DECIMAL_INT_RE = /^-?\d+$/;
+
+/**
+ * Normalise a decimal-or-hex integer field value.
+ *
+ * Bare decimal → number; hex / anything else → the trimmed string verbatim;
+ * empty → "". Shared by the integer renderer and the add-component coercer so
+ * neither canonicalises hex (``0x1111`` must not become ``4369`` or, via
+ * ``parseInt(..., 10)``, ``0``).
+ */
+export function coerceIntFieldValue(raw: unknown): number | string {
+  if (typeof raw === "number") return raw;
+  const v = String(raw ?? "").trim();
+  if (v === "") return "";
+  return DECIMAL_INT_RE.test(v) ? Number(v) : v;
+}

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -52,4 +52,12 @@ describe("coerceFields non-hex integers", () => {
   test('"5" still coerces to numeric 5', () => {
     expect(coerceFields([plainInt], { count: "5" })).toEqual({ count: 5 });
   });
+
+  test("hex 0x1111 stays a verbatim string (parseInt base 10 would truncate it to 0)", () => {
+    expect(coerceFields([plainInt], { count: "0x1111" })).toEqual({ count: "0x1111" });
+  });
+
+  test("a negative decimal coerces to a number", () => {
+    expect(coerceFields([plainInt], { count: "-5" })).toEqual({ count: -5 });
+  });
 });

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins that plain INTEGER fields render a text input accepting decimal
+ * or hex (ESPHome's ``cv.int_`` takes both) and emit the value verbatim
+ * so the user's notation round-trips (4369 stays 4369; 0x1111 stays
+ * 0x1111). Floats keep the native number input; the ``display_format:
+ * "hex"`` path keeps canonicalizing.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderNumberField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+
+/** The literal HTML of the rendered ``<input>`` (static strings, real quotes). */
+const inputHtml = (tpl: unknown): string =>
+  findTemplatesByAnchor(tpl, "<input")[0].strings.join("");
+
+/** The ``.value`` property bound on the rendered input. */
+const inputValue = (tpl: unknown): unknown =>
+  findElementBindings(tpl, "input")[0][".value"];
+
+/** Fire the input's ``@input`` handler with *value*. */
+function fireInput(tpl: unknown, value: string): void {
+  const handler = findElementBindings(tpl, "input")[0]["@input"] as (e: unknown) => void;
+  handler({ target: { value } });
+}
+
+function intEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return makeConfigEntry({
+    key: "address",
+    type: ConfigEntryType.INTEGER,
+    label: "Address",
+    ...overrides,
+  });
+}
+
+function makeCtx(values: Record<string, unknown>): {
+  ctx: RenderCtx;
+  emitChange: ReturnType<typeof vi.fn>;
+} {
+  const emitChange = vi.fn();
+  const ctx = makeRenderCtx(values, { board: null, overrides: { emitChange } });
+  return { ctx, emitChange };
+}
+
+describe("renderNumberField — integer fields accept decimal or hex", () => {
+  it("renders a text input (not a number spinner) for integers", () => {
+    const { ctx } = makeCtx({ address: "0x1111" });
+    const html = inputHtml(renderNumberField(intEntry(), ["address"], ctx));
+    expect(html).toContain('type="text"');
+    expect(html).not.toContain('type="number"');
+  });
+
+  it("displays the stored value verbatim — hex stays hex", () => {
+    const { ctx } = makeCtx({ address: "0x1111" });
+    expect(inputValue(renderNumberField(intEntry(), ["address"], ctx))).toBe("0x1111");
+  });
+
+  it("emits decimal input as a number (so YAML stays bare, not quoted)", () => {
+    const { ctx, emitChange } = makeCtx({ address: "" });
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "434343");
+    expect(emitChange).toHaveBeenCalledWith(["address"], 434343);
+  });
+
+  it("emits hex input verbatim as a string (no canonicalization)", () => {
+    const { ctx, emitChange } = makeCtx({ address: "" });
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "0x2A");
+    expect(emitChange).toHaveBeenCalledWith(["address"], "0x2A");
+  });
+
+  it("emits a negative decimal as a number (stays bare, not quoted)", () => {
+    const { ctx, emitChange } = makeCtx({ offset: "" });
+    const entry = intEntry({ key: "offset" });
+    fireInput(renderNumberField(entry, ["offset"], ctx), "-5");
+    expect(emitChange).toHaveBeenCalledWith(["offset"], -5);
+  });
+
+  it("trims surrounding whitespace and emits empty for a blank value", () => {
+    const { ctx, emitChange } = makeCtx({ address: "" });
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "  4369  ");
+    expect(emitChange).toHaveBeenCalledWith(["address"], 4369);
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "");
+    expect(emitChange).toHaveBeenCalledWith(["address"], "");
+  });
+
+  it("keeps the native number input for float fields", () => {
+    const { ctx, emitChange } = makeCtx({ gain: "1.5" });
+    const entry = makeConfigEntry({
+      key: "gain",
+      type: ConfigEntryType.FLOAT,
+      label: "Gain",
+    });
+    const tpl = renderNumberField(entry, ["gain"], ctx);
+    expect(inputHtml(tpl)).toContain('type="number"');
+    // The float path coerces to a number rather than preserving a string.
+    fireInput(tpl, "2.5");
+    expect(emitChange).toHaveBeenCalledWith(["gain"], 2.5);
+  });
+
+  it("leaves the display_format:hex path canonicalizing", () => {
+    const { ctx, emitChange } = makeCtx({ rom: "" });
+    const entry = intEntry({ key: "rom", display_format: "hex" });
+    fireInput(renderNumberField(entry, ["rom"], ctx), "118");
+    expect(emitChange).toHaveBeenCalledWith(["rom"], "0x76");
+  });
+});

--- a/test/components/device/render-int-field.test.ts
+++ b/test/components/device/render-int-field.test.ts
@@ -88,6 +88,30 @@ describe("renderNumberField — integer fields accept decimal or hex", () => {
     expect(emitChange).toHaveBeenCalledWith(["address"], "");
   });
 
+  it("mirrors raw keystrokes into the edit buffer (so reformatting doesn't fight the cursor)", () => {
+    const setEditingMagnitude = vi.fn();
+    const ctx = makeRenderCtx(
+      { address: "" },
+      { board: null, overrides: { emitChange: vi.fn(), setEditingMagnitude } }
+    );
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "0042");
+    expect(setEditingMagnitude).toHaveBeenCalledWith(["address"], "0042");
+  });
+
+  it("shows the edit buffer verbatim while it is set, overriding the committed value", () => {
+    const ctx = makeRenderCtx(
+      { address: 42 },
+      { board: null, overrides: { getEditingMagnitude: () => "0042" } }
+    );
+    expect(inputValue(renderNumberField(intEntry(), ["address"], ctx))).toBe("0042");
+  });
+
+  it("keeps a 64-bit decimal as a string (precision past 2^53)", () => {
+    const { ctx, emitChange } = makeCtx({ address: "" });
+    fireInput(renderNumberField(intEntry(), ["address"], ctx), "18446744073709551615");
+    expect(emitChange).toHaveBeenCalledWith(["address"], "18446744073709551615");
+  });
+
   it("keeps the native number input for float fields", () => {
     const { ctx, emitChange } = makeCtx({ gain: "1.5" });
     const entry = makeConfigEntry({

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -97,6 +97,24 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "abc")?.code).toBe("validation.not_a_number");
   });
 
+  it("accepts decimal or hex on a plain INTEGER field, but not forms cv.int_ rejects", () => {
+    const entry = makeEntry({ type: ConfigEntryType.INTEGER });
+    expect(validateEntry(entry, "4369")).toBeNull();
+    expect(validateEntry(entry, "0x1111")).toBeNull();
+    // 1e3 is Number()-valid (1000) but cv.int_ can't parse it — must be flagged.
+    expect(validateEntry(entry, "1e3")?.code).toBe("validation.not_an_integer");
+  });
+
+  it("range-checks a plain INTEGER field with BigInt so 64-bit decimals stay precise", () => {
+    const entry = makeEntry({
+      type: ConfigEntryType.INTEGER,
+      range: [0, 18446744073709551615],
+    });
+    // A value Number() would round to the imprecise bound stays distinguishable.
+    expect(validateEntry(entry, "18446744073709551615")).toBeNull();
+    expect(validateEntry(entry, "-1")?.code).toBe("validation.min");
+  });
+
   it("validates hex-typed INTEGER fields via BigInt (#944 range honesty)", () => {
     // ``Number(String(raw))`` rounds 0xbe030c9794184728 to
     // 0xbe030c9794184800 before the comparison; a precise input would

--- a/test/util/int-input.test.ts
+++ b/test/util/int-input.test.ts
@@ -31,6 +31,15 @@ describe("coerceIntFieldValue", () => {
     expect(coerceIntFieldValue("  4369  ")).toBe(4369);
   });
 
+  it("keeps a 64-bit decimal as a string to preserve precision past 2^53", () => {
+    // cv.uint64_t max; Number() would round it, corrupting the value.
+    expect(coerceIntFieldValue("18446744073709551615")).toBe("18446744073709551615");
+  });
+
+  it("drops leading zeros on a safe int (avoids YAML octal ambiguity)", () => {
+    expect(coerceIntFieldValue("0042")).toBe(42);
+  });
+
   it("passes an existing number through unchanged", () => {
     expect(coerceIntFieldValue(118)).toBe(118);
   });

--- a/test/util/int-input.test.ts
+++ b/test/util/int-input.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { coerceIntFieldValue } from "../../src/util/int-input.js";
+import { coerceIntFieldValue, parseIntInput } from "../../src/util/int-input.js";
 
 describe("coerceIntFieldValue", () => {
   it("turns a bare decimal into a number", () => {
@@ -49,5 +49,29 @@ describe("coerceIntFieldValue", () => {
     expect(coerceIntFieldValue("   ")).toBe("");
     expect(coerceIntFieldValue(null)).toBe("");
     expect(coerceIntFieldValue(undefined)).toBe("");
+  });
+});
+
+describe("parseIntInput", () => {
+  it("parses bare decimal (incl. negative) to a BigInt", () => {
+    expect(parseIntInput("4369")).toBe(4369n);
+    expect(parseIntInput("-5")).toBe(-5n);
+    expect(parseIntInput(118)).toBe(118n);
+  });
+
+  it("parses 0x hex (either case) to a BigInt", () => {
+    expect(parseIntInput("0x1111")).toBe(4369n);
+    expect(parseIntInput("0X2A")).toBe(42n);
+    expect(parseIntInput("0xffffffffffffffff")).toBe(18446744073709551615n);
+  });
+
+  it("rejects forms cv.int_ does not accept", () => {
+    // cv.int_ does int(value, 10) — these all raise there, so they must
+    // not validate clean in the editor either.
+    expect(parseIntInput("1e3")).toBeNull();
+    expect(parseIntInput("1.5")).toBeNull();
+    expect(parseIntInput("zzz")).toBeNull();
+    expect(parseIntInput("-0x5")).toBeNull();
+    expect(parseIntInput("")).toBeNull();
   });
 });

--- a/test/util/int-input.test.ts
+++ b/test/util/int-input.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Pins ``coerceIntFieldValue``: the shared decimal-or-hex normaliser used by
+ * the integer renderer and the add-component coercer. Bare decimal becomes a
+ * number; hex / anything else stays a verbatim string so 0x.. notation
+ * survives (ESPHome's cv.int_ parses it) instead of being canonicalised or
+ * truncated to 0 by parseInt(base 10).
+ */
+import { describe, expect, it } from "vitest";
+
+import { coerceIntFieldValue } from "../../src/util/int-input.js";
+
+describe("coerceIntFieldValue", () => {
+  it("turns a bare decimal into a number", () => {
+    expect(coerceIntFieldValue("434343")).toBe(434343);
+  });
+
+  it("turns a negative decimal into a number", () => {
+    expect(coerceIntFieldValue("-5")).toBe(-5);
+  });
+
+  it("keeps a hex literal verbatim (no canonicalisation, no parseInt truncation)", () => {
+    expect(coerceIntFieldValue("0x1111")).toBe("0x1111");
+    expect(coerceIntFieldValue("0X2A")).toBe("0X2A");
+  });
+
+  it("keeps junk verbatim for the validator to flag", () => {
+    expect(coerceIntFieldValue("zzz")).toBe("zzz");
+  });
+
+  it("trims surrounding whitespace before classifying", () => {
+    expect(coerceIntFieldValue("  4369  ")).toBe(4369);
+  });
+
+  it("passes an existing number through unchanged", () => {
+    expect(coerceIntFieldValue(118)).toBe(118);
+  });
+
+  it("returns empty string for blank / nullish input", () => {
+    expect(coerceIntFieldValue("")).toBe("");
+    expect(coerceIntFieldValue("   ")).toBe("");
+    expect(coerceIntFieldValue(null)).toBe("");
+    expect(coerceIntFieldValue(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In the Visual Editor, integer fields could not be set in hex (for example a modbus_controller register `address: 0x1111`). ESPHome's `cv.int_` accepts both decimal and hex for every integer field, but the editor rendered plain integers with `<input type="number">`, which rejects `0x..` literals. Integers now render as a text input that accepts either form and preserves the user's notation; decimal is emitted as a number so the YAML stays bare, and hex is kept as a verbatim string so `0x..` round-trips. Floats keep the native number input, and the existing `display_format: "hex"` path (i2c / ROM addresses) is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1350

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
