### PR TITLE
Collapse secrets editor split view into a Form/YAML toggle

### DIFF
--- a/src/components/secrets/secrets-structured-editor.styles.ts
+++ b/src/components/secrets/secrets-structured-editor.styles.ts
@@ -6,9 +6,11 @@ export const secretsStructuredEditorStyles = css`
     height: 100%;
     box-sizing: border-box;
     overflow-y: auto;
-    /* This element is the single scroll container for the form pane, so
-       the clearance for the floating Save button has to live here — the
-       wrapping pane never scrolls. */
+    /* Reserve the gutter so the scrollbar clears the row controls. */
+    scrollbar-gutter: stable;
+    /* Sole scroll container for the form pane; owns its padding plus
+       bottom clearance for the floating Save button. */
+    padding: var(--wa-space-m);
     padding-bottom: calc(var(--wa-space-m) * 2 + 2.25rem);
   }
 

--- a/src/components/secrets/secrets-structured-editor.styles.ts
+++ b/src/components/secrets/secrets-structured-editor.styles.ts
@@ -170,30 +170,6 @@ export const secretsStructuredEditorStyles = css`
     margin-top: var(--wa-space-m);
   }
 
-  .add-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 14px;
-    border: var(--wa-border-width-s) dashed var(--esphome-primary);
-    background: var(--esphome-tint);
-    color: var(--esphome-primary);
-    border-radius: var(--wa-border-radius-m);
-    cursor: pointer;
-    font-family: inherit;
-    font-size: var(--wa-font-size-xs);
-    font-weight: var(--wa-font-weight-bold);
-    transition: background 0.12s;
-  }
-
-  .add-btn:hover {
-    background: var(--esphome-tint-strong);
-  }
-
-  .add-btn wa-icon {
-    font-size: 16px;
-  }
-
   .empty {
     padding: var(--wa-space-l) 0;
     color: var(--wa-color-text-quiet);

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -104,7 +104,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
               ${entries.map((entry) => this._renderRow(entry, entries))}
             </div>`}
       <div class="add-row">
-        <button type="button" class="add-btn" @click=${this._openAdd}>
+        <button type="button" class="btn btn--add" @click=${this._openAdd}>
           <wa-icon library="mdi" name="plus"></wa-icon>
           ${this._localize("secrets.add_secret")}
         </button>

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -259,10 +259,11 @@ export class ESPHomePageSecrets extends LitElement {
         border: none;
         background: var(--esphome-primary);
         color: var(--esphome-on-primary);
-        padding: 8px 16px;
+        /* Match the shared .btn size so Save aligns with Add secret. */
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         cursor: pointer;
-        font-size: var(--wa-font-size-xs);
+        font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);
         font-family: inherit;
         box-shadow: var(--esphome-primary-shadow);
@@ -373,10 +374,10 @@ export class ESPHomePageSecrets extends LitElement {
         min-height: 0;
       }
 
-      /* The structured editor is its own scroll container (and owns the
-         Save-button clearance padding), so the pane just frames it. */
+      /* The editor scrolls itself and owns its padding, so its scrollbar
+         sits at the card edge, not over the row controls. */
       .editor-pane--form {
-        padding: var(--wa-space-m);
+        padding: 0;
       }
 
       .editor-layout--yaml .editor-pane--form,

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -1,13 +1,6 @@
 import { consume } from "@lit/context";
-import {
-  mdiContentSave,
-  mdiDockLeft,
-  mdiDockRight,
-  mdiEye,
-  mdiEyeOff,
-  mdiViewSplitHorizontal,
-} from "@mdi/js";
-import { css, html, LitElement, nothing } from "lit";
+import { mdiContentSave, mdiDockLeft, mdiDockRight, mdiEye, mdiEyeOff } from "@mdi/js";
+import { css, html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { apiErrorDetails } from "../api/api-error.js";
@@ -34,15 +27,14 @@ registerMdiIcons({
   "dock-right": mdiDockRight,
   eye: mdiEye,
   "eye-off": mdiEyeOff,
-  "view-split": mdiViewSplitHorizontal,
 });
 
 const SECRETS_FILE = "secrets.yaml";
 
-type SecretsLayout = "form" | "split" | "yaml";
+type SecretsLayout = "form" | "yaml";
 
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
-const LAYOUTS: readonly SecretsLayout[] = ["form", "split", "yaml"];
+const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
 
 @customElement("esphome-page-secrets")
 export class ESPHomePageSecrets extends LitElement {
@@ -71,18 +63,10 @@ export class ESPHomePageSecrets extends LitElement {
   @state()
   private _revealSensitive = false;
 
-  // Persisted form | split | yaml choice; defaults to the structured
-  // form on first visit since raw YAML is beyond many users.
+  // Persisted form | yaml choice; defaults to the structured form on
+  // first visit since raw YAML is beyond many users.
   @state()
   private _layout: SecretsLayout = "form";
-
-  // True below the 900px breakpoint where the split pane collapses to a
-  // single column; drives the effective layout so the toggle's pressed
-  // state matches what's shown when the split button is hidden.
-  @state()
-  private _narrow = false;
-
-  private _narrowMq: MediaQueryList | null = null;
 
   @query("esphome-unsaved-changes-dialog")
   private _unsavedDialog?: ESPHomeUnsavedChangesDialog;
@@ -96,11 +80,6 @@ export class ESPHomePageSecrets extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
     this._layout = this._readStoredLayout();
-    if (typeof window.matchMedia === "function") {
-      this._narrowMq = window.matchMedia("(max-width: 900px)");
-      this._narrow = this._narrowMq.matches;
-      this._narrowMq.addEventListener("change", this._onNarrowChange);
-    }
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
@@ -121,18 +100,7 @@ export class ESPHomePageSecrets extends LitElement {
     localStorage.setItem(LAYOUT_STORAGE_KEY, layout);
   }
 
-  private _onNarrowChange = (e: MediaQueryListEvent) => {
-    this._narrow = e.matches;
-  };
-
-  // Below the breakpoint the split pane collapses to the form, so the
-  // hidden split choice presents as the form for both layout and ARIA.
-  private get _effectiveLayout(): SecretsLayout {
-    return this._narrow && this._layout === "split" ? "form" : this._layout;
-  }
-
   disconnectedCallback() {
-    this._narrowMq?.removeEventListener("change", this._onNarrowChange);
     setLeaveGuard(null);
     window.removeEventListener("beforeunload", this._onBeforeUnload);
     window.removeEventListener("popstate", this._onPopState, { capture: true });
@@ -388,10 +356,6 @@ export class ESPHomePageSecrets extends LitElement {
         gap: 0;
       }
 
-      .editor-layout--split {
-        grid-template-columns: 1fr 1px 1fr;
-      }
-
       .editor-layout--form,
       .editor-layout--yaml {
         grid-template-columns: 1fr;
@@ -420,16 +384,6 @@ export class ESPHomePageSecrets extends LitElement {
         display: none;
       }
 
-      .pane-divider {
-        background: var(--wa-color-surface-border);
-        width: 1px;
-        align-self: stretch;
-      }
-
-      /* Below the breakpoint the split button is hidden; the collapse of
-         the split layout itself is driven by the effective-layout getter
-         in JS (matching the device editor), so no layout rules are
-         duplicated here. */
       @media (max-width: 900px) {
         .page {
           padding-block: var(--wa-space-s);
@@ -439,9 +393,6 @@ export class ESPHomePageSecrets extends LitElement {
         }
         .page-title {
           flex-basis: 100%;
-        }
-        .layout-toggle .split-btn {
-          display: none;
         }
       }
 
@@ -474,7 +425,7 @@ export class ESPHomePageSecrets extends LitElement {
           >
             <button
               type="button"
-              aria-pressed=${this._effectiveLayout === "form"}
+              aria-pressed=${this._layout === "form"}
               aria-label=${this._localize("secrets.layout_form")}
               title=${this._localize("secrets.layout_form")}
               @click=${() => this._setLayout("form")}
@@ -483,17 +434,7 @@ export class ESPHomePageSecrets extends LitElement {
             </button>
             <button
               type="button"
-              class="split-btn"
-              aria-pressed=${this._effectiveLayout === "split"}
-              aria-label=${this._localize("secrets.layout_split")}
-              title=${this._localize("secrets.layout_split")}
-              @click=${() => this._setLayout("split")}
-            >
-              <wa-icon library="mdi" name="view-split"></wa-icon>
-            </button>
-            <button
-              type="button"
-              aria-pressed=${this._effectiveLayout === "yaml"}
+              aria-pressed=${this._layout === "yaml"}
               aria-label=${this._localize("secrets.layout_yaml")}
               title=${this._localize("secrets.layout_yaml")}
               @click=${() => this._setLayout("yaml")}
@@ -530,7 +471,7 @@ export class ESPHomePageSecrets extends LitElement {
                     ? this._localize("secrets.saving")
                     : this._localize("secrets.save")}
                 </button>
-                <div class=${`editor-layout editor-layout--${this._effectiveLayout}`}>
+                <div class=${`editor-layout editor-layout--${this._layout}`}>
                   <div class="editor-pane editor-pane--form">
                     <esphome-secrets-structured-editor
                       .value=${this._yaml}
@@ -538,9 +479,6 @@ export class ESPHomePageSecrets extends LitElement {
                       @yaml-change=${this._onYamlChange}
                     ></esphome-secrets-structured-editor>
                   </div>
-                  ${this._effectiveLayout === "split"
-                    ? html`<div class="pane-divider"></div>`
-                    : nothing}
                   <div class="editor-pane editor-pane--yaml">
                     <esphome-yaml-editor
                       .value=${this._yaml}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1303,7 +1303,6 @@
     "hide_values": "Hide values",
     "layout_label": "Editor layout",
     "layout_form": "Form",
-    "layout_split": "Split",
     "layout_yaml": "YAML",
     "add_secret": "Add secret",
     "key_placeholder": "Name",

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -64,7 +64,7 @@ describe("esphome-secrets-structured-editor", () => {
     const el = await mount("");
     expect(rows(el)).toHaveLength(0);
     expect(el.shadowRoot!.querySelector(".empty")).not.toBeNull();
-    expect(el.shadowRoot!.querySelector(".add-btn")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".add-row .btn--add")).not.toBeNull();
   });
 
   test("the value field is a password input whose reveal follows the prop", async () => {
@@ -133,14 +133,14 @@ describe("esphome-secrets-structured-editor", () => {
   test("Add secret opens the dialog and writes name: value only on confirm", async () => {
     const el = await mount("wifi_ssid: home\n");
     const captured = onChange(el);
-    el.shadowRoot!.querySelector<HTMLButtonElement>(".add-btn")!.click();
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".add-row .btn--add")!.click();
     await el.updateComplete;
     // The dialog is open and nothing has been written yet.
     expect(captured.value).toBeNull();
     const view = el as unknown as AddView;
     view._addName = "api_key";
     view._addValue = "abc";
-    el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--add")!.click();
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".actions .btn--add")!.click();
     expect(captured.value).toBe("wifi_ssid: home\napi_key: abc\n");
   });
 

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -27,11 +27,9 @@ interface PageView {
   _savedYaml: string;
   _saving: boolean;
   _api: ESPHomeAPI;
-  _layout: "form" | "split" | "yaml";
-  _narrow: boolean;
-  readonly _effectiveLayout: "form" | "split" | "yaml";
-  _readStoredLayout(): "form" | "split" | "yaml";
-  _setLayout(layout: "form" | "split" | "yaml"): void;
+  _layout: "form" | "yaml";
+  _readStoredLayout(): "form" | "yaml";
+  _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
   _onUnsavedSave(): void;
@@ -310,8 +308,8 @@ describe("esphome-page-secrets layout persistence", () => {
   });
 
   test("reads a stored valid layout", () => {
-    localStorage.setItem("esphome-secrets-layout", "split");
-    expect(makePage()._readStoredLayout()).toBe("split");
+    localStorage.setItem("esphome-secrets-layout", "yaml");
+    expect(makePage()._readStoredLayout()).toBe("yaml");
   });
 
   test("_setLayout updates state and persists the choice", () => {
@@ -321,20 +319,10 @@ describe("esphome-page-secrets layout persistence", () => {
     expect(localStorage.getItem("esphome-secrets-layout")).toBe("yaml");
   });
 
-  test("a persisted split layout presents as the form below the breakpoint", () => {
-    const page = makePage({ _layout: "split", _narrow: true });
-    expect(page._effectiveLayout).toBe("form");
-  });
-
-  test("split stays split above the breakpoint", () => {
-    const page = makePage({ _layout: "split", _narrow: false });
-    expect(page._effectiveLayout).toBe("split");
-  });
-
   test("both panes bind the same buffer and either change advances it", () => {
     const page = makePage({
       _loaded: true,
-      _layout: "split",
+      _layout: "form",
       _yaml: "wifi_ssid: home\n",
     });
     const editors = findTemplatesByAnchor(


### PR DESCRIPTION
# What does this implement/fix?

Drops the side by side split mode from the secrets editor. The structured form and the YAML editor are now a simple two way toggle, since there is no reason to view both at once. The Add secret button used a dashed outline; it now matches the other filled buttons in the UI.

The YAML editor stays reachable so users can always fall back to editing raw YAML.

There are a few concerns we need to think about.

- We need to make secrets easy to do per device so users can easily follow https://esphome.io/guides/security_best_practices/ which is what the structured editor does. We want them to have a separate encryption key per device, and unique passwords per device so a singled compromised device does not lead to all devices being compromised.

- We will have some very unhappy users if they can't fallback to edits in YAML so ripping out YAML completely will generate some major community push back.


**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/backlog/issues/136

Button adjusted
<img width="837" height="674" alt="Screenshot 2026-06-10 at 10 43 57 AM" src="https://github.com/user-attachments/assets/e90636ae-9e1c-4445-91ce-7a8f6a629ef9" />

Split view dropped as there is no reason they need to see both at once
<img width="841" height="679" alt="Screenshot 2026-06-10 at 10 44 03 AM" src="https://github.com/user-attachments/assets/15a7f85b-8e97-44e0-b606-12233b6ca33c" />


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
