### PR TITLE
Rename custom component title to external component

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -321,7 +321,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
           <div class="section-header-title-row">
             <h3 class="section-title">
               ${this._isUnknown
-                ? this._localize("device.custom_component_title")
+                ? this._localize("device.external_component_title")
                 : this._config.title}
             </h3>
             ${this._config.docs_url

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -47,9 +47,9 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
     const yaml = host.yaml;
 
     if (!component) {
-      // Custom / external component — synthesise a config with no entries
+      // External component — synthesise a config with no entries
       // so the YAML-only notice fires. Store sectionKey as title (not a
-      // localised "Custom component" label) so the delete confirm + toast
+      // localised "External component" label) so the delete confirm + toast
       // read distinctly when a device has multiple unknown sections.
       host._config = {
         section_key: host.sectionKey,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -825,7 +825,7 @@
     "automation_remove": "Remove",
     "adding": "Adding…",
     "saving": "Saving…",
-    "custom_component_title": "Custom component",
+    "external_component_title": "External component",
     "load_config_error": "Failed to load section config",
     "yaml_only_section": "This section doesn't have a structured editor — edit it directly in the YAML pane on the right.",
     "security_generate": "Generate",


### PR DESCRIPTION
# What does this implement/fix?

Custom components are deprecated and were already removed in ESPHome, so the device editor's heading for an unrecognized section should say "External component" rather than "Custom component". This renames the translation key `device.custom_component_title` to `device.external_component_title`, updates its English text, and fixes a stale comment that still used the old term.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/850

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
