### PR TITLE
Style the Build remotely and View build buttons in the pairing row

### DIFF
--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -108,11 +108,14 @@ export const pairingRowStyles = css`
   }
 
   /* Shared chrome for the section's secondary action buttons: the
-     pairing row's icon-only squares and the alert's text Unpair
-     (.offloader-alert-unpair markup lives in build-offload-alert.ts;
-     its chrome stays here with its siblings). */
+     pairing row's icon-only squares, its Build-remote / View-build
+     text actions, and the alert's text Unpair (.offloader-alert-unpair
+     markup lives in build-offload-alert.ts; its chrome stays here with
+     its siblings). */
   .btn-unpair,
   .btn-edit-endpoint,
+  .btn-build-remote,
+  .btn-view-remote-build,
   .offloader-alert-unpair {
     height: 32px;
     display: inline-flex;
@@ -144,14 +147,19 @@ export const pairingRowStyles = css`
     border-color: var(--esphome-error);
   }
 
-  .btn-edit-endpoint:hover {
+  .btn-edit-endpoint:hover,
+  .btn-build-remote:hover,
+  .btn-view-remote-build:hover {
     background: color-mix(in srgb, var(--esphome-primary), white 90%);
     color: var(--esphome-primary);
     border-color: var(--esphome-primary);
   }
 
-  /* Text variant — the alert spells the action out next to the
-     Re-pair pill, so it gets padding and the pill's radius. */
+  /* Text variant — the pairing row's Build-remote / View-build actions
+     and the alert's spelled-out Unpair (next to the Re-pair pill) get
+     padding and the pill's radius instead of the icon-square shape. */
+  .btn-build-remote,
+  .btn-view-remote-build,
   .offloader-alert-unpair {
     padding: 0 12px;
     border-radius: var(--wa-border-radius-m);
@@ -160,6 +168,8 @@ export const pairingRowStyles = css`
     font-weight: var(--wa-font-weight-semibold);
   }
 
+  .btn-build-remote:focus-visible,
+  .btn-view-remote-build:focus-visible,
   .offloader-alert-unpair:focus-visible {
     outline: none;
     box-shadow: var(--esphome-focus-ring);

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -168,6 +168,8 @@ export const pairingRowStyles = css`
     font-weight: var(--wa-font-weight-semibold);
   }
 
+  .btn-unpair:focus-visible,
+  .btn-edit-endpoint:focus-visible,
   .btn-build-remote:focus-visible,
   .btn-view-remote-build:focus-visible,
   .offloader-alert-unpair:focus-visible {


### PR DESCRIPTION
# What does this implement/fix?

The Build remotely and View build buttons in the paired build server row rendered with the plain browser default; their classes `btn-build-remote` and `btn-view-remote-build` had no rules in `offload-styles.ts`. This joins them to the existing secondary button selectors so they match the edit and delete buttons in the same row, with a primary tint on hover and the shared focus ring; CSS only, no markup change.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
