### PR TITLE
Surface the backend reason in the rename-failure toast

### DIFF
--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -93,10 +93,15 @@ export async function executeRename(
   let response: Awaited<ReturnType<ESPHomeAPI["renameDevice"]>>;
   try {
     response = await host._api.renameDevice(device.configuration, newName);
-  } catch {
-    toast.error(host._localize("dashboard.action_rename_failed", { name: device.name }), {
-      richColors: true,
-    });
+  } catch (err) {
+    const reason = getErrorMessage(err);
+    toast.error(
+      host._localize("dashboard.action_rename_failed", {
+        name: device.name,
+        reason,
+      }),
+      { richColors: true }
+    );
     return;
   }
   clearJustCreated();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -106,7 +106,7 @@
     "action_rename_label": "Device name",
     "action_rename_confirm": "Rename",
     "action_rename_success": "\"{name}\" renamed successfully",
-    "action_rename_failed": "Failed to rename \"{name}\"",
+    "action_rename_failed": "Failed to rename \"{name}\": {reason}",
     "action_clone_title": "Duplicate {name}",
     "action_clone_name_label": "New hostname",
     "action_clone_friendly_name_label": "Friendly name (optional)",

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { executeRename } from "../../../src/components/dashboard/actions-ui.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+vi.mock("sonner-js", () => ({
+  default: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+// Append the interpolation params so the assertion sees the surfaced
+// reason; the stub has no access to the en.json template the real
+// _localize would expand, so embedding params is what proves the
+// handler forwarded the backend detail into the toast.
+const localize = ((key: string, params?: Record<string, string>) =>
+  params ? `${key} ${Object.values(params).join(" ")}` : key) as unknown as LocalizeFunc;
+
+function makeHost(renameDevice: ESPHomeAPI["renameDevice"]): ESPHomePageDashboard {
+  return {
+    _actionDevice: {
+      name: "rename_test",
+      friendly_name: "Rename_Test",
+      configuration: "rename_test.yaml",
+    } as ConfiguredDevice,
+    _api: { renameDevice } as unknown as ESPHomeAPI,
+    _localize: localize,
+  } as unknown as ESPHomePageDashboard;
+}
+
+describe("executeRename", () => {
+  beforeEach(() => toastError.mockClear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("surfaces the backend reason in the rename-failure toast", async () => {
+    const reason = "A device named rename-test.yaml already exists";
+    const renameDevice = vi.fn(async () => {
+      throw new Error(`invalid_args: ${reason}`);
+    }) as unknown as ESPHomeAPI["renameDevice"];
+
+    await executeRename(
+      makeHost(renameDevice),
+      new CustomEvent("rename-confirm", {
+        detail: "rename-test",
+      })
+    );
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError.mock.calls[0][0]).toContain(reason);
+  });
+});


### PR DESCRIPTION
## Description

Renaming a device could fail with a bare toast **"Failed to rename "<name>""** and no reason. `executeRename` was the only device action using a bare `catch {}`, so it discarded the rejected `devices/rename` command's error. The siblings (`executeClone`, `executeFriendlyName`) already bind the error and surface `getErrorMessage(err)` as a `{reason}`; this brings rename in line.

The most common trigger is a synchronous collision: a rename queues a compile + OTA job that writes `<new-name>.yaml` before the OTA step, so a retry while that job is still in flight rejects with `invalid_args: A device named <new-name>.yaml already exists` — a reason the user never saw.

Reproduced live over `/ws` and verified end-to-end in a headless browser; the toast now reads:

> Failed to rename "rename_test": invalid_args: A device named rename-test.yaml already exists

This is the error-reporting half. A follow-up will address the underlying job-failure path (a failed rename job currently reports `exit_code=1` with `error=None`, and the command-dialog banner shows a generic "Rename failed.").

related issue https://github.com/esphome/device-builder/issues/1465

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Testing

- New `test/components/dashboard/actions-ui.test.ts` asserts the rename-failure toast carries the backend reason.
- `npm run lint` + full vitest (3219 tests) pass; prettier clean.
