### PR TITLE
Update the design of edit mode

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -430,7 +430,9 @@ export const deviceEditorStyles = css`
   }
 
   .pane-divider:focus-visible {
-    outline: none;
+    /* Transparent outline keeps a ring in forced-colors mode. */
+    outline: 2px solid transparent;
+    box-shadow: var(--esphome-focus-ring-tight);
   }
 
   .editor-layout--left .editor-pane--right,

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -430,9 +430,7 @@ export const deviceEditorStyles = css`
   }
 
   .pane-divider:focus-visible {
-    /* Transparent outline keeps a ring in forced-colors mode. */
-    outline: 2px solid transparent;
-    box-shadow: var(--esphome-focus-ring-tight);
+    outline: none;
   }
 
   .editor-layout--left .editor-pane--right,

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -29,7 +29,7 @@ export const deviceEditorStyles = css`
   }
 
   :host([navcollapsed]) .card-header {
-    padding-left: calc(var(--wa-space-l) - var(--wa-space-2xs) + var(--wa-space-s));
+    padding-left: var(--wa-space-2xs);
   }
 
   /* Navigator hidden + YAML-only layout = the title bar is the only

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -7,9 +7,12 @@ export const deviceEditorStyles = css`
 
   .card {
     background: var(--wa-color-surface-default);
-    border-radius: var(--wa-border-radius-l);
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    box-shadow: var(--wa-elevation-02);
+    border-radius: var(--editor-border-radius, var(--wa-border-radius-l));
+    border: var(
+      --editor-border,
+      var(--wa-border-width-s) solid var(--wa-color-surface-border)
+    );
+    box-shadow: var(--editor-shadow, var(--wa-elevation-02));
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -20,8 +23,13 @@ export const deviceEditorStyles = css`
     align-items: center;
     justify-content: space-between;
     padding: var(--wa-space-s) var(--wa-space-m);
-    background: var(--esphome-primary);
-    color: var(--esphome-on-primary);
+    background: var(--esphome-tint);
+    color: var(--esphome-primary);
+    border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+  }
+
+  :host([navcollapsed]) .card-header {
+    padding-left: calc(var(--wa-space-l) - var(--wa-space-2xs) + var(--wa-space-s));
   }
 
   /* Navigator hidden + YAML-only layout = the title bar is the only
@@ -73,7 +81,7 @@ export const deviceEditorStyles = css`
   .editor-header-file {
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-normal);
-    color: color-mix(in srgb, var(--esphome-on-primary), transparent 25%);
+    color: var(--esphome-primary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -213,7 +221,7 @@ export const deviceEditorStyles = css`
   .diff-toggle {
     border: none;
     background: transparent;
-    color: var(--esphome-on-primary);
+    color: var(--esphome-primary);
     padding: 2px 4px;
     border-radius: 4px;
     cursor: pointer;
@@ -222,8 +230,13 @@ export const deviceEditorStyles = css`
     justify-content: center;
   }
 
+  .diff-toggle:hover:not(:disabled) {
+    background: var(--esphome-tint-border);
+  }
+
   .diff-toggle[aria-pressed="true"] {
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+    background: var(--esphome-primary);
+    color: var(--esphome-on-primary);
   }
 
   .diff-toggle:disabled {
@@ -244,7 +257,7 @@ export const deviceEditorStyles = css`
   .layout-toggle button {
     border: none;
     background: transparent;
-    color: var(--esphome-on-primary);
+    color: var(--esphome-primary);
     padding: 2px 4px;
     border-radius: 4px;
     cursor: pointer;
@@ -253,8 +266,13 @@ export const deviceEditorStyles = css`
     justify-content: center;
   }
 
+  .layout-toggle button:hover:not(:disabled) {
+    background: var(--esphome-tint-border);
+  }
+
   .layout-toggle button[aria-pressed="true"] {
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+    background: var(--esphome-primary);
+    color: var(--esphome-on-primary);
   }
 
   .layout-toggle button:disabled {
@@ -280,10 +298,16 @@ export const deviceEditorStyles = css`
     min-height: 0;
     display: grid;
     gap: 0;
+    --pane-divider-width: 9px;
   }
 
   .editor-layout--both {
-    grid-template-columns: 1fr 1px 1fr;
+    grid-template-columns: 1fr var(--pane-divider-width) 1fr;
+  }
+
+  .editor-layout.dragging {
+    cursor: col-resize;
+    user-select: none;
   }
 
   .editor-layout--left {
@@ -379,9 +403,34 @@ export const deviceEditorStyles = css`
   }
 
   .pane-divider {
-    background: var(--wa-color-surface-border);
-    width: 1px;
     align-self: stretch;
+    position: relative;
+    background: transparent;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  .pane-divider::before {
+    content: "";
+    position: absolute;
+    inset: 0 50%;
+    width: 1px;
+    transform: translateX(-50%);
+    background: var(--wa-color-surface-border);
+    transition:
+      background 0.12s,
+      width 0.12s;
+  }
+
+  .pane-divider:hover::before,
+  .pane-divider:focus-visible::before,
+  .pane-divider.dragging::before {
+    background: var(--esphome-primary);
+    width: 2px;
+  }
+
+  .pane-divider:focus-visible {
+    outline: none;
   }
 
   .editor-layout--left .editor-pane--right,
@@ -402,6 +451,10 @@ export const deviceEditorStyles = css`
       border: none;
       border-radius: 0;
       box-shadow: none;
+    }
+
+    .card-header {
+      padding-left: calc(var(--wa-space-l) - var(--wa-space-2xs) + var(--wa-space-s));
     }
   }
 `;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -389,6 +389,9 @@ export class ESPHomeDeviceEditor extends LitElement {
                   aria-valuemin=${Math.round(MIN_SPLIT_RATIO * 100)}
                   aria-valuemax=${Math.round(MAX_SPLIT_RATIO * 100)}
                   aria-valuenow=${Math.round(this._splitRatio * 100)}
+                  aria-valuetext=${this._localize("device.resize_panes_value", {
+                    percent: Math.round(this._splitRatio * 100),
+                  })}
                   tabindex="0"
                   @pointerdown=${this._onDividerPointerDown}
                   @keydown=${this._onDividerKeydown}

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -539,8 +539,6 @@ export class ESPHomeDeviceEditor extends LitElement {
     // listener leak) and auto-releases on up/cancel.
     const divider = e.currentTarget as HTMLElement;
     divider.setPointerCapture(e.pointerId);
-    // preventDefault suppressed focus; set it so keyboard resize works.
-    divider.focus();
 
     // The fr tracks split the width left after the fixed divider column,
     // so normalize against that (minus half the divider) for the bar to
@@ -554,16 +552,20 @@ export class ESPHomeDeviceEditor extends LitElement {
         (ev.clientX - rect.left - dividerPx / 2) / usable
       );
     };
+    // lostpointercapture covers up/cancel plus OS/browser interrupts
+    // that release capture without firing either.
     const onEnd = () => {
       this._dragging = false;
       saveSplitRatio(this._splitRatio);
       divider.removeEventListener("pointermove", onMove);
       divider.removeEventListener("pointerup", onEnd);
       divider.removeEventListener("pointercancel", onEnd);
+      divider.removeEventListener("lostpointercapture", onEnd);
     };
     divider.addEventListener("pointermove", onMove);
     divider.addEventListener("pointerup", onEnd);
     divider.addEventListener("pointercancel", onEnd);
+    divider.addEventListener("lostpointercapture", onEnd);
   };
 
   private _onDividerKeydown = (e: KeyboardEvent) => {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -554,16 +554,20 @@ export class ESPHomeDeviceEditor extends LitElement {
         (ev.clientX - rect.left - dividerPx / 2) / usable
       );
     };
+    // lostpointercapture covers up/cancel plus OS/browser interrupts
+    // that release capture without firing either.
     const onEnd = () => {
       this._dragging = false;
       saveSplitRatio(this._splitRatio);
       divider.removeEventListener("pointermove", onMove);
       divider.removeEventListener("pointerup", onEnd);
       divider.removeEventListener("pointercancel", onEnd);
+      divider.removeEventListener("lostpointercapture", onEnd);
     };
     divider.addEventListener("pointermove", onMove);
     divider.addEventListener("pointerup", onEnd);
     divider.addEventListener("pointercancel", onEnd);
+    divider.addEventListener("lostpointercapture", onEnd);
   };
 
   private _onDividerKeydown = (e: KeyboardEvent) => {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -554,20 +554,16 @@ export class ESPHomeDeviceEditor extends LitElement {
         (ev.clientX - rect.left - dividerPx / 2) / usable
       );
     };
-    // lostpointercapture covers up/cancel plus OS/browser interrupts
-    // that release capture without firing either.
     const onEnd = () => {
       this._dragging = false;
       saveSplitRatio(this._splitRatio);
       divider.removeEventListener("pointermove", onMove);
       divider.removeEventListener("pointerup", onEnd);
       divider.removeEventListener("pointercancel", onEnd);
-      divider.removeEventListener("lostpointercapture", onEnd);
     };
     divider.addEventListener("pointermove", onMove);
     divider.addEventListener("pointerup", onEnd);
     divider.addEventListener("pointercancel", onEnd);
-    divider.addEventListener("lostpointercapture", onEnd);
   };
 
   private _onDividerKeydown = (e: KeyboardEvent) => {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -542,9 +542,17 @@ export class ESPHomeDeviceEditor extends LitElement {
     // preventDefault suppressed focus; set it so keyboard resize works.
     divider.focus();
 
+    // The fr tracks split the width left after the fixed divider column,
+    // so normalize against that (minus half the divider) for the bar to
+    // track the cursor instead of drifting a couple px.
+    const dividerPx = divider.getBoundingClientRect().width;
+    const usable = rect.width - dividerPx;
+
     const onMove = (ev: PointerEvent) => {
-      if (rect.width === 0) return;
-      this._splitRatio = clampSplitRatio((ev.clientX - rect.left) / rect.width);
+      if (usable <= 0) return;
+      this._splitRatio = clampSplitRatio(
+        (ev.clientX - rect.left - dividerPx / 2) / usable
+      );
     };
     const onEnd = () => {
       this._dragging = false;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -18,6 +18,14 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, yamlDiffButtonContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import {
+  clampSplitRatio,
+  loadSplitRatio,
+  MAX_SPLIT_RATIO,
+  MIN_SPLIT_RATIO,
+  nextSplitRatioForKey,
+  saveSplitRatio,
+} from "../../util/split-ratio.js";
 import type { HighlightRange } from "../yaml-editor.js";
 import { deviceEditorStyles } from "./device-editor.styles.js";
 
@@ -44,36 +52,6 @@ export type DeviceLayoutMode = "both" | "left" | "right";
 
 /** Cap the errors listed in the invalid banner; the rest collapse to "+N more". */
 const MAX_BANNER_ERRORS = 6;
-const MIN_SPLIT_RATIO = 0.25;
-const MAX_SPLIT_RATIO = 0.75;
-const SPLIT_KEY_STEP = 0.02;
-
-const clampSplitRatio = (ratio: number): number =>
-  Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio));
-
-const SPLIT_RATIO_STORAGE_KEY = "esphome-editor-split-ratio";
-
-const loadSplitRatio = (): number => {
-  try {
-    const raw = localStorage.getItem(SPLIT_RATIO_STORAGE_KEY);
-    const parsed = raw === null ? NaN : Number.parseFloat(raw);
-    return Number.isFinite(parsed) ? clampSplitRatio(parsed) : 0.5;
-  } catch {
-    // localStorage can throw in private mode / sandboxed iframes /
-    // when quota is exhausted. Persistence is a nicety here, so fall
-    // back to the default ratio rather than breaking editor render.
-    return 0.5;
-  }
-};
-
-const saveSplitRatio = (ratio: number): void => {
-  try {
-    localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(ratio));
-  } catch {
-    // Same restricted-storage cases as loadSplitRatio — drop the write
-    // so resizing (drag or keyboard) always completes cleanly.
-  }
-};
 
 @customElement("esphome-device-editor")
 export class ESPHomeDeviceEditor extends LitElement {
@@ -557,16 +535,11 @@ export class ESPHomeDeviceEditor extends LitElement {
     const rect = layout.getBoundingClientRect();
     this._dragging = true;
 
-    // Capture the pointer on the divider so move/up/cancel keep firing
-    // on it even as the pointer leaves the element, instead of leaking
-    // global window listeners. Capture releases automatically on
-    // pointerup/pointercancel, and the cancel path makes sure a
-    // cancelled gesture still clears `_dragging` and the listeners.
+    // Pointer capture keeps move/up/cancel on the divider (no global
+    // listener leak) and auto-releases on up/cancel.
     const divider = e.currentTarget as HTMLElement;
     divider.setPointerCapture(e.pointerId);
-    // `preventDefault` above suppresses the click's default focus, so
-    // focus the divider explicitly — otherwise the keyboard resize
-    // (Arrow/Home/End) is hard to discover after a mouse drag.
+    // preventDefault suppressed focus; set it so keyboard resize works.
     divider.focus();
 
     const onMove = (ev: PointerEvent) => {
@@ -586,14 +559,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   };
 
   private _onDividerKeydown = (e: KeyboardEvent) => {
-    let next: number | null = null;
-    if (e.key === "ArrowLeft") next = this._splitRatio - SPLIT_KEY_STEP;
-    else if (e.key === "ArrowRight") next = this._splitRatio + SPLIT_KEY_STEP;
-    else if (e.key === "Home") next = MIN_SPLIT_RATIO;
-    else if (e.key === "End") next = MAX_SPLIT_RATIO;
+    const next = nextSplitRatioForKey(this._splitRatio, e.key);
     if (next === null) return;
     e.preventDefault();
-    this._splitRatio = clampSplitRatio(next);
+    this._splitRatio = next;
     saveSplitRatio(this._splitRatio);
   };
 

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -529,6 +529,8 @@ export class ESPHomeDeviceEditor extends LitElement {
   }
 
   private _onDividerPointerDown = (e: PointerEvent) => {
+    // Primary button only; let right/middle click through (context menu).
+    if (e.button !== 0) return;
     const layout = this._layoutEl;
     if (!layout) return;
     e.preventDefault();

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -541,18 +541,28 @@ export class ESPHomeDeviceEditor extends LitElement {
     const rect = layout.getBoundingClientRect();
     this._dragging = true;
 
+    // Capture the pointer on the divider so move/up/cancel keep firing
+    // on it even as the pointer leaves the element, instead of leaking
+    // global window listeners. Capture releases automatically on
+    // pointerup/pointercancel, and the cancel path makes sure a
+    // cancelled gesture still clears `_dragging` and the listeners.
+    const divider = e.currentTarget as HTMLElement;
+    divider.setPointerCapture(e.pointerId);
+
     const onMove = (ev: PointerEvent) => {
       if (rect.width === 0) return;
       this._splitRatio = clampSplitRatio((ev.clientX - rect.left) / rect.width);
     };
-    const onUp = () => {
+    const onEnd = () => {
       this._dragging = false;
       localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(this._splitRatio));
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
+      divider.removeEventListener("pointermove", onMove);
+      divider.removeEventListener("pointerup", onEnd);
+      divider.removeEventListener("pointercancel", onEnd);
     };
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+    divider.addEventListener("pointermove", onMove);
+    divider.addEventListener("pointerup", onEnd);
+    divider.addEventListener("pointercancel", onEnd);
   };
 
   private _onDividerKeydown = (e: KeyboardEvent) => {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -54,9 +54,25 @@ const clampSplitRatio = (ratio: number): number =>
 const SPLIT_RATIO_STORAGE_KEY = "esphome-editor-split-ratio";
 
 const loadSplitRatio = (): number => {
-  const raw = localStorage.getItem(SPLIT_RATIO_STORAGE_KEY);
-  const parsed = raw === null ? NaN : Number.parseFloat(raw);
-  return Number.isFinite(parsed) ? clampSplitRatio(parsed) : 0.5;
+  try {
+    const raw = localStorage.getItem(SPLIT_RATIO_STORAGE_KEY);
+    const parsed = raw === null ? NaN : Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? clampSplitRatio(parsed) : 0.5;
+  } catch {
+    // localStorage can throw in private mode / sandboxed iframes /
+    // when quota is exhausted. Persistence is a nicety here, so fall
+    // back to the default ratio rather than breaking editor render.
+    return 0.5;
+  }
+};
+
+const saveSplitRatio = (ratio: number): void => {
+  try {
+    localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(ratio));
+  } catch {
+    // Same restricted-storage cases as loadSplitRatio — drop the write
+    // so resizing (drag or keyboard) always completes cleanly.
+  }
 };
 
 @customElement("esphome-device-editor")
@@ -548,6 +564,10 @@ export class ESPHomeDeviceEditor extends LitElement {
     // cancelled gesture still clears `_dragging` and the listeners.
     const divider = e.currentTarget as HTMLElement;
     divider.setPointerCapture(e.pointerId);
+    // `preventDefault` above suppresses the click's default focus, so
+    // focus the divider explicitly — otherwise the keyboard resize
+    // (Arrow/Home/End) is hard to discover after a mouse drag.
+    divider.focus();
 
     const onMove = (ev: PointerEvent) => {
       if (rect.width === 0) return;
@@ -555,7 +575,7 @@ export class ESPHomeDeviceEditor extends LitElement {
     };
     const onEnd = () => {
       this._dragging = false;
-      localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(this._splitRatio));
+      saveSplitRatio(this._splitRatio);
       divider.removeEventListener("pointermove", onMove);
       divider.removeEventListener("pointerup", onEnd);
       divider.removeEventListener("pointercancel", onEnd);
@@ -574,7 +594,7 @@ export class ESPHomeDeviceEditor extends LitElement {
     if (next === null) return;
     e.preventDefault();
     this._splitRatio = clampSplitRatio(next);
-    localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(this._splitRatio));
+    saveSplitRatio(this._splitRatio);
   };
 
   /**

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -12,7 +12,7 @@ import {
   mdiViewSplitHorizontal,
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext, yamlDiffButtonContext } from "../../context/index.js";
@@ -44,6 +44,20 @@ export type DeviceLayoutMode = "both" | "left" | "right";
 
 /** Cap the errors listed in the invalid banner; the rest collapse to "+N more". */
 const MAX_BANNER_ERRORS = 6;
+const MIN_SPLIT_RATIO = 0.25;
+const MAX_SPLIT_RATIO = 0.75;
+const SPLIT_KEY_STEP = 0.02;
+
+const clampSplitRatio = (ratio: number): number =>
+  Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio));
+
+const SPLIT_RATIO_STORAGE_KEY = "esphome-editor-split-ratio";
+
+const loadSplitRatio = (): number => {
+  const raw = localStorage.getItem(SPLIT_RATIO_STORAGE_KEY);
+  const parsed = raw === null ? NaN : Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? clampSplitRatio(parsed) : 0.5;
+};
 
 @customElement("esphome-device-editor")
 export class ESPHomeDeviceEditor extends LitElement {
@@ -172,6 +186,15 @@ export class ESPHomeDeviceEditor extends LitElement {
    *  "configuration invalid" banner above the editor. */
   @state()
   private _liveErrors: string[] = [];
+
+  @state()
+  private _splitRatio = loadSplitRatio();
+
+  @state()
+  private _dragging = false;
+
+  @query(".editor-layout")
+  private _layoutEl?: HTMLElement;
 
   static styles = [espHomeStyles, deviceEditorStyles];
 
@@ -344,7 +367,12 @@ export class ESPHomeDeviceEditor extends LitElement {
               ${this._localize("device.save")}
             </button>
           </div>
-          <div class=${`editor-layout ${layoutClass}`}>
+          <div
+            class="editor-layout ${layoutClass} ${this._dragging ? "dragging" : ""}"
+            style=${effectiveLayout === "both"
+              ? `grid-template-columns: ${this._splitRatio}fr var(--pane-divider-width) ${1 - this._splitRatio}fr`
+              : ""}
+          >
             <div class="editor-pane editor-pane--left">
               <esphome-device-board-info
                 .board=${this.board}
@@ -359,7 +387,18 @@ export class ESPHomeDeviceEditor extends LitElement {
               ></esphome-device-board-info>
             </div>
             ${effectiveLayout === "both"
-              ? html`<div class="pane-divider"></div>`
+              ? html`<div
+                  class="pane-divider ${this._dragging ? "dragging" : ""}"
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label=${this._localize("device.resize_panes")}
+                  aria-valuemin=${Math.round(MIN_SPLIT_RATIO * 100)}
+                  aria-valuemax=${Math.round(MAX_SPLIT_RATIO * 100)}
+                  aria-valuenow=${Math.round(this._splitRatio * 100)}
+                  tabindex="0"
+                  @pointerdown=${this._onDividerPointerDown}
+                  @keydown=${this._onDividerKeydown}
+                ></div>`
               : nothing}
             <div class="editor-pane editor-pane--right">
               ${!this._showDiff && this._liveErrors.length > 0
@@ -494,6 +533,39 @@ export class ESPHomeDeviceEditor extends LitElement {
       })
     );
   }
+
+  private _onDividerPointerDown = (e: PointerEvent) => {
+    const layout = this._layoutEl;
+    if (!layout) return;
+    e.preventDefault();
+    const rect = layout.getBoundingClientRect();
+    this._dragging = true;
+
+    const onMove = (ev: PointerEvent) => {
+      if (rect.width === 0) return;
+      this._splitRatio = clampSplitRatio((ev.clientX - rect.left) / rect.width);
+    };
+    const onUp = () => {
+      this._dragging = false;
+      localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(this._splitRatio));
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  private _onDividerKeydown = (e: KeyboardEvent) => {
+    let next: number | null = null;
+    if (e.key === "ArrowLeft") next = this._splitRatio - SPLIT_KEY_STEP;
+    else if (e.key === "ArrowRight") next = this._splitRatio + SPLIT_KEY_STEP;
+    else if (e.key === "Home") next = MIN_SPLIT_RATIO;
+    else if (e.key === "End") next = MAX_SPLIT_RATIO;
+    if (next === null) return;
+    e.preventDefault();
+    this._splitRatio = clampSplitRatio(next);
+    localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(this._splitRatio));
+  };
 
   /**
    * Called when a "Show YAML editor" CTA bubbles up from the section

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -18,7 +18,7 @@ export const deviceNavigatorStyles = css`
       --navigator-border,
       var(--wa-border-width-s) solid var(--wa-color-surface-border)
     );
-    box-shadow: var(--wa-elevation-02);
+    box-shadow: var(--navigator-shadow, var(--wa-elevation-02));
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -30,43 +30,20 @@ export const deviceNavigatorStyles = css`
     justify-content: space-between;
     gap: var(--wa-space-s);
     padding: var(--wa-space-s) var(--wa-space-m);
-    background: var(--esphome-primary);
-    color: var(--esphome-on-primary);
+    background: var(--esphome-tint);
+    color: var(--esphome-primary);
+    border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     flex-shrink: 0;
   }
 
   .card-title {
     margin: 0;
-    line-height: 1;
-    min-width: 0;
-  }
-
-  .card-title-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-    border: none;
-    background: transparent;
-    color: inherit;
-    cursor: pointer;
-    padding: var(--wa-space-2xs) var(--wa-space-xs);
-    margin-left: calc(-1 * var(--wa-space-xs));
-    border-radius: var(--wa-border-radius-s);
-    min-width: 0;
-    line-height: 1;
-    font-family: inherit;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-  }
-
-  .card-title-btn:hover {
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-  }
-
-  .card-title-btn wa-icon {
-    display: block;
-    font-size: 18px;
-    flex-shrink: 0;
+    line-height: 1;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    min-width: 0;
   }
 
   .collapse-btn {
@@ -74,19 +51,22 @@ export const deviceNavigatorStyles = css`
     align-items: center;
     justify-content: center;
     border: none;
+    width: 30px;
+    height: 22px;
+    padding: 0;
     background: transparent;
-    color: var(--esphome-on-primary);
+    color: var(--esphome-primary);
     cursor: pointer;
-    padding: 2px 4px;
-    border-radius: var(--wa-border-radius-s);
+    border-radius: var(--wa-border-radius-m);
+    transition: background 0.12s;
   }
 
   .collapse-btn:hover {
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+    background: var(--esphome-tint-border);
   }
 
   .collapse-btn wa-icon {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   .card-body {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -67,7 +67,7 @@ export const deviceNavigatorStyles = css`
   }
 
   .collapse-btn wa-icon {
-    font-size: 16px;
+    font-size: 18px;
   }
 
   .card-body {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -42,6 +42,7 @@ export const deviceNavigatorStyles = css`
     font-weight: var(--wa-font-weight-bold);
     line-height: 1;
     white-space: nowrap;
+    overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
   }

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -5,7 +5,6 @@ import {
   mdiChevronRight,
   mdiChevronUp,
   mdiCog,
-  mdiHomeOutline,
   mdiPlusCircleOutline,
   mdiScriptTextOutline,
 } from "@mdi/js";
@@ -60,7 +59,6 @@ registerMdiIcons({
   "chevron-up": mdiChevronUp,
   "chevron-right": mdiChevronRight,
   cog: mdiCog,
-  "home-outline": mdiHomeOutline,
   "plus-circle-outline": mdiPlusCircleOutline,
   "script-text-outline": mdiScriptTextOutline,
 });
@@ -385,17 +383,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
           @automation-added=${this._onAutomationAdded}
         ></esphome-add-script-dialog>
         <header class="card-header">
-          <h2 class="card-title">
-            <button
-              type="button"
-              class="card-title-btn"
-              @click=${this._goToOverview}
-              title=${this._localize("device.navigator_home")}
-            >
-              <wa-icon library="mdi" name="home-outline"></wa-icon>
-              <span>${this._localize("device.navigator_title")}</span>
-            </button>
-          </h2>
+          <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
           <button
             type="button"
             class="collapse-btn"
@@ -471,18 +459,6 @@ export class ESPHomeDeviceNavigator extends LitElement {
     if (!next.delete(key)) next.add(key);
     this._collapsedGroups = next;
   }
-
-  /** Clear the current section selection so the editor pane returns to
-   *  the device overview (board image + "Change board"). Mirrors the
-   *  deselect branch of ``_onItemClick`` without a row to toggle. */
-  private _goToOverview = () => {
-    this.selectedKey = null;
-    this._selectedLine = null;
-    this._selectedRange = null;
-    this._hoveredLine = null;
-    this._emitHighlight(null, false);
-    this._emitSectionSelect(null, undefined);
-  };
 
   /** Ask the page to hide the navigator. The page decides between
    *  desktop (set ``_navCollapsed`` + persist) and mobile (close the

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -5,6 +5,7 @@ import {
   mdiChevronRight,
   mdiChevronUp,
   mdiCog,
+  mdiMenu,
   mdiPlusCircleOutline,
   mdiScriptTextOutline,
 } from "@mdi/js";
@@ -59,6 +60,7 @@ registerMdiIcons({
   "chevron-up": mdiChevronUp,
   "chevron-right": mdiChevronRight,
   cog: mdiCog,
+  menu: mdiMenu,
   "plus-circle-outline": mdiPlusCircleOutline,
   "script-text-outline": mdiScriptTextOutline,
 });
@@ -391,7 +393,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
             title=${this._localize("device.hide_navigator")}
             aria-label=${this._localize("device.hide_navigator")}
           >
-            <wa-icon library="mdi" name="chevron-left"></wa-icon>
+            <wa-icon library="mdi" name="menu"></wa-icon>
           </button>
         </header>
         <div class="card-body">

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -83,6 +83,8 @@ export class ESPHomeLayout extends LitElement {
            dashboard page and the device-table inherit it through the slot;
            trims on mobile to match the tighter body gutter. */
         --content-gutter: var(--wa-space-l);
+        /* Shared with .header-back padding so the arrow's edge aligns. */
+        --header-edge-inset: 6px;
       }
       @media (max-width: ${MOBILE_BREAKPOINT}px) {
         :host {
@@ -95,7 +97,7 @@ export class ESPHomeLayout extends LitElement {
         align-items: center;
         gap: var(--wa-space-m);
         padding-right: var(--content-gutter);
-        padding-left: 6px;
+        padding-left: var(--header-edge-inset);
         background: var(--esphome-primary);
         height: var(--esphome-header-height);
         box-sizing: border-box;
@@ -119,7 +121,7 @@ export class ESPHomeLayout extends LitElement {
         border: none;
         background: none;
         color: var(--esphome-on-primary);
-        padding: 6px;
+        padding: var(--header-edge-inset);
         border-radius: var(--wa-border-radius-m);
         opacity: 0.85;
         cursor: pointer;

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -94,7 +94,8 @@ export class ESPHomeLayout extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-m);
-        padding: 0 var(--content-gutter);
+        padding-right: var(--content-gutter);
+        padding-left: 6px;
         background: var(--esphome-primary);
         height: var(--esphome-header-height);
         box-sizing: border-box;

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -86,44 +86,6 @@ export const devicePageStyles = css`
     background: var(--esphome-tint-border);
   }
 
-  .page {
-    position: relative;
-  }
-
-  .nav-edge-tab {
-    position: absolute;
-    left: 0;
-    top: calc(var(--wa-space-s) - 1px);
-    z-index: 5;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: calc(var(--wa-space-l) - var(--wa-space-2xs));
-    height: 24px;
-    padding: 0;
-    border: none;
-    border-radius: 0 var(--wa-border-radius-m) var(--wa-border-radius-m) 0;
-    background: var(--esphome-primary);
-    color: var(--esphome-on-primary);
-    cursor: pointer;
-    box-shadow: var(--wa-elevation-02);
-    transition: background 0.12s;
-  }
-
-  .nav-edge-tab:hover {
-    background: color-mix(in srgb, var(--esphome-primary), black 8%);
-  }
-
-  .nav-edge-tab wa-icon {
-    font-size: 16px;
-  }
-
-  @media (max-width: 900px) {
-    .nav-edge-tab {
-      width: 24px;
-    }
-  }
-
   @media (max-width: 900px) {
     /* Drop the page padding on mobile so the editor goes edge-to-edge.
        The card itself is already small at this width — wasting ~16px

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -74,8 +74,8 @@ export const devicePageStyles = css`
     background: transparent;
     color: var(--esphome-primary);
     cursor: pointer;
-    padding: 4px;
-    border-radius: var(--wa-border-radius-m);
+    padding: 2px 4px;
+    border-radius: 4px;
   }
 
   .nav-toggle-btn wa-icon {

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -7,20 +7,23 @@ export const devicePageStyles = css`
 
   .page {
     box-sizing: border-box;
-    padding: var(--wa-space-l) var(--wa-space-l) 0;
+    padding: 0;
     min-height: calc(100vh - var(--esphome-header-height));
   }
 
   .layout-grid {
     display: grid;
     grid-template-columns: minmax(230px, 1fr) minmax(0, 5fr);
-    gap: var(--wa-space-l);
-    height: calc(
-      100vh - var(--esphome-header-height) - var(--esphome-footer-height) - var(
-          --wa-space-l
-        )
-    );
+    gap: 1px;
+    background: var(--wa-color-surface-border);
+    height: calc(100vh - var(--esphome-header-height) - var(--esphome-footer-height));
     transition: grid-template-columns 0.25s ease;
+    --navigator-border-radius: 0;
+    --navigator-border: none;
+    --navigator-shadow: none;
+    --editor-border-radius: 0;
+    --editor-border: none;
+    --editor-shadow: none;
   }
 
   .layout-grid.nav-collapsed {
@@ -41,8 +44,8 @@ export const devicePageStyles = css`
     align-items: center;
     justify-content: center;
     border: none;
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 80%);
-    color: var(--esphome-on-primary);
+    background: transparent;
+    color: var(--esphome-primary);
     cursor: pointer;
     padding: 4px;
     border-radius: var(--wa-border-radius-m);
@@ -54,15 +57,9 @@ export const devicePageStyles = css`
   }
 
   .back-btn:hover {
-    background: color-mix(in srgb, var(--esphome-on-primary), transparent 70%);
+    background: var(--esphome-tint-border);
   }
 
-  /* Sticky-bookmark expand affordance. Anchored to the left edge of
-     the page wrapper (position: relative below), so it hugs the
-     editor card and reads as a tab hanging off its side. Visible
-     only when the navigator is hidden (desktop collapsed or mobile
-     drawer closed) — the parent component gates rendering via the
-     showEdgeTab flag, so we don't need a CSS hide branch. */
   .page {
     position: relative;
   }
@@ -70,17 +67,13 @@ export const devicePageStyles = css`
   .nav-edge-tab {
     position: absolute;
     left: 0;
-    top: 50%;
-    transform: translateY(-50%);
+    top: calc(var(--wa-space-s) - 1px);
     z-index: 5;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    /* Width spans the page's left padding minus a small inset, so
-       the tab's right edge stops short of the editor card and the
-       gap (--wa-space-2xs) reads as deliberate breathing room. */
     width: calc(var(--wa-space-l) - var(--wa-space-2xs));
-    height: 44px;
+    height: 24px;
     padding: 0;
     border: none;
     border-radius: 0 var(--wa-border-radius-m) var(--wa-border-radius-m) 0;
@@ -96,14 +89,11 @@ export const devicePageStyles = css`
   }
 
   .nav-edge-tab wa-icon {
-    font-size: 18px;
+    font-size: 16px;
   }
 
   @media (max-width: 900px) {
     .nav-edge-tab {
-      /* Mobile page has no padding so the calc width collapses to a
-         negative value — fall back to a fixed width that sticks the
-         tab off the viewport's left edge over the editor. */
       width: 24px;
     }
   }

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -60,6 +60,32 @@ export const devicePageStyles = css`
     background: var(--esphome-tint-border);
   }
 
+  .header-start-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .nav-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--esphome-primary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: var(--wa-border-radius-m);
+  }
+
+  .nav-toggle-btn wa-icon {
+    font-size: 18px;
+  }
+
+  .nav-toggle-btn:hover {
+    background: var(--esphome-tint-border);
+  }
+
   .page {
     position: relative;
   }

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -948,39 +948,39 @@ export class ESPHomePageDevice extends LitElement {
               <wa-icon library="mdi" name="chevron-right"></wa-icon>
             </button>`
           : nothing}
+        <esphome-unsaved-changes-dialog
+          @discard=${this._onUnsavedDiscard}
+          @save=${this._onUnsavedSave}
+          @cancel=${this._onUnsavedCancel}
+        ></esphome-unsaved-changes-dialog>
+        <esphome-command-dialog
+          @request-show-logs-after-install=${this._onPostInstallShowLogs}
+          @request-open-editor=${this._onRequestOpenEditor}
+        ></esphome-command-dialog>
+        <esphome-firmware-install-dialog
+          @request-show-logs-after-install=${this._onPostInstallShowLogs}
+          @clean-build=${this._onCleanBuild}
+          @request-open-editor=${this._onRequestOpenEditor}
+        ></esphome-firmware-install-dialog>
+        <esphome-logs-dialog></esphome-logs-dialog>
+        <esphome-install-method-dialog
+          ?open=${this._installCtrl.installMethodOpen}
+          .deviceState=${this._installCtrl.deviceState}
+          .deviceTargetPlatform=${this._installCtrl.deviceTargetPlatform}
+          .deviceCurrentAddress=${this._installCtrl.deviceCurrentAddress}
+          @close=${this._installCtrl.onInstallMethodClose}
+          @select-method=${this._installCtrl.onInstallMethodSelect}
+        ></esphome-install-method-dialog>
+        <esphome-yaml-validation-dialog
+          .errorCount=${this._validationErrorCount}
+          .firstErrorLine=${this._validationFirstLine}
+          .firstErrorCol=${this._validationFirstCol}
+          .firstErrorMessage=${this._validationFirstMessage}
+          @save-anyway=${this._onValidationSaveAnyway}
+          @goto=${this._onValidationGoTo}
+          @cancel=${this._onValidationCancel}
+        ></esphome-yaml-validation-dialog>
       </div>
-      <esphome-unsaved-changes-dialog
-        @discard=${this._onUnsavedDiscard}
-        @save=${this._onUnsavedSave}
-        @cancel=${this._onUnsavedCancel}
-      ></esphome-unsaved-changes-dialog>
-      <esphome-command-dialog
-        @request-show-logs-after-install=${this._onPostInstallShowLogs}
-        @request-open-editor=${this._onRequestOpenEditor}
-      ></esphome-command-dialog>
-      <esphome-firmware-install-dialog
-        @request-show-logs-after-install=${this._onPostInstallShowLogs}
-        @clean-build=${this._onCleanBuild}
-        @request-open-editor=${this._onRequestOpenEditor}
-      ></esphome-firmware-install-dialog>
-      <esphome-logs-dialog></esphome-logs-dialog>
-      <esphome-install-method-dialog
-        ?open=${this._installCtrl.installMethodOpen}
-        .deviceState=${this._installCtrl.deviceState}
-        .deviceTargetPlatform=${this._installCtrl.deviceTargetPlatform}
-        .deviceCurrentAddress=${this._installCtrl.deviceCurrentAddress}
-        @close=${this._installCtrl.onInstallMethodClose}
-        @select-method=${this._installCtrl.onInstallMethodSelect}
-      ></esphome-install-method-dialog>
-      <esphome-yaml-validation-dialog
-        .errorCount=${this._validationErrorCount}
-        .firstErrorLine=${this._validationFirstLine}
-        .firstErrorCol=${this._validationFirstCol}
-        .firstErrorMessage=${this._validationFirstMessage}
-        @save-anyway=${this._onValidationSaveAnyway}
-        @goto=${this._onValidationGoTo}
-        @cancel=${this._onValidationCancel}
-      ></esphome-yaml-validation-dialog>
     `;
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { mdiArrowLeft, mdiChevronRight } from "@mdi/js";
+import { mdiArrowLeft, mdiChevronRight, mdiMenu } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import toast from "sonner-js";
@@ -61,6 +61,7 @@ import "../components/yaml-validation-dialog.js";
 registerMdiIcons({
   "arrow-left": mdiArrowLeft,
   "chevron-right": mdiChevronRight,
+  menu: mdiMenu,
 });
 
 @customElement("esphome-page-device")
@@ -924,30 +925,33 @@ export class ESPHomePageDevice extends LitElement {
             ?hasUpdateAvailable=${this._device?.update_available === true}
             ?busy=${this._activeJobs.has(this.id)}
           >
-            ${this._selectedSection
-              ? html`<button
-                  slot="header-start"
-                  class="back-btn"
-                  @click=${this._onBack}
-                  title=${backLabel}
-                  aria-label=${backLabel}
-                >
-                  <wa-icon library="mdi" name="arrow-left"></wa-icon>
-                </button>`
+            ${showEdgeTab || this._selectedSection
+              ? html`<div slot="header-start" class="header-start-group">
+                  ${showEdgeTab
+                    ? html`<button
+                        type="button"
+                        class="nav-toggle-btn"
+                        @click=${this._onNavExpand}
+                        title=${this._localize("device.show_navigator")}
+                        aria-label=${this._localize("device.show_navigator")}
+                      >
+                        <wa-icon library="mdi" name="menu"></wa-icon>
+                      </button>`
+                    : nothing}
+                  ${this._selectedSection
+                    ? html`<button
+                        class="back-btn"
+                        @click=${this._onBack}
+                        title=${backLabel}
+                        aria-label=${backLabel}
+                      >
+                        <wa-icon library="mdi" name="arrow-left"></wa-icon>
+                      </button>`
+                    : nothing}
+                </div>`
               : nothing}
           </esphome-device-editor>
         </div>
-        ${showEdgeTab
-          ? html`<button
-              type="button"
-              class="nav-edge-tab"
-              @click=${this._onNavExpand}
-              title=${this._localize("device.show_navigator")}
-              aria-label=${this._localize("device.show_navigator")}
-            >
-              <wa-icon library="mdi" name="chevron-right"></wa-icon>
-            </button>`
-          : nothing}
         <esphome-unsaved-changes-dialog
           @discard=${this._onUnsavedDiscard}
           @save=${this._onUnsavedSave}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -569,6 +569,7 @@
     "layout_split": "Split view",
     "layout_yaml_only": "Show YAML editor only",
     "resize_panes": "Resize panes",
+    "resize_panes_value": "{percent}% components",
     "yaml_reveal_sensitive": "Reveal sensitive values",
     "yaml_mask_sensitive": "Hide sensitive values",
     "yaml_editor": "YAML editor",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -551,7 +551,6 @@
   },
   "device": {
     "navigator_title": "Device navigator",
-    "navigator_home": "Back to device overview",
     "navigator_search_placeholder": "Filter by name or ID…",
     "navigator_search_clear": "Clear filter",
     "navigator_search_count": "{count} of {total}",
@@ -568,6 +567,7 @@
     "layout_components_only": "Show components only",
     "layout_split": "Split view",
     "layout_yaml_only": "Show YAML editor only",
+    "resize_panes": "Resize panes",
     "yaml_reveal_sensitive": "Reveal sensitive values",
     "yaml_mask_sensitive": "Hide sensitive values",
     "yaml_editor": "YAML editor",

--- a/src/util/split-ratio.ts
+++ b/src/util/split-ratio.ts
@@ -1,0 +1,53 @@
+/**
+ * Persisted split ratio (left-pane width fraction) for the device
+ * editor's resizable two-pane layout. Storage access is guarded so a
+ * throw (private mode / sandboxed iframe / quota) falls back to the
+ * default instead of breaking the editor.
+ */
+
+export const MIN_SPLIT_RATIO = 0.25;
+export const MAX_SPLIT_RATIO = 0.75;
+export const DEFAULT_SPLIT_RATIO = 0.5;
+
+/** Step applied per Arrow keypress when the divider has focus. */
+export const SPLIT_KEY_STEP = 0.02;
+
+const STORAGE_KEY = "esphome-editor-split-ratio";
+
+/** Clamp an arbitrary ratio into the allowed band. */
+export const clampSplitRatio = (ratio: number): number =>
+  Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio));
+
+/** Read the stored ratio, falling back to the default. */
+export const loadSplitRatio = (): number => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw === null ? NaN : Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? clampSplitRatio(parsed) : DEFAULT_SPLIT_RATIO;
+  } catch {
+    return DEFAULT_SPLIT_RATIO;
+  }
+};
+
+/** Persist the ratio; drops the write if storage is unavailable. */
+export const saveSplitRatio = (ratio: number): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(ratio));
+  } catch {
+    // Drop the write so resizing still completes.
+  }
+};
+
+/**
+ * Map a divider keydown to the next ratio, or null for non-resize keys.
+ * Arrow nudges one step, Home/End jump to the band ends; always clamped.
+ */
+export const nextSplitRatioForKey = (current: number, key: string): number | null => {
+  let next: number;
+  if (key === "ArrowLeft") next = current - SPLIT_KEY_STEP;
+  else if (key === "ArrowRight") next = current + SPLIT_KEY_STEP;
+  else if (key === "Home") next = MIN_SPLIT_RATIO;
+  else if (key === "End") next = MAX_SPLIT_RATIO;
+  else return null;
+  return clampSplitRatio(next);
+};

--- a/test/components/device/device-navigator-overview.test.ts
+++ b/test/components/device/device-navigator-overview.test.ts
@@ -43,16 +43,3 @@ describe("device-navigator section header icons", () => {
     ]);
   });
 });
-
-describe("device-navigator overview button", () => {
-  it("clears the selection when the title is clicked", async () => {
-    const nav = await mountNavigator();
-    const events: Array<{ sectionKey: string | null }> = [];
-    nav.addEventListener("section-select", (e) => events.push((e as CustomEvent).detail));
-    const title = nav.shadowRoot?.querySelector<HTMLButtonElement>(".card-title-btn");
-    expect(title).toBeTruthy();
-    title!.click();
-    expect(events).toHaveLength(1);
-    expect(events[0].sectionKey).toBeNull();
-  });
-});

--- a/test/util/split-ratio.test.ts
+++ b/test/util/split-ratio.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SPLIT_RATIO,
+  MAX_SPLIT_RATIO,
+  MIN_SPLIT_RATIO,
+  clampSplitRatio,
+  loadSplitRatio,
+  nextSplitRatioForKey,
+  saveSplitRatio,
+} from "../../src/util/split-ratio.js";
+
+describe("split-ratio", () => {
+  // Mirrors the auth-token.test.ts pattern: vitest runs in node, so
+  // localStorage has to be stubbed per-test.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("clampSplitRatio", () => {
+    it("clamps below the minimum", () => {
+      expect(clampSplitRatio(0.1)).toBe(MIN_SPLIT_RATIO);
+      expect(clampSplitRatio(-5)).toBe(MIN_SPLIT_RATIO);
+    });
+
+    it("clamps above the maximum", () => {
+      expect(clampSplitRatio(0.9)).toBe(MAX_SPLIT_RATIO);
+      expect(clampSplitRatio(42)).toBe(MAX_SPLIT_RATIO);
+    });
+
+    it("passes a value inside the band through unchanged", () => {
+      expect(clampSplitRatio(0.5)).toBe(0.5);
+      expect(clampSplitRatio(MIN_SPLIT_RATIO)).toBe(MIN_SPLIT_RATIO);
+      expect(clampSplitRatio(MAX_SPLIT_RATIO)).toBe(MAX_SPLIT_RATIO);
+    });
+  });
+
+  describe("loadSplitRatio", () => {
+    it("falls back to the default when nothing is stored", () => {
+      expect(loadSplitRatio()).toBe(DEFAULT_SPLIT_RATIO);
+    });
+
+    it("falls back to the default for an empty or garbage value", () => {
+      localStorage.setItem("esphome-editor-split-ratio", "");
+      expect(loadSplitRatio()).toBe(DEFAULT_SPLIT_RATIO);
+      localStorage.setItem("esphome-editor-split-ratio", "not-a-number");
+      expect(loadSplitRatio()).toBe(DEFAULT_SPLIT_RATIO);
+    });
+
+    it("clamps an out-of-band stored value", () => {
+      localStorage.setItem("esphome-editor-split-ratio", "0.95");
+      expect(loadSplitRatio()).toBe(MAX_SPLIT_RATIO);
+      localStorage.setItem("esphome-editor-split-ratio", "0.0");
+      expect(loadSplitRatio()).toBe(MIN_SPLIT_RATIO);
+    });
+
+    it("round-trips a valid ratio through save/load", () => {
+      saveSplitRatio(0.6);
+      expect(loadSplitRatio()).toBe(0.6);
+    });
+  });
+
+  it("tolerates localStorage throwing on read and write", () => {
+    // Private mode / sandboxed iframes can throw on every access.
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+      clear: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => saveSplitRatio(0.6)).not.toThrow();
+    expect(loadSplitRatio()).toBe(DEFAULT_SPLIT_RATIO);
+  });
+
+  describe("nextSplitRatioForKey", () => {
+    it("nudges left/right by one step", () => {
+      expect(nextSplitRatioForKey(0.5, "ArrowLeft")).toBeCloseTo(0.48);
+      expect(nextSplitRatioForKey(0.5, "ArrowRight")).toBeCloseTo(0.52);
+    });
+
+    it("jumps to the band ends on Home/End", () => {
+      expect(nextSplitRatioForKey(0.5, "Home")).toBe(MIN_SPLIT_RATIO);
+      expect(nextSplitRatioForKey(0.5, "End")).toBe(MAX_SPLIT_RATIO);
+    });
+
+    it("clamps when stepping past an end", () => {
+      expect(nextSplitRatioForKey(MIN_SPLIT_RATIO, "ArrowLeft")).toBe(MIN_SPLIT_RATIO);
+      expect(nextSplitRatioForKey(MAX_SPLIT_RATIO, "ArrowRight")).toBe(MAX_SPLIT_RATIO);
+    });
+
+    it("returns null for a non-resize key", () => {
+      expect(nextSplitRatioForKey(0.5, "Enter")).toBeNull();
+      expect(nextSplitRatioForKey(0.5, "a")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

- Adds a slider that remembers in local storage between the structured editor and the yaml editor
- Remove the padding around the editors to maximize edit space
- Better tie the sidebar expand together with shared icons

<!-- Quick description and explanation of changes. -->

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

## Screenshots

<img width="381" height="680" alt="Screenshot 2026-06-11 at 1 08 25 PM" src="https://github.com/user-attachments/assets/c52839de-a31c-4922-a295-00b7f6f5c721" />
<img width="389" height="683" alt="Screenshot 2026-06-11 at 1 08 30 PM" src="https://github.com/user-attachments/assets/26510b60-3715-4a3c-9cbf-06c5fe781762" />
