### PR TITLE
Consume preferences from the subscribe_events initial_state snapshot

### DIFF
--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -12,6 +12,7 @@ import {
 import { JobStatus, type FirmwareJob } from "./firmware-jobs.js";
 import type { OffloaderAlertSnapshotEntry } from "./remote-build-events.js";
 import type { PairingSummary, PeerSummary, RemoteBuildPeer } from "./remote-build.js";
+import type { UserPreferences } from "./system.js";
 
 // ─── Event Subscription ─────────────────────────────────────
 
@@ -148,6 +149,11 @@ export interface JobOutputEventData {
 
 /** Data payload for initial_state event. */
 export interface InitialStateEventData {
+  /** User preferences snapshot. Always sent (the backend reads
+   *  defaults when nothing is stored), so the app shell paints
+   *  theme and other UI state from this rather than a separate
+   *  ``config/get_preferences`` round trip. */
+  preferences: UserPreferences;
   devices: ConfiguredDevice[];
   /** Discovered factory-firmware devices the dashboard knew about
    *  before this client subscribed. The backend follows up with

--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -150,9 +150,9 @@ export interface JobOutputEventData {
 /** Data payload for initial_state event. */
 export interface InitialStateEventData {
   /** User preferences snapshot. Always sent (the backend reads
-   *  defaults when nothing is stored), so the app shell paints
-   *  theme and other UI state from this rather than a separate
-   *  ``config/get_preferences`` round trip. */
+   *  defaults when nothing is stored); the app shell applies theme
+   *  from it and marks preferences loaded rather than making a
+   *  separate ``config/get_preferences`` round trip. */
   preferences: UserPreferences;
   devices: ConfiguredDevice[];
   /** Discovered factory-firmware devices the dashboard knew about

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -53,11 +53,11 @@ import { espHomeStyles } from "../styles/shared.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
+  loadExpertModePreference,
   loadIntegrationDocs,
   loadLabels,
   loadOnboardingState,
   loadRemoteBuildSettings,
-  loadThemePreference,
 } from "./app-shell/data-load.js";
 import { handleEvent } from "./app-shell/events.js";
 import {
@@ -405,7 +405,7 @@ export class ESPHomeApp extends LitElement {
     subscribeToFollowJobs(this);
     void loadIntegrationDocs(this);
     void loadLabels(this);
-    void loadThemePreference(this);
+    void loadExpertModePreference(this);
     void loadRemoteBuildSettings(this);
     void loadOnboardingState(this);
   }

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -42,6 +42,7 @@ import {
   offloaderRemoteBuildsEnabledContext,
   offloaderVersionMatchPolicyContext,
   onboardingPendingContext,
+  prefsLoadedContext,
   recentJobsContext,
   remoteBuildCleanupTtlContext,
   remoteBuildEnabledContext,
@@ -120,6 +121,8 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: localizeContext }) @state() _localize: LocalizeFunc =
     defaultLocalize;
   @provide({ context: expertModeContext }) @state() _expertMode = false;
+  // False until the subscribe snapshot delivers preferences.
+  @provide({ context: prefsLoadedContext }) @state() _prefsLoaded = false;
   @provide({ context: remoteBuildEnabledContext }) @state() _remoteBuildEnabled = false;
   @provide({ context: remoteBuildCleanupTtlContext }) @state() _remoteBuildCleanupTtl =
     CLEANUP_TTL_DEFAULT_SECONDS;

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -53,7 +53,8 @@ export async function loadIntegrationDocs(host: ESPHomeApp): Promise<void> {
 export async function loadThemePreference(host: ESPHomeApp): Promise<void> {
   try {
     const prefs = await host._api.getPreferences();
-    host.applyTheme(prefs.theme);
+    // Theme rides the initial_state snapshot now; this refetch is for
+    // expert_mode, which the snapshot does not carry.
     host._expertMode = prefs.expert_mode;
   } catch {
     // Preferences not critical — keep localStorage value.

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -50,11 +50,11 @@ export async function loadIntegrationDocs(host: ESPHomeApp): Promise<void> {
   }
 }
 
-export async function loadThemePreference(host: ESPHomeApp): Promise<void> {
+export async function loadExpertModePreference(host: ESPHomeApp): Promise<void> {
   try {
     const prefs = await host._api.getPreferences();
-    // Theme rides the initial_state snapshot now; this refetch is for
-    // expert_mode, which the snapshot does not carry.
+    // This PR only moves theme to the initial_state snapshot; expert_mode keeps
+    // loading the way it did before, left to the experience-levels follow-up.
     host._expertMode = prefs.expert_mode;
   } catch {
     // Preferences not critical — keep localStorage value.

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -57,6 +57,7 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
   switch (event) {
     case DeviceEventType.INITIAL_STATE: {
       const {
+        preferences,
         devices,
         importable,
         peers,
@@ -67,6 +68,10 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
         remote_builds_enabled,
         version_match_policy,
       } = data as InitialStateEventData;
+      // Seed UI prefs from the snapshot so first paint skips a separate
+      // get_preferences round trip.
+      host.applyTheme(preferences.theme);
+      host._prefsLoaded = true;
       host._devices = devices;
       host._importableDevices = importable;
       host._devicesLoaded = true;

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -89,6 +89,11 @@ export const firmwareJobsContext = createContext<Map<string, FirmwareJob>>(
  *  ``expert_mode`` user preference. */
 export const expertModeContext = createContext<boolean>(Symbol("esphome-expert-mode"));
 
+/** Context for whether the preferences snapshot has arrived. False until the
+ *  ``subscribe_events`` ``initial_state`` push seeds preferences; consumers can
+ *  hold preference-dependent UI until then. */
+export const prefsLoadedContext = createContext<boolean>(Symbol("esphome-prefs-loaded"));
+
 /**
  * Context for the receiver-side remote-build master switch.
  *

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -21,6 +21,7 @@ export {
   offloaderRemoteBuildsEnabledContext,
   offloaderVersionMatchPolicyContext,
   onboardingPendingContext,
+  prefsLoadedContext,
   recentJobsContext,
   remoteBuildCleanupTtlContext,
   remoteBuildEnabledContext,

--- a/test/components/app-shell/events-initial-state-prefs.test.ts
+++ b/test/components/app-shell/events-initial-state-prefs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DeviceEventType,
+  type InitialStateEventData,
+} from "../../../src/api/types/event-subscription.js";
+import {
+  DashboardView,
+  Theme,
+  type UserPreferences,
+} from "../../../src/api/types/system.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+
+function makePrefs(overrides: Partial<UserPreferences> = {}): UserPreferences {
+  return {
+    dashboard_view: DashboardView.CARDS,
+    theme: Theme.DARK,
+    navigator_visible: true,
+    expert_mode: false,
+    table_page_size: 25,
+    table_column_visibility: {},
+    table_sort_column: null,
+    table_sort_direction: null,
+    onboarding_completed_version: 0,
+    ...overrides,
+  };
+}
+
+function makeInitial(preferences: UserPreferences): InitialStateEventData {
+  return { preferences, devices: [], importable: [] };
+}
+
+describe("handleEvent INITIAL_STATE preferences", () => {
+  it("applies theme from the snapshot and marks prefs loaded", () => {
+    const applyTheme = vi.fn();
+    const host = { applyTheme } as unknown as ESPHomeApp;
+
+    handleEvent(
+      host,
+      DeviceEventType.INITIAL_STATE,
+      makeInitial(makePrefs({ theme: Theme.LIGHT }))
+    );
+
+    expect(applyTheme).toHaveBeenCalledWith(Theme.LIGHT);
+    expect(host._prefsLoaded).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Frontend half of the preferences-in-initial-state plumbing; companion to esphome/device-builder#1479. The preferences snapshot now arrives on the `subscribe_events` `initial_state` push, so the app shell applies theme straight from it and sets a `prefsLoaded` flag rather than waiting on a separate `config/get_preferences` round trip. Expert mode keeps loading the way it does today; there are no experience-level changes here, that lands on top in a follow up.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
