### PR TITLE
Fix YAML editor auto-indent off-by-one on Enter

### DIFF
--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -19,8 +19,16 @@ import {
 import type { Input, SyntaxNodeRef } from "@lezer/common";
 import { parseMixed } from "@lezer/common";
 import { parser as yamlParser } from "@lezer/yaml";
+import { indentOf, stripComment } from "./yaml-line-walker.js";
 
 const LAMBDA_TAG = "!lambda";
+
+/** Line is a YAML list item: optional indent then ``- ``. */
+const RE_LIST_ITEM = /^ *-\s/;
+/** Trailing-colon block opener (``key:``). */
+const RE_BLOCK_OPENER = /:\s*$/;
+/** Block-scalar header (``key: |-`` / ``key: >+`` / ``lambda: |``). */
+const RE_BLOCK_SCALAR_OPENER = /:\s*[|>][+-]?\s*$/;
 
 /**
  * Single source of truth for ESPHome YAML's indent width. Two
@@ -111,53 +119,47 @@ export const esphomeYamlLanguage = LRLanguage.define({
  * YAML auto-indent service. Mirrors the legacy esphome dashboard's
  * Monaco rule (``beforeText: /:\s*$/`` → ``IndentAction.Indent``)
  * plus list-item continuation handling: pressing Enter under a
- * line that ends with ``:`` opens a child block (indent + 2), and
+ * line that ends with ``:`` opens a child block (indent + step), and
  * continuation lines inside a ``- item`` list are aligned to the
- * dash's content column (``dash + 2``) so siblings of the first
- * key in a list item land at the right depth automatically.
+ * dash's content column (``dash + step``) so siblings of the first
+ * key in a list item land at the right depth automatically (#134).
  *
- * Without this the new editor required the user to manually
- * Tab/space every nested line — a real regression from the
- * legacy editor (issue #134).
- *
- * Walks back over blank lines to find the nearest non-blank
- * predecessor so a stray blank between sections doesn't reset
- * indent to 0.
+ * Honors the simulated line break ``insertNewlineAndIndent`` sets at
+ * ``pos`` (via ``context.lineAt(pos, -1)``), so the reference line is the
+ * one the user is splitting — not the raw ``doc.lineAt(pos)``, which was
+ * one line too high and gave the wrong indent on Enter (#744). Walks back
+ * over blank lines so a stray blank between sections doesn't reset to 0.
  */
 const yamlIndentService = indentService.of((context, pos) => {
   // ``context.unit`` is the editor's configured indent width (the
-  // ``indentUnit`` facet, in columns). Deriving the step from it
-  // means the service tracks any future change to the editor's
-  // indent configuration instead of hard-coding ``+ 2``. The dash
-  // continuation also uses ``unit`` because YAML's ``- key`` is
-  // exactly one indent step deeper than the dash's column.
+  // ``indentUnit`` facet, in columns), so the step tracks any future
+  // change to the indent config instead of hard-coding ``+ 2``. A dash
+  // continuation uses the same unit: YAML's ``- key`` is exactly one step
+  // deeper than the dash's column.
   const step = context.unit;
-  const currentLineNumber = context.state.doc.lineAt(pos).number;
-  for (let n = currentLineNumber - 1; n >= 1; n--) {
-    const text = context.state.doc.line(n).text;
+  // ``lineAt(pos, -1)`` is the content up to the (simulated) break — the
+  // line being split. Anchoring the walk-back here (inclusive) is the
+  // #744 fix.
+  const breakLine = context.lineAt(pos, -1);
+  const startNumber = context.state.doc.lineAt(breakLine.from).number;
+  for (let n = startNumber; n >= 1; n--) {
+    // Start line: break-aware text (before the break). Earlier lines:
+    // their full text.
+    const text = n === startNumber ? breakLine.text : context.state.doc.line(n).text;
     if (!text.trim()) continue;
-    // A line of the form ``  - <something>``: the natural
-    // continuation column is one indent step past the dash's column,
-    // not the dash's leading whitespace. Without this, a
-    // continuation under ``  - platform: gpio`` would land at
-    // column 2 instead of 4.
-    const dashMatch = text.match(/^( *)-\s/);
-    const baseIndent = dashMatch
-      ? dashMatch[1].length + step
-      : (text.match(/^( *)/)?.[1].length ?? 0);
-    // Trailing-colon line opens a child block. Strip a trailing
-    // ``# comment`` first so ``key:  # note`` still triggers
-    // (ESPHome configs sprinkle inline comments freely).
-    const noComment = text.replace(/\s+#.*$/, "");
-    // Two block-opener shapes:
-    //   1. ``key:`` — plain mapping → child indent + step
-    //   2. ``key: |-`` / ``key: >+`` / ``lambda: |`` etc. — YAML
-    //      block-scalar header. The next line is the scalar's
-    //      content, which lives one step deeper than the key.
-    //      Crucial for ESPHome's ``lambda: |-`` and ``!lambda |-``
-    //      patterns, which would otherwise force the user to
-    //      hand-indent every line of C++.
-    if (/:\s*$/.test(noComment) || /:\s*[|>][+-]?\s*$/.test(noComment)) {
+    // A ``  - <something>`` line: the natural continuation column is one
+    // step past the dash's column (e.g. a sibling under
+    // ``  - platform: gpio`` lands at 4, not 2).
+    const baseIndent = RE_LIST_ITEM.test(text) ? indentOf(text) + step : indentOf(text);
+    // Strip a trailing ``# comment`` so ``key:  # note`` still triggers
+    // the block-opener rule (ESPHome configs sprinkle inline comments).
+    const noComment = stripComment(text);
+    // Two block-opener shapes, both opening a child one step deeper:
+    //   1. ``key:`` — plain mapping.
+    //   2. ``key: |-`` / ``key: >+`` / ``lambda: |`` — YAML block-scalar
+    //      header whose next line is the scalar content (ESPHome's
+    //      ``lambda: |-`` / ``!lambda |-`` shape).
+    if (RE_BLOCK_OPENER.test(noComment) || RE_BLOCK_SCALAR_OPENER.test(noComment)) {
       return baseIndent + step;
     }
     return baseIndent;

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -2,6 +2,7 @@ import {
   ensureSyntaxTree,
   foldable,
   getIndentation,
+  IndentContext,
   indentUnit,
 } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
@@ -95,6 +96,49 @@ describe("esphome-yaml indent service", () => {
     expect(indentAt("on_boot:\n  - lambda: |-\n")).toBe(6);
     expect(indentAt("foo:\n  bar: >+\n")).toBe(4);
     expect(indentAt("foo:\n  bar: |\n")).toBe(4);
+  });
+});
+
+/**
+ * Reproduce the real Enter flow: `insertNewlineAndIndent` calls
+ * `getIndentation` with `pos` at the END of the current line plus a
+ * `simulateBreak` there — it does NOT move `pos` to a new empty line. The
+ * `indentAt` helper above masks that by ending the doc in `\n`; this one
+ * pins the actual keypress so the #744 off-by-one can't come back.
+ */
+function indentOnEnter(yaml: string): number | null {
+  const state = EditorState.create({
+    doc: yaml,
+    extensions: [indentUnit.of(ESPHOME_YAML_INDENT), esphomeYaml()],
+  });
+  const pos = state.doc.length; // cursor at the end of the last content line
+  const cx = new IndentContext(state, { simulateBreak: pos });
+  return getIndentation(cx, pos);
+}
+
+describe("esphome-yaml auto-indent on Enter (simulated break)", () => {
+  it("indents +step after a top-level colon", () => {
+    expect(indentOnEnter("wifi:")).toBe(2);
+  });
+
+  it("indents +step under a nested colon", () => {
+    expect(indentOnEnter("wifi:\n  networks:")).toBe(4);
+  });
+
+  it("aligns a continuation under a list-item dash", () => {
+    expect(indentOnEnter("button:\n  - platform: a")).toBe(4);
+  });
+
+  it("combines list-item dash with a trailing colon", () => {
+    expect(indentOnEnter("button:\n  - on_press:")).toBe(6);
+  });
+
+  it("keeps a content line at its sibling indent", () => {
+    expect(indentOnEnter("esphome:\n  name: x")).toBe(2);
+  });
+
+  it("returns 0 after a top-level content line", () => {
+    expect(indentOnEnter("esphome: test")).toBe(0);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

In the YAML editor, pressing Enter at the end of a line ending with `:` indented the next line wrong — jumping to 4 spaces where all generated YAML uses 2, and producing 0 after a top-level `key:`.

**Root cause.** The auto-indent service read its reference line from the raw `doc.lineAt(pos)`, ignoring the simulated line break that CodeMirror's `insertNewlineAndIndent` sets at `pos`. On Enter, the service is called with `pos` at the **end of the current line** (not on a new empty line), so the walk-back started one line too high and took the wrong line's shape. The existing unit tests passed only because they faked the call by ending the doc in `\n`, putting `pos` on a trailing empty line — which masked the off-by-one.

Reproduced live against the running editor:

| Doc (cursor at end) | Expected | Before | After |
| --- | --- | --- | --- |
| `wifi:` | 2 | 0 | 2 |
| `wifi:\n  networks:` | 4 | 2 | 4 |
| `button:\n  - platform: a` | 4 | 2 | 4 |
| `button:\n  - on_press:` | 6 | 4 | 6 |
| `esphome:\n  name: x` | 2 | 2 | 2 |

**Fix.** Anchor the walk-back on `context.lineAt(pos, -1)` (the content up to the break — the line actually being split) and scan inclusive of it. Add `simulateBreak`-based regression tests that exercise the real keypress (5 of them fail on the old code). Also reuse `indentOf` / `stripComment` from `yaml-line-walker` instead of re-inlining the leading-space and comment-strip regexes (the shared `stripComment` additionally preserves `#RRGGBB` literals), and hoist the list-item / block-opener regexes to module constants.

**Related issue or feature (if applicable):**

- fixes #744

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
