### PR TITLE
Surface WebSerial connect failures instead of closing silently

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -32,7 +32,7 @@ import {
 } from "../context/index.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { downloadAnsiText } from "../util/download-text.js";
+import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
@@ -404,7 +404,7 @@ export class ESPHomeCommandDialog extends LitElement {
 
   _downloadOutput = () => {
     this._flushPendingLines();
-    const stem = this.configuration.replace(/\.ya?ml$/, "") || "output";
+    const stem = configurationStem(this.configuration, "output");
     downloadAnsiText(this._lines, `${stem}-${this._commandType}.txt`);
   };
 

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -11,6 +11,7 @@ import {
   connectToPort,
   detectChip,
   disconnect,
+  isPortPickerCancel,
   readDeviceManifest,
   readMacAddress,
 } from "../../util/web-serial.js";
@@ -359,7 +360,18 @@ export async function detectAndOpenWizard(
     }
 
     createDialog.openAtBoardStep(chipNameToFilterLabel(chipName) ?? undefined);
-  } catch {
+  } catch (err) {
+    // Detection failed (or the picker was cancelled) — the wizard still
+    // opens so the user can pick a board by hand, but a real connect
+    // failure gets named instead of vanishing (#1414).
+    if (!isPortPickerCancel(err) && options.localize) {
+      toast.error(
+        options.localize("dashboard.serial_connect_failed", {
+          error: getErrorMessage(err),
+        }),
+        { richColors: true }
+      );
+    }
     createDialog.open("board");
   }
 }

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -5,6 +5,7 @@ import {
   mdiChevronDown,
   mdiChevronUp,
   mdiClose,
+  mdiDownload,
   mdiTextBoxOutline,
 } from "@mdi/js";
 import { LitElement, html } from "lit";
@@ -47,6 +48,7 @@ registerMdiIcons({
   "chevron-down": mdiChevronDown,
   "chevron-up": mdiChevronUp,
   close: mdiClose,
+  download: mdiDownload,
   "text-box-outline": mdiTextBoxOutline,
 });
 

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -5,6 +5,7 @@ import {
 } from "../../api/types/firmware-jobs.js";
 import { chipNameToVariant } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
+import { getErrorMessage } from "../../util/error-message.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import {
   connectToPort,
@@ -58,10 +59,7 @@ export async function startWebSerialInstall(
     }
     // The picker succeeded but the chip never answered — fail loud with
     // the esptool log expanded instead of silently closing (#1414).
-    host._fail(
-      host._localize("serial.connect_failed"),
-      err instanceof Error ? err.message : String(err)
-    );
+    host._fail(host._localize("serial.connect_failed"), getErrorMessage(err));
     return;
   }
   host._detected = detected;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -11,6 +11,7 @@ import {
   detectChip,
   disconnect,
   flashFirmware,
+  isPortPickerCancel,
   resetAndDisconnect,
   type DetectedChip,
 } from "../../util/web-serial.js";
@@ -50,8 +51,17 @@ export async function startWebSerialInstall(
   let detected: DetectedChip;
   try {
     detected = await detectChip(onLog);
-  } catch {
-    host._close(); // User cancelled port selection
+  } catch (err) {
+    if (isPortPickerCancel(err)) {
+      host._close();
+      return;
+    }
+    // The picker succeeded but the chip never answered — fail loud with
+    // the esptool log expanded instead of silently closing (#1414).
+    host._fail(
+      host._localize("serial.connect_failed"),
+      err instanceof Error ? err.message : String(err)
+    );
     return;
   }
   host._detected = detected;

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { type FirmwareBinary, JobSource } from "../../api/types/firmware-jobs.js";
+import { downloadAnsiText } from "../../util/download-text.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 import type { ProcessTerminalState } from "../process-terminal/process-terminal.js";
 import {
@@ -206,6 +207,11 @@ export function renderStatusExtra(
   return html`<div slot="status-extra">${binaryList} ${downloadExtra} ${logs}</div>`;
 }
 
+function downloadInstallLogs(host: ESPHomeFirmwareInstallDialog): void {
+  const stem = host._device?.configuration.replace(/\.ya?ml$/, "") || "install";
+  downloadAnsiText(host._logLines, `${stem}-install.txt`);
+}
+
 export function renderLogs(
   host: ESPHomeFirmwareInstallDialog
 ): TemplateResult | typeof nothing {
@@ -225,6 +231,10 @@ export function renderLogs(
         ${host._logsExpanded
           ? host._localize("firmware.hide_details")
           : host._localize("firmware.show_details")}
+      </button>
+      <button class="logs-toggle" @click=${() => downloadInstallLogs(host)}>
+        <wa-icon library="mdi" name="download"></wa-icon>
+        ${host._localize("dashboard.logs_download")}
       </button>
     </div>
     ${host._logsExpanded

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { type FirmwareBinary, JobSource } from "../../api/types/firmware-jobs.js";
-import { downloadAnsiText } from "../../util/download-text.js";
+import { configurationStem, downloadAnsiText } from "../../util/download-text.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 import type { ProcessTerminalState } from "../process-terminal/process-terminal.js";
 import {
@@ -208,7 +208,7 @@ export function renderStatusExtra(
 }
 
 function downloadInstallLogs(host: ESPHomeFirmwareInstallDialog): void {
-  const stem = host._device?.configuration.replace(/\.ya?ml$/, "") || "install";
+  const stem = configurationStem(host._device?.configuration, "install");
   downloadAnsiText(host._logLines, `${stem}-install.txt`);
 }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -20,7 +20,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { downloadAnsiText } from "../util/download-text.js";
+import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
@@ -458,7 +458,7 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _downloadLogs() {
-    const stem = this.configuration.replace(/\.ya?ml$/, "") || "logs";
+    const stem = configurationStem(this.configuration, "logs");
     downloadAnsiText(this._lines, `${stem}-logs.txt`);
   }
 

--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -39,6 +39,12 @@ export const wizardStepBoardStyles = css`
     text-decoration: none;
   }
 
+  .detect-error {
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-danger-text-normal);
+    margin-top: calc(-1 * var(--wa-space-2xs));
+  }
+
   .connect-board-btn {
     display: inline-flex;
     align-items: center;

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -26,6 +26,7 @@ import { SerialPortsPollController } from "../../util/serial-ports-poll-controll
 import {
   detectChip,
   disconnect,
+  isPortPickerCancel,
   isWebSerialSupported,
   readDeviceManifest,
 } from "../../util/web-serial.js";
@@ -252,6 +253,9 @@ export class ESPHomeWizardStepBoard extends LitElement {
                 ${this._localize("wizard.dont_know_board")}
               </a>
             </div>
+            ${this._detectError
+              ? html`<div class="detect-error" role="alert">${this._detectError}</div>`
+              : nothing}
           `}
 
       <div class="boards-scroll">
@@ -437,6 +441,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   };
 
   private async _connectViaWebSerial() {
+    this._detectError = "";
     try {
       const detected = await detectChip();
       // e.g. "ESP32-S3 (QFN56) (revision v0.2)"
@@ -474,8 +479,12 @@ export class ESPHomeWizardStepBoard extends LitElement {
         this._search = "";
         void this._fetchBoards();
       }
-    } catch {
-      // User cancelled the port picker or detection failed
+    } catch (err) {
+      if (isPortPickerCancel(err)) return;
+      this._detectError = this._extractErrorDetail(
+        err,
+        this._localize("wizard.connect_your_board_detect_failed")
+      );
     }
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -100,6 +100,7 @@
     "action_visit_web_ui": "Visit web UI",
     "serial_recognized": "Recognized \"{name}\"",
     "serial_starterkit_detected": "Detected {name}",
+    "serial_connect_failed": "Could not connect to the device: {error}",
     "action_download_yaml_failed": "Failed to download YAML for \"{name}\"",
     "action_rename_title": "Rename device",
     "action_rename_label": "Device name",
@@ -443,7 +444,8 @@
     "no_firmware": "No firmware binary found — compile the device first.",
     "downloading": "Downloading {file}…",
     "flashing": "Flashing firmware…",
-    "resetting": "Resetting device…"
+    "resetting": "Resetting device…",
+    "connect_failed": "Could not connect to the device. Unplug and replug the cable, hold the BOOT button while plugging in, or try another USB port or browser."
   },
   "wizard": {
     "title_create": "Create configuration",

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -52,6 +52,19 @@ export function triggerDownload(url: string, filename: string): void {
 }
 
 /**
+ * Download-filename stem for a device configuration: the YAML name
+ * without its extension, or ``fallback`` when the configuration is
+ * missing/empty. Shared by the logs / command / install download
+ * buttons so ``device.yaml`` consistently saves as ``device-*.txt``.
+ */
+export function configurationStem(
+  configuration: string | undefined,
+  fallback: string
+): string {
+  return configuration?.replace(/\.ya?ml$/, "") || fallback;
+}
+
+/**
  * Save terminal-style output to a plain text file.
  *
  * Used by the logs and command dialogs' download buttons. ANSI

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -53,6 +53,16 @@ export function isWebSerialSupported(): boolean {
 }
 
 /**
+ * True when the user dismissed the browser's port picker —
+ * ``requestPort()`` rejects with DOMException ``NotFoundError``.
+ * Anything else out of ``detectChip`` is a real connect failure and
+ * must be surfaced, not treated as a cancel (#1414).
+ */
+export function isPortPickerCancel(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "NotFoundError";
+}
+
+/**
  * The ``127.0.0.1`` equivalent of a dashboard opened on ``0.0.0.0`` — same
  * port and path. ``0.0.0.0`` is reachable only from the same machine (it
  * resolves to loopback) but is NOT a secure context, so Web Serial is hidden;

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -11,6 +11,10 @@ const wsSerial = vi.hoisted(() => ({
   detectChip: vi.fn(),
   disconnect: vi.fn(),
   flashFirmware: vi.fn(),
+  // Real implementation — one line, and the cancel-vs-fail split under
+  // test routes through it.
+  isPortPickerCancel: (err: unknown) =>
+    err instanceof DOMException && err.name === "NotFoundError",
   resetAndDisconnect: vi.fn(),
 }));
 vi.mock("../../src/util/web-serial.js", () => wsSerial);
@@ -64,6 +68,7 @@ function makeHost() {
     _compileReject: null as null | ((e: unknown) => void),
     _localize: (key: string) => key,
     _fail: vi.fn(),
+    _close: vi.fn(),
   };
   host._fail = vi.fn((msg: string) => {
     host._step = "error";
@@ -121,6 +126,33 @@ describe("Web Serial install — HTTP byte download", () => {
     // esptool output never reached the log buffer.
     expect(host._logLines).toContain("Detecting chip type... ESP32");
     expect(host._logLines).toContain("Writing at 0x00010000...");
+  });
+
+  it("closes silently when the user cancels the port picker", async () => {
+    const { host } = makeHost();
+    wsSerial.detectChip.mockRejectedValueOnce(
+      new DOMException("No port selected by the user.", "NotFoundError")
+    );
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._close).toHaveBeenCalledTimes(1);
+    expect(host._fail).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a connect failure instead of closing the dialog (#1414)", async () => {
+    const { host } = makeHost();
+    wsSerial.detectChip.mockRejectedValueOnce(
+      new Error("Failed to connect with the device")
+    );
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._close).not.toHaveBeenCalled();
+    expect(host._fail).toHaveBeenCalledWith(
+      "serial.connect_failed",
+      "Failed to connect with the device"
+    );
   });
 
   it("fails cleanly when the HTTP byte fetch errors", async () => {

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -11,13 +11,14 @@ const wsSerial = vi.hoisted(() => ({
   detectChip: vi.fn(),
   disconnect: vi.fn(),
   flashFirmware: vi.fn(),
-  // Real implementation — one line, and the cancel-vs-fail split under
-  // test routes through it.
-  isPortPickerCancel: (err: unknown) =>
-    err instanceof DOMException && err.name === "NotFoundError",
   resetAndDisconnect: vi.fn(),
 }));
-vi.mock("../../src/util/web-serial.js", () => wsSerial);
+// Keep the rest of the module real — the cancel-vs-fail split under test
+// routes through the genuine isPortPickerCancel.
+vi.mock("../../src/util/web-serial.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/util/web-serial.js")>()),
+  ...wsSerial,
+}));
 vi.mock("../../src/util/download-text.js", () => ({ triggerDownload: vi.fn() }));
 vi.mock("../../src/util/post-install-logs.js", () => ({
   dispatchShowLogsAfterInstall: vi.fn(() => false),

--- a/test/components/wizard/wizard-step-board-webserial-error.test.ts
+++ b/test/components/wizard/wizard-step-board-webserial-error.test.ts
@@ -13,12 +13,15 @@ vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => (
 const wsSerial = vi.hoisted(() => ({
   detectChip: vi.fn(),
   disconnect: vi.fn(),
-  isPortPickerCancel: (err: unknown) =>
-    err instanceof DOMException && err.name === "NotFoundError",
   isWebSerialSupported: () => true,
   readDeviceManifest: vi.fn(),
 }));
-vi.mock("../../../src/util/web-serial.js", () => wsSerial);
+// Keep the rest of the module real — notably the genuine isPortPickerCancel
+// driving the cancel-vs-fail split under test.
+vi.mock("../../../src/util/web-serial.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/util/web-serial.js")>()),
+  ...wsSerial,
+}));
 
 import { defaultLocalize } from "../../../src/common/localize.js";
 import { ESPHomeWizardStepBoard } from "../../../src/components/wizard/wizard-step-board.js";

--- a/test/components/wizard/wizard-step-board-webserial-error.test.ts
+++ b/test/components/wizard/wizard-step-board-webserial-error.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A WebSerial connect failure in the boards view must render an error;
+ * a cancelled port picker must stay silent (#1414 cross-repo).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+const wsSerial = vi.hoisted(() => ({
+  detectChip: vi.fn(),
+  disconnect: vi.fn(),
+  isPortPickerCancel: (err: unknown) =>
+    err instanceof DOMException && err.name === "NotFoundError",
+  isWebSerialSupported: () => true,
+  readDeviceManifest: vi.fn(),
+}));
+vi.mock("../../../src/util/web-serial.js", () => wsSerial);
+
+import { defaultLocalize } from "../../../src/common/localize.js";
+import { ESPHomeWizardStepBoard } from "../../../src/components/wizard/wizard-step-board.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount() {
+  const el = new ESPHomeWizardStepBoard();
+  (el as any)._localize = defaultLocalize;
+  (el as any)._api = {
+    getBoards: async () => ({ boards: [] }),
+    getSerialPorts: async () => [],
+  };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const detectError = (el: ESPHomeWizardStepBoard) =>
+  el.shadowRoot!.querySelector(".detect-error");
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("wizard-step-board WebSerial detect errors", () => {
+  it("renders the connect failure in the boards view", async () => {
+    wsSerial.detectChip.mockRejectedValueOnce(
+      new Error("Failed to connect with the device")
+    );
+    const el = await mount();
+
+    await (el as any)._connectViaWebSerial();
+    await el.updateComplete;
+
+    expect(detectError(el)?.textContent).toContain("Failed to connect with the device");
+  });
+
+  it("stays silent when the user cancels the port picker", async () => {
+    wsSerial.detectChip.mockRejectedValueOnce(
+      new DOMException("No port selected by the user.", "NotFoundError")
+    );
+    const el = await mount();
+
+    await (el as any)._connectViaWebSerial();
+    await el.updateComplete;
+
+    expect(detectError(el)).toBeNull();
+  });
+
+  it("clears a previous error on retry", async () => {
+    wsSerial.detectChip.mockRejectedValueOnce(new Error("boom"));
+    const el = await mount();
+    await (el as any)._connectViaWebSerial();
+    await el.updateComplete;
+    expect(detectError(el)).not.toBeNull();
+
+    wsSerial.detectChip.mockResolvedValueOnce({
+      chipName: "ESP32-S3",
+      transport: {},
+      port: {},
+      loader: {},
+    });
+    wsSerial.readDeviceManifest.mockResolvedValueOnce(null);
+    wsSerial.disconnect.mockResolvedValueOnce(undefined);
+    await (el as any)._connectViaWebSerial();
+    await el.updateComplete;
+    expect(detectError(el)).toBeNull();
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/util/web-serial-availability.test.ts
+++ b/test/util/web-serial-availability.test.ts
@@ -3,6 +3,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  isPortPickerCancel,
   isWebSerialSupported,
   secureLoopbackUrl,
   webSerialAvailability,
@@ -58,6 +59,27 @@ describe("webSerialAvailability", () => {
     setSerial(false);
     setSecure(true);
     expect(webSerialAvailability()).toBe("unsupported");
+  });
+});
+
+describe("isPortPickerCancel", () => {
+  it("true for requestPort's NotFoundError cancel rejection", () => {
+    expect(
+      isPortPickerCancel(
+        new DOMException("No port selected by the user.", "NotFoundError")
+      )
+    ).toBe(true);
+  });
+
+  it("false for esptool connect failures and other errors", () => {
+    expect(isPortPickerCancel(new Error("Failed to connect with the device"))).toBe(
+      false
+    );
+    expect(isPortPickerCancel(new DOMException("open failed", "NetworkError"))).toBe(
+      false
+    );
+    expect(isPortPickerCancel(undefined)).toBe(false);
+    expect(isPortPickerCancel("timeout")).toBe(false);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The install dialog treated every chip detect failure as a cancelled port picker and closed silently, so a real connect failure (the Firefox plus CH340 case in the linked issue) vanished without a trace; the wizard's Connect your board and the dashboard Identify flow swallowed errors the same way.

Detect failures are now split from picker cancels via the DOMException NotFoundError that requestPort rejects with on cancel. A connect failure keeps the install dialog open in the error state with the esptool log expanded, the wizard shows the failure inline, Identify raises a toast and still falls back to the manual board picker. The install dialog log panel also gains a download button so reporters can attach the esptool output.

The underlying Firefox plus CH340 connect failure is not addressed here; this makes it visible and diagnosable instead of silent.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1414

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
