### PR TITLE
Let the dependency-detour banner flow as inline text

### DIFF
--- a/src/components/device/add-component-dialog.styles.ts
+++ b/src/components/device/add-component-dialog.styles.ts
@@ -19,9 +19,6 @@ export const addComponentDialogStyles = css`
      "add a dependency" mid-way through adding another component.
      Tells them we'll bring them back to the original after. */
   .return-banner {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
     margin-bottom: var(--wa-space-m);
     padding: var(--wa-space-2xs) var(--wa-space-s);
     background: var(--esphome-tint);


### PR DESCRIPTION
# What does this implement/fix?

The "Adding a dependency. We'll bring you back to X after." banner in the add-component dialog rendered poorly when the sentence was wider than the dialog. `.return-banner` was `display: flex`, so the prefix text, the bold component name, and the suffix text each became a separate flex item; instead of wrapping as one sentence, flex-shrink split them into three mis-aligned columns. Dropping the flex (and the `align-items` / `gap` that only applied to it) makes the banner a plain block, so the sentence wraps normally with the name inline. The sibling `.bundle-banner`, which needs flex for its leading icon, is unchanged.

**Related issue or feature (if applicable):**

- N/A; reported from the dashboard, no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
