### PR TITLE
Style remote build dialog action buttons via shared styles

### DIFF
--- a/src/components/remote-build-job-dialog.styles.ts
+++ b/src/components/remote-build-job-dialog.styles.ts
@@ -27,29 +27,22 @@ export const remoteBuildJobDialogStyles = css`
     margin-top: var(--wa-space-xs);
   }
 
-  /* Destructive variant for the per-row Cancel-this-job
-     button. Mirrors confirm-dialog's destructive btn tint
-     without dragging the whole confirm-dialog style block in.
-     The other two buttons in this dialog (.btn-primary /
-     .btn-secondary) inherit browser-default chrome. */
-  .btn-danger {
+  /* Destructive variant for the per-row Cancel-this-job button —
+     just the danger tint over the shared .btn base from
+     dialogActionButtonStyles, per that module's "destructive
+     variants stay in the consumer's local styles" contract. */
+  .btn--danger {
     background: var(--esphome-error);
     color: var(--esphome-on-primary);
     border: var(--wa-border-width-s) solid var(--esphome-error);
-    border-radius: var(--wa-border-radius-m);
-    padding: 0 var(--wa-space-m);
-    min-height: var(--wa-form-control-height);
-    font-family: inherit;
-    font-size: var(--wa-font-size-s);
-    cursor: pointer;
   }
 
-  .btn-danger:hover:not(:disabled) {
+  .btn--danger:hover:not(:disabled) {
     background: color-mix(in srgb, var(--esphome-error), black 10%);
     border-color: color-mix(in srgb, var(--esphome-error), black 10%);
   }
 
-  .btn-danger:disabled {
+  .btn--danger:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -16,6 +16,7 @@ import {
   localizeContext,
   type RemoteBuildJobState,
 } from "../context/index.js";
+import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { inputStyles } from "../styles/inputs.js";
 import { jobStatusPillStyles } from "../styles/job-status-pill.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -356,7 +357,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
       return html`
         <p class="empty">${this._localize("settings.remote_build_submit_no_devices")}</p>
         <div class="actions">
-          <button class="btn-secondary" type="button" @click=${this._close}>
+          <button class="btn btn--cancel" type="button" @click=${this._close}>
             ${this._localize("layout.close")}
           </button>
         </div>
@@ -392,11 +393,11 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
       </div>
       ${renderErrorBanner(this._submitErrorMessage)}
       <div class="actions">
-        <button class="btn-secondary" type="button" @click=${this._close}>
+        <button class="btn btn--cancel" type="button" @click=${this._close}>
           ${this._localize("layout.close")}
         </button>
         <button
-          class="btn-primary"
+          class="btn btn--primary"
           type="button"
           ?disabled=${!this._configuration}
           @click=${this._onSubmit}
@@ -433,7 +434,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
       return html`
         <p class="empty">${this._localize("settings.remote_build_list_empty")}</p>
         <div class="actions">
-          <button class="btn-secondary" type="button" @click=${this._close}>
+          <button class="btn btn--cancel" type="button" @click=${this._close}>
             ${this._localize("layout.close")}
           </button>
         </div>
@@ -444,7 +445,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
         ${jobs.map((job) => this._renderJobRow(job))}
       </ul>
       <div class="actions">
-        <button class="btn-secondary" type="button" @click=${this._close}>
+        <button class="btn btn--cancel" type="button" @click=${this._close}>
           ${this._localize("layout.close")}
         </button>
       </div>
@@ -493,14 +494,14 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
                 <div class="row-actions">
                   ${terminal
                     ? html`<button
-                        class="btn-secondary"
+                        class="btn btn--cancel"
                         type="button"
                         @click=${() => this._onDismissRow(job.job_id)}
                       >
                         ${this._localize("settings.remote_build_dismiss_row")}
                       </button>`
                     : html`<button
-                        class="btn-danger"
+                        class="btn btn--danger"
                         type="button"
                         ?disabled=${row.cancelInFlight || row.cancelRequested}
                         @click=${() => this._onCancel(job)}
@@ -567,6 +568,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    dialogActionButtonStyles,
     jobStatusPillStyles,
     remoteBuildJobDialogStyles,
   ];

--- a/test/components/remote-build-job-dialog-buttons.test.ts
+++ b/test/components/remote-build-job-dialog-buttons.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// happy-dom can't host webawesome's form-associated internals; the dialog's
+// own button markup is what's under test.
+vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mountInputStep() {
+  const el = new ESPHomeRemoteBuildJobDialog();
+  (el as any)._localize = (k: string) => k;
+  (el as any)._open = true;
+  (el as any)._step = "input";
+  (el as any)._pinSha256 = "ab".repeat(32);
+  (el as any)._devices = [{ configuration: "kitchen.yaml", name: "Kitchen" }];
+  (el as any)._configuration = "kitchen.yaml";
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("remote-build-job-dialog action buttons", () => {
+  test("use the shared dialog-action-button classes, not the unstyled ones", async () => {
+    const el = await mountInputStep();
+    const buttons = [...el.shadowRoot!.querySelectorAll(".actions button")];
+    const classes = buttons.map((b) => b.className);
+    expect(classes).toContain("btn btn--cancel");
+    expect(classes).toContain("btn btn--primary");
+    // The original unstyled classes must not linger.
+    expect(classes.some((c) => /\bbtn-(secondary|primary)\b/.test(c))).toBe(false);
+  });
+});

--- a/test/components/remote-build-job-dialog-buttons.test.ts
+++ b/test/components/remote-build-job-dialog-buttons.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 // own button markup is what's under test.
 vi.mock("@home-assistant/webawesome/dist/components/button/button.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 
 import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
 

--- a/test/components/remote-build-job-dialog-buttons.test.ts
+++ b/test/components/remote-build-job-dialog-buttons.test.ts
@@ -9,6 +9,7 @@ vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
 
 import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
+import { stubRemoteBuildJobState } from "../../src/context/index.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mountInputStep() {
@@ -23,20 +24,49 @@ async function mountInputStep() {
   await el.updateComplete;
   return el;
 }
+
+/** List step with one non-terminal (QUEUED) job, its row expanded so the
+ *  per-row Cancel (.btn--danger) button renders. */
+async function mountExpandedListStep() {
+  const el = new ESPHomeRemoteBuildJobDialog();
+  const job = stubRemoteBuildJobState("job-1", "ab".repeat(32));
+  (el as any)._localize = (k: string) => k;
+  (el as any)._open = true;
+  (el as any)._step = "list";
+  (el as any)._jobs = new Map([[job.job_id, job]]);
+  (el as any)._expandedJobId = job.job_id;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** A button carries every class in *want* and none of the old unstyled ones. */
+function hasClasses(el: Element, want: string[]): boolean {
+  return (
+    want.every((c) => el.classList.contains(c)) &&
+    !["btn-secondary", "btn-primary", "btn-danger"].some((c) => el.classList.contains(c))
+  );
+}
 
 afterEach(() => {
   document.body.innerHTML = "";
 });
 
 describe("remote-build-job-dialog action buttons", () => {
-  test("use the shared dialog-action-button classes, not the unstyled ones", async () => {
+  test("input-step buttons use the shared cancel / primary classes", async () => {
     const el = await mountInputStep();
     const buttons = [...el.shadowRoot!.querySelectorAll(".actions button")];
-    const classes = buttons.map((b) => b.className);
-    expect(classes).toContain("btn btn--cancel");
-    expect(classes).toContain("btn btn--primary");
-    // The original unstyled classes must not linger.
-    expect(classes.some((c) => /\bbtn-(secondary|primary)\b/.test(c))).toBe(false);
+    expect(buttons.some((b) => hasClasses(b, ["btn", "btn--cancel"]))).toBe(true);
+    expect(buttons.some((b) => hasClasses(b, ["btn", "btn--primary"]))).toBe(true);
+  });
+
+  test("the per-row Cancel button carries btn + btn--danger so it keeps the shared base", async () => {
+    // The danger rule dropped its hand-rolled base shape; without the .btn base
+    // the button would lose all sizing, so both classes must be present.
+    const el = await mountExpandedListStep();
+    const cancel = el.shadowRoot!.querySelector(".row-actions button");
+    expect(cancel).not.toBeNull();
+    expect(hasClasses(cancel!, ["btn", "btn--danger"])).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The remote build job dialog rendered its action row buttons (Close / Back and Build remotely) with the `.btn-secondary` / `.btn-primary` classes, which had no style rule, so they showed raw browser default chrome inside an otherwise design system styled dialog; the styles file's own comment even acknowledged it.

The dialog now pulls in the shared `dialogActionButtonStyles` and the buttons use `.btn .btn--cancel` / `.btn .btn--primary`, matching the inline action row convention the other dialogs use. The per row destructive Cancel button moves to `.btn .btn--danger`, keeping just the danger tint in the local styles over the shared base, per that module's destructive variant contract, which also drops the duplicated base shape it used to hand roll. Verified in the browser that Close picks up the neutral surface chrome and Build remotely the primary tint at equal height.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/801

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
