### PR TITLE
Show the platform in the Add-Component dialog header

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -25,6 +25,7 @@ import {
   type SelectionHost,
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
+import { componentDialogTitle } from "./component-card-category-label.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -218,7 +219,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // hide it with `hidden` rather than swapping it out of the DOM. The form
     // is fine to mount/unmount on demand since each selection starts fresh.
     const title = isForm
-      ? this._selected!.name
+      ? componentDialogTitle(this._selected!.name, this._selected!.category, {
+          core: isCore,
+        })
       : this.boardName
         ? this._localize(headerKey, { name: this.boardName })
         : this._localize(headerKey);

--- a/src/components/device/component-card-category-label.ts
+++ b/src/components/device/component-card-category-label.ts
@@ -37,6 +37,25 @@ export function categoryChipLabel(category: string): string {
 }
 
 /**
+ * Compose the Add-Component dialog header for a selected entry,
+ * appending the platform label (the same string the card chip
+ * shows) so same-name entries from different platforms stay
+ * distinguishable once the form view drops the chip. The
+ * core-config flow keeps the bare name: its components are
+ * unique top-level domains with no same-name collisions, where a
+ * "Wi-Fi · Wifi" suffix would be pure redundancy.
+ */
+export function componentDialogTitle(
+  name: string,
+  category: string,
+  opts: { core: boolean }
+): string {
+  if (opts.core) return name;
+  const label = categoryChipLabel(category);
+  return label ? `${name} · ${label}` : name;
+}
+
+/**
  * Whether the catalog card should render the category chip
  * given the current sidebar filter. Only useful under the
  * "All" filter where the category VARIES across visible

--- a/test/components/device/component-card-category-label.test.ts
+++ b/test/components/device/component-card-category-label.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   categoryChipLabel,
+  componentDialogTitle,
   shouldShowCategoryChip,
 } from "../../../src/components/device/component-card-category-label.js";
 
@@ -49,6 +50,35 @@ describe("categoryChipLabel", () => {
     expect(categoryChipLabel("_sensor")).toBe("Sensor");
     expect(categoryChipLabel("sensor_")).toBe("Sensor");
     expect(categoryChipLabel("sensor__platform")).toBe("Sensor Platform");
+  });
+});
+
+describe("componentDialogTitle", () => {
+  it("appends the platform label so same-name entries stay distinct", () => {
+    // All four ``*.atm90e32`` platforms ship the name "ATM90E32
+    // Power Sensor"; the form view drops the card chip, so the
+    // header is the only thing left to tell them apart
+    // (device-builder#1424 follow-up).
+    expect(componentDialogTitle("ATM90E32 Power Sensor", "button", { core: false })).toBe(
+      "ATM90E32 Power Sensor · Button"
+    );
+    expect(
+      componentDialogTitle("ATM90E32 Power Sensor", "text_sensor", {
+        core: false,
+      })
+    ).toBe("ATM90E32 Power Sensor · Text Sensor");
+  });
+
+  it("keeps the bare name in the core-config flow", () => {
+    // Core components are unique top-level domains, so "Wi-Fi ·
+    // Wifi" would be redundant noise.
+    expect(componentDialogTitle("Wi-Fi", "wifi", { core: true })).toBe("Wi-Fi");
+  });
+
+  it("keeps the bare name when the category is empty", () => {
+    expect(componentDialogTitle("Some Component", "", { core: false })).toBe(
+      "Some Component"
+    );
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Many component-catalog entries share a name across platforms — all four
`*.atm90e32` entries are titled "ATM90E32 Power Sensor", and "Copy Component"
spans 11 platforms. The catalog card disambiguates these with a category chip
(shown under the All / Recommended filters), but the chip is gone once a card
is selected, so the configuration dialog header alone gives the user no way to
tell which of the same-named entries they opened.

This appends ` · <Platform>` to the dialog header for a selected catalog
component (e.g. "ATM90E32 Power Sensor · Button"), reusing the existing
`categoryChipLabel` helper so the header suffix always matches the card chip.
The label composition is extracted into a small pure `componentDialogTitle`
helper next to `categoryChipLabel` (same module already owns same-name
disambiguation) and unit-tested without a DOM.

The core-config flow ("Add core configuration") keeps the bare name: its
components are unique top-level domains, so a "Wi-Fi · Wifi" suffix would be
pure redundancy.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1424 (disambiguation follow-up; the "None"-description half of that issue is a separate backend fix)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
