### PR TITLE
Restore the content-gutter inset on the header logo

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -121,8 +121,9 @@ export class ESPHomeLayout extends LitElement {
         background: none;
         color: var(--esphome-on-primary);
         padding: var(--header-edge-inset);
-        /* Hug the bar edge without costing no-arrow routes the gutter. */
-        margin-left: calc(var(--header-edge-inset) - var(--content-gutter));
+        /* Pull only the arrow to the bar edge; routes without an
+           arrow keep the header's content-gutter inset. */
+        margin-inline-start: calc(var(--header-edge-inset) - var(--content-gutter));
         border-radius: var(--wa-border-radius-m);
         opacity: 0.85;
         cursor: pointer;

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -96,8 +96,7 @@ export class ESPHomeLayout extends LitElement {
         display: flex;
         align-items: center;
         gap: var(--wa-space-m);
-        padding-right: var(--content-gutter);
-        padding-left: var(--header-edge-inset);
+        padding: 0 var(--content-gutter);
         background: var(--esphome-primary);
         height: var(--esphome-header-height);
         box-sizing: border-box;
@@ -122,6 +121,8 @@ export class ESPHomeLayout extends LitElement {
         background: none;
         color: var(--esphome-on-primary);
         padding: var(--header-edge-inset);
+        /* Hug the bar edge without costing no-arrow routes the gutter. */
+        margin-left: calc(var(--header-edge-inset) - var(--content-gutter));
         border-radius: var(--wa-border-radius-m);
         opacity: 0.85;
         cursor: pointer;


### PR DESCRIPTION
# What does this implement/fix?

The edit mode design update (#770) moved the app header's left padding to the 6px edge inset so the back arrow hugs the bar edge; on routes with no arrow (the dashboard) the logo lost its content gutter inset and sat flush against the edge.

Keep the gutter padding on the header and pull only the arrow leftward with a negative margin, the arrow geometry from #770 is unchanged.

**Related issue or feature (if applicable):**

- fixes the header alignment regression introduced by #770

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
