### PR TITLE
List nested provider ids in reference pickers (usb_uart uart)

### DIFF
--- a/src/api/types/components.ts
+++ b/src/api/types/components.ts
@@ -108,6 +108,11 @@ export interface ComponentCatalogEntry {
   /** Interfaces this component can be referenced *as* beyond its own domain
    *  (an `adc` sensor provides `voltage_sampler`). */
   provides?: string[];
+  /** For a provided interface whose id is nested rather than the component's
+   *  own top-level id (usb_uart exposes a uart via channels[].id), the YAML
+   *  key-paths to descend, keyed by interface (one per nested location).
+   *  Absent for own-id providers. */
+  provides_id_paths?: Record<string, string[][]>;
   /** Requirements this component imposes on the bus it attaches to, keyed
    *  by bus id ('i2c' / 'spi' / 'uart'): exact-match values (baud_rate,
    *  parity, ...), range bounds (min/max_frequency in Hz) and required

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -33,7 +33,7 @@ import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
 import {
-  parseCatalogId,
+  catalogEntryToProvider,
   type ComponentProvider,
 } from "../../util/config-entry-yaml-scan.js";
 import { type ValidationError } from "../../util/config-validation.js";
@@ -803,7 +803,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
         .then((resp) => {
           this._interfaceProviders.set(
             interfaceName,
-            resp.components.map((c) => parseCatalogId(c.id))
+            resp.components.map((c) => catalogEntryToProvider(c, interfaceName))
           );
           this.requestUpdate();
         })

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -16,8 +16,9 @@
  * collapses the worst case (paste a multi-thousand-line config,
  * type into a field) from O(N) per keystroke to O(1).
  */
+import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { scanPinGpios } from "./pin-gpio.js";
-import { parseYamlTopLevelSections } from "./yaml-sections-core.js";
+import { collectIdsAtPath, parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
 /**
  * Single-entry memo for the YAML scans. The hot path is the
@@ -236,10 +237,13 @@ export function sectionEndLine(yaml: string, fromLine?: number): number | undefi
 
 /** One provider of an interface: a catalog domain and optional platform
  *  stem. ``{sensor, adc}`` matches a ``sensor:`` item with ``platform: adc``;
- *  an empty stem matches every id in the ``domain:`` block. */
+ *  an empty stem matches every id in the ``domain:`` block. ``idPaths`` set
+ *  means the interface id is nested (usb_uart's ``channels[].id``): collect
+ *  ids at those key-paths within the matched section instead of its own id. */
 export interface ComponentProvider {
   domain: string;
   stem: string;
+  idPaths?: string[][];
 }
 
 /** Split a catalog id into a provider: ``"sensor.adc"`` → ``{sensor, adc}``;
@@ -249,6 +253,19 @@ export function parseCatalogId(id: string): ComponentProvider {
   return dot === -1
     ? { domain: id, stem: "" }
     : { domain: id.slice(0, dot), stem: id.slice(dot + 1) };
+}
+
+/** A catalog entry as a provider of *interfaceName*, carrying the nested
+ *  ``idPaths`` when its id for that interface isn't its own top-level id.
+ *  Single source of truth for the visual picker and YAML autocomplete so
+ *  the two surfaces can't drift on what counts as a candidate. */
+export function catalogEntryToProvider(
+  entry: ComponentCatalogEntry,
+  interfaceName: string
+): ComponentProvider {
+  const provider = parseCatalogId(entry.id);
+  const idPaths = entry.provides_id_paths?.[interfaceName];
+  return idPaths?.length ? { ...provider, idPaths } : provider;
 }
 
 interface ProviderKey {
@@ -276,34 +293,51 @@ export function findComponentsByProviders(
   providers: ReadonlyArray<ComponentProvider>
 ): Array<{ id: string; name: string }> {
   if (!providers.length) return [];
+  // JSON-encode each provider so the cache key can't collide on a separator
+  // char inside a domain / stem / path segment.
   const signature = providers
-    .map((p) => `${p.domain}.${p.stem}`)
+    .map((p) => JSON.stringify([p.domain, p.stem, p.idPaths ?? []]))
     .sort()
     .join(",");
   const probe: ProviderKey = { yaml, signature };
   const cached = providerMemo.get(probe);
   if (cached) return cached;
 
-  // ``stem === ""`` for any provider in a domain means "match every id".
-  const stemsByDomain = new Map<string, Set<string>>();
+  const byDomain = new Map<string, ComponentProvider[]>();
   for (const p of providers) {
-    const stems = stemsByDomain.get(p.domain) ?? new Set<string>();
-    stems.add(p.stem);
-    stemsByDomain.set(p.domain, stems);
+    const list = byDomain.get(p.domain) ?? [];
+    list.push(p);
+    byDomain.set(p.domain, list);
   }
 
   const result: Array<{ id: string; name: string }> = [];
   const seen = new Set<string>();
+  const add = (id: string, name: string): void => {
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      result.push({ id, name });
+    }
+  };
+  // Split once, lazily: only nested-id providers (the rare case) need the
+  // lines, so the common own-id scan pays nothing.
+  let lines: string[] | null = null;
   for (const section of parseYamlTopLevelSections(yaml)) {
-    if (!section.id || seen.has(section.id)) continue;
-    const stems = stemsByDomain.get(section.parentKey ?? section.key);
-    if (!stems) continue;
-    if (
-      stems.has("") ||
-      (section.platform !== undefined && stems.has(section.platform))
-    ) {
-      seen.add(section.id);
-      result.push({ id: section.id, name: section.name ?? "" });
+    const provs = byDomain.get(section.parentKey ?? section.key);
+    if (!provs) continue;
+    for (const p of provs) {
+      // ``stem === ""`` matches every id in the domain block.
+      if (p.stem !== "" && p.stem !== section.platform) continue;
+      if (p.idPaths?.length) {
+        // The interface id is nested (usb_uart channels[].id): collect the
+        // ids at those paths, not the section's own (non-interface) id.
+        lines ??= yaml.split("\n");
+        for (const path of p.idPaths) {
+          for (const inst of collectIdsAtPath(lines, section, path))
+            add(inst.id, inst.name);
+        }
+      } else if (section.id) {
+        add(section.id, section.name ?? "");
+      }
     }
   }
   providerMemo.set(probe, result);

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -22,7 +22,10 @@
 import { type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
-import { findReferenceCandidates, parseCatalogId } from "./config-entry-yaml-scan.js";
+import {
+  catalogEntryToProvider,
+  findReferenceCandidates,
+} from "./config-entry-yaml-scan.js";
 import { getConfigVarValueOptions } from "./esphome-schema.js";
 import { collectSubstitutionKeys, isUnderAutomationItem } from "./yaml-ast.js";
 import {
@@ -181,7 +184,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         const domain = entry.references_component;
         const providers = catalog.components
           .filter((c) => c.provides?.includes(domain))
-          .map((c) => parseCatalogId(c.id));
+          .map((c) => catalogEntryToProvider(c, domain));
         const candidates = findReferenceCandidates(
           state.doc.toString(),
           domain,

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -220,17 +220,12 @@ function _expandListItems(
   const firstContentIndent =
     firstContentIdx <= endIdx ? lineIndent(lines[firstContentIdx]) : -1;
 
-  const listStarts: number[] = [];
-  if (firstContentIdx <= endIdx && LIST_ITEM_START_RE.test(lines[firstContentIdx])) {
-    for (let i = firstContentIdx; i <= endIdx; i++) {
-      if (
-        LIST_ITEM_START_RE.test(lines[i]) &&
-        lineIndent(lines[i]) === firstContentIndent
-      ) {
-        listStarts.push(i);
-      }
-    }
-  }
+  // A list iff the first content line is a dash; then every sibling dash at
+  // that indent is an item (shared with the reference scan's level walk).
+  const listStarts =
+    firstContentIdx <= endIdx && LIST_ITEM_START_RE.test(lines[firstContentIdx])
+      ? _dashesAtIndent(lines, firstContentIdx, endIdx, firstContentIndent)
+      : [];
 
   if (listStarts.length === 0) {
     // Single-instance section (e.g. `uart:` configured as a flat
@@ -409,21 +404,6 @@ export function findFieldLine(
   if (relPath[0] === section.key) relPath = relPath.slice(1);
   if (relPath.length === 0) return null;
   const lines = yaml.split("\n");
-  const start = section.fromLine - 1;
-  const end = Math.min(section.toLine - 1, lines.length - 1);
-  if (start < 0 || start >= lines.length) return null;
-
-  // A dash item's inline key (``- name: x``) sits at the content column
-  // after ``- ``, not the dash column.
-  const keyIndentOf = (line: string): number =>
-    LIST_ITEM_START_RE.test(line) ? listItemChildIndent(line) : indentOf(line);
-  const firstChildIndent = (lo: number, hi: number): number | null => {
-    for (let i = lo; i <= hi; i++) {
-      const s = stripComment(lines[i]);
-      if (s.trim()) return indentOf(s);
-    }
-    return null;
-  };
 
   // Descend *path* within [lo, hi]; keys / dashes for this level sit at
   // *baseIndent*.
@@ -435,23 +415,17 @@ export function findFieldLine(
   ): number | null => {
     const seg = path[0];
     const rest = path.slice(1);
-    if (RE_PATH_INDEX.test(seg)) {
-      const dashes: number[] = [];
-      for (let i = lo; i <= hi; i++) {
-        const s = stripComment(lines[i]);
-        if (s.trim() && indentOf(s) === baseIndent && LIST_ITEM_START_RE.test(s))
-          dashes.push(i);
-      }
-      // A numeric segment is a list index only where this level actually has
-      // dash items; with none it's a literal numeric mapping key (a ``0:``
-      // substitution), so fall through to the key match below.
-      if (dashes.length) {
-        const itemLo = dashes[Number(seg)];
-        if (itemLo === undefined) return null;
-        if (rest.length === 0) return itemLo + 1;
-        const itemHi = Number(seg) + 1 < dashes.length ? dashes[Number(seg) + 1] - 1 : hi;
-        return descend(itemLo, itemHi, listItemChildIndent(lines[itemLo]), rest);
-      }
+    // A numeric segment is a list index only when this level actually is a
+    // list (first content line a dash); otherwise it's a literal numeric
+    // mapping key (a ``0:`` substitution) and falls through to the key match.
+    // A compact block-sequence value deeper in a mapping must not flip this.
+    if (RE_PATH_INDEX.test(seg) && _levelIsList(lines, lo, hi, baseIndent)) {
+      const dashes = _dashesAtIndent(lines, lo, hi, baseIndent);
+      const itemLo = dashes[Number(seg)];
+      if (itemLo === undefined) return null;
+      if (rest.length === 0) return itemLo + 1;
+      const itemHi = Number(seg) + 1 < dashes.length ? dashes[Number(seg) + 1] - 1 : hi;
+      return descend(itemLo, itemHi, listItemChildIndent(lines[itemLo]), rest);
     }
     for (let i = lo; i <= hi; i++) {
       const s = stripComment(lines[i]);
@@ -459,26 +433,160 @@ export function findFieldLine(
       const m = s.match(RE_PAIR_LINE);
       if (!m || m[1] !== seg) continue;
       if (rest.length === 0) return i + 1;
-      let blockHi = hi;
-      for (let j = i + 1; j <= hi; j++) {
-        // Shared block-end rule: a same-indent compact block-sequence
-        // value (``key:\n- a\n- b``) stays in the block; comments don't end it.
-        if (endsBlockAtIndent(lines[j], baseIndent)) {
-          blockHi = j - 1;
-          break;
-        }
-      }
-      const childIndent = firstChildIndent(i + 1, blockHi);
+      const blockHi = _blockEndAtIndent(lines, i + 1, hi, baseIndent);
+      const childIndent = firstContentIndentIn(lines, i + 1, blockHi);
       return childIndent === null ? null : descend(i + 1, blockHi, childIndent, rest);
     }
     return null;
   };
 
-  if (LIST_ITEM_START_RE.test(lines[start])) {
-    // List-item section: keys live at the item's child indent, and the
-    // header line itself carries the inline key.
-    return descend(start, end, listItemChildIndent(lines[start]), relPath);
+  const body = _sectionScanStart(lines, section);
+  return body === null ? null : descend(body.lo, body.hi, body.baseIndent, relPath);
+}
+
+/** Indent at which a line's key sits: a dash item's inline key (``- name: x``)
+ *  is at the content column after ``- ``, not the dash column. */
+function keyIndentOf(line: string): number {
+  return LIST_ITEM_START_RE.test(line) ? listItemChildIndent(line) : indentOf(line);
+}
+
+/** Raw indent column of the first non-blank line in [lo, hi], or null. */
+function firstContentIndentIn(lines: string[], lo: number, hi: number): number | null {
+  for (let i = lo; i <= hi; i++) {
+    const s = stripComment(lines[i]);
+    if (s.trim()) return indentOf(s);
   }
-  const childIndent = firstChildIndent(start + 1, end);
-  return childIndent === null ? null : descend(start + 1, end, childIndent, relPath);
+  return null;
+}
+
+/** Line indices of the list-item dashes sitting at exactly *indent* in [lo, hi]. */
+function _dashesAtIndent(
+  lines: string[],
+  lo: number,
+  hi: number,
+  indent: number
+): number[] {
+  const dashes: number[] = [];
+  for (let i = lo; i <= hi; i++) {
+    const s = stripComment(lines[i]);
+    if (s.trim() && indentOf(s) === indent && LIST_ITEM_START_RE.test(s)) dashes.push(i);
+  }
+  return dashes;
+}
+
+/** Last line of the block a key at *baseIndent* opens: the line before the
+ *  next sibling at or above *baseIndent*. A same-indent compact block-sequence
+ *  value (``key:\n- a``) and comments don't end it (see {@link endsBlockAtIndent}). */
+function _blockEndAtIndent(
+  lines: string[],
+  afterLine: number,
+  hi: number,
+  baseIndent: number
+): number {
+  for (let j = afterLine; j <= hi; j++) {
+    if (endsBlockAtIndent(lines[j], baseIndent)) return j - 1;
+  }
+  return hi;
+}
+
+/** Where to begin scanning *section*'s body: a list-item section starts at its
+ *  header (inline key at the item's child indent); a flat section opens below
+ *  its key line. Null when the section range is empty / out of bounds. */
+function _sectionScanStart(
+  lines: string[],
+  section: YamlSection
+): { lo: number; hi: number; baseIndent: number } | null {
+  const start = section.fromLine - 1;
+  const hi = Math.min(section.toLine - 1, lines.length - 1);
+  if (start < 0 || start >= lines.length) return null;
+  if (LIST_ITEM_START_RE.test(lines[start])) {
+    return { lo: start, hi, baseIndent: listItemChildIndent(lines[start]) };
+  }
+  const baseIndent = firstContentIndentIn(lines, start + 1, hi);
+  return baseIndent === null ? null : { lo: start + 1, hi, baseIndent };
+}
+
+/** Whether [lo, hi] is a YAML list at *levelIndent*: its *first* content line
+ *  is a dash there. Keying off the first line, not "any dash at this indent",
+ *  is what tells a list apart from a mapping that merely holds a compact
+ *  block-sequence value (``channels:\n- id: …``) deeper down. */
+function _levelIsList(
+  lines: string[],
+  lo: number,
+  hi: number,
+  levelIndent: number
+): boolean {
+  for (let i = lo; i <= hi; i++) {
+    const s = stripComment(lines[i]);
+    if (!s.trim()) continue;
+    return indentOf(s) === levelIndent && LIST_ITEM_START_RE.test(s);
+  }
+  return false;
+}
+
+/** Item sub-regions of [lo, hi] whose own keys sit at *levelIndent*: a list
+ *  yields one region per dash (keys at the dash's child indent); otherwise the
+ *  region is a single mapping (keys at *levelIndent*). */
+function _itemRegions(
+  lines: string[],
+  lo: number,
+  hi: number,
+  levelIndent: number
+): Array<{ lo: number; hi: number; keyIndent: number }> {
+  if (!_levelIsList(lines, lo, hi, levelIndent))
+    return [{ lo, hi, keyIndent: levelIndent }];
+  const dashes = _dashesAtIndent(lines, lo, hi, levelIndent);
+  return dashes.map((d, k) => ({
+    lo: d,
+    hi: k + 1 < dashes.length ? dashes[k + 1] - 1 : hi,
+    keyIndent: listItemChildIndent(lines[d]),
+  }));
+}
+
+/**
+ * Collect ``{id, name}`` for every instance at the key-path *path* within
+ * *section* (``["channels", "id"]`` → each usb_uart channel's id).
+ *
+ * Each segment is a mapping key; a segment whose value is a list expands over
+ * every item, so a nested-list provider (usb_uart channels, tca9548a channels)
+ * yields one entry per configured instance. The final segment is read as a
+ * scalar, its sibling ``name`` (if any) becoming the label. Takes pre-split
+ * *lines* so a caller scanning many sections / paths splits the YAML once.
+ */
+export function collectIdsAtPath(
+  lines: string[],
+  section: YamlSection,
+  path: string[]
+): Array<{ id: string; name: string }> {
+  if (path.length === 0) return [];
+  const out: Array<{ id: string; name: string }> = [];
+
+  const walk = (lo: number, hi: number, levelIndent: number, segs: string[]): void => {
+    for (const item of _itemRegions(lines, lo, hi, levelIndent)) {
+      if (segs.length === 1) {
+        let id = "";
+        let name = "";
+        for (let i = item.lo; i <= item.hi; i++) {
+          if (keyIndentOf(lines[i]) !== item.keyIndent) continue;
+          id = readInstanceScalar(lines[i], segs[0]) ?? id;
+          name = readInstanceScalar(lines[i], "name") ?? name;
+        }
+        if (id) out.push({ id, name });
+        continue;
+      }
+      for (let i = item.lo; i <= item.hi; i++) {
+        if (keyIndentOf(lines[i]) !== item.keyIndent) continue;
+        const m = stripComment(lines[i]).match(RE_PAIR_LINE);
+        if (!m || m[1] !== segs[0]) continue;
+        const blockHi = _blockEndAtIndent(lines, i + 1, item.hi, item.keyIndent);
+        const childIndent = firstContentIndentIn(lines, i + 1, blockHi);
+        if (childIndent !== null) walk(i + 1, blockHi, childIndent, segs.slice(1));
+        break;
+      }
+    }
+  };
+
+  const body = _sectionScanStart(lines, section);
+  if (body !== null) walk(body.lo, body.hi, body.baseIndent, path);
+  return out;
 }

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -1,11 +1,52 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
 import {
   _clearScanMemos,
+  catalogEntryToProvider,
   findComponentsByProviders,
   findReferenceCandidates,
   findUsedPins,
   yamlHasMergedSources,
 } from "../../src/util/config-entry-yaml-scan.js";
+
+function catalogEntry(over: Partial<ComponentCatalogEntry>): ComponentCatalogEntry {
+  return {
+    id: "usb_uart",
+    name: "",
+    description: "",
+    category: "misc" as ComponentCatalogEntry["category"],
+    docs_url: "",
+    image_url: "",
+    dependencies: [],
+    multi_conf: false,
+    supported_platforms: [],
+    config_entries: [],
+    ...over,
+  };
+}
+
+describe("catalogEntryToProvider", () => {
+  it("attaches the nested idPaths for the requested interface", () => {
+    const entry = catalogEntry({
+      id: "usb_uart",
+      provides: ["uart"],
+      provides_id_paths: { uart: [["channels", "id"]] },
+    });
+    expect(catalogEntryToProvider(entry, "uart")).toEqual({
+      domain: "usb_uart",
+      stem: "",
+      idPaths: [["channels", "id"]],
+    });
+  });
+
+  it("omits idPaths for an own-id provider (no path for that interface)", () => {
+    const entry = catalogEntry({ id: "ble_nus", provides: ["uart"] });
+    expect(catalogEntryToProvider(entry, "uart")).toEqual({
+      domain: "ble_nus",
+      stem: "",
+    });
+  });
+});
 
 // The scans use module-level single-entry memos. Within a single
 // test file vitest runs cases sequentially, so cache state from
@@ -320,6 +361,147 @@ describe("findComponentsByProviders", () => {
       { domain: "sensor", stem: "ads1115" },
     ]);
     expect(other).toEqual([{ id: "adc_b", name: "" }]);
+  });
+});
+
+describe("findComponentsByProviders (nested provider idPaths)", () => {
+  // The reported config (#1464): the configured uart is a usb_uart channel,
+  // not a top-level id, so the provider carries the path to descend.
+  const yaml = [
+    "usb_host:",
+    "  devices:",
+    "    - id: device_0",
+    "usb_uart:",
+    "  - type: CDC_ACM",
+    "    vid: 0x303A",
+    "    pid: 0x4001",
+    "    channels:",
+    "      - id: uch_1",
+    "        baud_rate: 115200",
+    "      - id: uch_2",
+    "        baud_rate: 9600",
+    "zwave_proxy:",
+    "  id: zw_proxy",
+    "",
+  ].join("\n");
+
+  it("collects nested channel ids the section's own id would miss", () => {
+    expect(
+      findComponentsByProviders(yaml, [
+        { domain: "usb_uart", stem: "", idPaths: [["channels", "id"]] },
+      ])
+    ).toEqual([
+      { id: "uch_1", name: "" },
+      { id: "uch_2", name: "" },
+    ]);
+  });
+
+  it("does not surface the usb_uart device-level id as a uart", () => {
+    const withDeviceId = yaml.replace(
+      "  - type: CDC_ACM",
+      "  - id: dev_bridge\n    type: CDC_ACM"
+    );
+    const ids = findComponentsByProviders(withDeviceId, [
+      { domain: "usb_uart", stem: "", idPaths: [["channels", "id"]] },
+    ]).map((c) => c.id);
+    expect(ids).toEqual(["uch_1", "uch_2"]);
+    expect(ids).not.toContain("dev_bridge");
+  });
+
+  it("reads a nested item's sibling name as the label", () => {
+    const named = yaml.replace(
+      "      - id: uch_1",
+      '      - id: uch_1\n        name: "Z-Wave UART"'
+    );
+    expect(
+      findComponentsByProviders(named, [
+        { domain: "usb_uart", stem: "", idPaths: [["channels", "id"]] },
+      ])[0]
+    ).toEqual({ id: "uch_1", name: "Z-Wave UART" });
+  });
+
+  it("surfaces the nested channel id through findReferenceCandidates (real call path)", () => {
+    // Mirrors the production call: the reference's own domain ("uart") is
+    // prepended as an implicit provider, and usb_uart arrives as an interface
+    // provider carrying the nested path.
+    expect(
+      findReferenceCandidates(yaml, "uart", [
+        { domain: "usb_uart", stem: "", idPaths: [["channels", "id"]] },
+      ])
+    ).toEqual([
+      { id: "uch_1", name: "" },
+      { id: "uch_2", name: "" },
+    ]);
+  });
+
+  it("collects a deeper key than id (tca9548a channels[].bus_id)", () => {
+    const mux = [
+      "tca9548a:",
+      "  - id: mux",
+      "    channels:",
+      "      - bus_id: mux_ch0",
+      "        channel: 0",
+      "      - bus_id: mux_ch1",
+      "        channel: 1",
+      "",
+    ].join("\n");
+    expect(
+      findComponentsByProviders(mux, [
+        { domain: "tca9548a", stem: "", idPaths: [["channels", "bus_id"]] },
+      ])
+    ).toEqual([
+      { id: "mux_ch0", name: "" },
+      { id: "mux_ch1", name: "" },
+    ]);
+  });
+
+  it("collects ids from every path when an interface is nested at several (sprinkler)", () => {
+    const sprinkler = [
+      "sprinkler:",
+      "  - id: lawn",
+      "    auto_advance_switch:",
+      "      id: lawn_auto",
+      "    valves:",
+      "      - valve_switch:",
+      "          id: zone1_sw",
+      "      - valve_switch:",
+      "          id: zone2_sw",
+      "",
+    ].join("\n");
+    expect(
+      findComponentsByProviders(sprinkler, [
+        {
+          domain: "sprinkler",
+          stem: "",
+          idPaths: [
+            ["auto_advance_switch", "id"],
+            ["valves", "valve_switch", "id"],
+          ],
+        },
+      ]).map((c) => c.id)
+    ).toEqual(["lawn_auto", "zone1_sw", "zone2_sw"]);
+  });
+
+  it("does not misread a mapping holding a compact block-sequence as a list", () => {
+    // ``channels`` uses YAML's compact block-sequence form (dashes at the same
+    // indent as the key), so the item's keys and the channel dashes share a
+    // column; the scan must still find the channel ids.
+    const compact = [
+      "usb_uart:",
+      "  - type: CDC_ACM",
+      "    channels:",
+      "    - id: uch_1",
+      "    - id: uch_2",
+      "",
+    ].join("\n");
+    expect(
+      findComponentsByProviders(compact, [
+        { domain: "usb_uart", stem: "", idPaths: [["channels", "id"]] },
+      ])
+    ).toEqual([
+      { id: "uch_1", name: "" },
+      { id: "uch_2", name: "" },
+    ]);
   });
 });
 

--- a/test/util/yaml-field-line.test.ts
+++ b/test/util/yaml-field-line.test.ts
@@ -152,6 +152,17 @@ describe("findFieldLine", () => {
     expect(findFieldLine(yaml, section, ["substitutions", "name"])).toBe(3);
   });
 
+  it("keeps a numeric mapping key a key when a sibling holds a compact block-sequence", () => {
+    // ``0:`` is a literal key; the ``items:`` sibling's compact dashes sit at
+    // the same indent, but list-vs-mapping is decided by the *first* content
+    // line, so the numeric segment must not resolve as a list index here.
+    const yaml = ["substitutions:", "  0: zero", "  items:", "  - a", "  - b", ""].join(
+      "\n"
+    );
+    const section = sectionAt(yaml, 1);
+    expect(findFieldLine(yaml, section, ["substitutions", "0"])).toBe(2);
+  });
+
   it("targets the correct instance among duplicates", () => {
     const yaml = [
       "binary_sensor:",


### PR DESCRIPTION
# What does this implement/fix?

A configured uart can be a nested id rather than a component's own top level id; `usb_uart` declares its uart on `channels[].id`. The id reference picker only read each section's own id, so the editor's uart dropdown stayed empty for a configured `usb_uart` channel.

When an interface provider carries the new `provides_id_paths` entry (from the backend), this descends that key path within the matched section and collects every instance id (one per channel), instead of the section's own id. Providers without a path keep using the section id, so own id providers like `ble_nus` are unchanged. It surfaces the `usb_uart` channel id without surfacing the `usb_uart` device id, which is not a uart.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1464
- backend PR: https://github.com/esphome/device-builder/pull/1467

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
