### PR TITLE
Show waiting messages for pending device-info fields in the drawer

### DIFF
--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -27,7 +27,8 @@ export function renderRow(
   icon: string,
   label: string,
   value: string | null,
-  mono = false
+  mono = false,
+  emptyText = "—"
 ): TemplateResult {
   const empty = !value;
   return html`
@@ -38,7 +39,7 @@ export function renderRow(
       <div class="content">
         <div class="label">${label}</div>
         <div class="value ${mono ? "mono" : ""} ${empty ? "muted" : ""}">
-          ${value || "—"}
+          ${value || emptyText}
         </div>
       </div>
     </div>
@@ -163,7 +164,8 @@ export function renderVersionSection(
               "upload",
               localize("dashboard.drawer_deployed_version"),
               deployed,
-              true
+              true,
+              localize("dashboard.drawer_waiting_for_mdns")
             )}
           `}
     </div>
@@ -329,36 +331,73 @@ export function renderMacAddressRow(
     "ethernet",
     localize("dashboard.drawer_mac_address"),
     d.mac_address,
-    true
+    true,
+    localize("dashboard.drawer_waiting_for_mdns")
   );
 }
 
-// Hidden when YAML doesn't load ethernet or the derived value duplicates mac_address
-// (single-MAC RP2040 / RP2350 platforms).
+// Mirrors the backend's mac_addresses._has_ethernet / _has_bluetooth: which
+// interface MACs the YAML loads. Used only to show a "waiting" row before the
+// primary MAC is observed (the derived value is empty until then); once the
+// primary MAC is present the derived value itself tells us whether the platform
+// has a distinct MAC.
+const deviceHasEthernet = (d: ConfiguredDevice): boolean =>
+  d.loaded_integrations.includes("ethernet");
+const deviceHasBluetooth = (d: ConfiguredDevice): boolean =>
+  d.loaded_integrations.some(
+    (n) => n.startsWith("esp32_ble") || n.startsWith("bluetooth_")
+  );
+
+// Show the distinct derived MAC when known; while the primary MAC is still
+// pending mDNS, show a "waiting" row if the YAML loads the interface; otherwise
+// hide (no such interface, or a single-MAC platform whose derived value just
+// duplicates mac_address).
 export function renderEthernetMacRow(
   d: ConfiguredDevice,
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
-  if (!d.ethernet_mac || d.ethernet_mac === d.mac_address) return nothing;
-  return renderRow(
-    "ethernet",
-    localize("dashboard.drawer_ethernet_mac"),
-    d.ethernet_mac,
-    true
-  );
+  if (d.ethernet_mac && d.ethernet_mac !== d.mac_address) {
+    return renderRow(
+      "ethernet",
+      localize("dashboard.drawer_ethernet_mac"),
+      d.ethernet_mac,
+      true
+    );
+  }
+  if (!d.mac_address && deviceHasEthernet(d)) {
+    return renderRow(
+      "ethernet",
+      localize("dashboard.drawer_ethernet_mac"),
+      "",
+      true,
+      localize("dashboard.drawer_waiting_for_mdns")
+    );
+  }
+  return nothing;
 }
 
 export function renderBluetoothMacRow(
   d: ConfiguredDevice,
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
-  if (!d.bluetooth_mac || d.bluetooth_mac === d.mac_address) return nothing;
-  return renderRow(
-    "bluetooth",
-    localize("dashboard.drawer_bluetooth_mac"),
-    d.bluetooth_mac,
-    true
-  );
+  if (d.bluetooth_mac && d.bluetooth_mac !== d.mac_address) {
+    return renderRow(
+      "bluetooth",
+      localize("dashboard.drawer_bluetooth_mac"),
+      d.bluetooth_mac,
+      true
+    );
+  }
+  if (!d.mac_address && deviceHasBluetooth(d)) {
+    return renderRow(
+      "bluetooth",
+      localize("dashboard.drawer_bluetooth_mac"),
+      "",
+      true,
+      localize("dashboard.drawer_waiting_for_mdns")
+    );
+  }
+  return nothing;
 }
 
 function emitCleanBuild(

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -217,7 +217,8 @@ export function renderConfigHashSection(
               "fingerprint",
               localize("dashboard.drawer_config_hash_deployed"),
               deployed,
-              true
+              true,
+              localize("dashboard.drawer_waiting_for_mdns")
             )}
           `}
     </div>
@@ -258,7 +259,15 @@ export function renderIpAddressRow(
   // fall back to it on a cold scan to keep the IP row and its visit link.
   const primary = list[0] ?? d.ip;
   if (!primary) {
-    return renderRow("ip-network-outline", label, "", true);
+    // IP is learned from any source (mDNS / ping), not only mDNS, so mirror
+    // the reachability section's "Waiting for first signal" wording.
+    return renderRow(
+      "ip-network-outline",
+      label,
+      "",
+      true,
+      host._localize("dashboard.drawer_waiting_for_signal")
+    );
   }
   if (list.length <= 1) {
     return html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -228,6 +228,7 @@
     "drawer_source_active": "active",
     "drawer_round_trip_ms": "{n} ms",
     "drawer_waiting_for_signal": "Waiting for first signal…",
+    "drawer_waiting_for_mdns": "Waiting for mDNS discovery…",
     "drawer_show_mdns_txt_records": "{count, plural, one {Show # mDNS TXT record} other {Show # mDNS TXT records}}",
     "drawer_ip_address": "IP Address",
     "drawer_ip_show_more": "Show {n} more",

--- a/test/components/dashboard/render-ip-address-row.test.ts
+++ b/test/components/dashboard/render-ip-address-row.test.ts
@@ -39,6 +39,15 @@ describe("renderIpAddressRow", () => {
     expect(findTemplatesByAnchor(result, "<a")).toHaveLength(0);
   });
 
+  it("shows waiting-for-first-signal when no IP is known", () => {
+    const result = renderIpAddressRow(
+      _host,
+      _device({ web_port: 80, ip: "", ip_addresses: [] })
+    );
+    const texts = findTemplatesByAnchor(result, 'class="value').flatMap((t) => t.values);
+    expect(texts).toContain("dashboard.drawer_waiting_for_signal");
+  });
+
   it("links the resolved address to its own host", () => {
     const result = renderIpAddressRow(
       _host,

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -6,6 +6,7 @@ import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import {
   renderBluetoothMacRow,
+  renderConfigHashSection,
   renderEthernetMacRow,
   renderMacAddressRow,
   renderVersionSection,
@@ -106,6 +107,18 @@ describe("renderVersionSection deployed row", () => {
     );
     const texts = valueTexts(result);
     expect(texts).toContain("2026.5.2");
+    expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+});
+
+describe("renderConfigHashSection deployed row", () => {
+  it("shows waiting-for-mDNS on the deployed hash when only the local hash is known", () => {
+    const result = renderConfigHashSection(
+      _device({ expected_config_hash: "abc123", deployed_config_hash: "" }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("abc123");
     expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
   });
 });

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pins that mDNS-derived rows (MAC, deployed version) show
+ * "Waiting for mDNS discovery" instead of a bare dash while empty (#1453).
+ */
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import {
+  renderBluetoothMacRow,
+  renderEthernetMacRow,
+  renderMacAddressRow,
+  renderVersionSection,
+} from "../../../src/components/dashboard/device-drawer-content/render-sections.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
+import { makeConfiguredDevice as _device } from "../../_make-configured-device.js";
+
+const _localize = (key: string) => key;
+
+// Text bound inside each row's `.value` div.
+const valueTexts = (result: unknown): unknown[] =>
+  findTemplatesByAnchor(result, 'class="value').flatMap((t) => t.values);
+
+describe("renderMacAddressRow", () => {
+  it("shows the waiting-for-mDNS message when mac_address is empty", () => {
+    const result = renderMacAddressRow(_device({ mac_address: "" }), _localize);
+    expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("shows the MAC when present", () => {
+    const result = renderMacAddressRow(
+      _device({ mac_address: "AA:BB:CC:DD:EE:FF" }),
+      _localize
+    );
+    expect(valueTexts(result)).toContain("AA:BB:CC:DD:EE:FF");
+  });
+});
+
+describe("renderEthernetMacRow", () => {
+  it("shows the distinct ethernet MAC when known", () => {
+    const result = renderEthernetMacRow(
+      _device({ mac_address: "AA:BB:CC:DD:EE:F1", ethernet_mac: "AA:BB:CC:DD:EE:F4" }),
+      _localize
+    );
+    expect(valueTexts(result)).toContain("AA:BB:CC:DD:EE:F4");
+  });
+
+  it("shows waiting-for-mDNS while the primary MAC is pending and the YAML loads ethernet", () => {
+    const result = renderEthernetMacRow(
+      _device({
+        mac_address: "",
+        ethernet_mac: "",
+        loaded_integrations: ["ethernet", "wifi"],
+      }),
+      _localize
+    );
+    expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("hides when the device has no ethernet integration", () => {
+    const result = renderEthernetMacRow(
+      _device({ mac_address: "", ethernet_mac: "", loaded_integrations: ["wifi"] }),
+      _localize
+    );
+    expect(result).toBe(nothing);
+  });
+
+  it("hides when the primary MAC is known but no distinct ethernet MAC was derived", () => {
+    const result = renderEthernetMacRow(
+      _device({
+        mac_address: "AA:BB:CC:DD:EE:F1",
+        ethernet_mac: "",
+        loaded_integrations: ["ethernet"],
+      }),
+      _localize
+    );
+    expect(result).toBe(nothing);
+  });
+});
+
+describe("renderBluetoothMacRow", () => {
+  it("shows waiting-for-mDNS while pending when the YAML loads a BLE integration", () => {
+    const result = renderBluetoothMacRow(
+      _device({
+        mac_address: "",
+        bluetooth_mac: "",
+        loaded_integrations: ["esp32_ble_tracker"],
+      }),
+      _localize
+    );
+    expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("hides when the device loads no bluetooth integration", () => {
+    const result = renderBluetoothMacRow(
+      _device({ mac_address: "", bluetooth_mac: "", loaded_integrations: ["wifi"] }),
+      _localize
+    );
+    expect(result).toBe(nothing);
+  });
+});
+
+describe("renderVersionSection deployed row", () => {
+  it("shows waiting-for-mDNS on the deployed row when only the local version is known", () => {
+    const result = renderVersionSection(
+      _device({ current_version: "2026.5.2", deployed_version: "" }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("2026.5.2");
+    expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In the device drawer, fields that are only learned once a device is seen showed a bare dash (or an empty/hidden row) before that happened, so users couldn't tell whether the value was missing or just pending. This replaces those empty states with a clear "waiting" message.

mDNS-derived rows now read "Waiting for mDNS discovery…" (muted, matching the existing "Waiting for first signal…"):

- MAC Address
- Ethernet MAC and Bluetooth MAC (previously hidden while empty; now show the waiting message while the primary MAC is pending and the YAML loads that integration — `ethernet`, `esp32_ble*` / `bluetooth_*`, mirroring the backend's derivation. Once the primary MAC is known, a platform with no distinct interface MAC still hides the row, so non-ethernet / non-BLE devices are unaffected.)
- Deployed ESPHome version
- Deployed config hash

The IP Address row reads "Waiting for first signal…" instead, because the IP is learned from any source (mDNS or ping), not only mDNS, so it mirrors the Reachability section's wording.

Implemented via an optional `emptyText` on the shared `renderRow` helper (default stays "—"), so every non-pending field keeps its dash.

This is a clarity improvement, not a fix for the underlying mDNS discovery failure; the root cause in the linked issue is still being investigated.

**Related issue or feature (if applicable):**

- Re: esphome/device-builder#1453

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
