### PR TITLE
Poll serial ports while the port picker is open

### DIFF
--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -13,16 +13,18 @@ import {
 } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import { DeviceState } from "../api/types/devices.js";
-import type { SerialPort } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { inputStyles } from "../styles/inputs.js";
+import { newItemHighlightStyles } from "../styles/new-item-highlight.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../util/environment.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { SerialPortsPollController } from "../util/serial-ports-poll-controller.js";
 import {
   secureLoopbackUrl,
   webSerialAvailability,
@@ -81,8 +83,8 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   deviceCurrentAddress = "";
 
   @state() private _view: DialogView = "method";
-  @state() private _ports: SerialPort[] = [];
-  @state() private _loadingPorts = false;
+
+  private _portsPoll = new SerialPortsPollController(this, () => this._api);
   /**
    * `true` when the user has opened the "Advanced options"
    * disclosure at the bottom of the method list. Holds the
@@ -128,17 +130,18 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     // resolved to, where the user just edits a single octet).
     if (changed.has("open") && this.open) {
       this._view = "method";
-      this._ports = [];
       this._advancedExpanded = false;
       this._otaAddressCardExpanded = false;
       this._otaAddressValue = this.deviceCurrentAddress;
     }
+    this._portsPoll.set(this.open && this._view === "port-select");
   }
 
   static styles = [
     espHomeStyles,
     primaryDialogHeaderStyles,
     inputStyles,
+    newItemHighlightStyles,
     installMethodDialogStyles,
   ];
 
@@ -373,7 +376,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   }
 
   private _renderPortList() {
-    if (this._loadingPorts) {
+    if (this._portsPoll.loading) {
       return html`
         <div class="loading">
           <wa-spinner></wa-spinner>
@@ -392,20 +395,31 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         <wa-icon library="mdi" name="arrow-left"></wa-icon>
         ${this._localize("dashboard.install_method_back")}
       </button>
-      ${this._ports.length === 0
+      ${this._portsPoll.ports.length === 0
         ? html`<div class="empty">
             ${this._localize("dashboard.install_method_no_ports")}
           </div>`
         : html`
             <div class="list">
-              ${this._ports.map(
+              ${this._portsPoll.ports.map(
                 (p) => html`
-                  <div class="option" @click=${() => this._selectPort(p.port)}>
+                  <div
+                    class=${classMap({
+                      option: true,
+                      "is-new": this._portsPoll.newPorts.has(p.port),
+                    })}
+                    @click=${() => this._selectPort(p.port)}
+                  >
                     <wa-icon library="mdi" name="serial-port"></wa-icon>
                     <div class="info">
                       <span class="title">${p.port}</span>
                       ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
                     </div>
+                    ${this._portsPoll.newPorts.has(p.port)
+                      ? html`<span class="new-badge"
+                          >${this._localize("dashboard.serial_port_new")}</span
+                        >`
+                      : nothing}
                   </div>
                 `
               )}
@@ -571,15 +585,8 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     this._selectMethod("ota", port);
   };
 
-  private async _onServerSerial() {
+  private _onServerSerial() {
     this._view = "port-select";
-    this._loadingPorts = true;
-    try {
-      this._ports = await this._api.getSerialPorts();
-    } catch {
-      this._ports = [];
-    }
-    this._loadingPorts = false;
   }
 
   private _selectMethod(method: string, port?: string) {

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -2,10 +2,12 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiSerialPort } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import type { SerialPort } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
+import { newItemHighlightStyles } from "../../styles/new-item-highlight.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { DeploymentEnvironment } from "../../util/environment.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -38,6 +40,9 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
   @property({ attribute: false })
   ports: SerialPort[] = [];
 
+  @property({ attribute: false })
+  newPorts: ReadonlySet<string> = new Set();
+
   @property({ type: Boolean })
   loading = false;
 
@@ -50,6 +55,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    newItemHighlightStyles,
     css`
       :host {
         display: flex;
@@ -211,12 +217,21 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
       <div class="list">
         ${this.ports.map(
           (p) => html`
-            <button type="button" class="option" @click=${() => this._onSelect(p.port)}>
+            <button
+              type="button"
+              class=${classMap({ option: true, "is-new": this.newPorts.has(p.port) })}
+              @click=${() => this._onSelect(p.port)}
+            >
               <wa-icon library="mdi" name="serial-port"></wa-icon>
               <div class="info">
                 <span class="title">${p.port}</span>
                 ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
               </div>
+              ${this.newPorts.has(p.port)
+                ? html`<span class="new-badge"
+                    >${this._localize("dashboard.serial_port_new")}</span
+                  >`
+                : nothing}
             </button>
           `
         )}

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -13,7 +13,6 @@ import memoizeOne from "memoize-one";
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
-import type { SerialPort } from "../../api/types/system.js";
 import { ESPHOME_DOCS_BASE } from "../../common/docs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
@@ -23,6 +22,7 @@ import { debounce } from "../../util/debounce.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../../util/environment.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { SerialPortsPollController } from "../../util/serial-ports-poll-controller.js";
 import {
   detectChip,
   disconnect,
@@ -114,11 +114,15 @@ export class ESPHomeWizardStepBoard extends LitElement {
   @state()
   private _view: "boards" | "select-port" = "boards";
 
-  @state()
-  private _serverPorts: SerialPort[] = [];
-
-  @state()
-  private _loadingServerPorts = false;
+  private _portsPoll = new SerialPortsPollController(this, () => this._api, {
+    onInitialError: (e) => {
+      console.error("Failed to load server serial ports:", e);
+      this._detectError = this._extractErrorDetail(
+        e,
+        this._localize("wizard.connect_your_board_detect_failed")
+      );
+    },
+  });
 
   @state()
   private _detectingChip = false;
@@ -155,6 +159,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
       this._filterFromDetection = true;
       void this._fetchBoards();
     }
+    this._portsPoll.set(this._view === "select-port");
   }
 
   private async _fetchBoards() {
@@ -183,8 +188,9 @@ export class ESPHomeWizardStepBoard extends LitElement {
       return html`
         <esphome-wizard-step-board-port-select
           .environment=${this._environment}
-          .ports=${this._serverPorts}
-          .loading=${this._loadingServerPorts}
+          .ports=${this._portsPoll.ports}
+          .newPorts=${this._portsPoll.newPorts}
+          .loading=${this._portsPoll.loading}
           .detecting=${this._detectingChip}
           .errorMessage=${this._detectError}
           @select-port=${this._onServerPortSelected}
@@ -435,7 +441,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
       void this._connectViaWebSerial();
       return;
     }
-    void this._openServerPortPicker();
+    this._openServerPortPicker();
   };
 
   private async _connectViaWebSerial() {
@@ -482,27 +488,14 @@ export class ESPHomeWizardStepBoard extends LitElement {
   }
 
   /**
-   * Open the server-side port picker, populate the port list via
-   * ``config/serial_ports``. The actual detection runs once the
-   * user picks a port (in ``_onServerPortSelected``).
+   * Open the server-side port picker. ``_portsPoll`` populates and
+   * refreshes the list while the view is showing; the actual
+   * detection runs once the user picks a port (in
+   * ``_onServerPortSelected``).
    */
-  private async _openServerPortPicker() {
+  private _openServerPortPicker() {
     this._view = "select-port";
     this._detectError = "";
-    this._serverPorts = [];
-    this._loadingServerPorts = true;
-    try {
-      this._serverPorts = await this._api.getSerialPorts();
-    } catch (e) {
-      console.error("Failed to load server serial ports:", e);
-      this._serverPorts = [];
-      this._detectError = this._extractErrorDetail(
-        e,
-        this._localize("wizard.connect_your_board_detect_failed")
-      );
-    } finally {
-      this._loadingServerPorts = false;
-    }
   }
 
   private _onServerPortSelected = async (e: CustomEvent<{ port: string }>) => {

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -114,15 +114,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   @state()
   private _view: "boards" | "select-port" = "boards";
 
-  private _portsPoll = new SerialPortsPollController(this, () => this._api, {
-    onInitialError: (e) => {
-      console.error("Failed to load server serial ports:", e);
-      this._detectError = this._extractErrorDetail(
-        e,
-        this._localize("wizard.connect_your_board_detect_failed")
-      );
-    },
-  });
+  private _portsPoll = new SerialPortsPollController(this, () => this._api);
 
   @state()
   private _detectingChip = false;
@@ -192,7 +184,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
           .newPorts=${this._portsPoll.newPorts}
           .loading=${this._portsPoll.loading}
           .detecting=${this._detectingChip}
-          .errorMessage=${this._detectError}
+          .errorMessage=${this._detectError || this._portsError()}
           @select-port=${this._onServerPortSelected}
           @back=${this._onBackFromPortSelect}
         ></esphome-wizard-step-board-port-select>
@@ -536,6 +528,20 @@ export class ESPHomeWizardStepBoard extends LitElement {
       this._detectingChip = false;
     }
   };
+
+  /**
+   * Port-list fetch failure from the poller. Kept separate from
+   * ``_detectError`` (chip-detect failures) so a recovering poll
+   * clears only its own error, not a detect error shown mid-list.
+   */
+  private _portsError(): string {
+    return this._portsPoll.error === null
+      ? ""
+      : this._extractErrorDetail(
+          this._portsPoll.error,
+          this._localize("wizard.connect_your_board_detect_failed")
+        );
+  }
 
   /**
    * Prefer ``APIError.details`` (the human-readable bit) over

--- a/src/styles/new-item-highlight.ts
+++ b/src/styles/new-item-highlight.ts
@@ -1,0 +1,44 @@
+import { css } from "lit";
+
+/**
+ * Highlight for a list row that appeared while the list was on
+ * screen (e.g. a serial port plugged in mid-session): a one-shot
+ * glow pulse to catch the eye, then a persistent primary border +
+ * tint and a "New" badge so the row stays findable.
+ */
+export const newItemHighlightStyles = css`
+  .is-new {
+    border-color: var(--esphome-primary);
+    background: var(--esphome-tint-faint);
+    animation: new-item-glow 2s ease-out 1;
+  }
+  @keyframes new-item-glow {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 40%);
+    }
+    50% {
+      box-shadow: 0 0 0 6px color-mix(in srgb, var(--esphome-primary), transparent 70%);
+    }
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--esphome-primary), transparent 100%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .is-new {
+      animation: none;
+    }
+  }
+
+  .new-badge {
+    flex-shrink: 0;
+    margin-left: auto;
+    padding: 1px var(--wa-space-xs);
+    border-radius: var(--wa-border-radius-pill, 999px);
+    background: var(--esphome-primary);
+    color: var(--esphome-on-primary);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+`;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -165,6 +165,7 @@
     "install_method_no_ports": "No serial ports found. Make sure the device is connected to the server.",
     "install_method_loading_ports": "Scanning for serial ports…",
     "install_method_back": "Back",
+    "serial_port_new": "New",
     "table_columns": "Columns",
     "table_toggle_columns": "Toggle columns",
     "view_cards": "Card view",

--- a/src/util/serial-ports-poll-controller.ts
+++ b/src/util/serial-ports-poll-controller.ts
@@ -1,0 +1,113 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ESPHomeAPI } from "../api/index.js";
+import type { SerialPort } from "../api/types/system.js";
+
+export const SERIAL_PORTS_POLL_INTERVAL_MS = 5000;
+
+export interface SerialPortsPollControllerOptions {
+  /** Called when the first fetch of an active cycle fails. Later
+   *  poll failures are swallowed, keeping the last good list. */
+  onInitialError?: (err: unknown) => void;
+}
+
+/**
+ * Reactive controller that polls ``config/serial_ports`` while a
+ * port-picker surface is visible. Hosts call ``set(visible)`` from
+ * ``willUpdate``; the controller fetches immediately, re-fetches every
+ * ``SERIAL_PORTS_POLL_INTERVAL_MS``, and flags ports that appear after
+ * the first fetch in ``newPorts`` so the UI can highlight a
+ * just-plugged-in device. The host re-renders only when the list
+ * actually changes.
+ */
+export class SerialPortsPollController implements ReactiveController {
+  ports: SerialPort[] = [];
+  loading = false;
+  newPorts: ReadonlySet<string> = new Set();
+
+  private _active = false;
+  private _cycle = 0;
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _inFlightCycle: number | null = null;
+  /** Port paths from the previous fetch; ``null`` until the first
+   *  successful fetch of a cycle seeds the new-port baseline. */
+  private _seen: Set<string> | null = null;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost,
+    private readonly _getApi: () => ESPHomeAPI,
+    private readonly _options: SerialPortsPollControllerOptions = {}
+  ) {
+    _host.addController(this);
+  }
+
+  hostDisconnected() {
+    this.set(false);
+  }
+
+  set(active: boolean) {
+    if (active === this._active) return;
+    this._active = active;
+    this._cycle++;
+    if (active) {
+      this.ports = [];
+      this.newPorts = new Set();
+      this._seen = null;
+      this.loading = true;
+      void this._poll();
+      this._timer = setInterval(() => void this._poll(), SERIAL_PORTS_POLL_INTERVAL_MS);
+    } else {
+      if (this._timer !== null) {
+        clearInterval(this._timer);
+        this._timer = null;
+      }
+      this.loading = false;
+    }
+  }
+
+  private async _poll() {
+    const cycle = this._cycle;
+    if (this._inFlightCycle === cycle) return;
+    this._inFlightCycle = cycle;
+    try {
+      const ports = await this._getApi().getSerialPorts();
+      if (cycle !== this._cycle) return;
+      this._apply(ports);
+    } catch (err) {
+      if (cycle !== this._cycle || !this.loading) return;
+      // First fetch of the cycle failed. ``_seen`` stays null so the
+      // next successful poll seeds the baseline instead of flagging
+      // every port as new.
+      this.loading = false;
+      this._options.onInitialError?.(err);
+      this._host.requestUpdate();
+    } finally {
+      if (this._inFlightCycle === cycle) this._inFlightCycle = null;
+    }
+  }
+
+  private _apply(ports: SerialPort[]) {
+    const paths = new Set(ports.map((p) => p.port));
+    // A port absent from the previous fetch is new, and stays flagged
+    // while present; pruning unplugged ports lets a replug re-flag.
+    const fresh = new Set(
+      this._seen === null
+        ? []
+        : [...paths].filter((path) => this.newPorts.has(path) || !this._seen!.has(path))
+    );
+    const changed =
+      this.loading ||
+      ports.length !== this.ports.length ||
+      ports.some(
+        (p, i) => p.port !== this.ports[i].port || p.desc !== this.ports[i].desc
+      ) ||
+      fresh.size !== this.newPorts.size ||
+      [...fresh].some((path) => !this.newPorts.has(path));
+
+    this._seen = paths;
+    if (!changed) return;
+    this.ports = ports;
+    this.newPorts = fresh;
+    this.loading = false;
+    this._host.requestUpdate();
+  }
+}

--- a/src/util/serial-ports-poll-controller.ts
+++ b/src/util/serial-ports-poll-controller.ts
@@ -4,12 +4,6 @@ import type { SerialPort } from "../api/types/system.js";
 
 export const SERIAL_PORTS_POLL_INTERVAL_MS = 5000;
 
-export interface SerialPortsPollControllerOptions {
-  /** Called when the first fetch of an active cycle fails. Later
-   *  poll failures are swallowed, keeping the last good list. */
-  onInitialError?: (err: unknown) => void;
-}
-
 /**
  * Reactive controller that polls ``config/serial_ports`` while a
  * port-picker surface is visible. Hosts call ``set(visible)`` from
@@ -22,6 +16,11 @@ export interface SerialPortsPollControllerOptions {
 export class SerialPortsPollController implements ReactiveController {
   ports: SerialPort[] = [];
   loading = false;
+  /** First-fetch failure of the active cycle; cleared by the next
+   *  successful poll so the recovered list isn't hidden behind a
+   *  stale error. Poll failures after a success are swallowed,
+   *  keeping the last good list. */
+  error: unknown = null;
   newPorts: ReadonlySet<string> = new Set();
 
   private _active = false;
@@ -34,8 +33,7 @@ export class SerialPortsPollController implements ReactiveController {
 
   constructor(
     private readonly _host: ReactiveControllerHost,
-    private readonly _getApi: () => ESPHomeAPI,
-    private readonly _options: SerialPortsPollControllerOptions = {}
+    private readonly _getApi: () => ESPHomeAPI
   ) {
     _host.addController(this);
   }
@@ -51,6 +49,7 @@ export class SerialPortsPollController implements ReactiveController {
     if (active) {
       this.ports = [];
       this.newPorts = new Set();
+      this.error = null;
       this._seen = null;
       this.loading = true;
       void this._poll();
@@ -65,6 +64,9 @@ export class SerialPortsPollController implements ReactiveController {
   }
 
   private async _poll() {
+    // An interval callback already queued when set(false) ran still
+    // fires after clearInterval — don't let it fetch.
+    if (!this._active) return;
     const cycle = this._cycle;
     if (this._inFlightCycle === cycle) return;
     this._inFlightCycle = cycle;
@@ -77,8 +79,9 @@ export class SerialPortsPollController implements ReactiveController {
       // First fetch of the cycle failed. ``_seen`` stays null so the
       // next successful poll seeds the baseline instead of flagging
       // every port as new.
+      console.error("Failed to load serial ports:", err);
       this.loading = false;
-      this._options.onInitialError?.(err);
+      this.error = err;
       this._host.requestUpdate();
     } finally {
       if (this._inFlightCycle === cycle) this._inFlightCycle = null;
@@ -96,6 +99,7 @@ export class SerialPortsPollController implements ReactiveController {
     );
     const changed =
       this.loading ||
+      this.error !== null ||
       ports.length !== this.ports.length ||
       ports.some(
         (p, i) => p.port !== this.ports[i].port || p.desc !== this.ports[i].desc
@@ -108,6 +112,7 @@ export class SerialPortsPollController implements ReactiveController {
     this.ports = ports;
     this.newPorts = fresh;
     this.loading = false;
+    this.error = null;
     this._host.requestUpdate();
   }
 }

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "Select a serial port" view must refresh while the dialog stays
+ * open and highlight a port that appears mid-session, so plugging in a
+ * device doesn't require closing and reopening the dialog (#1381).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import type { SerialPort } from "../../src/api/types/system.js";
+import { defaultLocalize } from "../../src/common/localize.js";
+import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
+import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../src/util/serial-ports-poll-controller.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(getSerialPorts: () => Promise<SerialPort[]>) {
+  const dialog = new ESPHomeInstallMethodDialog();
+  (dialog as any)._localize = defaultLocalize;
+  (dialog as any)._api = { getSerialPorts };
+  dialog.open = true;
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  (dialog as any)._view = "port-select";
+  await dialog.updateComplete;
+  return dialog;
+}
+
+const portRows = (d: ESPHomeInstallMethodDialog) =>
+  [...d.shadowRoot!.querySelectorAll(".list .option")] as HTMLElement[];
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+describe("install-method-dialog port polling", () => {
+  it("refreshes the open port list and highlights the newly connected port", async () => {
+    let ports: SerialPort[] = [{ port: "/dev/ttyUSB0", desc: "CP2102" }];
+    const getSerialPorts = vi.fn(async () => ports);
+    const dialog = await mount(getSerialPorts);
+
+    await vi.advanceTimersByTimeAsync(0);
+    await dialog.updateComplete;
+    expect(portRows(dialog)).toHaveLength(1);
+
+    ports = [...ports, { port: "/dev/ttyUSB1", desc: "CH340" }];
+    await vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
+    await dialog.updateComplete;
+
+    const rows = portRows(dialog);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].classList.contains("is-new")).toBe(false);
+    expect(rows[1].classList.contains("is-new")).toBe(true);
+    expect(rows[1].querySelector(".new-badge")?.textContent).toBe("New");
+  });
+
+  it("stops polling when the dialog closes", async () => {
+    const getSerialPorts = vi.fn(async () => [] as SerialPort[]);
+    const dialog = await mount(getSerialPorts);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getSerialPorts).toHaveBeenCalledTimes(1);
+
+    dialog.open = false;
+    await dialog.updateComplete;
+    await vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS * 3);
+    expect(getSerialPorts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
+++ b/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * An initial port-list fetch failure must not pin the wizard on the
+ * error view: when a later poll succeeds, the recovered list shows,
+ * while a chip-detect error keeps its own lifecycle.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import type { SerialPort } from "../../../src/api/types/system.js";
+import { defaultLocalize } from "../../../src/common/localize.js";
+import type { ESPHomeWizardStepBoardPortSelect } from "../../../src/components/wizard/wizard-step-board-port-select.js";
+import { ESPHomeWizardStepBoard } from "../../../src/components/wizard/wizard-step-board.js";
+import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../../src/util/serial-ports-poll-controller.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(getSerialPorts: () => Promise<SerialPort[]>) {
+  const el = new ESPHomeWizardStepBoard();
+  (el as any)._localize = defaultLocalize;
+  (el as any)._api = {
+    getBoards: async () => ({ boards: [] }),
+    getSerialPorts,
+  };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  (el as any)._view = "select-port";
+  await el.updateComplete;
+  return el;
+}
+
+const portSelect = (el: ESPHomeWizardStepBoard) =>
+  el.shadowRoot!.querySelector(
+    "esphome-wizard-step-board-port-select"
+  ) as ESPHomeWizardStepBoardPortSelect;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("wizard-step-board port fetch error recovery", () => {
+  it("clears the error and shows the list once a later poll succeeds", async () => {
+    let fail = true;
+    const getSerialPorts = vi.fn(async () => {
+      if (fail) throw new Error("backend offline");
+      return [{ port: "/dev/ttyUSB0", desc: "CP2102" }];
+    });
+    const el = await mount(getSerialPorts);
+
+    await vi.advanceTimersByTimeAsync(0);
+    await el.updateComplete;
+    expect(portSelect(el).errorMessage).toBe("backend offline");
+
+    fail = false;
+    await vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
+    await el.updateComplete;
+    expect(portSelect(el).errorMessage).toBe("");
+    expect(portSelect(el).ports).toEqual([{ port: "/dev/ttyUSB0", desc: "CP2102" }]);
+  });
+});

--- a/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
+++ b/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Ports flagged in ``newPorts`` render highlighted with a "New" badge
+ * so a just-plugged-in device is findable mid-wizard (#1381).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { defaultLocalize } from "../../../src/common/localize.js";
+import { ESPHomeWizardStepBoardPortSelect } from "../../../src/components/wizard/wizard-step-board-port-select.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(
+  props: Partial<ESPHomeWizardStepBoardPortSelect>
+): Promise<ESPHomeWizardStepBoardPortSelect> {
+  const el = new ESPHomeWizardStepBoardPortSelect();
+  (el as any)._localize = defaultLocalize;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("wizard-step-board-port-select new-port badge", () => {
+  it("highlights only the ports flagged as new", async () => {
+    const el = await mount({
+      ports: [
+        { port: "/dev/ttyUSB0", desc: "CP2102" },
+        { port: "/dev/ttyUSB1", desc: "CH340" },
+      ],
+      newPorts: new Set(["/dev/ttyUSB1"]),
+    });
+    const rows = [...el.shadowRoot!.querySelectorAll(".option")];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].classList.contains("is-new")).toBe(false);
+    expect(rows[0].querySelector(".new-badge")).toBeNull();
+    expect(rows[1].classList.contains("is-new")).toBe(true);
+    expect(rows[1].querySelector(".new-badge")?.textContent).toBe("New");
+  });
+});

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -30,17 +30,14 @@ function make(initial: SerialPort[] = [A]) {
     if (result instanceof Error) throw result;
     return result;
   });
-  const onInitialError = vi.fn();
   const ctrl = new SerialPortsPollController(
     host,
-    () => ({ getSerialPorts }) as unknown as ESPHomeAPI,
-    { onInitialError }
+    () => ({ getSerialPorts }) as unknown as ESPHomeAPI
   );
   return {
     host,
     ctrl,
     getSerialPorts,
-    onInitialError,
     respond(next: SerialPort[] | Error) {
       result = next;
     },
@@ -52,10 +49,12 @@ const tick = () => vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
 
 beforeEach(() => {
   vi.useFakeTimers();
+  vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe("SerialPortsPollController", () => {
@@ -116,6 +115,16 @@ describe("SerialPortsPollController", () => {
     expect(getSerialPorts).toHaveBeenCalledTimes(2);
   });
 
+  it("does not fetch from an interval callback that was queued before deactivation", async () => {
+    const { ctrl, getSerialPorts } = make();
+    ctrl.set(true);
+    await flush();
+    ctrl.set(false);
+    // A callback already queued when clearInterval ran still fires.
+    await (ctrl as unknown as { _poll(): Promise<void> })._poll();
+    expect(getSerialPorts).toHaveBeenCalledTimes(1);
+  });
+
   it("resets the list and the new-port baseline on each activation", async () => {
     const { ctrl, respond } = make([A]);
     ctrl.set(true);
@@ -144,31 +153,52 @@ describe("SerialPortsPollController", () => {
     expect(host.updates).toBe(after);
   });
 
-  it("reports an initial-fetch error once and seeds the baseline from the next success", async () => {
-    const { ctrl, host, respond, onInitialError } = make();
+  it("exposes an initial-fetch error and clears it on the next successful poll", async () => {
+    const { ctrl, host, respond } = make();
     const boom = new Error("boom");
     respond(boom);
     ctrl.set(true);
     await flush();
-    expect(onInitialError).toHaveBeenCalledWith(boom);
+    expect(ctrl.error).toBe(boom);
     expect(ctrl.loading).toBe(false);
     expect(host.updates).toBe(1);
 
+    // Recovery must surface even when the recovered list is empty.
+    respond([]);
+    await tick();
+    expect(ctrl.error).toBeNull();
+    expect(ctrl.ports).toEqual([]);
+    expect(host.updates).toBe(2);
+
+    // The empty success seeded the baseline, so later ports are new.
     respond([A, B]);
     await tick();
+    expect(ctrl.ports).toEqual([A, B]);
+    expect(ctrl.newPorts.size).toBe(2);
+  });
+
+  it("seeds the new-port baseline from the first success after an initial error", async () => {
+    const { ctrl, respond } = make();
+    respond(new Error("boom"));
+    ctrl.set(true);
+    await flush();
+
+    respond([A, B]);
+    await tick();
+    expect(ctrl.error).toBeNull();
     expect(ctrl.ports).toEqual([A, B]);
     expect(ctrl.newPorts.size).toBe(0);
   });
 
   it("swallows poll errors after a successful fetch, keeping the last good list", async () => {
-    const { ctrl, respond, onInitialError } = make([A]);
+    const { ctrl, respond } = make([A]);
     ctrl.set(true);
     await flush();
 
     respond(new Error("transient"));
     await tick();
     expect(ctrl.ports).toEqual([A]);
-    expect(onInitialError).not.toHaveBeenCalled();
+    expect(ctrl.error).toBeNull();
 
     respond([A, B]);
     await tick();

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -1,0 +1,178 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { SerialPort } from "../../src/api/types/system.js";
+import {
+  SERIAL_PORTS_POLL_INTERVAL_MS,
+  SerialPortsPollController,
+} from "../../src/util/serial-ports-poll-controller.js";
+
+class FakeHost implements ReactiveControllerHost {
+  controllers: ReactiveController[] = [];
+  updates = 0;
+  addController(c: ReactiveController) {
+    this.controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {
+    this.updates++;
+  }
+  updateComplete = Promise.resolve(true);
+}
+
+const A: SerialPort = { port: "/dev/ttyUSB0", desc: "CP2102" };
+const B: SerialPort = { port: "/dev/ttyUSB1", desc: "CH340" };
+
+function make(initial: SerialPort[] = [A]) {
+  const host = new FakeHost();
+  let result: SerialPort[] | Error = initial;
+  const getSerialPorts = vi.fn(async () => {
+    if (result instanceof Error) throw result;
+    return result;
+  });
+  const onInitialError = vi.fn();
+  const ctrl = new SerialPortsPollController(
+    host,
+    () => ({ getSerialPorts }) as unknown as ESPHomeAPI,
+    { onInitialError }
+  );
+  return {
+    host,
+    ctrl,
+    getSerialPorts,
+    onInitialError,
+    respond(next: SerialPort[] | Error) {
+      result = next;
+    },
+  };
+}
+
+const flush = () => vi.advanceTimersByTimeAsync(0);
+const tick = () => vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("SerialPortsPollController", () => {
+  it("fetches immediately on activation and re-fetches on the interval", async () => {
+    const { ctrl, getSerialPorts, respond } = make([A]);
+    expect(ctrl.loading).toBe(false);
+
+    ctrl.set(true);
+    expect(ctrl.loading).toBe(true);
+    await flush();
+    expect(getSerialPorts).toHaveBeenCalledTimes(1);
+    expect(ctrl.loading).toBe(false);
+    expect(ctrl.ports).toEqual([A]);
+    expect(ctrl.newPorts.size).toBe(0);
+
+    respond([A, B]);
+    await tick();
+    expect(getSerialPorts).toHaveBeenCalledTimes(2);
+    expect(ctrl.ports).toEqual([A, B]);
+  });
+
+  it("flags ports that appear after the first fetch and keeps them flagged while present", async () => {
+    const { ctrl, respond } = make([A]);
+    ctrl.set(true);
+    await flush();
+
+    respond([A, B]);
+    await tick();
+    expect(ctrl.newPorts.has(B.port)).toBe(true);
+    expect(ctrl.newPorts.has(A.port)).toBe(false);
+
+    await tick();
+    expect(ctrl.newPorts.has(B.port)).toBe(true);
+
+    respond([A]);
+    await tick();
+    expect(ctrl.newPorts.size).toBe(0);
+
+    respond([A, B]);
+    await tick();
+    expect(ctrl.newPorts.has(B.port)).toBe(true);
+  });
+
+  it("stops polling on deactivation and on host disconnect", async () => {
+    const { ctrl, getSerialPorts } = make();
+    ctrl.set(true);
+    await flush();
+    ctrl.set(false);
+    await tick();
+    await tick();
+    expect(getSerialPorts).toHaveBeenCalledTimes(1);
+
+    ctrl.set(true);
+    await flush();
+    expect(getSerialPorts).toHaveBeenCalledTimes(2);
+    ctrl.hostDisconnected();
+    await tick();
+    expect(getSerialPorts).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets the list and the new-port baseline on each activation", async () => {
+    const { ctrl, respond } = make([A]);
+    ctrl.set(true);
+    await flush();
+    respond([A, B]);
+    await tick();
+    expect(ctrl.newPorts.has(B.port)).toBe(true);
+
+    ctrl.set(false);
+    expect(ctrl.ports).toEqual([A, B]);
+
+    ctrl.set(true);
+    expect(ctrl.ports).toEqual([]);
+    await flush();
+    expect(ctrl.ports).toEqual([A, B]);
+    expect(ctrl.newPorts.size).toBe(0);
+  });
+
+  it("only requests a host update when the list actually changes", async () => {
+    const { ctrl, host } = make([A]);
+    ctrl.set(true);
+    await flush();
+    const after = host.updates;
+    await tick();
+    await tick();
+    expect(host.updates).toBe(after);
+  });
+
+  it("reports an initial-fetch error once and seeds the baseline from the next success", async () => {
+    const { ctrl, host, respond, onInitialError } = make();
+    const boom = new Error("boom");
+    respond(boom);
+    ctrl.set(true);
+    await flush();
+    expect(onInitialError).toHaveBeenCalledWith(boom);
+    expect(ctrl.loading).toBe(false);
+    expect(host.updates).toBe(1);
+
+    respond([A, B]);
+    await tick();
+    expect(ctrl.ports).toEqual([A, B]);
+    expect(ctrl.newPorts.size).toBe(0);
+  });
+
+  it("swallows poll errors after a successful fetch, keeping the last good list", async () => {
+    const { ctrl, respond, onInitialError } = make([A]);
+    ctrl.set(true);
+    await flush();
+
+    respond(new Error("transient"));
+    await tick();
+    expect(ctrl.ports).toEqual([A]);
+    expect(onInitialError).not.toHaveBeenCalled();
+
+    respond([A, B]);
+    await tick();
+    expect(ctrl.ports).toEqual([A, B]);
+    expect(ctrl.newPorts.has(B.port)).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

**Fixes a regression from the legacy `esphome dashboard`**: the old dashboard kept its serial-port picker live, re-polling the port list every few seconds while the dialog was open (the issue shows it side by side). The new Device Builder fetched `config/serial_ports` once when the view opened and never again, so plugging in (or unplugging) a USB device while the dialog was open did nothing — the user had to close and reopen the dialog, then guess which entry was the new one.

This restores the live refresh with a shared `SerialPortsPollController` (Lit ReactiveController, same lifecycle shape as `EscapeController`) that polls `config/serial_ports` every 5 s while a port picker is on screen, driven from the host's `willUpdate` so back/close/disconnect all stop it through one code path. On top of parity, it adds what the reporter asked for: ports that appear after the first fetch are flagged and rendered with a shared highlight style (one-shot glow pulse + persistent primary border + a "New" badge), so the just-plugged-in device is findable. Both port-picker surfaces are wired up:

- the install/logs method dialog (`install-method-dialog.ts`)
- the wizard's Connect-your-board server port picker (`wizard-step-board.ts` / `wizard-step-board-port-select.ts`)

The host only re-renders when the list actually changes; a replugged port re-flags; a failed first fetch surfaces as the controller's `error` state (the wizard renders it, and a later successful poll clears it so the recovered list isn't hidden behind a stale error), and poll errors after a success keep the last good list.

Verified end-to-end headless against a backend whose `config/serial_ports` alternated lists: the open dialog tracked unplug/replug live, the reappearing port showed the glow + "New" badge, and zero `config/serial_ports` frames went over the WS after the dialog closed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1381

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
