### PR TITLE
Coerce numeric combo box values to their declared type on emit

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -20,6 +20,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { ComponentProvider } from "../../util/config-entry-yaml-scan.js";
 import type { ValidationError } from "../../util/config-validation.js";
+import { coerceIntFieldValue } from "../../util/int-input.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -77,6 +78,23 @@ registerMdiIcons({
  */
 export function effectiveDisabled(entry: ConfigEntry, ctx: RenderCtx): boolean {
   return ctx.disabled || entry.locked;
+}
+
+/**
+ * Coerce a control's string value back to the entry's declared numeric
+ * type before emitting. A wa-select / combo box always hands back a
+ * string, but an INTEGER/FLOAT field's YAML must be a number or downstream
+ * validation (and the backend's locked-value compare) rejects it. INTEGER
+ * goes through ``coerceIntFieldValue`` so a >2^53 decimal stays a string
+ * (64-bit precision, #378/#944) and a ``0x…`` literal isn't truncated.
+ * Non-numeric entries, an empty string, and unparseable input pass through
+ * unchanged so the inline validator can flag them.
+ */
+export function coerceValueToEntryType(entry: ConfigEntry, raw: string): string | number {
+  if (entry.type === ConfigEntryType.INTEGER) return coerceIntFieldValue(raw);
+  if (entry.type !== ConfigEntryType.FLOAT || raw === "") return raw;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : raw;
 }
 
 /** Serialize a field path into the ``data-field-key`` attribute. JSON
@@ -514,18 +532,6 @@ function renderSuggestionSelect(
 ) {
   const valueLower = value.toLowerCase();
   const placeholder = String(entry.default_value ?? "");
-  // Coerce the picked value back to the entry's declared type before
-  // emitting — the wa-select hands us a string regardless, but a number
-  // entry's YAML value must be a number or downstream validation
-  // (and the backend's locked-value comparison) will reject it.
-  const isNumeric =
-    entry.type === ConfigEntryType.INTEGER || entry.type === ConfigEntryType.FLOAT;
-  const coerce = (raw: string): string | number => {
-    if (!isNumeric) return raw;
-    if (raw === "") return raw;
-    const n = entry.type === ConfigEntryType.INTEGER ? parseInt(raw, 10) : Number(raw);
-    return Number.isFinite(n) ? n : raw;
-  };
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
@@ -534,7 +540,10 @@ function renderSuggestionSelect(
         ?disabled=${disabled}
         placeholder=${placeholder}
         @change=${(e: Event) =>
-          ctx.emitChange(path, coerce((e.target as HTMLSelectElement).value))}
+          ctx.emitChange(
+            path,
+            coerceValueToEntryType(entry, (e.target as HTMLSelectElement).value)
+          )}
       >
         ${(entry.suggestions ?? []).map((s) => {
           const v = String(s);

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -21,6 +21,7 @@ import {
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import type { OptionsComboboxValueChange } from "../../options-combobox-event.js";
 import {
+  coerceValueToEntryType,
   effectiveDisabled,
   fieldKeyAttr,
   labelFor,
@@ -448,7 +449,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           ?disabled=${disabled}
           ?invalid=${invalid}
           @options-combobox-change=${(e: CustomEvent<OptionsComboboxValueChange>) =>
-            ctx.emitChange(path, e.detail.value)}
+            ctx.emitChange(path, coerceValueToEntryType(entry, e.detail.value))}
         ></esphome-options-combobox>
         ${renderFieldError(path, ctx)}
       </div>

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -100,4 +100,44 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
     expect(form._entries.find((e) => e.key === "sda")?.required).toBe(true);
     expect(form._entries.find((e) => e.key === "frequency")?.required).toBeFalsy();
   });
+
+  // baud_rate now carries a 115200 catalog default; a detour value (an
+  // LD2410 needing 256000) must win over it, and a plain add must commit
+  // the default so the required field isn't left empty.
+  function uartForm() {
+    const form = new ESPHomeAddComponentForm();
+    const internals = form as unknown as {
+      component: ComponentCatalogEntry;
+      _localize: (key: string) => string;
+      prefillFields: Record<string, unknown> | null;
+      _initValues: () => void;
+      _values: Record<string, unknown>;
+    };
+    internals.component = {
+      id: "uart",
+      config_entries: [
+        makeConfigEntry({
+          key: "baud_rate",
+          type: ConfigEntryType.INTEGER,
+          required: true,
+          default_value: 115200,
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    internals._localize = (key) => key;
+    return internals;
+  }
+
+  it("seeds the required baud_rate from its 115200 default on a plain add", () => {
+    const form = uartForm();
+    form._initValues();
+    expect(form._values.baud_rate).toBe(115200);
+  });
+
+  it("lets a detour baud_rate clobber the 115200 default", () => {
+    const form = uartForm();
+    form.prefillFields = { baud_rate: 256000 };
+    form._initValues();
+    expect(form._values.baud_rate).toBe(256000);
+  });
 });

--- a/test/components/device/config-entry-combobox.test.ts
+++ b/test/components/device/config-entry-combobox.test.ts
@@ -61,3 +61,65 @@ describe("renderSelectField — allow_custom_value combobox", () => {
     expect(findElementBindings(tpl, "wa-select")).toHaveLength(1);
   });
 });
+
+const BAUD_RATES: ConfigValueOption[] = [
+  { value: "9600", label: "9600" },
+  { value: "115200", label: "115200" },
+  { value: "256000", label: "256000" },
+];
+
+function baudEntry() {
+  return makeEntry(ConfigEntryType.INTEGER, {
+    key: "baud_rate",
+    label: "Baud Rate",
+    options: BAUD_RATES,
+    allow_custom_value: true,
+    default_value: 115200,
+  });
+}
+
+function emitCombo(value: string) {
+  const ctx = makeRenderCtx({ baud_rate: 115200 });
+  const [b] = findElementBindings(
+    renderSelectField(baudEntry(), ["baud_rate"], ctx),
+    "esphome-options-combobox"
+  );
+  (b["@options-combobox-change"] as (e: CustomEvent) => void)(
+    new CustomEvent("options-combobox-change", { detail: { value } })
+  );
+  return ctx.emitChange;
+}
+
+describe("renderSelectField — numeric combobox coercion", () => {
+  it("coerces a picked INTEGER baud rate to a number on emit", () => {
+    expect(emitCombo("9600")).toHaveBeenCalledWith(["baud_rate"], 9600);
+  });
+
+  it("coerces a custom typed INTEGER value to a number", () => {
+    expect(emitCombo("250000")).toHaveBeenCalledWith(["baud_rate"], 250000);
+  });
+
+  it("passes an empty value through unchanged so the field can be cleared", () => {
+    expect(emitCombo("")).toHaveBeenCalledWith(["baud_rate"], "");
+  });
+
+  it("keeps an INTEGER above 2^53 as a string to preserve 64-bit precision", () => {
+    // 2^53 + 1 — not a safe Number; coercing through Number() would round it.
+    expect(emitCombo("9007199254740993")).toHaveBeenCalledWith(
+      ["baud_rate"],
+      "9007199254740993"
+    );
+  });
+
+  it("leaves a non-numeric STRING combobox value verbatim", () => {
+    const ctx = makeRenderCtx({ board: "bw15" });
+    const [b] = findElementBindings(
+      renderSelectField(comboEntry(), ["board"], ctx),
+      "esphome-options-combobox"
+    );
+    (b["@options-combobox-change"] as (e: CustomEvent) => void)(
+      new CustomEvent("options-combobox-change", { detail: { value: "cr3l" } })
+    );
+    expect(ctx.emitChange).toHaveBeenCalledWith(["board"], "cr3l");
+  });
+});

--- a/test/util/bus-constraint-prefill.test.ts
+++ b/test/util/bus-constraint-prefill.test.ts
@@ -85,4 +85,26 @@ describe("busConstraintPrefill", () => {
   test("skips a constraint key with no matching bus field", () => {
     expect(busConstraintPrefill(uartEntries, { rx_buffer_size: 512 })).toBeNull();
   });
+
+  // The catalog now gives baud_rate a 115200 default; a detour constraint
+  // (e.g. an LD2410 needing 256000) must still win over that default.
+  const baudDefaulted = [
+    makeConfigEntry({
+      key: "baud_rate",
+      type: ConfigEntryType.INTEGER,
+      required: true,
+      default_value: 115200,
+    }),
+  ];
+
+  test("prefills a baud constraint that differs from the new 115200 default", () => {
+    expect(busConstraintPrefill(baudDefaulted, { baud_rate: 256000 })).toEqual({
+      fields: { baud_rate: 256000 },
+      required: [],
+    });
+  });
+
+  test("drops a baud constraint equal to the default (seed already supplies it)", () => {
+    expect(busConstraintPrefill(baudDefaulted, { baud_rate: 115200 })).toBeNull();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The `allow_custom_value` combo box (`esphome-options-combobox`) always emits a string, so a numeric field rendered as a combo box wrote a quoted value like `baud_rate: "9600"` into the YAML instead of a number. This coerces the picked / typed value back to the entry's declared type before emitting, so INTEGER and FLOAT fields stay numeric.

The coercion is extracted into a shared `coerceValueToEntryType` helper and reused by both the combo box and the existing suggestion select (which had the same inline logic). INTEGER goes through `coerceIntFieldValue`, so a decimal above 2^53 stays a string for 64-bit precision and a `0x…` literal isn't truncated; nothing new is reinvented.

This pairs with esphome/device-builder#1451, which turns the UART `baud_rate` field into a common-rate combo box.

**Related issue or feature (if applicable):**

- No tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
