### PR TITLE
Select the first list item when a bare-sequence header line is clicked

### DIFF
--- a/src/util/yaml-section-lexer.ts
+++ b/src/util/yaml-section-lexer.ts
@@ -39,6 +39,16 @@ export const KEY_PATTERN = "[a-zA-Z_][^\\s:#]*";
 export const TOP_LEVEL_KEY_START_RE = /^[a-zA-Z_]/;
 
 /**
+ * Capture a column-0 top-level key. Group 1 is the key; the prefix
+ * form (no end anchor) matches whether or not the key carries an
+ * inline value, so callers that only want the name can ignore the
+ * rest of the line. Companion to ``TOP_LEVEL_KEY_START_RE`` — shared
+ * so the several "what's the top-level key on this line" sites don't
+ * each re-spell the identifier class.
+ */
+export const TOP_LEVEL_KEY_RE = /^([a-zA-Z_][a-zA-Z0-9_]*):/;
+
+/**
  * Match the inline-key form on a YAML list-item line
  * (`  - platform: esphome`). Capture group 1 is the key.
  *

--- a/src/util/yaml-sections-core.ts
+++ b/src/util/yaml-sections-core.ts
@@ -18,6 +18,7 @@ import {
   _skipBlankAndCommentLines,
   endsBlockAtIndent,
   LIST_ITEM_START_RE,
+  TOP_LEVEL_KEY_RE,
 } from "./yaml-section-lexer.js";
 
 /** A field-path segment that addresses a list index (``["areas","0",…]``). */
@@ -123,7 +124,7 @@ export function parseYamlTopLevelSections(yaml: string): YamlSection[] {
   const rawSections: Array<{ key: string; fromLine: number; toLine: number }> = [];
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
+    const match = lines[i].match(TOP_LEVEL_KEY_RE);
     if (match) {
       if (rawSections.length > 0) {
         // The previous section content ends one line before the new

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -1,4 +1,5 @@
 import { parseYamlAutomations } from "./yaml-automations.js";
+import { TOP_LEVEL_KEY_RE } from "./yaml-section-lexer.js";
 import {
   _clearYamlSectionsMemo,
   findFieldLine,
@@ -179,7 +180,9 @@ export function findAddedSection(
  * gap between sections (file header, blank-line interstitial,
  * comment block above a top-level key — the trim done by
  * `parseYamlTopLevelSections` deliberately keeps those gaps
- * unattributed).
+ * unattributed). A bare top-level sequence's header line
+ * (`usb_uart:` above its `- ` items) is the one exception: it has no
+ * covering item range, so it resolves to the section's first item.
  *
  * `find` over the section array — sections are file-ordered with
  * non-overlapping ranges, and at typical config sizes (~10-30
@@ -227,7 +230,36 @@ export function sectionAtLine(yaml: string, line: number): YamlSection | null {
   const autoHit = smallestContainingSection(autos, line);
   if (autoHit) return autoHit;
   const tops = parseYamlTopLevelSections(yaml);
-  return smallestContainingSection(tops, line);
+  const topHit = smallestContainingSection(tops, line);
+  if (topHit) return topHit;
+  // A bare top-level sequence (usb_uart:, sensor:, …) expands into per-item
+  // ranges that start at the first dash, so the header line itself is covered
+  // by nothing. When the click lands exactly on such a header, select the
+  // section's first instance instead of leaving the selection unchanged.
+  return _firstItemForListHeader(tops, yaml, line);
+}
+
+function _firstItemForListHeader(
+  tops: YamlSection[],
+  yaml: string,
+  line: number
+): YamlSection | null {
+  // Cap the split at the requested line so a click near a header doesn't
+  // materialize the whole document on the cursor path.
+  const header = yaml.split("\n", line)[line - 1];
+  const key = header?.match(TOP_LEVEL_KEY_RE)?.[1];
+  if (!key) return null;
+  let first: YamlSection | null = null;
+  for (const s of tops) {
+    if (
+      s.parentKey === key &&
+      s.fromLine > line &&
+      (!first || s.fromLine < first.fromLine)
+    ) {
+      first = s;
+    }
+  }
+  return first;
 }
 
 /**

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -335,7 +335,7 @@ sensor:
   //   6: logger:                — logger [6..7]
   //   7:   level: INFO
   //   8: (blank)                — gap
-  //   9: sensor:                — covered by list-item ranges (no parent)
+  //   9: sensor:                — header line, selects the first item (dht)
   //  10:   - platform: dht      — sensor.dht [10..12]
   //  11:     name: kitchen
   //  12:     pin: D1
@@ -365,6 +365,22 @@ sensor:
   it("crosses to the next list item", () => {
     const m = sectionAtLine(yaml, 13);
     expect(m?.platform).toBe("bme280");
+  });
+
+  it("selects the first item when the bare-sequence header line is clicked", () => {
+    // `sensor:` header isn't covered by any item range; the click should
+    // still land on the first instance instead of leaving the selection put.
+    const m = sectionAtLine(yaml, 9);
+    expect(m?.key).toBe("sensor");
+    expect(m?.platform).toBe("dht");
+    expect(m?.fromLine).toBe(10); // the dash line, so the loader parses it
+  });
+
+  it("selects the first item for a bare-sequence header with a trailing comment", () => {
+    const commented = `sensor:  # my sensors\n  - platform: dht\n    name: x\n`;
+    const m = sectionAtLine(commented, 1);
+    expect(m?.key).toBe("sensor");
+    expect(m?.platform).toBe("dht");
   });
 
   it("returns null for the file header above the first section", () => {


### PR DESCRIPTION
# What does this implement/fix?

Clicking the top-level `usb_uart:` header line in the YAML pane did nothing; the structured editor stayed on the previously selected section. Clicking a child line (`- type: CDC_ACM`) worked, so the section was editable, only the header click failed.

`usb_uart:` is a bare top-level YAML sequence. `_expandListItems` replaces such a section with one section per list item, each ranged from the first dash line, so the header line itself is covered by no range. `sectionAtLine` then returns null and the cursor handler bails, leaving the selection put. Any bare top-level sequence (`sensor:`, `usb_uart:`, …) has the same gap; map sections (`mdns:`, `usb_host:`) keep their header and are unaffected.

This adds a narrow fallback in `sectionAtLine`: when no range covers the clicked line and that line is a bare-sequence header, it returns the section's first item, keeping the item's real dash `fromLine` so the structured editor still parses it. The change is scoped to UI selection (`sectionAtLine`'s only callers are the cursor handler and the URL deep-link resolver); parsing, serialization, item ranges, and the navigator are untouched, and only lines that previously resolved to null change behavior.

**Related issue or feature (if applicable):**

- N/A (reported via dashboard repro)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
