### PR TITLE
Fix descender clipping in device navigator header title

### DIFF
--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -40,17 +40,15 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    line-height: 1;
+    /* Match the editor header title's line-height so both header bars are the
+       same height (their dividers line up) and the title baselines align.
+       line-height 1 clipped the descender 'g' (#827) and left this header about
+       0.4px shorter than the editor's, offsetting the divider by a pixel. */
+    line-height: var(--wa-line-height-normal);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
-    /* line-height 1 keeps the title baseline aligned with the editor header.
-       The ellipsis overflow:hidden would crop descenders (the 'g' in #827), so
-       extend the clip box downward without changing the centered layout box:
-       the padding adds paint room, the negative margin cancels its layout. */
-    padding-bottom: 0.3em;
-    margin-bottom: -0.3em;
   }
 
   .header-actions {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -40,13 +40,17 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    /* Not line-height 1: the ellipsis overflow:hidden would crop descenders
-       (the 'g' in #827). 1.4 leaves room and stays under the 22px header. */
-    line-height: 1.4;
+    line-height: 1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
+    /* line-height 1 keeps the title baseline aligned with the editor header.
+       The ellipsis overflow:hidden would crop descenders (the 'g' in #827), so
+       extend the clip box downward without changing the centered layout box:
+       the padding adds paint room, the negative margin cancels its layout. */
+    padding-bottom: 0.3em;
+    margin-bottom: -0.3em;
   }
 
   .header-actions {

--- a/src/components/device/device-navigator.styles.ts
+++ b/src/components/device/device-navigator.styles.ts
@@ -40,7 +40,9 @@ export const deviceNavigatorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-    line-height: 1;
+    /* Not line-height 1: the ellipsis overflow:hidden would crop descenders
+       (the 'g' in #827). 1.4 leaves room and stays under the 22px header. */
+    line-height: 1.4;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
# What does this implement/fix?

The device navigator header title cropped descenders; the 'g' in "Device navigator" was clipped flat because the title used `line-height: 1` with the single-line ellipsis `overflow: hidden`. That same `line-height: 1` also left the navigator header about 0.4px shorter than the adjacent editor header, so their bottom dividers were a pixel off.

Both come from the navigator title using a different line-height than the editor header title. The fix sets the navigator title to the editor title's line-height, `--wa-line-height-normal`; the two header bars are now the same height with their dividers and title baselines aligned, and the descender has room.

Verified in the browser; the 'g' renders fully, the navigator and editor title baselines match, the header dividers line up, and a long title still truncates with an ellipsis.

**Related issue or feature (if applicable):**

- fixes #827

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
