### PR TITLE
Add manual cleanup input to the Lokalise upload workflow

### DIFF
--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -5,6 +5,10 @@ name: Upload translations
 # the English copy of existing keys is updated; keys removed from en.json
 # are left in the project (so a moved key keeps its translations for reuse)
 # and translated locales are left untouched (see build-scripts/translations.ts).
+#
+# Automated pushes never prune. To delete keys no longer in en.json (stale
+# keys orphaned by a rename or migration), run this workflow manually from
+# the Actions tab with the `cleanup` input checked.
 
 on:
   push:
@@ -15,6 +19,11 @@ on:
       - "build-scripts/translations-lib.ts"
       - ".github/workflows/translations-upload.yml"
   workflow_dispatch:
+    inputs:
+      cleanup:
+        description: "Delete Lokalise keys no longer in en.json (prunes stale keys)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,4 +62,5 @@ jobs:
         env:
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
           LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
-        run: npm run translations:upload
+          CLEANUP: ${{ inputs.cleanup && '--cleanup' || '' }}
+        run: npm run translations:upload -- $CLEANUP

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The frontend loader (`src/common/localize.ts`) is data-driven with no hardcoded 
 
 In CI this is automated by:
 
-- `translations-upload.yml` — pushes to Lokalise whenever `en.json` lands on `main`.
+- `translations-upload.yml` — pushes to Lokalise whenever `en.json` lands on `main`. Automated pushes never prune; run it manually from the Actions tab with the `cleanup` input checked to delete keys no longer in `en.json`.
 - `release.yml` — downloads translations before bundling so the released wheel ships every locale.
 
 There's no scheduled download workflow: because the locale files are gitignored, there's nothing to commit back to `main`. The translations only need to exist at build time, and `release.yml` pulls them fresh for the wheel; locally, run `npm run translations:download` whenever you want to work against the latest copy.


### PR DESCRIPTION
# What does this implement/fix?

Keys removed from `en.json` (for example the `_singular`/`_plural` keys dropped in the ICU plural migration) were never deleted from Lokalise, because the automated upload deliberately runs without `--cleanup` so a moved key keeps its translations.

This adds a `cleanup` boolean input to the `workflow_dispatch` of `translations-upload.yml`; a maintainer can run the workflow manually from the Actions tab with cleanup checked to prune keys no longer in `en.json`. Automated pushes are unchanged and stay non-destructive.

After this merges, the orphaned `_singular`/`_plural` keys still need a one-time run of the workflow with `cleanup` checked to actually remove them from Lokalise.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1457

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
