### PR TITLE
Preselect the current value when opening the options combobox

### DIFF
--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -166,7 +166,12 @@ export class ESPHomeOptionsCombobox extends LitElement {
     this._committed = this.value;
     this._query = this.value;
     this._dirty = false;
-    this._active = -1;
+    // Highlight the current value and scroll it into view, so a pre-filled
+    // field opens focused on its own selection instead of the top of the
+    // list; arrow keys then move relative to it. -1 (nothing active) when
+    // the value is free text not in the options.
+    this._active = this.options.findIndex((o) => o.value === this.value);
+    if (this._active >= 0) this._scrollActiveIntoView();
   };
 
   private _close = () => {

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -69,6 +69,23 @@ describe("esphome-options-combobox", () => {
     );
   });
 
+  test("opening preselects and highlights the current value", async () => {
+    const el = await mount("bw15");
+    await open(el);
+    const opts = options(el);
+    // bw15 is index 2 in OPTIONS — it opens active, not the top of the list.
+    expect(opts[2].classList.contains("option--active")).toBe(true);
+    expect(opts[2].getAttribute("aria-selected")).toBe("true");
+    expect(input(el).getAttribute("aria-activedescendant")).toBe("option-2");
+  });
+
+  test("opening a free-text value not in the list highlights nothing", async () => {
+    const el = await mount("cr3l");
+    await open(el);
+    expect(options(el).some((o) => o.classList.contains("option--active"))).toBe(false);
+    expect(input(el).getAttribute("aria-activedescendant")).toBeNull();
+  });
+
   test("typing filters to substring matches and emits the typed value", async () => {
     const el = await mount("bw15");
     const seen = track(el);
@@ -93,8 +110,8 @@ describe("esphome-options-combobox", () => {
     expect(options(el)).toHaveLength(0); // closed after select
   });
 
-  test("ArrowDown then Enter selects the active option", async () => {
-    const el = await mount("bw15");
+  test("ArrowDown then Enter moves from the preselected value and selects it", async () => {
+    const el = await mount("bw15"); // index 2; opens active there
     const seen = track(el);
     await open(el);
     const field = input(el);
@@ -104,8 +121,9 @@ describe("esphome-options-combobox", () => {
     await el.updateComplete;
     field.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await el.updateComplete;
-    expect(seen[seen.length - 1]).toBe("afw121t");
-    expect(el.value).toBe("afw121t");
+    // ArrowDown advances from bw15 (2) to rtl8710bn (3).
+    expect(seen[seen.length - 1]).toBe("rtl8710bn");
+    expect(el.value).toBe("rtl8710bn");
   });
 
   test("Escape reverts the query and closes", async () => {
@@ -184,14 +202,8 @@ describe("esphome-options-combobox", () => {
     const el = await mount("bw15");
     await open(el);
     const field = input(el);
-    field.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
-    );
-    field.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
-    );
-    await el.updateComplete;
-    expect(field.getAttribute("aria-activedescendant")).toBe("option-1");
+    // Opening preselects bw15 (index 2).
+    expect(field.getAttribute("aria-activedescendant")).toBe("option-2");
     // Options shrink under the still-open list; the now-stale index must not
     // leak a reference to a non-existent row.
     el.options = [{ label: "afw121t", value: "afw121t" }];


### PR DESCRIPTION
# What does this implement/fix?

Opening a pre-filled options combobox (the ESP8266/Libretiny **Board** picker is the obvious one) left the list scrolled to the top with nothing highlighted, so a committed value far down the list looked unselected. On open, the current value is now set as the active option and scrolled into view; arrow keys move relative to it, and a free-text value that isn't in the list stays unhighlighted.

Note: the first ArrowDown after opening now moves from the current value rather than always jumping to the top option; that matches the preselection and is the expected combobox behavior.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
