### PR TITLE
Narrow a detour bus field to a requester's choice list

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -299,6 +299,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
               .prefillReference=${this._prefillReference}
               .prefillFields=${this._depPrefill?.fields ?? null}
               .extraRequired=${this._depPrefill?.required ?? null}
+              .optionOverrides=${this._depPrefill?.optionOverrides ?? null}
               .submitting=${this._submitting}
               .submitError=${this._submitError}
             ></esphome-add-component-form>`

--- a/src/components/device/add-component-form-overlays.ts
+++ b/src/components/device/add-component-form-overlays.ts
@@ -1,0 +1,41 @@
+import type { ConfigEntry } from "../../api/types/config-entries.js";
+import { ConfigEntryType } from "../../api/types/config-entries.js";
+
+/** Mark `extra` keys required on the matching entries (require_tx -> tx_pin). */
+export function overlayRequired(
+  entries: ConfigEntry[],
+  extra: string[] | null
+): ConfigEntry[] {
+  if (!extra?.length) return entries;
+  const keys = new Set(extra);
+  return entries.map((e) =>
+    keys.has(e.key) && !e.required ? { ...e, required: true } : e
+  );
+}
+
+/**
+ * Narrow an entry's dropdown to a requester-imposed choice set, default-first.
+ *
+ * Existing catalog labels survive (only synthesized when the entry had none),
+ * `allow_custom_value` is untouched so a baud combo box stays typeable, the
+ * default is type-coerced for STRING entries, and `multi_value` fields (not a
+ * select) are skipped.
+ */
+export function overlayOptions(
+  entries: ConfigEntry[],
+  overrides: Record<string, (string | number)[]> | null
+): ConfigEntry[] {
+  if (!overrides || Object.keys(overrides).length === 0) return entries;
+  return entries.map((e) => {
+    const choices = overrides[e.key];
+    if (!choices?.length || e.multi_value) return e;
+    const byValue = new Map((e.options ?? []).map((o) => [o.value, o]));
+    return {
+      ...e,
+      options: choices.map(
+        (v) => byValue.get(String(v)) ?? { label: String(v), value: String(v) }
+      ),
+      default_value: e.type === ConfigEntryType.STRING ? String(choices[0]) : choices[0],
+    };
+  });
+}

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -145,9 +145,16 @@ export class ESPHomeAddComponentForm extends LitElement {
       return entries.map((e) => {
         const choices = overrides[e.key];
         if (!choices?.length) return e;
+        // Filter the entry's existing options to the constrained subset so a
+        // labeled field (a future `parity` / `stop_bits` with label !== value)
+        // keeps its human-readable labels; synthesize only when it had none
+        // (the baud case, where label and value are the same number).
+        const byValue = new Map((e.options ?? []).map((o) => [o.value, o]));
         return {
           ...e,
-          options: choices.map((v) => ({ label: String(v), value: String(v) })),
+          options: choices.map(
+            (v) => byValue.get(String(v)) ?? { label: String(v), value: String(v) }
+          ),
           default_value: choices[0],
         };
       });

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -28,6 +28,7 @@ import {
 } from "../../util/yaml-serialize.js";
 import { findMissingDependencies } from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
+import { overlayOptions, overlayRequired } from "./add-component-form-overlays.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
 import "./config-entry-form.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
@@ -119,47 +120,9 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   static styles = [espHomeStyles, inputStyles, addComponentFormStyles];
 
-  /** Schema with `extraRequired` keys overlaid as required. Memoized so
-   *  the shared form's `.entries` identity is render-stable. */
-  private _overlayRequired = memoizeOne(
-    (entries: ConfigEntry[], extra: string[] | null): ConfigEntry[] => {
-      if (!extra?.length) return entries;
-      const keys = new Set(extra);
-      return entries.map((e) =>
-        keys.has(e.key) && !e.required ? { ...e, required: true } : e
-      );
-    }
-  );
-
-  /** Narrow an entry's dropdown to a requester-imposed choice set and
-   *  default it to the first. `allow_custom_value` is left untouched, so a
-   *  combo box (baud) keeps the dropdown to the choices but still accepts a
-   *  typed-in value (a CN105 on a non-standard rate). Memoized to keep
-   *  `.entries` render-stable. */
-  private _overlayOptions = memoizeOne(
-    (
-      entries: ConfigEntry[],
-      overrides: Record<string, (string | number)[]> | null
-    ): ConfigEntry[] => {
-      if (!overrides || Object.keys(overrides).length === 0) return entries;
-      return entries.map((e) => {
-        const choices = overrides[e.key];
-        if (!choices?.length) return e;
-        // Filter the entry's existing options to the constrained subset so a
-        // labeled field (a future `parity` / `stop_bits` with label !== value)
-        // keeps its human-readable labels; synthesize only when it had none
-        // (the baud case, where label and value are the same number).
-        const byValue = new Map((e.options ?? []).map((o) => [o.value, o]));
-        return {
-          ...e,
-          options: choices.map(
-            (v) => byValue.get(String(v)) ?? { label: String(v), value: String(v) }
-          ),
-          default_value: choices[0],
-        };
-      });
-    }
-  );
+  // Memoized so the shared form's `.entries` identity is render-stable.
+  private _overlayRequired = memoizeOne(overlayRequired);
+  private _overlayOptions = memoizeOne(overlayOptions);
 
   private get _entries(): ConfigEntry[] {
     return this._overlayOptions(

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -79,6 +79,12 @@ export class ESPHomeAddComponentForm extends LitElement {
   @property({ attribute: false })
   extraRequired: string[] | null = null;
 
+  /** Per-field dropdown narrowing the requester imposes via a list
+   *  `bus_constraints` value (CN105 -> baud_rate [2400, 9600]); the
+   *  matching entry's `options` are limited to these, defaulting first. */
+  @property({ attribute: false })
+  optionOverrides: Record<string, (string | number)[]> | null = null;
+
   @property({ type: Boolean })
   submitting = false;
 
@@ -125,8 +131,34 @@ export class ESPHomeAddComponentForm extends LitElement {
     }
   );
 
+  /** Narrow an entry's dropdown to a requester-imposed choice set and
+   *  default it to the first. `allow_custom_value` is left untouched, so a
+   *  combo box (baud) keeps the dropdown to the choices but still accepts a
+   *  typed-in value (a CN105 on a non-standard rate). Memoized to keep
+   *  `.entries` render-stable. */
+  private _overlayOptions = memoizeOne(
+    (
+      entries: ConfigEntry[],
+      overrides: Record<string, (string | number)[]> | null
+    ): ConfigEntry[] => {
+      if (!overrides || Object.keys(overrides).length === 0) return entries;
+      return entries.map((e) => {
+        const choices = overrides[e.key];
+        if (!choices?.length) return e;
+        return {
+          ...e,
+          options: choices.map((v) => ({ label: String(v), value: String(v) })),
+          default_value: choices[0],
+        };
+      });
+    }
+  );
+
   private get _entries(): ConfigEntry[] {
-    return this._overlayRequired(this.component.config_entries, this.extraRequired);
+    return this._overlayOptions(
+      this._overlayRequired(this.component.config_entries, this.extraRequired),
+      this.optionOverrides
+    );
   }
 
   /** True once we've seeded `_values` for the current component. */

--- a/src/util/bus-constraint-prefill.ts
+++ b/src/util/bus-constraint-prefill.ts
@@ -49,8 +49,9 @@ export function busConstraintPrefill(
     const entry = entryOf(key);
     if (!entry) continue;
     // A list constraint narrows a single-value select/combobox to those
-    // choices, default-first (CN105's variable 2400/9600 baud). A multi_value
-    // field's list isn't a dropdown; keep only primitive choices.
+    // choices, default-first (CN105's variable 2400/9600 baud). Skip it for a
+    // multi_value field (a list there isn't a dropdown); otherwise keep only
+    // the primitive choices.
     if (Array.isArray(value)) {
       const choices = entry.multi_value
         ? []

--- a/src/util/bus-constraint-prefill.ts
+++ b/src/util/bus-constraint-prefill.ts
@@ -7,14 +7,19 @@ export interface BusPrefill {
   fields: Record<string, unknown>;
   /** Bus fields the requester forces (require_tx -> tx_pin). */
   required: string[];
+  /** Fields whose dropdown the requester narrows to a fixed choice set
+   *  (a list constraint, e.g. CN105 -> baud_rate [2400, 9600]); absent
+   *  when no constraint is a list. */
+  optionOverrides?: Record<string, (string | number)[]>;
 }
 
 /**
  * Bus-form prefill for a requester's `bus_constraints[bus]` dict.
  *
  * Exact-match values prefill unless the bus default already satisfies
- * them; min/max_frequency clamp the default into range; require_* map
- * to their pin fields. Returns null when nothing applies.
+ * them; a list value narrows the field to those choices and defaults to
+ * the first; min/max_frequency clamp the default into range; require_*
+ * map to their pin fields. Returns null when nothing applies.
  */
 export function busConstraintPrefill(
   busEntries: ConfigEntry[],
@@ -22,6 +27,7 @@ export function busConstraintPrefill(
 ): BusPrefill | null {
   const fields: Record<string, unknown> = {};
   const required: string[] = [];
+  const optionOverrides: Record<string, (string | number)[]> = {};
   const entryOf = (key: string): ConfigEntry | undefined =>
     busEntries.find((e) => e.key === key);
 
@@ -42,6 +48,18 @@ export function busConstraintPrefill(
     }
     const entry = entryOf(key);
     if (!entry) continue;
+    // A list constraint narrows the field to those choices and defaults
+    // to the first (e.g. CN105's variable 2400/9600 baud).
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      optionOverrides[key] = value as (string | number)[];
+      const first = value[0];
+      const dflt = entry.default_value;
+      if (dflt === null || dflt === undefined || String(dflt) !== String(first)) {
+        fields[key] = entry.type === ConfigEntryType.STRING ? String(first) : first;
+      }
+      continue;
+    }
     const dflt = entry.default_value;
     if (dflt === null || dflt === undefined || String(dflt) !== String(value)) {
       // Options-style fields ('stop_bits', 'parity') match on strings.
@@ -62,6 +80,14 @@ export function busConstraintPrefill(
     if (target !== null) fields.frequency = formatInBestUnit(target, unitOptions);
   }
 
-  if (Object.keys(fields).length === 0 && required.length === 0) return null;
-  return { fields, required };
+  if (
+    Object.keys(fields).length === 0 &&
+    required.length === 0 &&
+    Object.keys(optionOverrides).length === 0
+  ) {
+    return null;
+  }
+  const prefill: BusPrefill = { fields, required };
+  if (Object.keys(optionOverrides).length > 0) prefill.optionOverrides = optionOverrides;
+  return prefill;
 }

--- a/src/util/bus-constraint-prefill.ts
+++ b/src/util/bus-constraint-prefill.ts
@@ -48,12 +48,18 @@ export function busConstraintPrefill(
     }
     const entry = entryOf(key);
     if (!entry) continue;
-    // A list constraint narrows the field to those choices and defaults
-    // to the first (e.g. CN105's variable 2400/9600 baud).
+    // A list constraint narrows a single-value select/combobox to those
+    // choices, default-first (CN105's variable 2400/9600 baud). A multi_value
+    // field's list isn't a dropdown; keep only primitive choices.
     if (Array.isArray(value)) {
-      if (value.length === 0) continue;
-      optionOverrides[key] = value as (string | number)[];
-      const first = value[0];
+      const choices = entry.multi_value
+        ? []
+        : value.filter(
+            (v): v is string | number => typeof v === "string" || typeof v === "number"
+          );
+      if (choices.length === 0) continue;
+      optionOverrides[key] = choices;
+      const first = choices[0];
       const dflt = entry.default_value;
       if (dflt === null || dflt === undefined || String(dflt) !== String(first)) {
         fields[key] = entry.type === ConfigEntryType.STRING ? String(first) : first;

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -185,5 +185,7 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
       { label: "1 bit", value: "1" },
       { label: "2 bits", value: "2" },
     ]);
+    // STRING entry keeps a string default, not a coerced number.
+    expect(stop.default_value).toBe("1");
   });
 });

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -158,4 +158,32 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
     // allow_custom_value is preserved so an unknown CN105 rate can be typed.
     expect(baud.allow_custom_value).toBe(true);
   });
+
+  it("preserves an existing entry's labels when narrowing a labeled field", () => {
+    const form = uartForm() as ReturnType<typeof uartForm> & {
+      component: ComponentCatalogEntry;
+      optionOverrides: Record<string, (string | number)[]> | null;
+      _entries: ConfigEntry[];
+    };
+    form.component = {
+      id: "uart",
+      config_entries: [
+        makeConfigEntry({
+          key: "stop_bits",
+          type: ConfigEntryType.STRING,
+          options: [
+            { label: "1 bit", value: "1" },
+            { label: "2 bits", value: "2" },
+          ],
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    form.optionOverrides = { stop_bits: ["1", "2"] };
+    const stop = form._entries.find((e) => e.key === "stop_bits")!;
+    // Catalog labels survive; only the constrained subset remains.
+    expect(stop.options).toEqual([
+      { label: "1 bit", value: "1" },
+      { label: "2 bits", value: "2" },
+    ]);
+  });
 });

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
@@ -121,6 +122,7 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
           type: ConfigEntryType.INTEGER,
           required: true,
           default_value: 115200,
+          allow_custom_value: true,
         }),
       ],
     } as unknown as ComponentCatalogEntry;
@@ -139,5 +141,21 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
     form.prefillFields = { baud_rate: 256000 };
     form._initValues();
     expect(form._values.baud_rate).toBe(256000);
+  });
+
+  it("narrows the baud dropdown to a detour's choices but keeps it typeable", () => {
+    const form = uartForm() as ReturnType<typeof uartForm> & {
+      optionOverrides: Record<string, (string | number)[]> | null;
+      _entries: ConfigEntry[];
+    };
+    form.optionOverrides = { baud_rate: [2400, 9600] };
+    const baud = form._entries.find((e) => e.key === "baud_rate")!;
+    expect(baud.options).toEqual([
+      { label: "2400", value: "2400" },
+      { label: "9600", value: "9600" },
+    ]);
+    expect(baud.default_value).toBe(2400);
+    // allow_custom_value is preserved so an unknown CN105 rate can be typed.
+    expect(baud.allow_custom_value).toBe(true);
   });
 });

--- a/test/util/bus-constraint-prefill.test.ts
+++ b/test/util/bus-constraint-prefill.test.ts
@@ -107,4 +107,25 @@ describe("busConstraintPrefill", () => {
   test("drops a baud constraint equal to the default (seed already supplies it)", () => {
     expect(busConstraintPrefill(baudDefaulted, { baud_rate: 115200 })).toBeNull();
   });
+
+  test("a list baud constraint narrows the options and defaults to the first", () => {
+    // CN105's variable rate -> offer 2400/9600, default 2400.
+    expect(busConstraintPrefill(baudDefaulted, { baud_rate: [2400, 9600] })).toEqual({
+      fields: { baud_rate: 2400 },
+      required: [],
+      optionOverrides: { baud_rate: [2400, 9600] },
+    });
+  });
+
+  test("a list whose first value equals the default still narrows but skips the prefill", () => {
+    expect(busConstraintPrefill(baudDefaulted, { baud_rate: [115200, 9600] })).toEqual({
+      fields: {},
+      required: [],
+      optionOverrides: { baud_rate: [115200, 9600] },
+    });
+  });
+
+  test("an empty list contributes nothing", () => {
+    expect(busConstraintPrefill(baudDefaulted, { baud_rate: [] })).toBeNull();
+  });
 });

--- a/test/util/bus-constraint-prefill.test.ts
+++ b/test/util/bus-constraint-prefill.test.ts
@@ -128,4 +128,18 @@ describe("busConstraintPrefill", () => {
   test("an empty list contributes nothing", () => {
     expect(busConstraintPrefill(baudDefaulted, { baud_rate: [] })).toBeNull();
   });
+
+  test("ignores a list constraint on a multi_value field", () => {
+    const multi = [
+      makeConfigEntry({ key: "addrs", type: ConfigEntryType.STRING, multi_value: true }),
+    ];
+    expect(busConstraintPrefill(multi, { addrs: ["a", "b"] })).toBeNull();
+  });
+
+  test("drops non-primitive entries from a list constraint", () => {
+    const result = busConstraintPrefill(baudDefaulted, {
+      baud_rate: [2400, { bad: true }, 9600] as unknown as (string | number)[],
+    });
+    expect(result?.optionOverrides).toEqual({ baud_rate: [2400, 9600] });
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

When a component spawns a "+ Add UART" detour, it can pin the new bus's fields through its `bus_constraints`. This adds support for a **list** constraint value, which narrows the field's dropdown to those choices and defaults to the first, instead of only setting a single value.

The motivating case is the Mitsubishi CN105 climate, whose UART runs at 2400 or 9600 depending on the heat-pump model: the detour now offers just those two, defaulting to 2400. `allow_custom_value` is left untouched, so the baud field stays a typeable combo box (someone on a non-standard rate can still enter it); the value coerces back to a number on emit as before.

Implemented in `busConstraintPrefill` (array -> default-first + `optionOverrides`) and overlaid onto the entry in the add-component form, mirroring the existing `extraRequired` overlay. Scalar constraints are unchanged.

This pairs with esphome/device-builder#1455, which curates the baud constraints (CN105 plus known fixed-baud devices).

**Related issue or feature (if applicable):**

- No tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
