### PR TITLE
Clear the error jump highlight once the error is fixed

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1125,9 +1125,16 @@ export class ESPHomePageDevice extends LitElement {
     ></esphome-device-navigator>`;
   }
 
-  private _onYamlChange(e: CustomEvent<{ value: string }>) {
-    this._yaml = e.detail.value;
+  /** Advance the YAML buffer. Any mutation while an error-jump
+   *  highlight is active (YAML-pane typing, form drafts, completed
+   *  component edits) arms the next lint pass to clear it. */
+  private _setYaml(value: string) {
+    this._yaml = value;
     if (this._errorHighlight === "active") this._errorHighlight = "edited";
+  }
+
+  private _onYamlChange(e: CustomEvent<{ value: string }>) {
+    this._setYaml(e.detail.value);
     this._retryPendingFieldLine();
   }
 
@@ -1305,7 +1312,7 @@ export class ESPHomePageDevice extends LitElement {
      * ``yaml-draft`` event (see ``_onYamlDraft`` below) which
      * advances only ``_yaml`` — those are committed via the right-
      * pane Save button. */
-    this._yaml = e.detail.yaml;
+    this._setYaml(e.detail.yaml);
     this._savedYaml = e.detail.yaml;
   }
 
@@ -1315,7 +1322,7 @@ export class ESPHomePageDevice extends LitElement {
      * in the YAML pane. Only ``_yaml`` advances; ``_savedYaml``
      * stays put so the right-pane Save button activates and the
      * user sees the buffer is dirty. */
-    this._yaml = e.detail.yaml;
+    this._setYaml(e.detail.yaml);
     this._retryPendingFieldLine();
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -135,16 +135,11 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _scrollToHighlight = false;
 
-  /** The current ``_highlightRange`` came from the validation prompt's
-   *  "Go to error" jump; eligible for auto-clear once the user edits
-   *  and the inline lint pass completes, or a save succeeds. Navigation
-   *  and field-focus highlights never set this. */
-  private _errorHighlight = false;
-
-  /** The user edited the YAML while an error highlight was active;
-   *  gates the lint-complete clear so the lint pass that *produced*
-   *  the error doesn't immediately wipe the just-set highlight. */
-  private _errorHighlightEditPending = false;
+  /** Lifecycle of an error-jump highlight (the validation prompt's
+   *  "Go to error"): "active" until the user edits, "edited" after,
+   *  which arms the next lint pass to clear the highlight. Navigation
+   *  and field-focus highlights stay "none". */
+  private _errorHighlight: "none" | "active" | "edited" = "none";
 
   @state()
   private _selectedSection: string | null = this._readUrlParam("section", null);
@@ -771,7 +766,7 @@ export class ESPHomePageDevice extends LitElement {
     // A committed save ends the fix-the-error errand the error-jump
     // highlight was guiding (validation passed, or the user chose
     // "Save anyway"), so drop it. A failed save keeps it.
-    if (saved && this._errorHighlight) {
+    if (saved && this._errorHighlight !== "none") {
       this._setHighlight(null, false);
     }
     const message = saved ? "device.yaml_saved" : "device.yaml_save_error";
@@ -1132,7 +1127,7 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onYamlChange(e: CustomEvent<{ value: string }>) {
     this._yaml = e.detail.value;
-    if (this._errorHighlight) this._errorHighlightEditPending = true;
+    if (this._errorHighlight === "active") this._errorHighlight = "edited";
     this._retryPendingFieldLine();
   }
 
@@ -1144,7 +1139,7 @@ export class ESPHomePageDevice extends LitElement {
     e: CustomEvent<{ errors: string[]; configuration: string }>
   ) {
     if (e.detail.configuration !== this.id) return;
-    if (this._errorHighlight && this._errorHighlightEditPending) {
+    if (this._errorHighlight === "edited") {
       this._setHighlight(null, false);
     }
   }
@@ -1296,8 +1291,7 @@ export class ESPHomePageDevice extends LitElement {
   private _setHighlight(range: HighlightRange | null, scroll: boolean, isError = false) {
     this._highlightRange = range;
     this._scrollToHighlight = scroll;
-    this._errorHighlight = isError && range !== null;
-    this._errorHighlightEditPending = false;
+    this._errorHighlight = isError && range !== null ? "active" : "none";
   }
 
   private _onYamlUpdated(e: CustomEvent<{ yaml: string }>) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -135,6 +135,17 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _scrollToHighlight = false;
 
+  /** The current ``_highlightRange`` came from the validation prompt's
+   *  "Go to error" jump; eligible for auto-clear once the user edits
+   *  and the inline lint pass completes, or a save succeeds. Navigation
+   *  and field-focus highlights never set this. */
+  private _errorHighlight = false;
+
+  /** The user edited the YAML while an error highlight was active;
+   *  gates the lint-complete clear so the lint pass that *produced*
+   *  the error doesn't immediately wipe the just-set highlight. */
+  private _errorHighlightEditPending = false;
+
   @state()
   private _selectedSection: string | null = this._readUrlParam("section", null);
 
@@ -618,8 +629,7 @@ export class ESPHomePageDevice extends LitElement {
     // event, but the navigator's update-from-prop-change path
     // doesn't emit, so URL-only arrivals would otherwise mount
     // the editor without ever scrolling.
-    this._highlightRange = resolved.range;
-    this._scrollToHighlight = true;
+    this._setHighlight(resolved.range, true);
   }
 
   /** Promise resolver wired up while the validation dialog is open.
@@ -758,6 +768,12 @@ export class ESPHomePageDevice extends LitElement {
         console.error("Failed to save YAML:", e);
       }
     }
+    // A committed save ends the fix-the-error errand the error-jump
+    // highlight was guiding (validation passed, or the user chose
+    // "Save anyway"), so drop it. A failed save keeps it.
+    if (saved && this._errorHighlight) {
+      this._setHighlight(null, false);
+    }
     const message = saved ? "device.yaml_saved" : "device.yaml_save_error";
     const variant = saved ? toast.success : toast.error;
     variant(this._localize(message), { richColors: true });
@@ -785,8 +801,7 @@ export class ESPHomePageDevice extends LitElement {
         this._layout = "both";
         localStorage.setItem("esphome-editor-layout", "both");
       }
-      this._highlightRange = { fromLine: line, toLine: line };
-      this._scrollToHighlight = true;
+      this._setHighlight({ fromLine: line, toLine: line }, true, true);
       const resolved = resolveSectionForUrlLine(this._yaml, line, null);
       if (resolved) {
         this._selectedSection = resolved.sectionKey;
@@ -887,6 +902,7 @@ export class ESPHomePageDevice extends LitElement {
           @section-reveal=${this._onSectionReveal}
           @layout-change=${this._onLayoutChange}
           @yaml-change=${this._onYamlChange}
+          @yaml-diagnostics=${this._onYamlDiagnostics}
           @yaml-cursor-line=${this._onYamlCursorLine}
           @yaml-highlight=${this._onYamlHighlight}
           @yaml-updated=${this._onYamlUpdated}
@@ -1005,8 +1021,7 @@ export class ESPHomePageDevice extends LitElement {
         this._selectedSection = null;
         this._selectedFromLine = undefined;
       }
-      this._highlightRange = null;
-      this._scrollToHighlight = false;
+      this._setHighlight(null, false);
       this._updateUrl();
     });
   };
@@ -1117,7 +1132,21 @@ export class ESPHomePageDevice extends LitElement {
 
   private _onYamlChange(e: CustomEvent<{ value: string }>) {
     this._yaml = e.detail.value;
+    if (this._errorHighlight) this._errorHighlightEditPending = true;
     this._retryPendingFieldLine();
+  }
+
+  /** Inline lint pass completed. If the user has edited since jumping
+   *  to the error, the highlight has served its purpose; clear it
+   *  rather than leave a stale blue line the user can't dismiss
+   *  (esphome/device-builder#1404). */
+  private _onYamlDiagnostics(
+    e: CustomEvent<{ errors: string[]; configuration: string }>
+  ) {
+    if (e.detail.configuration !== this.id) return;
+    if (this._errorHighlight && this._errorHighlightEditPending) {
+      this._setHighlight(null, false);
+    }
   }
 
   /**
@@ -1208,8 +1237,7 @@ export class ESPHomePageDevice extends LitElement {
     const section = this._focusedSection();
     const line = section ? findFieldLine(this._yaml, section, path) : null;
     if (line !== null) {
-      this._highlightRange = { fromLine: line, toLine: line };
-      this._scrollToHighlight = true;
+      this._setHighlight({ fromLine: line, toLine: line }, true);
     }
     return { section, found: line !== null };
   }
@@ -1230,10 +1258,10 @@ export class ESPHomePageDevice extends LitElement {
       section: this._selectedSection,
       fromLine: this._selectedFromLine,
     };
-    this._highlightRange = section
-      ? { fromLine: section.fromLine, toLine: section.toLine }
-      : null;
-    this._scrollToHighlight = section !== undefined;
+    this._setHighlight(
+      section ? { fromLine: section.fromLine, toLine: section.toLine } : null,
+      section !== undefined
+    );
   }
 
   /** Once the pending field's YAML line exists (debounced write landed),
@@ -1260,8 +1288,16 @@ export class ESPHomePageDevice extends LitElement {
   private _onYamlHighlight(
     e: CustomEvent<{ range: HighlightRange | null; scroll: boolean }>
   ) {
-    this._highlightRange = e.detail.range;
-    this._scrollToHighlight = e.detail.scroll;
+    this._setHighlight(e.detail.range, e.detail.scroll);
+  }
+
+  /** Single write path for the editor highlight, so the error-jump
+   *  flag can't leak into navigation / field-focus highlights. */
+  private _setHighlight(range: HighlightRange | null, scroll: boolean, isError = false) {
+    this._highlightRange = range;
+    this._scrollToHighlight = scroll;
+    this._errorHighlight = isError && range !== null;
+    this._errorHighlightEditPending = false;
   }
 
   private _onYamlUpdated(e: CustomEvent<{ yaml: string }>) {

--- a/test/pages/device-error-highlight.test.ts
+++ b/test/pages/device-error-highlight.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the error-jump highlight lifecycle (esphome/device-builder#1404):
+ * the "Go to error" highlight clears after an edit's lint pass or a
+ * successful save, while navigation highlights stay untouched.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("../../src/components/command-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-editor.js", () => ({}));
+vi.mock("../../src/components/device/device-navigator.js", () => ({}));
+vi.mock("../../src/components/firmware-install-dialog.js", () => ({}));
+vi.mock("../../src/components/install-method-dialog.js", () => ({}));
+vi.mock("../../src/components/logs-dialog.js", () => ({}));
+vi.mock("../../src/components/unsaved-changes-dialog.js", () => ({}));
+vi.mock("../../src/components/yaml-validation-dialog.js", () => ({}));
+vi.mock("../../src/components/device/device-install-controller.js", () => ({
+  DeviceInstallController: class {
+    constructor() {}
+  },
+}));
+
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+
+const YAML = "esphome:\n  name: kitchen\nswitch:\n  - platform: gpio\n";
+
+function makePage(api: Partial<ESPHomeAPI> = {}): ESPHomePageDevice {
+  const page = new ESPHomePageDevice();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._api = api as ESPHomeAPI;
+  page.id = "kitchen.yaml";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._yaml = YAML;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._savedYaml = YAML;
+  return page;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const internals = (page: ESPHomePageDevice) => page as any;
+
+function goToError(page: ESPHomePageDevice, line = 4) {
+  internals(page)._onValidationGoTo(
+    new CustomEvent("goto", { detail: { line, col: 1 } })
+  );
+}
+
+function editYaml(page: ESPHomePageDevice, value = YAML + "    pin: GPIO11\n") {
+  internals(page)._onYamlChange(new CustomEvent("yaml-change", { detail: { value } }));
+}
+
+function lintCompleted(page: ESPHomePageDevice, configuration = "kitchen.yaml") {
+  internals(page)._onYamlDiagnostics(
+    new CustomEvent("yaml-diagnostics", { detail: { errors: [], configuration } })
+  );
+}
+
+describe("error-jump highlight lifecycle (#1404)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clears after an edit once the lint pass completes", () => {
+    const page = makePage();
+    goToError(page);
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 4, toLine: 4 });
+
+    editYaml(page);
+    expect(internals(page)._highlightRange).not.toBeNull();
+
+    lintCompleted(page);
+    expect(internals(page)._highlightRange).toBeNull();
+    expect(internals(page)._scrollToHighlight).toBe(false);
+  });
+
+  it("survives a lint pass with no intervening edit", () => {
+    const page = makePage();
+    goToError(page);
+
+    lintCompleted(page);
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 4, toLine: 4 });
+  });
+
+  it("ignores a lint result for a different configuration", () => {
+    const page = makePage();
+    goToError(page);
+    editYaml(page);
+
+    lintCompleted(page, "other.yaml");
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 4, toLine: 4 });
+  });
+
+  it("clears on a successful save", async () => {
+    const page = makePage({ updateConfig: vi.fn().mockResolvedValue(undefined) });
+    goToError(page);
+    editYaml(page);
+
+    await internals(page)._doSaveYaml();
+    expect(internals(page)._highlightRange).toBeNull();
+  });
+
+  it("survives a failed save", async () => {
+    const page = makePage({
+      updateConfig: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    goToError(page);
+
+    await internals(page)._doSaveYaml();
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 4, toLine: 4 });
+  });
+
+  it("leaves a navigation highlight alone through edit + lint + save", async () => {
+    const page = makePage({ updateConfig: vi.fn().mockResolvedValue(undefined) });
+    internals(page)._onYamlHighlight(
+      new CustomEvent("yaml-highlight", {
+        detail: { range: { fromLine: 2, toLine: 2 }, scroll: true },
+      })
+    );
+
+    editYaml(page);
+    lintCompleted(page);
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 2, toLine: 2 });
+
+    await internals(page)._doSaveYaml();
+    expect(internals(page)._highlightRange).toEqual({ fromLine: 2, toLine: 2 });
+  });
+});

--- a/test/pages/device-error-highlight.test.ts
+++ b/test/pages/device-error-highlight.test.ts
@@ -79,6 +79,28 @@ describe("error-jump highlight lifecycle (#1404)", () => {
     expect(internals(page)._scrollToHighlight).toBe(false);
   });
 
+  it("clears after a form draft edit once the lint pass completes", () => {
+    const page = makePage();
+    goToError(page);
+
+    internals(page)._onYamlDraft(
+      new CustomEvent("yaml-draft", { detail: { yaml: YAML + "    pin: GPIO11\n" } })
+    );
+    lintCompleted(page);
+    expect(internals(page)._highlightRange).toBeNull();
+  });
+
+  it("clears after a completed component edit once the lint pass completes", () => {
+    const page = makePage();
+    goToError(page);
+
+    internals(page)._onYamlUpdated(
+      new CustomEvent("yaml-updated", { detail: { yaml: YAML + "    pin: GPIO11\n" } })
+    );
+    lintCompleted(page);
+    expect(internals(page)._highlightRange).toBeNull();
+  });
+
   it("survives a lint pass with no intervening edit", () => {
     const page = makePage();
     goToError(page);


### PR DESCRIPTION
# What does this implement/fix?

The "Go to error" jump from the save validation prompt highlights the failing line in blue, but nothing ever cleared it, so the highlight stayed forever after the user fixed the YAML.

All highlight writes now go through a single helper that tags error jumps; the highlight is dropped once the next lint pass after an edit completes, or when a save commits. Navigation and field focus highlights keep their current behaviour.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1404

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
