### PR TITLE
Keep ${var} substitutions editable in the structured editor

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -47,7 +47,10 @@ import {
 } from "../../util/pin-registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
-import { parseSubstitutions } from "../../util/substitutions.js";
+import {
+  hasSubstitutionReference,
+  parseSubstitutions,
+} from "../../util/substitutions.js";
 import {
   _isStructuralType,
   filterRenderable,
@@ -507,6 +510,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
   }
 
   private _renderEntryLeaf(entry: ConfigEntry, path: string[], ctx: RenderCtx): unknown {
+    // A ${var} value can't drive a typed widget (number/select/switch): it
+    // blanks the literal and the first interaction clobbers it. Edit it as
+    // text so the token round-trips; SECURE_STRING stays masked (#1391).
+    const raw = ctx.getAt(path);
+    if (typeof raw === "string" && hasSubstitutionReference(raw)) {
+      const inputType =
+        entry.type === ConfigEntryType.SECURE_STRING ? "password" : "text";
+      return renderStringField(entry, inputType, path, ctx);
+    }
     if (entry.type === ConfigEntryType.DIVIDER) {
       return html`<wa-divider></wa-divider>`;
     }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -47,10 +47,7 @@ import {
 } from "../../util/pin-registry-modes-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SessionBlobCacheController } from "../../util/session-blob-cache-controller.js";
-import {
-  hasSubstitutionReference,
-  parseSubstitutions,
-} from "../../util/substitutions.js";
+import { looksLikeSubstitution, parseSubstitutions } from "../../util/substitutions.js";
 import {
   _isStructuralType,
   filterRenderable,
@@ -512,9 +509,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
   private _renderEntryLeaf(entry: ConfigEntry, path: string[], ctx: RenderCtx): unknown {
     // A ${var} value can't drive a typed widget (number/select/switch): it
     // blanks the literal and the first interaction clobbers it. Edit it as
-    // text so the token round-trips; SECURE_STRING stays masked (#1391).
+    // text so the token round-trips and stays editable mid-keystroke;
+    // SECURE_STRING stays masked (#1391).
     const raw = ctx.getAt(path);
-    if (typeof raw === "string" && hasSubstitutionReference(raw)) {
+    if (typeof raw === "string" && looksLikeSubstitution(raw)) {
       const inputType =
         entry.type === ConfigEntryType.SECURE_STRING ? "password" : "text";
       return renderStringField(entry, inputType, path, ctx);

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -135,8 +135,8 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   if (isEmpty) return null;
 
   // A ${var} reference resolves at build time, so its value is unknowable
-  // here; never flag the literal (or a mid-edit partial) as "not a number"
-  // (#1391).
+  // here; skip all validation (range, options, not-a-number) for the literal
+  // or a mid-edit partial (#1391).
   if (typeof raw === "string" && looksLikeSubstitution(raw)) return null;
 
   if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -4,6 +4,7 @@ import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord } from "./nested-values.js";
+import { hasSubstitutionReference } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
@@ -132,6 +133,10 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
     return { key: entry.key, code: "validation.required" };
   }
   if (isEmpty) return null;
+
+  // A ${var} reference resolves at build time, so its value is unknowable
+  // here; never flag the literal as "not a number" (#1391).
+  if (typeof raw === "string" && hasSubstitutionReference(raw)) return null;
 
   if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {
     // BigInt-route the hex-typed integer check so cv.hex_uint64_t

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -4,7 +4,7 @@ import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord } from "./nested-values.js";
-import { hasSubstitutionReference } from "./substitutions.js";
+import { looksLikeSubstitution } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
@@ -135,8 +135,9 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
   if (isEmpty) return null;
 
   // A ${var} reference resolves at build time, so its value is unknowable
-  // here; never flag the literal as "not a number" (#1391).
-  if (typeof raw === "string" && hasSubstitutionReference(raw)) return null;
+  // here; never flag the literal (or a mid-edit partial) as "not a number"
+  // (#1391).
+  if (typeof raw === "string" && looksLikeSubstitution(raw)) return null;
 
   if (entry.type === ConfigEntryType.INTEGER && entry.display_format === "hex") {
     // BigInt-route the hex-typed integer check so cv.hex_uint64_t

--- a/src/util/substitutions.ts
+++ b/src/util/substitutions.ts
@@ -52,12 +52,17 @@ export function hasSubstitutionReference(text: string): boolean {
   return SUBSTITUTION_REF_RE.test(text);
 }
 
-/** True when *text* holds a ``$``: a complete or in-progress reference.
- *  Looser than ``hasSubstitutionReference`` so a typed field stays in the
- *  text editor mid-edit (``${voltage_div`` after the brace is deleted)
- *  instead of snapping back to a widget that blanks the partial. */
+// A complete or in-progress reference start (``${`` or ``$<letter>``) that
+// isn't an escaped ``$$``. Looser than SUBSTITUTION_REF_RE (accepts an
+// unclosed ``${...``) so a field stays editable mid-keystroke, but tight
+// enough to skip ``$$`` escapes and a stray mid-string ``$`` (``12$34``).
+const SUBSTITUTION_LIKE_RE = /(?:^|[^$])\$(?:\{|[a-zA-Z_])/;
+
+/** True when *text* is or is becoming a ``${var}`` / ``$var`` reference
+ *  (mid-edit partials included); keeps such values in the editable text
+ *  field and out of numeric validation. */
 export function looksLikeSubstitution(text: string): boolean {
-  return text.includes("$");
+  return SUBSTITUTION_LIKE_RE.test(text);
 }
 
 /** Expand ``${name}`` / ``$name`` in *text* against *subs*, leaving

--- a/src/util/substitutions.ts
+++ b/src/util/substitutions.ts
@@ -52,6 +52,14 @@ export function hasSubstitutionReference(text: string): boolean {
   return SUBSTITUTION_REF_RE.test(text);
 }
 
+/** True when *text* holds a ``$``: a complete or in-progress reference.
+ *  Looser than ``hasSubstitutionReference`` so a typed field stays in the
+ *  text editor mid-edit (``${voltage_div`` after the brace is deleted)
+ *  instead of snapping back to a widget that blanks the partial. */
+export function looksLikeSubstitution(text: string): boolean {
+  return text.includes("$");
+}
+
 /** Expand ``${name}`` / ``$name`` in *text* against *subs*, leaving
  *  unknown refs literal. Iterates (capped) so chained substitutions
  *  resolve without looping on cycles. */

--- a/src/util/substitutions.ts
+++ b/src/util/substitutions.ts
@@ -52,11 +52,10 @@ export function hasSubstitutionReference(text: string): boolean {
   return SUBSTITUTION_REF_RE.test(text);
 }
 
-// A complete or in-progress reference start (``${`` or ``$<letter>``) that
-// isn't an escaped ``$$``. Looser than SUBSTITUTION_REF_RE (accepts an
-// unclosed ``${...``) so a field stays editable mid-keystroke, but tight
-// enough to skip ``$$`` escapes and a stray mid-string ``$`` (``12$34``).
-const SUBSTITUTION_LIKE_RE = /(?:^|[^$])\$(?:\{|[a-zA-Z_])/;
+// A ``$`` beginning a reference (followed by ``{`` or a letter). Looser than
+// SUBSTITUTION_REF_RE (accepts an unclosed ``${...``) so a field stays editable
+// mid-keystroke; a stray mid-string ``$`` (``12$34``) doesn't match.
+const SUBSTITUTION_LIKE_RE = /\$(?:\{|[a-zA-Z_])/;
 
 /** True when *text* is or is becoming a ``${var}`` / ``$var`` reference
  *  (mid-edit partials included); keeps such values in the editable text

--- a/test/components/device/render-substitution-typed-fields.test.ts
+++ b/test/components/device/render-substitution-typed-fields.test.ts
@@ -51,6 +51,18 @@ describe("leaf dispatch routes ${var} values to an editable text field (#1391)",
     expect(json).toContain("0.05");
   });
 
+  it("keeps a mid-edit partial substitution (${voltage_div) on the text input", () => {
+    // Deleting the closing brace must not snap the field back to the number
+    // widget (which blanks the partial and reblocks editing) (#1391).
+    const result = renderLeaf(
+      makeConfigEntry({ key: "field", type: ConfigEntryType.FLOAT }),
+      "${voltage_div"
+    );
+    const inputs = findElementBindings(result, "input");
+    expect(inputs[0]["type"]).toBe("text");
+    expect(inputs[0][".value"]).toBe("${voltage_div");
+  });
+
   it("leaves a plain FLOAT value on the number input (no fallback, no hint)", () => {
     const result = renderLeaf(
       makeConfigEntry({ key: "field", type: ConfigEntryType.FLOAT }),

--- a/test/components/device/render-substitution-typed-fields.test.ts
+++ b/test/components/device/render-substitution-typed-fields.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the leaf dispatch: a typed field holding a ${var} substitution
+ * renders as an editable text input, not a number/switch/select (#1391).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+
+const YAML = ["substitutions:", '  current_res: "0.05"', '  voltage_div: "720"', ""].join(
+  "\n"
+);
+
+const serialize = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+/** Drive the form's private leaf dispatch with a one-field ctx rooted at
+ *  *value*, so the test exercises the type→renderer choice directly. */
+function renderLeaf(entry: ConfigEntry, value: unknown): unknown {
+  const form = new ESPHomeConfigEntryForm();
+  const ctx: RenderCtx = makeRenderCtx(
+    { field: value },
+    { board: null, overrides: { sectionKey: "sensor.hlw8012", yaml: YAML } }
+  );
+  return (
+    form as unknown as {
+      _renderEntryLeaf(e: ConfigEntry, p: string[], c: RenderCtx): unknown;
+    }
+  )._renderEntryLeaf(entry, ["field"], ctx);
+}
+
+describe("leaf dispatch routes ${var} values to an editable text field (#1391)", () => {
+  it("renders a FLOAT ${var} as a text input with the resolution hint", () => {
+    const result = renderLeaf(
+      makeConfigEntry({ key: "field", type: ConfigEntryType.FLOAT }),
+      "${current_res}"
+    );
+    const inputs = findElementBindings(result, "input");
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]["type"]).toBe("text");
+    expect(inputs[0][".value"]).toBe("${current_res}");
+    const json = serialize(result);
+    expect(json).toContain("substitution-note");
+    expect(json).toContain("0.05");
+  });
+
+  it("leaves a plain FLOAT value on the number input (no fallback, no hint)", () => {
+    const result = renderLeaf(
+      makeConfigEntry({ key: "field", type: ConfigEntryType.FLOAT }),
+      "0.05"
+    );
+    const inputs = findElementBindings(result, "input");
+    expect(inputs[0][".value"]).toBe("0.05");
+    // type="number" is static, so it never shows as a "text" binding; proves
+    // no text fallback fired.
+    expect(inputs[0]["type"]).not.toBe("text");
+    expect(serialize(result)).not.toContain("substitution-note");
+  });
+
+  it("renders a FLOAT_WITH_UNIT ${var} as text, not a unit picker", () => {
+    const result = renderLeaf(
+      makeConfigEntry({
+        key: "field",
+        type: ConfigEntryType.FLOAT_WITH_UNIT,
+        unit_options: ["Ω"],
+      }),
+      "${current_res}"
+    );
+    expect(findElementBindings(result, "input")[0]["type"]).toBe("text");
+    expect(findElementBindings(result, "wa-select")).toHaveLength(0);
+  });
+
+  it("renders a BOOLEAN ${var} as text, not a switch", () => {
+    const result = renderLeaf(
+      makeConfigEntry({ key: "field", type: ConfigEntryType.BOOLEAN }),
+      "${enabled}"
+    );
+    expect(findElementBindings(result, "input")[0][".value"]).toBe("${enabled}");
+    expect(findElementBindings(result, "wa-switch")).toHaveLength(0);
+  });
+
+  it("renders an options SELECT ${var} as text, not a dropdown", () => {
+    const result = renderLeaf(
+      makeConfigEntry({
+        key: "field",
+        type: ConfigEntryType.SELECT,
+        options: [
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ],
+      }),
+      "${mode}"
+    );
+    expect(findElementBindings(result, "input")[0]["type"]).toBe("text");
+    expect(findElementBindings(result, "wa-select")).toHaveLength(0);
+  });
+
+  it("keeps a SECURE_STRING ${var} on the masked input and never previews it", () => {
+    const result = renderLeaf(
+      makeConfigEntry({ key: "field", type: ConfigEntryType.SECURE_STRING }),
+      "${voltage_div}"
+    );
+    expect(findElementBindings(result, "esphome-password-input")).toHaveLength(1);
+    const json = serialize(result);
+    expect(json).not.toContain("substitution-note");
+    expect(json).not.toContain("720");
+  });
+});

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -183,6 +183,31 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, undefined)).toBeNull();
   });
 
+  it("never flags a numeric field holding a ${var} substitution (#1391)", () => {
+    // A substitution resolves at build time; its value is unknowable here,
+    // so it must not surface "Must be a number" on the structured form.
+    expect(
+      validateEntry(makeEntry({ type: ConfigEntryType.FLOAT }), "${voltage_div}")
+    ).toBeNull();
+    expect(
+      validateEntry(makeEntry({ type: ConfigEntryType.FLOAT }), "$voltage_div")
+    ).toBeNull();
+    expect(
+      validateEntry(makeEntry({ type: ConfigEntryType.INTEGER }), "${count}")
+    ).toBeNull();
+    expect(
+      validateEntry(
+        makeEntry({ type: ConfigEntryType.FLOAT_WITH_UNIT, unit_options: ["Ω"] }),
+        "${current_res}"
+      )
+    ).toBeNull();
+  });
+
+  it("treats a required field as satisfied when it holds a ${var} (#1391)", () => {
+    const entry = makeEntry({ type: ConfigEntryType.FLOAT, required: true });
+    expect(validateEntry(entry, "${current_res}")).toBeNull();
+  });
+
   it("rejects values not in options list", () => {
     const entry = makeEntry({
       type: ConfigEntryType.SELECT,

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -213,7 +213,16 @@ describe("validateEntry", () => {
     // value must not surface an error that blocks finishing the edit.
     const entry = makeEntry({ type: ConfigEntryType.FLOAT });
     expect(validateEntry(entry, "${voltage_div")).toBeNull();
-    expect(validateEntry(entry, "$")).toBeNull();
+    expect(validateEntry(entry, "${")).toBeNull();
+  });
+
+  it("still flags numeric junk with a stray or escaped $ (#773 review)", () => {
+    // A bare includes("$") bypass would let these through; only real
+    // ${var}/$var syntax should suppress the not-a-number error.
+    const entry = makeEntry({ type: ConfigEntryType.FLOAT });
+    expect(validateEntry(entry, "12$34")?.code).toBe("validation.not_a_number");
+    expect(validateEntry(entry, "$$5")?.code).toBe("validation.not_a_number");
+    expect(validateEntry(entry, "5$")?.code).toBe("validation.not_a_number");
   });
 
   it("rejects values not in options list", () => {

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -208,6 +208,14 @@ describe("validateEntry", () => {
     expect(validateEntry(entry, "${current_res}")).toBeNull();
   });
 
+  it("does not flag a mid-edit partial substitution as not-a-number (#1391)", () => {
+    // While the user is editing ${voltage_div} (e.g. the brace is gone), the
+    // value must not surface an error that blocks finishing the edit.
+    const entry = makeEntry({ type: ConfigEntryType.FLOAT });
+    expect(validateEntry(entry, "${voltage_div")).toBeNull();
+    expect(validateEntry(entry, "$")).toBeNull();
+  });
+
   it("rejects values not in options list", () => {
     const entry = makeEntry({
       type: ConfigEntryType.SELECT,

--- a/test/util/substitutions.test.ts
+++ b/test/util/substitutions.test.ts
@@ -117,11 +117,12 @@ describe("looksLikeSubstitution", () => {
     expect(looksLikeSubstitution("${")).toBe(true);
     expect(looksLikeSubstitution("$var")).toBe(true);
     expect(looksLikeSubstitution("a ${x} b")).toBe(true);
+    // Agrees with hasSubstitutionReference: the inner ${x} still counts.
+    expect(looksLikeSubstitution("$${x}")).toBe(true);
   });
 
-  it("excludes $$ escapes and stray mid-string $ (#773 review)", () => {
-    expect(looksLikeSubstitution("$$5")).toBe(false); // escaped literal $
-    expect(looksLikeSubstitution("$${x}")).toBe(false);
+  it("excludes a stray mid-string $ and $$ literals (#773 review)", () => {
+    expect(looksLikeSubstitution("$$5")).toBe(false); // no { or letter after a $
     expect(looksLikeSubstitution("12$34")).toBe(false);
     expect(looksLikeSubstitution("5$")).toBe(false);
     expect(looksLikeSubstitution("$5.00")).toBe(false);

--- a/test/util/substitutions.test.ts
+++ b/test/util/substitutions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasSubstitutionReference,
+  looksLikeSubstitution,
   parseSubstitutions,
   resolveSubstitutions,
 } from "../../src/util/substitutions.js";
@@ -106,5 +107,24 @@ describe("hasSubstitutionReference", () => {
   it("is false for plain text and dollar amounts", () => {
     expect(hasSubstitutionReference("Front Door")).toBe(false);
     expect(hasSubstitutionReference("costs $5.00")).toBe(false);
+  });
+});
+
+describe("looksLikeSubstitution", () => {
+  it("matches complete and mid-edit references", () => {
+    expect(looksLikeSubstitution("${voltage_div}")).toBe(true);
+    expect(looksLikeSubstitution("${voltage_div")).toBe(true); // brace deleted
+    expect(looksLikeSubstitution("${")).toBe(true);
+    expect(looksLikeSubstitution("$var")).toBe(true);
+    expect(looksLikeSubstitution("a ${x} b")).toBe(true);
+  });
+
+  it("excludes $$ escapes and stray mid-string $ (#773 review)", () => {
+    expect(looksLikeSubstitution("$$5")).toBe(false); // escaped literal $
+    expect(looksLikeSubstitution("$${x}")).toBe(false);
+    expect(looksLikeSubstitution("12$34")).toBe(false);
+    expect(looksLikeSubstitution("5$")).toBe(false);
+    expect(looksLikeSubstitution("$5.00")).toBe(false);
+    expect(looksLikeSubstitution("0.05")).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Substitutions on typed fields were lost in the structured editor. A value like `current_resistor: ${current_res}` landed in a number/float/select/switch widget that can't hold the token, so the field showed the catalog default instead of the substitution, and the first interaction (an arrow-up, a toggle) overwrote `${current_res}` with a literal value in the YAML. Worse, once any field changed, full-form validation flagged every other untouched `${var}` numeric field red with "Must be a number", since `Number("${voltage_div}")` is `NaN`.

This routes any field whose value is a `${var}` / `$var` reference through the existing editable text renderer (the same path string fields already use), so the literal token round-trips, shows its resolved value as a hint, and is editable in place; `SECURE_STRING` keeps its masked input. Validation now treats a substitution reference as valid, since it resolves at build time and can't be checked here. Both are single guards at the form's leaf-dispatch and the validator.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1391

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
