### PR TITLE
Parse list items whose first field is a nested mapping

### DIFF
--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -125,6 +125,15 @@ export const parseBlockScalarHeader = (raw: string): BlockScalarHeader | null =>
 export const LIST_ITEM_BARE_DASH_RE = /^\s+-\s*$/;
 
 /**
+ * Capture the ``<indent>-<spaces>`` prefix up to the first non-space of a
+ * list item's inline key (``  - file:`` → ``"  - "``). Its length is the
+ * column the item's child keys align to, which `_detectSectionChildIndent`
+ * uses so a first field that is itself a nested mapping doesn't pull the
+ * child column down to its grandchildren. No match for a bare dash.
+ */
+export const LIST_ITEM_INLINE_KEY_PREFIX_RE = /^(\s*-\s*)\S/;
+
+/**
  * Match a list item whose value is a key-style sub-dict header
  * (`- then:`, `- lambda:`, `- logger.log: pressed`,
  * `- switch.turn_on: relay`). The dash + key + colon shape is the
@@ -220,6 +229,18 @@ export const _detectSectionChildIndent = (
   // child key (at ``dash + 2``) clears it while a sibling dash
   // (same column as ours) doesn't.
   const headLine = lines[startIdx];
+  // An inline key on the dash line (``- key:``) fixes the item's child
+  // column at that key — even when the key's own value is a deeper nested
+  // block (``- file:\n      type: …``). Scanning the next line would then
+  // read the grandchild's indent and mis-level the item's sibling keys,
+  // dropping them and the nested value (#1389 follow-up). The bare-dash
+  // case (value on the next line) still falls through to the scan below.
+  if (isListItem) {
+    // The inline key's column is where the item's child keys align — even
+    // when that first field is itself a nested mapping (#1389 follow-up).
+    const inlineKey = headLine.match(LIST_ITEM_INLINE_KEY_PREFIX_RE);
+    if (inlineKey) return " ".repeat(inlineKey[1].length);
+  }
   const floor = isListItem ? headLine.indexOf("-") + 1 : _leadingIndent(headLine).length;
   const fallback = isListItem
     ? `${ESPHOME_YAML_INDENT}${ESPHOME_YAML_INDENT}`

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -375,6 +375,20 @@ export function parseSectionCore(
   const childIndent = _detectSectionChildIndent(lines, startIdx, isListItem);
   const childRegex = childRegexFor(childIndent);
 
+  // Parse a ``key:``-with-nested-mapping value: the block on the lines after
+  // *afterIdx* indented deeper than this section's child column. Returns
+  // ``null`` when there's no such block. Shared by the dash-line inline key
+  // and the in-loop ``key:`` paths so both read a nested mapping identically.
+  const readNestedMappingAfter = (
+    afterIdx: number
+  ): { values: Record<string, unknown>; endIdx: number } | null => {
+    const peek = _skipBlankAndCommentLines(lines, afterIdx);
+    if (peek >= lines.length) return null;
+    const peekLead = _leadingIndent(lines[peek]);
+    if (peekLead.length <= childIndent.length) return null;
+    return parseNestedBlock(lines, afterIdx, peekLead);
+  };
+
   // Top-level list-bodied section (globals): the item array lives at
   // [sectionKey], where the wrapper's multi_value entry reads it.
   if (!isListItem && LIST_SECTIONS.has(sectionKey)) {
@@ -398,6 +412,14 @@ export function parseSectionCore(
         const { comment } = splitInlineComment(raw);
         if (comment) comments.set(firstMatch[1], comment);
         values[firstMatch[1]] = parseScalar(raw);
+      } else {
+        // ``- file:`` with the value as a nested mapping on the following
+        // deeper-indented lines. The key rides on the dash line, so the
+        // main loop (which starts below it) never sees this value; capture
+        // it here so a list item whose first field is a nested mapping
+        // (font.file's structured form) round-trips into the form (#1389).
+        const sub = readNestedMappingAfter(startIdx + 1);
+        if (sub && Object.keys(sub.values).length > 0) values[firstMatch[1]] = sub.values;
       }
     }
   }
@@ -465,11 +487,10 @@ export function parseSectionCore(
         continue;
       }
 
-      // Read the deeper indent from the peek line itself so a
-      // user-typed 4-space file recurses correctly.
-      const peekLead = _leadingIndent(peekLine);
-      if (peekLead.length > childIndent.length) {
-        const result = parseNestedBlock(lines, i + 1, peekLead);
+      // Nested mapping under ``key:`` (deeper indent read from the block
+      // itself so a user-typed 4-space file recurses correctly).
+      const result = readNestedMappingAfter(i + 1);
+      if (result) {
         if (Object.keys(result.values).length > 0) {
           values[key] = result.values;
           recordSpan(key, i, result.endIdx);

--- a/test/util/yaml-section-reader-nested-list.test.ts
+++ b/test/util/yaml-section-reader-nested-list.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { parseYamlSectionValues } from "../../src/util/yaml-section-reader.js";
+import { updateSectionInYaml } from "../../src/util/yaml-section-values.js";
+
+// A multi_conf list item whose FIRST field is a nested mapping (font.file's
+// structured form). The child-indent detection used to read the item's child
+// column from the nested grandchildren, mis-levelling everything: it captured
+// the nested grandchildren as item-level keys and dropped the nested field
+// plus every sibling (#1389 follow-up). Order-dependent, so the not-first and
+// round-trip cases below guard against re-breaking either direction.
+
+describe("parseYamlSectionValues — list item whose first field is a nested mapping", () => {
+  it("captures the nested mapping plus its sibling keys (gfonts)", () => {
+    const yaml = `font:
+  - file:
+      type: gfonts
+      family: Roboto
+      weight: 300
+    id: my_font
+    size: 20
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v.id).toBe("my_font");
+    expect(v.size).toBe("20");
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: "300" });
+  });
+
+  it("captures a local nested mapping (path)", () => {
+    const yaml = `font:
+  - file:
+      type: local
+      path: fonts/arial.ttf
+    id: f
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v.file).toEqual({ type: "local", path: "fonts/arial.ttf" });
+    expect(v.id).toBe("f");
+  });
+
+  it("captures a web nested mapping (url)", () => {
+    const yaml = `font:
+  - file:
+      type: web
+      url: https://example.com/x.ttf
+    id: f
+    size: 12
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v.file).toEqual({ type: "web", url: "https://example.com/x.ttf" });
+    expect(v.id).toBe("f");
+    expect(v.size).toBe("12");
+  });
+
+  it("handles 4-space user indentation", () => {
+    const yaml = `font:
+    -   file:
+            type: gfonts
+            family: Roboto
+        id: my_font
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v.id).toBe("my_font");
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto" });
+  });
+
+  it("still parses when the nested field is NOT first (regression guard)", () => {
+    const yaml = `font:
+  - id: my_font
+    size: 20
+    file:
+      type: gfonts
+      family: Roboto
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v.id).toBe("my_font");
+    expect(v.size).toBe("20");
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto" });
+  });
+
+  it("handles a sibling both before and after the nested field", () => {
+    const yaml = `font:
+  - id: f
+    file:
+      type: gfonts
+      family: Roboto
+    size: 18
+`;
+    const v = parseYamlSectionValues(yaml, "font", 2);
+    expect(v).toEqual({
+      id: "f",
+      file: { type: "gfonts", family: "Roboto" },
+      size: "18",
+    });
+  });
+});
+
+describe("updateSectionInYaml — list item whose first field is a nested mapping", () => {
+  const START = `font:
+  - file:
+      type: gfonts
+      family: Roboto
+      weight: 300
+    id: my_font
+    size: 20
+`;
+
+  it("preserves the nested block when a sibling field is edited", () => {
+    const values = parseYamlSectionValues(START, "font", 2);
+    values.size = "24";
+    const after = updateSectionInYaml(START, "font", values, 2);
+    const v = parseYamlSectionValues(after, "font", 2);
+    expect(v.size).toBe("24");
+    expect(v.id).toBe("my_font");
+    expect(v.file).toEqual({ type: "gfonts", family: "Roboto", weight: "300" });
+  });
+
+  it("round-trips an unchanged save without dropping or duplicating keys", () => {
+    const values = parseYamlSectionValues(START, "font", 2);
+    const after = updateSectionInYaml(START, "font", values, 2);
+    const v = parseYamlSectionValues(after, "font", 2);
+    expect(v).toEqual(values);
+    expect(after.match(/type: gfonts/g)).toHaveLength(1);
+    expect(after.match(/id: my_font/g)).toHaveLength(1);
+  });
+
+  it("writes an edited nested field back into the block", () => {
+    const values = parseYamlSectionValues(START, "font", 2);
+    (values.file as Record<string, unknown>).weight = "700";
+    const after = updateSectionInYaml(START, "font", values, 2);
+    const v = parseYamlSectionValues(after, "font", 2);
+    expect((v.file as Record<string, unknown>).weight).toBe("700");
+    expect((v.file as Record<string, unknown>).family).toBe("Roboto");
+    expect(v.id).toBe("my_font");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

`parseYamlSectionValues` dropped every field of a `multi_conf` list item when the item's first field was a nested mapping. It read the item's child indent from the nested grandchildren instead of the item's field column, so it hoisted the grandchildren to the item level and lost the nested field plus all the sibling keys; the structured editor then rendered an empty form. This fixes the child indent detection for an inline dash key, and captures a dash line key whose value is a nested block. A small shared helper now does the nested mapping read for both the inline and the in loop paths so they stay in agreement.

This surfaced while testing the `font.file` structured editor (esphome/device-builder#1389), but it is an independent parser bug that already affected any component whose first list item field is a nested mapping; reordering the fields avoided it.

Tested with new read cases (gfonts, local, web, 4 space indent, sibling before and after) and round trip cases (edit a sibling, edit a nested field, unchanged save) that parse then write back through `updateSectionInYaml`; the full suite (2942 tests) and `npm run lint` pass, and it was verified live in the editor.

**Related issue or feature (if applicable):**

- relates to esphome/device-builder#1389

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
