### PR TITLE
Style the identity-changed alert's Unpair as a text button

### DIFF
--- a/src/components/settings-dialog/build-offload-alert.ts
+++ b/src/components/settings-dialog/build-offload-alert.ts
@@ -43,7 +43,7 @@ export function renderOffloaderAlert(
           </button>
           <button
             type="button"
-            class="btn-unpair"
+            class="offloader-alert-unpair"
             aria-label=${localize("settings.offloader_alert_unpair_aria", {
               label: alert.receiver_label,
             })}
@@ -73,7 +73,7 @@ export function renderOffloaderAlert(
       <div class="offloader-alert-actions">
         <button
           type="button"
-          class="btn-unpair"
+          class="offloader-alert-unpair"
           aria-label=${localize("settings.offloader_alert_unpair_aria", {
             label: alert.receiver_label,
           })}

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -41,36 +41,6 @@ export const offloaderAlertStyles = css`
     gap: var(--wa-space-xs);
     flex-shrink: 0;
   }
-
-  /* Text variant of the pairing row's icon-only .btn-unpair — the
-     alert spells the action out next to the Re-pair pill. */
-  .offloader-alert-unpair {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    height: 32px;
-    padding: 0 12px;
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-m);
-    background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-quiet);
-    font: inherit;
-    font-size: var(--wa-font-size-xs);
-    font-weight: var(--wa-font-weight-semibold);
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-
-  .offloader-alert-unpair:hover {
-    background: color-mix(in srgb, var(--esphome-error), white 90%);
-    color: var(--esphome-error);
-    border-color: var(--esphome-error);
-  }
-
-  .offloader-alert-unpair:focus-visible {
-    outline: none;
-    box-shadow: var(--esphome-focus-ring);
-  }
 `;
 
 export const pairingRowStyles = css`
@@ -137,42 +107,41 @@ export const pairingRowStyles = css`
     font-size: 14px;
   }
 
-  .btn-unpair {
+  /* Shared chrome for the section's secondary action buttons: the
+     pairing row's icon-only squares and the alert's text Unpair
+     (.offloader-alert-unpair markup lives in build-offload-alert.ts;
+     its chrome stays here with its siblings). */
+  .btn-unpair,
+  .btn-edit-endpoint,
+  .offloader-alert-unpair {
     height: 32px;
-    width: 32px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-s);
     background: var(--wa-color-surface-default);
     color: var(--wa-color-text-quiet);
     cursor: pointer;
     flex-shrink: 0;
   }
 
-  .btn-unpair:hover {
-    background: color-mix(in srgb, var(--esphome-error), white 90%);
-    color: var(--esphome-error);
-    border-color: var(--esphome-error);
+  .btn-unpair,
+  .btn-edit-endpoint {
+    width: 32px;
+    border-radius: var(--wa-border-radius-s);
   }
 
-  .btn-unpair wa-icon {
+  .btn-unpair wa-icon,
+  .btn-edit-endpoint wa-icon {
     font-size: 16px;
   }
 
-  .btn-edit-endpoint {
-    height: 32px;
-    width: 32px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-s);
-    background: var(--wa-color-surface-default);
-    color: var(--wa-color-text-quiet);
-    cursor: pointer;
-    flex-shrink: 0;
+  /* Destructive actions tint error on hover; edit tints primary. */
+  .btn-unpair:hover,
+  .offloader-alert-unpair:hover {
+    background: color-mix(in srgb, var(--esphome-error), white 90%);
+    color: var(--esphome-error);
+    border-color: var(--esphome-error);
   }
 
   .btn-edit-endpoint:hover {
@@ -181,8 +150,19 @@ export const pairingRowStyles = css`
     border-color: var(--esphome-primary);
   }
 
-  .btn-edit-endpoint wa-icon {
-    font-size: 16px;
+  /* Text variant — the alert spells the action out next to the
+     Re-pair pill, so it gets padding and the pill's radius. */
+  .offloader-alert-unpair {
+    padding: 0 12px;
+    border-radius: var(--wa-border-radius-m);
+    font: inherit;
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-semibold);
+  }
+
+  .offloader-alert-unpair:focus-visible {
+    outline: none;
+    box-shadow: var(--esphome-focus-ring);
   }
 
   /* The per-pairing enable toggle stays on the title line beside

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -41,6 +41,36 @@ export const offloaderAlertStyles = css`
     gap: var(--wa-space-xs);
     flex-shrink: 0;
   }
+
+  /* Text variant of the pairing row's icon-only .btn-unpair — the
+     alert spells the action out next to the Re-pair pill. */
+  .offloader-alert-unpair {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    padding: 0 12px;
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+    background: var(--wa-color-surface-default);
+    color: var(--wa-color-text-quiet);
+    font: inherit;
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-semibold);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .offloader-alert-unpair:hover {
+    background: color-mix(in srgb, var(--esphome-error), white 90%);
+    color: var(--esphome-error);
+    border-color: var(--esphome-error);
+  }
+
+  .offloader-alert-unpair:focus-visible {
+    outline: none;
+    box-shadow: var(--esphome-focus-ring);
+  }
 `;
 
 export const pairingRowStyles = css`

--- a/test/components/build-offload-section/render-offloader-alert.test.ts
+++ b/test/components/build-offload-section/render-offloader-alert.test.ts
@@ -34,17 +34,23 @@ const peerRevoked: OffloaderPeerRevokedAlert = {
 
 const ctx = () => ({ localize, onRepair: vi.fn(), onUnpair: vi.fn() });
 
+/** All class tokens used across the template's static markup. */
+const classTokens = (markup: string): string[] =>
+  [...markup.matchAll(/class="([^"]*)"/g)]
+    .flatMap((m) => m[1].split(/\s+/))
+    .filter(Boolean);
+
 describe("renderOffloaderAlert", () => {
   it("styles the pin-mismatch actions as a primary Re-pair and a text Unpair", () => {
-    const markup = renderOffloaderAlert(pinMismatch, ctx()).strings.join("");
-    expect(markup).toContain('class="btn-pair-build-server"');
-    expect(markup).toContain('class="offloader-alert-unpair"');
-    expect(markup).not.toContain('class="btn-unpair"');
+    const tokens = classTokens(renderOffloaderAlert(pinMismatch, ctx()).strings.join(""));
+    expect(tokens).toContain("btn-pair-build-server");
+    expect(tokens).toContain("offloader-alert-unpair");
+    expect(tokens).not.toContain("btn-unpair");
   });
 
   it("styles the peer-revoked Unpair as a text button", () => {
-    const markup = renderOffloaderAlert(peerRevoked, ctx()).strings.join("");
-    expect(markup).toContain('class="offloader-alert-unpair"');
-    expect(markup).not.toContain('class="btn-unpair"');
+    const tokens = classTokens(renderOffloaderAlert(peerRevoked, ctx()).strings.join(""));
+    expect(tokens).toContain("offloader-alert-unpair");
+    expect(tokens).not.toContain("btn-unpair");
   });
 });

--- a/test/components/build-offload-section/render-offloader-alert.test.ts
+++ b/test/components/build-offload-section/render-offloader-alert.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The alert's Unpair action is a text button and must use the padded
+ * text style, never the pairing row's 32×32 icon-only ``btn-unpair``
+ * (text overflowed the square and read as an unstyled button, #766).
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  OffloaderPeerRevokedAlert,
+  OffloaderPinMismatchAlert,
+} from "../../../src/api/types/remote-build-events.js";
+import { renderOffloaderAlert } from "../../../src/components/settings-dialog/build-offload-alert.js";
+
+const localize = (key: string) => key;
+
+const pinMismatch: OffloaderPinMismatchAlert = {
+  kind: "pin_mismatch",
+  receiver_hostname: "macbook-pro.local",
+  receiver_port: 6053,
+  pin_sha256: "abc123",
+  receiver_label: "macbook-pro",
+  expected_pin: "111111",
+  observed_pin: "222222",
+  fired_at: 1_700_000_000,
+};
+
+const peerRevoked: OffloaderPeerRevokedAlert = {
+  kind: "peer_revoked",
+  receiver_hostname: "macbook-pro.local",
+  receiver_port: 6053,
+  pin_sha256: "abc123",
+  receiver_label: "macbook-pro",
+  fired_at: 1_700_000_000,
+};
+
+const ctx = () => ({ localize, onRepair: vi.fn(), onUnpair: vi.fn() });
+
+describe("renderOffloaderAlert", () => {
+  it("styles the pin-mismatch actions as a primary Re-pair and a text Unpair", () => {
+    const markup = renderOffloaderAlert(pinMismatch, ctx()).strings.join("");
+    expect(markup).toContain('class="btn-pair-build-server"');
+    expect(markup).toContain('class="offloader-alert-unpair"');
+    expect(markup).not.toContain('class="btn-unpair"');
+  });
+
+  it("styles the peer-revoked Unpair as a text button", () => {
+    const markup = renderOffloaderAlert(peerRevoked, ctx()).strings.join("");
+    expect(markup).toContain('class="offloader-alert-unpair"');
+    expect(markup).not.toContain('class="btn-unpair"');
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In Settings → Send builds, the "{label}'s identity changed" alert showed a styled blue **Re-pair** button with **Unpair** rendering as bare floating text. #389 restyled `.btn-unpair` into a 32×32 icon-only square (and switched the pairing row to a `wa-icon` delete button), but the two alert templates in `build-offload-alert.ts` still put the *text* "Unpair" inside that class — text overflowing an invisible fixed-width square reads as an unstyled button. The peer-revoked alert had the same problem.

Both alert unpair buttons now use a dedicated `offloader-alert-unpair` text-button style in `offloaderAlertStyles`: padded secondary button (32 px, surface + border, radius matching the Re-pair pill beside it) with the icon button's destructive error-tint hover and the standard focus ring. The pairing row's icon-only `.btn-unpair` is untouched.

Verified in the live dashboard by injecting both alert kinds into the section; a template test pins that the alert templates use the text-button class and never the icon-square class.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/766

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

## Fixed screenshots

<img width="504" height="322" alt="Screenshot 2026-06-11 at 11 51 47 AM" src="https://github.com/user-attachments/assets/1e8cbd8d-85d8-4395-8a5d-3803e0a6b218" />


## How to view the alerts in the UI

A real identity-changed alert needs a paired build server whose identity rotated, so for review there's a console shortcut. With the dashboard open (dev or prod build), paste into the browser console:

```js
(() => {
  const deep = (root, sel, out = []) => {
    if (!root.querySelectorAll) return out;
    for (const el of root.querySelectorAll(sel)) out.push(el);
    for (const el of root.querySelectorAll("*")) el.shadowRoot && deep(el.shadowRoot, sel, out);
    return out;
  };
  const dlg = deep(document, "esphome-settings-dialog")[0];
  dlg.open();
  dlg._section = "build_offload";
  setTimeout(() => {
    deep(document, "esphome-settings-build-offload")[0]._alerts = new Map([
      ["a", { kind: "pin_mismatch", receiver_hostname: "macbook-pro.local", receiver_port: 6055,
              pin_sha256: "abc", receiver_label: "macbook-pro", expected_pin: "111111",
              observed_pin: "222222", fired_at: Date.now() / 1000 }],
      ["b", { kind: "peer_revoked", receiver_hostname: "nas.local", receiver_port: 6053,
              pin_sha256: "def", receiver_label: "nas", fired_at: Date.now() / 1000 }],
    ]);
  }, 300);
})();
```

Settings → Send builds opens with one alert of each kind: Re-pair + Unpair on the identity-changed warning, standalone Unpair on the peer-revoked one.
