### PR TITLE
Fix select-mode checkbox alignment in card view and stacked table

### DIFF
--- a/src/components/dashboard/table-styles.ts
+++ b/src/components/dashboard/table-styles.ts
@@ -465,13 +465,26 @@ export const tableLayoutStyles = css`
       padding: 0;
     }
 
-    /* Select checkbox sits at the top of the card. */
+    /* Select checkbox pins to the card's top-left corner, mirroring
+       the kebab at top-right, instead of stacking as its own
+       full-width row above the title. */
     td.select-col {
-      order: -2;
+      position: absolute;
+      top: var(--wa-space-xs);
+      left: var(--wa-space-xs);
       width: auto;
       min-width: 0;
       max-width: none;
-      justify-content: flex-start;
+      padding: 0;
+    }
+    td.select-col .row-checkbox {
+      width: var(--table-kebab-size);
+      height: var(--table-kebab-size);
+    }
+    /* Reserve title room for the pinned checkbox, matching the
+       kebab reservation on the right. */
+    :host([select-mode]) td.col-name {
+      padding-left: calc(var(--table-kebab-size) + var(--wa-space-xs));
     }
   }
 `;

--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -247,6 +247,12 @@ export const deviceCardStyles = [
       color: var(--wa-color-text-quiet);
       flex-shrink: 0;
       transition: color 0.12s;
+      /* Box the glyph to the title's first-line height so it centers
+         on the device name while the header keeps align-items:
+         flex-start (the status badge stays top-anchored). */
+      display: flex;
+      align-items: center;
+      height: calc(var(--wa-font-size-m) * var(--wa-line-height-normal));
     }
 
     .device-checkbox--checked {


### PR DESCRIPTION
# What does this implement/fix?

In select mode the checkbox was misaligned in both device views:

- **Card view**: the 22px checkbox top-aligned against the two-line name+config block instead of centering on the title line (~2px high). The checkbox glyph now gets a flex box sized to the title's line height (`--wa-font-size-m` × `--wa-line-height-normal`), so it centers exactly on the device name while the header keeps `align-items: flex-start` (status badge stays top-anchored).
- **Table stacked/mobile layout**: `td.select-col` rendered as its own full-width row above the card title, visually detached from everything. It now pins to the card's top-left corner, mirroring the kebab pinned top-right, with the title cell reserving room on the left exactly like the kebab reservation on the right.

Verified empirically (headless Chrome at 1100px and 390px): card checkbox center now matches the title-line center to the pixel; stacked cards show checkbox top-left / kebab top-right flanking the title; desktop table is untouched (rules are scoped to the stacked-layout media query and `:host([select-mode])`).

**Related issue or feature (if applicable):**

- part of esphome/backlog#135 (item 3: select-multiple checkbox misaligned)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
