### PR TITLE
Hide the green lock for all encrypted devices in compact views

### DIFF
--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -1,6 +1,10 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfiguredDevice } from "../../../api/types/devices.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import {
+  getEncryptionVisual,
+  type EncryptionState,
+} from "../../../util/encryption-state.js";
 import { formatFileSize } from "../../../util/format-file-size.js";
 import { splitIntegrations } from "../../../util/integration-split.js";
 import { buildWebUiUrl } from "../../../util/web-ui-url.js";
@@ -43,38 +47,12 @@ export function renderRow(
 
 export function renderEncryptionBadge(
   localize: LocalizeFunc,
-  state: "active" | "plaintext" | "pending" | "mismatch" | "none"
+  state: EncryptionState
 ): TemplateResult | typeof nothing {
-  const variants = {
-    active: {
-      cls: "status-badge--encrypted",
-      icon: "lock",
-      labelKey: "dashboard.table_status_encrypted",
-      titleKey: "dashboard.table_status_encrypted_tooltip",
-    },
-    plaintext: {
-      cls: "status-badge--unencrypted",
-      icon: "lock-open-variant",
-      labelKey: "dashboard.table_status_unencrypted",
-      titleKey: "dashboard.table_status_unencrypted_tooltip",
-    },
-    pending: {
-      cls: "status-badge--encryption-pending",
-      icon: "lock-clock",
-      labelKey: "dashboard.table_status_encryption_pending",
-      titleKey: "dashboard.table_status_encryption_pending_tooltip",
-    },
-    mismatch: {
-      cls: "status-badge--encryption-mismatch",
-      icon: "lock-alert",
-      labelKey: "dashboard.table_status_encryption_mismatch",
-      titleKey: "dashboard.table_status_encryption_mismatch_tooltip",
-    },
-  } as const;
-  if (state === "none") return nothing;
-  const v = variants[state];
-  return html`<span class="status-badge ${v.cls}" title=${localize(v.titleKey)}>
-    <wa-icon library="mdi" name=${v.icon}></wa-icon>
+  const v = getEncryptionVisual(state);
+  if (!v) return nothing;
+  return html`<span class="status-badge ${v.badgeClass}" title=${localize(v.tooltipKey)}>
+    <wa-icon library="mdi" name=${v.iconName}></wa-icon>
     ${localize(v.labelKey)}
   </span>`;
 }

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -145,13 +145,8 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
       header: localize("dashboard.table_col_name"),
       cell: (info) => {
         const row = info.row.original;
-        // Compact-view variant: hides the green lock for
-        // mDNS-confirmed-encrypted devices (the noisy steady
-        // state on a healthy fleet) but keeps the icon for
-        // every other state, including "waiting / unknown"
-        // when mDNS hasn't broadcast yet. The drawer uses
-        // the full ``getEncryptionVisual`` for single-device
-        // inspection. (issue #141)
+        // Compact view: no lock for encrypted devices, only the
+        // attention states (plaintext / pending / mismatch) get an icon.
         const encVisual = getCompactEncryptionVisual({
           api_enabled: row.api_enabled,
           api_encrypted: row.api_encrypted,

--- a/src/components/device-card/render-bits.ts
+++ b/src/components/device-card/render-bits.ts
@@ -39,10 +39,8 @@ export function renderLabels(card: ESPHomeDeviceCard): TemplateResult | typeof n
   </div>`;
 }
 
-// Compact-view variant: same gate the dashboard table uses, hiding the
-// green lock when mDNS has confirmed encryption (steady state on a healthy
-// fleet) while keeping every other state including "waiting / unknown"
-// visible. (issue #141)
+// Compact view: no lock for encrypted devices, only the attention
+// states (plaintext / pending / mismatch) get an icon.
 export function renderEncryptionIcon(
   card: ESPHomeDeviceCard
 ): TemplateResult | typeof nothing {

--- a/src/util/encryption-state.ts
+++ b/src/util/encryption-state.ts
@@ -94,6 +94,15 @@ export interface EncryptionVisual {
    *  Maps to the ``.encryption-icon.<class>`` rules already in the
    *  card / table styles. */
   cssClass: "secure" | "insecure" | "pending" | "mismatch";
+  /** CSS class on the drawer status badge — the ``.status-badge.<class>``
+   *  rules in the drawer styles. */
+  badgeClass:
+    | "status-badge--encrypted"
+    | "status-badge--unencrypted"
+    | "status-badge--encryption-pending"
+    | "status-badge--encryption-mismatch";
+  /** Localize key for the drawer badge label text. */
+  labelKey: string;
   /** Localize key for the title / aria-label. */
   tooltipKey: string;
 }
@@ -103,24 +112,32 @@ const VISUALS: Record<Exclude<EncryptionState, "none">, EncryptionVisual> = {
     iconName: "lock",
     iconPath: mdiLock,
     cssClass: "secure",
+    badgeClass: "status-badge--encrypted",
+    labelKey: "dashboard.table_status_encrypted",
     tooltipKey: "dashboard.table_status_encrypted_tooltip",
   },
   plaintext: {
     iconName: "lock-open-variant",
     iconPath: mdiLockOpenVariant,
     cssClass: "insecure",
+    badgeClass: "status-badge--unencrypted",
+    labelKey: "dashboard.table_status_unencrypted",
     tooltipKey: "dashboard.table_status_unencrypted_tooltip",
   },
   pending: {
     iconName: "lock-clock",
     iconPath: mdiLockClock,
     cssClass: "pending",
+    badgeClass: "status-badge--encryption-pending",
+    labelKey: "dashboard.table_status_encryption_pending",
     tooltipKey: "dashboard.table_status_encryption_pending_tooltip",
   },
   mismatch: {
     iconName: "lock-alert",
     iconPath: mdiLockAlert,
     cssClass: "mismatch",
+    badgeClass: "status-badge--encryption-mismatch",
+    labelKey: "dashboard.table_status_encryption_mismatch",
     tooltipKey: "dashboard.table_status_encryption_mismatch_tooltip",
   },
 };
@@ -131,20 +148,13 @@ export function getEncryptionVisual(state: EncryptionState): EncryptionVisual | 
 }
 
 /**
- * Compact-view variant of :func:`getEncryptionVisual` for the
- * dashboard table rows and device cards. Returns ``null`` for the
- * confirmed-encrypted-by-mDNS case (truthy ``api_encryption_active``
- * combined with ``"active"`` state) — that's the steady state on
- * a healthy fleet, and repeating a green lock on every row / card
- * drowns out the rows / cards that need attention. The
- * unconfirmed-but-YAML-says-encrypted case (``api_encryption_active``
- * null/undefined) keeps its icon so "waiting / unknown" stays
- * visible. Use the full :func:`getEncryptionVisual` in
- * single-device contexts (drawer / details pane) where confirmation
- * is useful. (issue #141)
+ * Compact-view (table / card) variant of :func:`getEncryptionVisual`:
+ * returns ``null`` for every ``"active"`` device, so only the attention
+ * states (plaintext / pending / mismatch) get an icon. The drawer keeps
+ * the full visual.
  */
 export function getCompactEncryptionVisual(d: EncryptionInputs): EncryptionVisual | null {
   const state = getEncryptionState(d);
-  if (state === "active" && d.api_encryption_active) return null;
+  if (state === "active") return null;
   return getEncryptionVisual(state);
 }

--- a/test/util/encryption-state.test.ts
+++ b/test/util/encryption-state.test.ts
@@ -163,6 +163,8 @@ describe("getEncryptionVisual", () => {
       expect(seen.has(v!.iconName)).toBe(false);
       seen.add(v!.iconName);
       expect(v!.cssClass).toBeTruthy();
+      expect(v!.badgeClass).toMatch(/^status-badge--/);
+      expect(v!.labelKey).toMatch(/^dashboard\./);
       expect(v!.tooltipKey).toMatch(/^dashboard\./);
     }
   });
@@ -179,12 +181,12 @@ describe("getCompactEncryptionVisual", () => {
     ).toBeNull();
   });
 
-  it("keeps the lock when YAML enables encryption but mDNS hasn't broadcast", () => {
-    // active state with null api_encryption_active is the
-    // "waiting / unknown" case the issue explicitly wants visible.
-    const v = getCompactEncryptionVisual(inputs({ api_encryption_active: null }));
-    expect(v).not.toBeNull();
-    expect(v!.cssClass).toBe("secure");
+  it("hides the lock for every active state, including unconfirmed mDNS", () => {
+    // No green lock in compact views at all; the YAML-encrypted but
+    // not-yet-broadcast device is still "active" and stays hidden.
+    expect(
+      getCompactEncryptionVisual(inputs({ api_encryption_active: null }))
+    ).toBeNull();
   });
 
   it("keeps showing the icon for plaintext / pending / mismatch states", () => {


### PR DESCRIPTION
# What does this implement/fix?

The green encryption lock showed in the device detail drawer but not in the device list for confirmed-encrypted devices, so the two views disagreed. The list and the drawer were deriving the lock through separate code paths, and the list only hid the lock for mDNS-confirmed devices; YAML-encrypted-but-unconfirmed ones still showed it, which read as random.

Now the compact views (table rows, cards) hide the lock for every encrypted (active) device, so the list shows only attention states (plaintext, pending, mismatch). The drawer still shows the full encrypted badge for single-device inspection, and it now reads from the same VISUALS source the list uses so the two can't drift apart again.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1369

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
