### PR TITLE
Read zero-indented LIST_SECTIONS bodies against the header indent

### DIFF
--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -122,8 +122,8 @@ export const parseBlockScalarHeader = (raw: string): BlockScalarHeader | null =>
  * dropped from the values dict, and the user's empty row vanishes
  * on save. Marking it complex routes the block through
  * ``collectBlockListMappings`` which already treats bare dashes
- * as ``{}`` placeholders. Indent is ``\s*`` — a zero-indented
- * sequence puts dashes at column 0, like ``LIST_ITEM_START_RE``.
+ * as ``{}`` placeholders. Indent is ``\s*`` for
+ * ``LIST_ITEM_START_RE``'s column-0 reason.
  */
 export const LIST_ITEM_BARE_DASH_RE = /^\s*-\s*$/;
 
@@ -153,8 +153,8 @@ export const LIST_ITEM_INLINE_KEY_PREFIX_RE = /^(\s*-\s*)\S/;
  *
  * Allows zero trailing whitespace after the colon (header-only
  * line) AND content after it (`- lambda: |-`); both forms are
- * complex. Indent is ``\s*`` — a zero-indented sequence puts
- * dashes at column 0, like ``LIST_ITEM_START_RE``.
+ * complex. Indent is ``\s*`` for ``LIST_ITEM_START_RE``'s
+ * column-0 reason.
  */
 export const LIST_ITEM_DICT_KEY_RE = /^\s*-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
 

--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -122,9 +122,10 @@ export const parseBlockScalarHeader = (raw: string): BlockScalarHeader | null =>
  * dropped from the values dict, and the user's empty row vanishes
  * on save. Marking it complex routes the block through
  * ``collectBlockListMappings`` which already treats bare dashes
- * as ``{}`` placeholders.
+ * as ``{}`` placeholders. Indent is ``\s*`` — a zero-indented
+ * sequence puts dashes at column 0, like ``LIST_ITEM_START_RE``.
  */
-export const LIST_ITEM_BARE_DASH_RE = /^\s+-\s*$/;
+export const LIST_ITEM_BARE_DASH_RE = /^\s*-\s*$/;
 
 /**
  * Capture the ``<indent>-<spaces>`` prefix up to the first non-space of a
@@ -152,9 +153,10 @@ export const LIST_ITEM_INLINE_KEY_PREFIX_RE = /^(\s*-\s*)\S/;
  *
  * Allows zero trailing whitespace after the colon (header-only
  * line) AND content after it (`- lambda: |-`); both forms are
- * complex.
+ * complex. Indent is ``\s*`` — a zero-indented sequence puts
+ * dashes at column 0, like ``LIST_ITEM_START_RE``.
  */
-export const LIST_ITEM_DICT_KEY_RE = /^\s+-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
+export const LIST_ITEM_DICT_KEY_RE = /^\s*-\s+[a-zA-Z_][\w.]*:(?:\s|$)/;
 
 export const childRegexFor = (indent: string) =>
   new RegExp(`^${indent}(${KEY_PATTERN}):\\s*(.*)$`);

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -392,9 +392,13 @@ export function parseSectionCore(
   // Top-level list-bodied section (globals): the item array lives at
   // [sectionKey], where the wrapper's multi_value entry reads it.
   if (!isListItem && LIST_SECTIONS.has(sectionKey)) {
+    // Peek and parse against the header's own indent, not the detected
+    // child indent: a zero-indented sequence puts its dashes at the
+    // header's column, below the child-indent fallback.
+    const headerIndent = _leadingIndent(lines[startIdx]);
     const peek = _skipBlankAndCommentLines(lines, startIdx + 1);
-    if (peek < lines.length && isChildListItemLine(lines[peek], childIndent)) {
-      values[sectionKey] = parseListBlock(lines, startIdx + 1, childIndent).value;
+    if (peek < lines.length && isChildListItemLine(lines[peek], headerIndent)) {
+      values[sectionKey] = parseListBlock(lines, startIdx + 1, headerIndent).value;
       // No per-key spans — `updateSectionInYaml` re-emits this whole
       // list through its dedicated LIST_SECTIONS branch.
       return { values, spans, comments, childIndent, isListItem, startIdx };

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -123,7 +123,8 @@ export function updateSectionInYaml(
 
   // Top-level list-bodied section (globals): re-emit through the
   // mapping serializer's array branch — { sectionKey: array } yields
-  // `sectionKey:` plus the dash items at the section's child indent.
+  // `sectionKey:` plus the dash items at the detected child indent
+  // (canonical 2-space when the body was a zero-indented sequence).
   if (LIST_SECTIONS.has(sectionKey)) {
     const raw = values[sectionKey];
     // No array → leave the YAML untouched rather than collapse the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2456,11 +2456,6 @@ describe("globals list section — zero-indented sequence", () => {
     expect(items[1].restore_value).toBe(true);
   });
 
-  it("keeps items as mappings, not scalar strings", () => {
-    const items = parseYamlSectionValues(COL0, "globals").globals as unknown[];
-    for (const item of items) expect(typeof item).toBe("object");
-  });
-
   it("round-trips adding a row without losing the existing items", () => {
     const items = parseYamlSectionValues(COL0, "globals").globals as Record<
       string,
@@ -2473,22 +2468,6 @@ describe("globals list section — zero-indented sequence", () => {
       unknown
     >[];
     expect(ritems.map((i) => i.id)).toEqual(["my_int", "my_bool", "my_str"]);
-  });
-
-  it("round-trips editing one item, keeping every entry", () => {
-    const items = parseYamlSectionValues(COL0, "globals").globals as Record<
-      string,
-      unknown
-    >[];
-    items[0].initial_value = "42";
-    const out = updateSectionInYaml(COL0, "globals", { globals: items });
-    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
-      string,
-      unknown
-    >[];
-    expect(ritems).toHaveLength(2);
-    expect(ritems[0].initial_value).toBe("42");
-    expect(ritems[1].id).toBe("my_bool");
   });
 
   it("preserves a sibling section on round-trip", () => {

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2432,6 +2432,89 @@ describe("globals list section (LIST_SECTIONS)", () => {
   });
 });
 
+describe("globals list section — zero-indented sequence", () => {
+  // device-builder-frontend#788: column-0 dashes read as empty, and a
+  // save after adding a row replaced the whole block.
+  const COL0 =
+    "globals:\n" +
+    "- id: my_int\n" +
+    "  type: int\n" +
+    "  initial_value: '0'\n" +
+    "- id: my_bool\n" +
+    "  type: bool\n" +
+    "  restore_value: true\n";
+
+  it("parses a column-0 globals block into an item array", () => {
+    const parsed = parseYamlSectionValues(COL0, "globals");
+    const items = parsed.globals as Record<string, unknown>[];
+    expect(Array.isArray(items)).toBe(true);
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    expect(items[0].type).toBe("int");
+    expect(items[0].initial_value).toBe("0");
+    expect(items[1].id).toBe("my_bool");
+    expect(items[1].restore_value).toBe(true);
+  });
+
+  it("keeps items as mappings, not scalar strings", () => {
+    const items = parseYamlSectionValues(COL0, "globals").globals as unknown[];
+    for (const item of items) expect(typeof item).toBe("object");
+  });
+
+  it("round-trips adding a row without losing the existing items", () => {
+    const items = parseYamlSectionValues(COL0, "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    items.push({ id: "my_str", type: "std::string" });
+    const out = updateSectionInYaml(COL0, "globals", { globals: items });
+    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    expect(ritems.map((i) => i.id)).toEqual(["my_int", "my_bool", "my_str"]);
+  });
+
+  it("round-trips editing one item, keeping every entry", () => {
+    const items = parseYamlSectionValues(COL0, "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    items[0].initial_value = "42";
+    const out = updateSectionInYaml(COL0, "globals", { globals: items });
+    const ritems = parseYamlSectionValues(out + "\n", "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    expect(ritems).toHaveLength(2);
+    expect(ritems[0].initial_value).toBe("42");
+    expect(ritems[1].id).toBe("my_bool");
+  });
+
+  it("preserves a sibling section on round-trip", () => {
+    const WITH_SIBLING = COL0 + "wifi:\n  ssid: home\n";
+    const items = parseYamlSectionValues(WITH_SIBLING, "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    items[0].initial_value = "7";
+    const out = updateSectionInYaml(WITH_SIBLING, "globals", { globals: items });
+    expect(out).toContain("wifi:");
+    expect(out).toContain("ssid: home");
+  });
+
+  it("keeps a column-0 bare-dash placeholder row as an empty item", () => {
+    const WITH_BARE = "globals:\n- id: my_int\n  type: int\n-\n";
+    const items = parseYamlSectionValues(WITH_BARE, "globals").globals as Record<
+      string,
+      unknown
+    >[];
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("my_int");
+    expect(items[1]).toEqual({});
+  });
+});
+
 describe("LIST_SECTIONS is membership-driven, not hardcoded to globals", () => {
   // Pins genericity: parse/serialize key off membership, so a future
   // top-level list section is one allowlist edit.


### PR DESCRIPTION
# What does this implement/fix?

A `LIST_SECTIONS` singleton whose whole value is a zero indented sequence (`globals:` with column 0 dashes) read as empty in the values layer, the editor showed no global variables, and saving after adding a row replaced the entire block with just the new row. The reader's list bodied peek and `parseListBlock` call now use the section header's own indent instead of the detected child indent, matching `parseListBlock`'s documented contract; the child indent fallback of two spaces was what rejected column 0 dashes. The coupled complexity regexes `LIST_ITEM_BARE_DASH_RE` and `LIST_ITEM_DICT_KEY_RE` are loosened to `\s*` in the same change, without that a column 0 `- id:` classifies the block as a scalar list and the items round trip as quoted strings. The loosenings only activate for header indent zero blocks; every other path terminates on those lines before the complexity checks run, and the full suite confirms no behavior change elsewhere.

Verified in the browser against a column 0 `globals:` config: the editor now renders both variables as structured rows, and the add row round trip is pinned by unit tests.

**Related issue or feature (if applicable):**

- fixes #788

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
