### PR TITLE
Resolve aliased pin values and grey a pin field's default

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -29,6 +29,9 @@ export interface BoardPin {
   available: boolean | null;
   occupied_by: string | null;
   notes: string | null;
+  /** Named forms a config may refer to this pin by (``RX``, ``D1``); the
+   *  catalog omits the key when there are none. */
+  aliases?: string[];
 }
 
 /**

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -47,6 +47,24 @@ interface PinOptionView {
   supported: boolean;
 }
 
+/** Resolve a pin value that names a pin by alias (ESP8266 ``RX``, ``D1``)
+ *  to its GPIO, so the option still selects when the value isn't a
+ *  ``GPIOn`` form ``parsePinGpio`` recognises. Reads the bare string or a
+ *  long-form block's ``number``; matches the catalog's per-pin ``aliases``
+ *  case-insensitively. ``null`` when nothing matches. */
+function gpioFromAlias(rawValue: unknown, pins: BoardPin[]): number | null {
+  const name =
+    typeof rawValue === "string"
+      ? rawValue.trim()
+      : isPlainObject(rawValue) && typeof rawValue.number === "string"
+        ? rawValue.number.trim()
+        : "";
+  if (!name) return null;
+  const lower = name.toLowerCase();
+  const match = pins.find((p) => p.aliases?.some((a) => a.toLowerCase() === lower));
+  return match ? match.gpio : null;
+}
+
 function buildPinOption(
   pin: BoardPin,
   entry: ConfigEntry,
@@ -182,7 +200,10 @@ export function renderPinField(
   // for nRF52), so normalise before comparing or the disabled select renders
   // blank.
   const rawValue = ctx.getAt(path);
-  const valueGpio = parsePinGpio(rawValue);
+  // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a
+  // `GPIOn` form; this drives both the selected option and the re-add of a
+  // filtered-out active pin below.
+  const valueGpio = parsePinGpio(rawValue) ?? gpioFromAlias(rawValue, ctx.board.pins);
   const platform = ctx.board.esphome.platform;
   // Fallback to ``String(rawValue)`` only when the value is a
   // primitive — js-yaml emits null-prototype maps for partial /

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -219,6 +219,19 @@ export function renderPinField(
         ? String(rawValue ?? "")
         : "";
   const invalid = ctx.errorAt(path) !== null;
+  // When the field is unset, grey the schema default in the box (parity with
+  // the select renderer). A default named by alias (i2c ``sda: SDA``) resolves
+  // to its GPIO so the box shows the real pin label rather than the raw name.
+  const defaultGpio =
+    entry.default_value != null
+      ? (parsePinGpio(entry.default_value) ??
+        gpioFromAlias(entry.default_value, ctx.board.pins))
+      : null;
+  const defaultPlaceholder =
+    defaultGpio !== null
+      ? (ctx.board.pins.find((p) => p.gpio === defaultGpio)?.label ??
+        formatPinValue(defaultGpio, platform))
+      : "";
   // Show every board pin; a pin that doesn't match the field's required
   // features (or direction) isn't hidden — it's grouped under "Other pins"
   // and stays selectable (issue #1012). Only a direction conflict
@@ -291,6 +304,7 @@ export function renderPinField(
       <wa-select
         data-no-value-sync
         class=${invalid ? "invalid" : ""}
+        placeholder=${defaultPlaceholder}
         ?disabled=${fieldDisabled}
         @change=${onPinChange}
       >

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -334,6 +334,23 @@ describe("renderPinField ESP8266 named aliases", () => {
       expect(option["?selected"]).toBe(true);
     }
   });
+
+  it("greys the schema default in the box when unset, resolving an alias default", () => {
+    const board = makeTestBoard({
+      pins: [
+        makeBoardPin(4, { label: "GPIO4", features: ["i2c_sda"], aliases: ["SDA"] }),
+      ],
+      overrides: { esphome: { platform: "esp8266", board: "esp01_1m" } as never },
+    });
+    const ctx = makeRenderCtx({}, { board });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "sda", default_value: "SDA" }),
+      ["sda"],
+      ctx
+    );
+    const select = findElementBindings(result, "wa-select")[0];
+    expect(select.placeholder).toBe("GPIO4");
+  });
 });
 
 describe("renderPinField wa-select binding", () => {

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type ConfigEntry,
   ConfigEntryType,
+  PinFeature,
 } from "../../../src/api/types/config-entries.js";
 import {
   formatPinValue,
@@ -291,6 +292,47 @@ describe("renderPinField rtl87xx pin values", () => {
     const onChange = extractAttributeBindings(select)["@change"] as (e: Event) => void;
     onChange({ target: { value: "GPIO2" } } as never);
     expect(ctx.emitChange).toHaveBeenCalledWith(["pin"], "GPIO2");
+  });
+});
+
+describe("renderPinField ESP8266 named aliases", () => {
+  // ESP8266 configs name pins by alias (`RX` = GPIO3); the catalog carries
+  // the alias on the pin so the option still selects.
+  const esp8266Board = () =>
+    makeTestBoard({
+      pins: [makeBoardPin(3, { label: "GPIO3", features: ["uart_rx"], aliases: ["RX"] })],
+      overrides: { esphome: { platform: "esp8266", board: "esp01_1m" } as never },
+    });
+
+  it("selects the GPIO option for an aliased value", () => {
+    const ctx = makeRenderCtx({ rx_pin: "RX" }, { board: esp8266Board() });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "rx_pin",
+        pin_features: [PinFeature.UART_RX],
+      }),
+      ["rx_pin"],
+      ctx
+    );
+    const option = findElementBindings(result, "wa-option")[0];
+    expect(option.value).toBe("GPIO3");
+    expect(option["?selected"]).toBe(true);
+  });
+
+  it("matches the alias case-insensitively and through a long-form block", () => {
+    for (const value of ["rx", { number: "RX", inverted: true }]) {
+      const ctx = makeRenderCtx({ rx_pin: value }, { board: esp8266Board() });
+      const result = renderPinField(
+        makeEntry(ConfigEntryType.PIN, {
+          key: "rx_pin",
+          pin_features: [PinFeature.UART_RX],
+        }),
+        ["rx_pin"],
+        ctx
+      );
+      const option = findElementBindings(result, "wa-option")[0];
+      expect(option["?selected"]).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

A pin field whose value is a named alias rendered with nothing selected. On ESP8266 a `uart: { rx_pin: RX }` (where `RX` is GPIO3) showed a blank RX Pin dropdown; `parsePinGpio` only understands `GPIOn` / integer / `P0.x` forms, so the value fell through as the raw string `RX` and matched no option.

When the value isn't a `GPIOn` form, the pin renderer now resolves it against the board's per-pin `aliases` (the catalog carries `RX`/`TX`/`D1`/... on each pin) before falling back to the string; the resolved GPIO drives both the selected option and the re-add of a filtered-out active pin, so an aliased value stays visible. `BoardPin` gains the optional `aliases` field.

It also greys a pin field's schema default in the box when the field is unset, matching the select renderer; an alias-named default (i2c `sda: SDA`) resolves to its GPIO so the box shows the real pin (GPIO4). A field with no default (uart `tx_pin`) stays blank.

Needs the companion backend that adds the aliases to the catalog and resolves a config's `board:` to its exact entry; fixes esphome/device-builder#1442.

**Related issue or feature (if applicable):**

- Reported for the structured editor; no separate tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

