### PR TITLE
Extract a shared visit Web UI link renderer

### DIFF
--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -9,7 +9,7 @@ import { formatFileSize } from "../../../util/format-file-size.js";
 import { splitIntegrations } from "../../../util/integration-split.js";
 import { buildWebUiUrlForHost } from "../../../util/web-ui-url.js";
 import type { ESPHomeDeviceDrawerContent } from "../device-drawer-content.js";
-import { renderIpValue } from "../device-drawer-render.js";
+import { renderAddressValue } from "../device-drawer-render.js";
 
 // Whitelist docs URLs to https://esphome.io. The map is backend-populated;
 // a compromised entry interpolating a javascript: / data: scheme would run
@@ -234,7 +234,7 @@ export function renderHostnameRow(
       </div>
       <div class="content">
         <div class="label">${host._localize("dashboard.drawer_hostname")}</div>
-        ${renderIpValue(
+        ${renderAddressValue(
           d.address,
           buildWebUiUrlForHost(d.address, d.web_port),
           host._localize
@@ -266,7 +266,7 @@ export function renderIpAddressRow(
         </div>
         <div class="content">
           <div class="label">${label}</div>
-          ${renderIpValue(
+          ${renderAddressValue(
             primary,
             buildWebUiUrlForHost(primary, d.web_port),
             host._localize
@@ -284,7 +284,7 @@ export function renderIpAddressRow(
       </div>
       <div class="content">
         <div class="label">${label}</div>
-        ${renderIpValue(
+        ${renderAddressValue(
           list[0],
           buildWebUiUrlForHost(list[0], d.web_port),
           host._localize
@@ -293,7 +293,11 @@ export function renderIpAddressRow(
           ? list
               .slice(1)
               .map((ip) =>
-                renderIpValue(ip, buildWebUiUrlForHost(ip, d.web_port), host._localize)
+                renderAddressValue(
+                  ip,
+                  buildWebUiUrlForHost(ip, d.web_port),
+                  host._localize
+                )
               )
           : nothing}
         <button

--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -96,17 +96,17 @@ export const deviceDrawerContentStyles = css`
     font-size: 14px;
   }
 
-  .ip-value {
+  .address-value {
     display: inline-flex;
     align-items: center;
     gap: var(--wa-space-xs);
     max-width: 100%;
   }
-  .ip-value-text {
+  .address-value-text {
     min-width: 0;
     overflow-wrap: anywhere;
   }
-  .ip-visit-link {
+  .address-visit-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -120,16 +120,16 @@ export const deviceDrawerContentStyles = css`
       background 0.12s,
       color 0.12s;
   }
-  .ip-visit-link:hover {
+  .address-visit-link:hover {
     background: var(--wa-color-surface-lowered);
     color: var(--esphome-primary);
   }
-  .ip-visit-link:focus-visible {
+  .address-visit-link:focus-visible {
     outline: 2px solid var(--esphome-primary);
     outline-offset: 2px;
     color: var(--esphome-primary);
   }
-  .ip-visit-link wa-icon {
+  .address-visit-link wa-icon {
     font-size: 14px;
   }
 

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -10,40 +10,28 @@
  */
 import { html, nothing } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 
 /**
- * Render the primary IP cell, optionally suffixed with a "Visit web UI"
- * icon-link.
+ * Render a hostname or IP value cell, optionally suffixed with a
+ * "Visit web UI" icon-link.
  *
- * *url* is the precomputed ``buildWebUiUrl`` result for the device —
- * passed in (rather than recomputed) so the empty-IP guard in the
+ * *url* is the precomputed ``buildWebUiUrl`` result for the host —
+ * passed in (rather than recomputed) so the empty-value guard in the
  * caller and this render share a single URL parse. An empty *url*
- * suppresses the link, mirroring the original "no link" branch.
- * Pass an empty *ip* to render the ``—`` placeholder alongside the
- * link; used in the "no resolved IPs yet but ``device.address`` is
- * known" branch so the visit affordance isn't gated on the first
- * mDNS A-record.
+ * suppresses the link. Pass an empty *value* to render the ``—``
+ * placeholder alongside the link.
  */
-export function renderIpValue(ip: string, url: string, localize: LocalizeFunc) {
-  const isPlaceholder = !ip;
-  const display = ip || "—";
+export function renderAddressValue(value: string, url: string, localize: LocalizeFunc) {
+  const isPlaceholder = !value;
+  const display = value || "—";
   if (!url) {
     return html`<div class="value mono ${isPlaceholder ? "muted" : ""}">${display}</div>`;
   }
-  const visitLabel = localize("dashboard.action_visit_web_ui");
   return html`
-    <div class="value mono ip-value ${isPlaceholder ? "muted" : ""}">
-      <span class="ip-value-text">${display}</span>
-      <a
-        class="ip-visit-link"
-        href=${url}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label=${visitLabel}
-        title=${visitLabel}
-      >
-        <wa-icon library="mdi" name="open-in-new"></wa-icon>
-      </a>
+    <div class="value mono address-value ${isPlaceholder ? "muted" : ""}">
+      <span class="address-value-text">${display}</span>
+      ${renderVisitWebUiLink(url, localize, { className: "address-visit-link" })}
     </div>
   `;
 }

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -9,6 +9,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
+import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
 export interface DeviceRow {
@@ -340,17 +341,10 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             <wa-icon library="mdi" name="text-box-outline"></wa-icon>
           </button>
           ${showVisit
-            ? html`<a
-                class="cell-action-btn cell-action-btn--visit-web"
-                href=${visitUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label=${localize("dashboard.action_visit_web_ui")}
-                title=${localize("dashboard.action_visit_web_ui")}
-                @click=${(e: Event) => e.stopPropagation()}
-              >
-                <wa-icon library="mdi" name="open-in-new"></wa-icon>
-              </a>`
+            ? renderVisitWebUiLink(visitUrl, localize, {
+                className: "cell-action-btn cell-action-btn--visit-web",
+                onClick: (e) => e.stopPropagation(),
+              })
             : nothing}
         </span>`;
       },

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -24,6 +24,7 @@ import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -399,23 +400,11 @@ export class ESPHomeTableRowMenu extends LitElement {
     if (this.device == null) return nothing;
     const url = buildWebUiUrl(this.device);
     if (!url) return nothing;
-    // Anchor element with ``rel="noopener noreferrer"`` is the
-    // codebase's standard external-link pattern; the browser enforces
-    // the security defaults instead of relying on
-    // ``window.open(..., "noopener")`` which doesn't suppress the
-    // Referer header and isn't honoured uniformly across browsers.
-    return html`
-      <a
-        class="menu-item menu-item--link menu-item--visit-web"
-        href=${url}
-        target="_blank"
-        rel="noopener noreferrer"
-        @click=${this._close}
-      >
-        <wa-icon library="mdi" name="open-in-new"></wa-icon>
-        ${this._localize("dashboard.action_visit_web_ui")}
-      </a>
-    `;
+    return renderVisitWebUiLink(url, this._localize, {
+      className: "menu-item menu-item--link menu-item--visit-web",
+      onClick: this._close,
+      withLabel: true,
+    });
   }
 }
 

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -28,6 +28,7 @@ import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
   renderEncryptionIcon,
@@ -211,17 +212,10 @@ export class ESPHomeDeviceCard extends LitElement {
                   <wa-icon library="mdi" name="text-box-outline"></wa-icon>
                 </button>
                 ${this.webUrl
-                  ? html`<a
-                      class="action-btn action-btn--ghost action-btn--tile"
-                      href=${this.webUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label=${this._localize("dashboard.action_visit_web_ui")}
-                      title=${this._localize("dashboard.action_visit_web_ui")}
-                      @click=${(e: Event) => e.stopPropagation()}
-                    >
-                      <wa-icon library="mdi" name="open-in-new"></wa-icon>
-                    </a>`
+                  ? renderVisitWebUiLink(this.webUrl, this._localize, {
+                      className: "action-btn action-btn--ghost action-btn--tile",
+                      onClick: (e) => e.stopPropagation(),
+                    })
                   : nothing}
                 <button
                   class="action-btn action-btn--ghost action-btn--icon-only"

--- a/src/components/discovered-device-card.ts
+++ b/src/components/discovered-device-card.ts
@@ -7,6 +7,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { safeWebUiUrl } from "../util/web-ui-url.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -286,17 +287,10 @@ export class ESPHomeDiscoveredDeviceCard extends LitElement {
                 </button>
               `}
           ${safeWebUrl && !this.compact
-            ? html`<a
-                class="btn btn--ghost btn--icon"
-                href=${safeWebUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                title=${this._localize("dashboard.action_visit_web_ui")}
-                aria-label=${this._localize("dashboard.action_visit_web_ui")}
-                @click=${(e: Event) => e.stopPropagation()}
-              >
-                <wa-icon library="mdi" name="open-in-new"></wa-icon>
-              </a>`
+            ? renderVisitWebUiLink(safeWebUrl, this._localize, {
+                className: "btn btn--ghost btn--icon",
+                onClick: (e) => e.stopPropagation(),
+              })
             : nothing}
           <button
             class="btn btn--ghost"

--- a/src/util/visit-web-ui-link.ts
+++ b/src/util/visit-web-ui-link.ts
@@ -1,0 +1,42 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { LocalizeFunc } from "../common/localize.js";
+
+export interface VisitWebUiLinkOptions {
+  /** Per-site class on the anchor; styling stays with each call site. */
+  className: string;
+  onClick?: (e: Event) => void;
+  /** Render the label as visible text (menu item) instead of an icon-only
+   *  link carrying it on aria-label/title. */
+  withLabel?: boolean;
+}
+
+/**
+ * Single source of truth for the "open the device web UI" anchor.
+ *
+ * Centralizes the ``target="_blank"`` + ``rel="noopener noreferrer"`` security
+ * pair so a new call site can't drift from it. *url* is a pre-built
+ * ``buildWebUiUrl`` result; callers gate on its truthiness.
+ */
+export function renderVisitWebUiLink(
+  url: string,
+  localize: LocalizeFunc,
+  options: VisitWebUiLinkOptions
+): TemplateResult {
+  const label = localize("dashboard.action_visit_web_ui");
+  // A visible-label menu item carries the text itself, so drop the
+  // redundant aria/title there (``nothing`` removes the attribute).
+  const a11yLabel = options.withLabel ? nothing : label;
+  return html`<a
+    class=${options.className}
+    href=${url}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label=${a11yLabel}
+    title=${a11yLabel}
+    @click=${options.onClick}
+  >
+    <wa-icon library="mdi" name="open-in-new"></wa-icon>${options.withLabel
+      ? html` ${label}`
+      : nothing}
+  </a>`;
+}

--- a/test/components/dashboard/render-address-value.test.ts
+++ b/test/components/dashboard/render-address-value.test.ts
@@ -1,14 +1,10 @@
 /**
- * Tests for the drawer's IP-value renderer.
+ * Tests for the drawer's address-value renderer (Hostname + IP rows).
  *
- * The renderer is the helper behind the IP Address row in the
- * device drawer's "Network" section: it stamps the IP text and,
- * when ``buildWebUiUrl`` produced a URL for the device, an
- * ``open-in-new`` icon-link to the device's web UI. The empty-IP
- * branch is the interesting one — the affordance has to render
- * even before the first resolved A-record arrives so a freshly-
- * adopted device with only a YAML mDNS hostname (``device.address``)
- * still gets a visit link.
+ * It stamps the host text and, when ``buildWebUiUrl`` produced a URL,
+ * the shared ``open-in-new`` visit link. The empty-value branch is the
+ * interesting one: the placeholder renders alongside the link so the
+ * affordance isn't gated on the first resolved value.
  *
  * Vitest runs in the ``node`` environment so we don't mount Lit;
  * the existing template-walker (``test/_lit-template-walker.ts``)
@@ -17,7 +13,7 @@
  * placeholder text — without a DOM.
  */
 import { describe, expect, it } from "vitest";
-import { renderIpValue } from "../../../src/components/dashboard/device-drawer-render.js";
+import { renderAddressValue } from "../../../src/components/dashboard/device-drawer-render.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
@@ -25,11 +21,11 @@ import {
 
 const _identityLocalize: (key: string) => string = (key) => key;
 
-describe("renderIpValue", () => {
+describe("renderAddressValue", () => {
   it("omits the visit link when url is empty", () => {
-    const result = renderIpValue("192.168.1.42", "", _identityLocalize);
+    const result = renderAddressValue("192.168.1.42", "", _identityLocalize);
     expect(findTemplatesByAnchor(result, "<a").length).toBe(0);
-    expect(findTemplatesByAnchor(result, "ip-visit-link").length).toBe(0);
+    expect(findTemplatesByAnchor(result, "address-visit-link").length).toBe(0);
     // Still emits the IP value cell.
     const valueCells = findTemplatesByAnchor(result, "value mono");
     expect(valueCells.length).toBeGreaterThan(0);
@@ -37,7 +33,7 @@ describe("renderIpValue", () => {
 
   it("renders the visit-web link when url is set", () => {
     const url = "http://kitchen.local";
-    const result = renderIpValue("192.168.1.42", url, _identityLocalize);
+    const result = renderAddressValue("192.168.1.42", url, _identityLocalize);
     const anchors = findTemplatesByAnchor(result, "<a");
     expect(anchors.length).toBe(1);
     const bindings = extractAttributeBindings(anchors[0]);
@@ -53,7 +49,7 @@ describe("renderIpValue", () => {
   it("uses the localised visit-web label for aria-label and title", () => {
     const localize = (key: string): string =>
       key === "dashboard.action_visit_web_ui" ? "Visit web UI" : key;
-    const result = renderIpValue("192.168.1.42", "http://kitchen.local", localize);
+    const result = renderAddressValue("192.168.1.42", "http://kitchen.local", localize);
     const [anchor] = findTemplatesByAnchor(result, "<a");
     const bindings = extractAttributeBindings(anchor);
     expect(bindings["aria-label"]).toBe("Visit web UI");
@@ -62,14 +58,14 @@ describe("renderIpValue", () => {
 
   it("renders the em-dash placeholder when ip is empty", () => {
     // No URL: render the bare placeholder cell with the muted class.
-    const noUrl = renderIpValue("", "", _identityLocalize);
+    const noUrl = renderAddressValue("", "", _identityLocalize);
     const noUrlValues = noUrl.values.flat(Infinity);
     expect(noUrlValues).toContain("—");
 
     // With URL: still render the placeholder, plus the visit link
     // alongside it so the affordance isn't blocked on the first
     // mDNS A-record.
-    const withUrl = renderIpValue("", "http://kitchen.local", _identityLocalize);
+    const withUrl = renderAddressValue("", "http://kitchen.local", _identityLocalize);
     const withUrlValues = withUrl.values.flat(Infinity);
     expect(withUrlValues).toContain("—");
     expect(findTemplatesByAnchor(withUrl, "<a").length).toBe(1);
@@ -79,10 +75,10 @@ describe("renderIpValue", () => {
     // The class string is built via ``class="value mono ${expr}"``,
     // so ``muted`` lives in ``values`` (an empty string when
     // populated; ``"muted"`` when the placeholder is rendering).
-    const placeholder = renderIpValue("", "", _identityLocalize);
+    const placeholder = renderAddressValue("", "", _identityLocalize);
     expect(placeholder.values).toContain("muted");
 
-    const populated = renderIpValue("192.168.1.42", "", _identityLocalize);
+    const populated = renderAddressValue("192.168.1.42", "", _identityLocalize);
     expect(populated.values).not.toContain("muted");
   });
 });

--- a/test/components/dashboard/render-ip-address-row.test.ts
+++ b/test/components/dashboard/render-ip-address-row.test.ts
@@ -26,7 +26,7 @@ describe("renderIpAddressRow", () => {
       _host,
       _device({ web_port: 80, ip: "10.0.0.5", ip_addresses: [] })
     );
-    const valueText = findTemplatesByAnchor(result, "ip-value-text");
+    const valueText = findTemplatesByAnchor(result, "address-value-text");
     expect(valueText.flatMap((t) => t.values)).toContain("10.0.0.5");
     expect(hrefs(result)).toEqual(["http://10.0.0.5"]);
   });

--- a/test/util/render-visit-web-ui-link.test.ts
+++ b/test/util/render-visit-web-ui-link.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pins the shared visit-Web-UI anchor: the target=_blank + rel=noopener
+ * Pins the shared visit-Web-UI anchor: the target="_blank" + rel="noopener noreferrer"
  * security pair, the open-in-new glyph, the passed class/href/onClick, and
  * the icon-only (aria/title) vs withLabel (visible text, no aria) shapes.
  */

--- a/test/util/render-visit-web-ui-link.test.ts
+++ b/test/util/render-visit-web-ui-link.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Pins the shared visit-Web-UI anchor: the target=_blank + rel=noopener
+ * security pair, the open-in-new glyph, the passed class/href/onClick, and
+ * the icon-only (aria/title) vs withLabel (visible text, no aria) shapes.
+ */
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderVisitWebUiLink } from "../../src/util/visit-web-ui-link.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+  visitTemplates,
+} from "../_lit-template-walker.js";
+
+const _localize = (key: string) =>
+  key === "dashboard.action_visit_web_ui" ? "Visit web UI" : key;
+
+const anchorOf = (result: ReturnType<typeof renderVisitWebUiLink>) =>
+  findTemplatesByAnchor(result, "<a")[0];
+
+describe("renderVisitWebUiLink", () => {
+  it("enforces the external-link security pair and open-in-new glyph", () => {
+    const result = renderVisitWebUiLink("http://kitchen.local", _localize, {
+      className: "x",
+    });
+    const anchor = anchorOf(result);
+    const staticText = anchor.strings.join("§");
+    expect(staticText).toContain('target="_blank"');
+    expect(staticText).toContain('rel="noopener noreferrer"');
+    expect(findTemplatesByAnchor(result, "open-in-new").length).toBe(1);
+  });
+
+  it("binds the passed class, href, and click handler", () => {
+    const onClick = () => {};
+    const result = renderVisitWebUiLink("http://kitchen.local:8080", _localize, {
+      className: "menu-item menu-item--link",
+      onClick,
+    });
+    const b = extractAttributeBindings(anchorOf(result));
+    expect(b.class).toBe("menu-item menu-item--link");
+    expect(b.href).toBe("http://kitchen.local:8080");
+    expect(b["@click"]).toBe(onClick);
+  });
+
+  it("icon-only mode labels via aria-label and title", () => {
+    const b = extractAttributeBindings(
+      anchorOf(renderVisitWebUiLink("http://k.local", _localize, { className: "x" }))
+    );
+    expect(b["aria-label"]).toBe("Visit web UI");
+    expect(b.title).toBe("Visit web UI");
+  });
+
+  it("withLabel mode drops aria/title and renders visible text", () => {
+    const result = renderVisitWebUiLink("http://k.local", _localize, {
+      className: "x",
+      withLabel: true,
+    });
+    const b = extractAttributeBindings(anchorOf(result));
+    expect(b["aria-label"]).toBe(nothing);
+    expect(b.title).toBe(nothing);
+    const allValues: unknown[] = [];
+    visitTemplates(result, (t) => allValues.push(...t.values));
+    expect(allValues).toContain("Visit web UI");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

DRY follow-up to #757; no behavior change.

The "open Web UI" anchor was hand-rolled in five places (drawer hostname/IP rows,
table action cell, device card, discovered-device card, table row menu), each
repeating the `target="_blank"` + `rel="noopener noreferrer"` security pair, the
`action_visit_web_ui` aria/title, and the `open-in-new` glyph. This extracts one
`renderVisitWebUiLink` helper (`src/util/visit-web-ui-link.ts`) that every site
now calls, so the security pair can't drift from a new call site.

It also renames the drawer value renderer that #757 made serve the hostname row;
`renderIpValue` becomes `renderAddressValue` and its `.ip-value` / `.ip-value-text`
/ `.ip-visit-link` classes become `.address-*`, since they are no longer IP only.

Each anchor renders the same DOM as before; the renamed and new tests pin the
shapes, and a browser check confirmed the drawer is unchanged.

**Related issue or feature (if applicable):**

- n/a; follows up #757

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
