### PR TITLE
Hug the mobile editor header menu icon to the left edge

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -455,8 +455,10 @@ export const deviceEditorStyles = css`
       box-shadow: none;
     }
 
+    /* Hug the always-present leading menu/back control to the edge on
+       mobile, not the wide title indent of the pre-hamburger design. */
     .card-header {
-      padding-left: calc(var(--wa-space-l) - var(--wa-space-2xs) + var(--wa-space-s));
+      padding-left: var(--wa-space-2xs);
     }
   }
 `;


### PR DESCRIPTION
# What does this implement/fix?

On a mobile viewport the device editor header showed a large gap to the left of the hamburger menu icon, pushing it well away from the screen edge. The mobile `.card-header` rule set `padding-left` to `calc(var(--wa-space-l) - var(--wa-space-2xs) + var(--wa-space-s))` (32px), a wide title indent from the pre-hamburger design; now that the header always shows a leading menu/back control on mobile, that indent is wrong. This drops it to `var(--wa-space-2xs)` (4px), matching the existing desktop-collapsed header treatment, so the icon hugs the edge.

**Related issue or feature (if applicable):**

- fixes #776

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
