### PR TITLE
Ignore local scratch-* debug scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build/
 /*.yaml
 /*.yml
 !/.pre-commit-config.yaml
+
+# Local puppeteer/debug eyeballing scripts — never commit
+scratch-*


### PR DESCRIPTION
# What does this implement/fix?

Local puppeteer eyeballing scripts used to view dialogs in a real browser get named `scratch-*` and live in the repo root; a stray one slipped into a PR via `git add -A` recently. This ignores them so they cannot be committed again.

**Related issue or feature (if applicable):**

- none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
