### PR TITLE
Move first-paint state writes to willUpdate

### DIFF
--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -324,9 +324,6 @@ export class ESPHomeCommandPalette extends LitElement {
 
   protected willUpdate(changed: Map<string, unknown>) {
     if (changed.has("_open")) this._escape.set(this._open);
-  }
-
-  protected updated(changed: Map<string, unknown>) {
     if (changed.has("_open") || changed.has("_query")) {
       const items = this._filtered();
       if (items.length && !items.find((i) => i.id === this._selectedId)) {

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -131,10 +131,16 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
 
   private _reloadTimer: ReturnType<typeof setTimeout> | null = null;
 
-  updated(changedProperties: Map<string, unknown>) {
+  willUpdate(changedProperties: Map<string, unknown>) {
+    // _refreshAlternateBoards synchronously resets _alternateBoards before its
+    // await; doing that in willUpdate folds it into the in-progress render
+    // instead of scheduling a second one.
     if (changedProperties.has("board")) {
       this._refreshAlternateBoards();
     }
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
     // Coalesce typing in the YAML editor pane to one
     // `reload()` per debounce window, but bypass the debounce
     // on the empty-to-populated transition (page-load arrival,

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -452,10 +452,10 @@ export class ESPHomeDeviceEditor extends LitElement {
     );
   }
 
-  updated(changed: Map<string, unknown>) {
+  willUpdate(changed: Map<string, unknown>) {
     // Switching device clears the banner until the new file re-lints, so a
     // stale "invalid" never flashes over a freshly-opened valid config.
-    if (changed.has("configuration")) {
+    if (changed.has("configuration") && this._liveErrors.length) {
       this._liveErrors = [];
     }
     if (this._showDiff && changed.has("_showDiffButton") && !this._showDiffButton) {

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -181,7 +181,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   static styles = [espHomeStyles, inputStyles, deviceSectionConfigStyles];
 
-  updated(changedProperties: Map<string, unknown>) {
+  willUpdate(changedProperties: Map<string, unknown>) {
+    // loadConfig synchronously flips _loading/_config/_error; running it in
+    // willUpdate folds those into the in-progress render rather than
+    // scheduling a second one.
     if (
       (changedProperties.has("sectionKey") ||
         changedProperties.has("configuration") ||
@@ -191,6 +194,9 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     ) {
       void loadConfig(this);
     }
+  }
+
+  updated() {
     this._triggerCatalog.ensure();
   }
 


### PR DESCRIPTION
# What does this implement/fix?

On first load of the device editor, four components wrote reactive state from inside `updated()`. That callback runs after the render commits, so on first paint (when every initialized property is in `changedProperties`) each write scheduled a second, wasted render; Lit logged a `change-in-update` warning for each. Moving the first-paint writes into `willUpdate` folds them into the in-progress render, so both the warnings and the extra passes are gone. The DOM-dependent work stays in `updated()`, since `device-board-info` still drives its child editors through `@query` refs that exist only after render.

Verified with a headless before/after: the four warnings (`command-palette`, `device-editor`, `device-board-info`, `device-section-config`) go from one each to zero.

**Related issue or feature (if applicable):**

- N/A; console-only warning, no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
