### PR TITLE
Match a column-0 inline id in findAddedSection

### DIFF
--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -154,7 +154,7 @@ export function findAddedSection(
   // (the common "I added a second sensor.dht" case).
   if (newId) {
     const lines = yaml.split("\n");
-    const idRe = new RegExp(`^\\s+(?:-\\s+)?id:\\s*["']?${newId}["']?\\s*$`);
+    const idRe = new RegExp(`^\\s*(?:-\\s+)?id:\\s*["']?${newId}["']?\\s*$`);
     for (const s of candidates) {
       for (let i = s.fromLine - 1; i < s.toLine && i < lines.length; i++) {
         if (idRe.test(lines[i])) {

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -154,7 +154,9 @@ export function findAddedSection(
   // (the common "I added a second sensor.dht" case).
   if (newId) {
     const lines = yaml.split("\n");
-    const idRe = new RegExp(`^\\s*(?:-\\s+)?id:\\s*["']?${newId}["']?\\s*$`);
+    // The id is form input — escape it so the match is literal.
+    const escapedId = newId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const idRe = new RegExp(`^\\s*(?:-\\s+)?id:\\s*["']?${escapedId}["']?\\s*$`);
     for (const s of candidates) {
       for (let i = s.fromLine - 1; i < s.toLine && i < lines.length; i++) {
         if (idRe.test(lines[i])) {

--- a/test/util/yaml-sections-find-added.test.ts
+++ b/test/util/yaml-sections-find-added.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _clearYamlSectionsMemo,
+  findAddedSection,
+} from "../../src/util/yaml-sections.js";
+
+/**
+ * Pins `findAddedSection`'s post-add selection: bare-key match,
+ * single-candidate shortcut, id disambiguation among duplicate
+ * platform candidates (including a column-0 inline `- id:`, #787),
+ * and the last-candidate fallback.
+ */
+
+beforeEach(() => {
+  _clearYamlSectionsMemo();
+});
+
+const TWO_DHT = `esphome:
+  name: dev
+sensor:
+  - platform: dht
+    id: dht_one
+    pin: GPIO1
+  - platform: dht
+    id: dht_two
+    pin: GPIO2
+`;
+
+const TWO_DHT_COL0 = `esphome:
+  name: dev
+sensor:
+- id: dht_one
+  platform: dht
+  pin: GPIO1
+- id: dht_two
+  platform: dht
+  pin: GPIO2
+`;
+
+describe("findAddedSection", () => {
+  it("matches a bare top-level component key", () => {
+    const yaml = "esphome:\n  name: dev\nwifi:\n  ssid: x\n";
+    expect(findAddedSection(yaml, "wifi", undefined)).toEqual({
+      sectionKey: "wifi",
+      fromLine: 3,
+    });
+  });
+
+  it("returns the single platform candidate without needing an id", () => {
+    const yaml = "sensor:\n  - platform: dht\n    pin: GPIO1\n";
+    expect(findAddedSection(yaml, "sensor.dht", undefined)).toEqual({
+      sectionKey: "sensor.dht",
+      fromLine: 2,
+    });
+  });
+
+  it("disambiguates duplicate candidates by the submitted id", () => {
+    expect(findAddedSection(TWO_DHT, "sensor.dht", "dht_one")?.fromLine).toBe(4);
+    expect(findAddedSection(TWO_DHT, "sensor.dht", "dht_two")?.fromLine).toBe(7);
+  });
+
+  it("disambiguates by a column-0 inline `- id:`", () => {
+    expect(findAddedSection(TWO_DHT_COL0, "sensor.dht", "dht_one")?.fromLine).toBe(4);
+    expect(findAddedSection(TWO_DHT_COL0, "sensor.dht", "dht_two")?.fromLine).toBe(7);
+  });
+
+  it("falls back to the last candidate when no id matches", () => {
+    expect(findAddedSection(TWO_DHT, "sensor.dht", "missing")?.fromLine).toBe(7);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findAddedSection("logger:\n", "sensor.dht", undefined)).toBeNull();
+  });
+});

--- a/test/util/yaml-sections-find-added.test.ts
+++ b/test/util/yaml-sections-find-added.test.ts
@@ -68,6 +68,17 @@ describe("findAddedSection", () => {
     expect(findAddedSection(TWO_DHT, "sensor.dht", "missing")?.fromLine).toBe(7);
   });
 
+  it("treats regex metacharacters in the id literally", () => {
+    // `dht.one` must not wildcard-match the first candidate's `dhtxone`.
+    const yaml = `sensor:
+  - platform: dht
+    id: dhtxone
+  - platform: dht
+    id: dht_two
+`;
+    expect(findAddedSection(yaml, "sensor.dht", "dht.one")?.fromLine).toBe(4);
+  });
+
   it("returns null when nothing matches", () => {
     expect(findAddedSection("logger:\n", "sensor.dht", undefined)).toBeNull();
   });


### PR DESCRIPTION
# What does this implement/fix?

`findAddedSection` disambiguates duplicate platform candidates after an add by scanning for the submitted id, but the regex required at least one leading space, so an inline `- id: x` on a column 0 dash never matched and selection fell back to the last candidate. The indent is now `\s*`, matching the rest of the dash regex family after #786 and #789; a column 0 continuation `id:` line already matched since item children sit at two or more spaces. The whole disambiguation path was previously untested, the new test file pins the bare key match, single candidate shortcut, id disambiguation at both indent styles, the last candidate fallback, and the null case.

**Related issue or feature (if applicable):**

- fixes #787

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
