### PR TITLE
Render the command palette in a wa-dialog so it stacks above open dialogs

### DIFF
--- a/src/components/command-palette.styles.ts
+++ b/src/components/command-palette.styles.ts
@@ -1,62 +1,29 @@
 import { css } from "lit";
 
 export const commandPaletteStyles = css`
-  :host {
-    position: fixed;
-    inset: 0;
-    /* Above WA component overlays (wa-popup is 899, wa-select is 900).
-       Note: top-layer popovers are above any z-index — open() also
-       force-closes them so this matters mainly for non-popover layers. */
-    z-index: 10000;
-    pointer-events: none;
+  wa-dialog {
+    --width: min(640px, calc(100vw - var(--wa-space-l)));
+    --spacing: 0;
+    --backdrop-filter: blur(2px);
+    --wa-color-overlay-modal: rgba(0, 0, 0, 0.45);
+    --show-duration: 140ms;
+    --hide-duration: 120ms;
   }
 
-  :host([hidden]) {
-    display: none;
-  }
-
-  .backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    backdrop-filter: blur(2px);
-    pointer-events: auto;
-    animation: fade-in 0.12s ease-out;
-  }
-
-  .dialog {
-    position: fixed;
-    top: 18%;
-    left: 50%;
-    transform: translate(-50%, 0);
-    width: min(640px, calc(100vw - var(--wa-space-l)));
-    background: var(--wa-color-surface-raised);
+  /* Pin the card at 18% from the top instead of wa-dialog's
+     vertical centering. */
+  wa-dialog::part(dialog) {
+    margin-block: 18vh auto;
     border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     border-radius: var(--wa-border-radius-l);
     box-shadow: 0 24px 56px rgba(0, 0, 0, 0.25);
     overflow: hidden;
-    pointer-events: auto;
-    animation: pop-in 0.14s ease-out;
   }
 
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes pop-in {
-    from {
-      opacity: 0;
-      transform: translate(-50%, -8px) scale(0.98);
-    }
-    to {
-      opacity: 1;
-      transform: translate(-50%, 0) scale(1);
-    }
+  wa-dialog::part(body) {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 
   .search {

--- a/src/components/command-palette.styles.ts
+++ b/src/components/command-palette.styles.ts
@@ -20,6 +20,12 @@ export const commandPaletteStyles = css`
     overflow: hidden;
   }
 
+  /* Hidden, not without-header: the label inside still names the
+     dialog through its aria-labelledby. */
+  wa-dialog::part(header) {
+    display: none;
+  }
+
   wa-dialog::part(body) {
     display: flex;
     flex-direction: column;

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -92,6 +92,9 @@ export class ESPHomeCommandPalette extends LitElement {
   private _api!: ESPHomeAPI;
 
   @state() private _open = false;
+  /* True from open() until the hide animation ends; gates content so a
+     closed palette doesn't re-render the command list on device events. */
+  @state() private _contentRendered = false;
   @state() private _query = "";
   @state() private _selectedId = "";
 
@@ -139,6 +142,7 @@ export class ESPHomeCommandPalette extends LitElement {
     // linger inert under the modal backdrop.
     closeAllOpenPopovers(document);
     this._open = true;
+    this._contentRendered = true;
     this._query = "";
     this._selectedId = "";
     this._yamlSearch.clear();
@@ -157,10 +161,12 @@ export class ESPHomeCommandPalette extends LitElement {
     else this.open();
   }
 
-  // Esc and light-dismiss close the wa-dialog on their own; sync our flag.
-  private _onAfterHide = () => {
-    this._open = false;
-    this._yamlSearch.clear();
+  // Esc and light-dismiss close the wa-dialog on their own; sync our
+  // flag, then drop the content now that the hide animation is done.
+  private _onAfterHide = (e: Event) => {
+    if (e.target !== e.currentTarget) return;
+    this.close();
+    this._contentRendered = false;
   };
 
   private _allCommands(): CommandAction[] {
@@ -329,17 +335,19 @@ export class ESPHomeCommandPalette extends LitElement {
 
   /* wa-dialog shows via showModal(), so the palette lives in the top
      layer and stacks above an already-open dialog (Settings, Firmware
-     Tasks, ...) instead of painting behind it. Content stays rendered
-     while closed so the hide animation doesn't run on an empty card. */
+     Tasks, ...) instead of painting behind it. Raw wa-dialog on purpose:
+     base-dialog's header / close-button / busy chrome isn't wanted here.
+     The header is hidden via ::part(header) rather than without-header
+     so ``label`` still gives the dialog its accessible name. */
   protected render() {
     return html`
       <wa-dialog
-        without-header
+        label=${this._localize("command_palette.title")}
         light-dismiss
         ?open=${this._open}
         @wa-after-hide=${this._onAfterHide}
       >
-        ${this._renderContent()}
+        ${this._contentRendered ? this._renderContent() : nothing}
       </wa-dialog>
     `;
   }
@@ -372,6 +380,7 @@ export class ESPHomeCommandPalette extends LitElement {
           type="text"
           .value=${this._query}
           placeholder=${this._localize("command_palette.placeholder")}
+          aria-label=${this._localize("command_palette.placeholder")}
           @input=${this._onQueryInput}
           @keydown=${this._onInputKeyDown}
           autocomplete="off"

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -146,6 +146,8 @@ export class ESPHomeCommandPalette extends LitElement {
     this._query = "";
     this._selectedId = "";
     this._yamlSearch.clear();
+    // Belt and braces with wa-dialog's own [autofocus] handling.
+    requestAnimationFrame(() => this._searchInput?.focus());
   }
 
   close() {

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -23,7 +23,6 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -35,6 +34,7 @@ import {
 import { commandPaletteStyles } from "./command-palette.styles.js";
 import { YamlSearchController } from "./yaml-search-controller.js";
 
+import "@home-assistant/webawesome/dist/components/dialog/dialog.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
@@ -114,21 +114,15 @@ export class ESPHomeCommandPalette extends LitElement {
 
   static styles = [espHomeStyles, commandPaletteStyles];
 
+  /* Cmd+K is always-on (it opens the palette), so it stays on a
+     dedicated keydown listener. Esc is wa-dialog's job: its
+     dismissible stack closes only the topmost open dialog. */
   private _onGlobalKeyDown = (e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
       e.preventDefault();
       this._toggle();
     }
   };
-
-  /* Cmd+K is always-on (it opens the palette), so it stays on a
-     dedicated keydown listener. Esc only matters while the palette is
-     open and is handled by EscapeController, which attaches/detaches
-     in lockstep with ``_open``. */
-  private _escape = new EscapeController(this, (e) => {
-    e.preventDefault();
-    this.close();
-  });
 
   connectedCallback() {
     super.connectedCallback();
@@ -141,24 +135,20 @@ export class ESPHomeCommandPalette extends LitElement {
   }
 
   open() {
-    // Any open wa-select / wa-dropdown sits in the browser top layer
-    // via the popover API and would float above us regardless of
-    // z-index. Walk the document + every shadow root and close them
-    // before showing the palette.
+    // Close any open wa-select / wa-dropdown popover so it doesn't
+    // linger inert under the modal backdrop.
     closeAllOpenPopovers(document);
     this._open = true;
     this._query = "";
     this._selectedId = "";
     this._yamlSearch.clear();
-    requestAnimationFrame(() => this._searchInput?.focus());
   }
 
   close() {
     this._open = false;
-    // The palette is hidden by ``render() → nothing``, not by
-    // disconnecting from the DOM, so ``hostDisconnected`` doesn't
-    // fire and a pending debounce timer / queued dispatcher input
-    // would otherwise still flush a ``yaml/search`` after close.
+    // wa-dialog hides via its close animation, not by disconnecting,
+    // so a pending debounce timer / queued dispatcher input would
+    // otherwise still flush a ``yaml/search`` after close.
     this._yamlSearch.clear();
   }
 
@@ -166,6 +156,12 @@ export class ESPHomeCommandPalette extends LitElement {
     if (this._open) this.close();
     else this.open();
   }
+
+  // Esc and light-dismiss close the wa-dialog on their own; sync our flag.
+  private _onAfterHide = () => {
+    this._open = false;
+    this._yamlSearch.clear();
+  };
 
   private _allCommands(): CommandAction[] {
     const t = this._localize;
@@ -323,7 +319,6 @@ export class ESPHomeCommandPalette extends LitElement {
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
-    if (changed.has("_open")) this._escape.set(this._open);
     if (changed.has("_open") || changed.has("_query")) {
       const items = this._filtered();
       if (items.length && !items.find((i) => i.id === this._selectedId)) {
@@ -332,9 +327,24 @@ export class ESPHomeCommandPalette extends LitElement {
     }
   }
 
+  /* wa-dialog shows via showModal(), so the palette lives in the top
+     layer and stacks above an already-open dialog (Settings, Firmware
+     Tasks, ...) instead of painting behind it. Content stays rendered
+     while closed so the hide animation doesn't run on an empty card. */
   protected render() {
-    if (!this._open) return nothing;
+    return html`
+      <wa-dialog
+        without-header
+        light-dismiss
+        ?open=${this._open}
+        @wa-after-hide=${this._onAfterHide}
+      >
+        ${this._renderContent()}
+      </wa-dialog>
+    `;
+  }
 
+  private _renderContent() {
     const items = this._filtered();
     const groups: { name: string; items: CommandAction[] }[] = [];
     let cursor = "";
@@ -355,21 +365,20 @@ export class ESPHomeCommandPalette extends LitElement {
     const inYamlMode = this._isYamlMode;
     const searchIcon = inYamlMode ? "code-braces" : "magnify";
     return html`
-      <div class="backdrop" @click=${this.close}></div>
-      <div class="dialog" role="dialog" aria-modal="true">
-        <div class="search">
-          <wa-icon library="mdi" name=${searchIcon}></wa-icon>
-          <input
-            class="search-input"
-            type="text"
-            .value=${this._query}
-            placeholder=${this._localize("command_palette.placeholder")}
-            @input=${this._onQueryInput}
-            @keydown=${this._onInputKeyDown}
-            autocomplete="off"
-            spellcheck="false"
-          />
-          <!--
+      <div class="search">
+        <wa-icon library="mdi" name=${searchIcon}></wa-icon>
+        <input
+          class="search-input"
+          type="text"
+          .value=${this._query}
+          placeholder=${this._localize("command_palette.placeholder")}
+          @input=${this._onQueryInput}
+          @keydown=${this._onInputKeyDown}
+          autocomplete="off"
+          spellcheck="false"
+          autofocus
+        />
+        <!--
             Mode toggle: explicit switch-to-YAML / switch-to-commands
             button next to the input. Same effect as typing or removing
             the leading slash but discoverable for users who haven't
@@ -377,52 +386,48 @@ export class ESPHomeCommandPalette extends LitElement {
             mode so the affordance reads as an action rather than a
             status badge.
           -->
-          <button
-            class="mode-toggle ${inYamlMode ? "mode-toggle--yaml" : ""}"
-            type="button"
-            title=${this._localize(
-              inYamlMode
-                ? "command_palette.switch_to_commands"
-                : "command_palette.switch_to_yaml"
+        <button
+          class="mode-toggle ${inYamlMode ? "mode-toggle--yaml" : ""}"
+          type="button"
+          title=${this._localize(
+            inYamlMode
+              ? "command_palette.switch_to_commands"
+              : "command_palette.switch_to_yaml"
+          )}
+          aria-label=${this._localize(
+            inYamlMode
+              ? "command_palette.switch_to_commands"
+              : "command_palette.switch_to_yaml"
+          )}
+          aria-pressed=${inYamlMode ? "true" : "false"}
+          @click=${this._onToggleMode}
+        >
+          <wa-icon library="mdi" name=${inYamlMode ? "magnify" : "code-braces"}></wa-icon>
+        </button>
+      </div>
+      <div class="list" role="listbox">
+        ${items.length === 0
+          ? html`<div class="empty">${this._renderEmptyMessage()}</div>`
+          : groups.map(
+              (g) => html`
+                <div class="group">
+                  <div class="group-heading">${g.name}</div>
+                  ${g.items.map((item) => this._renderItem(item))}
+                </div>
+              `
             )}
-            aria-label=${this._localize(
-              inYamlMode
-                ? "command_palette.switch_to_commands"
-                : "command_palette.switch_to_yaml"
-            )}
-            aria-pressed=${inYamlMode ? "true" : "false"}
-            @click=${this._onToggleMode}
-          >
-            <wa-icon
-              library="mdi"
-              name=${inYamlMode ? "magnify" : "code-braces"}
-            ></wa-icon>
-          </button>
-        </div>
-        <div class="list" role="listbox">
-          ${items.length === 0
-            ? html`<div class="empty">${this._renderEmptyMessage()}</div>`
-            : groups.map(
-                (g) => html`
-                  <div class="group">
-                    <div class="group-heading">${g.name}</div>
-                    ${g.items.map((item) => this._renderItem(item))}
-                  </div>
-                `
-              )}
-        </div>
-        <div class="footer">
-          <span
-            ><kbd>↑</kbd><kbd>↓</kbd> ${this._localize(
-              "command_palette.navigate_hint"
-            )}</span
-          >
-          <span><kbd>↵</kbd> ${this._localize("command_palette.select_hint")}</span>
-          <span><kbd>esc</kbd> ${this._localize("command_palette.close_hint")}</span>
-          <span class="yaml-hint">
-            <kbd>/</kbd> ${this._localize("command_palette.yaml_search_hint")}
-          </span>
-        </div>
+      </div>
+      <div class="footer">
+        <span
+          ><kbd>↑</kbd><kbd>↓</kbd> ${this._localize(
+            "command_palette.navigate_hint"
+          )}</span
+        >
+        <span><kbd>↵</kbd> ${this._localize("command_palette.select_hint")}</span>
+        <span><kbd>esc</kbd> ${this._localize("command_palette.close_hint")}</span>
+        <span class="yaml-hint">
+          <kbd>/</kbd> ${this._localize("command_palette.yaml_search_hint")}
+        </span>
       </div>
     `;
   }

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -161,12 +161,19 @@ export class ESPHomeCommandPalette extends LitElement {
     else this.open();
   }
 
-  // Esc and light-dismiss close the wa-dialog on their own; sync our
-  // flag, then drop the content now that the hide animation is done.
-  private _onAfterHide = (e: Event) => {
+  // Esc and light-dismiss close the wa-dialog on their own; sync state
+  // on the initiating hide so a queued yaml/search can't flush during
+  // the hide animation.
+  private _onHide = (e: Event) => {
     if (e.target !== e.currentTarget) return;
     this.close();
-    this._contentRendered = false;
+  };
+
+  // Drop the content once the hide animation ends; keep it when the
+  // palette was reopened mid-animation.
+  private _onAfterHide = (e: Event) => {
+    if (e.target !== e.currentTarget) return;
+    if (!this._open) this._contentRendered = false;
   };
 
   private _allCommands(): CommandAction[] {
@@ -345,6 +352,7 @@ export class ESPHomeCommandPalette extends LitElement {
         label=${this._localize("command_palette.title")}
         light-dismiss
         ?open=${this._open}
+        @wa-hide=${this._onHide}
         @wa-after-hide=${this._onAfterHide}
       >
         ${this._contentRendered ? this._renderContent() : nothing}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -943,6 +943,7 @@
     "discord": "Chat on the ESPHome Discord"
   },
   "command_palette": {
+    "title": "Command palette",
     "placeholder": "Type a command — or / to search YAML content",
     "no_results": "No results found",
     "group_navigation": "Navigation",

--- a/test/components/command-palette-after-hide.test.ts
+++ b/test/components/command-palette-after-hide.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { describe, expect, test, vi } from "vitest";
+
+// Stub the real wa-dialog: happy-dom can't run its form-associated
+// internals, and these tests only cover the palette's own flag sync.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
+
+/**
+ * Pins the palette's wa-dialog close contract: ``_onAfterHide`` syncs
+ * ``_open`` and drops the content only for the palette's own wa-dialog
+ * (not a bubbled descendant), and ``close()`` keeps the content
+ * rendered so the hide animation doesn't run on an empty card.
+ */
+
+interface PaletteView extends EventTarget {
+  _open: boolean;
+  _contentRendered: boolean;
+  _yamlSearch: { clear: () => void };
+  _onAfterHide(e: Event): void;
+  open(): void;
+  close(): void;
+}
+
+function makePalette(): PaletteView {
+  return new ESPHomeCommandPalette() as unknown as PaletteView;
+}
+
+function afterHideEvent(sameTarget: boolean): Event {
+  const event = new Event("wa-after-hide", { bubbles: true });
+  const own = document.createElement("wa-dialog");
+  const target = sameTarget ? own : document.createElement("wa-dialog");
+  Object.defineProperty(event, "currentTarget", { value: own });
+  Object.defineProperty(event, "target", { value: target });
+  return event;
+}
+
+describe("esphome-command-palette wa-after-hide contract", () => {
+  test("own wa-after-hide closes, drops content, clears yaml search", () => {
+    const palette = makePalette();
+    palette.open();
+    expect(palette._open).toBe(true);
+    expect(palette._contentRendered).toBe(true);
+    const clear = vi.spyOn(palette._yamlSearch, "clear");
+
+    palette._onAfterHide(afterHideEvent(true));
+
+    expect(palette._open).toBe(false);
+    expect(palette._contentRendered).toBe(false);
+    expect(clear).toHaveBeenCalled();
+  });
+
+  test("bubbled wa-after-hide from a descendant is ignored", () => {
+    const palette = makePalette();
+    palette.open();
+
+    palette._onAfterHide(afterHideEvent(false));
+
+    expect(palette._open).toBe(true);
+    expect(palette._contentRendered).toBe(true);
+  });
+
+  test("close() flips _open but keeps content for the hide animation", () => {
+    const palette = makePalette();
+    palette.open();
+
+    palette.close();
+
+    expect(palette._open).toBe(false);
+    expect(palette._contentRendered).toBe(true);
+  });
+});

--- a/test/components/command-palette-after-hide.test.ts
+++ b/test/components/command-palette-after-hide.test.ts
@@ -8,16 +8,19 @@ vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}
 import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
 
 /**
- * Pins the palette's wa-dialog close contract: ``_onAfterHide`` syncs
- * ``_open`` and drops the content only for the palette's own wa-dialog
- * (not a bubbled descendant), and ``close()`` keeps the content
- * rendered so the hide animation doesn't run on an empty card.
+ * Pins the palette's wa-dialog close contract: ``_onHide`` syncs
+ * ``_open`` / clears the YAML search on the initiating hide (so a
+ * queued ``yaml/search`` can't flush during the hide animation),
+ * ``_onAfterHide`` drops the content only once hidden and only when
+ * not reopened mid-animation, and both ignore bubbled events from
+ * descendants.
  */
 
 interface PaletteView extends EventTarget {
   _open: boolean;
   _contentRendered: boolean;
   _yamlSearch: { clear: () => void };
+  _onHide(e: Event): void;
   _onAfterHide(e: Event): void;
   open(): void;
   close(): void;
@@ -27,8 +30,8 @@ function makePalette(): PaletteView {
   return new ESPHomeCommandPalette() as unknown as PaletteView;
 }
 
-function afterHideEvent(sameTarget: boolean): Event {
-  const event = new Event("wa-after-hide", { bubbles: true });
+function hideEvent(type: string, sameTarget: boolean): Event {
+  const event = new Event(type, { bubbles: true });
   const own = document.createElement("wa-dialog");
   const target = sameTarget ? own : document.createElement("wa-dialog");
   Object.defineProperty(event, "currentTarget", { value: own });
@@ -36,26 +39,50 @@ function afterHideEvent(sameTarget: boolean): Event {
   return event;
 }
 
-describe("esphome-command-palette wa-after-hide contract", () => {
-  test("own wa-after-hide closes, drops content, clears yaml search", () => {
+describe("esphome-command-palette wa-dialog close contract", () => {
+  test("own wa-hide closes immediately and clears yaml search", () => {
     const palette = makePalette();
     palette.open();
     expect(palette._open).toBe(true);
     expect(palette._contentRendered).toBe(true);
     const clear = vi.spyOn(palette._yamlSearch, "clear");
 
-    palette._onAfterHide(afterHideEvent(true));
+    palette._onHide(hideEvent("wa-hide", true));
 
     expect(palette._open).toBe(false);
-    expect(palette._contentRendered).toBe(false);
     expect(clear).toHaveBeenCalled();
+    // Content survives until the hide animation finishes.
+    expect(palette._contentRendered).toBe(true);
   });
 
-  test("bubbled wa-after-hide from a descendant is ignored", () => {
+  test("own wa-after-hide drops the content once hidden", () => {
+    const palette = makePalette();
+    palette.open();
+    palette._onHide(hideEvent("wa-hide", true));
+
+    palette._onAfterHide(hideEvent("wa-after-hide", true));
+
+    expect(palette._contentRendered).toBe(false);
+  });
+
+  test("wa-after-hide keeps the content when reopened mid-animation", () => {
+    const palette = makePalette();
+    palette.open();
+    palette._onHide(hideEvent("wa-hide", true));
+    palette.open();
+
+    palette._onAfterHide(hideEvent("wa-after-hide", true));
+
+    expect(palette._open).toBe(true);
+    expect(palette._contentRendered).toBe(true);
+  });
+
+  test("bubbled events from a descendant are ignored", () => {
     const palette = makePalette();
     palette.open();
 
-    palette._onAfterHide(afterHideEvent(false));
+    palette._onHide(hideEvent("wa-hide", false));
+    palette._onAfterHide(hideEvent("wa-after-hide", false));
 
     expect(palette._open).toBe(true);
     expect(palette._contentRendered).toBe(true);


### PR DESCRIPTION
# What does this implement/fix?

Ctrl+K opened the command palette behind an already open dialog; Settings and Firmware Tasks are wa-dialogs shown via showModal, which puts them in the browser top layer, and no z-index can put a plain fixed overlay above that. The palette is now a wa-dialog itself, so it opens in the top layer above the current dialog and joins the dismissible stack; Escape closes the palette first and leaves the dialog underneath open, backdrop click and focus handling come from wa-dialog's light-dismiss and autofocus instead of the custom backdrop and EscapeController.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1402

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

