### PR TITLE
Test multi-word trigger key humanization

### DIFF
--- a/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
@@ -80,6 +80,23 @@ describe("automation-action-node trigger labels (esphome/device-builder#1390)", 
     expect(nestedLabels(el)).toEqual(["On Response", "On Error"]);
   });
 
+  it("humanizes a multi-word trigger key", async () => {
+    const action = {
+      id: "binary_sensor.x",
+      name: "X",
+      description: "",
+      config_entries: [],
+      accepts_action_list: ["on_multi_click"],
+    } as unknown as AutomationAction;
+    const node = {
+      action_id: "binary_sensor.x",
+      params: {},
+      children: { on_multi_click: [] },
+    } as unknown as ActionNode;
+    const el = await mount(action, node);
+    expect(nestedLabels(el)).toEqual(["On Multi Click"]);
+  });
+
   it("renders one nested action list per trigger key alongside the params form", async () => {
     const el = await mount(httpGetAction, httpGetNode);
     expect(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up test coverage for #775 (the nested-action-list trigger labels for #1390). The existing tests pinned the two-word `on_response` / `on_error` keys; this adds a case proving the humanizer also handles a multi-word key, `on_multi_click` rendering as "On Multi Click". Test only, no behavior change.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder-frontend#775 (issue esphome/device-builder#1390)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
