### PR TITLE
Group the select-multiple toggle with the device count

### DIFF
--- a/src/components/dashboard/render-toolbar.ts
+++ b/src/components/dashboard/render-toolbar.ts
@@ -150,11 +150,12 @@ export function renderToolbar(
   total: number
 ): TemplateResult {
   // Layout: [search] [view-toggle] [facets…]
-  //         [X devices]                 [Select multiple]
+  //         [X devices] [Select multiple]
   // Select-multiple sits paired with the device-count on its own
   // row — both reference the device list ("operate on these N
-  // devices") so semantically they belong together. Frees the
-  // toolbar-row above for filter-related controls only.
+  // devices") so semantically they belong together, grouped at the
+  // start under the search box. Frees the toolbar-row above for
+  // filter-related controls only.
   return html`
     <div class="toolbar">
       <div class="toolbar-row">

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -48,8 +48,10 @@ export const dashboardStyles = css`
     /* Inter-row gap inside the toolbar. Card view's .toolbar and the
        table view's .toolbar-stack both use it, and the table count
        row mirrors it as padding-top, so the rows line up identically
-       when toggling between views. */
-    --toolbar-row-gap: 2px;
+       when toggling between views. Matches .toolbar-row's wrap
+       row-gap so every stacked toolbar row (search, wrapped Filters,
+       count) shares one even gap when the controls wrap on mobile. */
+    --toolbar-row-gap: var(--wa-space-xs);
   }
 
   /* YAML mode renders over any underlying view, so it shares this

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -274,21 +274,21 @@ export const dashboardStyles = css`
 
   /* Pairs the count with the Select-multiple toggle on a row of
      their own — both reference the device list, so they belong
-     side-by-side. justify-content:space-between puts the count on
-     the left and the toggle on the right at every width. */
+     side-by-side. Grouped at the start so the toggle anchors to the
+     count (and the search box above) in both card and table views
+     rather than floating against the far edge. */
   .device-count-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--wa-space-m);
+    justify-content: flex-start;
+    gap: var(--wa-space-s);
   }
 
   /* Table view slots the device-count-row through esphome-device-
      table's below-controls slot so the row spans the full table
-     width and Select-multiple right-aligns with Columns / Create
-     device in the row above. Horizontal padding matches .controls
-     and .table-wrap above/below so the count and toggle line up
-     with the column headers on the right. 2px top padding mirrors
+     width. Horizontal padding matches .controls and .table-wrap
+     above/below so the count and toggle line up with the leftmost
+     column header and the search box above. 2px top padding mirrors
      card view's .toolbar gap so the inter-row spacing reads
      identically between views. Horizontal padding and top gap draw
      from the shared --content-gutter / --toolbar-row-gap tokens, so

--- a/src/components/dashboard/styles.ts
+++ b/src/components/dashboard/styles.ts
@@ -290,12 +290,12 @@ export const dashboardStyles = css`
      table's below-controls slot so the row spans the full table
      width. Horizontal padding matches .controls and .table-wrap
      above/below so the count and toggle line up with the leftmost
-     column header and the search box above. 2px top padding mirrors
-     card view's .toolbar gap so the inter-row spacing reads
-     identically between views. Horizontal padding and top gap draw
-     from the shared --content-gutter / --toolbar-row-gap tokens, so
-     the count row trims on mobile and lines up with the toolbar
-     above it without a separate @media rule. */
+     column header and the search box above. Top padding draws from
+     --toolbar-row-gap, mirroring card view's .toolbar gap so the
+     inter-row spacing reads identically between views. Horizontal
+     padding and top gap draw from the shared --content-gutter /
+     --toolbar-row-gap tokens, so the count row trims on mobile and
+     lines up with the toolbar above it without a separate @media rule. */
   .table-device-count-row {
     padding: var(--toolbar-row-gap) var(--content-gutter) var(--wa-space-xs);
   }


### PR DESCRIPTION
# What does this implement/fix?

The select-multiple toggle used space-between, so it floated against the far edge of the count row; in card view it sat unanchored opposite the search box, in table view it split across the width away from the count. It is now grouped next to the device count, left-aligned under the search box, so the placement reads the same in card and table views and on mobile.

While reviewing, the toolbar rows also had uneven vertical spacing on mobile; the column gap was 2px while the control-row wrap gap was larger, so the search-to-Filters gap did not match the Filters-to-count gap. Both now share one token, so every stacked toolbar row has an even gap.

Trade-off: grouping the toggle on the left is slightly harder to thumb-reach on mobile than the old far-right spot, but in practice it is minor; the previous layout was worse when the controls reflowed, so it stays grouped for the cleaner, consistent look.

**Related issue or feature (if applicable):**

- fixes esphome/backlog#141

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

## Screenshots


<img width="379" height="670" alt="Screenshot 2026-06-10 at 11 39 04 AM" src="https://github.com/user-attachments/assets/426c56dc-55aa-4f3e-b64a-3418588e1596" />
<img width="1704" height="344" alt="Screenshot 2026-06-10 at 11 39 14 AM" src="https://github.com/user-attachments/assets/a3baaa7b-d97b-46d3-839d-c8ee9d10956b" />
