### PR TITLE
Render the module image on featured bundle cards

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -83,6 +83,9 @@ export interface FeaturedBundle {
   name: string;
   description: string;
   component_ids: string[];
+  // Photo of the physical module this bundle maps to; rendered on the
+  // bundle card in place of the box icon when set.
+  image_url?: string;
 }
 
 export interface BoardCatalogEntry {

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -20,6 +20,7 @@ export function renderBundleCard(
   host: ESPHomeComponentCatalog,
   bundle: FeaturedBundle
 ): TemplateResult {
+  const hasImage = !!bundle.image_url && !host._imageFailed.has(bundle.id);
   return html`
     <article
       class="component-card component-card--featured"
@@ -28,9 +29,19 @@ export function renderBundleCard(
       }}
     >
       <div class="component-card-header">
-        <div class="component-image--placeholder">
-          <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
-        </div>
+        ${hasImage
+          ? html`<div class="component-image">
+              <img
+                src=${bundle.image_url}
+                alt=${bundle.name}
+                referrerpolicy="no-referrer"
+                loading="lazy"
+                @error=${() => host._onImageError(bundle.id)}
+              />
+            </div>`
+          : html`<div class="component-image--placeholder">
+              <wa-icon library="mdi" name="package-variant-closed"></wa-icon>
+            </div>`}
         <div class="component-card-header-text">
           <h3 class="component-title">${bundle.name}</h3>
         </div>

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -14,6 +14,7 @@ function host(failed: string[] = []): unknown {
   return {
     _imageFailed: new Set(failed),
     _onAddBundle: () => {},
+    _onImageError: () => {},
     _localize: (key: string) => key,
   };
 }

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -57,4 +57,18 @@ describe("renderBundleCard image", () => {
     expect(el.querySelector("img")).toBeNull();
     expect(el.querySelector(".component-image--placeholder")).not.toBeNull();
   });
+
+  it("calls _onImageError with the bundle id when the img fires an error", () => {
+    const failedIds: string[] = [];
+    const spyHost = {
+      _imageFailed: new Set<string>(),
+      _onAddBundle: () => {},
+      _onImageError: (id: string) => failedIds.push(id),
+      _localize: (key: string) => key,
+    };
+    const b = bundle({ image_url: "https://example.com/module.jpg" });
+    const el = renderInto(renderBundleCard(spyHost as never, b));
+    el.querySelector("img")!.dispatchEvent(new Event("error"));
+    expect(failedIds).toEqual([b.id]);
+  });
 });

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+//
+// Tests for renderBundleCard image handling: a featured bundle with an
+// image_url shows the module photo; without one (or once it has failed to
+// load) it falls back to the box-icon placeholder.
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import type { FeaturedBundle } from "../../../../src/api/types/boards.js";
+import { renderBundleCard } from "../../../../src/components/device/component-catalog/renderers.js";
+
+function host(failed: string[] = []): unknown {
+  return {
+    _imageFailed: new Set(failed),
+    _onAddBundle: () => {},
+    _localize: (key: string) => key,
+  };
+}
+
+function bundle(overrides: Partial<FeaturedBundle> = {}): FeaturedBundle {
+  return {
+    id: "rgb_buzzer_module",
+    name: "RGB LED + Buzzer Module",
+    description: "",
+    component_ids: ["rgb_leds", "buzzer_output"],
+    ...overrides,
+  };
+}
+
+function renderInto(value: unknown): HTMLElement {
+  const container = document.createElement("div");
+  render(value, container);
+  return container;
+}
+
+describe("renderBundleCard image", () => {
+  it("renders the module image when the bundle has an image_url", () => {
+    const b = bundle({ image_url: "https://example.com/module.jpg" });
+    const el = renderInto(renderBundleCard(host() as never, b));
+    const img = el.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://example.com/module.jpg");
+    expect(el.querySelector(".component-image--placeholder")).toBeNull();
+  });
+
+  it("falls back to the box-icon placeholder without an image_url", () => {
+    const el = renderInto(renderBundleCard(host() as never, bundle()));
+    expect(el.querySelector("img")).toBeNull();
+    expect(el.querySelector(".component-image--placeholder")).not.toBeNull();
+  });
+
+  it("falls back to the placeholder once the image has failed to load", () => {
+    const b = bundle({ image_url: "https://example.com/module.jpg" });
+    const el = renderInto(renderBundleCard(host([b.id]) as never, b));
+    expect(el.querySelector("img")).toBeNull();
+    expect(el.querySelector(".component-image--placeholder")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Featured bundle cards now show the module photo when the bundle carries an `image_url`, matching the component cards; they fall back to the box icon when no image is set. This pairs with the backend change that adds `image_url` to featured components and bundles so a recommended card links visually to the real hardware module (for example the Apollo starter kit modules).

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
