### PR TITLE
Pre-fill required nested sensors and tidy the add-component layout

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -227,6 +227,18 @@ export class ESPHomeAddComponentForm extends LitElement {
     for (const entry of entries) {
       if (entry.type === ConfigEntryType.NESTED) {
         const sub = this._seedDefaults(entry.config_entries ?? [], seedAll);
+        // A required entity sub-reading (ags10's tvoc) serializes only
+        // once it holds a value; seed its name (the label) so an
+        // untouched Add still produces a valid sensor, matching the
+        // optional-entity enable toggle.
+        if (
+          entry.required &&
+          entry.platform_type != null &&
+          sub.name === undefined &&
+          sub.id === undefined
+        ) {
+          sub.name = resolveEntryLabel(entry, this._localize);
+        }
         if (Object.keys(sub).length > 0) out[entry.key] = sub;
         continue;
       }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -272,11 +272,21 @@ export class ESPHomeConfigEntryForm extends LitElement {
 
   protected render() {
     const ctx = this._buildCtx();
+    // In the add-component dialog, float required entries above optional
+    // ones (stable, so each keeps its catalog order) so the user fills the
+    // mandatory fields first. The section editor mirrors the on-disk YAML
+    // order, so it's left untouched.
+    const entries = this.requiredOnly
+      ? [
+          ...this.entries.filter((e) => e.required),
+          ...this.entries.filter((e) => !e.required),
+        ]
+      : this.entries;
     // Each exclusive_group renders as one always-shown dropdown at its
     // first member's slot; other entries keep the advanced/visibility
     // filter (the Set preserves order while dropping filtered-out ones).
-    const ordered = orderExclusiveGroups(this.entries);
-    const nonExclusive = this.entries.filter((entry) => !entry.exclusive_group);
+    const ordered = orderExclusiveGroups(entries);
+    const nonExclusive = entries.filter((entry) => !entry.exclusive_group);
     const visible = new Set(this._filterRenderable(nonExclusive, this.values));
     // An empty key means "this entry IS the whole values dict" —
     // used by top-level user-keyed sections (substitutions:) where
@@ -707,9 +717,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
   }
 
   private _toggleNested(key: string) {
-    // The set's semantics depend on `requiredOnly` — see
-    // `renderNestedField` — but the toggle is the same either way:
-    // membership flips between "tracked" and "untracked".
+    // The set tracks open groups; flip membership to expand/collapse.
     const next = new Set(this._nestedOpenSections);
     if (next.has(key)) next.delete(key);
     else next.add(key);
@@ -720,13 +728,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * Force a nested group open. Used by parent forms (e.g. section
    * editor scrolling to a validation error) to make sure a deep field
    * is rendered before searching the DOM. Idempotent.
-   *
-   * Only meaningful in normal (non-requiredOnly) mode where the set
-   * tracks "open" entries; in `requiredOnly` mode groups default open
-   * already so this is a no-op.
    */
   public openNested(key: string) {
-    if (this.requiredOnly) return;
     if (this._nestedOpenSections.has(key)) return;
     const next = new Set(this._nestedOpenSections);
     next.add(key);
@@ -739,7 +742,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    * keeps it to one shot.
    */
   private _seedNestedOpen(key: string) {
-    if (this.requiredOnly || this._seededNestedOpen.has(key)) return;
+    if (this._seededNestedOpen.has(key)) return;
     this._seededNestedOpen.add(key);
     this._nestedOpenSections.add(key);
   }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -277,10 +277,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // mandatory fields first. The section editor mirrors the on-disk YAML
     // order, so it's left untouched.
     const entries = this.requiredOnly
-      ? [
-          ...this.entries.filter((e) => e.required),
-          ...this.entries.filter((e) => !e.required),
-        ]
+      ? this._floatRequiredFirst(this.entries)
       : this.entries;
     // Each exclusive_group renders as one always-shown dropdown at its
     // first member's slot; other entries keep the advanced/visibility
@@ -299,6 +296,24 @@ export class ESPHomeConfigEntryForm extends LitElement {
           ? this._renderEntry(item, item.key ? [item.key] : [], ctx)
           : nothing
     )}`;
+  }
+
+  /** Stable-partition so required entries lead. An exclusive_group is
+   *  treated atomically (required if any member is) so its members stay
+   *  contiguous and ``orderExclusiveGroups`` folds them at the same slot. */
+  private _floatRequiredFirst(entries: ConfigEntry[]): ConfigEntry[] {
+    const groupRequired = new Map<string, boolean>();
+    for (const e of entries) {
+      if (e.exclusive_group) {
+        groupRequired.set(
+          e.exclusive_group,
+          (groupRequired.get(e.exclusive_group) ?? false) || !!e.required
+        );
+      }
+    }
+    const isRequired = (e: ConfigEntry): boolean =>
+      e.exclusive_group ? groupRequired.get(e.exclusive_group)! : !!e.required;
+    return [...entries.filter(isRequired), ...entries.filter((e) => !isRequired(e))];
   }
 
   protected willUpdate(changed: PropertyValues) {

--- a/src/components/device/config-entry-renderers/nested.ts
+++ b/src/components/device/config-entry-renderers/nested.ts
@@ -31,9 +31,9 @@ function _enableStash(ctx: RenderCtx): Map<string, Record<string, unknown>> {
   return m;
 }
 
-// In requiredOnly mode (add-component dialog) groups default open and the
-// set tracks groups the user explicitly *collapsed*. Otherwise groups default
-// closed and the set tracks groups they *opened*.
+// The set tracks groups that are *open*. A group seeds open once when it's
+// required or already carries a value (see seedNestedOpen below); optional
+// empty groups stay collapsed until the user expands them.
 export function renderNestedField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   // A scalar at a NESTED key (an unmodellable shorthand the user set in
   // YAML) renders read-only with its value, not as an empty flag group.
@@ -59,8 +59,7 @@ export function renderNestedField(entry: ConfigEntry, path: string[], ctx: Rende
   // remote_receiver's raw are otherwise collapsed). seedNestedOpen is
   // one-shot, so a later user collapse sticks.
   if (entry.required || hasSerializableValue(raw)) ctx.seedNestedOpen(key);
-  const inSet = ctx.nestedOpenSections.has(key);
-  const isOpen = ctx.requiredOnly ? !inSet : inSet;
+  const isOpen = ctx.nestedOpenSections.has(key);
   // Optional entity sub-readings (a debug component's per-metric sensors,
   // a DHT's temperature/humidity, …) are only written to YAML once their
   // group holds a value, so an untouched one is silently "off". Give those

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -61,3 +61,23 @@ describe("coerceFields non-hex integers", () => {
     expect(coerceFields([plainInt], { count: "-5" })).toEqual({ count: -5 });
   });
 });
+
+describe("coerceFields nested entity readings", () => {
+  const tvoc = makeConfigEntry({
+    key: "tvoc",
+    type: ConfigEntryType.NESTED,
+    required: true,
+    platform_type: "sensor",
+    config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+  });
+
+  test("a required nested entity with a seeded name survives", () => {
+    expect(coerceFields([tvoc], { tvoc: { name: "TVOC" } })).toEqual({
+      tvoc: { name: "TVOC" },
+    });
+  });
+
+  test("an empty nested group is pruned from the payload", () => {
+    expect(coerceFields([tvoc], { tvoc: {} })).toEqual({});
+  });
+});

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A required nested entity reading (ags10's tvoc) must seed a name so an
+ * untouched Add produces a valid sensor instead of "Missing required
+ * field" (#1423).
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+function ags10Component(): ComponentCatalogEntry {
+  return {
+    id: "sensor.ags10",
+    config_entries: [
+      makeConfigEntry({
+        key: "tvoc",
+        type: ConfigEntryType.NESTED,
+        required: true,
+        platform_type: "sensor",
+        label: "TVOC",
+        config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+      }),
+      makeConfigEntry({
+        key: "resistance",
+        type: ConfigEntryType.NESTED,
+        platform_type: "sensor",
+        config_entries: [makeConfigEntry({ key: "name", type: ConfigEntryType.STRING })],
+      }),
+    ],
+  } as unknown as ComponentCatalogEntry;
+}
+
+function seededValues(component: ComponentCatalogEntry): Record<string, unknown> {
+  const form = new ESPHomeAddComponentForm();
+  const internals = form as unknown as {
+    component: ComponentCatalogEntry;
+    _localize: (key: string) => string;
+    _initValues: () => void;
+    _values: Record<string, unknown>;
+  };
+  internals.component = component;
+  internals._localize = (key) => key;
+  internals._initValues();
+  return internals._values;
+}
+
+describe("add-component-form seeds required nested entity names (#1423)", () => {
+  it("prefills the required reading's name with its label", () => {
+    const values = seededValues(ags10Component());
+    expect(values.tvoc).toEqual({ name: "TVOC" });
+  });
+
+  it("leaves the optional reading unseeded", () => {
+    const values = seededValues(ags10Component());
+    expect(values.resistance).toBeUndefined();
+  });
+});

--- a/test/components/device/config-entry-form-required-order.test.ts
+++ b/test/components/device/config-entry-form-required-order.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The add dialog floats required entries first; an exclusive_group is
+ * treated atomically so its members stay contiguous and in order.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+const float = (entries: ConfigEntry[]): string[] =>
+  (
+    new ESPHomeConfigEntryForm() as unknown as {
+      _floatRequiredFirst(e: ConfigEntry[]): ConfigEntry[];
+    }
+  )
+    ._floatRequiredFirst(entries)
+    .map((e) => e.key);
+
+describe("config-entry-form required-first ordering", () => {
+  it("floats required entries ahead of optional ones, stably", () => {
+    const entries = [
+      makeConfigEntry({ key: "opt_a", type: ConfigEntryType.STRING }),
+      makeConfigEntry({ key: "req_a", type: ConfigEntryType.STRING, required: true }),
+      makeConfigEntry({ key: "opt_b", type: ConfigEntryType.STRING }),
+      makeConfigEntry({ key: "req_b", type: ConfigEntryType.STRING, required: true }),
+    ];
+    expect(float(entries)).toEqual(["req_a", "req_b", "opt_a", "opt_b"]);
+  });
+
+  it("keeps a required+optional exclusive_group contiguous and ordered", () => {
+    const entries = [
+      makeConfigEntry({ key: "opt", type: ConfigEntryType.STRING }),
+      makeConfigEntry({
+        key: "grp_first",
+        type: ConfigEntryType.STRING,
+        exclusive_group: "g",
+      }),
+      makeConfigEntry({
+        key: "grp_second",
+        type: ConfigEntryType.STRING,
+        exclusive_group: "g",
+        required: true,
+      }),
+    ];
+    // The group floats as a unit (a member is required) and grp_first
+    // stays its lead member, so orderExclusiveGroups folds at the same slot.
+    expect(float(entries)).toEqual(["grp_first", "grp_second", "opt"]);
+  });
+});

--- a/test/components/device/render-nested-field-auto-expand.test.ts
+++ b/test/components/device/render-nested-field-auto-expand.test.ts
@@ -52,4 +52,28 @@ describe("renderNestedField auto-expand", () => {
     renderNestedField(entry, ["clk"], ctx);
     expect(open.has("clk")).toBe(true);
   });
+
+  it("collapses an optional empty group in the add dialog (#1423)", () => {
+    // requiredOnly no longer forces every group open; an optional empty
+    // reading (ags10's resistance) stays collapsed so it doesn't overload
+    // the dialog.
+    const entry = makeEntry(ConfigEntryType.NESTED, {
+      key: "resistance",
+      platform_type: "sensor",
+      config_entries: [makeEntry(ConfigEntryType.STRING, { key: "name" })],
+    });
+    const open = new Set<string>();
+    const ctx = makeRenderCtx(
+      {},
+      {
+        overrides: {
+          requiredOnly: true,
+          nestedOpenSections: open,
+          seedNestedOpen: (k: string) => open.add(k),
+        },
+      }
+    );
+    renderNestedField(entry, ["resistance"], ctx);
+    expect(open.has("resistance")).toBe(false);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adding a component with a required nested entity reading (ags10's `tvoc`) failed with "invalid_args: Missing required field: TVOC". The group serialized only once it held a value, so an untouched Add sent no `tvoc` and the backend rejected it.

Seed the reading's name from its label (the same value the optional enable toggle already uses) so a bare Add produces a valid sensor. While here, float required fields above optional ones in the add dialog, and stop force-expanding every nested group; optional readings now start collapsed so the form does not overload the screen.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1423

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
