### PR TITLE
Surface a select field's schema default in the box and menu

### DIFF
--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -461,8 +461,9 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   // still flags as selected.
   const valueLower = value.toLowerCase();
   const defaultStr = entry.default_value != null ? String(entry.default_value) : "";
+  const defaultLower = defaultStr.toLowerCase();
   const defaultOption = entry.options?.find(
-    (o) => o.value.toLowerCase() === defaultStr.toLowerCase()
+    (o) => o.value.toLowerCase() === defaultLower
   );
   const placeholder = defaultOption?.label ?? defaultStr;
   const { clearable, visibleOptions } = selectOptions(entry);
@@ -480,14 +481,31 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ${clearable
           ? html`<wa-icon slot="clear-icon" library="mdi" name="close"></wa-icon>`
           : nothing}
-        ${visibleOptions.map(
-          (opt) =>
-            html`<wa-option
-              value=${opt.value}
-              ?selected=${opt.value.toLowerCase() === valueLower}
+        ${visibleOptions.map((opt) => {
+          const selected = opt.value.toLowerCase() === valueLower;
+          const isDefault = defaultStr !== "" && opt.value.toLowerCase() === defaultLower;
+          if (!isDefault) {
+            return html`<wa-option value=${opt.value} ?selected=${selected}
               >${opt.label}</wa-option
-            >`
-        )}
+            >`;
+          }
+          // wa-select activates the first option when nothing is committed,
+          // so give the default a muted second line (like the pin menu's
+          // notes) — the honest "this applies if you leave it" signal.
+          // `.label` keeps the closed control showing just the label.
+          return html`<wa-option
+            value=${opt.value}
+            .label=${opt.label}
+            ?selected=${selected}
+          >
+            <span class="option-default-stack">
+              <span>${opt.label}</span>
+              <small class="option-default-note"
+                >${ctx.localize("device.default_option_tag")}</small
+              >
+            </span>
+          </wa-option>`;
+        })}
       </wa-select>
       ${renderFieldError(path, ctx)}
     </div>

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -122,6 +122,22 @@ export const inputStyles = css`
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--esphome-error), transparent 80%);
   }
 
+  /* Default option in a select menu: a label with a quiet second line, so
+     the default stays identifiable even though wa-select activates the
+     first option when nothing is committed. Mirrors the pin menu's notes. */
+  .option-default-stack {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 1px;
+    line-height: 1.25;
+  }
+
+  .option-default-note {
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+    font-style: italic;
+  }
+
   wa-select::part(listbox) {
     padding-block: 0;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -655,6 +655,7 @@
     "password_reveal": "Show password",
     "password_hide": "Hide password",
     "value_from_secret": "Using stored secret:",
+    "default_option_tag": "default",
     "substitution_resolves_to": "Resolved substitution value",
     "substitution_unresolved": "Not defined in this file",
     "substitution_unresolved_hint": "Substitutions from packages, included files, or the command line aren't previewed here; they're still resolved when the device is built.",

--- a/test/components/device/config-entry-select-default.test.ts
+++ b/test/components/device/config-entry-select-default.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+// The discriminator the backend ships for a typed_schema (spi `type`) is
+// optional with a default. An unset select shows the default's label as a
+// muted placeholder and tags the default option in the menu, since
+// wa-select activates the first option when nothing is committed.
+const OPTIONS: ConfigValueOption[] = [
+  { value: "single", label: "single" },
+  { value: "quad", label: "quad" },
+  { value: "octal", label: "octal" },
+];
+
+const serialize = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+function renderFor(value: string | undefined, overrides: Record<string, unknown> = {}) {
+  const entry = makeEntry(ConfigEntryType.SELECT, {
+    options: OPTIONS,
+    default_value: "single",
+    ...overrides,
+  });
+  const values = value === undefined ? {} : { type: value };
+  return renderSelectField(entry, ["type"], makeRenderCtx(values));
+}
+
+function selectPlaceholder(tpl: unknown): unknown {
+  return findElementBindings(tpl, "wa-select")[0]?.placeholder;
+}
+
+describe("renderSelectField — default in the menu", () => {
+  it("shows the default's label as the placeholder when unset", () => {
+    expect(selectPlaceholder(renderFor(undefined))).toBe("single");
+  });
+
+  it("gives the default option a muted second line so it stays identifiable", () => {
+    const json = serialize(renderFor(undefined));
+    expect(json).toContain("option-default-note");
+    expect(json).toContain("device.default_option_tag");
+  });
+
+  it("marks only the default option, not the others", () => {
+    const json = serialize(renderFor(undefined));
+    expect(json.match(/option-default-note/g) ?? []).toHaveLength(1);
+  });
+
+  it("does not mark anything when the schema has no default", () => {
+    expect(serialize(renderFor(undefined, { default_value: null }))).not.toContain(
+      "option-default-note"
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A select in the structured editor rendered blank when its field was
omitted from YAML, even when the schema carried a default — and opening
the menu activated the *first* option (wa-select's default behavior with
no committed value) rather than the actual default. So the field looked
unset and the wrong option looked selected (the `spi` `type` discriminator
was the reported case: it defaults to `single`).

This surfaces the default in two places:

- **In the box:** the default's label shows as a muted placeholder. Muted
  reads as "this is the default"; a solid value means an explicit pick —
  that contrast is the default-vs-selected signal, so no separate hint
  line is needed.
- **In the menu:** the default option gets a quiet "default" second line
  (same shape as the pin menu's notes), so it stays identifiable even
  though wa-select still keyboard-activates the first option.

Pairs with the backend recovering `cv.typed_schema` discriminator
defaults (esphome/device-builder#1437), so `spi` `type` shows a muted
`single`. Also helps every ordinary `cv.Optional(default=...)` enum that
already carries a default (e.g. `sensor.aht10`'s `variant`).

**Related issue or feature (if applicable):**

- Companion to esphome/device-builder#1437

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
