### PR TITLE
Map the speaker domain to the speaker glyph in navigator rows

### DIFF
--- a/src/components/device/navigator-row-icons.ts
+++ b/src/components/device/navigator-row-icons.ts
@@ -246,6 +246,7 @@ const DOMAIN_ICON: Record<string, readonly [string, string]> = {
   microphone: ["microphone", mdiMicrophone],
   micro_wake_word: ["microphone", mdiMicrophone],
   voice_assistant: ["microphone-message", mdiMicrophoneMessage],
+  speaker: ["speaker", mdiSpeaker],
   dfplayer: ["speaker", mdiSpeaker],
   rtttl: ["speaker", mdiSpeaker],
 

--- a/test/components/device/navigator-row-icons.test.ts
+++ b/test/components/device/navigator-row-icons.test.ts
@@ -82,6 +82,7 @@ describe("iconForDomain", () => {
     expect(iconForDomain("remote_transmitter")).toBe("remote");
     expect(iconForDomain("remote_receiver")).toBe("remote");
     expect(iconForDomain("deep_sleep")).not.toBe("shape-outline");
+    expect(iconForDomain("speaker")).toBe("speaker");
     // Top-level keys that look like platforms but aren't (own YAML block).
     expect(iconForDomain("esp32_camera")).toBe(iconForDomain("camera"));
     expect(iconForDomain("syslog")).toBe(iconForDomain("logger"));


### PR DESCRIPTION
# What does this implement/fix?

A configured speaker platform block (for example the I²S Audio Speaker, `speaker.i2s_audio`) showed the neutral shape-outline fallback in the device navigator instead of an audio glyph. Its YAML domain is `speaker`, which had no `DOMAIN_ICON` entry, so it fell through to the fallback; `i2s_audio` and `media_player` were already mapped, which is why neighbouring rows looked fine. Add a `speaker` entry pointing at the speaker glyph already used by `media_player` / `dfplayer` / `rtttl`. Surfaced while verifying the speaker media player fix.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
