### PR TITLE
Pre-fill dep-added buses from the requester's bus constraints

### DIFF
--- a/src/api/types/components.ts
+++ b/src/api/types/components.ts
@@ -108,6 +108,11 @@ export interface ComponentCatalogEntry {
   /** Interfaces this component can be referenced *as* beyond its own domain
    *  (an `adc` sensor provides `voltage_sampler`). */
   provides?: string[];
+  /** Requirements this component imposes on the bus it attaches to, keyed
+   *  by bus id ('i2c' / 'spi' / 'uart'): exact-match values (baud_rate,
+   *  parity, ...), range bounds (min/max_frequency in Hz) and required
+   *  pins (require_tx / require_mosi / ...). Drives dep-add prefill. */
+  bus_constraints?: Record<string, Record<string, unknown>>;
   /** The component's configuration schema. May contain `nested` entries
    *  (`type === "nested"`) whose `config_entries` recurse. */
   config_entries: ConfigEntry[];

--- a/src/components/device/add-component-dialog-dep-nav.ts
+++ b/src/components/device/add-component-dialog-dep-nav.ts
@@ -1,5 +1,9 @@
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
+import {
+  busConstraintPrefill,
+  type BusPrefill,
+} from "../../util/bus-constraint-prefill.js";
 import { fetchComponent } from "../../util/component-name-cache.js";
 
 /** Slice of ``ESPHomeAddComponentDialog`` state ``navigateToDep`` reads / writes. */
@@ -11,6 +15,7 @@ export interface DepNavHost {
   _selected: ComponentCatalogEntry | null;
   _returnTo: ComponentCatalogEntry | null;
   _depDomain: string | null;
+  _depPrefill: BusPrefill | null;
   _submitError: string;
   _submitting: boolean;
   _depNavSeq: number;
@@ -49,6 +54,12 @@ export async function navigateToDep(host: DepNavHost, domain: string): Promise<v
     host._depDomain = domain;
   }
   if (direct) {
+    // The requester's bus constraints become the new bus's starting
+    // values (ags10 caps i2c at 15kHz, most uart devices pin a baud).
+    const constraints = previousSelected?.bus_constraints?.[domain];
+    host._depPrefill = constraints
+      ? busConstraintPrefill(direct.config_entries, constraints)
+      : null;
     host._selected = direct;
     return;
   }

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -11,6 +11,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -118,6 +119,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @state()
   private _prefillReference: { domain: string; id: string } | null = null;
 
+  /** Bus-form prefill + forced fields for the dep detour, derived from
+   *  the requesting component's `bus_constraints`. */
+  @state()
+  private _depPrefill: BusPrefill | null = null;
+
   /**
    * Featured-component ids waiting to be added as part of the current
    * bundle, excluding the one currently in `_selected`. Each id is
@@ -191,6 +197,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._returnTo = null;
     this._depDomain = null;
     this._prefillReference = null;
+    this._depPrefill = null;
     this._bundleQueue = [];
     this._bundleProgress = null;
     this._depNavSeq++;
@@ -287,6 +294,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
               .board=${this.board}
               .yaml=${this.yaml}
               .prefillReference=${this._prefillReference}
+              .prefillFields=${this._depPrefill?.fields ?? null}
+              .extraRequired=${this._depPrefill?.required ?? null}
               .submitting=${this._submitting}
               .submitError=${this._submitError}
             ></esphome-add-component-form>`
@@ -382,6 +391,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._returnTo = null;
     this._depDomain = null;
     this._prefillReference = null;
+    this._depPrefill = null;
     this._bundleQueue = rest;
     this._bundleProgress = {
       current: 1,
@@ -503,6 +513,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         }
         this._returnTo = null;
         this._depDomain = null;
+        this._depPrefill = null;
         this._selected = restore;
       } else if (this._bundleQueue.length > 0 && this._bundleProgress) {
         // Bundle in flight — pop the next featured id and refresh the

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { mdiAlertCircleOutline } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
@@ -67,6 +68,16 @@ export class ESPHomeAddComponentForm extends LitElement {
   @property({ attribute: false })
   prefillReference: { domain: string; id: string } | null = null;
 
+  /** Initial field values for a dep-added bus, derived from the
+   *  requesting component's `bus_constraints` (ags10 -> i2c at 15kHz). */
+  @property({ attribute: false })
+  prefillFields: Record<string, unknown> | null = null;
+
+  /** Bus fields the requesting component forces (require_tx -> tx_pin);
+   *  overlaid as `required` so the form gates submit on them. */
+  @property({ attribute: false })
+  extraRequired: string[] | null = null;
+
   @property({ type: Boolean })
   submitting = false;
 
@@ -100,6 +111,22 @@ export class ESPHomeAddComponentForm extends LitElement {
   );
 
   static styles = [espHomeStyles, inputStyles, addComponentFormStyles];
+
+  /** Schema with `extraRequired` keys overlaid as required. Memoized so
+   *  the shared form's `.entries` identity is render-stable. */
+  private _overlayRequired = memoizeOne(
+    (entries: ConfigEntry[], extra: string[] | null): ConfigEntry[] => {
+      if (!extra?.length) return entries;
+      const keys = new Set(extra);
+      return entries.map((e) =>
+        keys.has(e.key) && !e.required ? { ...e, required: true } : e
+      );
+    }
+  );
+
+  private get _entries(): ConfigEntry[] {
+    return this._overlayRequired(this.component.config_entries, this.extraRequired);
+  }
 
   /** True once we've seeded `_values` for the current component. */
   private _initialized = false;
@@ -142,9 +169,9 @@ export class ESPHomeAddComponentForm extends LitElement {
     // field actually emits its preset on submit — otherwise the
     // backend's locked-validation would reject the empty payload.
     const seedAll = this.component.id.startsWith("featured.");
-    let next = this._seedDefaults(this.component.config_entries, seedAll);
+    let next = this._seedDefaults(this._entries, seedAll);
 
-    const idEntry = this.component.config_entries.find(
+    const idEntry = this._entries.find(
       (e) => e.key === "id" && e.type === ConfigEntryType.ID
     );
     if (idEntry && next["id"] === undefined) {
@@ -159,22 +186,22 @@ export class ESPHomeAddComponentForm extends LitElement {
     // either invalid or wrong-numbered: i2c on C3 emits an
     // "Invalid pin number: 22" squiggle because the bus block
     // falls back to ESP32 GPIO22/21.
-    next = seedBoardPinDefaults(
-      this.component.id,
-      this.component.config_entries,
-      this.board,
-      next
-    );
+    next = seedBoardPinDefaults(this.component.id, this._entries, this.board, next);
 
     if (this.prefillReference) {
       const targetPath = this._findReferencePath(
-        this.component.config_entries,
+        this._entries,
         this.prefillReference.domain,
         []
       );
       if (targetPath) {
         next = setIn(next, targetPath, this.prefillReference.id);
       }
+    }
+
+    // Last so a constraint-derived value beats the bare catalog default.
+    if (this.prefillFields) {
+      next = { ...next, ...this.prefillFields };
     }
 
     this._values = next;
@@ -278,7 +305,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // submit button. Run validation against the current values; if
     // any required errors come back, the form is incomplete.
     const validation = validateEntries(
-      this.component.config_entries,
+      this._entries,
       this._values,
       presentComponents,
       this.board?.esphome.platform ?? null
@@ -290,7 +317,7 @@ export class ESPHomeAddComponentForm extends LitElement {
         <p class="form-desc">${renderMarkdown(this.component.description)}</p>
         ${missingDeps.length > 0 ? this._renderMissingDeps(missingDeps) : nothing}
         <esphome-config-entry-form
-          .entries=${this.component.config_entries}
+          .entries=${this._entries}
           .values=${this._values}
           .errors=${this._errors}
           .board=${this.board}
@@ -418,7 +445,7 @@ export class ESPHomeAddComponentForm extends LitElement {
    */
   private _labelForErrorKey(errKey: string): string {
     const segments = errKey.split(".");
-    let entries: ConfigEntry[] | null = this.component.config_entries;
+    let entries: ConfigEntry[] | null = this._entries;
     let entry: ConfigEntry | undefined;
     for (const seg of segments) {
       if (!entries) break;
@@ -449,16 +476,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     // ``errors.size > 0``, but we keep the guard so the helper is
     // safe to call from anywhere.
     if (errors.size === 0) return false;
-    const renderedPaths = collectRenderablePaths(
-      this.component.config_entries,
-      this._values,
-      {
-        requiredOnly: true,
-        showAdvanced: false,
-        presentComponents,
-        targetPlatform: this.board?.esphome.platform ?? null,
-      }
-    );
+    const renderedPaths = collectRenderablePaths(this._entries, this._values, {
+      requiredOnly: true,
+      showAdvanced: false,
+      presentComponents,
+      targetPlatform: this.board?.esphome.platform ?? null,
+    });
     for (const key of errors.keys()) {
       if (renderedPaths.has(key)) return true;
     }
@@ -519,7 +542,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // Validate the entire schema. If anything fails, surface the
     // errors inline (the shared form will pick them up by path).
     const errors = validateEntries(
-      this.component.config_entries,
+      this._entries,
       this._values,
       presentComponents,
       this.board?.esphome.platform ?? null
@@ -553,7 +576,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     this._errors = new Map();
     this._localBlockMessage = "";
 
-    const fields = coerceFields(this.component.config_entries, this._values);
+    const fields = coerceFields(this._entries, this._values);
 
     this.dispatchEvent(
       new CustomEvent("form-submit", {

--- a/src/util/bus-constraint-prefill.ts
+++ b/src/util/bus-constraint-prefill.ts
@@ -1,6 +1,6 @@
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
-import { floatWithUnitToBase } from "./float-with-unit.js";
+import { floatWithUnitToBase, formatInBestUnit } from "./float-with-unit.js";
 
 export interface BusPrefill {
   /** Field values the dep-added bus form starts with. */
@@ -41,27 +41,27 @@ export function busConstraintPrefill(
       continue;
     }
     const entry = entryOf(key);
-    const dflt = entry?.default_value;
+    if (!entry) continue;
+    const dflt = entry.default_value;
     if (dflt === null || dflt === undefined || String(dflt) !== String(value)) {
       // Options-style fields ('stop_bits', 'parity') match on strings.
-      fields[key] = entry?.type === ConfigEntryType.STRING ? String(value) : value;
+      fields[key] = entry.type === ConfigEntryType.STRING ? String(value) : value;
     }
   }
 
   if (minHz !== null || maxHz !== null) {
     const entry = entryOf("frequency");
-    const hz = floatWithUnitToBase(entry?.default_value, entry?.unit_options ?? ["Hz"]);
+    const unitOptions = entry?.unit_options?.length ? entry.unit_options : ["Hz"];
+    const hz = floatWithUnitToBase(entry?.default_value, unitOptions);
     let target: number | null = null;
     if (hz === null) target = maxHz ?? minHz;
     else if (maxHz !== null && hz > maxHz) target = maxHz;
     else if (minHz !== null && hz < minHz) target = minHz;
-    if (target !== null) fields.frequency = _formatHz(target);
+    // Formatting through the entry's own units keeps the prefill
+    // inside the option set validateEntries checks against.
+    if (target !== null) fields.frequency = formatInBestUnit(target, unitOptions);
   }
 
   if (Object.keys(fields).length === 0 && required.length === 0) return null;
   return { fields, required };
-}
-
-function _formatHz(hz: number): string {
-  return hz % 1000 === 0 ? `${hz / 1000}kHz` : `${hz}Hz`;
 }

--- a/src/util/bus-constraint-prefill.ts
+++ b/src/util/bus-constraint-prefill.ts
@@ -1,0 +1,67 @@
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType } from "../api/types/config-entries.js";
+import { floatWithUnitToBase } from "./float-with-unit.js";
+
+export interface BusPrefill {
+  /** Field values the dep-added bus form starts with. */
+  fields: Record<string, unknown>;
+  /** Bus fields the requester forces (require_tx -> tx_pin). */
+  required: string[];
+}
+
+/**
+ * Bus-form prefill for a requester's `bus_constraints[bus]` dict.
+ *
+ * Exact-match values prefill unless the bus default already satisfies
+ * them; min/max_frequency clamp the default into range; require_* map
+ * to their pin fields. Returns null when nothing applies.
+ */
+export function busConstraintPrefill(
+  busEntries: ConfigEntry[],
+  constraints: Record<string, unknown>
+): BusPrefill | null {
+  const fields: Record<string, unknown> = {};
+  const required: string[] = [];
+  const entryOf = (key: string): ConfigEntry | undefined =>
+    busEntries.find((e) => e.key === key);
+
+  let minHz: number | null = null;
+  let maxHz: number | null = null;
+  for (const [key, value] of Object.entries(constraints)) {
+    if (key === "min_frequency") {
+      if (typeof value === "number") minHz = value;
+      continue;
+    }
+    if (key === "max_frequency") {
+      if (typeof value === "number") maxHz = value;
+      continue;
+    }
+    if (key.startsWith("require_")) {
+      if (value === true) required.push(`${key.slice("require_".length)}_pin`);
+      continue;
+    }
+    const entry = entryOf(key);
+    const dflt = entry?.default_value;
+    if (dflt === null || dflt === undefined || String(dflt) !== String(value)) {
+      // Options-style fields ('stop_bits', 'parity') match on strings.
+      fields[key] = entry?.type === ConfigEntryType.STRING ? String(value) : value;
+    }
+  }
+
+  if (minHz !== null || maxHz !== null) {
+    const entry = entryOf("frequency");
+    const hz = floatWithUnitToBase(entry?.default_value, entry?.unit_options ?? ["Hz"]);
+    let target: number | null = null;
+    if (hz === null) target = maxHz ?? minHz;
+    else if (maxHz !== null && hz > maxHz) target = maxHz;
+    else if (minHz !== null && hz < minHz) target = minHz;
+    if (target !== null) fields.frequency = _formatHz(target);
+  }
+
+  if (Object.keys(fields).length === 0 && required.length === 0) return null;
+  return { fields, required };
+}
+
+function _formatHz(hz: number): string {
+  return hz % 1000 === 0 ? `${hz / 1000}kHz` : `${hz}Hz`;
+}

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -118,6 +118,26 @@ export function serializeFloatWithUnit(parsed: FloatWithUnit): string {
 }
 
 /**
+ * Parse to the base (first) unit's scale: '50kHz' with Hz-based options
+ * yields 50000. Null when valueless or the unit isn't metric-prefixed.
+ */
+export function floatWithUnitToBase(
+  raw: unknown,
+  unitOptions: readonly string[]
+): number | null {
+  const { value, unit } = parseFloatWithUnit(raw, unitOptions);
+  if (value === null) return null;
+  const base = unitOptions[0] ?? "";
+  if (unit === base) return value;
+  if (!unit.endsWith(base)) return null;
+  const prefix = unit.slice(0, unit.length - base.length);
+  if (!Object.prototype.hasOwnProperty.call(METRIC_PREFIX_MULTIPLIERS, prefix)) {
+    return null;
+  }
+  return value * METRIC_PREFIX_MULTIPLIERS[prefix];
+}
+
+/**
  * Compute the numeric placeholder shown in the FLOAT_WITH_UNIT
  * field's number input from the catalog's `default_value`.
  *

--- a/src/util/float-with-unit.ts
+++ b/src/util/float-with-unit.ts
@@ -118,6 +118,32 @@ export function serializeFloatWithUnit(parsed: FloatWithUnit): string {
 }
 
 /**
+ * Format a base-unit value with the largest listed unit dividing it
+ * cleanly: 15000 with Hz-based options yields '15kHz'. Falls back to
+ * the base unit so the result always validates against the options.
+ */
+export function formatInBestUnit(
+  baseValue: number,
+  unitOptions: readonly string[]
+): string {
+  const base = unitOptions[0] ?? "";
+  let bestUnit = base;
+  let bestMult = 1;
+  for (const option of unitOptions) {
+    if (option === base || !option.endsWith(base)) continue;
+    const prefix = option.slice(0, option.length - base.length);
+    if (!Object.prototype.hasOwnProperty.call(METRIC_PREFIX_MULTIPLIERS, prefix))
+      continue;
+    const mult = METRIC_PREFIX_MULTIPLIERS[prefix];
+    if (mult > bestMult && baseValue % mult === 0) {
+      bestMult = mult;
+      bestUnit = option;
+    }
+  }
+  return `${baseValue / bestMult}${bestUnit}`;
+}
+
+/**
  * Parse to the base (first) unit's scale: '50kHz' with Hz-based options
  * yields 50000. Null when valueless or the unit isn't metric-prefixed.
  */

--- a/test/components/device/add-component-dialog-dep-nav.test.ts
+++ b/test/components/device/add-component-dialog-dep-nav.test.ts
@@ -5,6 +5,7 @@ import {
   ComponentCategory,
   type ComponentCatalogEntry,
 } from "../../../src/api/types/components.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import {
   matchesDepDomain,
   navigateToDep,
@@ -12,6 +13,7 @@ import {
 } from "../../../src/components/device/add-component-dialog-dep-nav.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
 function makeHost(
   getComponentBodies: (...args: unknown[]) => unknown,
@@ -25,6 +27,7 @@ function makeHost(
     _selected: null,
     _returnTo: null,
     _depDomain: null,
+    _depPrefill: null,
     _submitError: "",
     _submitting: false,
     _depNavSeq: 0,
@@ -186,5 +189,41 @@ describe("matchesDepDomain", () => {
       category: ComponentCategory.SENSOR,
     });
     expect(matchesDepDomain(sensor, "output")).toBe(false);
+  });
+});
+
+describe("navigateToDep bus-constraint prefill", () => {
+  afterEach(() => _clearComponentCache());
+
+  const i2cWithFrequency = () =>
+    makeComponentEntry("i2c", {
+      config_entries: [
+        makeConfigEntry({
+          key: "frequency",
+          type: ConfigEntryType.FLOAT_WITH_UNIT,
+          default_value: "50kHz",
+          unit_options: ["Hz", "kHz", "MHz"],
+        }),
+      ],
+    });
+
+  test("stashes a prefill when the requester constrains the bus", async () => {
+    const host = makeHost(respond(i2cWithFrequency()));
+    host._selected = makeComponentEntry("sensor.ags10", {
+      bus_constraints: { i2c: { max_frequency: 15000 } },
+    });
+
+    await navigateToDep(host, "i2c");
+
+    expect(host._depPrefill).toEqual({ fields: { frequency: "15kHz" }, required: [] });
+  });
+
+  test("leaves the prefill null for an unconstrained requester", async () => {
+    const host = makeHost(respond(i2cWithFrequency()));
+    host._selected = makeComponentEntry("sensor.dht");
+
+    await navigateToDep(host, "i2c");
+
+    expect(host._depPrefill).toBeNull();
   });
 });

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -59,3 +59,45 @@ describe("add-component-form seeds required nested entity names (#1423)", () => 
     expect(values.resistance).toBeUndefined();
   });
 });
+
+describe("add-component-form dep-add bus prefill (#1425)", () => {
+  function busForm() {
+    const form = new ESPHomeAddComponentForm();
+    const internals = form as unknown as {
+      component: ComponentCatalogEntry;
+      _localize: (key: string) => string;
+      prefillFields: Record<string, unknown> | null;
+      extraRequired: string[] | null;
+      _initValues: () => void;
+      _values: Record<string, unknown>;
+      _entries: Array<{ key: string; required?: boolean | null }>;
+    };
+    internals.component = {
+      id: "i2c",
+      config_entries: [
+        makeConfigEntry({
+          key: "frequency",
+          type: ConfigEntryType.STRING,
+          default_value: "50kHz",
+        }),
+        makeConfigEntry({ key: "sda", type: ConfigEntryType.PIN }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    internals._localize = (key) => key;
+    return internals;
+  }
+
+  it("merges prefillFields over the seeded defaults", () => {
+    const form = busForm();
+    form.prefillFields = { frequency: "15kHz" };
+    form._initValues();
+    expect(form._values.frequency).toBe("15kHz");
+  });
+
+  it("overlays extraRequired keys as required entries", () => {
+    const form = busForm();
+    form.extraRequired = ["sda"];
+    expect(form._entries.find((e) => e.key === "sda")?.required).toBe(true);
+    expect(form._entries.find((e) => e.key === "frequency")?.required).toBeFalsy();
+  });
+});

--- a/test/util/bus-constraint-prefill.test.ts
+++ b/test/util/bus-constraint-prefill.test.ts
@@ -66,4 +66,23 @@ describe("busConstraintPrefill", () => {
   test("returns null when nothing applies", () => {
     expect(busConstraintPrefill(uartEntries, { data_bits: 8 })).toBeNull();
   });
+
+  test("formats the clamped frequency within the entry's unit options", () => {
+    const hzOnly = [
+      makeConfigEntry({
+        key: "frequency",
+        type: ConfigEntryType.FLOAT_WITH_UNIT,
+        default_value: "50000Hz",
+        unit_options: ["Hz"],
+      }),
+    ];
+    expect(busConstraintPrefill(hzOnly, { max_frequency: 15000 })).toEqual({
+      fields: { frequency: "15000Hz" },
+      required: [],
+    });
+  });
+
+  test("skips a constraint key with no matching bus field", () => {
+    expect(busConstraintPrefill(uartEntries, { rx_buffer_size: 512 })).toBeNull();
+  });
 });

--- a/test/util/bus-constraint-prefill.test.ts
+++ b/test/util/bus-constraint-prefill.test.ts
@@ -1,0 +1,69 @@
+/**
+ * busConstraintPrefill turns a requester's bus_constraints dict into the
+ * dep-added bus form's starting values and forced-required pin fields.
+ */
+import { describe, expect, test } from "vitest";
+
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { busConstraintPrefill } from "../../src/util/bus-constraint-prefill.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const i2cEntries = [
+  makeConfigEntry({
+    key: "frequency",
+    type: ConfigEntryType.FLOAT_WITH_UNIT,
+    default_value: "50kHz",
+    unit_options: ["Hz", "kHz", "MHz"],
+  }),
+];
+
+const uartEntries = [
+  makeConfigEntry({ key: "baud_rate", type: ConfigEntryType.INTEGER, required: true }),
+  makeConfigEntry({ key: "parity", type: ConfigEntryType.STRING, default_value: "NONE" }),
+  makeConfigEntry({ key: "stop_bits", type: ConfigEntryType.STRING, default_value: "1" }),
+  makeConfigEntry({ key: "data_bits", type: ConfigEntryType.INTEGER, default_value: 8 }),
+];
+
+describe("busConstraintPrefill", () => {
+  test("clamps the bus frequency down to a max constraint", () => {
+    expect(busConstraintPrefill(i2cEntries, { max_frequency: 15000 })).toEqual({
+      fields: { frequency: "15kHz" },
+      required: [],
+    });
+  });
+
+  test("leaves the frequency alone when the default is in range", () => {
+    expect(busConstraintPrefill(i2cEntries, { min_frequency: 10000 })).toBeNull();
+  });
+
+  test("raises the frequency up to a min constraint", () => {
+    expect(busConstraintPrefill(i2cEntries, { min_frequency: 100000 })).toEqual({
+      fields: { frequency: "100kHz" },
+      required: [],
+    });
+  });
+
+  test("prefills exact-match uart values that differ from the defaults", () => {
+    const result = busConstraintPrefill(uartEntries, {
+      baud_rate: 9600,
+      parity: "EVEN",
+      stop_bits: 1,
+      data_bits: 8,
+    });
+    // stop_bits / data_bits already match their defaults and stay out.
+    expect(result).toEqual({
+      fields: { baud_rate: 9600, parity: "EVEN" },
+      required: [],
+    });
+  });
+
+  test("maps require_* constraints to required pin fields", () => {
+    expect(
+      busConstraintPrefill(uartEntries, { require_tx: true, require_rx: true })
+    ).toEqual({ fields: {}, required: ["tx_pin", "rx_pin"] });
+  });
+
+  test("returns null when nothing applies", () => {
+    expect(busConstraintPrefill(uartEntries, { data_bits: 8 })).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A bus added through the dependency detour came up with defaults the requesting component rejects at final validation: ags10 needs i2c at or below 15kHz, most uart devices pin an exact baud rate, and many require specific pins.

The detour now reads the requester's `bus_constraints` from the catalog (added in esphome/device-builder#1429), prefills exact-match values and a clamped frequency on the bus form, and marks constraint-required pins as required so submit waits for a pin choice. Verified against the live backend: ags10 yields an i2c form at 15kHz, dfplayer yields a uart form at 9600 baud with tx_pin required, mcp9600 leaves the in-range default alone.

Depends on esphome/device-builder#1429 for the catalog field; without it the detour behaves exactly as today.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1425

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
