### PR TITLE
Reveal control characters in single-line string fields

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -32,6 +32,10 @@ import {
   hasSubstitutionReference,
   resolveSubstitutions,
 } from "../../util/substitutions.js";
+import {
+  escapeControlForInput,
+  unescapeControlForInput,
+} from "../../util/yaml-escape.js";
 import { configEntryFormExtraStyles } from "./config-entry-form-extra.styles.js";
 import { configEntryFormStyles } from "./config-entry-form.styles.js";
 import { filterRenderable, renderFilterOptions } from "./config-entry-render-filter.js";
@@ -465,13 +469,17 @@ export function renderStringField(
       </div>
     `;
   }
+  // A single-line input can't show control characters, so reveal them as
+  // ``\r`` / ``\n`` / ``\t`` and decode on edit; a CRLF in a uart.write
+  // payload stays visible and round-trips instead of silently vanishing.
   const textInput = html`<input
     type=${inputType}
     class=${invalid ? "invalid" : ""}
-    .value=${value}
+    .value=${escapeControlForInput(value)}
     ?disabled=${disabled}
     placeholder=${placeholder}
-    @input=${(e: Event) => ctx.emitChange(path, (e.target as HTMLInputElement).value)}
+    @input=${(e: Event) =>
+      ctx.emitChange(path, unescapeControlForInput((e.target as HTMLInputElement).value))}
   />`;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -34,6 +34,7 @@ import {
 } from "../../util/substitutions.js";
 import {
   escapeControlForInput,
+  hasEscapeWorthyChar,
   unescapeControlForInput,
 } from "../../util/yaml-escape.js";
 import { configEntryFormExtraStyles } from "./config-entry-form-extra.styles.js";
@@ -469,17 +470,23 @@ export function renderStringField(
       </div>
     `;
   }
-  // A single-line input can't show control characters, so reveal them as
-  // ``\r`` / ``\n`` / ``\t`` and decode on edit; a CRLF in a uart.write
-  // payload stays visible and round-trips instead of silently vanishing.
+  // A single-line input can't show control characters. Only when the
+  // stored value actually contains one (a CRLF in a uart.write payload, an
+  // invisible glyph) do we reveal them as ``\r`` / ``\n`` / ``\xNN`` and
+  // decode on edit; an ordinary string renders verbatim so a typed path
+  // like ``C:\temp`` is never rewritten into control bytes. Display and
+  // decode stay coupled on this one flag.
+  const escapeMode = hasEscapeWorthyChar(value);
   const textInput = html`<input
     type=${inputType}
     class=${invalid ? "invalid" : ""}
-    .value=${escapeControlForInput(value)}
+    .value=${escapeMode ? escapeControlForInput(value) : value}
     ?disabled=${disabled}
     placeholder=${placeholder}
-    @input=${(e: Event) =>
-      ctx.emitChange(path, unescapeControlForInput((e.target as HTMLInputElement).value))}
+    @input=${(e: Event) => {
+      const raw = (e.target as HTMLInputElement).value;
+      ctx.emitChange(path, escapeMode ? unescapeControlForInput(raw) : raw);
+    }}
   />`;
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>

--- a/src/util/yaml-escape.ts
+++ b/src/util/yaml-escape.ts
@@ -6,7 +6,7 @@
  * ``Café`` survives unchanged. The escape *format* follows PyYAML's
  * emitter (uppercase hex; ``\x`` / ``\u`` / ``\U`` chosen by width).
  *
- * Two layers share the predicate below:
+ * Three layers share the predicate below:
  *   - ``escapeYamlDoubleQuoted`` / ``unescapeYamlDoubleQuoted`` model a
  *     YAML double-quoted *scalar* — the short escapes the serializer emits
  *     (``\\`` ``\"`` ``\n`` ``\r`` ``\t``) plus numeric escapes; used by
@@ -16,6 +16,10 @@
  *     form inputs: only numeric (``\x`` / ``\u`` / ``\U``) escapes and the
  *     backslash, so editing a non-glyph multi_value field never rewrites
  *     a literal ``\t`` / quote / path the user typed.
+ *   - ``escapeControlForInput`` / ``unescapeControlForInput`` are the
+ *     single-line text-field pair: the ``\n`` ``\r`` ``\t`` short forms
+ *     (so a uart.write CRLF reads as ``\r\n``) plus numeric escapes, but
+ *     no quote escaping.
  */
 
 /** True for control / Private-Use code points that are written as escapes. */
@@ -79,6 +83,20 @@ const BACKSLASH_ONLY_UNESCAPE: Record<string, string> = { "\\": "\\" };
 const YAML_SHORT_UNESCAPE: Record<string, string> = {
   "\\": "\\",
   '"': '"',
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
+
+// Short escapes for a free-text form input: the control forms, but not
+// the quote (a literal ``"`` is visible and stays raw in a text field).
+const CONTROL_SHORT_ESCAPE: Record<string, string> = {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+};
+const CONTROL_SHORT_UNESCAPE: Record<string, string> = {
+  "\\": "\\",
   n: "\n",
   r: "\r",
   t: "\t",
@@ -157,4 +175,20 @@ export function escapeForInput(s: string): string {
  */
 export function unescapeForInput(s: string): string {
   return unescapeBody(s, BACKSLASH_ONLY_UNESCAPE);
+}
+
+/**
+ * Show a stored value in a single-line text field: render ``\r`` ``\n``
+ * ``\t`` as the readable short forms (so a ``uart.write`` payload with a
+ * trailing CRLF is visible and editable) and other escape-worthy code
+ * points numerically. Leaves quotes raw; pair with
+ * :func:`unescapeControlForInput`.
+ */
+export function escapeControlForInput(s: string): string {
+  return escapeBody(s, CONTROL_SHORT_ESCAPE);
+}
+
+/** Inverse of :func:`escapeControlForInput`. */
+export function unescapeControlForInput(s: string): string {
+  return unescapeBody(s, CONTROL_SHORT_UNESCAPE);
 }

--- a/test/components/device/render-string-field-control-chars.test.ts
+++ b/test/components/device/render-string-field-control-chars.test.ts
@@ -32,11 +32,24 @@ describe("renderStringField — control characters", () => {
   });
 
   it("decodes the escaped edit back to literal control characters", () => {
-    const { ctx, emitChange } = ctxFor("");
+    // Escape mode is keyed on the stored value, so seed one with a control char.
+    const { ctx, emitChange } = ctxFor("saveConfig\r\n");
     const tpl = renderStringField(makeEntry(), "text", ["data"], ctx);
     const [input] = findElementBindings(tpl, "input");
     const onInput = input["@input"] as (e: Event) => void;
     onInput({ target: { value: "saveConfig\\r\\n" } } as unknown as Event);
     expect(emitChange).toHaveBeenCalledWith(["data"], "saveConfig\r\n");
+  });
+
+  it("leaves an ordinary value verbatim and never rewrites a typed path", () => {
+    // No control char stored → no escape mode, so a literal ``C:\temp`` is
+    // shown as-is and a typed ``\t`` / ``\n`` is not decoded to a control byte.
+    const { ctx, emitChange } = ctxFor("C:\\temp");
+    const tpl = renderStringField(makeEntry(), "text", ["data"], ctx);
+    const [input] = findElementBindings(tpl, "input");
+    expect(input[".value"]).toBe("C:\\temp");
+    const onInput = input["@input"] as (e: Event) => void;
+    onInput({ target: { value: "C:\\new" } } as unknown as Event);
+    expect(emitChange).toHaveBeenCalledWith(["data"], "C:\\new");
   });
 });

--- a/test/components/device/render-string-field-control-chars.test.ts
+++ b/test/components/device/render-string-field-control-chars.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Pins that ``renderStringField`` reveals control characters in a
+ * single-line input as ``\r`` / ``\n`` (a uart.write CRLF payload stays
+ * visible) and decodes the escaped form back on edit.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findElementBindings, makeRenderCtx } from "./_renderer-fixtures.js";
+
+function makeEntry(): ConfigEntry {
+  return makeConfigEntry({ key: "data", type: ConfigEntryType.STRING, label: "Data" });
+}
+
+function ctxFor(value: string): { ctx: RenderCtx; emitChange: ReturnType<typeof vi.fn> } {
+  const emitChange = vi.fn();
+  const ctx = makeRenderCtx({ data: value }, { board: null, overrides: { emitChange } });
+  return { ctx, emitChange };
+}
+
+describe("renderStringField — control characters", () => {
+  it("reveals a CRLF payload as \\r\\n in the single-line input", () => {
+    const { ctx } = ctxFor("saveConfig\r\n");
+    const tpl = renderStringField(makeEntry(), "text", ["data"], ctx);
+    const [input] = findElementBindings(tpl, "input");
+    expect(input[".value"]).toBe("saveConfig\\r\\n");
+  });
+
+  it("decodes the escaped edit back to literal control characters", () => {
+    const { ctx, emitChange } = ctxFor("");
+    const tpl = renderStringField(makeEntry(), "text", ["data"], ctx);
+    const [input] = findElementBindings(tpl, "input");
+    const onInput = input["@input"] as (e: Event) => void;
+    onInput({ target: { value: "saveConfig\\r\\n" } } as unknown as Event);
+    expect(emitChange).toHaveBeenCalledWith(["data"], "saveConfig\r\n");
+  });
+});

--- a/test/util/yaml-escape.test.ts
+++ b/test/util/yaml-escape.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  escapeControlForInput,
   escapeForInput,
   escapeYamlDoubleQuoted,
   hasEscapeWorthyChar,
   isEscapeWorthy,
+  unescapeControlForInput,
   unescapeForInput,
   unescapeYamlDoubleQuoted,
 } from "../../src/util/yaml-escape.js";
@@ -97,6 +99,43 @@ describe("escapeForInput / unescapeForInput (form input)", () => {
     // back unchanged rather than decoding ``\x41`` to ``A`` (#647 review).
     for (const s of ["C:\\x41bc", "plain", MDI, "\\Users", "a\\b", "\\U0001"]) {
       expect(unescapeForInput(escapeForInput(s))).toBe(s);
+    }
+  });
+});
+
+describe("escapeControlForInput / unescapeControlForInput (text field)", () => {
+  it("shows CR / LF / tab as readable short forms and decodes them back", () => {
+    expect(escapeControlForInput("saveConfig\r\n")).toBe("saveConfig\\r\\n");
+    expect(unescapeControlForInput("saveConfig\\r\\n")).toBe("saveConfig\r\n");
+    expect(escapeControlForInput("a\tb")).toBe("a\\tb");
+  });
+
+  it("escapes other control bytes (ESC / NUL / DEL) numerically", () => {
+    // A uart.write payload can carry arbitrary escapes; only \r \n \t get
+    // the short form, everything else escape-worthy stays editable as \xNN.
+    expect(escapeControlForInput("setRange\x1B")).toBe("setRange\\x1B");
+    expect(escapeControlForInput("a\x00b")).toBe("a\\x00b");
+    expect(escapeControlForInput("x\x7Fy")).toBe("x\\x7Fy");
+  });
+
+  it("leaves quotes raw and escapes a PUA glyph numerically", () => {
+    expect(escapeControlForInput('a"b')).toBe('a"b');
+    expect(escapeControlForInput(MDI)).toBe("\\U000F058F");
+  });
+
+  it("is invertible, so a no-op edit of escape-like text round-trips", () => {
+    // ``C:\x41bc`` is a literally-typed backslash-x-41, not the byte 0x41;
+    // doubling the backslash on display stops a no-op edit decoding it to A.
+    for (const s of [
+      "saveConfig\r\n",
+      "AT\r\n\x1B[2J",
+      "C:\\x41bc",
+      "a\\nb",
+      'q"q',
+      MDI,
+      "plain",
+    ]) {
+      expect(unescapeControlForInput(escapeControlForInput(s))).toBe(s);
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A `uart.write` data value with a trailing CRLF showed up in the visual editor as just `saveConfig`; the `\r\n` was invisible, because a single-line input cannot display control characters, and a stray edit could silently drop it.

This escapes control characters for display in the string field, the same way the multi_value list editor already does, and decodes them back on input. CR, LF and tab show as `\r` `\n` `\t`; other bytes such as an embedded ESC show as `\xNN`, so any `uart.write` escape sequence stays visible and round-trips losslessly. The backend already delivers the bytes intact, so this is display-only.

**Related issue or feature (if applicable):**

- Reported for the structured editor; no separate tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
