### PR TITLE
Use shared actionFieldLabel for navigator action-field rows

### DIFF
--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -1,4 +1,5 @@
 import type { LocalizeFunc } from "../../common/localize.js";
+import { actionFieldLabel } from "../../util/action-field-label.js";
 import { getCachedComponent } from "../../util/component-name-cache.js";
 import { stripRedundantComponentSuffix } from "../../util/component-title.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
@@ -158,9 +159,10 @@ function automationLabels(
   }
   // Component action-list field (``turn_on_action`` / ``set_action``) — lead
   // with the action so the two switch.template actions (turn on vs turn off)
-  // are distinct; entity on line 2, mirroring the trigger rows.
+  // are distinct; entity on line 2, mirroring the trigger rows. Shared
+  // ``actionFieldLabel`` so the row matches the editor heading ("Set action").
   if (item.parentKey && item.actionField) {
-    const primary = humanizeEvent(item.actionField.replace(/_action$/, ""));
+    const primary = actionFieldLabel(item.actionField, ctx.localize);
     return { primary, secondary: componentTarget(item, ctx, primary) };
   }
   // Unscoped / unrecognised — fall back to displayLabel.

--- a/test/components/device/device-navigator-row-icons.test.ts
+++ b/test/components/device/device-navigator-row-icons.test.ts
@@ -126,6 +126,12 @@ describe("device-navigator row icons", () => {
 
   it("leads action-field automations with the action so they stay distinct", async () => {
     const nav = new ESPHomeDeviceNavigator();
+    // The shared action-field label localizes through "{name} action"; wire a
+    // localize that applies it so the rows render the production strings.
+    (
+      nav as unknown as { _localize: (k: string, p?: { name: string }) => string }
+    )._localize = (key, params) =>
+      key === "device.action_field_label" ? `${params?.name} action` : key;
     nav.yaml = [
       "esphome:",
       "  name: t",
@@ -146,7 +152,7 @@ describe("device-navigator row icons", () => {
       ...(nav.shadowRoot?.querySelectorAll(".nav-item-content p") ?? []),
     ].map((el) => el.textContent?.trim());
     // The two switch.template actions lead with the action, not "mmWave Status → …".
-    expect(primaries).toContain("Turn On");
-    expect(primaries).toContain("Turn Off");
+    expect(primaries).toContain("Turn on action");
+    expect(primaries).toContain("Turn off action");
   });
 });

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -48,6 +48,32 @@ describe("resolveNavItemLabels core suffix", () => {
   });
 });
 
+describe("resolveNavItemLabels component action fields", () => {
+  const actionCtx: LabelContext = {
+    ...ctx,
+    localize: ((key: string, params?: { name: string }) =>
+      key === "device.action_field_label"
+        ? `${params?.name} action`
+        : key) as LabelContext["localize"],
+  };
+  const actionRow = (actionField: string): YamlSection =>
+    ({ key: "number", parentKey: "number", actionField }) as unknown as YamlSection;
+
+  it("labels a set_action row 'Set action', matching the editor heading", () => {
+    mockGetCached.mockReturnValue(undefined);
+    expect(
+      resolveNavItemLabels(actionRow("set_action"), "automation", actionCtx).primary
+    ).toBe("Set action");
+  });
+
+  it("keeps the action word for multi-word fields (turn_on_action)", () => {
+    mockGetCached.mockReturnValue(undefined);
+    expect(
+      resolveNavItemLabels(actionRow("turn_on_action"), "automation", actionCtx).primary
+    ).toBe("Turn on action");
+  });
+});
+
 describe("resolveNavItemLabels substitution resolution", () => {
   const subs = new Map([["upper_devicename", "Driveway Gate"]]);
   const row = (name: string): YamlSection =>


### PR DESCRIPTION
# What does this implement/fix?

The Device navigator (left sidebar) hand-rolled the label for component
action-list fields (`set_action`, `turn_on_action`, ...): it stripped the
`_action` suffix and title-cased the stem, dropping the word "action". A
`set_action` row therefore read **"Set"**, while the editor panel heading for
the very same node read **"Set action"**.

This delegates the navigator's action-field branch to the shared
`actionFieldLabel` helper that the editor heading and the section-config action
table already use, so the row now reads **"Set action"** / **"Turn on action"**,
matching the rest of the UI.

**Related issue or feature (if applicable):**

- n/a (reported via screenshot: Athom Presence Sensor `set_action` rows)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
