### PR TITLE
Filter select options to the device's ESP32 variant

### DIFF
--- a/src/api/types/config-entries.ts
+++ b/src/api/types/config-entries.ts
@@ -12,6 +12,11 @@ export type ConfigPrimitive = string | number | boolean;
 export interface ConfigValueOption {
   label: string;
   value: string;
+  /** ESP32 variants that accept this value (lowercased, e.g. `esp32s3`); absent
+   *  or empty means every variant. When the device resolves to an ESP32 variant
+   *  the select filters to it; otherwise (non-ESP32 or unknown) all options
+   *  show. */
+  variants?: string[];
 }
 
 /** Known GPIO pin features/capabilities (matches backend PinFeature enum). */

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -403,20 +403,47 @@ export function renderBooleanField(entry: ConfigEntry, path: string[], ctx: Rend
   `;
 }
 
-// esp32's variant has no static default — it follows the chosen board. Derive
-// it from the live `board:` sibling (or the saved board) so the select shows
-// the board's variant greyed out as the default, like any other default. Only
-// returns a value that's actually one of the entry's options.
+// The device's ESP32 variant (lowercased, e.g. `esp32s3`), from the live
+// `board:` sibling first (so a just-picked board resolves before `ctx.board`
+// catches up) or the saved board. `""` when unknown or non-ESP32: per-variant
+// options only exist on ESP32 components, so a non-`esp32*` result never
+// filters.
+function resolveEsp32Variant(ctx: RenderCtx): string {
+  const board = String(ctx.getAt(["board"]) ?? "");
+  const variant = (
+    board ? chipNameToVariant(board) : (ctx.board?.esphome.variant ?? "")
+  ).toLowerCase();
+  return variant.startsWith("esp32") ? variant : "";
+}
+
+// Keep options whose `variants` is absent/empty or includes the device's
+// variant — plus the currently-stored value, so a board swap can't hide what
+// the YAML still holds. Falls back to all options when the variant is unknown or
+// the filter would empty the select (e.g. psram on a no-PSRAM variant).
+function filterOptionsByVariant<T extends { value: string; variants?: string[] }>(
+  options: T[],
+  variant: string,
+  current = ""
+): T[] {
+  if (!variant) return options;
+  const cur = current.toLowerCase();
+  const kept = options.filter(
+    (o) =>
+      !o.variants?.length || o.variants.includes(variant) || o.value.toLowerCase() === cur
+  );
+  return kept.length > 0 ? kept : options;
+}
+
+// esp32's variant has no static default — it follows the chosen board, so the
+// select shows the board's variant greyed out as the default. Only returns a
+// value that's actually one of the entry's options.
 function boardDerivedVariantDefault(
   entry: ConfigEntry,
-  ctx: RenderCtx
+  ctx: RenderCtx,
+  variant: string
 ): string | undefined {
-  if (entry.key !== "variant" || ctx.sectionKey !== "esp32") return undefined;
-  const board = String(ctx.getAt(["board"]) ?? "");
-  const variant = board ? chipNameToVariant(board) : (ctx.board?.esphome.variant ?? "");
-  if (!variant) return undefined;
-  const lower = variant.toLowerCase();
-  return entry.options?.some((o) => o.value.toLowerCase() === lower)
+  if (!variant || entry.key !== "variant" || ctx.sectionKey !== "esp32") return undefined;
+  return entry.options?.some((o) => o.value.toLowerCase() === variant)
     ? variant
     : undefined;
 }
@@ -453,6 +480,9 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
       </div>
     `;
   }
+  // The device's ESP32 variant, used to filter per-variant options (and derive
+  // the esp32 variant default below); resolved once per render.
+  const variant = resolveEsp32Variant(ctx);
   if (entry.allow_custom_value && entry.options && entry.options.length > 0) {
     // ``label`` only names the combobox's shadow-DOM input (renderLabel's
     // visible label isn't associated via for=); the combobox draws no label
@@ -461,7 +491,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <esphome-options-combobox
-          .options=${entry.options}
+          .options=${filterOptionsByVariant(entry.options, variant, value)}
           .value=${value}
           label=${entry.label}
           placeholder=${String(entry.default_value ?? "")}
@@ -481,7 +511,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   // still flags as selected.
   const valueLower = value.toLowerCase();
   const defaultStr =
-    boardDerivedVariantDefault(entry, ctx) ??
+    boardDerivedVariantDefault(entry, ctx, variant) ??
     (entry.default_value != null ? String(entry.default_value) : "");
   const defaultLower = defaultStr.toLowerCase();
   const defaultOption = entry.options?.find(
@@ -489,6 +519,8 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   );
   const placeholder = defaultOption?.label ?? defaultStr;
   const { clearable, visibleOptions } = selectOptions(entry);
+  // Filtered after the (entry-keyed) selectOptions memo since it depends on the board.
+  const shownOptions = filterOptionsByVariant(visibleOptions, variant, value);
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
@@ -503,7 +535,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ${clearable
           ? html`<wa-icon slot="clear-icon" library="mdi" name="close"></wa-icon>`
           : nothing}
-        ${visibleOptions.map((opt) => {
+        ${shownOptions.map((opt) => {
           const selected = opt.value.toLowerCase() === valueLower;
           const isDefault = defaultStr !== "" && opt.value.toLowerCase() === defaultLower;
           if (!isDefault) {

--- a/test/components/device/config-entry-variant-options.test.ts
+++ b/test/components/device/config-entry-variant-options.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import {
+  findElementBindings,
+  makeEntry,
+  makeRenderCtx,
+  makeTestBoard,
+} from "./_renderer-fixtures.js";
+
+// A per-variant enum (psram `mode`): each value carries the ESP32 variants that
+// accept it; an untagged value applies to every variant.
+const MODE: ConfigValueOption[] = [
+  { value: "quad", label: "quad", variants: ["esp32", "esp32s3"] },
+  { value: "octal", label: "octal", variants: ["esp32s3"] },
+  { value: "hex", label: "hex", variants: ["esp32p4"] },
+  { value: "auto", label: "auto" },
+];
+
+function boardWithVariant(variant: string): BoardCatalogEntry {
+  return makeTestBoard({
+    overrides: { esphome: { platform: "esp32", board: "b", variant, framework: null } },
+  });
+}
+
+function renderedValues(
+  options: ConfigValueOption[],
+  board: BoardCatalogEntry | null
+): string[] {
+  const entry = makeEntry(ConfigEntryType.SELECT, { key: "mode", options });
+  const tpl = renderSelectField(entry, ["mode"], makeRenderCtx({}, { board }));
+  return findElementBindings(tpl, "wa-option").map((b) => String(b.value));
+}
+
+describe("renderSelectField — per-variant option filtering", () => {
+  it("keeps the stored value's option even when its variant no longer matches", () => {
+    // mode "hex" is esp32p4-only, but the board is esp32s3 — keep it so a board
+    // swap can't hide the value the YAML still holds.
+    const entry = makeEntry(ConfigEntryType.SELECT, { key: "mode", options: MODE });
+    const tpl = renderSelectField(
+      entry,
+      ["mode"],
+      makeRenderCtx({ mode: "hex" }, { board: boardWithVariant("esp32s3") })
+    );
+    expect(findElementBindings(tpl, "wa-option").map((b) => String(b.value))).toContain(
+      "hex"
+    );
+  });
+
+  it("keeps the device variant's options plus untagged ones", () => {
+    expect(renderedValues(MODE, boardWithVariant("esp32s3"))).toEqual([
+      "quad",
+      "octal",
+      "auto",
+    ]);
+    expect(renderedValues(MODE, boardWithVariant("esp32p4"))).toEqual(["hex", "auto"]);
+    expect(renderedValues(MODE, boardWithVariant("esp32"))).toEqual(["quad", "auto"]);
+  });
+
+  it("shows every option when the board variant is unknown", () => {
+    expect(renderedValues(MODE, null)).toEqual(["quad", "octal", "hex", "auto"]);
+  });
+
+  it("resolves the variant from the live `board:` sibling before ctx.board", () => {
+    // No saved board catalog entry yet; the just-picked `board:` value alone
+    // drives filtering.
+    const entry = makeEntry(ConfigEntryType.SELECT, { key: "mode", options: MODE });
+    const tpl = renderSelectField(
+      entry,
+      ["mode"],
+      makeRenderCtx({ board: "esp32-s3-devkitc-1" }, { board: null })
+    );
+    expect(findElementBindings(tpl, "wa-option").map((b) => String(b.value))).toEqual([
+      "quad",
+      "octal",
+      "auto",
+    ]);
+  });
+
+  it("does not filter when the resolved board isn't ESP32", () => {
+    // An esp8266 board id must not accidentally filter ESP32-tagged options.
+    const entry = makeEntry(ConfigEntryType.SELECT, { key: "mode", options: MODE });
+    const tpl = renderSelectField(
+      entry,
+      ["mode"],
+      makeRenderCtx({ board: "nodemcuv2" }, { board: null })
+    );
+    expect(findElementBindings(tpl, "wa-option").map((b) => String(b.value))).toEqual([
+      "quad",
+      "octal",
+      "hex",
+      "auto",
+    ]);
+  });
+
+  it("falls back to all options when filtering would empty the select", () => {
+    const strict: ConfigValueOption[] = [
+      { value: "quad", label: "quad", variants: ["esp32"] },
+      { value: "hex", label: "hex", variants: ["esp32p4"] },
+    ];
+    // esp32c3 accepts neither and there's no untagged option — show all.
+    expect(renderedValues(strict, boardWithVariant("esp32c3"))).toEqual(["quad", "hex"]);
+  });
+
+  it("filters the allow_custom_value combobox options too", () => {
+    const comboboxValues = (board: BoardCatalogEntry | null): string[] => {
+      const entry = makeEntry(ConfigEntryType.SELECT, {
+        key: "mode",
+        options: MODE,
+        allow_custom_value: true,
+      });
+      const tpl = renderSelectField(entry, ["mode"], makeRenderCtx({}, { board }));
+      const combobox = findElementBindings(tpl, "esphome-options-combobox")[0];
+      return (combobox[".options"] as ConfigValueOption[]).map((o) => o.value);
+    };
+    expect(comboboxValues(boardWithVariant("esp32s3"))).toEqual([
+      "quad",
+      "octal",
+      "auto",
+    ]);
+    // Unknown variant falls back to all options, like the plain select.
+    expect(comboboxValues(null)).toEqual(["quad", "octal", "hex", "auto"]);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A per-variant enum option (psram `mode` / `speed`) can now carry the ESP32 variants that accept it. The select renderer filters its options to those whose `variants` include the device's variant; options without `variants` always show, and an unknown variant or a filter that would empty the select falls back to all options.

The variant is resolved exactly like the esp32 variant default (live `board:` sibling, then the saved board); the resolver is factored out and shared. The filter runs after the entry-keyed `selectOptions` memo since it depends on the board, and applies to both the plain `wa-select` and the `allow_custom_value` combobox.

Backend companion: esphome/device-builder#1472 (catalog ships the `variants`).

**Related issue or feature (if applicable):**

- supports esphome/esphome#16949

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
