### PR TITLE
Tokenize the shared action-button padding

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -171,7 +171,7 @@ export class ESPHomeAdoptDialog extends LitElement {
       }
 
       .btn {
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -215,7 +215,7 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
       }
 
       .btn {
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -90,7 +90,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
       }
 
       .btn {
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/components/device/add-component-form.styles.ts
+++ b/src/components/device/add-component-form.styles.ts
@@ -133,7 +133,7 @@ export const addComponentFormStyles = css`
     align-items: center;
     justify-content: center;
     gap: 6px;
-    padding: 8px 18px;
+    padding: var(--esphome-button-padding);
     border-radius: var(--wa-border-radius-m);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);

--- a/src/components/device/change-board-dialog.styles.ts
+++ b/src/components/device/change-board-dialog.styles.ts
@@ -86,7 +86,7 @@ export const changeBoardDialogStyles = css`
   }
 
   .btn {
-    padding: 8px 18px;
+    padding: var(--esphome-button-padding);
     border-radius: var(--wa-border-radius-m);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -106,7 +106,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
       }
 
       .btn {
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -63,7 +63,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
       }
 
       .btn {
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -118,7 +118,7 @@ export class ESPHomeSelectBar extends LitElement {
         display: inline-flex;
         align-items: center;
         gap: 6px;
-        padding: 8px 18px;
+        padding: var(--esphome-button-padding);
         border-radius: var(--wa-border-radius-m);
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-bold);

--- a/src/styles/dialog-action-buttons.ts
+++ b/src/styles/dialog-action-buttons.ts
@@ -32,7 +32,7 @@ import { css } from "lit";
  */
 export const dialogActionButtonStyles = css`
   .btn {
-    padding: 8px 18px;
+    padding: var(--esphome-button-padding);
     border-radius: var(--wa-border-radius-m);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);

--- a/src/styles/modal-dialog.ts
+++ b/src/styles/modal-dialog.ts
@@ -100,7 +100,7 @@ export const modalDialogStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 18px;
+    padding: var(--esphome-button-padding);
     border-radius: var(--wa-border-radius-m);
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -64,6 +64,8 @@ export const espHomeStyles = css`
        view-toggle, facet pills, clear-filters) so the search row stays
        pixel-aligned from one source. */
     --esphome-control-height: 36px;
+    /* Shared action-button padding; 18px has no spacing-scale token. */
+    --esphome-button-padding: var(--wa-space-xs) 18px;
 
     font-family: var(--wa-font-family-body);
   }


### PR DESCRIPTION
# What does this implement/fix?

The primary action button padding `8px 18px` was repeated as a literal in the shared `.btn` rules and in every dialog's action row. This adds an `--esphome-button-padding` token and points all of them at it, so the value lives in one place. The 8px reuses `--wa-space-xs`; the 18px has no spacing-scale token, so it stays inline inside the token.

No visual change at the default root font size; the computed padding matches the prior 8px 18px literal. The 8px reuses --wa-space-xs, so under a non-default root font size the vertical axis scales while the 18px stays fixed.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

