### PR TITLE
Render remote build submit dialog pickers with wa-select

### DIFF
--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -23,6 +23,9 @@ import { isTerminalJobStatus } from "../util/firmware-job-status.js";
 import { renderErrorBanner } from "../util/render-error.js";
 import { remoteBuildJobDialogStyles } from "./remote-build-job-dialog.styles.js";
 
+import "@home-assistant/webawesome/dist/components/option/option.js";
+import "@home-assistant/webawesome/dist/components/select/select.js";
+
 import "./ansi-log.js";
 import "./base-dialog.js";
 
@@ -364,31 +367,45 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
     }
     return html`
       <div class="field">
-        <label for="rb-config">
+        <label id="rb-config-label">
           ${this._localize("settings.remote_build_submit_configuration_label")}
         </label>
-        <select
+        <wa-select
           id="rb-config"
-          .value=${this._configuration}
+          aria-labelledby="rb-config-label"
+          value=${this._configuration}
           @change=${this._onConfigurationChange}
         >
           ${this._devices.map(
-            (d) => html`<option value=${d.configuration}>${d.name}</option>`
+            (d) =>
+              html`<wa-option
+                value=${d.configuration}
+                ?selected=${d.configuration === this._configuration}
+                >${d.name}</wa-option
+              >`
           )}
-        </select>
+        </wa-select>
       </div>
       <div class="field">
-        <label for="rb-target">
+        <label id="rb-target-label">
           ${this._localize("settings.remote_build_submit_target_label")}
         </label>
-        <select id="rb-target" .value=${this._target} @change=${this._onTargetChange}>
-          <option value=${JobType.COMPILE}>
+        <wa-select
+          id="rb-target"
+          aria-labelledby="rb-target-label"
+          value=${this._target}
+          @change=${this._onTargetChange}
+        >
+          <wa-option
+            value=${JobType.COMPILE}
+            ?selected=${this._target === JobType.COMPILE}
+          >
             ${this._localize("settings.remote_build_submit_target_compile")}
-          </option>
-          <option value=${JobType.UPLOAD}>
+          </wa-option>
+          <wa-option value=${JobType.UPLOAD} ?selected=${this._target === JobType.UPLOAD}>
             ${this._localize("settings.remote_build_submit_target_upload")}
-          </option>
-        </select>
+          </wa-option>
+        </wa-select>
       </div>
       ${renderErrorBanner(this._submitErrorMessage)}
       <div class="actions">

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -377,12 +377,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
           @change=${this._onConfigurationChange}
         >
           ${this._devices.map(
-            (d) =>
-              html`<wa-option
-                value=${d.configuration}
-                ?selected=${d.configuration === this._configuration}
-                >${d.name}</wa-option
-              >`
+            (d) => html`<wa-option value=${d.configuration}>${d.name}</wa-option>`
           )}
         </wa-select>
       </div>
@@ -396,13 +391,10 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
           value=${this._target}
           @change=${this._onTargetChange}
         >
-          <wa-option
-            value=${JobType.COMPILE}
-            ?selected=${this._target === JobType.COMPILE}
-          >
+          <wa-option value=${JobType.COMPILE}>
             ${this._localize("settings.remote_build_submit_target_compile")}
           </wa-option>
-          <wa-option value=${JobType.UPLOAD} ?selected=${this._target === JobType.UPLOAD}>
+          <wa-option value=${JobType.UPLOAD}>
             ${this._localize("settings.remote_build_submit_target_upload")}
           </wa-option>
         </wa-select>

--- a/test/components/remote-build-job-dialog-selects.test.ts
+++ b/test/components/remote-build-job-dialog-selects.test.ts
@@ -49,11 +49,11 @@ describe("remote-build-job-dialog submit form selects", () => {
     expect(el.shadowRoot!.querySelector("#rb-target-label")).not.toBeNull();
   });
 
-  test("the configured device's option is marked selected", async () => {
+  test("the wa-select value drives the selection, one option per device", async () => {
     const el = await mountInputStep();
-    const selected = el
-      .shadowRoot!.querySelector("wa-select#rb-config wa-option[selected]")
-      ?.getAttribute("value");
-    expect(selected).toBe("kitchen.yaml");
+    const config = el.shadowRoot!.querySelector("wa-select#rb-config");
+    // value= is the canonical selection source (no per-option ?selected).
+    expect(config!.getAttribute("value")).toBe("kitchen.yaml");
+    expect(config!.querySelectorAll("wa-option").length).toBe(2);
   });
 });

--- a/test/components/remote-build-job-dialog-selects.test.ts
+++ b/test/components/remote-build-job-dialog-selects.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// happy-dom can't host webawesome's form-associated internals; the
+// attributes under test are readable on the unknown elements.
+vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+
+import { JobType } from "../../src/api/types/firmware-jobs.js";
+import { defaultLocalize } from "../../src/common/localize.js";
+import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mountInputStep() {
+  const el = new ESPHomeRemoteBuildJobDialog();
+  (el as any)._localize = defaultLocalize;
+  (el as any)._open = true;
+  (el as any)._step = "input";
+  (el as any)._pinSha256 = "ab".repeat(32);
+  (el as any)._devices = [
+    { configuration: "kitchen.yaml", name: "Kitchen" },
+    { configuration: "porch.yaml", name: "Porch" },
+  ];
+  (el as any)._configuration = "kitchen.yaml";
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("remote-build-job-dialog submit form selects", () => {
+  test("configuration and target pickers are labelled wa-selects with values", async () => {
+    const el = await mountInputStep();
+    const config = el.shadowRoot!.querySelector("wa-select#rb-config");
+    const target = el.shadowRoot!.querySelector("wa-select#rb-target");
+    expect(config).not.toBeNull();
+    expect(target).not.toBeNull();
+    expect(config!.getAttribute("value")).toBe("kitchen.yaml");
+    expect(target!.getAttribute("value")).toBe(JobType.COMPILE);
+    expect(config!.getAttribute("aria-labelledby")).toBe("rb-config-label");
+    expect(target!.getAttribute("aria-labelledby")).toBe("rb-target-label");
+    expect(el.shadowRoot!.querySelector("#rb-config-label")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector("#rb-target-label")).not.toBeNull();
+  });
+
+  test("the configured device's option is marked selected", async () => {
+    const el = await mountInputStep();
+    const selected = el
+      .shadowRoot!.querySelector("wa-select#rb-config wa-option[selected]")
+      ?.getAttribute("value");
+    expect(selected).toBe("kitchen.yaml");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The remote build submit job dialog rendered its configuration and target pickers as native selects, so both showed browser default chrome inside an otherwise design system styled dialog; the component already pulls in inputStyles, which only covers native inputs and wa-select, so a bare select matched neither.

Both pickers are now wa-select with wa-option, picking up the shared form control chrome like every other picker in the app; the labels use aria-labelledby since a native label for does not reliably associate with a custom element. Verified in the browser that both render at the shared form control height, and a unit test pins the labelled wa-select shape and the seeded selection.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/799

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
