### PR TITLE
Parse ESPHome time-unit aliases (sec, seconds, ...) in the editor

### DIFF
--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -42,6 +42,11 @@ import { espHomeStyles } from "../../../styles/shared.js";
 import { actionAdvancedState } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
+import {
+  parseTimePeriodScalar,
+  TIME_PERIOD_UNITS,
+  type TimePeriodUnit,
+} from "../../../util/time-period.js";
 import { renderAdvancedToggle } from "../advanced-toggle.js";
 import "../config-entry-form.js";
 import type { ConfigEntryValueChange } from "../config-entry-form.js";
@@ -74,12 +79,10 @@ registerMdiIcons({
   "pencil-outline": mdiPencilOutline,
 });
 
-/** Time units the Delay action picker offers. Ordered from
- *  least → most coarse so the dropdown opens with the most
- *  common pick (seconds) near the top of the visible options
- *  without making the list feel reversed. */
-const DELAY_UNITS = ["us", "ms", "s", "min", "h", "d"] as const;
-type DelayUnit = (typeof DELAY_UNITS)[number];
+/** Time units the Delay action picker offers (the shared canonical
+ *  set, least → most coarse). */
+const DELAY_UNITS = TIME_PERIOD_UNITS;
+type DelayUnit = TimePeriodUnit;
 
 /** Maps each picker unit to the catalog field key the backend's
  *  YAML writer expects. ESPHome's time_period coercer accepts any
@@ -549,14 +552,14 @@ export class ESPHomeAutomationActionNode extends LitElement {
       }
     }
     // Backend shortcut form: ``delay: 2s`` → ``params.id = "2s"``.
-    // Split into numeric prefix + unit suffix so the picker
-    // doesn't blank out for round-tripped historic values.
+    // Split into numeric value + canonical unit (honouring ESPHome's
+    // ``sec`` / ``seconds`` / ... aliases) so the picker doesn't blank
+    // out for round-tripped values.
     const shortcut = params.id;
     if (typeof shortcut === "string") {
-      const m = shortcut.match(/^(\d+(?:\.\d+)?)(us|ms|s|min|h|d)$/);
-      if (m) {
-        const [, num, suf] = m;
-        return { value: num, unit: suf as DelayUnit };
+      const parsed = parseTimePeriodScalar(shortcut);
+      if (parsed.parseable && parsed.value !== "") {
+        return { value: parsed.value, unit: parsed.unit };
       }
     }
     return { value: "", unit: "s" };

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -43,6 +43,7 @@ import { actionAdvancedState } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import {
+  looksLikeTimePeriodScalar,
   parseTimePeriodScalar,
   TIME_PERIOD_UNITS,
   type TimePeriodUnit,
@@ -554,13 +555,12 @@ export class ESPHomeAutomationActionNode extends LitElement {
     // Backend shortcut form: ``delay: 2s`` → ``params.id = "2s"``.
     // Split into numeric value + canonical unit (honouring ESPHome's
     // ``sec`` / ``seconds`` / ... aliases) so the picker doesn't blank
-    // out for round-tripped values.
+    // out for round-tripped values. Requires an explicit unit — ESPHome
+    // rejects a bare-number delay, so we don't pretend ``5`` is seconds.
     const shortcut = params.id;
-    if (typeof shortcut === "string") {
+    if (typeof shortcut === "string" && looksLikeTimePeriodScalar(shortcut)) {
       const parsed = parseTimePeriodScalar(shortcut);
-      if (parsed.parseable && parsed.value !== "") {
-        return { value: parsed.value, unit: parsed.unit };
-      }
+      return { value: parsed.value, unit: parsed.unit };
     }
     return { value: "", unit: "s" };
   }

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -12,6 +12,12 @@ import {
 } from "../../../util/float-with-unit.js";
 import { formatHexInt, parseHexInt } from "../../../util/hex-int.js";
 import { coerceIntFieldValue } from "../../../util/int-input.js";
+import {
+  parseTimePeriodScalar,
+  serializeTimePeriod,
+  TIME_PERIOD_UNITS,
+  type TimePeriodUnit,
+} from "../../../util/time-period.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -186,54 +192,6 @@ function hexDisplayOrFallback(rawValue: unknown): string {
  * backend's parser handles it the same as if the user had typed
  * it raw into YAML.
  */
-const TIME_PERIOD_UNITS = ["us", "ms", "s", "min", "h", "d"] as const;
-type TimePeriodUnit = (typeof TIME_PERIOD_UNITS)[number];
-
-/** Detect a polymorphic time-period scalar shorthand (``50ms``,
- *  ``2.5s``); requires an explicit unit suffix so unitless numbers
- *  like ``delta: 0.5`` don't false-positive. Units are escaped when
- *  building the regex so a future entry with regex metacharacters
- *  doesn't quietly malform the pattern. */
-const TIME_PERIOD_SCALAR_RE = new RegExp(
-  `^\\d+(?:\\.\\d+)?(?:${TIME_PERIOD_UNITS.map((u) =>
-    u.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  ).join("|")})$`
-);
-export function looksLikeTimePeriodScalar(raw: unknown): boolean {
-  return typeof raw === "string" && TIME_PERIOD_SCALAR_RE.test(raw.trim());
-}
-
-function parseTimePeriod(raw: unknown): {
-  value: string;
-  unit: TimePeriodUnit;
-  parseable: boolean;
-} {
-  if (raw === undefined || raw === null || raw === "") {
-    return { value: "", unit: "s", parseable: true };
-  }
-  const text = String(raw).trim();
-  // Single "<number><unit>" form. Number can be a fraction. Unit is
-  // optional — a bare number is interpreted as seconds by ESPHome.
-  const m = text.match(/^(\d+(?:\.\d+)?)(us|ms|s|min|h|d)?$/);
-  if (m) {
-    const [, num, suf] = m;
-    return {
-      value: num,
-      unit: (suf as TimePeriodUnit) ?? "s",
-      parseable: true,
-    };
-  }
-  // Compound form ("1h30s") or unrecognised — surface the raw string
-  // so the user can edit it as plain text without us mangling it.
-  return { value: text, unit: "s", parseable: false };
-}
-
-function serializeTimePeriod(value: string, unit: TimePeriodUnit): string {
-  const trimmed = value.trim();
-  if (trimmed === "") return "";
-  return `${trimmed}${unit}`;
-}
-
 export function renderTimePeriodField(
   entry: ConfigEntry,
   path: string[],
@@ -245,7 +203,7 @@ export function renderTimePeriodField(
   // ``"5s"`` and a save would clobber the original list.
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
-  const parsed = parseTimePeriod(raw);
+  const parsed = parseTimePeriodScalar(raw);
   const invalid = ctx.errorAt(path) !== null;
   const disabled = effectiveDisabled(entry, ctx);
   // Compound / unparseable strings fall through to a plain text
@@ -258,7 +216,7 @@ export function renderTimePeriodField(
   // number, the unit lives in the dropdown beside it.
   const defaultParsed =
     entry.default_value !== undefined && entry.default_value !== null
-      ? parseTimePeriod(entry.default_value)
+      ? parseTimePeriodScalar(entry.default_value)
       : null;
   const placeholderText =
     defaultParsed && defaultParsed.parseable ? defaultParsed.value : "";

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -198,7 +198,7 @@ export function renderTimePeriodField(
   ctx: RenderCtx
 ) {
   const raw = ctx.getAt(path);
-  // Bail above parseTimePeriod — its ``String(raw).trim()`` would
+  // Bail above parseTimePeriodScalar — its ``String(raw).trim()`` would
   // turn a single-element list ``["5s"]`` into the parseable string
   // ``"5s"`` and a save would clobber the original list.
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);

--- a/src/components/device/config-entry-renderers/registry-list.ts
+++ b/src/components/device/config-entry-renderers/registry-list.ts
@@ -24,6 +24,7 @@ import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { apiContext } from "../../../context/index.js";
 import { subscribeAutomationCatalogCache } from "../../../util/automation-catalog-cache.js";
 import { makeConfigEntry } from "../../../util/config-entry-defaults.js";
+import { looksLikeTimePeriodScalar } from "../../../util/time-period.js";
 import { YamlRawValue } from "../../../util/yaml-serialize.js";
 import {
   effectiveDisabled,
@@ -38,7 +39,6 @@ import {
   renderListEmptyHint,
   renderListRemoveButton,
 } from "./lists.js";
-import { looksLikeTimePeriodScalar } from "./primitives.js";
 import {
   asList,
   editableEntries,

--- a/src/util/time-period.ts
+++ b/src/util/time-period.ts
@@ -1,0 +1,83 @@
+/**
+ * Parse and serialize ESPHome time-period scalars (`50ms`, `1sec`,
+ * `34.1seconds`) for the structured editor's value + unit widgets.
+ *
+ * The dashboard offers six canonical units; ESPHome's
+ * `cv.time_period_str_unit` accepts a wider alias set (`sec` and
+ * `seconds` for `s`, `milliseconds` for `ms`, ...). We normalize every
+ * accepted suffix onto its canonical unit so an aliased value still
+ * splits into the picker instead of blanking out. `ns` / `nanoseconds`
+ * have no canonical picker unit and fall through to the raw-text editor.
+ */
+
+/** Canonical units the time-period / delay pickers offer, least to
+ *  most coarse. */
+export const TIME_PERIOD_UNITS = ["us", "ms", "s", "min", "h", "d"] as const;
+export type TimePeriodUnit = (typeof TIME_PERIOD_UNITS)[number];
+
+/** Every time-unit suffix ESPHome accepts, mapped to its canonical
+ *  picker unit. Mirrors `cv.time_period_str_unit`'s `unit_to_kwarg`. */
+const TIME_PERIOD_UNIT_ALIASES: Record<string, TimePeriodUnit> = {
+  us: "us",
+  µs: "us",
+  microseconds: "us",
+  ms: "ms",
+  milliseconds: "ms",
+  s: "s",
+  sec: "s",
+  seconds: "s",
+  min: "min",
+  minutes: "min",
+  h: "h",
+  hours: "h",
+  d: "d",
+  days: "d",
+};
+
+// Longest-first so the alternation prefers `seconds` over `sec` over `s`.
+const _UNIT_PATTERN = Object.keys(TIME_PERIOD_UNIT_ALIASES)
+  .sort((a, b) => b.length - a.length)
+  .map((u) => u.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  .join("|");
+
+// Optional whitespace between number and unit, matching ESPHome's regex.
+const TIME_PERIOD_PARSE_RE = new RegExp(`^(\\d+(?:\\.\\d+)?)\\s*(${_UNIT_PATTERN})?$`);
+const TIME_PERIOD_SCALAR_RE = new RegExp(`^\\d+(?:\\.\\d+)?\\s*(?:${_UNIT_PATTERN})$`);
+
+/** Detect a time-period scalar shorthand (`50ms`, `1sec`). Requires an
+ *  explicit unit so bare numbers like `delta: 0.5` don't false-positive. */
+export function looksLikeTimePeriodScalar(raw: unknown): boolean {
+  return typeof raw === "string" && TIME_PERIOD_SCALAR_RE.test(raw.trim());
+}
+
+/** Split a time-period scalar into its numeric value and canonical unit.
+ *  A bare number is seconds (ESPHome's default); a compound (`1h30s`) or
+ *  unrecognised form surfaces verbatim with `parseable: false`. */
+export function parseTimePeriodScalar(raw: unknown): {
+  value: string;
+  unit: TimePeriodUnit;
+  parseable: boolean;
+} {
+  if (raw === undefined || raw === null || raw === "") {
+    return { value: "", unit: "s", parseable: true };
+  }
+  const text = String(raw).trim();
+  const m = text.match(TIME_PERIOD_PARSE_RE);
+  if (m) {
+    const [, num, suf] = m;
+    return {
+      value: num,
+      unit: suf ? TIME_PERIOD_UNIT_ALIASES[suf] : "s",
+      parseable: true,
+    };
+  }
+  return { value: text, unit: "s", parseable: false };
+}
+
+/** Combine a value and canonical unit into the YAML string form; empty
+ *  value yields `""` so the caller can drop the field. */
+export function serializeTimePeriod(value: string, unit: TimePeriodUnit): string {
+  const trimmed = value.trim();
+  if (trimmed === "") return "";
+  return `${trimmed}${unit}`;
+}

--- a/src/util/time-period.ts
+++ b/src/util/time-period.ts
@@ -34,9 +34,9 @@ const TIME_PERIOD_UNIT_ALIASES: Record<string, TimePeriodUnit> = {
   days: "d",
 };
 
-// Longest-first so the alternation prefers `seconds` over `sec` over `s`.
+// The trailing `$` forces a full match, so the alternation captures the
+// whole suffix (`seconds`, not just `s`) regardless of key order.
 const _UNIT_PATTERN = Object.keys(TIME_PERIOD_UNIT_ALIASES)
-  .sort((a, b) => b.length - a.length)
   .map((u) => u.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
   .join("|");
 

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -179,4 +179,20 @@ describe("automation-action-node delay lambda", () => {
     expect(valueInput(el)!.value).toBe("5");
     expect(selectedUnit(el)).toBe("s");
   });
+
+  it("parses an aliased shorthand (1sec) as value + seconds", async () => {
+    const { el } = await mountDelay({ id: "1sec" });
+    expect(lambdaEditor(el)).toBeNull();
+    expect(valueInput(el)!.value).toBe("1");
+    expect(selectedUnit(el)).toBe("s");
+  });
+
+  it("normalizes an aliased shorthand to the canonical field on edit", async () => {
+    const { el, emitted } = await mountDelay({ id: "1sec" });
+    const input = valueInput(el)!;
+    input.value = "2";
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(emitted[emitted.length - 1].params).toEqual({ seconds: "2" });
+  });
 });

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -187,6 +187,12 @@ describe("automation-action-node delay lambda", () => {
     expect(selectedUnit(el)).toBe("s");
   });
 
+  it("blanks the picker for a bare-number shortcut (ESPHome needs a unit)", async () => {
+    const { el } = await mountDelay({ id: "5" });
+    expect(valueInput(el)!.value).toBe("");
+    expect(selectedUnit(el)).toBe("s");
+  });
+
   it("normalizes an aliased shorthand to the canonical field on edit", async () => {
     const { el, emitted } = await mountDelay({ id: "1sec" });
     const input = valueInput(el)!;

--- a/test/components/device/render-string-field-bails.test.ts
+++ b/test/components/device/render-string-field-bails.test.ts
@@ -164,6 +164,19 @@ describe("renderTimePeriodField / renderFloatWithUnitField — bail on non-primi
     expect(json).toContain("time-period");
   });
 
+  it("renders the split UI for an aliased unit (1sec), not the text fallback", () => {
+    const entry = makeConfigEntry({
+      key: "delay",
+      type: ConfigEntryType.TIME_PERIOD,
+      label: "Delay",
+    });
+    const { ctx } = makeCtx({ delay: "1sec" });
+    const tpl = renderTimePeriodField(entry, ["delay"], ctx);
+    const json = JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+    expect(json).toContain("time-period");
+    expect(json).toContain('"1"');
+  });
+
   it("bails on a list value for a float-with-unit field", () => {
     const entry = makeConfigEntry({
       key: "frequency",

--- a/test/util/time-period.test.ts
+++ b/test/util/time-period.test.ts
@@ -1,0 +1,65 @@
+/**
+ * parseTimePeriodScalar normalizes every ESPHome time-unit alias onto a
+ * canonical picker unit so a value like `1sec` splits into the widget
+ * instead of blanking out.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  looksLikeTimePeriodScalar,
+  parseTimePeriodScalar,
+  serializeTimePeriod,
+} from "../../src/util/time-period.js";
+
+describe("parseTimePeriodScalar", () => {
+  it.each([
+    ["1sec", { value: "1", unit: "s", parseable: true }],
+    ["34.1sec", { value: "34.1", unit: "s", parseable: true }],
+    ["1.0sec", { value: "1.0", unit: "s", parseable: true }],
+    ["5seconds", { value: "5", unit: "s", parseable: true }],
+    ["200ms", { value: "200", unit: "ms", parseable: true }],
+    ["10milliseconds", { value: "10", unit: "ms", parseable: true }],
+    ["1min", { value: "1", unit: "min", parseable: true }],
+    ["2minutes", { value: "2", unit: "min", parseable: true }],
+    ["3hours", { value: "3", unit: "h", parseable: true }],
+    ["4days", { value: "4", unit: "d", parseable: true }],
+    ["500microseconds", { value: "500", unit: "us", parseable: true }],
+    ["1 sec", { value: "1", unit: "s", parseable: true }],
+    ["100", { value: "100", unit: "s", parseable: true }],
+  ])("parses %s", (input, expected) => {
+    expect(parseTimePeriodScalar(input)).toEqual(expected);
+  });
+
+  it("treats an empty value as parseable seconds", () => {
+    expect(parseTimePeriodScalar("")).toEqual({ value: "", unit: "s", parseable: true });
+  });
+
+  it("surfaces a compound form as unparseable raw text", () => {
+    expect(parseTimePeriodScalar("1h30s")).toEqual({
+      value: "1h30s",
+      unit: "s",
+      parseable: false,
+    });
+  });
+});
+
+describe("looksLikeTimePeriodScalar", () => {
+  it("matches aliased units", () => {
+    expect(looksLikeTimePeriodScalar("1sec")).toBe(true);
+    expect(looksLikeTimePeriodScalar("34.1seconds")).toBe(true);
+  });
+
+  it("rejects a bare number", () => {
+    expect(looksLikeTimePeriodScalar("5")).toBe(false);
+  });
+});
+
+describe("serializeTimePeriod", () => {
+  it("joins value and canonical unit", () => {
+    expect(serializeTimePeriod("15", "s")).toBe("15s");
+  });
+
+  it("drops an empty value", () => {
+    expect(serializeTimePeriod("", "s")).toBe("");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A `delay: 1sec` rendered in the structured editor as Value=0, Unit=Seconds; the `1sec` time period was not parsed (and `34.1sec`, `seconds`, `milliseconds`, `minutes`, ... the same). ESPHome accepts a wide alias set via `cv.time_period_str_unit`, but two independent parsers (the automation Delay action editor and the generic time-period field) each recognised only the canonical short forms `us ms s min h d`.

Add a shared `src/util/time-period.ts` mirroring ESPHome's `unit_to_kwarg` that normalises every accepted suffix onto its canonical picker unit, and route both parsers through it so they cannot drift apart again. The picker still offers the same six units, so an aliased value just selects the existing option; editing normalises to the canonical form.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1434

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
