### PR TITLE
Render the Delay unit picker with wa-select

### DIFF
--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -483,7 +483,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
         <label class="field-label" for="ae-delay-unit-select">
           ${this._localize("device.automation_action_delay_unit")}
         </label>
-        <select
+        <wa-select
           id="ae-delay-unit-select"
           ?disabled=${this.disabled}
           @change=${(e: Event) =>
@@ -494,11 +494,11 @@ export class ESPHomeAutomationActionNode extends LitElement {
         >
           ${DELAY_UNITS.map(
             (u) =>
-              html`<option value=${u} ?selected=${u === unit}>
+              html`<wa-option value=${u} ?selected=${u === unit}>
                 ${this._localize(`device.automation_action_delay_unit_${u}`)}
-              </option>`
+              </wa-option>`
           )}
-        </select>
+        </wa-select>
       </div>
     </div>`;
   }

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -485,6 +485,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
         </label>
         <wa-select
           id="ae-delay-unit-select"
+          value=${unit}
           ?disabled=${this.disabled}
           @change=${(e: Event) =>
             this._writeDelay(

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -480,11 +480,12 @@ export class ESPHomeAutomationActionNode extends LitElement {
         />
       </div>
       <div class="ae-delay-unit">
-        <label class="field-label" for="ae-delay-unit-select">
+        <label class="field-label" id="ae-delay-unit-label">
           ${this._localize("device.automation_action_delay_unit")}
         </label>
         <wa-select
           id="ae-delay-unit-select"
+          aria-labelledby="ae-delay-unit-label"
           value=${unit}
           ?disabled=${this.disabled}
           @change=${(e: Event) =>

--- a/src/components/device/automation-editor/automation-editor-rows.styles.ts
+++ b/src/components/device/automation-editor/automation-editor-rows.styles.ts
@@ -201,14 +201,9 @@ export const automationEditorRowStyles = css`
     margin-bottom: var(--wa-space-2xs);
     display: block;
   }
-  .ae-delay-row input,
-  .ae-delay-row select {
+  /* Input and wa-select chrome both come from the shared inputStyles,
+     keyed on --wa-form-control-height, so the pair stays equal-height. */
+  .ae-delay-row wa-select {
     width: 100%;
-    padding: var(--wa-space-2xs) var(--wa-space-s);
-    border: 1px solid var(--wa-color-neutral-border-quiet, #d1d5db);
-    border-radius: var(--wa-border-radius-s);
-    background: var(--wa-color-surface-default);
-    font-size: var(--wa-font-size-s);
-    box-sizing: border-box;
   }
 `;

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -90,7 +90,7 @@ function valueInput(el: ESPHomeAutomationActionNode): HTMLInputElement | null {
 function selectedUnit(el: ESPHomeAutomationActionNode): string | null {
   return (
     el
-      .shadowRoot!.querySelector("#ae-delay-unit-select option[selected]")
+      .shadowRoot!.querySelector("#ae-delay-unit-select wa-option[selected]")
       ?.getAttribute("value") ?? null
   );
 }

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -85,14 +85,15 @@ function valueInput(el: ESPHomeAutomationActionNode): HTMLInputElement | null {
   return el.shadowRoot!.querySelector<HTMLInputElement>("#ae-delay-value-input");
 }
 
-/** The unit the renderer marked ``selected`` (read the attribute Lit's
- *  ``?selected`` binding sets; happy-dom's ``select.value`` ignores it). */
+/** The unit on the wa-select's own ``value`` attribute — the control's
+ *  canonical selection source — cross-checked against the option the
+ *  renderer marked ``selected``. */
 function selectedUnit(el: ESPHomeAutomationActionNode): string | null {
-  return (
-    el
-      .shadowRoot!.querySelector("#ae-delay-unit-select wa-option[selected]")
-      ?.getAttribute("value") ?? null
-  );
+  const select = el.shadowRoot!.querySelector("#ae-delay-unit-select");
+  const value = select?.getAttribute("value") ?? null;
+  const marked =
+    select?.querySelector("wa-option[selected]")?.getAttribute("value") ?? null;
+  return value === marked ? value : `value=${value} selected=${marked}`;
 }
 
 function toggleButtons(el: ESPHomeAutomationActionNode): HTMLButtonElement[] {


### PR DESCRIPTION
# What does this implement/fix?

In the automation editor's Delay action form the Value input and the Unit picker rendered at different heights; the unit picker was a native select, so it missed both the shared input min-height and the wa-select chrome that every other value plus unit pair uses.

The unit picker is now a wa-select like the time period and interval fields, and the local input/select chrome overrides are dropped so both controls take the shared form-control styling; verified in the browser that the pair renders equal height and that changing the unit still round-trips to the YAML.

**Related issue or feature (if applicable):**

- none, reported during testing of the visual editor

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
