### PR TITLE
Tag the default option in allow_custom_value combobox selects

### DIFF
--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -465,6 +465,8 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
           .value=${value}
           label=${entry.label}
           placeholder=${String(entry.default_value ?? "")}
+          .defaultValue=${String(entry.default_value ?? "")}
+          .defaultNote=${ctx.localize("device.default_option_tag")}
           ?disabled=${disabled}
           ?invalid=${invalid}
           @options-combobox-change=${(e: CustomEvent<OptionsComboboxValueChange>) =>

--- a/src/components/options-combobox.ts
+++ b/src/components/options-combobox.ts
@@ -52,6 +52,15 @@ export class ESPHomeOptionsCombobox extends LitElement {
   @property()
   label = "";
 
+  /** Option value that applies when the field is left empty, tagged in the
+   *  menu with ``defaultNote`` (mirrors the plain select). */
+  @property()
+  defaultValue = "";
+
+  /** Localized "default" note shown under the ``defaultValue`` option. */
+  @property()
+  defaultNote = "";
+
   /** Open state of the dropdown. */
   @state() private _open = false;
 
@@ -142,13 +151,26 @@ export class ESPHomeOptionsCombobox extends LitElement {
                     @click=${() => this._select(opt)}
                     @mouseenter=${() => (this._active = i)}
                   >
-                    <span class="option-label">${opt.label}</span>
+                    ${this._isDefault(opt)
+                      ? html`<span class="option-default-stack">
+                          <span class="option-label">${opt.label}</span>
+                          <small class="option-default-note">${this.defaultNote}</small>
+                        </span>`
+                      : html`<span class="option-label">${opt.label}</span>`}
                   </div>`
               )}
             </div>`
           : nothing}
       </wa-popup>
     `;
+  }
+
+  private _isDefault(opt: ComboboxOption): boolean {
+    return (
+      this.defaultNote !== "" &&
+      this.defaultValue !== "" &&
+      opt.value.toLowerCase() === this.defaultValue.toLowerCase()
+    );
   }
 
   private get _filtered(): ComboboxOption[] {

--- a/test/components/device/config-entry-combobox.test.ts
+++ b/test/components/device/config-entry-combobox.test.ts
@@ -41,6 +41,21 @@ describe("renderSelectField — allow_custom_value combobox", () => {
     expect(ctx.emitChange).toHaveBeenCalledWith(["board"], "cr3l");
   });
 
+  it("forwards the default value and localized note so the menu can tag it", () => {
+    const entry = makeEntry(ConfigEntryType.STRING, {
+      key: "hardware_uart",
+      options: BOARDS,
+      allow_custom_value: true,
+      default_value: "bw15",
+    });
+    const [b] = findElementBindings(
+      renderSelectField(entry, ["hardware_uart"], makeRenderCtx({})),
+      "esphome-options-combobox"
+    );
+    expect(b[".defaultValue"]).toBe("bw15");
+    expect(b[".defaultNote"]).toBe("device.default_option_tag");
+  });
+
   it("passes invalid and disabled through to the combobox", () => {
     const ctx = makeRenderCtx(
       { board: "bw15" },

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -186,6 +186,38 @@ describe("esphome-options-combobox", () => {
     expect(opts[0].classList.contains("option--active")).toBe(true);
   });
 
+  test("tags the default option with the muted note when opened", async () => {
+    const el = await mount("");
+    el.defaultValue = "bw15"; // index 2
+    el.defaultNote = "default";
+    await el.updateComplete;
+    await open(el);
+    const opts = options(el);
+    const noteOf = (o: HTMLElement) =>
+      o.querySelector(".option-default-note")?.textContent?.trim() ?? null;
+    expect(noteOf(opts[2])).toBe("default");
+    expect(opts.filter((o) => noteOf(o) !== null)).toHaveLength(1);
+  });
+
+  test("matches the default case-insensitively", async () => {
+    const el = await mount("");
+    el.defaultValue = "BW15";
+    el.defaultNote = "default";
+    await el.updateComplete;
+    await open(el);
+    expect(
+      options(el)[2].querySelector(".option-default-note")?.textContent?.trim()
+    ).toBe("default");
+  });
+
+  test("tags nothing without a default value or note", async () => {
+    const el = await mount("");
+    el.defaultNote = "default"; // value missing → no tag
+    await el.updateComplete;
+    await open(el);
+    expect(el.shadowRoot!.querySelector(".option-default-note")).toBeNull();
+  });
+
   test("the change event is namespaced (no generic value-changed)", () => {
     expect(OPTIONS_COMBOBOX_CHANGE_EVENT).toBe("options-combobox-change");
   });


### PR DESCRIPTION
# What does this implement/fix?

In the logger structured editor, the `level` select shows its default (`DEBUG`) greyed on the closed control and tags `DEBUG` with a muted "default" note in the open dropdown. `hardware_uart` showed `UART0` greyed on the closed control but tagged nothing in the open list.

The cause is purely rendering: `hardware_uart` has `allow_custom_value: true`, so `renderSelectField` routes it to the `esphome-options-combobox` branch, which set only the placeholder; the combobox component had no concept of a default option and never rendered the note. `level` (no custom values) uses the plain `wa-select` branch, the only one that tagged the default.

This teaches the combobox to tag the option matching the default, reusing the existing `option-default-note` styling (already available via `inputStyles`) and the `device.default_option_tag` translation key. It generalizes to any `allow_custom_value` select with a default, not just `hardware_uart`.

**Related issue or feature (if applicable):**

- N/A (reported via dashboard screenshots)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
