### PR TITLE
Accept dropped YAML and bundle files in the create wizard

### DIFF
--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -2,9 +2,11 @@ import { consume } from "@lit/context";
 import { mdiChevronDown, mdiChevronRight, mdiCog } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { FileDropController } from "../../util/file-drop-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { ACCEPTED_UPLOAD_EXTENSIONS } from "../../util/upload-file-types.js";
 
@@ -27,6 +29,8 @@ export class ESPHomeWizardStepMethod extends LitElement {
 
   @state()
   private _advancedOpen = false;
+
+  private _drop = new FileDropController(this, (file) => this._sendImportFile(file));
 
   static styles = [
     espHomeStyles,
@@ -144,50 +148,72 @@ export class ESPHomeWizardStepMethod extends LitElement {
         color: var(--wa-color-text-quiet);
         font-style: italic;
       }
+
+      /* Negative margin + matching padding keep the highlight outline
+         from shifting the step content when a file drag hovers. */
+      .drop-zone {
+        margin: calc(-1 * var(--wa-space-s));
+        padding: var(--wa-space-s);
+        border-radius: var(--wa-border-radius-l);
+      }
+
+      .drop-zone--active {
+        outline: var(--wa-border-width-m) dashed var(--esphome-primary);
+        outline-offset: calc(-1 * var(--wa-border-width-m));
+        background: var(--esphome-tint-faint);
+      }
+
+      .drop-zone--active .drop-hint {
+        color: var(--esphome-primary);
+      }
     `,
   ];
 
   protected render() {
     return html`
-      <div class="step-heading">
-        <wa-icon library="mdi" name="cog"></wa-icon>
-        <h2>${this._localize("wizard.how_create")}</h2>
-      </div>
-
-      <div class="method-layout">
-        <div class="option-cards">
-          <button class="option-card" @click=${this._goToBoard}>
-            <div class="option-card-text">
-              <h3>${this._localize("wizard.create_new")}</h3>
-              <p>${this._localize("wizard.create_new_desc")}</p>
-            </div>
-            <wa-icon library="mdi" name="chevron-right"></wa-icon>
-          </button>
+      <div
+        class=${classMap({ "drop-zone": true, "drop-zone--active": this._drop.dragging })}
+      >
+        <div class="step-heading">
+          <wa-icon library="mdi" name="cog"></wa-icon>
+          <h2>${this._localize("wizard.how_create")}</h2>
         </div>
 
-        <button
-          class="advanced-toggle"
-          aria-expanded=${this._advancedOpen}
-          @click=${this._toggleAdvanced}
-        >
-          ${this._localize("wizard.advanced_options")}
-          <wa-icon library="mdi" name="chevron-down"></wa-icon>
-        </button>
+        <div class="method-layout">
+          <div class="option-cards">
+            <button class="option-card" @click=${this._goToBoard}>
+              <div class="option-card-text">
+                <h3>${this._localize("wizard.create_new")}</h3>
+                <p>${this._localize("wizard.create_new_desc")}</p>
+              </div>
+              <wa-icon library="mdi" name="chevron-right"></wa-icon>
+            </button>
+          </div>
 
-        ${this._advancedOpen
-          ? html`<div class="option-cards">${this._renderAdvancedOptions()}</div>`
-          : nothing}
+          <button
+            class="advanced-toggle"
+            aria-expanded=${this._advancedOpen}
+            @click=${this._toggleAdvanced}
+          >
+            ${this._localize("wizard.advanced_options")}
+            <wa-icon library="mdi" name="chevron-down"></wa-icon>
+          </button>
+
+          ${this._advancedOpen
+            ? html`<div class="option-cards">${this._renderAdvancedOptions()}</div>`
+            : nothing}
+        </div>
+
+        <p class="drop-hint">${this._localize("wizard.drop_yaml")}</p>
+
+        <input
+          id="file-input"
+          type="file"
+          accept=${ACCEPTED_UPLOAD_EXTENSIONS.join(",")}
+          hidden
+          @change=${this._onFileSelected}
+        />
       </div>
-
-      <p class="drop-hint">${this._localize("wizard.drop_yaml")}</p>
-
-      <input
-        id="file-input"
-        type="file"
-        accept=${ACCEPTED_UPLOAD_EXTENSIONS.join(",")}
-        hidden
-        @change=${this._onFileSelected}
-      />
     `;
   }
 
@@ -231,7 +257,10 @@ export class ESPHomeWizardStepMethod extends LitElement {
 
     // Reset so the same file can be re-selected if needed
     this._fileInput.value = "";
+    this._sendImportFile(file);
+  }
 
+  private _sendImportFile(file: File) {
     // Imports don't ask for a board — the YAML already declares its platform.
     // The dialog reads the file and creates the device immediately.
     this.dispatchEvent(

--- a/src/util/file-drop-controller.ts
+++ b/src/util/file-drop-controller.ts
@@ -74,9 +74,12 @@ export class FileDropController implements ReactiveController {
     this._setDragging(true);
   };
 
-  private _onDragLeave = (e: DragEvent) => {
-    if (!hasFiles(e)) return;
-    this._depth = Math.max(0, this._depth - 1);
+  /* No hasFiles guard: ``dataTransfer`` can arrive null/stripped on
+     leave, and ``_depth`` only ever increments for file drags — an
+     early return here would leave the highlight stuck. Clearing at
+     depth 0 also covers a drag that only ever fired dragover. */
+  private _onDragLeave = () => {
+    if (this._depth > 0) this._depth--;
     if (this._depth === 0) this._setDragging(false);
   };
 
@@ -115,8 +118,12 @@ export class FileDropController implements ReactiveController {
   }
 }
 
+/* ``files.length`` fallback: this also gates the window navigation
+   guard, so a UA delivering a file drop without the "Files" type must
+   still be caught. ``files`` stays empty for text drags. */
 function hasFiles(e: DragEvent): boolean {
-  return e.dataTransfer?.types.includes("Files") ?? false;
+  if (!e.dataTransfer) return false;
+  return e.dataTransfer.types.includes("Files") || e.dataTransfer.files.length > 0;
 }
 
 function isVisible(el: HTMLElement): boolean {

--- a/src/util/file-drop-controller.ts
+++ b/src/util/file-drop-controller.ts
@@ -1,0 +1,124 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { ACCEPTED_UPLOAD_EXTENSIONS } from "./upload-file-types.js";
+
+export interface FileDropControllerOptions {
+  /** Drop target. Defaults to the host element. Injectable for tests. */
+  target?: HTMLElement;
+  /** Accepted filename extensions (lowercase). Defaults to the
+   *  wizard upload set (.yaml/.yml + bundle archives). */
+  extensions?: readonly string[];
+}
+
+/**
+ * Reactive controller that turns the host element into a file drop
+ * zone. While a file drag hovers the target, ``dragging`` is true so
+ * the host can render a highlight; a drop hands the first file with
+ * an accepted extension to ``onFile``.
+ *
+ * Also guards ``window`` while the target is visible: a file drop
+ * that misses the target is swallowed instead of letting the browser
+ * navigate to the file (Firefox would replace the SPA, losing all
+ * state). Non-file drags (e.g. text into an editor) pass through
+ * untouched, and a hidden-but-connected host (the create dialog stays
+ * mounted while closed) doesn't suppress browser behavior elsewhere.
+ */
+export class FileDropController implements ReactiveController {
+  dragging = false;
+
+  private readonly _target: HTMLElement;
+  private readonly _extensions: readonly string[];
+  /** dragenter/dragleave fire per child node; a bare boolean flickers. */
+  private _depth = 0;
+
+  constructor(
+    private readonly _host: ReactiveControllerHost & HTMLElement,
+    private readonly _onFile: (file: File) => void,
+    options: FileDropControllerOptions = {}
+  ) {
+    this._target = options.target ?? _host;
+    this._extensions = options.extensions ?? ACCEPTED_UPLOAD_EXTENSIONS;
+    _host.addController(this);
+  }
+
+  hostConnected() {
+    this._target.addEventListener("dragenter", this._onDragEnter);
+    this._target.addEventListener("dragover", this._onDragOver);
+    this._target.addEventListener("dragleave", this._onDragLeave);
+    this._target.addEventListener("drop", this._onDrop);
+    window.addEventListener("dragover", this._onWindowDragOver);
+    window.addEventListener("drop", this._onWindowDrop);
+  }
+
+  hostDisconnected() {
+    this._target.removeEventListener("dragenter", this._onDragEnter);
+    this._target.removeEventListener("dragover", this._onDragOver);
+    this._target.removeEventListener("dragleave", this._onDragLeave);
+    this._target.removeEventListener("drop", this._onDrop);
+    window.removeEventListener("dragover", this._onWindowDragOver);
+    window.removeEventListener("drop", this._onWindowDrop);
+    this._setDragging(false);
+    this._depth = 0;
+  }
+
+  private _onDragEnter = (e: DragEvent) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    this._depth++;
+    this._setDragging(true);
+  };
+
+  private _onDragOver = (e: DragEvent) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    this._setDragging(true);
+  };
+
+  private _onDragLeave = (e: DragEvent) => {
+    if (!hasFiles(e)) return;
+    this._depth = Math.max(0, this._depth - 1);
+    if (this._depth === 0) this._setDragging(false);
+  };
+
+  private _onDrop = (e: DragEvent) => {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    this._depth = 0;
+    this._setDragging(false);
+    const file = [...(e.dataTransfer?.files ?? [])].find((f) => {
+      const name = f.name.toLowerCase();
+      return this._extensions.some((ext) => name.endsWith(ext));
+    });
+    if (file) this._onFile(file);
+  };
+
+  /** Swallow file drags that miss the target while it's visible.
+   *  ``dropEffect = "none"`` shows the not-allowed cursor and keeps
+   *  the drop from firing; the drop guard is belt-and-braces. */
+  private _onWindowDragOver = (e: DragEvent) => {
+    if (!hasFiles(e) || e.defaultPrevented) return;
+    if (!isVisible(this._target)) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "none";
+  };
+
+  private _onWindowDrop = (e: DragEvent) => {
+    if (!hasFiles(e) || e.defaultPrevented) return;
+    if (!isVisible(this._target)) return;
+    e.preventDefault();
+  };
+
+  private _setDragging(dragging: boolean) {
+    if (dragging === this.dragging) return;
+    this.dragging = dragging;
+    this._host.requestUpdate();
+  }
+}
+
+function hasFiles(e: DragEvent): boolean {
+  return e.dataTransfer?.types.includes("Files") ?? false;
+}
+
+function isVisible(el: HTMLElement): boolean {
+  return el.isConnected && (el.checkVisibility?.() ?? el.offsetParent !== null);
+}

--- a/test/_drag-event.ts
+++ b/test/_drag-event.ts
@@ -1,0 +1,19 @@
+/** Synthetic drag event for happy-dom tests.
+ *
+ *  happy-dom lacks DragEvent; the production code only reads
+ *  ``dataTransfer`` and ``defaultPrevented``, so a plain Event with a
+ *  stub suffices. */
+export function dragEvent(
+  type: string,
+  opts: { files?: File[]; types?: string[] } = {}
+): Event & { dataTransfer: { types: string[]; files: File[]; dropEffect: string } } {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "dataTransfer", {
+    value: {
+      types: opts.types ?? ["Files"],
+      files: opts.files ?? [],
+      dropEffect: "",
+    },
+  });
+  return e as ReturnType<typeof dragEvent>;
+}

--- a/test/_fake-host.ts
+++ b/test/_fake-host.ts
@@ -1,0 +1,15 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/** Minimal ReactiveControllerHost for controller unit tests. */
+export class FakeHost implements ReactiveControllerHost {
+  controllers: ReactiveController[] = [];
+  updates = 0;
+  addController(c: ReactiveController) {
+    this.controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {
+    this.updates++;
+  }
+  updateComplete = Promise.resolve(true);
+}

--- a/test/components/wizard/wizard-step-method-drop.test.ts
+++ b/test/components/wizard/wizard-step-method-drop.test.ts
@@ -11,6 +11,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { defaultLocalize } from "../../../src/common/localize.js";
 import { ESPHomeWizardStepMethod } from "../../../src/components/wizard/wizard-step-method.js";
+import { dragEvent } from "../../_drag-event.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mount(): Promise<ESPHomeWizardStepMethod> {
@@ -22,14 +23,6 @@ async function mount(): Promise<ESPHomeWizardStepMethod> {
   return el;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-function dragEvent(type: string, files: File[] = []): Event {
-  const e = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperty(e, "dataTransfer", {
-    value: { types: ["Files"], files, dropEffect: "" },
-  });
-  return e;
-}
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -54,7 +47,7 @@ describe("wizard-step-method drag and drop", () => {
       seen.push((e as CustomEvent<{ file: File }>).detail.file)
     );
     const yaml = new File(["esphome:"], "kitchen.yaml");
-    const drop = dragEvent("drop", [yaml]);
+    const drop = dragEvent("drop", { files: [yaml] });
     el.dispatchEvent(drop);
     expect(drop.defaultPrevented).toBe(true);
     expect(seen).toEqual([yaml]);

--- a/test/components/wizard/wizard-step-method-drop.test.ts
+++ b/test/components/wizard/wizard-step-method-drop.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The method step's promised drag-and-drop (the "you can also drag and
+ * drop" hint) must import the dropped file through the same
+ * ``import-file`` event as the file-input path (#1386).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { defaultLocalize } from "../../../src/common/localize.js";
+import { ESPHomeWizardStepMethod } from "../../../src/components/wizard/wizard-step-method.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(): Promise<ESPHomeWizardStepMethod> {
+  const el = new ESPHomeWizardStepMethod();
+  (el as any)._localize = defaultLocalize;
+  document.body.appendChild(el);
+  el.checkVisibility = () => true;
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function dragEvent(type: string, files: File[] = []): Event {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "dataTransfer", {
+    value: { types: ["Files"], files, dropEffect: "" },
+  });
+  return e;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("wizard-step-method drag and drop", () => {
+  it("highlights the step while a file drag hovers", async () => {
+    const el = await mount();
+    el.dispatchEvent(dragEvent("dragover"));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(".drop-zone--active")).not.toBeNull();
+
+    el.dispatchEvent(dragEvent("dragleave"));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(".drop-zone--active")).toBeNull();
+  });
+
+  it("fires import-file with the dropped YAML, like the file-input path", async () => {
+    const el = await mount();
+    const seen: File[] = [];
+    el.addEventListener("import-file", (e) =>
+      seen.push((e as CustomEvent<{ file: File }>).detail.file)
+    );
+    const yaml = new File(["esphome:"], "kitchen.yaml");
+    const drop = dragEvent("drop", [yaml]);
+    el.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(seen).toEqual([yaml]);
+  });
+});

--- a/test/util/file-drop-controller.test.ts
+++ b/test/util/file-drop-controller.test.ts
@@ -1,39 +1,10 @@
 /**
  * @vitest-environment happy-dom
  */
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileDropController } from "../../src/util/file-drop-controller.js";
-
-class FakeHost implements ReactiveControllerHost {
-  controllers: ReactiveController[] = [];
-  updates = 0;
-  addController(c: ReactiveController) {
-    this.controllers.push(c);
-  }
-  removeController() {}
-  requestUpdate() {
-    this.updates++;
-  }
-  updateComplete = Promise.resolve(true);
-}
-
-/* happy-dom lacks DragEvent; the controller only reads ``dataTransfer``
-   and ``defaultPrevented``, so a plain Event with a stub suffices. */
-function dragEvent(
-  type: string,
-  opts: { files?: File[]; types?: string[] } = {}
-): Event & { dataTransfer: { types: string[]; files: File[]; dropEffect: string } } {
-  const e = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperty(e, "dataTransfer", {
-    value: {
-      types: opts.types ?? ["Files"],
-      files: opts.files ?? [],
-      dropEffect: "",
-    },
-  });
-  return e as ReturnType<typeof dragEvent>;
-}
+import { dragEvent } from "../_drag-event.js";
+import { FakeHost } from "../_fake-host.js";
 
 function make(opts: { visible?: boolean } = {}) {
   const host = new FakeHost();

--- a/test/util/file-drop-controller.test.ts
+++ b/test/util/file-drop-controller.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileDropController } from "../../src/util/file-drop-controller.js";
+
+class FakeHost implements ReactiveControllerHost {
+  controllers: ReactiveController[] = [];
+  updates = 0;
+  addController(c: ReactiveController) {
+    this.controllers.push(c);
+  }
+  removeController() {}
+  requestUpdate() {
+    this.updates++;
+  }
+  updateComplete = Promise.resolve(true);
+}
+
+/* happy-dom lacks DragEvent; the controller only reads ``dataTransfer``
+   and ``defaultPrevented``, so a plain Event with a stub suffices. */
+function dragEvent(
+  type: string,
+  opts: { files?: File[]; types?: string[] } = {}
+): Event & { dataTransfer: { types: string[]; files: File[]; dropEffect: string } } {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "dataTransfer", {
+    value: {
+      types: opts.types ?? ["Files"],
+      files: opts.files ?? [],
+      dropEffect: "",
+    },
+  });
+  return e as ReturnType<typeof dragEvent>;
+}
+
+function make(opts: { visible?: boolean } = {}) {
+  const host = new FakeHost();
+  const target = document.createElement("div");
+  target.checkVisibility = () => opts.visible ?? true;
+  document.body.appendChild(target);
+  const onFile = vi.fn();
+  const ctrl = new FileDropController(host as never, onFile, { target });
+  ctrl.hostConnected();
+  return { host, target, onFile, ctrl };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("FileDropController", () => {
+  it("accepts a dragged file: prevents default and flags dragging", () => {
+    const { host, target, ctrl } = make();
+    const over = dragEvent("dragover");
+    target.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(true);
+    expect(over.dataTransfer.dropEffect).toBe("copy");
+    expect(ctrl.dragging).toBe(true);
+    expect(host.updates).toBe(1);
+  });
+
+  it("ignores non-file drags entirely", () => {
+    const { target, ctrl } = make();
+    const over = dragEvent("dragover", { types: ["text/plain"] });
+    target.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(false);
+    expect(ctrl.dragging).toBe(false);
+  });
+
+  it("keeps dragging through child enter/leave churn, clears on real leave", () => {
+    const { target, ctrl } = make();
+    target.dispatchEvent(dragEvent("dragenter"));
+    target.dispatchEvent(dragEvent("dragenter")); // child
+    target.dispatchEvent(dragEvent("dragleave")); // child
+    expect(ctrl.dragging).toBe(true);
+    target.dispatchEvent(dragEvent("dragleave"));
+    expect(ctrl.dragging).toBe(false);
+  });
+
+  it("hands the first accepted file to onFile on drop", () => {
+    const { target, onFile, ctrl } = make();
+    target.dispatchEvent(dragEvent("dragenter"));
+    const yaml = new File(["esphome:"], "Config.YAML");
+    const drop = dragEvent("drop", { files: [new File([""], "photo.png"), yaml] });
+    target.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(onFile).toHaveBeenCalledExactlyOnceWith(yaml);
+    expect(ctrl.dragging).toBe(false);
+  });
+
+  it("accepts bundle archives", () => {
+    const { target, onFile } = make();
+    const bundle = new File([""], "device.tar.gz");
+    target.dispatchEvent(dragEvent("drop", { files: [bundle] }));
+    expect(onFile).toHaveBeenCalledExactlyOnceWith(bundle);
+  });
+
+  it("swallows a drop with no accepted file without importing", () => {
+    const { target, onFile } = make();
+    const drop = dragEvent("drop", { files: [new File([""], "photo.png")] });
+    target.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(onFile).not.toHaveBeenCalled();
+  });
+
+  it("guards window file drags while the target is visible", () => {
+    make();
+    const over = dragEvent("dragover");
+    window.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(true);
+    expect(over.dataTransfer.dropEffect).toBe("none");
+    const drop = dragEvent("drop", { files: [new File([""], "a.yaml")] });
+    window.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+  });
+
+  it("leaves window drags alone while the target is hidden", () => {
+    make({ visible: false });
+    const over = dragEvent("dragover");
+    window.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(false);
+  });
+
+  it("leaves window text drags alone", () => {
+    make();
+    const over = dragEvent("dragover", { types: ["text/plain"] });
+    window.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(false);
+  });
+
+  it("detaches everything on hostDisconnected", () => {
+    const { target, onFile, ctrl } = make();
+    target.dispatchEvent(dragEvent("dragenter"));
+    ctrl.hostDisconnected();
+    expect(ctrl.dragging).toBe(false);
+    const over = dragEvent("dragover");
+    window.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(false);
+    target.dispatchEvent(dragEvent("drop", { files: [new File([""], "a.yaml")] }));
+    expect(onFile).not.toHaveBeenCalled();
+  });
+});

--- a/test/util/file-drop-controller.test.ts
+++ b/test/util/file-drop-controller.test.ts
@@ -79,6 +79,27 @@ describe("FileDropController", () => {
     expect(ctrl.dragging).toBe(false);
   });
 
+  it("clears the highlight on a dragleave with no dataTransfer", () => {
+    const { target, ctrl } = make();
+    target.dispatchEvent(dragEvent("dragenter"));
+    expect(ctrl.dragging).toBe(true);
+    target.dispatchEvent(new Event("dragleave", { bubbles: true, cancelable: true }));
+    expect(ctrl.dragging).toBe(false);
+  });
+
+  it('recognizes a file drop whose types lack "Files" but whose files are populated', () => {
+    const { target, onFile } = make();
+    const yaml = new File(["esphome:"], "a.yaml");
+    const drop = dragEvent("drop", { files: [yaml], types: [] });
+    target.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(onFile).toHaveBeenCalledExactlyOnceWith(yaml);
+
+    const winDrop = dragEvent("drop", { files: [yaml], types: [] });
+    window.dispatchEvent(winDrop);
+    expect(winDrop.defaultPrevented).toBe(true);
+  });
+
   it("hands the first accepted file to onFile on drop", () => {
     const { target, onFile, ctrl } = make();
     target.dispatchEvent(dragEvent("dragenter"));


### PR DESCRIPTION
# What does this implement/fix?

The create-configuration wizard's first step has long said "You can also drag and drop a .yaml file or a bundle here", but the feature was never implemented — there were zero drag/drop listeners in the frontend. Dropping a file just let the browser handle it: Chrome opened it in a new tab, Firefox navigated away and replaced the whole SPA (losing all dashboard state).

This wires it up with a shared `FileDropController` (Lit ReactiveController, same lifecycle shape as `EscapeController`):

- Turns the method step into a drop zone: a file drag hovering it shows a dashed highlight, and a drop hands the first file with an accepted extension (`.yaml`/`.yml` or a bundle archive) to the **existing** `import-file` event — the same path the "Import from file" button already uses, so YAML-vs-bundle branching, validation, and the overwrite-conflict flow all come for free.
- Guards `window` while the drop zone is visible so a file drop that *misses* the dialog is swallowed instead of navigating the browser (the Firefox state-loss case). Non-file drags (text into the YAML editor) and the closed/hidden dialog are untouched — the guard checks visibility at event time, since the create dialog stays mounted while closed.

Verified end-to-end headless: opening the wizard and dropping a YAML created the device on disk and surfaced the import flow's overwrite prompt on a repeat drop; a drop outside the dialog (open or closed) does not navigate.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1386

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
