### PR TITLE
Resolve a bare-mapping platform section to its structured editor

### DIFF
--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -236,9 +236,13 @@ function _expandListItems(
     // Single-instance section (e.g. `uart:` configured as a flat
     // dict with `id:`, `tx_pin:` etc. directly under it). Extract a
     // top-level `id:`/`name:` so the navigator can show them as the
-    // primary label instead of falling back to the bare key.
+    // primary label instead of falling back to the bare key, and a
+    // top-level `platform:` so a bare-mapping platform component (the
+    // legacy `ota:\n  platform: esphome` form) resolves to its
+    // `<key>.<platform>` editor like the `- platform:` list form does.
     let name = "";
     let id = "";
+    let platform = "";
     for (let i = keyIdx + 1; i <= endIdx; i++) {
       // Only the block's own direct keys; deeper nested keys aren't
       // the singleton's id/name, and a compact child sequence's
@@ -247,6 +251,7 @@ function _expandListItems(
       if (LIST_ITEM_START_RE.test(lines[i])) continue;
       name = readInstanceScalar(lines[i], "name") ?? name;
       id = readInstanceScalar(lines[i], "id") ?? id;
+      platform = readInstanceScalar(lines[i], "platform") ?? platform;
     }
     return [
       {
@@ -255,6 +260,7 @@ function _expandListItems(
         toLine: section.toLine,
         name: name || undefined,
         id: id || undefined,
+        platform: platform || undefined,
       },
     ];
   }

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -75,6 +75,19 @@ wifi:
     expect(sectionKeyOf(sections[0])).toBe("logger");
   });
 
+  it("ignores a nested platform: deeper than the singleton's direct keys", () => {
+    // The direct-child indent guard must keep a nested ``platform:``
+    // from overriding the section's own (mirrors the id/name guard).
+    const yaml = `ota:
+  platform: esphome
+  some_block:
+    platform: bogus
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections[0].platform).toBe("esphome");
+    expect(sectionKeyOf(sections[0])).toBe("ota.esphome");
+  });
+
   it("extracts continuation id/name when the dash has extra spaces", () => {
     // ``-   platform`` pushes the child column past dash+2; id/name on
     // continuation lines must still be picked up (a fixed +2 missed them).

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -8,6 +8,7 @@ import {
   parseYamlTopLevelSections,
   resolveCurrentFromLine,
   sectionAtLine,
+  sectionKeyOf,
   type YamlSection,
 } from "../../src/util/yaml-sections.js";
 
@@ -50,6 +51,28 @@ wifi:
     expect(sections[0].parentKey).toBe("sensor");
     expect(sections[1].platform).toBe("bme280");
     expect(sections[1].name).toBe("bedroom");
+  });
+
+  it("resolves a bare-mapping platform section to its platform editor (#1436)", () => {
+    const yaml = `ota:
+  platform: esphome
+  password: "x"
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe("ota");
+    expect(sections[0].platform).toBe("esphome");
+    expect(sections[0].parentKey).toBeUndefined();
+    expect(sectionKeyOf(sections[0])).toBe("ota.esphome");
+  });
+
+  it("leaves a plain singleton without a platform key", () => {
+    const yaml = `logger:
+  level: DEBUG
+`;
+    const sections = parseYamlTopLevelSections(yaml);
+    expect(sections[0].platform).toBeUndefined();
+    expect(sectionKeyOf(sections[0])).toBe("logger");
   });
 
   it("extracts continuation id/name when the dash has extra spaces", () => {


### PR DESCRIPTION
# What does this implement/fix?

A platform component written as a bare mapping, the legacy form

```yaml
ota:
  platform: esphome
  password: !secret ota_password
```

showed "This section doesn't have a structured editor" even though `ota.esphome` is in the catalog with full fields. The modern list form (`ota:` then `- platform: esphome`) already rendered the structured editor.

The single-instance section parser extracted `id` and `name` but not `platform`, so the section resolved to the bare umbrella key (`ota`, no fields) instead of `ota.esphome`. Extract `platform` there too, exactly as the list-item branch already does, and the bare-mapping form opens the same structured editor. Verified in the browser: the OTA section now shows the Password field and advanced settings.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1436

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
