### PR TITLE
Label nested action lists by trigger key

### DIFF
--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -332,15 +332,13 @@ export class ESPHomeAutomationActionNode extends LitElement {
     </div>`;
   }
 
-  /**
-   * Label a nested action list. ``then`` / ``else`` keep their
-   * control-flow wording; triggered-action keys (``on_response`` /
-   * ``on_error`` on ``http_request.get`` …) title-case so each list
-   * is self-describing.
-   */
+  /** Label a nested action list: ``then`` / ``else`` keep their
+   *  control-flow wording, other keys title-case so each is distinct. */
   private _nestedListLabel(key: string): string {
     if (key === "else") return this._localize("device.automation_else");
     if (key === "then") return this._localize("device.automation_action");
+    // Backend-driven trigger keys have no fixed localization key;
+    // title-case for now (English only).
     return key
       .split("_")
       .map((w) => w.charAt(0).toUpperCase() + w.slice(1))

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -333,6 +333,21 @@ export class ESPHomeAutomationActionNode extends LitElement {
   }
 
   /**
+   * Label a nested action list. ``then`` / ``else`` keep their
+   * control-flow wording; triggered-action keys (``on_response`` /
+   * ``on_error`` on ``http_request.get`` …) title-case so each list
+   * is self-describing.
+   */
+  private _nestedListLabel(key: string): string {
+    if (key === "else") return this._localize("device.automation_else");
+    if (key === "then") return this._localize("device.automation_action");
+    return key
+      .split("_")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+  }
+
+  /**
    * Render one nested action list per entry in
    * ``def.accepts_action_list``. ``"then"`` / ``"else"`` for
    * ``if``, ``"then"`` for ``while`` / ``repeat`` / ``wait_until``.
@@ -348,11 +363,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
     return def.accepts_action_list.map(
       (key) =>
         html`<div class="ae-nested">
-          <p class="ae-nested-label">
-            ${key === "else"
-              ? this._localize("device.automation_else")
-              : this._localize("device.automation_action")}
-          </p>
+          <p class="ae-nested-label">${this._nestedListLabel(key)}</p>
           <esphome-automation-action-list
             no-header
             .actions=${this.value.children?.[key] ?? []}

--- a/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
@@ -88,7 +88,7 @@ describe("automation-action-node trigger labels (esphome/device-builder#1390)", 
     expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).not.toBeNull();
   });
 
-  it("keeps else routed through the control-flow localization key", async () => {
+  it("keeps then and else routed through the control-flow localization keys", async () => {
     const ifAction = {
       id: "if",
       name: "If",
@@ -107,5 +107,8 @@ describe("automation-action-node trigger labels (esphome/device-builder#1390)", 
     const labels = nestedLabels(el);
     expect(labels).toContain("device.automation_else");
     expect(labels).not.toContain("Else");
+    // then keeps its control-flow wording, not a title-cased "Then".
+    expect(labels).toContain("device.automation_action");
+    expect(labels).not.toContain("Then");
   });
 });

--- a/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A triggered action (http_request.get) renders one nested action list
+ * per trigger key, each labeled by its humanized key so on_response and
+ * on_error read distinctly; else keeps its control-flow wording.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-action-list.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/automation-condition-tree.js",
+  () => ({})
+);
+vi.mock(
+  "../../../../src/components/device/automation-editor/catalog-picker-dialog.js",
+  () => ({})
+);
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import type {
+  ActionNode,
+  AutomationAction,
+} from "../../../../src/api/types/automations.js";
+import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
+import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+
+const urlEntry = {
+  key: "url",
+  type: "string",
+  label: "URL",
+  required: true,
+} as unknown as ConfigEntry;
+
+const httpGetAction: AutomationAction = {
+  id: "http_request.get",
+  name: "Http Request → Get",
+  description: "",
+  config_entries: [urlEntry],
+  accepts_action_list: ["on_response", "on_error"],
+} as unknown as AutomationAction;
+
+const httpGetNode: ActionNode = {
+  action_id: "http_request.get",
+  params: {},
+  children: { on_response: [], on_error: [] },
+} as unknown as ActionNode;
+
+async function mount(
+  action: AutomationAction,
+  node: ActionNode
+): Promise<ESPHomeAutomationActionNode> {
+  const el = new ESPHomeAutomationActionNode();
+  el.value = node;
+  el.catalog = [action];
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function nestedLabels(el: ESPHomeAutomationActionNode): string[] {
+  return [...el.shadowRoot!.querySelectorAll(".ae-nested-label")].map((p) =>
+    p.textContent!.trim()
+  );
+}
+
+describe("automation-action-node trigger labels (esphome/device-builder#1390)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("labels each trigger list by its humanized key", async () => {
+    const el = await mount(httpGetAction, httpGetNode);
+    expect(nestedLabels(el)).toEqual(["On Response", "On Error"]);
+  });
+
+  it("renders one nested action list per trigger key alongside the params form", async () => {
+    const el = await mount(httpGetAction, httpGetNode);
+    expect(
+      el.shadowRoot!.querySelectorAll("esphome-automation-action-list")
+    ).toHaveLength(2);
+    expect(el.shadowRoot!.querySelector("esphome-config-entry-form")).not.toBeNull();
+  });
+
+  it("keeps else routed through the control-flow localization key", async () => {
+    const ifAction = {
+      id: "if",
+      name: "If",
+      description: "",
+      config_entries: [],
+      accepts_action_list: ["then", "else"],
+    } as unknown as AutomationAction;
+    const ifNode = {
+      action_id: "if",
+      params: {},
+      children: { then: [], else: [] },
+    } as unknown as ActionNode;
+    const el = await mount(ifAction, ifNode);
+    // Default _localize echoes the key; else takes the localize branch,
+    // not the humanizer (which would emit "Else").
+    const labels = nestedLabels(el);
+    expect(labels).toContain("device.automation_else");
+    expect(labels).not.toContain("Else");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A triggered action like `http_request.get` exposes its `on_response` and `on_error` handlers as nested action lists; both rendered with the generic "Actions" label, so they were indistinguishable. Each nested list is now labeled by its key (`on_response` becomes "On Response"); `then` and `else` keep their existing control-flow wording, so `if` / `while` / `repeat` look unchanged.

This is the frontend half of the fix; the backend PR (esphome/device-builder#1393) makes these trigger keys reach the catalog in the first place.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1390

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
