### PR TITLE
Show the header Beta badge only for beta backends

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -12,6 +12,7 @@ import {
 import { MOBILE_BREAKPOINT } from "../styles/breakpoints.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { stripBase, withBase } from "../util/base-path.js";
+import { isDeviceBuilderBeta } from "../util/device-builder-beta.js";
 import { navigate, runLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -341,7 +342,11 @@ export class ESPHomeLayout extends LitElement {
         <div class="header-text">
           <h1>
             <span class="header-title-text">${this._localize("dashboard.title")}</span>
-            <span class="preview-badge">${this._localize("layout.preview_badge")}</span>
+            ${isDeviceBuilderBeta(this._serverVersion)
+              ? html`<span class="preview-badge"
+                  >${this._localize("layout.preview_badge")}</span
+                >`
+              : nothing}
           </h1>
           <p>${this._localize("dashboard.subtitle")}</p>
         </div>

--- a/src/util/device-builder-beta.ts
+++ b/src/util/device-builder-beta.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether the Device Builder backend is a pre-release build.
+ *
+ * Stable versions are pure dotted digits (``0.1.0``); any PEP 440
+ * pre-release / dev / local suffix (``0.1.0b117``, ``0.2.0.dev3+g…``)
+ * counts as beta. An empty or ``0.0.0`` version is unknown → assume beta.
+ */
+export function isDeviceBuilderBeta(version: string): boolean {
+  const v = version.trim().replace(/^v/, "");
+  if (!v || v === "0.0.0") return true;
+  return !/^\d+(\.\d+)*$/.test(v);
+}

--- a/test/util/device-builder-beta.test.ts
+++ b/test/util/device-builder-beta.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isDeviceBuilderBeta } from "../../src/util/device-builder-beta.js";
+
+describe("isDeviceBuilderBeta", () => {
+  it("treats a plain dotted-digit version as stable", () => {
+    expect(isDeviceBuilderBeta("0.1.0")).toBe(false);
+    expect(isDeviceBuilderBeta("1.0.0")).toBe(false);
+    expect(isDeviceBuilderBeta("2026.5.3")).toBe(false);
+  });
+
+  it("ignores a leading v", () => {
+    expect(isDeviceBuilderBeta("v0.1.0")).toBe(false);
+    expect(isDeviceBuilderBeta("v0.0.0")).toBe(true);
+  });
+
+  it("flags any PEP 440 pre-release / dev / local suffix as beta", () => {
+    expect(isDeviceBuilderBeta("0.1.0b117")).toBe(true);
+    expect(isDeviceBuilderBeta("0.2.0rc1")).toBe(true);
+    expect(isDeviceBuilderBeta("0.1.0a1")).toBe(true);
+    expect(isDeviceBuilderBeta("0.1.0.dev5+g1234")).toBe(true);
+  });
+
+  it("assumes beta when the version is empty or 0.0.0", () => {
+    expect(isDeviceBuilderBeta("")).toBe(true);
+    expect(isDeviceBuilderBeta("   ")).toBe(true);
+    expect(isDeviceBuilderBeta("0.0.0")).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Makes the header "Beta" badge version-aware instead of removing it. Previously the badge was hardcoded and shown on every build. Now it renders only when the Device Builder backend reports a pre-release version (a PEP 440 suffix like `0.1.0b117`) and disappears on a stable release (`0.1.0`). An empty or `0.0.0` version is treated as beta.

The frontend already has the backend version in the header (`_serverVersion`, from `serverVersionContext`), so a new pure helper `isDeviceBuilderBeta()` (`src/util/device-builder-beta.ts`) classifies it and gates the existing `preview-badge` span. Adds a unit test covering stable/beta/unknown versions.

Addresses @jesserockz's review: the builder is a standalone package, so it can have its own beta releases; the badge now tracks them and goes away once a stable build ships.

**Related issue or feature (if applicable):**

- No tracking issue.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
