### PR TITLE
Show the pretty name first for nameless configured-component targets

### DIFF
--- a/src/api/types/automations.ts
+++ b/src/api/types/automations.ts
@@ -292,6 +292,8 @@ export interface AvailableComponentInstance {
   id: string;
   /** The configured ``name:`` value, if any (purely for display). */
   name?: string;
+  /** Catalog title for ``component_id`` — the display name when ``name`` is unset. */
+  title?: string;
   /** True for a multi-entity platform container; its sub-entities carry the
    *  triggers, so the picker shows it as a non-selectable header. */
   is_entity_container?: boolean;

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -7,10 +7,19 @@ import type {
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
 import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
+import { CORE_KEYS } from "../../../util/yaml-sections.js";
+import { stripRedundantComponentSuffix } from "../navigator-labels.js";
 
-/** The instance's display label: its ``name:`` when set, else its id. */
+/** The instance's display label: its ``name:`` when set, else the catalog
+ *  title (core titles trimmed like the navigator), else its id. */
 export function instanceName(device: AvailableComponentInstance): string {
-  return device.name ?? device.id;
+  if (device.name) return device.name;
+  if (device.title) {
+    return CORE_KEYS.has(componentDomain(device.component_id))
+      ? stripRedundantComponentSuffix(device.title)
+      : device.title;
+  }
+  return device.id;
 }
 
 /** Bare domain of a ``component_id`` (``sensor.aht10`` → ``sensor``). */

--- a/src/components/device/automation-editor/component-targets.ts
+++ b/src/components/device/automation-editor/component-targets.ts
@@ -6,9 +6,9 @@ import type {
   AutomationTrigger,
   AvailableComponentInstance,
 } from "../../../api/types/automations.js";
+import { stripRedundantComponentSuffix } from "../../../util/component-title.js";
 import { parseCatalogId } from "../../../util/config-entry-yaml-scan.js";
 import { CORE_KEYS } from "../../../util/yaml-sections.js";
-import { stripRedundantComponentSuffix } from "../navigator-labels.js";
 
 /** The instance's display label: its ``name:`` when set, else the catalog
  *  title (core titles trimmed like the navigator), else its id. */

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -1,18 +1,12 @@
 import type { LocalizeFunc } from "../../common/localize.js";
 import { getCachedComponent } from "../../util/component-name-cache.js";
+import { stripRedundantComponentSuffix } from "../../util/component-title.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
 import { type YamlSection, sectionKeyOf } from "../../util/yaml-sections.js";
 import type { NavigatorBuckets } from "./navigator-buckets.js";
 import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
 
 export type NavCategory = "core" | "component" | "automation";
-
-/** Trim a core catalog title's redundant tail (" Component" / esphome's
- *  "ESPHome Core Configuration") so rows stay scannable. Core-only — many
- *  non-core titles legitimately end in " Component" (e.g. "Copy Component"). */
-export function stripRedundantComponentSuffix(name: string): string {
-  return name.replace(/ (Component|Configuration)$/, "") || name;
-}
 
 export interface NavItemLabels {
   primary: string;

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -7,6 +7,13 @@ import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
 
 export type NavCategory = "core" | "component" | "automation";
 
+/** Trim a core catalog title's redundant tail (" Component" / esphome's
+ *  "ESPHome Core Configuration") so rows stay scannable. Core-only — many
+ *  non-core titles legitimately end in " Component" (e.g. "Copy Component"). */
+export function stripRedundantComponentSuffix(name: string): string {
+  return name.replace(/ (Component|Configuration)$/, "") || name;
+}
+
 export interface NavItemLabels {
   primary: string;
   secondary?: string;
@@ -55,12 +62,7 @@ export function resolveNavItemLabels(
   let primary = raw;
   const cached = getCachedComponent(raw, ctx.platform || undefined);
   if (cached?.name) primary = cached.name;
-  if (category === "core") {
-    // Core infrastructure names carry a redundant suffix in the nav:
-    // " Component" ("Native API Component"), and esphome's catalog title
-    // is "ESPHome Core Configuration" — trim both so rows stay scannable.
-    primary = primary.replace(/ (Component|Configuration)$/, "") || primary;
-  }
+  if (category === "core") primary = stripRedundantComponentSuffix(primary);
 
   // Prefer the backend-resolved node name for the esphome core section
   // so a `name: $devicename` substitution shows the expanded hostname,

--- a/src/util/component-title.ts
+++ b/src/util/component-title.ts
@@ -1,0 +1,6 @@
+/** Trim a core catalog title's redundant tail (" Component" / esphome's
+ *  "ESPHome Core Configuration") so rows stay scannable. Core-only — many
+ *  non-core titles legitimately end in " Component" (e.g. "Copy Component"). */
+export function stripRedundantComponentSuffix(name: string): string {
+  return name.replace(/ (Component|Configuration)$/, "") || name;
+}

--- a/test/components/device/automation-editor/component-targets.test.ts
+++ b/test/components/device/automation-editor/component-targets.test.ts
@@ -73,10 +73,27 @@ describe("component-targets", () => {
 });
 
 describe("instance label helpers", () => {
-  it("instanceName falls back from name to id", () => {
+  it("instanceName falls back name → catalog title → id", () => {
+    // A user name always wins.
     expect(instanceName(inst({ id: "x", component_id: "sensor", name: "Kit" }))).toBe(
       "Kit"
     );
+    // No name → the catalog title, with the core suffix trimmed like the navigator.
+    expect(
+      instanceName(inst({ id: "wifi", component_id: "wifi", title: "WiFi Component" }))
+    ).toBe("WiFi");
+    expect(
+      instanceName(
+        inst({ id: "api", component_id: "api", title: "Native API Component" })
+      )
+    ).toBe("Native API");
+    // A non-core title keeps its " Component" tail (e.g. a nameless copy sensor).
+    expect(
+      instanceName(
+        inst({ id: "s", component_id: "binary_sensor.copy", title: "Copy Component" })
+      )
+    ).toBe("Copy Component");
+    // No name and no title → the raw id.
     expect(instanceName(inst({ id: "x", component_id: "sensor" }))).toBe("x");
   });
 


### PR DESCRIPTION
# What does this implement/fix?

In the automation editor's "Which configured component?" picker, options read `<name> (<component_id>)`. Components with a `name:` showed it first ("Motion Module (binary_sensor.gpio)"), but singleton config blocks with no `name:` (`logger`, `api`, `wifi`) fell back to the raw key, so the first field read the key, not a human name ("logger (logger)", "api (api)", "wifi (wifi)"). The navigator already shows the pretty catalog title for these same components ("Logger", "Native API", "WiFi"), so the picker was inconsistent with the rest of the UI. `instanceName` now falls back name then catalog title then id, and trims the redundant " Component" suffix for core titles exactly as the navigator does, via the shared `stripRedundantComponentSuffix` helper, so the dropdown reads "Logger (logger)", "Native API (api)", "WiFi (wifi)".

The catalog title arrives on a new `AvailableComponentInstance.title` field from the backend.

**Related issue or feature (if applicable):**

- Companion backend PR: esphome/device-builder#1419

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
