### PR TITLE
Split oversized header-actions and command-palette components

### DIFF
--- a/src/components/command-palette-actions.ts
+++ b/src/components/command-palette-actions.ts
@@ -1,0 +1,151 @@
+import type { ConfiguredDevice, YamlSearchHit } from "../api/types/devices.js";
+import type { LanguageChoice, LocalizeFunc } from "../common/localize.js";
+import { LANGUAGES, languageLabel } from "../common/localize.js";
+import { navigate } from "../util/navigation.js";
+import {
+  forEachYamlMatch,
+  yamlHitHref,
+  yamlHitLabel,
+} from "../util/yaml-search-helpers.js";
+
+export interface CommandAction {
+  id: string;
+  group: string;
+  label: string;
+  /** MDI icon name registered via ``registerMdiIcons``; rendered
+   *  through ``<wa-icon library="mdi">``. Mutually exclusive with
+   *  ``flag`` — when both are set, ``flag`` wins. */
+  icon?: string;
+  /** Emoji prefix shown in place of the MDI icon column. Used for
+   *  language entries so the picker reads as flags-not-icons. */
+  flag?: string;
+  keywords?: string[];
+  run: () => void;
+}
+
+/** Inputs the static command list needs from the palette host. */
+export interface CommandActionContext {
+  t: LocalizeFunc;
+  devices: ConfiguredDevice[];
+  yamlDiffEnabled: boolean;
+  setTheme: (theme: string) => void;
+  setLanguage: (lang: LanguageChoice) => void;
+  toggleDiffButton: () => void;
+}
+
+/** The default (non-YAML-mode) command list: navigation, devices,
+ *  themes, languages, editor toggles. */
+export function buildCommands(ctx: CommandActionContext): CommandAction[] {
+  const { t } = ctx;
+
+  const nav: CommandAction[] = [
+    {
+      id: "nav.home",
+      group: t("command_palette.group_navigation"),
+      label: t("command_palette.go_dashboard"),
+      icon: "home",
+      keywords: ["dashboard", "devices"],
+      run: () => navigate("/"),
+    },
+    {
+      id: "nav.secrets",
+      group: t("command_palette.group_navigation"),
+      label: t("layout.secrets"),
+      icon: "key-variant",
+      keywords: ["password", "wifi"],
+      run: () => navigate("/secrets"),
+    },
+  ];
+
+  const deviceGroup = t("command_palette.group_devices");
+  const devices: CommandAction[] = ctx.devices.map((d) => ({
+    id: `device.${d.configuration}`,
+    group: deviceGroup,
+    label: d.friendly_name || d.name || d.configuration,
+    icon: "chip",
+    keywords: [d.configuration, d.name],
+    run: () => navigate(`/device/${d.configuration}`),
+  }));
+
+  const themeGroup = t("layout.theme");
+  const themes: CommandAction[] = [
+    {
+      id: "theme.light",
+      group: themeGroup,
+      label: t("layout.theme_light"),
+      icon: "weather-sunny",
+      keywords: ["light", "theme"],
+      run: () => ctx.setTheme("light"),
+    },
+    {
+      id: "theme.dark",
+      group: themeGroup,
+      label: t("layout.theme_dark"),
+      icon: "weather-night",
+      keywords: ["dark", "theme"],
+      run: () => ctx.setTheme("dark"),
+    },
+    {
+      id: "theme.system",
+      group: themeGroup,
+      label: t("layout.theme_system"),
+      icon: "theme-light-dark",
+      keywords: ["system", "auto"],
+      run: () => ctx.setTheme("system"),
+    },
+  ];
+
+  const editor: CommandAction[] = [
+    {
+      id: "editor.yaml_diff_button",
+      group: t("layout.editor"),
+      label: ctx.yamlDiffEnabled
+        ? t("command_palette.hide_yaml_diff_button")
+        : t("command_palette.show_yaml_diff_button"),
+      icon: "vector-difference",
+      keywords: ["diff", "yaml", "compare"],
+      run: () => ctx.toggleDiffButton(),
+    },
+  ];
+
+  const languageGroup = t("command_palette.group_language");
+  const languages: CommandAction[] = LANGUAGES.map((l) => ({
+    id: `language.${l.value}`,
+    group: languageGroup,
+    label: languageLabel(l, t),
+    flag: l.flag,
+    keywords: ["language", "locale", l.value],
+    run: () => ctx.setLanguage(l.value),
+  }));
+
+  return [...nav, ...devices, ...themes, ...languages, ...editor];
+}
+
+/**
+ * Materialise the live YAML-content hits as ``CommandAction``s so
+ * the existing render + keyboard-nav code handles them without a
+ * parallel branch. Each match becomes its own row (one device with
+ * three matches → three rows) so the user can pick the specific
+ * line they want to land on. Click → navigate to
+ * ``/device/<configuration>?line=<n>``; the editor's ``_readUrlLine``
+ * already wires that param to scroll-to + the existing highlight
+ * machinery.
+ */
+export function buildYamlHitActions(
+  hits: YamlSearchHit[] | null,
+  t: LocalizeFunc
+): CommandAction[] {
+  const groupName = t("command_palette.group_yaml_matches");
+  return forEachYamlMatch(hits, (hit, match) => ({
+    id: `yaml.${hit.configuration}:${match.line_number}`,
+    group: groupName,
+    label: yamlHitLabel(hit, match),
+    icon: "code-braces",
+    // No ``keywords`` — YAML mode bypasses ``_filtered()``'s
+    // keyword search entirely (the backend already did the
+    // matching) so an unused keywords array would just retain
+    // raw YAML line text — including potentially-sensitive
+    // values — in memory for nothing.
+    run: () => navigate(yamlHitHref(hit, match)),
+  }));
+}

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -15,7 +15,6 @@ import { customElement, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { LanguageChoice, LocalizeFunc } from "../common/localize.js";
-import { LANGUAGES, languageLabel } from "../common/localize.js";
 import {
   apiContext,
   devicesContext,
@@ -23,14 +22,10 @@ import {
   yamlDiffButtonContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import {
-  forEachYamlMatch,
-  yamlEmptyMessageKey,
-  yamlHitHref,
-  yamlHitLabel,
-} from "../util/yaml-search-helpers.js";
+import { yamlEmptyMessageKey } from "../util/yaml-search-helpers.js";
+import type { CommandAction } from "./command-palette-actions.js";
+import { buildCommands, buildYamlHitActions } from "./command-palette-actions.js";
 import { commandPaletteStyles } from "./command-palette.styles.js";
 import { YamlSearchController } from "./yaml-search-controller.js";
 
@@ -57,21 +52,6 @@ function closeAllOpenPopovers(root: Document | ShadowRoot) {
   for (const el of root.querySelectorAll<HTMLElement>("*")) {
     if (el.shadowRoot) closeAllOpenPopovers(el.shadowRoot);
   }
-}
-
-interface CommandAction {
-  id: string;
-  group: string;
-  label: string;
-  /** MDI icon name registered via ``registerMdiIcons``; rendered
-   *  through ``<wa-icon library="mdi">``. Mutually exclusive with
-   *  ``flag`` — when both are set, ``flag`` wins. */
-  icon?: string;
-  /** Emoji prefix shown in place of the MDI icon column. Used for
-   *  language entries so the picker reads as flags-not-icons. */
-  flag?: string;
-  keywords?: string[];
-  run: () => void;
 }
 
 @customElement("esphome-command-palette")
@@ -179,89 +159,14 @@ export class ESPHomeCommandPalette extends LitElement {
   };
 
   private _allCommands(): CommandAction[] {
-    const t = this._localize;
-
-    const nav: CommandAction[] = [
-      {
-        id: "nav.home",
-        group: t("command_palette.group_navigation"),
-        label: t("command_palette.go_dashboard"),
-        icon: "home",
-        keywords: ["dashboard", "devices"],
-        run: () => navigate("/"),
-      },
-      {
-        id: "nav.secrets",
-        group: t("command_palette.group_navigation"),
-        label: t("layout.secrets"),
-        icon: "key-variant",
-        keywords: ["password", "wifi"],
-        run: () => navigate("/secrets"),
-      },
-    ];
-
-    const deviceGroup = t("command_palette.group_devices");
-    const devices: CommandAction[] = this._devices.map((d) => ({
-      id: `device.${d.configuration}`,
-      group: deviceGroup,
-      label: d.friendly_name || d.name || d.configuration,
-      icon: "chip",
-      keywords: [d.configuration, d.name],
-      run: () => navigate(`/device/${d.configuration}`),
-    }));
-
-    const themeGroup = t("layout.theme");
-    const themes: CommandAction[] = [
-      {
-        id: "theme.light",
-        group: themeGroup,
-        label: t("layout.theme_light"),
-        icon: "weather-sunny",
-        keywords: ["light", "theme"],
-        run: () => this._setTheme("light"),
-      },
-      {
-        id: "theme.dark",
-        group: themeGroup,
-        label: t("layout.theme_dark"),
-        icon: "weather-night",
-        keywords: ["dark", "theme"],
-        run: () => this._setTheme("dark"),
-      },
-      {
-        id: "theme.system",
-        group: themeGroup,
-        label: t("layout.theme_system"),
-        icon: "theme-light-dark",
-        keywords: ["system", "auto"],
-        run: () => this._setTheme("system"),
-      },
-    ];
-
-    const editor: CommandAction[] = [
-      {
-        id: "editor.yaml_diff_button",
-        group: t("layout.editor"),
-        label: this._yamlDiffEnabled
-          ? t("command_palette.hide_yaml_diff_button")
-          : t("command_palette.show_yaml_diff_button"),
-        icon: "vector-difference",
-        keywords: ["diff", "yaml", "compare"],
-        run: () => this._toggleDiffButton(),
-      },
-    ];
-
-    const languageGroup = t("command_palette.group_language");
-    const languages: CommandAction[] = LANGUAGES.map((l) => ({
-      id: `language.${l.value}`,
-      group: languageGroup,
-      label: languageLabel(l, t),
-      flag: l.flag,
-      keywords: ["language", "locale", l.value],
-      run: () => this._setLanguage(l.value),
-    }));
-
-    return [...nav, ...devices, ...themes, ...languages, ...editor];
+    return buildCommands({
+      t: this._localize,
+      devices: this._devices,
+      yamlDiffEnabled: this._yamlDiffEnabled,
+      setTheme: (theme) => this._setTheme(theme),
+      setLanguage: (lang) => this._setLanguage(lang),
+      toggleDiffButton: () => this._toggleDiffButton(),
+    });
   }
 
   /**
@@ -307,30 +212,8 @@ export class ESPHomeCommandPalette extends LitElement {
     });
   }
 
-  /**
-   * Materialise the live YAML-content hits as ``CommandAction``s
-   * so the existing render + keyboard-nav code handles them
-   * without a parallel branch. Each match becomes its own row
-   * (one device with three matches → three rows) so the user can
-   * pick the specific line they want to land on. Click → navigate
-   * to ``/device/<configuration>?line=<n>``; the editor's
-   * ``_readUrlLine`` already wires that param to scroll-to + the
-   * existing highlight machinery.
-   */
   private _yamlHitActions(): CommandAction[] {
-    const groupName = this._localize("command_palette.group_yaml_matches");
-    return forEachYamlMatch(this._yamlSearch.hits, (hit, match) => ({
-      id: `yaml.${hit.configuration}:${match.line_number}`,
-      group: groupName,
-      label: yamlHitLabel(hit, match),
-      icon: "code-braces",
-      // No ``keywords`` — YAML mode bypasses ``_filtered()``'s
-      // keyword search entirely (the backend already did the
-      // matching) so an unused keywords array would just retain
-      // raw YAML line text — including potentially-sensitive
-      // values — in memory for nothing.
-      run: () => navigate(yamlHitHref(hit, match)),
-    }));
+    return buildYamlHitActions(this._yamlSearch.hits, this._localize);
   }
 
   protected willUpdate(changed: Map<string, unknown>) {

--- a/src/components/esphome-header-actions.styles.ts
+++ b/src/components/esphome-header-actions.styles.ts
@@ -1,0 +1,145 @@
+import { css } from "lit";
+
+export const headerActionsStyles = css`
+  :host {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+  }
+
+  .menu-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    border: none;
+    background: none;
+    color: var(--esphome-on-primary);
+    cursor: pointer;
+    padding: 6px;
+    border-radius: var(--wa-border-radius-m);
+    opacity: 0.85;
+    transition:
+      opacity 0.12s,
+      background 0.12s;
+  }
+
+  .menu-btn:hover {
+    opacity: 1;
+    background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
+  }
+
+  .menu-btn:focus-visible {
+    outline: 2px solid var(--esphome-on-primary);
+    outline-offset: 2px;
+    opacity: 1;
+  }
+
+  .menu-btn wa-icon {
+    font-size: 20px;
+  }
+
+  .menu-btn-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--esphome-warning, #f59e0b);
+    box-shadow: 0 0 0 2px var(--esphome-primary);
+  }
+
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+  }
+
+  .menu {
+    position: fixed;
+    z-index: 101;
+    min-width: 220px;
+    background: var(--wa-color-surface-raised);
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-l);
+    box-shadow: var(--wa-shadow-l);
+    padding: var(--wa-space-xs) 0;
+    animation: menu-in 0.12s ease-out;
+  }
+
+  @keyframes menu-in {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-s);
+    padding: 8px var(--wa-space-m);
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-normal);
+    cursor: pointer;
+    transition: background 0.1s;
+    user-select: none;
+  }
+
+  .menu-item:hover {
+    background: var(--esphome-tint);
+  }
+
+  .menu-item wa-icon {
+    font-size: 16px;
+    color: var(--wa-color-text-quiet);
+  }
+
+  .menu-item:hover wa-icon {
+    color: var(--esphome-primary);
+  }
+
+  .menu-item--active wa-icon {
+    color: var(--esphome-primary);
+  }
+
+  .menu-item-label {
+    flex: 1;
+  }
+
+  .menu-item .check {
+    font-size: 14px;
+    color: var(--esphome-primary);
+  }
+
+  .menu-item-count {
+    margin-left: auto;
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--esphome-on-primary);
+    background: var(--esphome-primary);
+    border-radius: 999px;
+    padding: 1px 8px;
+    min-width: 18px;
+    text-align: center;
+  }
+
+  .menu-divider {
+    height: 1px;
+    background: var(--wa-color-surface-border);
+    margin: var(--wa-space-2xs) 0;
+  }
+
+  .menu-label {
+    padding: var(--wa-space-2xs) var(--wa-space-m);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-quiet);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+`;

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -12,7 +12,7 @@ import {
   mdiPlaylistCheck,
   mdiWifiCog,
 } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
@@ -30,6 +30,7 @@ import { espHomeStyles } from "../styles/shared.js";
 import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { headerActionsStyles } from "./esphome-header-actions.styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
@@ -104,152 +105,7 @@ export class ESPHomeHeaderActions extends LitElement {
   @state()
   private _showIgnored = false;
 
-  static styles = [
-    espHomeStyles,
-    css`
-      :host {
-        display: inline-flex;
-        align-items: center;
-        gap: 0;
-      }
-
-      .menu-btn {
-        position: relative;
-        display: inline-flex;
-        align-items: center;
-        border: none;
-        background: none;
-        color: var(--esphome-on-primary);
-        cursor: pointer;
-        padding: 6px;
-        border-radius: var(--wa-border-radius-m);
-        opacity: 0.85;
-        transition:
-          opacity 0.12s,
-          background 0.12s;
-      }
-
-      .menu-btn:hover {
-        opacity: 1;
-        background: color-mix(in srgb, var(--esphome-on-primary), transparent 85%);
-      }
-
-      .menu-btn:focus-visible {
-        outline: 2px solid var(--esphome-on-primary);
-        outline-offset: 2px;
-        opacity: 1;
-      }
-
-      .menu-btn wa-icon {
-        font-size: 20px;
-      }
-
-      .menu-btn-badge {
-        position: absolute;
-        top: 4px;
-        right: 4px;
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: var(--esphome-warning, #f59e0b);
-        box-shadow: 0 0 0 2px var(--esphome-primary);
-      }
-
-      .backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 100;
-      }
-
-      .menu {
-        position: fixed;
-        z-index: 101;
-        min-width: 220px;
-        background: var(--wa-color-surface-raised);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        border-radius: var(--wa-border-radius-l);
-        box-shadow: var(--wa-shadow-l);
-        padding: var(--wa-space-xs) 0;
-        animation: menu-in 0.12s ease-out;
-      }
-
-      @keyframes menu-in {
-        from {
-          opacity: 0;
-          transform: scale(0.95);
-        }
-        to {
-          opacity: 1;
-          transform: scale(1);
-        }
-      }
-
-      .menu-item {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-s);
-        padding: 8px var(--wa-space-m);
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-normal);
-        cursor: pointer;
-        transition: background 0.1s;
-        user-select: none;
-      }
-
-      .menu-item:hover {
-        background: var(--esphome-tint);
-      }
-
-      .menu-item wa-icon {
-        font-size: 16px;
-        color: var(--wa-color-text-quiet);
-      }
-
-      .menu-item:hover wa-icon {
-        color: var(--esphome-primary);
-      }
-
-      .menu-item--active wa-icon {
-        color: var(--esphome-primary);
-      }
-
-      .menu-item-label {
-        flex: 1;
-      }
-
-      .menu-item .check {
-        font-size: 14px;
-        color: var(--esphome-primary);
-      }
-
-      .menu-item-count {
-        margin-left: auto;
-        font-size: var(--wa-font-size-2xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--esphome-on-primary);
-        background: var(--esphome-primary);
-        border-radius: 999px;
-        padding: 1px 8px;
-        min-width: 18px;
-        text-align: center;
-      }
-
-      .menu-divider {
-        height: 1px;
-        background: var(--wa-color-surface-border);
-        margin: var(--wa-space-2xs) 0;
-      }
-
-      .menu-label {
-        padding: var(--wa-space-2xs) var(--wa-space-m);
-        font-size: var(--wa-font-size-2xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-    `,
-  ];
+  static styles = [espHomeStyles, headerActionsStyles];
 
   connectedCallback(): void {
     super.connectedCallback();


### PR DESCRIPTION
# What does this implement/fix?

A behaviour-free split of two components that were already over the repo's 500 to 600 line file-size limit, so follow-up work can extend them without making grandfathered files worse.

`esphome-header-actions.ts` (538 lines) moves its `static styles` CSS block into a new `esphome-header-actions.styles.ts`, mirroring the existing `command-palette.styles.ts` pattern; the component drops to 394 lines.

`command-palette.ts` (608 lines) moves the `CommandAction` interface and the command-list builders (`_allCommands` and the YAML-hit actions) into a new `command-palette-actions.ts` as pure functions; the component keeps thin wrappers that pass its own callbacks, and drops to 491 lines.

No behaviour changes; the existing test suite passes unchanged.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
