### PR TITLE
Align structured editor top padding with the YAML editor

### DIFF
--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -5,7 +5,9 @@ export const deviceSectionConfigStyles = css`
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-m);
-    margin-top: var(--wa-space-m);
+    /* No top margin: the shared .editor-pane padding already supplies the top
+       gap. The extra margin pushed the structured editor below the YAML pane
+       (#826); the automation/script editors never had it. */
   }
 
   .section-header {


### PR DESCRIPTION
# What does this implement/fix?

The structured (visual) section editor sat lower than the YAML editor on the right; its `:host` added a top margin on top of the shared editor pane padding, so the content started about 16px too far down. This removes that margin; the pane padding already supplies the top gap, and the automation and script editors never had it, so all section types and the YAML pane now start at the same height.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/826

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
