### PR TITLE
Link YAML search hit titles by configuration, not friendly name

### DIFF
--- a/src/components/dashboard/render-yaml.ts
+++ b/src/components/dashboard/render-yaml.ts
@@ -76,6 +76,7 @@ function renderSnippetBlock(
 
 function renderYamlDeviceTitle(
   configuration: string,
+  label: string,
   trailing: TemplateResult | string,
   body: TemplateResult | string
 ): TemplateResult {
@@ -92,7 +93,7 @@ function renderYamlDeviceTitle(
             e.preventDefault();
             navigate(deviceHref);
           }}
-          >${configuration}</a
+          >${label}</a
         >
         ${trailing}
       </header>
@@ -104,7 +105,9 @@ function renderYamlDeviceTitle(
 function renderYamlTitleList(devices: ConfiguredDevice[]): TemplateResult {
   return html`
     <div class="yaml-hits">
-      ${devices.map((d) => renderYamlDeviceTitle(d.configuration, "", ""))}
+      ${devices.map((d) =>
+        renderYamlDeviceTitle(d.configuration, d.configuration, "", "")
+      )}
     </div>
   `;
 }
@@ -128,7 +131,12 @@ function renderYamlHits(
           >${matchCount} ${countUnit}</span
         >`;
         const body = html`${blocks.map((block) => renderSnippetBlock(hit, block, query))}`;
-        return renderYamlDeviceTitle(yamlHitDeviceLabel(hit), trailing, body);
+        return renderYamlDeviceTitle(
+          hit.configuration,
+          yamlHitDeviceLabel(hit),
+          trailing,
+          body
+        );
       })}
     </div>
   `;

--- a/test/components/dashboard/render-yaml.test.ts
+++ b/test/components/dashboard/render-yaml.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the YAML-search hit header: the title link navigates by
+ * configuration filename (not the friendly label), so opening the editor
+ * from a search hit loads the device instead of an empty editor.
+ */
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { YamlSearchHit } from "../../../src/api/types/devices.js";
+import { renderYamlMode } from "../../../src/components/dashboard/render-yaml.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+function makeHit(): YamlSearchHit {
+  return {
+    configuration: "living_room.yaml",
+    device_name: "living_room",
+    friendly_name: "Living Room",
+    matches: [
+      {
+        line_number: 3,
+        line_text: "  name: living_room",
+        before: ["esphome:"],
+        after: ["  platform: ESP32"],
+      },
+    ],
+  };
+}
+
+function makeHost(hits: YamlSearchHit[]): ESPHomePageDashboard {
+  return {
+    _localize: (k: string) => k,
+    _search: "living",
+    _yamlSearch: { hits },
+  } as unknown as ESPHomePageDashboard;
+}
+
+function renderInto(host: ESPHomePageDashboard): HTMLElement {
+  const container = document.createElement("div");
+  render(renderYamlMode(host), container);
+  return container;
+}
+
+describe("renderYamlMode hit header", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("links the title to the configuration filename, not the friendly label", () => {
+    const container = renderInto(makeHost([makeHit()]));
+    const anchor = container.querySelector<HTMLAnchorElement>(".yaml-hit-group-name");
+    expect(anchor?.getAttribute("href")).toBe("/device/living_room.yaml");
+  });
+
+  it("displays the friendly label as the title text", () => {
+    const container = renderInto(makeHost([makeHit()]));
+    const anchor = container.querySelector<HTMLAnchorElement>(".yaml-hit-group-name");
+    expect(anchor?.textContent?.trim()).toBe("Living Room");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Searching YAML and clicking a result's title opened an empty editor; the title link was navigating by the friendly name instead of the configuration filename. It now navigates by configuration so the editor loads the device, and the friendly name still shows as the heading.

**Related issue or feature (if applicable):**

- part of esphome/backlog#135
- closes https://github.com/esphome/backlog/issues/139

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
