### PR TITLE
Add depends_on_value_any set-valued visibility gate

### DIFF
--- a/src/api/types/config-entries.ts
+++ b/src/api/types/config-entries.ts
@@ -141,6 +141,8 @@ export interface ConfigEntry {
   depends_on_value: ConfigPrimitive | null;
   /** Show only when dependency value does NOT equal this. */
   depends_on_value_not: ConfigPrimitive | null;
+  /** Show only when dependency value is in this list. */
+  depends_on_value_any: ConfigPrimitive[] | null;
   /**
    * Hide this entry unless the named component is configured on the
    * same device (e.g. `qos` only matters when an `mqtt:` block exists).

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -53,11 +53,12 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
     `;
   }
   const key = path.join(".");
-  // A group that already carries a value in the YAML opens once so its
-  // filled fields are visible without a manual expand (advanced groups
-  // like remote_receiver's raw are otherwise collapsed). seedNestedOpen is
+  // A group that already carries a value in the YAML, or is itself
+  // required (its required children must be filled), opens once so its
+  // fields are visible without a manual expand (advanced groups like
+  // remote_receiver's raw are otherwise collapsed). seedNestedOpen is
   // one-shot, so a later user collapse sticks.
-  if (hasSerializableValue(raw)) ctx.seedNestedOpen(key);
+  if (entry.required || hasSerializableValue(raw)) ctx.seedNestedOpen(key);
   const inSet = ctx.nestedOpenSections.has(key);
   const isOpen = ctx.requiredOnly ? !inSet : inSet;
   // Optional entity sub-readings (a debug component's per-metric sensors,

--- a/src/util/config-entry-defaults.ts
+++ b/src/util/config-entry-defaults.ts
@@ -44,6 +44,7 @@ export function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEnt
     depends_on: null,
     depends_on_value: null,
     depends_on_value_not: null,
+    depends_on_value_any: null,
     depends_on_component: null,
     references_component: null,
     pin_features: [],

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,4 +1,4 @@
-import type { ConfigEntry } from "../api/types/config-entries.js";
+import type { ConfigEntry, ConfigPrimitive } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
@@ -60,6 +60,9 @@ export function isEntryVisible(
   }
   if (entry.depends_on_value_not !== null && entry.depends_on_value_not !== undefined) {
     return depValue !== entry.depends_on_value_not;
+  }
+  if (entry.depends_on_value_any != null) {
+    return entry.depends_on_value_any.includes(depValue as ConfigPrimitive);
   }
   return true;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -54,6 +54,8 @@ export function isEntryVisible(
   }
 
   if (!entry.depends_on) return true;
+  // The backend sets at most one of the three gate fields, so the
+  // check order below is immaterial.
   const depValue = values[entry.depends_on];
   if (entry.depends_on_value !== null && entry.depends_on_value !== undefined) {
     return depValue === entry.depends_on_value;

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -359,6 +359,65 @@ describe("filterRenderable", () => {
     ).toEqual(["mode", "advanced_opt"]);
   });
 
+  it("respects depends_on_value_any subset gating", () => {
+    // Typed-schema shape (ethernet): one entry per unique field, gated
+    // on the set of variants carrying it.
+    const entries = [
+      makeEntry({ key: "type", required: true }),
+      makeEntry({
+        key: "mdc_pin",
+        required: true,
+        depends_on: "type",
+        depends_on_value_any: ["LAN8720", "RTL8201"],
+      }),
+      makeEntry({
+        key: "cs_pin",
+        required: true,
+        depends_on: "type",
+        depends_on_value_any: ["W5500"],
+      }),
+    ];
+    const visible = (values: Record<string, unknown>) =>
+      filterRenderable(entries, values, {
+        requiredOnly: true,
+        showAdvanced: false,
+      }).map((e) => e.key);
+    expect(visible({ type: "LAN8720" })).toEqual(["type", "mdc_pin"]);
+    expect(visible({ type: "RTL8201" })).toEqual(["type", "mdc_pin"]);
+    expect(visible({ type: "W5500" })).toEqual(["type", "cs_pin"]);
+    expect(visible({})).toEqual(["type"]);
+  });
+
+  it("shows at most one of two same-key entries with disjoint gates", () => {
+    // Per-variant copies of a field whose definition differs (required
+    // local path vs optional git path) share one value slot; disjoint
+    // gates mean only one renders for any discriminator value.
+    const entries = [
+      makeEntry({ key: "type", required: true }),
+      makeEntry({
+        key: "path",
+        required: true,
+        depends_on: "type",
+        depends_on_value_any: ["local"],
+      }),
+      makeEntry({
+        key: "path",
+        depends_on: "type",
+        depends_on_value_any: ["git"],
+      }),
+    ];
+    const paths = (values: Record<string, unknown>) =>
+      filterRenderable(entries, values, {
+        requiredOnly: false,
+        showAdvanced: true,
+      }).filter((e) => e.key === "path");
+    expect(paths({ type: "local" })).toHaveLength(1);
+    expect(paths({ type: "local" })[0].required).toBe(true);
+    expect(paths({ type: "git" })).toHaveLength(1);
+    expect(paths({ type: "git" })[0].required).toBe(false);
+    expect(paths({ type: "other" })).toHaveLength(0);
+  });
+
   it("respects depends_on_component visibility", () => {
     const entries = [
       makeEntry({

--- a/test/components/device/render-nested-field-auto-expand.test.ts
+++ b/test/components/device/render-nested-field-auto-expand.test.ts
@@ -39,4 +39,17 @@ describe("renderNestedField auto-expand", () => {
     renderNestedField(rawEntry(), ["raw"], ctx);
     expect(open.has("raw")).toBe(false);
   });
+
+  it("seeds a required group open even with no value", () => {
+    // ethernet's clk: required group whose required children would
+    // otherwise hide behind a collapsed header.
+    const entry = makeEntry(ConfigEntryType.NESTED, {
+      key: "clk",
+      required: true,
+      config_entries: [makeEntry(ConfigEntryType.PIN, { key: "pin", required: true })],
+    });
+    const { ctx, open } = ctxWithOpenSet({});
+    renderNestedField(entry, ["clk"], ctx);
+    expect(open.has("clk")).toBe(true);
+  });
 });

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -260,6 +260,22 @@ describe("validateEntries", () => {
     expect(errors.size).toBe(0);
   });
 
+  it("skips required entries gated out by depends_on_value_any", () => {
+    const entries = [
+      makeEntry({ key: "type", required: true }),
+      makeEntry({
+        key: "cs_pin",
+        required: true,
+        depends_on: "type",
+        depends_on_value_any: ["W5500", "W6100"],
+      }),
+    ];
+    expect(validateEntries(entries, { type: "LAN8720" }).size).toBe(0);
+    expect(validateEntries(entries, { type: "W5500" }).get("cs_pin")?.code).toBe(
+      "validation.required"
+    );
+  });
+
   it("recurses into NESTED entries with dotted error keys", () => {
     const entries = [
       makeEntry({


### PR DESCRIPTION
# What does this implement/fix?

Adds a set-valued visibility gate to config entries: `depends_on_value_any` shows an entry only when the dependency's value is in the list. `isEntryVisible` checks it after the existing scalar gates, so rendering, validation and serialization all honor it through the one shared predicate.

This is the frontend half of polymorphic structured editors for components whose whole CONFIG_SCHEMA is a `cv.typed_schema` union (ethernet, spi, usb_uart, i2s_audio and friends). The backend companion PR (esphome/device-builder#1409) emits one entry per unique field, gated on the set of variants that carry it; picking a different type in the editor swaps the visible fields. Verified live against the companion backend: ethernet renders a structured editor, switching the type from LAN8720 to W5500 swaps the RMII pin fields for the SPI ones.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1397

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
