### PR TITLE
Show the board-derived variant as the esp32 variant default

### DIFF
--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
+import { chipNameToVariant } from "../../../util/chip-variant.js";
 import {
   chooseDisplayUnit,
   defaultUnitForFloatWithUnit,
@@ -402,6 +403,24 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
   `;
 }
 
+// esp32's variant has no static default — it follows the chosen board. Derive
+// it from the live `board:` sibling (or the saved board) so the select shows
+// the board's variant greyed out as the default, like any other default. Only
+// returns a value that's actually one of the entry's options.
+function boardDerivedVariantDefault(
+  entry: ConfigEntry,
+  ctx: RenderCtx
+): string | undefined {
+  if (entry.key !== "variant" || ctx.sectionKey !== "esp32") return undefined;
+  const board = String(ctx.getAt(["board"]) ?? "");
+  const variant = board ? chipNameToVariant(board) : (ctx.board?.esphome.variant ?? "");
+  if (!variant) return undefined;
+  const lower = variant.toLowerCase();
+  return entry.options?.some((o) => o.value.toLowerCase() === lower)
+    ? variant
+    : undefined;
+}
+
 export function renderSelectField(entry: ConfigEntry, path: string[], ctx: RenderCtx) {
   const raw = ctx.getAt(path);
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
@@ -459,7 +478,9 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   // (ESP32C6 vs esp32c6) — case-insensitive compare so the matching option
   // still flags as selected.
   const valueLower = value.toLowerCase();
-  const defaultStr = entry.default_value != null ? String(entry.default_value) : "";
+  const defaultStr =
+    boardDerivedVariantDefault(entry, ctx) ??
+    (entry.default_value != null ? String(entry.default_value) : "");
   const defaultLower = defaultStr.toLowerCase();
   const defaultOption = entry.options?.find(
     (o) => o.value.toLowerCase() === defaultLower

--- a/test/components/device/config-entry-variant-default.test.ts
+++ b/test/components/device/config-entry-variant-default.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type {
+  ConfigEntry,
+  ConfigValueOption,
+} from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
 import {
@@ -23,18 +27,22 @@ const serialize = (tpl: unknown): string =>
 
 function renderVariant(
   values: unknown,
-  options: { sectionKey?: string; board?: unknown; default_value?: unknown } = {}
+  options: {
+    sectionKey?: string;
+    board?: BoardCatalogEntry | null;
+    default_value?: ConfigEntry["default_value"];
+  } = {}
 ): unknown {
   const { sectionKey = "esp32", default_value = null } = options;
   const entry = makeEntry(ConfigEntryType.SELECT, {
     key: "variant",
     options: VARIANT_OPTIONS,
-    default_value: default_value as never,
+    default_value,
   });
-  const ctxOptions: { board?: never; overrides: { sectionKey: string } } = {
+  const ctxOptions: Parameters<typeof makeRenderCtx>[1] = {
     overrides: { sectionKey },
   };
-  if ("board" in options) ctxOptions.board = options.board as never;
+  if ("board" in options) ctxOptions.board = options.board;
   return renderSelectField(entry, ["variant"], makeRenderCtx(values, ctxOptions));
 }
 
@@ -57,10 +65,25 @@ describe("renderSelectField — esp32 variant default from board", () => {
   it("falls back to the saved board's variant when nothing is typed", () => {
     const board = makeTestBoard({
       overrides: {
-        esphome: { platform: "esp32", board: "esp32-c6-devkitm-1", variant: "esp32c6" },
-      } as never,
+        esphome: {
+          platform: "esp32",
+          board: "esp32-c6-devkitm-1",
+          variant: "esp32c6",
+          framework: null,
+        },
+      },
     });
     expect(selectPlaceholder(renderVariant({}, { board }))).toBe("ESP32-C6");
+  });
+
+  it("falls back to the static default when the board's variant isn't an option", () => {
+    // esp32-s2 derives esp32s2, absent from VARIANT_OPTIONS — the membership
+    // gate must reject it so a board off the option list doesn't leak through.
+    expect(
+      selectPlaceholder(
+        renderVariant({ board: "esp32-s2-saola-1" }, { default_value: "ESP32" })
+      )
+    ).toBe("ESP32");
   });
 
   it("does not derive outside the esp32 section, so the static default wins", () => {

--- a/test/components/device/config-entry-variant-default.test.ts
+++ b/test/components/device/config-entry-variant-default.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import {
+  findElementBindings,
+  makeEntry,
+  makeRenderCtx,
+  makeTestBoard,
+} from "./_renderer-fixtures.js";
+
+// esp32's variant select has no static default; it follows the chosen board.
+// The renderer derives it from the live `board:` sibling (or the saved board)
+// so the board's variant shows greyed out as the default, like any other.
+const VARIANT_OPTIONS: ConfigValueOption[] = [
+  { value: "ESP32", label: "ESP32" },
+  { value: "ESP32C6", label: "ESP32-C6" },
+  { value: "ESP32S3", label: "ESP32-S3" },
+];
+
+const serialize = (tpl: unknown): string =>
+  JSON.stringify(tpl, (k, v) => (k === "_$litType$" ? 0 : v));
+
+function renderVariant(
+  values: unknown,
+  options: { sectionKey?: string; board?: unknown; default_value?: unknown } = {}
+): unknown {
+  const { sectionKey = "esp32", default_value = null } = options;
+  const entry = makeEntry(ConfigEntryType.SELECT, {
+    key: "variant",
+    options: VARIANT_OPTIONS,
+    default_value: default_value as never,
+  });
+  const ctxOptions: { board?: never; overrides: { sectionKey: string } } = {
+    overrides: { sectionKey },
+  };
+  if ("board" in options) ctxOptions.board = options.board as never;
+  return renderSelectField(entry, ["variant"], makeRenderCtx(values, ctxOptions));
+}
+
+function selectPlaceholder(tpl: unknown): unknown {
+  return findElementBindings(tpl, "wa-select")[0]?.placeholder;
+}
+
+describe("renderSelectField — esp32 variant default from board", () => {
+  it("derives the variant default from a live typed board", () => {
+    expect(selectPlaceholder(renderVariant({ board: "esp32-c6-devkitm-1" }))).toBe(
+      "ESP32-C6"
+    );
+  });
+
+  it("tags the derived variant as the default option in the menu", () => {
+    const json = serialize(renderVariant({ board: "esp32-c6-devkitm-1" }));
+    expect(json.match(/option-default-note/g) ?? []).toHaveLength(1);
+  });
+
+  it("falls back to the saved board's variant when nothing is typed", () => {
+    const board = makeTestBoard({
+      overrides: {
+        esphome: { platform: "esp32", board: "esp32-c6-devkitm-1", variant: "esp32c6" },
+      } as never,
+    });
+    expect(selectPlaceholder(renderVariant({}, { board }))).toBe("ESP32-C6");
+  });
+
+  it("does not derive outside the esp32 section, so the static default wins", () => {
+    expect(
+      selectPlaceholder(
+        renderVariant(
+          { board: "esp32-c6-devkitm-1" },
+          { sectionKey: "wifi", default_value: "ESP32" }
+        )
+      )
+    ).toBe("ESP32");
+  });
+
+  it("marks nothing when there is no board and no static default", () => {
+    expect(serialize(renderVariant({}, { board: null }))).not.toContain(
+      "option-default-note"
+    );
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 Platform editor's Variant select rendered empty even when the chosen board already implies a variant. This derives the variant from the live `board:` value in the YAML (falling back to the saved board) and shows it greyed out as the default, reusing the existing default-placeholder mechanism every other select uses. Typing `board: esp32-c6-devkitm-1` now shows `ESP32-C6` as the Variant default.

The derivation is gated to the esp32 section's `variant` field and only kicks in when the derived variant is actually one of the field's options, so a non-espressif board falls back to the static default.

The framework Type default (esp-idf) is a fixed catalog default and is handled in the companion backend PR.

**Related issue or feature (if applicable):**

- Companion backend PR: esphome/device-builder#1468

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

