### PR TITLE
Extract shared ghost-icon-btn utility

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -218,32 +218,8 @@ export const deviceEditorStyles = css`
     gap: var(--wa-space-s);
   }
 
-  .diff-toggle {
-    border: none;
-    background: transparent;
-    color: var(--esphome-primary);
-    padding: 2px 4px;
-    border-radius: 4px;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .diff-toggle:hover:not(:disabled) {
-    background: var(--esphome-tint-border);
-  }
-
-  .diff-toggle[aria-pressed="true"] {
-    background: var(--esphome-primary);
-    color: var(--esphome-on-primary);
-  }
-
-  .diff-toggle:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
-
+  /* Box + hover + pressed + disabled come from .ghost-icon-btn
+     (shared.ts); only the icon size is per-site here. */
   .diff-toggle wa-icon {
     font-size: 18px;
   }
@@ -252,32 +228,6 @@ export const deviceEditorStyles = css`
     display: inline-flex;
     align-items: center;
     gap: 2px;
-  }
-
-  .layout-toggle button {
-    border: none;
-    background: transparent;
-    color: var(--esphome-primary);
-    padding: 2px 4px;
-    border-radius: 4px;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .layout-toggle button:hover:not(:disabled) {
-    background: var(--esphome-tint-border);
-  }
-
-  .layout-toggle button[aria-pressed="true"] {
-    background: var(--esphome-primary);
-    color: var(--esphome-on-primary);
-  }
-
-  .layout-toggle button:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
   }
 
   .layout-toggle wa-icon {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -258,18 +258,22 @@ export class ESPHomeDeviceEditor extends LitElement {
                 })()
               : nothing}
             ${this._showDiffButton
-              ? html`<button
-                  type="button"
-                  class="ghost-icon-btn diff-toggle"
-                  aria-pressed=${this._showDiff}
-                  ?disabled=${this.yaml === this.savedYaml && !this._showDiff}
-                  @click=${this._toggleDiff}
-                  title=${this._showDiff
+              ? (() => {
+                  const diffLabel = this._showDiff
                     ? this._localize("device.diff_view_editor")
-                    : this._localize("device.diff_view_diff")}
-                >
-                  <wa-icon library="mdi" name="vector-difference"></wa-icon>
-                </button>`
+                    : this._localize("device.diff_view_diff");
+                  return html`<button
+                    type="button"
+                    class="ghost-icon-btn diff-toggle"
+                    aria-pressed=${this._showDiff}
+                    ?disabled=${this.yaml === this.savedYaml && !this._showDiff}
+                    aria-label=${diffLabel}
+                    @click=${this._toggleDiff}
+                    title=${diffLabel}
+                  >
+                    <wa-icon library="mdi" name="vector-difference"></wa-icon>
+                  </button>`;
+                })()
               : nothing}
             <div
               class="layout-toggle"
@@ -280,6 +284,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 class="ghost-icon-btn"
                 aria-pressed=${effectiveLayout === "left"}
                 @click=${() => this._setLayout("left")}
+                aria-label=${this._localize("device.layout_components_only")}
                 title=${this._localize("device.layout_components_only")}
               >
                 <wa-icon library="mdi" name="layout-left"></wa-icon>
@@ -289,6 +294,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 type="button"
                 aria-pressed=${effectiveLayout === "both"}
                 @click=${() => this._setLayout("both")}
+                aria-label=${this._localize("device.layout_split")}
                 title=${this._localize("device.layout_split")}
               >
                 <wa-icon library="mdi" name="layout-split"></wa-icon>
@@ -298,6 +304,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 class="ghost-icon-btn"
                 aria-pressed=${effectiveLayout === "right"}
                 @click=${() => this._setLayout("right")}
+                aria-label=${this._localize("device.layout_yaml_only")}
                 title=${this._localize("device.layout_yaml_only")}
               >
                 <wa-icon library="mdi" name="layout-right"></wa-icon>

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -244,7 +244,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                   );
                   return html`<button
                     type="button"
-                    class="diff-toggle"
+                    class="ghost-icon-btn diff-toggle"
                     aria-pressed=${this._revealSensitive}
                     aria-label=${sensitiveLabel}
                     @click=${this._toggleRevealSensitive}
@@ -260,7 +260,7 @@ export class ESPHomeDeviceEditor extends LitElement {
             ${this._showDiffButton
               ? html`<button
                   type="button"
-                  class="diff-toggle"
+                  class="ghost-icon-btn diff-toggle"
                   aria-pressed=${this._showDiff}
                   ?disabled=${this.yaml === this.savedYaml && !this._showDiff}
                   @click=${this._toggleDiff}
@@ -277,6 +277,7 @@ export class ESPHomeDeviceEditor extends LitElement {
             >
               <button
                 type="button"
+                class="ghost-icon-btn"
                 aria-pressed=${effectiveLayout === "left"}
                 @click=${() => this._setLayout("left")}
                 title=${this._localize("device.layout_components_only")}
@@ -284,7 +285,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                 <wa-icon library="mdi" name="layout-left"></wa-icon>
               </button>
               <button
-                class="split-btn"
+                class="ghost-icon-btn split-btn"
                 type="button"
                 aria-pressed=${effectiveLayout === "both"}
                 @click=${() => this._setLayout("both")}
@@ -294,6 +295,7 @@ export class ESPHomeDeviceEditor extends LitElement {
               </button>
               <button
                 type="button"
+                class="ghost-icon-btn"
                 aria-pressed=${effectiveLayout === "right"}
                 @click=${() => this._setLayout("right")}
                 title=${this._localize("device.layout_yaml_only")}

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -47,23 +47,15 @@ export const deviceNavigatorStyles = css`
     min-width: 0;
   }
 
+  /* Box + hover come from .ghost-icon-btn (shared.ts). This button
+     swaps the shared padding for a fixed width/height and adds a hover
+     transition; the icon size is per-site. */
   .collapse-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
     width: 30px;
     height: 22px;
     padding: 0;
-    background: transparent;
-    color: var(--esphome-primary);
-    cursor: pointer;
     border-radius: var(--wa-border-radius-m);
     transition: background 0.12s;
-  }
-
-  .collapse-btn:hover {
-    background: var(--esphome-tint-border);
   }
 
   .collapse-btn wa-icon {

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -388,7 +388,7 @@ export class ESPHomeDeviceNavigator extends LitElement {
           <h2 class="card-title">${this._localize("device.navigator_title")}</h2>
           <button
             type="button"
-            class="collapse-btn"
+            class="ghost-icon-btn collapse-btn"
             @click=${this._onCollapseClick}
             title=${this._localize("device.hide_navigator")}
             aria-label=${this._localize("device.hide_navigator")}

--- a/src/pages/device-styles.ts
+++ b/src/pages/device-styles.ts
@@ -39,14 +39,9 @@ export const devicePageStyles = css`
     display: none;
   }
 
+  /* Box + hover come from .ghost-icon-btn (shared.ts); this button uses
+     a square 4px pad, a trailing margin, and a smaller (14px) icon. */
   .back-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
-    background: transparent;
-    color: var(--esphome-primary);
-    cursor: pointer;
     padding: 4px;
     border-radius: var(--wa-border-radius-m);
     margin-right: var(--wa-space-xs);
@@ -56,34 +51,16 @@ export const devicePageStyles = css`
     font-size: 14px;
   }
 
-  .back-btn:hover {
-    background: var(--esphome-tint-border);
-  }
-
   .header-start-group {
     display: inline-flex;
     align-items: center;
     gap: 2px;
   }
 
-  .nav-toggle-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
-    background: transparent;
-    color: var(--esphome-primary);
-    cursor: pointer;
-    padding: 2px 4px;
-    border-radius: 4px;
-  }
-
+  /* Box + hover + padding all come from .ghost-icon-btn (shared.ts);
+     only the icon size is per-site. */
   .nav-toggle-btn wa-icon {
     font-size: 18px;
-  }
-
-  .nav-toggle-btn:hover {
-    background: var(--esphome-tint-border);
   }
 
   @media (max-width: 900px) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -930,7 +930,7 @@ export class ESPHomePageDevice extends LitElement {
                   ${showEdgeTab
                     ? html`<button
                         type="button"
-                        class="nav-toggle-btn"
+                        class="ghost-icon-btn nav-toggle-btn"
                         @click=${this._onNavExpand}
                         title=${this._localize("device.show_navigator")}
                         aria-label=${this._localize("device.show_navigator")}
@@ -940,7 +940,7 @@ export class ESPHomePageDevice extends LitElement {
                     : nothing}
                   ${this._selectedSection
                     ? html`<button
-                        class="back-btn"
+                        class="ghost-icon-btn back-btn"
                         @click=${this._onBack}
                         title=${backLabel}
                         aria-label=${backLabel}

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -115,18 +115,11 @@ export const espHomeStyles = css`
   }
 
   /* ─── Ghost icon button ───
-     Transparent, icon-only button used in headers and toolbars (the
-     device page's back / nav-expand buttons, the editor's diff and
-     layout toggles, the navigator's collapse button). The box + hover +
-     pressed + disabled states are shared here so the half-dozen
-     near-identical copies that used to live in three separate shadow
-     roots (page, editor, navigator) stay in sync.
-
-     Per-site overrides stay at the call site: icon font-size, container
-     gaps, and the few buttons that swap padding for a fixed width/height
-     or add a margin. The [aria-pressed="true"] filled state is harmless
-     on the plain (non-toggle) buttons — they never set aria-pressed — so
-     it lives in the shared base too. */
+     Transparent icon-only button for headers and toolbars; the box,
+     hover, pressed, and disabled states live here so the per-site copies
+     in the page, editor, and navigator shadow roots stay in sync. Call
+     sites keep only their real differences, such as icon size, fixed
+     dimensions, and margin. */
   .ghost-icon-btn {
     display: inline-flex;
     align-items: center;

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -114,6 +114,45 @@ export const espHomeStyles = css`
     background-color: color-mix(in srgb, var(--esphome-primary-light), black 5%);
   }
 
+  /* ─── Ghost icon button ───
+     Transparent, icon-only button used in headers and toolbars (the
+     device page's back / nav-expand buttons, the editor's diff and
+     layout toggles, the navigator's collapse button). The box + hover +
+     pressed + disabled states are shared here so the half-dozen
+     near-identical copies that used to live in three separate shadow
+     roots (page, editor, navigator) stay in sync.
+
+     Per-site overrides stay at the call site: icon font-size, container
+     gaps, and the few buttons that swap padding for a fixed width/height
+     or add a margin. The [aria-pressed="true"] filled state is harmless
+     on the plain (non-toggle) buttons — they never set aria-pressed — so
+     it lives in the shared base too. */
+  .ghost-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--esphome-primary);
+    padding: 2px 4px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .ghost-icon-btn:hover:not(:disabled) {
+    background: var(--esphome-tint-border);
+  }
+
+  .ghost-icon-btn[aria-pressed="true"] {
+    background: var(--esphome-primary);
+    color: var(--esphome-on-primary);
+  }
+
+  .ghost-icon-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
   /* ─── Inline markdown rendering ─── */
   /* Used by util/markdown.ts for links and inline code inside any
      description (config field, board, component, section). */

--- a/src/styles/shared.ts
+++ b/src/styles/shared.ts
@@ -139,7 +139,9 @@ export const espHomeStyles = css`
     cursor: pointer;
   }
 
-  .ghost-icon-btn:hover:not(:disabled) {
+  /* Exclude the pressed state, whose filled background would otherwise be
+     out-specified by this hover rule and disappear while hovered. */
+  .ghost-icon-btn:hover:not(:disabled):not([aria-pressed="true"]) {
     background: var(--esphome-tint-border);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Several components carried almost identical copies of the same ghost icon button styling; this pulls that shared box, hover, pressed, and disabled styling into one `.ghost-icon-btn` utility in `shared.ts`. The editor diff and layout toggles, the navigator collapse button, the page back button, and the navigator toggle now use it, keeping only their real per site differences like icon size, fixed dimensions, and margin. There is no visual change; the two buttons that used the medium corner radius keep it through an override.

**Related issue or feature (if applicable):**

- follow up to #770

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
