### PR TITLE
Bound a block scalar by indentation so it drops a trailing comment

### DIFF
--- a/src/util/yaml-section-list.ts
+++ b/src/util/yaml-section-list.ts
@@ -12,6 +12,7 @@ import {
   stripQuotes,
 } from "./yaml-scalar.js";
 import {
+  _leadingIndent,
   BLOCK_SCALAR_RE,
   endsBlockAtIndent,
   isBlankOrCommentLine,
@@ -177,4 +178,42 @@ export const _scanValueBlock = (
     }
   }
   return { endIdx: lines.length, isComplex };
+};
+
+/**
+ * Exclusive end index of a block scalar's body (the lines after a
+ * ``key: |-`` / ``!lambda |-`` header), one past the last content line.
+ *
+ * A block scalar terminates on indentation alone, unlike a mapping
+ * value block: the first non-blank line less-indented than the body's
+ * own content indent ends it, *even when it's a comment*. A ``#``
+ * indented at or past the body's content indent is literal scalar text
+ * and stays in the block; a column-0 ``# ...`` before the next
+ * top-level key does not (it would otherwise be swallowed into the
+ * lambda). Trailing blank lines are excluded — they belong to the
+ * inter-section gap that ``updateSectionInYaml`` preserves, so the
+ * round-trip neither drops nor duplicates them; interior blanks between
+ * content lines are kept. The content indent is set by the first
+ * non-blank line; a header with no deeper line (indent <=
+ * *parentIndentLen*) has an empty body.
+ */
+export const _blockScalarBodyEnd = (
+  lines: string[],
+  startIdx: number,
+  parentIndentLen: number
+): number => {
+  let contentIndent = -1;
+  let lastContent = startIdx - 1;
+  for (let i = startIdx; i < lines.length; i++) {
+    if (lines[i].trim() === "") continue;
+    const indent = _leadingIndent(lines[i]).length;
+    if (contentIndent === -1) {
+      if (indent <= parentIndentLen) break;
+      contentIndent = indent;
+    } else if (indent < contentIndent) {
+      break;
+    }
+    lastContent = i;
+  }
+  return lastContent + 1;
 };

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -473,6 +473,7 @@ export function parseSectionCore(
       const endIdx = _blockScalarBodyEnd(lines, i + 1, childIndent.length);
       values[key] = blockScalarValue(blockHeader, raw, lines.slice(i + 1, endIdx));
       recordSpan(key, i, endIdx);
+      // Auto-increment ``for`` loop: resume so the next ``i++`` lands on endIdx.
       i = endIdx - 1;
       continue;
     }
@@ -599,7 +600,10 @@ function parseNestedBlock(
     if (nestedBlockHeader) {
       const endIdx = _blockScalarBodyEnd(lines, i + 1, indent.length);
       values[key] = blockScalarValue(nestedBlockHeader, raw, lines.slice(i + 1, endIdx));
-      i = endIdx - 1;
+      // This is a manual-increment ``while`` loop; ``continue`` skips the
+      // trailing ``i++``, so resume *at* endIdx (not endIdx - 1) or the last
+      // body line gets re-scanned as a nested key.
+      i = endIdx;
       continue;
     }
 

--- a/src/util/yaml-section-reader.ts
+++ b/src/util/yaml-section-reader.ts
@@ -33,6 +33,7 @@ import {
   TOP_LEVEL_KEY_START_RE,
 } from "./yaml-section-lexer.js";
 import {
+  _blockScalarBodyEnd,
   _detectFirstDashIndent,
   _matchFlatMappingField,
   _scanValueBlock,
@@ -219,10 +220,10 @@ const collectBlockListMappings = (
       const blockHeader = parseBlockScalarHeader(headerRaw);
       if (blockHeader) {
         if (!isEditableLambdaBlock(blockHeader)) return null;
-        const { endIdx } = _scanValueBlock(
+        const endIdx = _blockScalarBodyEnd(
           lines,
           at + 1,
-          `${dashIndent}${ESPHOME_YAML_INDENT}`
+          `${dashIndent}${ESPHOME_YAML_INDENT}`.length
         );
         // A sibling sub-key after the lambda body would be lost by the
         // early return; bail to the whole-list YamlRawValue fallback
@@ -469,7 +470,7 @@ export function parseSectionCore(
     // through `YamlRawValue` (header replayed on serialize).
     const blockHeader = parseBlockScalarHeader(raw);
     if (blockHeader) {
-      const { endIdx } = _scanValueBlock(lines, i + 1, childIndent);
+      const endIdx = _blockScalarBodyEnd(lines, i + 1, childIndent.length);
       values[key] = blockScalarValue(blockHeader, raw, lines.slice(i + 1, endIdx));
       recordSpan(key, i, endIdx);
       i = endIdx - 1;
@@ -596,9 +597,9 @@ function parseNestedBlock(
     // `"|-"` / `"!lambda |-"` string.
     const nestedBlockHeader = parseBlockScalarHeader(raw);
     if (nestedBlockHeader) {
-      const { endIdx } = _scanValueBlock(lines, i + 1, indent);
+      const endIdx = _blockScalarBodyEnd(lines, i + 1, indent.length);
       values[key] = blockScalarValue(nestedBlockHeader, raw, lines.slice(i + 1, endIdx));
-      i = endIdx;
+      i = endIdx - 1;
       continue;
     }
 

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -122,15 +122,16 @@ export function updateSectionInYaml(
   const childIndent = _detectSectionChildIndent(lines, start, isListItem);
 
   // The range runs to the next top-level key, swallowing trailing
-  // blank lines and trailing comments the splice would then wipe.
-  // Walk that run back from `end` and stop the splice before it so
-  // those lines survive verbatim. A trailing comment counts as a YAML
-  // comment (preserve) when it's at the section's child indent or
-  // shallower OR shallower than the deepest value line's indent (a block
-  // scalar's body sits deeper than its key, so a comment between the
-  // two is a real comment, not block text). A `#` at or past the body
-  // indent is literal block-scalar text, already inside the field
-  // value, so the walk stops there. (`> start + 1` keeps the header.)
+  // blank lines and trailing comments the splice would then wipe. Stop
+  // the splice before that run so those lines survive verbatim. This
+  // indent heuristic is the fallback for the `globals` path below, which
+  // has no per-key spans; the main per-key path overrides `spliceEnd`
+  // with the parser's exact value end once it has parsed (see below).
+  // A trailing comment counts as a YAML comment (preserve) when it's at
+  // the section's child indent or shallower OR shallower than the deepest
+  // value line's indent (a block scalar's body sits deeper than its key,
+  // so a comment between the two is a real comment, not block text).
+  // (`> start + 1` keeps the header.)
   const bodyIndent = _deepestValueLineIndent(lines, start, end, childIndent.length);
   let runStart = end;
   while (runStart > start + 1) {
@@ -149,7 +150,7 @@ export function updateSectionInYaml(
       break;
     }
   }
-  const spliceEnd = runStart;
+  let spliceEnd = runStart;
 
   // Top-level list-bodied section (globals): re-emit through the
   // mapping serializer's array branch — { sectionKey: array } yields
@@ -178,6 +179,20 @@ export function updateSectionInYaml(
   // Re-parse the original to recover each key's source-line span and
   // on-disk value — the diff below needs both.
   const parsed = parseSectionCore(lines, sectionKey, fromLine);
+
+  // The parser already pinned each value's exact end — block scalars via
+  // `_blockScalarBodyEnd`, so a `#` indented at/past the block content
+  // indent is body and a less-indented one is a trailing comment. The
+  // last value's span end is therefore the real start of the trailing
+  // run, exact where the indent heuristic above can only approximate
+  // (it underestimates an all-`#` block body and can't see a nested
+  // mapping deeper than the final value). Use it so the splice boundary
+  // and the parse extent agree on every block body.
+  let lastContentEnd = -1;
+  for (const span of parsed.spans.values()) {
+    if (span.end > lastContentEnd) lastContentEnd = span.end;
+  }
+  if (lastContentEnd >= 0) spliceEnd = lastContentEnd;
 
   // `childIndent` (detected above) also matches the user's existing
   // indent step on save, so 4-space (or other consistent) YAML isn't

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -72,22 +72,27 @@ export function findSectionRange(
   return { start, end };
 }
 
-/** Indent of the last non-blank, non-comment line in ``[start, end)`` —
- *  the section's deepest real value line, used to tell a trailing
- *  comment apart from block-scalar body text. Falls back to the
+/** Indent of the deepest non-blank, non-comment line in ``[start, end)``
+ *  — the section's deepest real value line, used to tell a trailing
+ *  comment apart from block-scalar body text. Must be the maximum, not
+ *  the last line's: a nested mapping earlier in the section can be deeper
+ *  than the final value, and a trailing comment between the two indents
+ *  is a real comment to preserve, not block text. Falls back to the
  *  section's child indent when the section has no such line. */
-function _lastValueLineIndent(
+function _deepestValueLineIndent(
   lines: string[],
   start: number,
   end: number,
   fallback: number
 ): number {
-  for (let i = end - 1; i > start; i--) {
+  let deepest = -1;
+  for (let i = start + 1; i < end; i++) {
     const line = lines[i];
     if (line.trim() === "" || isCommentLine(line)) continue;
-    return _leadingIndent(line).length;
+    const indent = _leadingIndent(line).length;
+    if (indent > deepest) deepest = indent;
   }
-  return fallback;
+  return deepest < 0 ? fallback : deepest;
 }
 
 /**
@@ -121,12 +126,12 @@ export function updateSectionInYaml(
   // Walk that run back from `end` and stop the splice before it so
   // those lines survive verbatim. A trailing comment counts as a YAML
   // comment (preserve) when it's at the section's child indent or
-  // shallower OR shallower than the last value line's indent (a block
+  // shallower OR shallower than the deepest value line's indent (a block
   // scalar's body sits deeper than its key, so a comment between the
   // two is a real comment, not block text). A `#` at or past the body
   // indent is literal block-scalar text, already inside the field
   // value, so the walk stops there. (`> start + 1` keeps the header.)
-  const bodyIndent = _lastValueLineIndent(lines, start, end, childIndent.length);
+  const bodyIndent = _deepestValueLineIndent(lines, start, end, childIndent.length);
   let runStart = end;
   while (runStart > start + 1) {
     const prev = lines[runStart - 1];

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -40,6 +40,24 @@ import {
  * button's `on_press` lambda body persisting verbatim after the
  * form-side save mangled the on_press header.
  */
+/** Indent of the last non-blank, non-comment line in ``[start, end)`` —
+ *  the section's deepest real value line, used to tell a trailing
+ *  comment apart from block-scalar body text. Falls back to the
+ *  section's child indent when the section has no such line. */
+function _lastValueLineIndent(
+  lines: string[],
+  start: number,
+  end: number,
+  fallback: number
+): number {
+  for (let i = end - 1; i > start; i--) {
+    const line = lines[i];
+    if (line.trim() === "" || isCommentLine(line)) continue;
+    return _leadingIndent(line).length;
+  }
+  return fallback;
+}
+
 export function findSectionRange(
   lines: string[],
   sectionKey: string,
@@ -99,27 +117,32 @@ export function updateSectionInYaml(
   const childIndent = _detectSectionChildIndent(lines, start, isListItem);
 
   // The range runs to the next top-level key, swallowing trailing
-  // comments the splice would then wipe. Walk the trailing run back
-  // from `end`; if it holds a section-level comment, stop the splice
-  // before the run so those lines survive. A `#` line indented deeper
-  // than the section's children is block-scalar body content, not a
-  // YAML comment — break there so it stays on the byte-identical path
-  // rather than being duplicated. Pure-blank runs (incl. the terminal
-  // newline) also stay on that path. (`> start + 1` keeps the header.)
+  // blank lines and trailing comments the splice would then wipe.
+  // Walk that run back from `end` and stop the splice before it so
+  // those lines survive verbatim. A trailing comment counts as a YAML
+  // comment (preserve) when it's at the section's child indent or
+  // shallower OR shallower than the last value line's indent (a block
+  // scalar's body sits deeper than its key, so a comment between the
+  // two is a real comment, not block text). A `#` at or past the body
+  // indent is literal block-scalar text, already inside the field
+  // value, so the walk stops there. (`> start + 1` keeps the header.)
+  const bodyIndent = _lastValueLineIndent(lines, start, end, childIndent.length);
   let runStart = end;
-  let trailingHasComment = false;
   while (runStart > start + 1) {
     const prev = lines[runStart - 1];
     if (prev.trim() === "") {
       runStart--;
-    } else if (isCommentLine(prev) && _leadingIndent(prev).length <= childIndent.length) {
-      trailingHasComment = true;
+    } else if (
+      isCommentLine(prev) &&
+      (_leadingIndent(prev).length <= childIndent.length ||
+        _leadingIndent(prev).length < bodyIndent)
+    ) {
       runStart--;
     } else {
       break;
     }
   }
-  const spliceEnd = trailingHasComment ? runStart : end;
+  const spliceEnd = runStart;
 
   // Top-level list-bodied section (globals): re-emit through the
   // mapping serializer's array branch — { sectionKey: array } yields

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -184,7 +184,7 @@ export function updateSectionInYaml(
   // `_blockScalarBodyEnd`, so a `#` indented at/past the block content
   // indent is body and a less-indented one is a trailing comment. The
   // last value's span end is therefore the real start of the trailing
-  // run, exact where the indent heuristic above can only approximate
+  // run, exactly where the indent heuristic above can only approximate
   // (it underestimates an all-`#` block body and can't see a nested
   // mapping deeper than the final value). Use it so the splice boundary
   // and the parse extent agree on every block body.

--- a/src/util/yaml-section-values.ts
+++ b/src/util/yaml-section-values.ts
@@ -40,24 +40,6 @@ import {
  * button's `on_press` lambda body persisting verbatim after the
  * form-side save mangled the on_press header.
  */
-/** Indent of the last non-blank, non-comment line in ``[start, end)`` —
- *  the section's deepest real value line, used to tell a trailing
- *  comment apart from block-scalar body text. Falls back to the
- *  section's child indent when the section has no such line. */
-function _lastValueLineIndent(
-  lines: string[],
-  start: number,
-  end: number,
-  fallback: number
-): number {
-  for (let i = end - 1; i > start; i--) {
-    const line = lines[i];
-    if (line.trim() === "" || isCommentLine(line)) continue;
-    return _leadingIndent(line).length;
-  }
-  return fallback;
-}
-
 export function findSectionRange(
   lines: string[],
   sectionKey: string,
@@ -88,6 +70,24 @@ export function findSectionRange(
     }
   }
   return { start, end };
+}
+
+/** Indent of the last non-blank, non-comment line in ``[start, end)`` —
+ *  the section's deepest real value line, used to tell a trailing
+ *  comment apart from block-scalar body text. Falls back to the
+ *  section's child indent when the section has no such line. */
+function _lastValueLineIndent(
+  lines: string[],
+  start: number,
+  end: number,
+  fallback: number
+): number {
+  for (let i = end - 1; i > start; i--) {
+    const line = lines[i];
+    if (line.trim() === "" || isCommentLine(line)) continue;
+    return _leadingIndent(line).length;
+  }
+  return fallback;
 }
 
 /**
@@ -132,10 +132,12 @@ export function updateSectionInYaml(
     const prev = lines[runStart - 1];
     if (prev.trim() === "") {
       runStart--;
-    } else if (
+      continue;
+    }
+    const prevIndent = _leadingIndent(prev).length;
+    if (
       isCommentLine(prev) &&
-      (_leadingIndent(prev).length <= childIndent.length ||
-        _leadingIndent(prev).length < bodyIndent)
+      (prevIndent <= childIndent.length || prevIndent < bodyIndent)
     ) {
       runStart--;
     } else {

--- a/test/util/yaml-block-scalar-extent.test.ts
+++ b/test/util/yaml-block-scalar-extent.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Block-scalar (`|-` / `!lambda |-`) body extent in the section reader.
+ *
+ * The expected values below were cross-checked against PyYAML 6.0.3
+ * (`yaml.safe_load`, with `!lambda` mapped to its scalar): the frontend
+ * must include exactly the lines PyYAML treats as the block body, so a
+ * column-0 comment after the block is never swallowed into a lambda and
+ * an indented `#` stays literal text. See device-builder issue: lambda
+ * captured a trailing `# ...` comment.
+ */
+import { describe, expect, it } from "vitest";
+import { parseYamlSectionValues } from "../../src/util/yaml-section-reader.js";
+import { updateSectionInYaml } from "../../src/util/yaml-section-values.js";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
+
+/** A block-scalar field value (LambdaValue or YamlRawValue) as the
+ *  dedented, trailing-newline-stripped string PyYAML would produce. */
+function blockText(v: unknown): string {
+  if (v && typeof v === "object" && "_lambda" in (v as object)) {
+    return String((v as { _lambda: string })._lambda).replace(/\n+$/, "");
+  }
+  if (v instanceof YamlRawValue) return v.body.replace(/\n+$/, "");
+  return String(v).replace(/\n+$/, "");
+}
+
+interface Case {
+  name: string;
+  yaml: string;
+  key: string;
+  from: number;
+  field: string;
+  /** PyYAML 6.0.3 scalar value for `field`. */
+  pyyaml: string;
+}
+
+const CASES: Case[] = [
+  {
+    name: "trailing blanks then a column-0 comment (the bug)",
+    yaml: `binary_sensor:
+  - platform: template
+    id: s
+    lambda: |-
+      return id(x) && id(y);
+
+
+# Enable logging
+logger:
+  level: DEBUG
+`,
+    key: "binary_sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "return id(x) && id(y);",
+  },
+  {
+    name: "block directly before the next top-level key",
+    yaml: `sensor:
+  - platform: template
+    lambda: |-
+      return 1;
+logger:
+  level: DEBUG
+`,
+    key: "sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "return 1;",
+  },
+  {
+    name: "an indented # line is literal body, not a comment",
+    yaml: `mqtt:
+  log_format: |-
+    line one
+    # literal not a comment
+    line two
+sensor:
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "line one\n# literal not a comment\nline two",
+  },
+  {
+    name: "an interior blank line is kept",
+    yaml: `sensor:
+  - platform: template
+    lambda: |-
+      auto a = 1;
+
+      return a;
+# c
+logger:
+`,
+    key: "sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "auto a = 1;\n\nreturn a;",
+  },
+  {
+    name: "trailing blank at EOF",
+    yaml: `binary_sensor:
+  - platform: template
+    lambda: |-
+      return true;
+
+`,
+    key: "binary_sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "return true;",
+  },
+  {
+    name: "deeper body lines then a less-indented sibling comment",
+    yaml: `mqtt:
+  log_format: |-
+    a
+      b
+    c
+  # sibling comment
+  topic: t
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "a\n  b\nc",
+  },
+  {
+    name: "comment immediately after the block (no blank between)",
+    yaml: `sensor:
+  - platform: template
+    lambda: |-
+      return 1;
+# c
+logger:
+`,
+    key: "sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "return 1;",
+  },
+  {
+    name: "4-space body indent",
+    yaml: `sensor:
+  - platform: template
+    lambda: |-
+        return 2;
+# c
+logger:
+`,
+    key: "sensor.template",
+    from: 2,
+    field: "lambda",
+    pyyaml: "return 2;",
+  },
+  {
+    name: "two stacked trailing comments",
+    yaml: `mqtt:
+  log_format: |-
+    x
+# one
+# two
+sensor:
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "x",
+  },
+  {
+    name: "trailing comment at the child indent (less than body indent)",
+    yaml: `mqtt:
+  log_format: |-
+    x
+  # one
+sensor:
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "x",
+  },
+  {
+    name: "trailing comment indented between the child and body indents",
+    yaml: `mqtt:
+  log_format: |-
+    x
+   # one
+sensor:
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "x",
+  },
+  {
+    name: "comment at the body indent is literal block text",
+    yaml: `mqtt:
+  log_format: |-
+    x
+    # one
+sensor:
+`,
+    key: "mqtt",
+    from: 1,
+    field: "log_format",
+    pyyaml: "x\n# one",
+  },
+];
+
+describe("block-scalar body extent matches PyYAML 6.0.3", () => {
+  for (const c of CASES) {
+    it(c.name, () => {
+      const values = parseYamlSectionValues(c.yaml, c.key, c.from);
+      expect(blockText(values[c.field])).toBe(c.pyyaml);
+    });
+  }
+
+  it("round-trips every case byte-identically when nothing is edited", () => {
+    for (const c of CASES) {
+      const values = parseYamlSectionValues(c.yaml, c.key, c.from);
+      expect(updateSectionInYaml(c.yaml, c.key, values, c.from)).toBe(c.yaml);
+    }
+  });
+
+  it("keeps the trailing comment exactly once after editing a sibling field", () => {
+    const c = CASES[0];
+    const values = parseYamlSectionValues(c.yaml, c.key, c.from);
+    (values as Record<string, unknown>).name = "Renamed";
+    const after = updateSectionInYaml(c.yaml, c.key, values, c.from);
+    expect(after.match(/# Enable logging/g)).toHaveLength(1);
+    expect(after).toContain("logger:");
+    // The comment did not leak into the lambda body.
+    expect(blockText(parseYamlSectionValues(after, c.key, c.from).lambda)).toBe(c.pyyaml);
+  });
+
+  it("keeps both of two stacked trailing comments after an edit", () => {
+    const before = `mqtt:
+  log_format: |-
+    x
+# one
+# two
+sensor:
+`;
+    const values = parseYamlSectionValues(before, "mqtt", 1);
+    (values as Record<string, unknown>).topic = "t";
+    const after = updateSectionInYaml(before, "mqtt", values, 1);
+    expect(after.match(/# one/g)).toHaveLength(1);
+    expect(after.match(/# two/g)).toHaveLength(1);
+    // Both stay after the section, before the next top-level key.
+    expect(after.indexOf("# one")).toBeLessThan(after.indexOf("sensor:"));
+  });
+});

--- a/test/util/yaml-block-scalar-extent.test.ts
+++ b/test/util/yaml-block-scalar-extent.test.ts
@@ -233,6 +233,23 @@ describe("block-scalar body extent matches PyYAML 6.0.3", () => {
     expect(blockText(parseYamlSectionValues(after, c.key, c.from).lambda)).toBe(c.pyyaml);
   });
 
+  it("bounds a folded `>-` marker the same way (extent is marker-independent)", () => {
+    // Folding is a value transform; the body extent rule is the same, so the
+    // trailing comment is excluded and the block round-trips opaquely.
+    const before = `mqtt:
+  log_format: >-
+    line one
+    line two
+
+# next
+sensor:
+`;
+    const values = parseYamlSectionValues(before, "mqtt", 1);
+    expect(blockText(values.log_format)).not.toContain("# next");
+    expect(blockText(values.log_format)).toContain("line one");
+    expect(updateSectionInYaml(before, "mqtt", values, 1)).toBe(before);
+  });
+
   it("keeps both of two stacked trailing comments after an edit", () => {
     const before = `mqtt:
   log_format: |-

--- a/test/util/yaml-block-scalar-extent.test.ts
+++ b/test/util/yaml-block-scalar-extent.test.ts
@@ -16,7 +16,7 @@ import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 /** A block-scalar field value (LambdaValue or YamlRawValue) as the
  *  dedented, trailing-newline-stripped string PyYAML would produce. */
 function blockText(v: unknown): string {
-  if (v && typeof v === "object" && "_lambda" in (v as object)) {
+  if (v && typeof v === "object" && Object.prototype.hasOwnProperty.call(v, "_lambda")) {
     return String((v as { _lambda: string })._lambda).replace(/\n+$/, "");
   }
   if (v instanceof YamlRawValue) return v.body.replace(/\n+$/, "");

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2130,6 +2130,34 @@ sensor:
     });
   });
 
+  it("bounds a block scalar nested under a mapping key by indent", () => {
+    // ``parseNestedBlock``'s block-scalar branch slices the body with
+    // ``_blockScalarBodyEnd`` and resumes the manual-increment ``while``
+    // loop *at* endIdx (not endIdx - 1) so the last body line isn't
+    // re-scanned as a key. Pin the contract: the nested ``inner: |-``
+    // stops at its two body lines, ``sibling`` parses as its own field,
+    // there is no spurious key from the body, and the section round-trips
+    // byte-identically with the next top-level key untouched.
+    const yaml = [
+      "outer:",
+      "  level1:",
+      "    inner: |-",
+      "      body one",
+      "      body two",
+      "    sibling: keep",
+      "next_section:",
+      "  level: DEBUG",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "outer");
+    const level1 = values.level1 as Record<string, unknown>;
+    expect(Object.keys(level1)).toEqual(["inner", "sibling"]);
+    const inner = level1.inner as YamlRawValue;
+    expect(inner.body.replace(/\n+$/, "")).toBe("body one\nbody two");
+    expect(level1.sibling).toBe("keep");
+    expect(updateSectionInYaml(yaml, "outer", values)).toBe(yaml);
+  });
+
   it("round-trips 4-space user YAML through update without mixing indents", () => {
     // The save path detects the user's indent step and threads it
     // through the serializer so the rewritten section keeps the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2225,6 +2225,31 @@ sensor:
     expect(after.match(/# shallow/g)).toHaveLength(1);
   });
 
+  it("keeps a literal # line at the block content indent inside the value when a deeper body line precedes it", () => {
+    // A deeper non-comment body line (`b`) must not inflate the splice's
+    // idea of where the body ends: the `# literal` at the block content
+    // indent is scalar text (PyYAML 6.0.3: 'a\n  b\n# literal'), so it
+    // stays in the value and is emitted exactly once, never pulled out as
+    // a trailing comment.
+    const yaml = [
+      "mqtt:",
+      "  log_format: |-",
+      "    a",
+      "      b",
+      "    # literal",
+      "sensor:",
+      "  x: 1",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "mqtt");
+    expect((values.log_format as YamlRawValue).body.replace(/\n+$/, "")).toBe(
+      "a\n  b\n# literal"
+    );
+    const after = updateSectionInYaml(yaml, "mqtt", values);
+    expect(after).toBe(yaml);
+    expect(after.match(/# literal/g)).toHaveLength(1);
+  });
+
   it("round-trips 4-space user YAML through update without mixing indents", () => {
     // The save path detects the user's indent step and threads it
     // through the serializer so the rewritten section keeps the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2178,6 +2178,53 @@ sensor:
     expect(updateSectionInYaml(yaml, "esphome", values)).toBe(yaml);
   });
 
+  it("preserves a trailing comment after a block scalar whose body is all # lines", () => {
+    // The splice boundary comes from the parser's exact value end, not an
+    // indent heuristic that skips `#` lines. PyYAML 6.0.3 parses `key` as
+    // exactly the indent-6 line ('# body is only comment lines'); the
+    // less-indented indent-4 `#` is a real trailing comment, so it must
+    // survive a no-op save.
+    const yaml = [
+      "parent:",
+      "  key: |-",
+      "      # body is only comment lines",
+      "    # trailing comment, indent 4",
+      "next:",
+      "  level: DEBUG",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "parent");
+    expect((values.key as YamlRawValue).body.replace(/\n+$/, "")).toBe(
+      "# body is only comment lines"
+    );
+    expect(updateSectionInYaml(yaml, "parent", values)).toBe(yaml);
+  });
+
+  it("does not duplicate a # body line shallower than a deeper one on save", () => {
+    // A block body of `x` / deeper `# deep` / shallower `# shallow` is
+    // entirely literal text (PyYAML 6.0.3: 'x\n  # deep\n# shallow'); the
+    // splice must keep all of it inside the value, never pulling the
+    // shallower `# shallow` out as a trailing comment and emitting it
+    // twice.
+    const yaml = [
+      "mqtt:",
+      "  log_format: |-",
+      "    x",
+      "      # deep",
+      "    # shallow",
+      "next:",
+      "  level: DEBUG",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "mqtt");
+    expect((values.log_format as YamlRawValue).body.replace(/\n+$/, "")).toBe(
+      "x\n  # deep\n# shallow"
+    );
+    const after = updateSectionInYaml(yaml, "mqtt", values);
+    expect(after).toBe(yaml);
+    expect(after.match(/# shallow/g)).toHaveLength(1);
+  });
+
   it("round-trips 4-space user YAML through update without mixing indents", () => {
     // The save path detects the user's indent step and threads it
     // through the serializer so the rewritten section keeps the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -2158,6 +2158,26 @@ sensor:
     expect(updateSectionInYaml(yaml, "outer", values)).toBe(yaml);
   });
 
+  it("preserves an oddly-indented trailing comment when the deepest line is an earlier nested mapping", () => {
+    // The trailing-comment trim keys off the section's *deepest* value
+    // line, not its last one. A nested mapping (deep) followed by a
+    // shallow scalar leaves the last value shallower than the deepest;
+    // a trailing comment indented between the shallow last value and the
+    // deeper nested line is a real comment, so it must survive the save.
+    const yaml = [
+      "esphome:",
+      "  nested:",
+      "    deep: 1",
+      "  name: test",
+      "   # weird trailing comment at indent 3",
+      "logger:",
+      "  level: DEBUG",
+      "",
+    ].join("\n");
+    const values = parseYamlSectionValues(yaml, "esphome");
+    expect(updateSectionInYaml(yaml, "esphome", values)).toBe(yaml);
+  });
+
   it("round-trips 4-space user YAML through update without mixing indents", () => {
     // The save path detects the user's indent step and threads it
     // through the serializer so the rewritten section keeps the

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -636,6 +636,46 @@ describe("parseYamlSectionValues / updateSectionInYaml — block scalars and com
     expect(after.match(/lambda:/g)).toHaveLength(1);
   });
 
+  it("stops a list-item lambda block at a less-indented trailing comment", () => {
+    // The block scalar must end where its indentation does; the blank
+    // lines and the column-0 `# ...` belong to the next section, not the
+    // lambda body (which would otherwise become literal C++ on save).
+    const before = `binary_sensor:
+  - platform: template
+    id: opening_sensor
+    lambda: |-
+      return id(x) && id(y);
+
+
+# Enable logging
+logger:
+  level: DEBUG
+`;
+    const values = parseYamlSectionValues(before, "binary_sensor.template", 2);
+    expect(JSON.stringify(values.lambda)).not.toContain("Enable logging");
+    const after = updateSectionInYaml(before, "binary_sensor.template", values, 2);
+    expect(after).toBe(before);
+    expect(after.match(/# Enable logging/g)).toHaveLength(1);
+  });
+
+  it("stops a direct block scalar at a less-indented trailing comment", () => {
+    // Same boundary for the `key: |-` (non-list) path; the comment stays
+    // outside the raw block and isn't duplicated on round-trip.
+    const before = `mqtt:
+  topic: foo
+  log_format: |-
+    line one
+    line two
+
+# next section
+sensor:
+`;
+    const values = parseYamlSectionValues(before, "mqtt", 1);
+    const after = updateSectionInYaml(before, "mqtt", values, 1);
+    expect(after).toBe(before);
+    expect(after.match(/# next section/g)).toHaveLength(1);
+  });
+
   it("overrides raw preservation when the form writes a new value to that key", () => {
     // Contract pin: YamlRawValue is the parser's "I can't model
     // this, paste it back unchanged" sentinel. If the form does


### PR DESCRIPTION
# What does this implement/fix?

A `lambda: |-` field in the structured editor captured the blank lines and the column-0 comment that followed it, so the comment showed up in the lambda editor and turned into literal C++ on save.

The block scalar extent is now read by indentation, the way PyYAML does it; a less indented line ends the block even when it is a comment, while a deeper `#` stays literal body. Trailing blanks and shallow comments stay in the inter section gap, and updateSectionInYaml preserves them by comparing a trailing comment's indent against the section's deepest value line, so even an oddly indented comment is not lost on save. The new test's expected values were cross checked against PyYAML 6.0.3, so the frontend extent matches Python YAML exactly. Verified in the browser; the lambda field shows only the return statement and the comment stays put.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1440

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
