### PR TITLE
Close the Create new label dialog on Cancel

### DIFF
--- a/src/components/labels/label-dialog.ts
+++ b/src/components/labels/label-dialog.ts
@@ -83,7 +83,7 @@ export class ESPHomeLabelDialog extends LitElement {
           .editing=${this.editing}
           default-open
           compact
-          @editing-cancel=${this._requestClose}
+          @form-cancel=${this._requestClose}
         ></esphome-label-form>
       </esphome-base-dialog>
     `;

--- a/src/components/labels/label-form.ts
+++ b/src/components/labels/label-form.ts
@@ -444,28 +444,21 @@ export class ESPHomeLabelForm extends LitElement {
   }
 
   private _cancel() {
-    if (this.editing) {
-      // Edit mode owns "exit" at the host level — fire an event
-      // and let the host clear the ``editing`` prop. Don't touch
-      // local state here; the willUpdate hook will reset on the
-      // next prop change.
-      this.dispatchEvent(
-        new CustomEvent("editing-cancel", { bubbles: true, composed: true })
-      );
+    // Device-drawer inline create form: collapse back to its toggle.
+    if (!this.editing && !this.defaultOpen) {
+      this.collapse();
       return;
     }
-    // The labels filter's empty popover relies on the form staying
-    // visible, so when ``defaultOpen`` is set we never collapse —
-    // we just blank the inputs. Hosts that want a real "close"
-    // behaviour leave ``defaultOpen`` false (the editor's dialog
-    // does this).
-    if (this.defaultOpen) {
+    // Create dialog: clear inputs so the next open starts clean (edit
+    // mode resets via willUpdate when ``editing`` clears).
+    if (!this.editing) {
       this._name = "";
       this._color = null;
       this._colorManual = false;
-      return;
     }
-    this.collapse();
+    // Edit mode and the standalone create dialog let the host own
+    // "close".
+    this.dispatchEvent(new CustomEvent("form-cancel", { bubbles: true, composed: true }));
   }
 
   private async _submit() {

--- a/test/components/labels/label-dialog.test.ts
+++ b/test/components/labels/label-dialog.test.ts
@@ -73,6 +73,16 @@ describe("esphome-label-dialog", () => {
     expect(got).toEqual(["request-close", "after-hide"]);
   });
 
+  it("requests close when the form fires form-cancel", async () => {
+    const el = await mount({ open: true });
+    const onClose = vi.fn();
+    el.addEventListener("request-close", onClose);
+    el.shadowRoot!.querySelector("esphome-label-form")!.dispatchEvent(
+      new CustomEvent("form-cancel", { bubbles: true, composed: true })
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it("requests close when a catalog push drops the label being edited", async () => {
     const el = await mount({ open: true, editing: LABEL });
     const onClose = vi.fn();

--- a/test/components/labels/label-form.test.ts
+++ b/test/components/labels/label-form.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins _cancel() routing: the standalone create dialog and edit mode fire
+ * form-cancel so the host closes (#1477); the device-drawer inline create
+ * form collapses back to its toggle and stays silent.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { Label } from "../../../src/api/types/devices.js";
+import { ESPHomeLabelForm } from "../../../src/components/labels/label-form.js";
+
+const LABEL: Label = { id: "l1", name: "kitchen", color: "#ff0000" } as Label;
+
+async function mount(
+  overrides: Partial<Record<string, unknown>> = {}
+): Promise<ESPHomeLabelForm> {
+  const el = new ESPHomeLabelForm();
+  Object.assign(el, overrides);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const cancelButton = (el: ESPHomeLabelForm): HTMLButtonElement =>
+  el.shadowRoot!.querySelector(".create-actions .btn")!;
+
+const toggleButton = (el: ESPHomeLabelForm): HTMLButtonElement | null =>
+  el.shadowRoot!.querySelector(".create-toggle");
+
+describe("esphome-label-form cancel", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("fires form-cancel from the default-open create dialog", async () => {
+    const el = await mount({ defaultOpen: true });
+    const onCancel = vi.fn();
+    el.addEventListener("form-cancel", onCancel);
+    cancelButton(el).click();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("fires form-cancel from edit mode", async () => {
+    const el = await mount({ editing: LABEL });
+    const onCancel = vi.fn();
+    el.addEventListener("form-cancel", onCancel);
+    cancelButton(el).click();
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("collapses the inline create form to its toggle without firing form-cancel", async () => {
+    const el = await mount();
+    el.expand();
+    await el.updateComplete;
+    const onCancel = vi.fn();
+    el.addEventListener("form-cancel", onCancel);
+    cancelButton(el).click();
+    await el.updateComplete;
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(toggleButton(el)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The dashboard "Create new label" dialog only cleared the name field when you clicked Cancel; the dialog stayed open. Cancel now closes it, matching the X and Escape paths.

The shared label form took a `default-open` shortcut that blanked the inputs and returned without telling the host to close. The dashboard dialog is the only host that sets `default-open` now (the labels filter opens the dialog instead of mounting the form), so the form fires a single `form-cancel` event for both edit mode and the create dialog, and the device-drawer inline create still collapses back to its toggle.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1477

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
