### PR TITLE
Disable browser autofill on config-entry text inputs

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -479,6 +479,7 @@ export function renderStringField(
   const escapeMode = hasEscapeWorthyChar(value);
   const textInput = html`<input
     type=${inputType}
+    autocomplete="off"
     class=${invalid ? "invalid" : ""}
     .value=${escapeMode ? escapeControlForInput(value) : value}
     ?disabled=${disabled}

--- a/test/components/device/render-string-field-autocomplete.test.ts
+++ b/test/components/device/render-string-field-autocomplete.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Pins that ``renderStringField``'s single-line input opts out of browser
+ * autofill (``autocomplete="off"``) so an api/ota/wifi password elsewhere
+ * in the form doesn't trigger password autocomplete on the ID input.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConfigEntry,
+  ConfigEntryType,
+} from "../../../src/api/types/config-entries.js";
+import type { RenderCtx } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { makeConfigEntry } from "../../../src/util/config-entry-defaults.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
+import { makeRenderCtx } from "./_renderer-fixtures.js";
+
+function ctxFor(value: string): RenderCtx {
+  return makeRenderCtx(
+    { id: value },
+    { board: null, overrides: { emitChange: vi.fn() } }
+  );
+}
+
+function makeEntry(): ConfigEntry {
+  return makeConfigEntry({ key: "id", type: ConfigEntryType.STRING, label: "ID" });
+}
+
+describe("renderStringField — autocomplete", () => {
+  it("renders the text input with autocomplete off", () => {
+    const tpl = renderStringField(makeEntry(), "text", ["id"], ctxFor("ld2410_radar"));
+    const [input] = findTemplatesByAnchor(tpl, "<input");
+    expect(input.strings.join("")).toContain('autocomplete="off"');
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The single-line text input in the structured editor didn't opt out of browser autofill, so the browser's password manager would offer to fill plain text fields like a component ID. When the same config carries an api/ota/wifi password, the browser treats the whole form as a login form and the key icon shows up on the ID field.

Adds `autocomplete="off"` to that input, matching what the integer, hex, and password inputs already do.

**Related issue or feature (if applicable):**

- No tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
