### PR TITLE
Show a Publish button in the install dialog

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -24,6 +24,9 @@ export interface ConfiguredDevice {
    *  declare one. Surfaced in the drawer and as an opt-in table
    *  column. */
   area: string;
+  /** True when ``esphome.publish_shell_command`` is set in the YAML — the
+   *  install dialog should offer a "Publish" option. */
+  has_publish_command: boolean;
   board_id: string;
   target_platform: string;
   /** mDNS hostname from StorageJSON (e.g. "my_device.local"). */

--- a/src/components/dashboard/install.ts
+++ b/src/components/dashboard/install.ts
@@ -29,6 +29,8 @@ export function onInstallMethodSelect(
     openCommand(host, device, "install", port ?? "OTA");
   } else if (method === "server-serial") {
     openCommand(host, device, "install", port!);
+  } else if (method === "publish") {
+    openCommand(host, device, "install", "PUBLISH");
   } else if (method === "web-serial") {
     host._firmwareDialog.installWebSerial(device);
   } else if (method === "web-download") {

--- a/src/components/dashboard/render-dialogs.ts
+++ b/src/components/dashboard/render-dialogs.ts
@@ -185,6 +185,7 @@ export function renderDialogs(host: ESPHomePageDashboard): TemplateResult {
     <esphome-logs-dialog></esphome-logs-dialog>
     <esphome-install-method-dialog
       ?open=${host._installMethodOpen}
+      .hasPublishCommand=${host._installMethodDevice?.has_publish_command ?? false}
       .deviceState=${host._installMethodDevice?.state ?? DeviceState.UNKNOWN}
       .deviceTargetPlatform=${host._installMethodDevice?.target_platform ?? ""}
       .deviceCurrentAddress=${host._installMethodDevice?.ip ||

--- a/src/components/device/device-install-controller.ts
+++ b/src/components/device/device-install-controller.ts
@@ -37,6 +37,10 @@ export class DeviceInstallController implements ReactiveController {
     return this._host.device?.ip || this._host.device?.address || "";
   }
 
+  get hasPublishCommand(): boolean {
+    return this._host.device?.has_publish_command ?? false;
+  }
+
   /** "Install" entry point — opens the install-method picker. */
   onInstall = () => {
     if (!this._host.device) return;
@@ -70,6 +74,8 @@ export class DeviceInstallController implements ReactiveController {
       this._openCommand(device, "install", port ?? "OTA");
     } else if (method === "server-serial") {
       this._openCommand(device, "install", port!);
+    } else if (method === "publish") {
+      this._openCommand(device, "install", "PUBLISH");
     } else if (method === "web-serial") {
       this._host.firmwareDialog?.installWebSerial(device);
     } else if (method === "web-download") {

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -7,6 +7,7 @@ import {
   mdiCloudDownload,
   mdiDownload,
   mdiIpNetworkOutline,
+  mdiPublish,
   mdiSerialPort,
   mdiUsb,
   mdiWifi,
@@ -45,6 +46,7 @@ registerMdiIcons({
   "cloud-download": mdiCloudDownload,
   download: mdiDownload,
   "ip-network-outline": mdiIpNetworkOutline,
+  publish: mdiPublish,
 });
 
 type DialogView = "method" | "port-select";
@@ -66,6 +68,9 @@ export class ESPHomeInstallMethodDialog extends LitElement {
 
   @property()
   deviceTargetPlatform = "";
+
+  @property({ type: Boolean })
+  hasPublishCommand = false;
 
   @property()
   mode: "install" | "logs" = "install";
@@ -209,6 +214,9 @@ export class ESPHomeInstallMethodDialog extends LitElement {
                 <span class="desc">${this._localize(serverSerialKeys.desc)}</span>
               </div>
             </div>`
+          : nothing}
+        ${this.hasPublishCommand && this.mode === "install"
+          ? this._renderPublishOption()
           : nothing}
       </div>
       ${this._renderAdvancedSection()}
@@ -570,6 +578,20 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     if (!port || port === "OTA") return;
     this._selectMethod("ota", port);
   };
+
+  private _renderPublishOption() {
+    return html`
+      <div class="option" @click=${() => this._selectMethod("publish")}>
+        <wa-icon library="mdi" name="publish"></wa-icon>
+        <div class="info">
+          <span class="title">${this._localize("dashboard.install_method_publish")}</span>
+          <span class="desc"
+            >${this._localize("dashboard.install_method_publish_desc")}</span
+          >
+        </div>
+      </div>
+    `;
+  }
 
   private async _onServerSerial() {
     this._view = "port-select";

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -966,6 +966,7 @@ export class ESPHomePageDevice extends LitElement {
       <esphome-logs-dialog></esphome-logs-dialog>
       <esphome-install-method-dialog
         ?open=${this._installCtrl.installMethodOpen}
+        .hasPublishCommand=${this._installCtrl.hasPublishCommand}
         .deviceState=${this._installCtrl.deviceState}
         .deviceTargetPlatform=${this._installCtrl.deviceTargetPlatform}
         .deviceCurrentAddress=${this._installCtrl.deviceCurrentAddress}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -190,6 +190,8 @@
     "install_method_web_download_desc": "Requires a browser with Web Serial support (e.g. Chrome)",
     "install_method_manual_download": "Download firmware binary",
     "install_method_manual_download_desc": "Compile here and download the binary, then flash it manually with your preferred tool",
+    "install_method_publish": "Publish",
+    "install_method_publish_desc": "Run the configured publish command on the server",
     "install": "Install",
     "install_method_select_port": "Select a serial port",
     "install_method_no_ports": "No serial ports found. Make sure the device is connected to the server.",

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -42,6 +42,7 @@ const _BASE = {
   deployed_config_hash: "",
   has_pending_changes: false,
   update_available: false,
+  has_publish_command: false,
   api_enabled: false,
   api_encrypted: false,
   api_encryption_active: null,

--- a/test/components/install-method-dialog-publish-option.test.ts
+++ b/test/components/install-method-dialog-publish-option.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the Publish option visibility rules in the install-method dialog.
+ * The option appears only when ``hasPublishCommand`` is true and the dialog
+ * is in ``install`` mode; it stays hidden in ``logs`` mode even when the
+ * command is configured, and clicking it fires ``select-method`` with
+ * ``method: "publish"``.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { DeviceState } from "../../src/api/types/devices.js";
+import { defaultLocalize } from "../../src/common/localize.js";
+import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(opts: {
+  hasPublishCommand: boolean;
+  mode?: "install" | "logs";
+}): Promise<ESPHomeInstallMethodDialog> {
+  const dialog = new ESPHomeInstallMethodDialog();
+  (dialog as any)._localize = defaultLocalize;
+  (dialog as any)._api = {};
+  dialog.deviceState = DeviceState.ONLINE;
+  dialog.hasPublishCommand = opts.hasPublishCommand;
+  dialog.mode = opts.mode ?? "install";
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  return dialog;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const publishOption = (d: ESPHomeInstallMethodDialog): Element | null => {
+  const titles = d.shadowRoot?.querySelectorAll(".option .title") ?? [];
+  const titleEl = Array.from(titles).find((el) => el.textContent?.trim() === "Publish");
+  return titleEl?.closest(".option") ?? null;
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("install-method-dialog Publish option", () => {
+  it("is shown in install mode when hasPublishCommand is true", async () => {
+    const dialog = await mount({ hasPublishCommand: true });
+    expect(publishOption(dialog)).not.toBeNull();
+  });
+
+  it("is hidden when hasPublishCommand is false", async () => {
+    const dialog = await mount({ hasPublishCommand: false });
+    expect(publishOption(dialog)).toBeNull();
+  });
+
+  it("is hidden in logs mode even when hasPublishCommand is true", async () => {
+    const dialog = await mount({ hasPublishCommand: true, mode: "logs" });
+    expect(publishOption(dialog)).toBeNull();
+  });
+
+  it("fires select-method with publish when clicked", async () => {
+    const dialog = await mount({ hasPublishCommand: true });
+    const events: CustomEvent[] = [];
+    dialog.addEventListener("select-method", (e) => events.push(e as CustomEvent));
+    (publishOption(dialog) as HTMLElement).click();
+    expect(events).toHaveLength(1);
+    expect(events[0].detail.method).toBe("publish");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

This is the dashboard frontend part of this feature: https://github.com/esphome/esphome/pull/16906

When `esphome.publish_shell_command` is set in the YAML, this shows a Publish button in the install dialog that runs the upload with the special "PUBLISH" port (akin to "OTA").

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [X] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `npm run lint` passes.
- [X] `npm run test` passes. (There are currently two failed tests that seem unrelated to this change.)
- [X] Tests have been added to verify that the new code works (where applicable).
