### PR TITLE
Fix Expert Mode typo in settings description

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1009,7 +1009,7 @@
     "language_system": "System",
     "theme_desc": "Choose between light, dark, or follow your system preference.",
     "expert_mode": "Expert Mode",
-    "expert_mode_desc": "Enabling Export Mode will unlock some additional powerful options in the Device Builder for experienced power users of ESPHome.",
+    "expert_mode_desc": "Enabling Expert Mode will unlock some additional powerful options in the Device Builder for experienced power users of ESPHome.",
     "expert_mode_features_title": "What Expert Mode adds",
     "expert_mode_feature_diff": "Editor diff view",
     "expert_mode_feature_diff_desc": "Compare your unsaved YAML against the last saved version from the editor toolbar.",


### PR DESCRIPTION
# What does this implement/fix?

Fixes a typo in the Expert Mode settings description; it read "Enabling Export Mode" and now reads "Enabling Expert Mode".

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1478

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
