### PR TITLE
Hide unbuildable dashboards from Known Dashboards

### DIFF
--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -268,15 +268,10 @@ export interface RemoteBuildPeer {
   pin_sha256: string;
   /**
    * Receiver's peer-link Noise WS port from the TXT
-   * `remote_build_port` key, NOT the SRV-advertised dashboard
-   * HTTP port (`port` above). `0` for receivers that haven't
-   * bound the peer-link listener (default-off mode, e.g. an HA
-   * addon); such hosts can't accept builds, so the Known
-   * Dashboards list filters them out and they never render a
-   * discovered row. Rows that do render therefore always carry a
-   * `> 0` port, which the Pair button pre-fills into the wizard so
-   * operators on a non-default `--remote-build-port` don't have to
-   * retype it on every pair.
+   * `remote_build_port` key, NOT the SRV dashboard HTTP `port` above.
+   * `0` when no peer-link listener is bound (default-off, e.g. HA addon);
+   * such hosts can't build, so Known Dashboards filters them out. Rendered
+   * rows always carry a `> 0` port, which the Pair button pre-fills.
    */
   remote_build_port: number;
 }

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -269,9 +269,9 @@ export interface RemoteBuildPeer {
   /**
    * Receiver's peer-link Noise WS port from the TXT
    * `remote_build_port` key, NOT the SRV dashboard HTTP `port` above.
-   * `0` when no peer-link listener is bound (default-off, e.g. HA addon);
-   * such hosts can't build, so Known Dashboards filters them out. Rendered
-   * rows always carry a `> 0` port, which the Pair button pre-fills.
+   * `0` when no peer-link listener is bound (default-off, e.g. HA addon),
+   * i.e. the host can't accept builds. The Send Builds → Known Dashboards
+   * list filters those out; the Pair button there pre-fills a `> 0` port.
    */
   remote_build_port: number;
 }

--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -269,11 +269,14 @@ export interface RemoteBuildPeer {
   /**
    * Receiver's peer-link Noise WS port from the TXT
    * `remote_build_port` key, NOT the SRV-advertised dashboard
-   * HTTP port (`port` above). The discovered-row Pair button
-   * pre-fills this into the wizard so operators on a non-default
-   * `--remote-build-port` don't have to retype it on every pair.
-   * `0` for receivers that haven't bound the peer-link listener
-   * yet; the wizard falls back to its 6055 default in that case.
+   * HTTP port (`port` above). `0` for receivers that haven't
+   * bound the peer-link listener (default-off mode, e.g. an HA
+   * addon); such hosts can't accept builds, so the Known
+   * Dashboards list filters them out and they never render a
+   * discovered row. Rows that do render therefore always carry a
+   * `> 0` port, which the Pair button pre-fills into the wizard so
+   * operators on a non-default `--remote-build-port` don't have to
+   * retype it on every pair.
    */
   remote_build_port: number;
 }

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -312,9 +312,8 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     if (this._discoveredHosts === null) {
       return this._statusRow("settings.remote_build_peers_loading");
     }
-    // remote_build_port === 0 means no peer-link receiver is bound, so the
-    // dashboard can't accept builds (an HA addon advertises this way). Hide it
-    // here: there's nothing to send builds to in this context.
+    // remote_build_port === 0 means no peer-link receiver, so the dashboard
+    // can't accept builds (e.g. an HA addon); hide it from this list.
     const peers = Array.from(this._discoveredHosts.values()).filter(
       (peer) => peer.remote_build_port > 0 && !this._hasPairingFor(peer.hostname)
     );

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -312,8 +312,11 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     if (this._discoveredHosts === null) {
       return this._statusRow("settings.remote_build_peers_loading");
     }
+    // remote_build_port === 0 means no peer-link receiver is bound, so the
+    // dashboard can't accept builds (an HA addon advertises this way). Hide it
+    // here: there's nothing to send builds to in this context.
     const peers = Array.from(this._discoveredHosts.values()).filter(
-      (peer) => !this._hasPairingFor(peer.hostname)
+      (peer) => peer.remote_build_port > 0 && !this._hasPairingFor(peer.hostname)
     );
     if (peers.length === 0) {
       return this._statusRow("settings.remote_build_peers_empty");

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -5,9 +5,10 @@
  * (``remote_build_port === 0``, i.e. no peer-link receiver bound, as an HA
  * addon advertises) and keeps real build servers.
  *
- * Runs in vitest's default ``node`` environment, calling the render method
- * against a faked host with the sibling helpers stubbed to sentinels rather
- * than mounting a DOM.
+ * Uses ``happy-dom`` only so the component module imports: it pulls in
+ * WebAwesome side-effect imports that touch ``CSSStyleSheet`` at load time.
+ * The render call itself never mounts a DOM; the sibling helpers
+ * (``_statusRow`` / ``_renderDiscoveredRow``) are stubbed to plain sentinels.
  */
 import { describe, expect, it } from "vitest";
 import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that ``_renderDiscoveredHosts`` hides dashboards that can't build
+ * (``remote_build_port === 0``, i.e. no peer-link receiver bound, as an HA
+ * addon advertises) and keeps real build servers.
+ *
+ * Runs in vitest's default ``node`` environment, calling the render method
+ * against a faked host with the sibling helpers stubbed to sentinels rather
+ * than mounting a DOM.
+ */
+import { describe, expect, it } from "vitest";
+import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";
+import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
+
+function peer(name: string, remote_build_port: number): RemoteBuildPeer {
+  return {
+    name,
+    hostname: `${name}.local`,
+    port: 6052,
+    source: "mdns",
+    addresses: ["192.168.1.10"],
+    server_version: "0.1.0",
+    esphome_version: "2026.5.0",
+    pin_sha256: remote_build_port > 0 ? "abc" : "",
+    remote_build_port,
+  };
+}
+
+type Row = { row: string };
+
+function makeHost(peers: RemoteBuildPeer[]) {
+  return {
+    _discoveredHosts: new Map(peers.map((p) => [p.name, p])),
+    _hasPairingFor: () => false,
+    _statusRow: (key: string) => ({ status: key }),
+    _renderDiscoveredRow: (p: RemoteBuildPeer): Row => ({ row: p.name }),
+  };
+}
+
+function renderDiscoveredHosts(host: ReturnType<typeof makeHost>): unknown {
+  // Private method; call it against the faked host.
+  const fn = (
+    ESPHomeSettingsBuildOffload.prototype as unknown as Record<string, () => unknown>
+  )._renderDiscoveredHosts;
+  return fn.call(host);
+}
+
+describe("_renderDiscoveredHosts", () => {
+  it("hides dashboards with no peer-link receiver (remote_build_port === 0)", () => {
+    const host = makeHost([peer("addon", 0)]);
+    // Every discovered host filtered out → the empty status row, not rows.
+    expect(renderDiscoveredHosts(host)).toEqual({
+      status: "settings.remote_build_peers_empty",
+    });
+  });
+
+  it("keeps build servers that bound a peer-link receiver", () => {
+    const host = makeHost([peer("buildbox", 6055)]);
+    expect(renderDiscoveredHosts(host)).toEqual([{ row: "buildbox" }]);
+  });
+
+  it("renders only the buildable peers from a mixed set", () => {
+    const host = makeHost([peer("addon", 0), peer("buildbox", 6055)]);
+    expect(renderDiscoveredHosts(host)).toEqual([{ row: "buildbox" }]);
+  });
+});

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -1,14 +1,10 @@
 /**
  * @vitest-environment happy-dom
  *
- * Pins that ``_renderDiscoveredHosts`` hides dashboards that can't build
- * (``remote_build_port === 0``, i.e. no peer-link receiver bound, as an HA
- * addon advertises) and keeps real build servers.
- *
- * Uses ``happy-dom`` only so the component module imports: it pulls in
- * WebAwesome side-effect imports that touch ``CSSStyleSheet`` at load time.
- * The render call itself never mounts a DOM; the sibling helpers
- * (``_statusRow`` / ``_renderDiscoveredRow``) are stubbed to plain sentinels.
+ * Pins that ``_renderDiscoveredHosts`` hides un-buildable dashboards
+ * (``remote_build_port === 0``) and keeps real build servers. ``happy-dom`` is
+ * only for the component import (WebAwesome touches ``CSSStyleSheet`` at load);
+ * the render call uses stubbed sentinels, no DOM.
  */
 import { describe, expect, it } from "vitest";
 import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";


### PR DESCRIPTION
# What does this implement/fix?

Discovered dashboards with no peer-link receiver advertise `remote_build_port` 0 (a Home Assistant addon does this, since the receiver is default off there). They can never act as build servers, yet they appeared in the Send builds "Known Dashboards" list with a Pair button that always fails. This filters them out at render time, so only dashboards that can actually accept builds show up.

The discovered-host data layer is untouched, so the Desktop still receives these dashboards for a future welcome or discovery story; only the send builds list filters them.

Pairs with the backend change that makes the addon discoverable over mDNS: esphome/device-builder#1367

**Related issue or feature (if applicable):**

- No related issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
