### PR TITLE
Use the shared FakeHost test helpers everywhere

### DIFF
--- a/test/_fake-host.ts
+++ b/test/_fake-host.ts
@@ -1,4 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { vi } from "vitest";
 
 /** Minimal ReactiveControllerHost for controller unit tests. */
 export class FakeHost implements ReactiveControllerHost {
@@ -13,3 +14,12 @@ export class FakeHost implements ReactiveControllerHost {
   }
   updateComplete = Promise.resolve(true);
 }
+
+/** Spy-based variant for tests that assert on the host calls. */
+export const fakeHost = (): ReactiveControllerHost =>
+  ({
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  }) as unknown as ReactiveControllerHost;

--- a/test/components/device/automation-editor/parse-error-controller.test.ts
+++ b/test/components/device/automation-editor/parse-error-controller.test.ts
@@ -2,7 +2,6 @@
  * Unit tests for ``ParseErrorController.resolve`` — the classify step
  * behind the editors' read-only-on-parse-error behaviour (#1050).
  */
-import type { ReactiveControllerHost } from "lit";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
@@ -10,14 +9,7 @@ import type {
   ParsedAutomation,
 } from "../../../../src/api/types/automations.js";
 import { ParseErrorController } from "../../../../src/components/device/automation-editor/parse-error-controller.js";
-
-const fakeHost = (): ReactiveControllerHost =>
-  ({
-    addController: vi.fn(),
-    removeController: vi.fn(),
-    requestUpdate: vi.fn(),
-    updateComplete: Promise.resolve(true),
-  }) as unknown as ReactiveControllerHost;
+import { fakeHost } from "../../../_fake-host.js";
 
 const SCRIPT: AutomationLocation = {
   kind: "script",

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -1,4 +1,3 @@
-import type { ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ESPHomeAPI } from "../../../src/api/index.js";
@@ -9,14 +8,7 @@ import {
   fetchAutomationTriggers,
   getCachedAutomationTriggers,
 } from "../../../src/util/automation-catalog-cache.js";
-
-const fakeHost = (): ReactiveControllerHost =>
-  ({
-    addController: vi.fn(),
-    removeController: vi.fn(),
-    requestUpdate: vi.fn(),
-    updateComplete: Promise.resolve(true),
-  }) as unknown as ReactiveControllerHost;
+import { fakeHost } from "../../_fake-host.js";
 
 const trigger = (id: string, name: string): AutomationTrigger => ({
   id,

--- a/test/components/yaml-search-controller.test.ts
+++ b/test/components/yaml-search-controller.test.ts
@@ -1,23 +1,8 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { YamlSearchHit } from "../../src/api/types/devices.js";
 import { YamlSearchController } from "../../src/components/yaml-search-controller.js";
-
-class FakeHost implements ReactiveControllerHost {
-  controllers: ReactiveController[] = [];
-  updates = 0;
-  addController(c: ReactiveController) {
-    this.controllers.push(c);
-  }
-  removeController() {
-    /* no-op */
-  }
-  requestUpdate() {
-    this.updates++;
-  }
-  updateComplete = Promise.resolve(true);
-}
+import { FakeHost } from "../_fake-host.js";
 
 /* The controller's only API surface is ``hits``, ``scheduleQuery``,
    ``clear``, and the host-lifecycle hooks. Tests stub the API and

--- a/test/util/escape-controller.test.ts
+++ b/test/util/escape-controller.test.ts
@@ -1,16 +1,6 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { EscapeController } from "../../src/util/escape-controller.js";
-
-class FakeHost implements ReactiveControllerHost {
-  controllers: ReactiveController[] = [];
-  addController(c: ReactiveController) {
-    this.controllers.push(c);
-  }
-  removeController() {}
-  requestUpdate() {}
-  updateComplete = Promise.resolve(true);
-}
+import { FakeHost } from "../_fake-host.js";
 
 /* The runtime test environment is plain Node (no jsdom), so we feed
    the controller our own EventTarget and dispatch raw ``Event``s with

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -1,4 +1,3 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { SerialPort } from "../../src/api/types/system.js";
@@ -6,19 +5,7 @@ import {
   SERIAL_PORTS_POLL_INTERVAL_MS,
   SerialPortsPollController,
 } from "../../src/util/serial-ports-poll-controller.js";
-
-class FakeHost implements ReactiveControllerHost {
-  controllers: ReactiveController[] = [];
-  updates = 0;
-  addController(c: ReactiveController) {
-    this.controllers.push(c);
-  }
-  removeController() {}
-  requestUpdate() {
-    this.updates++;
-  }
-  updateComplete = Promise.resolve(true);
-}
+import { FakeHost } from "../_fake-host.js";
 
 const A: SerialPort = { port: "/dev/ttyUSB0", desc: "CP2102" };
 const B: SerialPort = { port: "/dev/ttyUSB1", desc: "CH340" };

--- a/test/util/session-blob-cache-controller.test.ts
+++ b/test/util/session-blob-cache-controller.test.ts
@@ -1,17 +1,9 @@
-import type { ReactiveControllerHost } from "lit";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { SessionBlobCacheController } from "../../src/util/session-blob-cache-controller.js";
 import { createSessionBlobCache } from "../../src/util/session-blob-cache.js";
-
-const fakeHost = (): ReactiveControllerHost =>
-  ({
-    addController: vi.fn(),
-    removeController: vi.fn(),
-    requestUpdate: vi.fn(),
-    updateComplete: Promise.resolve(true),
-  }) as unknown as ReactiveControllerHost;
+import { fakeHost } from "../_fake-host.js";
 
 const fakeApi = (): ESPHomeAPI => ({}) as unknown as ESPHomeAPI;
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #771, which introduced the shared `test/_fake-host.ts` helper but deliberately migrated only its own new call site to keep the feature diff small.

This moves the remaining duplicated ReactiveControllerHost stubs onto the shared helpers:

- The three local `class FakeHost` copies (`escape-controller`, `serial-ports-poll-controller`, `yaml-search-controller` tests) now import the shared class — it's a superset of all of them (the `updates` counter is simply unused where not asserted).
- The three verbatim-identical `vi.fn()`-based `fakeHost()` arrow stubs (`session-blob-cache-controller`, `trigger-catalog-controller`, `parse-error-controller` tests) move to a new spy-based `fakeHost` export in the same helper, keeping the existing call sites and assertion styles unchanged.

Intentionally-minimal one-off stubs stay local (`enter-controller`'s `{ addController() {} }`, `catalog-load-controller`'s one-liner, `component-name-resolver-controller`'s lifecycle-capturing stub) — they aren't the shared shape and exist for local reasons.

Net −52 lines, behavior-free: no test bodies or assertions changed.

**Related issue or feature (if applicable):**

- follow-up to #771

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
