### PR TITLE
Resolve featured-add id references to the existing bus

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -16,7 +16,7 @@ import { seedBoardPinDefaults } from "../../util/board-pin-defaults.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
 import {
   findReferenceCandidates,
-  yamlHasMergedSources,
+  resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
 import { validateEntries, type ValidationError } from "../../util/config-validation.js";
 import {
@@ -281,8 +281,8 @@ export class ESPHomeAddComponentForm extends LitElement {
       // preset (`i2c_bus`) can't outlive the bus it names. Locked refs are
       // deliberate pins — keep their literal.
       if (entry.references_component && !entry.locked) {
-        const ref = this._seedReference(entry);
-        if (ref !== undefined) out[entry.key] = ref;
+        const ref = this._seedReference(entry.references_component);
+        if (ref !== undefined) out[entry.key] = entry.multi_value ? [ref] : ref;
         continue;
       }
       if (entry.default_value != null) {
@@ -297,21 +297,16 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   /**
-   * Seed value for an id-reference field: a preset that names a real
-   * component, else the sole existing match. Ambiguous (none / several /
-   * merged sources) → unset, deferring to the dep detour or the picker.
+   * Seed an unlocked id-reference field with the bus already in the config, so
+   * a stale featured preset can't write an id that doesn't exist. Ambiguous
+   * cases — none, several, or a `packages:`/`<<:` merge that could hide one —
+   * stay unset, deferring to the dep detour or the picker.
    */
-  private _seedReference(entry: ConfigEntry): string | undefined {
-    const domain = entry.references_component!;
-    const preset = entry.default_value != null ? String(entry.default_value) : null;
+  private _seedReference(domain: string): string | undefined {
     // Same-domain provider covers bus refs (i2c/spi/uart); async cross-domain
     // interface providers are unavailable here, so those defer to the picker.
     const candidates = findReferenceCandidates(this.yaml, domain, []);
-    if (preset && candidates.some((c) => c.id === preset)) return preset;
-    if (candidates.length === 1 && !yamlHasMergedSources(this.yaml)) {
-      return candidates[0].id;
-    }
-    return undefined;
+    return resolveSoleCandidate(candidates, this.yaml)?.id;
   }
 
   private _generateDefaultId(): string | null {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -14,6 +14,10 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { seedBoardPinDefaults } from "../../util/board-pin-defaults.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
+import {
+  findReferenceCandidates,
+  yamlHasMergedSources,
+} from "../../util/config-entry-yaml-scan.js";
 import { validateEntries, type ValidationError } from "../../util/config-validation.js";
 import {
   collectExistingIds,
@@ -273,6 +277,14 @@ export class ESPHomeAddComponentForm extends LitElement {
         continue;
       }
       if (!seedAll && !entry.required) continue;
+      // Resolve an id reference against the live YAML so a stale featured
+      // preset (`i2c_bus`) can't outlive the bus it names. Locked refs are
+      // deliberate pins — keep their literal.
+      if (entry.references_component && !entry.locked) {
+        const ref = this._seedReference(entry);
+        if (ref !== undefined) out[entry.key] = ref;
+        continue;
+      }
       if (entry.default_value != null) {
         out[entry.key] = entry.multi_value
           ? [String(entry.default_value)]
@@ -282,6 +294,24 @@ export class ESPHomeAddComponentForm extends LitElement {
       }
     }
     return out;
+  }
+
+  /**
+   * Seed value for an id-reference field: a preset that names a real
+   * component, else the sole existing match. Ambiguous (none / several /
+   * merged sources) → unset, deferring to the dep detour or the picker.
+   */
+  private _seedReference(entry: ConfigEntry): string | undefined {
+    const domain = entry.references_component!;
+    const preset = entry.default_value != null ? String(entry.default_value) : null;
+    // Same-domain provider covers bus refs (i2c/spi/uart); async cross-domain
+    // interface providers are unavailable here, so those defer to the picker.
+    const candidates = findReferenceCandidates(this.yaml, domain, []);
+    if (preset && candidates.some((c) => c.id === preset)) return preset;
+    if (candidates.length === 1 && !yamlHasMergedSources(this.yaml)) {
+      return candidates[0].id;
+    }
+    return undefined;
   }
 
   private _generateDefaultId(): string | null {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -282,7 +282,11 @@ export class ESPHomeAddComponentForm extends LitElement {
       // deliberate pins — keep their literal.
       if (entry.references_component && !entry.locked) {
         const ref = this._seedReference(entry.references_component);
-        if (ref !== undefined) out[entry.key] = entry.multi_value ? [ref] : ref;
+        if (ref !== undefined) {
+          out[entry.key] = entry.multi_value ? [ref] : ref;
+        } else if (entry.multi_value && entry.required) {
+          out[entry.key] = [];
+        }
         continue;
       }
       if (entry.default_value != null) {
@@ -303,8 +307,9 @@ export class ESPHomeAddComponentForm extends LitElement {
    * stay unset, deferring to the dep detour or the picker.
    */
   private _seedReference(domain: string): string | undefined {
-    // Same-domain provider covers bus refs (i2c/spi/uart); async cross-domain
-    // interface providers are unavailable here, so those defer to the picker.
+    // Resolve against same-domain candidates only (i2c/spi/uart buses); the
+    // picker also folds in async interface providers, so a pure cross-domain
+    // ref finds nothing here and defers to it.
     const candidates = findReferenceCandidates(this.yaml, domain, []);
     return resolveSoleCandidate(candidates, this.yaml)?.id;
   }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -308,8 +308,10 @@ export class ESPHomeAddComponentForm extends LitElement {
    */
   private _seedReference(domain: string): string | undefined {
     // Resolve against same-domain candidates only (i2c/spi/uart buses); the
-    // picker also folds in async interface providers, so a pure cross-domain
-    // ref finds nothing here and defers to it.
+    // picker also folds in async interface providers. A cross-domain ref finds
+    // nothing here and defers to the picker; for a domain that is both a block
+    // and a provided interface, seeding may fill a value the picker would call
+    // ambiguous — harmless, since it's a real id the user can still change.
     const candidates = findReferenceCandidates(this.yaml, domain, []);
     return resolveSoleCandidate(candidates, this.yaml)?.id;
   }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -301,10 +301,10 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   /**
-   * Seed an unlocked id-reference field with the bus already in the config, so
-   * a stale featured preset can't write an id that doesn't exist. Ambiguous
-   * cases — none, several, or a `packages:`/`<<:` merge that could hide one —
-   * stay unset, deferring to the dep detour or the picker.
+   * Seed an unlocked id-reference field with the matching component already in
+   * the config, so a stale featured preset can't write an id that doesn't
+   * exist. Ambiguous cases — none, several, or a `packages:`/`<<:` merge that
+   * could hide one — stay unset, deferring to the dep detour or the picker.
    */
   private _seedReference(domain: string): string | undefined {
     // Resolve against same-domain candidates only (i2c/spi/uart buses); the

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -9,7 +9,7 @@ import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import {
   findReferenceCandidates,
-  yamlHasMergedSources,
+  resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
 import {
   effectiveDisabled,
@@ -39,14 +39,10 @@ export function renderIdReferenceField(
   const value = String(raw ?? "");
   const invalid = ctx.errorAt(path) !== null;
 
-  // ESPHome auto-resolves an omitted reference when exactly one matching
-  // component exists. Surface that target as the default — but only when the
-  // scan can see the whole config; a `packages:` / `<<:` merge could hide a
-  // second match, making "the one we see" the wrong (or ambiguous) target.
+  // Surface ESPHome's auto-resolved target as the default, but only on an
+  // empty field — a committed value isn't a "default".
   const defaultCandidate =
-    value === "" && candidates.length === 1 && !yamlHasMergedSources(ctx.yaml)
-      ? candidates[0]
-      : null;
+    value === "" ? resolveSoleCandidate(candidates, ctx.yaml) : null;
 
   const idOption = (optValue: string, primary: string, secondary: string) => html`
     <wa-option

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -346,6 +346,19 @@ export function yamlHasMergedSources(yaml: string): boolean {
 }
 
 /**
+ * The candidate ESPHome auto-resolves an omitted reference to, or null when
+ * ambiguous — several candidates, none, or a `packages:`/`<<:` merge that
+ * could hide one. Shared by the id-reference picker (shows it as the default)
+ * and featured-add seeding (writes it).
+ */
+export function resolveSoleCandidate(
+  candidates: ReadonlyArray<{ id: string; name: string }>,
+  yaml: string
+): { id: string; name: string } | null {
+  return candidates.length === 1 && !yamlHasMergedSources(yaml) ? candidates[0] : null;
+}
+
+/**
  * Test-only: clear both memos so cache state can't leak between
  * cases. Production callers don't need this — within an editor
  * session the memo's eviction-on-key-change is the right

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -346,10 +346,10 @@ export function yamlHasMergedSources(yaml: string): boolean {
 }
 
 /**
- * The candidate ESPHome auto-resolves an omitted reference to, or null when
- * ambiguous — several candidates, none, or a `packages:`/`<<:` merge that
- * could hide one. Shared by the id-reference picker (shows it as the default)
- * and featured-add seeding (writes it).
+ * The single candidate to resolve an omitted reference to, or null when
+ * ambiguous — none, several, or a `packages:`/`<<:` merge that could hide one.
+ * Shared by the id-reference picker (shows it as the default) and featured-add
+ * seeding (writes it).
  */
 export function resolveSoleCandidate(
   candidates: ReadonlyArray<{ id: string; name: string }>,

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -61,6 +61,73 @@ describe("add-component-form seeds required nested entity names (#1423)", () => 
   });
 });
 
+describe("add-component-form resolves featured id references to the live config", () => {
+  // sensor.max17043's i2c_id carries the Apollo manifest preset `i2c_bus`;
+  // it must never leak into a config whose bus has a different id.
+  function batteryMonitor(presetLocked = false): ComponentCatalogEntry {
+    return {
+      id: "featured.apollo-esk-1.battery_monitor",
+      config_entries: [
+        makeConfigEntry({
+          key: "i2c_id",
+          type: ConfigEntryType.ID,
+          references_component: "i2c",
+          default_value: "i2c_bus",
+          locked: presetLocked,
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+  }
+
+  function seedWithYaml(
+    component: ComponentCatalogEntry,
+    yaml: string
+  ): Record<string, unknown> {
+    const form = new ESPHomeAddComponentForm();
+    const internals = form as unknown as {
+      component: ComponentCatalogEntry;
+      yaml: string;
+      _localize: (key: string) => string;
+      _initValues: () => void;
+      _values: Record<string, unknown>;
+    };
+    internals.component = component;
+    internals.yaml = yaml;
+    internals._localize = (key) => key;
+    internals._initValues();
+    return internals._values;
+  }
+
+  const ONE_BUS = "i2c:\n  - sda: 1\n    scl: 0\n    id: i2c_1\n";
+  const TWO_BUSES = `${ONE_BUS}  - sda: 3\n    scl: 2\n    id: i2c_2\n`;
+
+  it("fills the field with the sole existing bus instead of the stale preset", () => {
+    expect(seedWithYaml(batteryMonitor(), ONE_BUS).i2c_id).toBe("i2c_1");
+  });
+
+  it("keeps a preset that names an existing bus", () => {
+    const yaml = "i2c:\n  - id: i2c_bus\n";
+    expect(seedWithYaml(batteryMonitor(), yaml).i2c_id).toBe("i2c_bus");
+  });
+
+  it("leaves the field unset when two buses exist so the user picks", () => {
+    expect(seedWithYaml(batteryMonitor(), TWO_BUSES).i2c_id).toBeUndefined();
+  });
+
+  it("leaves the field unset (not the literal) when no bus exists", () => {
+    expect(seedWithYaml(batteryMonitor(), "").i2c_id).toBeUndefined();
+  });
+
+  it("leaves the field unset when a packages merge could hide a bus", () => {
+    const yaml = `packages:\n  base: !include base.yaml\n${ONE_BUS}`;
+    expect(seedWithYaml(batteryMonitor(), yaml).i2c_id).toBeUndefined();
+  });
+
+  it("keeps a locked reference's literal verbatim (bundled output pin)", () => {
+    expect(seedWithYaml(batteryMonitor(true), ONE_BUS).i2c_id).toBe("i2c_bus");
+  });
+});
+
 describe("add-component-form dep-add bus prefill (#1425)", () => {
   function busForm() {
     const form = new ESPHomeAddComponentForm();

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -112,6 +112,22 @@ describe("add-component-form resolves featured id references to the live config"
   it("keeps a locked reference's literal verbatim (bundled output pin)", () => {
     expect(seededValues(batteryMonitor(true), ONE_BUS).i2c_id).toBe("i2c_bus");
   });
+
+  it("seeds a required multi_value reference with [] when it can't resolve", () => {
+    const component = {
+      id: "featured.x.multi_ref",
+      config_entries: [
+        makeConfigEntry({
+          key: "buses",
+          type: ConfigEntryType.ID,
+          references_component: "i2c",
+          required: true,
+          multi_value: true,
+        }),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    expect(seededValues(component, "").buses).toEqual([]);
+  });
 });
 
 describe("add-component-form dep-add bus prefill (#1425)", () => {

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -35,15 +35,20 @@ function ags10Component(): ComponentCatalogEntry {
   } as unknown as ComponentCatalogEntry;
 }
 
-function seededValues(component: ComponentCatalogEntry): Record<string, unknown> {
+function seededValues(
+  component: ComponentCatalogEntry,
+  yaml = ""
+): Record<string, unknown> {
   const form = new ESPHomeAddComponentForm();
   const internals = form as unknown as {
     component: ComponentCatalogEntry;
+    yaml: string;
     _localize: (key: string) => string;
     _initValues: () => void;
     _values: Record<string, unknown>;
   };
   internals.component = component;
+  internals.yaml = yaml;
   internals._localize = (key) => key;
   internals._initValues();
   return internals._values;
@@ -79,52 +84,33 @@ describe("add-component-form resolves featured id references to the live config"
     } as unknown as ComponentCatalogEntry;
   }
 
-  function seedWithYaml(
-    component: ComponentCatalogEntry,
-    yaml: string
-  ): Record<string, unknown> {
-    const form = new ESPHomeAddComponentForm();
-    const internals = form as unknown as {
-      component: ComponentCatalogEntry;
-      yaml: string;
-      _localize: (key: string) => string;
-      _initValues: () => void;
-      _values: Record<string, unknown>;
-    };
-    internals.component = component;
-    internals.yaml = yaml;
-    internals._localize = (key) => key;
-    internals._initValues();
-    return internals._values;
-  }
-
   const ONE_BUS = "i2c:\n  - sda: 1\n    scl: 0\n    id: i2c_1\n";
   const TWO_BUSES = `${ONE_BUS}  - sda: 3\n    scl: 2\n    id: i2c_2\n`;
 
   it("fills the field with the sole existing bus instead of the stale preset", () => {
-    expect(seedWithYaml(batteryMonitor(), ONE_BUS).i2c_id).toBe("i2c_1");
+    expect(seededValues(batteryMonitor(), ONE_BUS).i2c_id).toBe("i2c_1");
   });
 
-  it("keeps a preset that names an existing bus", () => {
+  it("fills the sole bus even when its id equals the preset", () => {
     const yaml = "i2c:\n  - id: i2c_bus\n";
-    expect(seedWithYaml(batteryMonitor(), yaml).i2c_id).toBe("i2c_bus");
+    expect(seededValues(batteryMonitor(), yaml).i2c_id).toBe("i2c_bus");
   });
 
   it("leaves the field unset when two buses exist so the user picks", () => {
-    expect(seedWithYaml(batteryMonitor(), TWO_BUSES).i2c_id).toBeUndefined();
+    expect(seededValues(batteryMonitor(), TWO_BUSES).i2c_id).toBeUndefined();
   });
 
   it("leaves the field unset (not the literal) when no bus exists", () => {
-    expect(seedWithYaml(batteryMonitor(), "").i2c_id).toBeUndefined();
+    expect(seededValues(batteryMonitor(), "").i2c_id).toBeUndefined();
   });
 
   it("leaves the field unset when a packages merge could hide a bus", () => {
     const yaml = `packages:\n  base: !include base.yaml\n${ONE_BUS}`;
-    expect(seedWithYaml(batteryMonitor(), yaml).i2c_id).toBeUndefined();
+    expect(seededValues(batteryMonitor(), yaml).i2c_id).toBeUndefined();
   });
 
   it("keeps a locked reference's literal verbatim (bundled output pin)", () => {
-    expect(seedWithYaml(batteryMonitor(true), ONE_BUS).i2c_id).toBe("i2c_bus");
+    expect(seededValues(batteryMonitor(true), ONE_BUS).i2c_id).toBe("i2c_bus");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Adding a featured component whose id reference (like the Apollo Starter Kit battery monitor's `i2c_id`) carries a backend manifest preset would write that literal verbatim; on a config whose bus has a different id (e.g. `i2c_1`), the result was `i2c_id: i2c_bus`, a dangling reference that won't compile.

Now an unlocked id-reference field is seeded with the matching component already in the config: exactly one matching bus is filled in, and anything ambiguous (no bus, two or more buses, or a `packages:` merge that could hide one) is left unset so the existing missing-dependency detour or the picker takes over. A stale preset literal is never written. Locked references (a deliberately pinned bundled `output`) keep their literal.

The resolution rule is shared with the id-reference picker via `resolveSoleCandidate`. The two agree for same-domain bus refs (i2c/spi/uart); a cross-domain interface ref finds no same-domain candidate at seed time and defers to the picker, which resolves it with its async interface providers.

Note on scope: this seeding sits after the `required` gate, so it also resolves *required* reference fields on regular (non-featured) components, pre-selecting a single existing bus there too. That matches the picker's own single-candidate default and is the intended behaviour, just broader than the "featured-add" framing.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
