### PR TITLE
Satisfy hub dependencies from configured platforms

### DIFF
--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,0 +1,40 @@
+import { ComponentCategory } from "../../api/types/components.js";
+import {
+  parseConfiguredPlatforms,
+  parseTopLevelComponents,
+} from "../../util/yaml-serialize.js";
+
+// Platform domains (sensor, switch, number, ...) are satisfied only by
+// a top-level block of that name, never by a same-named platform under
+// another domain: a `binary_sensor: - platform: switch` mirror must not
+// pass for a `switch:` dependency. Guards the stem-match branch below.
+const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCategory));
+
+/**
+ * Catalog dependencies not yet satisfied by the current YAML.
+ *
+ * A dependency is satisfied when any of:
+ *  - a top-level block of that name exists (`ld2410:`, `i2c:`);
+ *  - a dotted dep (`ota.http_request`) matches a configured platform; or
+ *  - a configured platform's stem equals the dep and the dep isn't a
+ *    platform domain — platform-style hubs (`atm90e32`) live under a
+ *    domain (`sensor: - platform: atm90e32`), not at the top level.
+ */
+export function findMissingDependencies(
+  dependencies: readonly string[],
+  yaml: string
+): string[] {
+  const present = parseTopLevelComponents(yaml);
+  const configured = parseConfiguredPlatforms(yaml);
+  const platformStems = new Set<string>();
+  for (const id of configured) {
+    const dot = id.indexOf(".");
+    if (dot !== -1) platformStems.add(id.slice(dot + 1));
+  }
+  return dependencies.filter((dep) => {
+    if (present.has(dep)) return false;
+    if (dep.includes(".")) return !configured.has(dep);
+    if (!PLATFORM_DOMAINS.has(dep) && platformStems.has(dep)) return false;
+    return true;
+  });
+}

--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -19,12 +19,18 @@ const PLATFORM_DOMAINS: ReadonlySet<string> = new Set(Object.values(ComponentCat
  *  - a configured platform's stem equals the dep and the dep isn't a
  *    platform domain — platform-style hubs (`atm90e32`) live under a
  *    domain (`sensor: - platform: atm90e32`), not at the top level.
+ *
+ * `presentComponents` may be passed precomputed to avoid re-parsing
+ * the top-level blocks when the caller already has them.
  */
 export function findMissingDependencies(
   dependencies: readonly string[],
-  yaml: string
+  yaml: string,
+  presentComponents?: ReadonlySet<string>
 ): string[] {
-  const present = parseTopLevelComponents(yaml);
+  // Most components declare no dependencies — skip the YAML scans.
+  if (dependencies.length === 0) return [];
+  const present = presentComponents ?? parseTopLevelComponents(yaml);
   const configured = parseConfiguredPlatforms(yaml);
   const platformStems = new Set<string>();
   for (const id of configured) {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -26,6 +26,7 @@ import {
   parseTopLevelComponents,
   serializeYamlValues,
 } from "../../util/yaml-serialize.js";
+import { findMissingDependencies } from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
 import "./config-entry-form.js";
@@ -292,12 +293,14 @@ export class ESPHomeAddComponentForm extends LitElement {
   protected render() {
     const disabled = this.submitting;
     const presentComponents = parseTopLevelComponents(this.yaml);
-    // Top-level dependencies the catalog entry declares as required.
-    // For example a `light.binary` light needs an `output:` block
-    // configured first. Surface these to the user instead of letting
-    // them submit a config that won't validate.
-    const missingDeps = (this.component.dependencies ?? []).filter(
-      (d) => !presentComponents.has(d)
+    // Dependencies the catalog entry declares as required but the YAML
+    // doesn't satisfy yet — a top-level block (`output:`, `i2c:`) or a
+    // configured platform for hub-style deps (`atm90e32` under
+    // `sensor:`). Surface these instead of letting the user submit a
+    // config that won't validate.
+    const missingDeps = findMissingDependencies(
+      this.component.dependencies ?? [],
+      this.yaml
     );
 
     // The shared form filters its own visibility — but we still need
@@ -522,11 +525,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     // own message; the success path leaves it cleared.
     this._localBlockMessage = "";
     const presentComponents = parseTopLevelComponents(this.yaml);
-    // Block submit when there are missing top-level dependencies.
-    // The button should already be disabled in that case, but defend
-    // here too in case the YAML changed under us between renders.
-    const missingDeps = (this.component.dependencies ?? []).filter(
-      (d) => !presentComponents.has(d)
+    // Block submit when a declared dependency isn't satisfied. The
+    // button should already be disabled in that case, but defend here
+    // too in case the YAML changed under us between renders.
+    const missingDeps = findMissingDependencies(
+      this.component.dependencies ?? [],
+      this.yaml
     );
     if (missingDeps.length > 0) {
       // Should be unreachable — the button-disabled predicate uses the

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -300,7 +300,8 @@ export class ESPHomeAddComponentForm extends LitElement {
     // config that won't validate.
     const missingDeps = findMissingDependencies(
       this.component.dependencies ?? [],
-      this.yaml
+      this.yaml,
+      presentComponents
     );
 
     // The shared form filters its own visibility — but we still need
@@ -530,7 +531,8 @@ export class ESPHomeAddComponentForm extends LitElement {
     // too in case the YAML changed under us between renders.
     const missingDeps = findMissingDependencies(
       this.component.dependencies ?? [],
-      this.yaml
+      this.yaml,
+      presentComponents
     );
     if (missingDeps.length > 0) {
       // Should be unreachable — the button-disabled predicate uses the

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { findMissingDependencies } from "../../../src/components/device/add-component-deps.js";
+
+describe("findMissingDependencies", () => {
+  it("flags a top-level hub dep that isn't configured", () => {
+    expect(findMissingDependencies(["ld2410"], "sensor:\n  - platform: dht\n")).toEqual([
+      "ld2410",
+    ]);
+  });
+
+  it("satisfies a top-level hub dep from its block", () => {
+    expect(findMissingDependencies(["ld2410"], "ld2410:\n  uart_id: u\n")).toEqual([]);
+  });
+
+  it("satisfies a platform-style hub dep from a configured platform", () => {
+    // atm90e32's hub lives under `sensor:`, not at the top level — the
+    // button platform depends on the bare `atm90e32` stem.
+    const yaml = "sensor:\n  - platform: atm90e32\n    id: power\n";
+    expect(findMissingDependencies(["atm90e32"], yaml)).toEqual([]);
+  });
+
+  it("flags a platform-style hub dep when its platform is absent", () => {
+    expect(findMissingDependencies(["atm90e32"], "sensor:\n  - platform: dht\n")).toEqual(
+      ["atm90e32"]
+    );
+  });
+
+  it("satisfies a dotted dep from a matching configured platform", () => {
+    // The pre-existing always-blocked update.http_request case.
+    const yaml = "ota:\n  - platform: http_request\n";
+    expect(findMissingDependencies(["ota.http_request"], yaml)).toEqual([]);
+  });
+
+  it("does not let a mirror platform satisfy a domain dependency", () => {
+    // A `binary_sensor: - platform: switch` mirror must not pass for a
+    // `switch:` dependency — switch is a platform domain, satisfied
+    // only by a top-level `switch:` block.
+    const yaml = "binary_sensor:\n  - platform: switch\n    name: x\n";
+    expect(findMissingDependencies(["switch"], yaml)).toEqual(["switch"]);
+  });
+
+  it("satisfies a domain dependency from its top-level block", () => {
+    const yaml = "switch:\n  - platform: gpio\n    pin: 1\n";
+    expect(findMissingDependencies(["switch"], yaml)).toEqual([]);
+  });
+
+  it("returns only the unsatisfied subset", () => {
+    const yaml = "ld2410:\n  uart_id: u\nsensor:\n  - platform: atm90e32\n";
+    expect(findMissingDependencies(["ld2410", "atm90e32", "uart"], yaml)).toEqual([
+      "uart",
+    ]);
+  });
+
+  it("treats an empty dependency list as satisfied", () => {
+    expect(findMissingDependencies([], "")).toEqual([]);
+  });
+});

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -54,4 +54,10 @@ describe("findMissingDependencies", () => {
   it("treats an empty dependency list as satisfied", () => {
     expect(findMissingDependencies([], "")).toEqual([]);
   });
+
+  it("honours a precomputed presentComponents set over the yaml", () => {
+    // Caller passes its already-parsed top-level set; the empty yaml
+    // would otherwise report ld2410 missing.
+    expect(findMissingDependencies(["ld2410"], "", new Set(["ld2410"]))).toEqual([]);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The Add-Component form's "requires other components" check only matched
**top-level** YAML blocks (`parseTopLevelComponents`). That breaks for dependencies
on platform-style hubs, which live *under a domain* rather than at the top level —
e.g. a component depending on `atm90e32` (configured as `sensor: - platform: atm90e32`)
or the OTA `http_request` platform. Such a dependency could never be marked satisfied,
so the **Add** button stayed permanently disabled.

This extracts a tested `findMissingDependencies(deps, yaml)` helper and broadens the
satisfaction rule. A dependency is met when:

- a top-level block of that name exists (`ld2410:`, `i2c:`); or
- a dotted dep (`ota.http_request`) matches a configured platform (also fixes the
  pre-existing always-blocked `update.http_request`); or
- a configured platform's stem equals the dep — guarded so a platform *domain*
  (`switch`, `number`, …) is never satisfied by a same-named mirror platform
  (`binary_sensor: - platform: switch` must not pass for a `switch:` dependency).

**Related issue or feature (if applicable):**

- Backend PR: esphome/device-builder#1432 (fixes esphome/device-builder#1431) — the catalog change that emits
  these hub dependencies). Without this PR, that catalog change would block the Add
  button for ~15 platform-style hubs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

