### PR TITLE
Color the table edit pencil as a primary action

### DIFF
--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -306,7 +306,7 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
         // out; the row-end kebab keeps every action reachable.
         return html`<span class="cell-actions">
           <button
-            class="cell-action-btn cell-action-btn--edit"
+            class="cell-action-btn cell-action-btn--accent cell-action-btn--edit"
             aria-label=${localize("dashboard.table_action_edit")}
             title=${localize("dashboard.table_action_edit")}
             ?disabled=${row.busy}

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -39,6 +39,22 @@ function rendered(t: TemplateResult): string {
   );
 }
 
+function renderActionsCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
+  const col = columns.find((c) => "id" in c && c.id === "actions");
+  if (!col?.cell || typeof col.cell !== "function") {
+    throw new Error("no cell renderer for actions column");
+  }
+  const row = {
+    busy: false,
+    hasUpdateAvailable: false,
+    hasPendingChanges: false,
+    _device: { web_port: null },
+    ...rowOverrides,
+  } as unknown as DeviceRow;
+  const info = { row: { original: row } } as unknown as CellContext<DeviceRow, unknown>;
+  return col.cell(info) as TemplateResult;
+}
+
 const DATA_COLUMNS = ["address", "ip", "version", "comment", "area", "mac_address"];
 
 describe("device table empty-cell placeholder (#1038)", () => {
@@ -63,5 +79,12 @@ describe("device table empty-cell placeholder (#1038)", () => {
     const html = rendered(renderCell("ip", "192.168.1.42"));
     expect(html).toContain("cell-mono");
     expect(html).toContain("192.168.1.42");
+  });
+});
+
+describe("device table actions", () => {
+  it("renders the edit pencil with the accent (action) color", () => {
+    const html = rendered(renderActionsCell());
+    expect(html).toContain("cell-action-btn--accent cell-action-btn--edit");
   });
 });

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -1,11 +1,13 @@
 /**
+ * @vitest-environment happy-dom
+ *
  * Pins the #1038 fix: every column renders the same "no data" placeholder
  * (muted proportional em dash), instead of embedding the dash in a
  * column's value font where monospace made it render as a narrow,
  * hyphen-looking glyph. Populated cells keep their own font.
  */
 import type { CellContext } from "@tanstack/lit-table";
-import type { TemplateResult } from "lit";
+import { render, type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
 import {
   createDeviceColumns,
@@ -84,7 +86,10 @@ describe("device table empty-cell placeholder (#1038)", () => {
 
 describe("device table actions", () => {
   it("renders the edit pencil with the accent (action) color", () => {
-    const html = rendered(renderActionsCell());
-    expect(html).toContain("cell-action-btn--accent cell-action-btn--edit");
+    const container = document.createElement("div");
+    render(renderActionsCell(), container);
+    const edit = container.querySelector(".cell-action-btn--edit");
+    expect(edit).not.toBeNull();
+    expect(edit?.classList.contains("cell-action-btn--accent")).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The edit pencil in the table view rendered in the muted secondary color, so it did not read as an actionable control; install and update already use the accent color. This applies the existing accent modifier to the pencil, so every row action shares the same actionable color.

**Related issue or feature (if applicable):**

- fixes esphome/backlog#140

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
