### PR TITLE
Show auto-resolved default for single-candidate ID reference fields

### DIFF
--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -7,7 +7,10 @@
 
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
-import { findReferenceCandidates } from "../../util/config-entry-yaml-scan.js";
+import {
+  findReferenceCandidates,
+  yamlHasMergedSources,
+} from "../../util/config-entry-yaml-scan.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -35,6 +38,15 @@ export function renderIdReferenceField(
   if (bail) return bail;
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
+
+  // ESPHome auto-resolves an omitted reference when exactly one matching
+  // component exists. Surface that target as the default — but only when the
+  // scan can see the whole config; a `packages:` / `<<:` merge could hide a
+  // second match, making "the one we see" the wrong (or ambiguous) target.
+  const defaultCandidate =
+    value === "" && candidates.length === 1 && !yamlHasMergedSources(ctx.yaml)
+      ? candidates[0]
+      : null;
 
   const idOption = (optValue: string, primary: string, secondary: string) => html`
     <wa-option
@@ -115,12 +127,22 @@ export function renderIdReferenceField(
       <wa-select
         class=${invalid ? "invalid" : ""}
         ?disabled=${effectiveDisabled(entry, ctx)}
+        placeholder=${defaultCandidate
+          ? defaultCandidate.name || defaultCandidate.id
+          : nothing}
         @change=${onChange}
       >
         ${orphanOption}
-        ${candidates.map((c) =>
-          idOption(c.id, c.name || c.id, c.name ? `${c.id} · ${domain}` : domain)
-        )}
+        ${candidates.map((c) => {
+          const secondary = c.name ? `${c.id} · ${domain}` : domain;
+          return idOption(
+            c.id,
+            c.name || c.id,
+            c === defaultCandidate
+              ? `${secondary} · ${ctx.localize("device.default_option_tag")}`
+              : secondary
+          );
+        })}
         ${addOption}
       </wa-select>
       ${renderFieldError(path, ctx)}

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -327,6 +327,24 @@ export function findReferenceCandidates(
   return findComponentsByProviders(yaml, [{ domain, stem: "" }, ...providers]);
 }
 
+// A top-level (zero-indent) `packages:` block or `<<:` merge key — the two
+// constructs that merge whole component sections in from sources the scan
+// can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
+// replaces that key's value, so it deliberately doesn't match.
+const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/;
+
+/**
+ * Whether the YAML root-merges components the scan can't enumerate.
+ *
+ * True when a top-level `packages:` block or `<<:` merge key is present —
+ * either can introduce additional `<domain>:` sections from another file, so
+ * single-candidate reference resolution can't be trusted.
+ */
+export function yamlHasMergedSources(yaml: string): boolean {
+  if (!yaml) return false;
+  return yaml.split("\n").some((line) => MERGED_SOURCE_RE.test(line));
+}
+
 /**
  * Test-only: clear both memos so cache state can't leak between
  * cases. Production callers don't need this — within an editor

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -4,9 +4,11 @@
  * ``packages:`` include / another file); the picker must still surface it as
  * a selected option so it displays and round-trips instead of vanishing.
  */
+import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderIdReferenceField } from "../../../src/components/device/config-entry-id-reference-renderer.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 const LOCAL_SCRIPT_YAML = "script:\n  - id: local_script\n";
@@ -47,5 +49,62 @@ describe("renderIdReferenceField — value defined outside the scanned YAML (#13
       "wa-option"
     ).map((o) => o.value);
     expect(values.filter((v) => v === "local_script")).toHaveLength(1);
+  });
+});
+
+describe("renderIdReferenceField — single-candidate auto-resolve default", () => {
+  const SINGLE_LD2410 = "ld2410:\n  id: radar\n";
+
+  function renderRef(domain: string, yaml: string, value: string) {
+    const entry = makeEntry(ConfigEntryType.STRING, { references_component: domain });
+    return renderIdReferenceField(
+      entry,
+      ["id"],
+      makeRenderCtx({ id: value }, { overrides: { yaml } })
+    );
+  }
+
+  const placeholderOf = (tmpl: unknown): unknown =>
+    findElementBindings(tmpl, "wa-select")[0]?.placeholder;
+
+  const hasDefaultTag = (tmpl: unknown): boolean =>
+    findTemplatesByAnchor(tmpl, "<wa-option").some((t) =>
+      (t.values as unknown[]).some(
+        (v) => typeof v === "string" && v.includes("device.default_option_tag")
+      )
+    );
+
+  it("shows the sole candidate as the default and tags its option", () => {
+    const tmpl = renderRef("ld2410", SINGLE_LD2410, "");
+    expect(placeholderOf(tmpl)).toBe("radar");
+    expect(hasDefaultTag(tmpl)).toBe(true);
+  });
+
+  it("does not auto-select the default option (the field stays omitted)", () => {
+    const opt = findElementBindings(
+      renderRef("ld2410", SINGLE_LD2410, ""),
+      "wa-option"
+    ).find((o) => o.value === "radar");
+    expect(opt?.["?selected"]).toBe(false);
+  });
+
+  it("suppresses the default when packages: can merge in another match", () => {
+    const tmpl = renderRef(
+      "ld2410",
+      `packages:\n  base: !include base.yaml\n${SINGLE_LD2410}`,
+      ""
+    );
+    expect(placeholderOf(tmpl)).toBe(nothing);
+    expect(hasDefaultTag(tmpl)).toBe(false);
+  });
+
+  it("shows no default when more than one candidate exists", () => {
+    const tmpl = renderRef("script", "script:\n  - id: a\n  - id: b\n", "");
+    expect(placeholderOf(tmpl)).toBe(nothing);
+    expect(hasDefaultTag(tmpl)).toBe(false);
+  });
+
+  it("shows no default once the field has a committed value", () => {
+    expect(placeholderOf(renderRef("ld2410", SINGLE_LD2410, "radar"))).toBe(nothing);
   });
 });

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -98,6 +98,12 @@ describe("renderIdReferenceField — single-candidate auto-resolve default", () 
     expect(hasDefaultTag(tmpl)).toBe(false);
   });
 
+  it("suppresses the default when a top-level <<: merge can hide another match", () => {
+    const tmpl = renderRef("ld2410", `<<: !include common.yaml\n${SINGLE_LD2410}`, "");
+    expect(placeholderOf(tmpl)).toBe(nothing);
+    expect(hasDefaultTag(tmpl)).toBe(false);
+  });
+
   it("shows no default when more than one candidate exists", () => {
     const tmpl = renderRef("script", "script:\n  - id: a\n  - id: b\n", "");
     expect(placeholderOf(tmpl)).toBe(nothing);

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -4,6 +4,7 @@ import {
   findComponentsByProviders,
   findReferenceCandidates,
   findUsedPins,
+  yamlHasMergedSources,
 } from "../../src/util/config-entry-yaml-scan.js";
 
 // The scans use module-level single-entry memos. Within a single
@@ -319,5 +320,28 @@ describe("findComponentsByProviders", () => {
       { domain: "sensor", stem: "ads1115" },
     ]);
     expect(other).toEqual([{ id: "adc_b", name: "" }]);
+  });
+});
+
+describe("yamlHasMergedSources", () => {
+  it("is true for a top-level packages: block", () => {
+    expect(yamlHasMergedSources("packages:\n  base: !include base.yaml\n")).toBe(true);
+  });
+
+  it("is true for a top-level <<: merge key", () => {
+    expect(yamlHasMergedSources("<<: !include common.yaml\nesphome:\n")).toBe(true);
+  });
+
+  it("is false for a value-position !include", () => {
+    expect(yamlHasMergedSources("wifi: !include wifi.yaml\n")).toBe(false);
+  });
+
+  it("is false for an indented packages-like token inside another block", () => {
+    expect(yamlHasMergedSources("sensor:\n  - packages: not-a-merge\n")).toBe(false);
+  });
+
+  it("is false for plain YAML and empty input", () => {
+    expect(yamlHasMergedSources("ld2410:\n  id: radar\n")).toBe(false);
+    expect(yamlHasMergedSources("")).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

An ID reference field such as **Ld2410 ID** renders an empty dropdown when it has no value, even when the config holds exactly one matching component that ESPHome resolves to automatically. This shows that sole match as a greyed default in the closed select and tags its option, mirroring how GPIO and enum fields display their default; the value stays omitted, so ESPHome keeps resolving it. When a top level `packages:` block or a `<<:` merge could pull in another match, the hint is suppressed, since the in editor scan cannot see merged files.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
