### PR TITLE
Add reusable options-combobox component

### DIFF
--- a/src/components/options-combobox-event.ts
+++ b/src/components/options-combobox-event.ts
@@ -1,0 +1,39 @@
+/**
+ * Event contract for `<esphome-options-combobox>` — kept separate from the
+ * component so test code can import the builder / wire name without pulling
+ * in Lit + the webawesome style-sheet polyfill the component registers
+ * eagerly (which fails in a Node test environment). The component imports
+ * from here in lockstep, so a rename or detail-shape change fails to compile
+ * both sites.
+ */
+
+/** Detail shape of the `options-combobox-change` event. */
+export interface OptionsComboboxValueChange {
+  value: string;
+}
+
+/**
+ * Wire name for the combobox's change event.
+ *
+ * Deliberately namespaced and non-bubbling: a generic, bubbling
+ * `value-change(d)` would collide with the config-entry form's own
+ * `value-change` event (a `{path, value}` detail), letting this
+ * `{value}`-only detail reach a parent form listener expecting `{path}`.
+ */
+export const OPTIONS_COMBOBOX_CHANGE_EVENT = "options-combobox-change";
+
+/**
+ * Build the change event the component fires. Non-bubbling, non-composed:
+ * the only consumer is a direct `@options-combobox-change` listener on the
+ * element, so bubbling buys nothing and invites collisions. Direct listeners
+ * fire regardless of `bubbles`.
+ */
+export function buildOptionsComboboxChangeEvent(
+  value: string
+): CustomEvent<OptionsComboboxValueChange> {
+  return new CustomEvent<OptionsComboboxValueChange>(OPTIONS_COMBOBOX_CHANGE_EVENT, {
+    detail: { value },
+    bubbles: false,
+    composed: false,
+  });
+}

--- a/src/components/options-combobox.styles.ts
+++ b/src/components/options-combobox.styles.ts
@@ -1,0 +1,73 @@
+import { css } from "lit";
+
+/**
+ * Styles for `<esphome-options-combobox>`. Pulled in alongside
+ * `inputStyles` (which draws the input chrome / form-control height);
+ * these add the chevron overlay and the anchored option listbox.
+ */
+export const optionsComboboxStyles = css`
+  :host {
+    display: block;
+  }
+
+  .control {
+    position: relative;
+    display: block;
+  }
+
+  /* Leave room for the chevron sitting over the input's right edge. */
+  input {
+    padding-right: 34px;
+  }
+
+  .chevron {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 32px;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    color: var(--wa-color-text-quiet);
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  .chevron:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .listbox {
+    max-height: 280px;
+    overflow-y: auto;
+    background: var(--wa-color-surface-raised);
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+    box-shadow: var(--wa-shadow-m);
+    padding: var(--wa-space-2xs);
+  }
+
+  .option {
+    padding: var(--wa-space-2xs) var(--wa-space-s);
+    border-radius: var(--wa-border-radius-s);
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-text-normal);
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .option--active {
+    background: var(--esphome-tint, var(--wa-color-surface-border));
+  }
+
+  .option-label {
+    display: block;
+  }
+`;

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -72,6 +72,9 @@ export class ESPHomeOptionsCombobox extends LitElement {
   @query("input")
   private _input?: HTMLInputElement;
 
+  @query(".option--active")
+  private _activeOption?: HTMLElement;
+
   static styles = [inputStyles, optionsComboboxStyles];
 
   protected render() {
@@ -252,11 +255,10 @@ export class ESPHomeOptionsCombobox extends LitElement {
   }
 
   private _scrollActiveIntoView(): void {
-    requestAnimationFrame(() => {
-      this.shadowRoot
-        ?.querySelector(".option--active")
-        ?.scrollIntoView({ block: "nearest" });
-    });
+    // Wait for the re-render so the @query ref resolves to the new active row.
+    void this.updateComplete.then(() =>
+      this._activeOption?.scrollIntoView({ block: "nearest" })
+    );
   }
 }
 

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -7,8 +7,8 @@
  * list. `<wa-combobox>` is not available in HA's webawesome fork.
  *
  * `wa-popup` is pure positioning (the input keeps focus, unlike
- * `wa-dropdown` which moves focus into the menu). Emits `value-changed`
- * on every keystroke and on option select.
+ * `wa-dropdown` which moves focus into the menu). Emits
+ * `options-combobox-change` on every keystroke and on option select.
  */
 import { mdiChevronDown } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
@@ -65,8 +65,8 @@ export class ESPHomeOptionsCombobox extends LitElement {
   @state() private _active = -1;
 
   /** Committed value snapshotted when the dropdown opened, so Escape can
-   *  restore it even after per-keystroke ``value-changed`` has driven the
-   *  host to update ``value``. */
+   *  restore it even after per-keystroke ``options-combobox-change`` has
+   *  driven the host to update ``value``. */
   private _committed = "";
 
   @query("input")

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -1,0 +1,329 @@
+/**
+ * Reusable combobox: a dropdown of options that shows the whole list on
+ * open, filters as you type, and accepts arbitrary typed values
+ * (pre-filled with the current value). Fills the gap left by the native
+ * `<input list=datalist>`, which filters its suggestions by the text
+ * already in the field, so a pre-filled field can't browse the full
+ * list. `<wa-combobox>` is not available in HA's webawesome fork.
+ *
+ * `wa-popup` is pure positioning (the input keeps focus, unlike
+ * `wa-dropdown` which moves focus into the menu). Emits `value-changed`
+ * on every keystroke and on option select.
+ */
+import { mdiChevronDown } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import { inputStyles } from "../styles/inputs.js";
+import { registerMdiIcons } from "../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/popup/popup.js";
+
+registerMdiIcons({ "chevron-down": mdiChevronDown });
+
+export interface ComboboxOption {
+  label: string;
+  value: string;
+}
+
+/** Detail for the ``value-changed`` event. */
+export interface ComboboxValueChangedDetail {
+  value: string;
+}
+
+@customElement("esphome-options-combobox")
+export class ESPHomeOptionsCombobox extends LitElement {
+  /** Selectable options; the list also accepts free-text not in here. */
+  @property({ attribute: false })
+  options: ComboboxOption[] = [];
+
+  /** Committed value — an option value or arbitrary typed text. */
+  @property()
+  value = "";
+
+  @property()
+  placeholder = "";
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  /** Error styling on the control border. */
+  @property({ type: Boolean })
+  invalid = false;
+
+  /** Accessible name for the input. */
+  @property()
+  label = "";
+
+  /** Open state of the dropdown. */
+  @state() private _open = false;
+
+  /** Text shown while editing; the closed field shows ``value``. */
+  @state() private _query = "";
+
+  /** Typed since opening — gates show-all (false) vs substring filter. */
+  @state() private _dirty = false;
+
+  /** Keyboard-active option index into the filtered list, or -1. */
+  @state() private _active = -1;
+
+  @query("input")
+  private _input?: HTMLInputElement;
+
+  static styles = [
+    inputStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .control {
+        position: relative;
+        display: block;
+      }
+
+      /* Leave room for the chevron sitting over the input's right edge. */
+      input {
+        padding-right: 34px;
+      }
+
+      .chevron {
+        position: absolute;
+        top: 0;
+        right: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        width: 32px;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        color: var(--wa-color-text-quiet);
+        font-size: 18px;
+        cursor: pointer;
+      }
+
+      .chevron:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
+
+      .listbox {
+        max-height: 280px;
+        overflow-y: auto;
+        background: var(--wa-color-surface-raised);
+        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        border-radius: var(--wa-border-radius-m);
+        box-shadow: var(--wa-shadow-m);
+        padding: var(--wa-space-2xs);
+      }
+
+      .option {
+        padding: var(--wa-space-2xs) var(--wa-space-s);
+        border-radius: var(--wa-border-radius-s);
+        font-size: var(--wa-font-size-s);
+        color: var(--wa-color-text-normal);
+        cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .option--active {
+        background: var(--esphome-tint, var(--wa-color-surface-border));
+      }
+
+      .option-label {
+        display: block;
+      }
+    `,
+  ];
+
+  protected render() {
+    const filtered = this._filtered;
+    const display = this._open ? this._query : this.value;
+    return html`
+      <wa-popup
+        placement="bottom-start"
+        sync="width"
+        distance="4"
+        ?active=${this._open && filtered.length > 0}
+      >
+        <div slot="anchor" class="control">
+          <input
+            type="text"
+            class=${this.invalid ? "invalid" : ""}
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded=${this._open ? "true" : "false"}
+            aria-controls="listbox"
+            aria-activedescendant=${this._active >= 0
+              ? `option-${this._active}`
+              : nothing}
+            aria-label=${this.label || nothing}
+            .value=${display}
+            placeholder=${this.placeholder}
+            ?disabled=${this.disabled}
+            autocomplete="off"
+            spellcheck="false"
+            @focus=${this._open_}
+            @input=${this._onInput}
+            @keydown=${this._onKeyDown}
+            @blur=${this._close}
+          />
+          <button
+            class="chevron"
+            type="button"
+            tabindex="-1"
+            ?disabled=${this.disabled}
+            aria-hidden="true"
+            @mousedown=${this._preventBlur}
+            @click=${this._toggle}
+          >
+            <wa-icon library="mdi" name="chevron-down"></wa-icon>
+          </button>
+        </div>
+        ${this._open
+          ? html`<div id="listbox" class="listbox" role="listbox">
+              ${filtered.map(
+                (opt, i) =>
+                  html`<div
+                    id="option-${i}"
+                    class="option ${i === this._active ? "option--active" : ""}"
+                    role="option"
+                    aria-selected=${opt.value === this.value ? "true" : "false"}
+                    @mousedown=${this._preventBlur}
+                    @click=${() => this._select(opt)}
+                    @mouseenter=${() => (this._active = i)}
+                  >
+                    <span class="option-label">${opt.label}</span>
+                  </div>`
+              )}
+            </div>`
+          : nothing}
+      </wa-popup>
+    `;
+  }
+
+  private get _filtered(): ComboboxOption[] {
+    if (!this._dirty) return this.options;
+    const q = this._query.trim().toLowerCase();
+    if (!q) return this.options;
+    return this.options.filter(
+      (o) => o.value.toLowerCase().includes(q) || o.label.toLowerCase().includes(q)
+    );
+  }
+
+  private _open_ = () => {
+    if (this.disabled || this._open) return;
+    this._open = true;
+    this._query = this.value;
+    this._dirty = false;
+    this._active = -1;
+  };
+
+  private _close = () => {
+    this._open = false;
+    this._active = -1;
+  };
+
+  private _toggle = () => {
+    if (this.disabled) return;
+    if (this._open) {
+      this._close();
+    } else {
+      this._open_();
+      this._input?.focus();
+    }
+  };
+
+  /** Keep focus on the input so a click on the chevron / an option doesn't
+   *  blur-close the popup before the click registers. */
+  private _preventBlur = (e: Event) => e.preventDefault();
+
+  private _onInput = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value;
+    this._query = value;
+    this._dirty = true;
+    this._open = true;
+    this._active = -1;
+    this._emit(value);
+  };
+
+  private _onKeyDown = (e: KeyboardEvent) => {
+    const filtered = this._filtered;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (!this._open) this._open_();
+        if (filtered.length) {
+          this._active = this._active >= filtered.length - 1 ? 0 : this._active + 1;
+          this._scrollActiveIntoView();
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (!this._open) this._open_();
+        if (filtered.length) {
+          this._active = this._active <= 0 ? filtered.length - 1 : this._active - 1;
+          this._scrollActiveIntoView();
+        }
+        break;
+      case "Enter":
+        if (this._open && this._active >= 0 && filtered[this._active]) {
+          e.preventDefault();
+          this._select(filtered[this._active]);
+        } else {
+          this._close();
+        }
+        break;
+      case "Escape":
+        if (this._open) {
+          // Don't let Escape bubble to a parent dialog's dismiss handler.
+          e.preventDefault();
+          e.stopPropagation();
+          this._query = this.value;
+          this._close();
+        }
+        break;
+      case "Tab":
+        this._close();
+        break;
+    }
+  };
+
+  private _select(opt: ComboboxOption): void {
+    // The input keeps focus on its own (option rows preventDefault the
+    // blur), so no refocus here — refocusing would re-fire ``@focus`` and
+    // reopen the popup we're closing.
+    this.value = opt.value;
+    this._query = opt.value;
+    this._emit(opt.value);
+    this._close();
+  }
+
+  private _emit(value: string): void {
+    this.dispatchEvent(
+      new CustomEvent<ComboboxValueChangedDetail>("value-changed", {
+        detail: { value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _scrollActiveIntoView(): void {
+    requestAnimationFrame(() => {
+      this.shadowRoot
+        ?.querySelector(".option--active")
+        ?.scrollIntoView({ block: "nearest" });
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-options-combobox": ESPHomeOptionsCombobox;
+  }
+}

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -11,10 +11,11 @@
  * on every keystroke and on option select.
  */
 import { mdiChevronDown } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { optionsComboboxStyles } from "./options-combobox.styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/popup/popup.js";
@@ -70,75 +71,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
   @query("input")
   private _input?: HTMLInputElement;
 
-  static styles = [
-    inputStyles,
-    css`
-      :host {
-        display: block;
-      }
-
-      .control {
-        position: relative;
-        display: block;
-      }
-
-      /* Leave room for the chevron sitting over the input's right edge. */
-      input {
-        padding-right: 34px;
-      }
-
-      .chevron {
-        position: absolute;
-        top: 0;
-        right: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-        width: 32px;
-        padding: 0;
-        background: transparent;
-        border: 0;
-        color: var(--wa-color-text-quiet);
-        font-size: 18px;
-        cursor: pointer;
-      }
-
-      .chevron:disabled {
-        cursor: not-allowed;
-        opacity: 0.5;
-      }
-
-      .listbox {
-        max-height: 280px;
-        overflow-y: auto;
-        background: var(--wa-color-surface-raised);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        border-radius: var(--wa-border-radius-m);
-        box-shadow: var(--wa-shadow-m);
-        padding: var(--wa-space-2xs);
-      }
-
-      .option {
-        padding: var(--wa-space-2xs) var(--wa-space-s);
-        border-radius: var(--wa-border-radius-s);
-        font-size: var(--wa-font-size-s);
-        color: var(--wa-color-text-normal);
-        cursor: pointer;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .option--active {
-        background: var(--esphome-tint, var(--wa-color-surface-border));
-      }
-
-      .option-label {
-        display: block;
-      }
-    `,
-  ];
+  static styles = [inputStyles, optionsComboboxStyles];
 
   protected render() {
     const filtered = this._filtered;

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -168,6 +168,10 @@ export class ESPHomeOptionsCombobox extends LitElement {
   private _close = () => {
     this._open = false;
     this._active = -1;
+    // Clear the edit flag too: a close that left it set (Escape / blur after
+    // typing) would make the next keystroke filter against the stale query
+    // before the reopen resets it. _open_ sets it false on every open anyway.
+    this._dirty = false;
   };
 
   private _toggle = () => {

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -15,6 +15,7 @@ import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { inputStyles } from "../styles/inputs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { buildOptionsComboboxChangeEvent } from "./options-combobox-event.js";
 import { optionsComboboxStyles } from "./options-combobox.styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -24,11 +25,6 @@ registerMdiIcons({ "chevron-down": mdiChevronDown });
 
 export interface ComboboxOption {
   label: string;
-  value: string;
-}
-
-/** Detail for the ``value-changed`` event. */
-export interface ComboboxValueChangedDetail {
   value: string;
 }
 
@@ -92,6 +88,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
             class=${this.invalid ? "invalid" : ""}
             role="combobox"
             aria-autocomplete="list"
+            aria-invalid=${this.invalid ? "true" : nothing}
             aria-expanded=${expanded ? "true" : "false"}
             aria-controls=${expanded ? "listbox" : nothing}
             aria-activedescendant=${this._active >= 0
@@ -121,7 +118,12 @@ export class ESPHomeOptionsCombobox extends LitElement {
           </button>
         </div>
         ${expanded
-          ? html`<div id="listbox" class="listbox" role="listbox">
+          ? html`<div
+              id="listbox"
+              class="listbox"
+              role="listbox"
+              @mousedown=${this._preventBlur}
+            >
               ${filtered.map(
                 (opt, i) =>
                   html`<div
@@ -246,13 +248,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
   }
 
   private _emit(value: string): void {
-    this.dispatchEvent(
-      new CustomEvent<ComboboxValueChangedDetail>("value-changed", {
-        detail: { value },
-        bubbles: true,
-        composed: true,
-      })
-    );
+    this.dispatchEvent(buildOptionsComboboxChangeEvent(value));
   }
 
   private _scrollActiveIntoView(): void {

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -68,6 +68,11 @@ export class ESPHomeOptionsCombobox extends LitElement {
   /** Keyboard-active option index into the filtered list, or -1. */
   @state() private _active = -1;
 
+  /** Committed value snapshotted when the dropdown opened, so Escape can
+   *  restore it even after per-keystroke ``value-changed`` has driven the
+   *  host to update ``value``. */
+  private _committed = "";
+
   @query("input")
   private _input?: HTMLInputElement;
 
@@ -76,21 +81,19 @@ export class ESPHomeOptionsCombobox extends LitElement {
   protected render() {
     const filtered = this._filtered;
     const display = this._open ? this._query : this.value;
+    // Reflects whether the listbox is actually shown — the popup only
+    // activates with matches, so ARIA must track the same condition.
+    const expanded = this._open && filtered.length > 0;
     return html`
-      <wa-popup
-        placement="bottom-start"
-        sync="width"
-        distance="4"
-        ?active=${this._open && filtered.length > 0}
-      >
+      <wa-popup placement="bottom-start" sync="width" distance="4" ?active=${expanded}>
         <div slot="anchor" class="control">
           <input
             type="text"
             class=${this.invalid ? "invalid" : ""}
             role="combobox"
             aria-autocomplete="list"
-            aria-expanded=${this._open ? "true" : "false"}
-            aria-controls="listbox"
+            aria-expanded=${expanded ? "true" : "false"}
+            aria-controls=${expanded ? "listbox" : nothing}
             aria-activedescendant=${this._active >= 0
               ? `option-${this._active}`
               : nothing}
@@ -117,7 +120,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
             <wa-icon library="mdi" name="chevron-down"></wa-icon>
           </button>
         </div>
-        ${this._open
+        ${expanded
           ? html`<div id="listbox" class="listbox" role="listbox">
               ${filtered.map(
                 (opt, i) =>
@@ -151,6 +154,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
   private _open_ = () => {
     if (this.disabled || this._open) return;
     this._open = true;
+    this._committed = this.value;
     this._query = this.value;
     this._dirty = false;
     this._active = -1;
@@ -216,7 +220,12 @@ export class ESPHomeOptionsCombobox extends LitElement {
           // Don't let Escape bubble to a parent dialog's dismiss handler.
           e.preventDefault();
           e.stopPropagation();
-          this._query = this.value;
+          // Restore the value the field held when it opened and emit it, so
+          // a host that committed each keystroke reverts too (Escape cancels
+          // the edit, not just the local text).
+          this.value = this._committed;
+          this._query = this._committed;
+          this._emit(this._committed);
           this._close();
         }
         break;

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -83,6 +83,12 @@ export class ESPHomeOptionsCombobox extends LitElement {
     // Reflects whether the listbox is actually shown — the popup only
     // activates with matches, so ARIA must track the same condition.
     const expanded = this._open && filtered.length > 0;
+    // Only point aria-activedescendant at a row that's actually rendered —
+    // never when collapsed, never out of the (possibly newly-filtered) range.
+    const activeId =
+      expanded && this._active >= 0 && this._active < filtered.length
+        ? `option-${this._active}`
+        : nothing;
     return html`
       <wa-popup placement="bottom-start" sync="width" distance="4" ?active=${expanded}>
         <div slot="anchor" class="control">
@@ -94,9 +100,7 @@ export class ESPHomeOptionsCombobox extends LitElement {
             aria-invalid=${this.invalid ? "true" : nothing}
             aria-expanded=${expanded ? "true" : "false"}
             aria-controls=${expanded ? "listbox" : nothing}
-            aria-activedescendant=${this._active >= 0
-              ? `option-${this._active}`
-              : nothing}
+            aria-activedescendant=${activeId}
             aria-label=${this.label || nothing}
             .value=${display}
             placeholder=${this.placeholder}

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -180,6 +180,25 @@ describe("esphome-options-combobox", () => {
     expect(input(el).getAttribute("aria-invalid")).toBe("true");
   });
 
+  test("aria-activedescendant never points past the rendered options", async () => {
+    const el = await mount("bw15");
+    await open(el);
+    const field = input(el);
+    field.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+    );
+    field.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+    );
+    await el.updateComplete;
+    expect(field.getAttribute("aria-activedescendant")).toBe("option-1");
+    // Options shrink under the still-open list; the now-stale index must not
+    // leak a reference to a non-existent row.
+    el.options = [{ label: "afw121t", value: "afw121t" }];
+    await el.updateComplete;
+    expect(field.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
   test("mousedown inside the listbox doesn't blur the input", async () => {
     const el = await mount("bw15");
     await open(el);

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -148,6 +148,26 @@ describe("esphome-options-combobox", () => {
     );
   });
 
+  test("ArrowDown right after Escape activates the first option on one press", async () => {
+    // Custom committed value matches no option, so a leftover _dirty would
+    // make the post-Escape ArrowDown filter to an empty list and select nothing.
+    const el = await mount("cr3l");
+    await open(el);
+    const field = input(el);
+    field.value = "zz";
+    field.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    field.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await el.updateComplete;
+    field.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+    );
+    await el.updateComplete;
+    const opts = options(el);
+    expect(opts).toHaveLength(OPTIONS.length);
+    expect(opts[0].classList.contains("option--active")).toBe(true);
+  });
+
   test("the change event is namespaced (no generic value-changed)", () => {
     expect(OPTIONS_COMBOBOX_CHANGE_EVENT).toBe("options-combobox-change");
   });

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-// happy-dom can't host webawesome's custom elements; we only assert the
-// component's own light-DOM markup (input + option rows).
+// happy-dom can't host webawesome's custom elements; we assert the
+// component's own shadow-DOM markup (input + option rows).
 vi.mock("@home-assistant/webawesome/dist/components/popup/popup.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
@@ -115,6 +115,24 @@ describe("esphome-options-combobox", () => {
     field.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     await el.updateComplete;
     expect(options(el)).toHaveLength(0);
+    expect(input(el).value).toBe("bw15");
+  });
+
+  test("Escape cancels the edit even when the host commits each keystroke", async () => {
+    const el = await mount("bw15");
+    // Mirror renderSelectField: every value-changed is committed back to value.
+    el.addEventListener("value-changed", (e) => {
+      el.value = (e as CustomEvent).detail.value;
+    });
+    await open(el);
+    const field = input(el);
+    field.value = "zz";
+    field.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    expect(el.value).toBe("zz"); // host committed the typed text
+    field.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await el.updateComplete;
+    expect(el.value).toBe("bw15"); // Escape restored & re-emitted the pre-edit value
     expect(input(el).value).toBe("bw15");
   });
 

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -9,6 +9,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
   registerIconLibrary: () => {},
 }));
 
+import { OPTIONS_COMBOBOX_CHANGE_EVENT } from "../../src/components/options-combobox-event.js";
 import { ESPHomeOptionsCombobox } from "../../src/components/options-combobox.js";
 
 const OPTIONS = [
@@ -35,10 +36,12 @@ function options(el: ESPHomeOptionsCombobox): HTMLElement[] {
   return [...el.shadowRoot!.querySelectorAll<HTMLElement>(".option")];
 }
 
-/** Collect every value-changed detail the element emits. */
+/** Collect every change-event detail the element emits. */
 function track(el: ESPHomeOptionsCombobox): string[] {
   const seen: string[] = [];
-  el.addEventListener("value-changed", (e) => seen.push((e as CustomEvent).detail.value));
+  el.addEventListener(OPTIONS_COMBOBOX_CHANGE_EVENT, (e) =>
+    seen.push((e as CustomEvent).detail.value)
+  );
   return seen;
 }
 
@@ -120,8 +123,8 @@ describe("esphome-options-combobox", () => {
 
   test("Escape cancels the edit even when the host commits each keystroke", async () => {
     const el = await mount("bw15");
-    // Mirror renderSelectField: every value-changed is committed back to value.
-    el.addEventListener("value-changed", (e) => {
+    // Mirror renderSelectField: every change is committed back to value.
+    el.addEventListener(OPTIONS_COMBOBOX_CHANGE_EVENT, (e) => {
       el.value = (e as CustomEvent).detail.value;
     });
     await open(el);
@@ -143,5 +146,26 @@ describe("esphome-options-combobox", () => {
     expect(options(el).map((o) => o.textContent?.trim())).toEqual(
       OPTIONS.map((o) => o.label)
     );
+  });
+
+  test("the change event is namespaced (no generic value-changed)", () => {
+    expect(OPTIONS_COMBOBOX_CHANGE_EVENT).toBe("options-combobox-change");
+  });
+
+  test("invalid is exposed to assistive tech via aria-invalid", async () => {
+    const el = await mount("bw15");
+    expect(input(el).getAttribute("aria-invalid")).toBeNull();
+    el.invalid = true;
+    await el.updateComplete;
+    expect(input(el).getAttribute("aria-invalid")).toBe("true");
+  });
+
+  test("mousedown inside the listbox doesn't blur the input", async () => {
+    const el = await mount("bw15");
+    await open(el);
+    const listbox = el.shadowRoot!.querySelector("#listbox")!;
+    const ev = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    listbox.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true); // keeps focus so the popup stays open
   });
 });

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// happy-dom can't host webawesome's custom elements; we only assert the
+// component's own light-DOM markup (input + option rows).
+vi.mock("@home-assistant/webawesome/dist/components/popup/popup.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
+  registerIconLibrary: () => {},
+}));
+
+import { ESPHomeOptionsCombobox } from "../../src/components/options-combobox.js";
+
+const OPTIONS = [
+  { label: "afw121t", value: "afw121t" },
+  { label: "bw12", value: "bw12" },
+  { label: "bw15", value: "bw15" },
+  { label: "rtl8710bn", value: "rtl8710bn" },
+];
+
+async function mount(value = "bw15") {
+  const el = new ESPHomeOptionsCombobox();
+  el.options = OPTIONS;
+  el.value = value;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function input(el: ESPHomeOptionsCombobox): HTMLInputElement {
+  return el.shadowRoot!.querySelector("input")!;
+}
+
+function options(el: ESPHomeOptionsCombobox): HTMLElement[] {
+  return [...el.shadowRoot!.querySelectorAll<HTMLElement>(".option")];
+}
+
+/** Collect every value-changed detail the element emits. */
+function track(el: ESPHomeOptionsCombobox): string[] {
+  const seen: string[] = [];
+  el.addEventListener("value-changed", (e) => seen.push((e as CustomEvent).detail.value));
+  return seen;
+}
+
+async function open(el: ESPHomeOptionsCombobox) {
+  input(el).dispatchEvent(new FocusEvent("focus"));
+  await el.updateComplete;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("esphome-options-combobox", () => {
+  test("closed field shows the committed value and no list", async () => {
+    const el = await mount("bw15");
+    expect(input(el).value).toBe("bw15");
+    expect(options(el)).toHaveLength(0);
+  });
+
+  test("opening shows the full option list regardless of current value", async () => {
+    const el = await mount("bw15");
+    await open(el);
+    expect(options(el).map((o) => o.textContent?.trim())).toEqual(
+      OPTIONS.map((o) => o.label)
+    );
+  });
+
+  test("typing filters to substring matches and emits the typed value", async () => {
+    const el = await mount("bw15");
+    const seen = track(el);
+    await open(el);
+    const field = input(el);
+    field.value = "bw1";
+    field.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    expect(options(el).map((o) => o.textContent?.trim())).toEqual(["bw12", "bw15"]);
+    expect(seen[seen.length - 1]).toBe("bw1");
+  });
+
+  test("clicking an option emits its value and updates the field", async () => {
+    const el = await mount("bw15");
+    const seen = track(el);
+    await open(el);
+    options(el)[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await el.updateComplete;
+    expect(seen[seen.length - 1]).toBe("afw121t");
+    expect(el.value).toBe("afw121t");
+    expect(input(el).value).toBe("afw121t");
+    expect(options(el)).toHaveLength(0); // closed after select
+  });
+
+  test("ArrowDown then Enter selects the active option", async () => {
+    const el = await mount("bw15");
+    const seen = track(el);
+    await open(el);
+    const field = input(el);
+    field.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+    );
+    await el.updateComplete;
+    field.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+    expect(seen[seen.length - 1]).toBe("afw121t");
+    expect(el.value).toBe("afw121t");
+  });
+
+  test("Escape reverts the query and closes", async () => {
+    const el = await mount("bw15");
+    await open(el);
+    const field = input(el);
+    field.value = "zzz";
+    field.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+    field.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await el.updateComplete;
+    expect(options(el)).toHaveLength(0);
+    expect(input(el).value).toBe("bw15");
+  });
+
+  test("a custom value not in the list is kept and the list stays full on reopen", async () => {
+    const el = await mount("cr3l"); // host already committed a free-text board
+    expect(input(el).value).toBe("cr3l");
+    await open(el);
+    expect(options(el).map((o) => o.textContent?.trim())).toEqual(
+      OPTIONS.map((o) => o.label)
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds a reusable `<esphome-options-combobox>` component; a dropdown of options that shows the full list on open, filters as you type, and accepts arbitrary typed values, pre-filled with the current value. It fills the gap left by the native `<input list=datalist>`, which filters its suggestions by the text already in the field, so a pre-filled field can't browse the full list; `<wa-combobox>` is not available in HA's webawesome fork.

It is built on `wa-popup` (pure positioning, so the text input keeps focus) and emits `options-combobox-change` on every keystroke and on option select. This PR is the standalone primitive, wired to nothing yet; a follow-up swaps `renderSelectField`'s native datalist over to it, which lights it up for `board` and `unit_of_measurement`.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

