### PR TITLE
Add a Search commands item to the global kebab menu

### DIFF
--- a/src/components/command-palette-actions.ts
+++ b/src/components/command-palette-actions.ts
@@ -8,6 +8,9 @@ import {
   yamlHitLabel,
 } from "../util/yaml-search-helpers.js";
 
+/** Window event that opens the palette from outside (kebab Search item). */
+export const OPEN_COMMAND_PALETTE_EVENT = "esphome-open-command-palette";
+
 export interface CommandAction {
   id: string;
   group: string;

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -25,7 +25,11 @@ import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { yamlEmptyMessageKey } from "../util/yaml-search-helpers.js";
 import type { CommandAction } from "./command-palette-actions.js";
-import { buildCommands, buildYamlHitActions } from "./command-palette-actions.js";
+import {
+  OPEN_COMMAND_PALETTE_EVENT,
+  buildCommands,
+  buildYamlHitActions,
+} from "./command-palette-actions.js";
 import { commandPaletteStyles } from "./command-palette.styles.js";
 import { YamlSearchController } from "./yaml-search-controller.js";
 
@@ -107,14 +111,20 @@ export class ESPHomeCommandPalette extends LitElement {
     }
   };
 
+  /* The kebab menu's Search item fires this so a visible affordance opens
+     the same palette as Cmd+K. */
+  private _onOpenEvent = () => this.open();
+
   connectedCallback() {
     super.connectedCallback();
     window.addEventListener("keydown", this._onGlobalKeyDown);
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, this._onOpenEvent);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener("keydown", this._onGlobalKeyDown);
+    window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, this._onOpenEvent);
   }
 
   open() {

--- a/src/components/esphome-header-actions.styles.ts
+++ b/src/components/esphome-header-actions.styles.ts
@@ -128,6 +128,23 @@ export const headerActionsStyles = css`
     text-align: center;
   }
 
+  .menu-item-shortcut {
+    margin-left: auto;
+    font-family: var(--wa-font-family-code, monospace);
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+    background: var(--esphome-tint);
+    border-radius: 4px;
+    padding: 1px 6px;
+  }
+
+  /* Touch-primary viewports have no hardware keyboard to teach. */
+  @media (hover: none) {
+    .menu-item-shortcut {
+      display: none;
+    }
+  }
+
   .menu-divider {
     height: 1px;
     background: var(--wa-color-surface-border);

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -9,6 +9,7 @@ import {
   mdiEyeOffOutline,
   mdiEyeOutline,
   mdiKeyVariant,
+  mdiMagnify,
   mdiPlaylistCheck,
   mdiWifiCog,
 } from "@mdi/js";
@@ -30,6 +31,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { OPEN_COMMAND_PALETTE_EVENT } from "./command-palette-actions.js";
 import { headerActionsStyles } from "./esphome-header-actions.styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -44,9 +46,20 @@ registerMdiIcons({
   "eye-off-outline": mdiEyeOffOutline,
   "eye-outline": mdiEyeOutline,
   "key-variant": mdiKeyVariant,
+  magnify: mdiMagnify,
   "playlist-check": mdiPlaylistCheck,
   "wifi-cog": mdiWifiCog,
 });
+
+/** Cmd+K on Apple platforms, Ctrl K elsewhere — matches the command
+ *  palette binding. ``userAgentData`` first; ``navigator.platform`` is
+ *  deprecated but remains the only signal on Firefox and Safari. */
+const SEARCH_SHORTCUT = /mac|iphone|ipad/i.test(
+  (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ??
+    navigator.platform
+)
+  ? "⌘K"
+  : "Ctrl K";
 
 @customElement("esphome-header-actions")
 export class ESPHomeHeaderActions extends LitElement {
@@ -258,6 +271,17 @@ export class ESPHomeHeaderActions extends LitElement {
                     >`
                   : nothing}
               </div>
+              <div
+                class="menu-item"
+                role="menuitem"
+                tabindex="0"
+                @click=${this._openSearch}
+                @keydown=${this._onMenuItemKeydown}
+              >
+                <wa-icon library="mdi" name="magnify"></wa-icon>
+                <span class="menu-item-label">${this._localize("layout.search")}</span>
+                <kbd class="menu-item-shortcut">${SEARCH_SHORTCUT}</kbd>
+              </div>
               <div class="menu-divider" role="separator"></div>
               <div
                 class="menu-item"
@@ -370,6 +394,11 @@ export class ESPHomeHeaderActions extends LitElement {
         composed: true,
       })
     );
+  }
+
+  private _openSearch() {
+    this._close();
+    window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
   }
 
   private _offloaderAlertsCount(): number {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -920,6 +920,7 @@
     "theme_dark": "Dark",
     "theme_system": "System",
     "settings": "Settings",
+    "search": "Search commands",
     "archived_devices": "Archived devices",
     "show_ignored_discoveries": "Show ignored discoveries ({count})",
     "hide_ignored_discoveries": "Hide ignored discoveries",

--- a/test/components/command-palette-open-event.test.ts
+++ b/test/components/command-palette-open-event.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// Stub the real wa-dialog: happy-dom can't run its form-associated internals.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { OPEN_COMMAND_PALETTE_EVENT } from "../../src/components/command-palette-actions.js";
+import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
+
+/** A connected palette opens on the window event the kebab Search item fires. */
+describe("esphome-command-palette open-on-event", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("the open-palette event opens the palette", async () => {
+    const palette = new ESPHomeCommandPalette();
+    document.body.appendChild(palette);
+    await palette.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((palette as any)._open).toBe(false);
+
+    window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((palette as any)._open).toBe(true);
+  });
+
+  test("the listener is removed on disconnect", async () => {
+    const palette = new ESPHomeCommandPalette();
+    document.body.appendChild(palette);
+    await palette.updateComplete;
+    palette.remove();
+
+    window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((palette as any)._open).toBe(false);
+  });
+});

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The kebab Search item is the visible affordance for the Cmd+K command
+ * palette; clicking it must fire the window event the palette listens for and
+ * close the menu.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OPEN_COMMAND_PALETTE_EVENT } from "../../src/components/command-palette-actions.js";
+import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+
+async function renderOpenMenu(): Promise<ESPHomeHeaderActions> {
+  const el = new ESPHomeHeaderActions();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._open = true;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function searchItem(el: ESPHomeHeaderActions): HTMLElement {
+  return el.shadowRoot!.querySelector('wa-icon[name="magnify"]')!
+    .parentElement as HTMLElement;
+}
+
+describe("header-actions Search item", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the Search item with a shortcut hint", async () => {
+    const el = await renderOpenMenu();
+    expect(el.shadowRoot!.querySelector('wa-icon[name="magnify"]')).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".menu-item-shortcut")).not.toBeNull();
+  });
+
+  it("fires the open-palette event and closes the menu on click", async () => {
+    const el = await renderOpenMenu();
+    const listener = vi.fn();
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, listener);
+
+    searchItem(el).click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(false);
+    window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, listener);
+  });
+});


### PR DESCRIPTION
## needs to be gated on https://github.com/esphome/device-builder-frontend/pull/818 

# What does this implement/fix?

The command palette already exists and opens with Cmd+K / Ctrl+K, but the only way to reach it is the keyboard shortcut, so users who never press it never find the feature. This adds a "Search commands" item to the global header kebab menu, directly below Settings, that opens the same palette; the row shows the Cmd+K / Ctrl+K shortcut on the right so the menu also teaches the keybinding. The shortcut hint is hidden on touch-primary devices (`@media (hover: none)`), since there is no hardware keyboard to teach; the menu item itself still works by tap. The menu item fires a window event the palette already listens for, so nothing about the palette's behaviour changes.

**Related issue or feature (if applicable):**

fixes https://github.com/esphome/device-builder-frontend/issues/795

## Screenshot

<img width="235" height="376" alt="Screenshot 2026-06-12 at 4 01 08 PM" src="https://github.com/user-attachments/assets/bcaae1bc-d65b-4403-8fdf-83b111dd32f7" />


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


