### PR TITLE
Persist device and secrets editor layout in preferences

### DIFF
--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -52,9 +52,8 @@ export enum SortDirection {
 }
 
 /**
- * Which editor panes are open, persisted per editor. The device editor
- * uses all three; the secrets editor only ever stores VISUAL or YAML.
- * Keep in lockstep with the backend's ``EditorLayout`` enum.
+ * Device editor pane layout: the form, the YAML pane, or both. Keep in
+ * lockstep with the backend's ``EditorLayout`` enum.
  */
 export enum EditorLayout {
   /** Form / guide only, YAML pane hidden. */
@@ -63,6 +62,16 @@ export enum EditorLayout {
   YAML = "yaml",
   /** Split: form / guide alongside the YAML pane. */
   BOTH = "both",
+}
+
+/**
+ * Secrets editor layout: the form or the YAML pane, never both. A
+ * dedicated enum keeps ``both`` off the wire. Keep in lockstep with the
+ * backend's ``SecretsEditorLayout`` enum.
+ */
+export enum SecretsEditorLayout {
+  VISUAL = "visual",
+  YAML = "yaml",
 }
 
 /**
@@ -83,9 +92,9 @@ export interface UserPreferences {
   theme: Theme;
   navigator_visible: boolean;
   /** Which editor panes the user keeps open, persisted so the choice
-   *  survives a new browser. The secrets editor never uses ``BOTH``. */
+   *  survives a new browser. The secrets editor has no split view. */
   device_editor_layout: EditorLayout;
-  secrets_editor_layout: EditorLayout;
+  secrets_editor_layout: SecretsEditorLayout;
   table_page_size: number;
   table_column_visibility: Record<string, boolean>;
   table_sort_column: string | null;

--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -52,6 +52,20 @@ export enum SortDirection {
 }
 
 /**
+ * Which editor panes are open, persisted per editor. The device editor
+ * uses all three; the secrets editor only ever stores VISUAL or YAML.
+ * Keep in lockstep with the backend's ``EditorLayout`` enum.
+ */
+export enum EditorLayout {
+  /** Form / guide only, YAML pane hidden. */
+  VISUAL = "visual",
+  /** YAML pane only. */
+  YAML = "yaml",
+  /** Split: form / guide alongside the YAML pane. */
+  BOTH = "both",
+}
+
+/**
  * How much ESPHome the user knows — tailors UI weight. Chosen in
  * onboarding, changeable in Settings. ``null`` (a fresh install that
  * hasn't picked) is distinct from any level. Keep in lockstep with
@@ -68,6 +82,10 @@ export interface UserPreferences {
   dashboard_view: DashboardView;
   theme: Theme;
   navigator_visible: boolean;
+  /** Which editor panes the user keeps open, persisted so the choice
+   *  survives a new browser. The secrets editor never uses ``BOTH``. */
+  device_editor_layout: EditorLayout;
+  secrets_editor_layout: EditorLayout;
   table_page_size: number;
   table_column_visibility: Record<string, boolean>;
   table_sort_column: string | null;

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -545,13 +545,16 @@ export class ESPHomePageDevice extends LitElement {
     }
   };
 
+  private _readStoredLayout(): DeviceLayoutMode | null {
+    const stored = localStorage.getItem("esphome-editor-layout");
+    return stored === "both" || stored === "left" || stored === "right" ? stored : null;
+  }
+
   private async _loadPreferences() {
     // localStorage is the instant per-browser seed; the backend pref below is
     // the durable cross-browser source when localStorage is empty.
-    const savedLayout = localStorage.getItem("esphome-editor-layout");
-    const hasSavedLayout =
-      savedLayout === "both" || savedLayout === "left" || savedLayout === "right";
-    if (hasSavedLayout) {
+    const savedLayout = this._readStoredLayout();
+    if (savedLayout) {
       this._layout = savedLayout;
     }
 
@@ -559,10 +562,10 @@ export class ESPHomePageDevice extends LitElement {
       const prefs = await this._api.getPreferences();
       this._navCollapsed = !prefs.navigator_visible;
       // No local layout yet (new browser): restore the backend choice, which
-      // defaults to the split view on a fresh install. Re-check localStorage
-      // after the await: a toggle during the in-flight fetch writes it, and
-      // that newer user choice must win over the seed.
-      if (!hasSavedLayout && localStorage.getItem("esphome-editor-layout") === null) {
+      // defaults to the split view on a fresh install. Re-check after the
+      // await: a toggle during the in-flight fetch writes a valid value that
+      // must win, but a stale invalid value still seeds from the backend.
+      if (!savedLayout && this._readStoredLayout() === null) {
         this._layout = prefToDeviceLayout(prefs.device_editor_layout);
       }
     } catch (err) {

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -30,7 +30,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
-import { editorLayoutForExperience } from "../util/experience.js";
+import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -546,7 +546,8 @@ export class ESPHomePageDevice extends LitElement {
   };
 
   private async _loadPreferences() {
-    // Editor layout stored locally (not in backend preferences)
+    // localStorage is the instant per-browser seed; the backend pref below is
+    // the durable cross-browser source when localStorage is empty.
     const savedLayout = localStorage.getItem("esphome-editor-layout");
     const hasSavedLayout =
       savedLayout === "both" || savedLayout === "left" || savedLayout === "right";
@@ -557,11 +558,10 @@ export class ESPHomePageDevice extends LitElement {
     try {
       const prefs = await this._api.getPreferences();
       this._navCollapsed = !prefs.navigator_visible;
-      // First editor open (no stored layout yet): seed the YAML pane from the
-      // experience level. Once the user touches the layout toggle it persists
-      // to localStorage and wins.
+      // No local layout yet (new browser): restore the backend choice, which
+      // defaults to the split view on a fresh install.
       if (!hasSavedLayout) {
-        this._layout = editorLayoutForExperience(prefs.experience_level);
+        this._layout = prefToDeviceLayout(prefs.device_editor_layout);
       }
     } catch (err) {
       // Preferences not critical; fall back to defaults. Logged so a YAML
@@ -805,8 +805,7 @@ export class ESPHomePageDevice extends LitElement {
       // to the split view so the user actually sees where they're
       // landing.
       if (this._layout === "left") {
-        this._layout = "both";
-        localStorage.setItem("esphome-editor-layout", "both");
+        this._persistLayout("both");
       }
       this._setHighlight({ fromLine: line, toLine: line }, true, true);
       const resolved = resolveSectionForUrlLine(this._yaml, line, null);
@@ -1111,8 +1110,17 @@ export class ESPHomePageDevice extends LitElement {
   }
 
   private _onLayoutChange(e: CustomEvent<DeviceLayoutMode>) {
-    this._layout = e.detail;
-    localStorage.setItem("esphome-editor-layout", e.detail);
+    this._persistLayout(e.detail);
+  }
+
+  // Single writer for the editor layout: localStorage is the instant
+  // per-browser cache, the backend pref is the durable cross-browser store.
+  private _persistLayout(mode: DeviceLayoutMode) {
+    this._layout = mode;
+    localStorage.setItem("esphome-editor-layout", mode);
+    this._api
+      .updatePreferences({ device_editor_layout: deviceLayoutToPref(mode) })
+      .catch(() => {});
   }
 
   /**

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -807,7 +807,9 @@ export class ESPHomePageDevice extends LitElement {
       // to the split view so the user actually sees where they're
       // landing.
       if (this._layout === "left") {
-        this._persistLayout("both");
+        // Implicit expand to reveal the error: cache it locally but don't
+        // record it as the user's durable layout preference.
+        this._cacheLayout("both");
       }
       this._setHighlight({ fromLine: line, toLine: line }, true, true);
       const resolved = resolveSectionForUrlLine(this._yaml, line, null);
@@ -1115,11 +1117,17 @@ export class ESPHomePageDevice extends LitElement {
     this._persistLayout(e.detail);
   }
 
-  // Single writer for the editor layout: localStorage is the instant
-  // per-browser cache, the backend pref is the durable cross-browser store.
-  private _persistLayout(mode: DeviceLayoutMode) {
+  // Instant per-browser cache only; used for implicit layout changes (e.g.
+  // auto-expanding to show a validation error) that shouldn't become the
+  // user's durable cross-browser preference.
+  private _cacheLayout(mode: DeviceLayoutMode) {
     this._layout = mode;
     localStorage.setItem("esphome-editor-layout", mode);
+  }
+
+  // A deliberate toggle: cache locally and record the cross-browser pref.
+  private _persistLayout(mode: DeviceLayoutMode) {
+    this._cacheLayout(mode);
     this._api
       .updatePreferences({ device_editor_layout: deviceLayoutToPref(mode) })
       .catch((err) => console.warn("Failed to persist device layout preference:", err));

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -559,8 +559,10 @@ export class ESPHomePageDevice extends LitElement {
       const prefs = await this._api.getPreferences();
       this._navCollapsed = !prefs.navigator_visible;
       // No local layout yet (new browser): restore the backend choice, which
-      // defaults to the split view on a fresh install.
-      if (!hasSavedLayout) {
+      // defaults to the split view on a fresh install. Re-check localStorage
+      // after the await: a toggle during the in-flight fetch writes it, and
+      // that newer user choice must win over the seed.
+      if (!hasSavedLayout && localStorage.getItem("esphome-editor-layout") === null) {
         this._layout = prefToDeviceLayout(prefs.device_editor_layout);
       }
     } catch (err) {
@@ -1120,7 +1122,7 @@ export class ESPHomePageDevice extends LitElement {
     localStorage.setItem("esphome-editor-layout", mode);
     this._api
       .updatePreferences({ device_editor_layout: deviceLayoutToPref(mode) })
-      .catch(() => {});
+      .catch((err) => console.warn("Failed to persist device layout preference:", err));
   }
 
   /**

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -87,7 +87,7 @@ export class ESPHomePageSecrets extends LitElement {
       this._layout = stored;
     } else {
       // No local choice (new browser): restore from the backend pref.
-      this._seedLayoutFromBackend();
+      void this._seedLayoutFromBackend();
     }
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
@@ -107,7 +107,11 @@ export class ESPHomePageSecrets extends LitElement {
   private async _seedLayoutFromBackend() {
     try {
       const prefs = await this._api.getPreferences();
-      this._layout = prefToSecretsLayout(prefs.secrets_editor_layout);
+      // A toggle during the in-flight fetch writes localStorage; honor that
+      // newer user choice instead of clobbering it with the stored seed.
+      if (this._readStoredLayout() === null) {
+        this._layout = prefToSecretsLayout(prefs.secrets_editor_layout);
+      }
     } catch (err) {
       // Layout is not critical; keep the default form view on failure.
       console.warn("Failed to load secrets layout preference:", err);
@@ -119,7 +123,7 @@ export class ESPHomePageSecrets extends LitElement {
     localStorage.setItem(LAYOUT_STORAGE_KEY, layout);
     this._api
       .updatePreferences({ secrets_editor_layout: secretsLayoutToPref(layout) })
-      .catch(() => {});
+      .catch((err) => console.warn("Failed to persist secrets layout preference:", err));
   }
 
   disconnectedCallback() {

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -10,6 +10,11 @@ import type { ESPHomeUnsavedChangesDialog } from "../components/unsaved-changes-
 import { apiContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
+import {
+  prefToSecretsLayout,
+  secretsLayoutToPref,
+  type SecretsLayout,
+} from "../util/editor-layout.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
@@ -30,8 +35,6 @@ registerMdiIcons({
 });
 
 const SECRETS_FILE = "secrets.yaml";
-
-type SecretsLayout = "form" | "yaml";
 
 const LAYOUT_STORAGE_KEY = "esphome-secrets-layout";
 const LAYOUTS: readonly SecretsLayout[] = ["form", "yaml"];
@@ -79,7 +82,13 @@ export class ESPHomePageSecrets extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
-    this._layout = this._readStoredLayout();
+    const stored = this._readStoredLayout();
+    if (stored) {
+      this._layout = stored;
+    } else {
+      // No local choice (new browser): restore from the backend pref.
+      this._seedLayoutFromBackend();
+    }
     setLeaveGuard(this._confirmLeave);
     window.addEventListener("beforeunload", this._onBeforeUnload);
     window.addEventListener("popstate", this._onPopState, { capture: true });
@@ -90,14 +99,27 @@ export class ESPHomePageSecrets extends LitElement {
     await this._loadFromServer();
   }
 
-  private _readStoredLayout(): SecretsLayout {
+  private _readStoredLayout(): SecretsLayout | null {
     const stored = localStorage.getItem(LAYOUT_STORAGE_KEY);
-    return LAYOUTS.includes(stored as SecretsLayout) ? (stored as SecretsLayout) : "form";
+    return LAYOUTS.includes(stored as SecretsLayout) ? (stored as SecretsLayout) : null;
+  }
+
+  private async _seedLayoutFromBackend() {
+    try {
+      const prefs = await this._api.getPreferences();
+      this._layout = prefToSecretsLayout(prefs.secrets_editor_layout);
+    } catch (err) {
+      // Layout is not critical; keep the default form view on failure.
+      console.warn("Failed to load secrets layout preference:", err);
+    }
   }
 
   private _setLayout(layout: SecretsLayout) {
     this._layout = layout;
     localStorage.setItem(LAYOUT_STORAGE_KEY, layout);
+    this._api
+      .updatePreferences({ secrets_editor_layout: secretsLayoutToPref(layout) })
+      .catch(() => {});
   }
 
   disconnectedCallback() {

--- a/src/util/editor-layout.ts
+++ b/src/util/editor-layout.ts
@@ -1,0 +1,34 @@
+import { EditorLayout } from "../api/types/system.js";
+import type { DeviceLayoutMode } from "../components/device/device-editor.js";
+
+// The secrets editor only has two panes, so its layout never includes BOTH.
+export type SecretsLayout = "form" | "yaml";
+
+const DEVICE_TO_PREF: Record<DeviceLayoutMode, EditorLayout> = {
+  left: EditorLayout.VISUAL,
+  right: EditorLayout.YAML,
+  both: EditorLayout.BOTH,
+};
+
+const PREF_TO_DEVICE: Record<EditorLayout, DeviceLayoutMode> = {
+  [EditorLayout.VISUAL]: "left",
+  [EditorLayout.YAML]: "right",
+  [EditorLayout.BOTH]: "both",
+};
+
+export function deviceLayoutToPref(mode: DeviceLayoutMode): EditorLayout {
+  return DEVICE_TO_PREF[mode];
+}
+
+export function prefToDeviceLayout(layout: EditorLayout): DeviceLayoutMode {
+  return PREF_TO_DEVICE[layout];
+}
+
+export function secretsLayoutToPref(layout: SecretsLayout): EditorLayout {
+  return layout === "yaml" ? EditorLayout.YAML : EditorLayout.VISUAL;
+}
+
+export function prefToSecretsLayout(layout: EditorLayout): SecretsLayout {
+  // Secrets has no split pane; a stray BOTH falls back to the YAML pane.
+  return layout === EditorLayout.VISUAL ? "form" : "yaml";
+}

--- a/src/util/editor-layout.ts
+++ b/src/util/editor-layout.ts
@@ -21,7 +21,9 @@ export function deviceLayoutToPref(mode: DeviceLayoutMode): EditorLayout {
 }
 
 export function prefToDeviceLayout(layout: EditorLayout): DeviceLayoutMode {
-  return PREF_TO_DEVICE[layout];
+  // Default to the split view if an unexpected value slips through (e.g. a
+  // hand-edited prefs file), mirroring prefToSecretsLayout's defaulting.
+  return PREF_TO_DEVICE[layout] ?? "both";
 }
 
 export function secretsLayoutToPref(layout: SecretsLayout): SecretsEditorLayout {

--- a/src/util/editor-layout.ts
+++ b/src/util/editor-layout.ts
@@ -1,4 +1,4 @@
-import { EditorLayout } from "../api/types/system.js";
+import { EditorLayout, SecretsEditorLayout } from "../api/types/system.js";
 import type { DeviceLayoutMode } from "../components/device/device-editor.js";
 
 // The secrets editor only has two panes, so its layout never includes BOTH.
@@ -24,11 +24,10 @@ export function prefToDeviceLayout(layout: EditorLayout): DeviceLayoutMode {
   return PREF_TO_DEVICE[layout];
 }
 
-export function secretsLayoutToPref(layout: SecretsLayout): EditorLayout {
-  return layout === "yaml" ? EditorLayout.YAML : EditorLayout.VISUAL;
+export function secretsLayoutToPref(layout: SecretsLayout): SecretsEditorLayout {
+  return layout === "yaml" ? SecretsEditorLayout.YAML : SecretsEditorLayout.VISUAL;
 }
 
-export function prefToSecretsLayout(layout: EditorLayout): SecretsLayout {
-  // Secrets has no split pane; a stray BOTH falls back to the YAML pane.
-  return layout === EditorLayout.VISUAL ? "form" : "yaml";
+export function prefToSecretsLayout(layout: SecretsEditorLayout): SecretsLayout {
+  return layout === SecretsEditorLayout.YAML ? "yaml" : "form";
 }

--- a/src/util/experience.ts
+++ b/src/util/experience.ts
@@ -18,14 +18,3 @@ export const EXPERIENCE_OPTIONS: ReadonlyArray<readonly [ExperienceLevel, string
 export function isExpert(level: ExperienceLevel | null): boolean {
   return level === ExperienceLevel.EXPERT;
 }
-
-/**
- * Editor layout to seed on first open: experts land in the split view,
- * everyone else (including an unchosen level) starts on the navigator with
- * the YAML pane hidden.
- */
-export function editorLayoutForExperience(
-  level: ExperienceLevel | null
-): "both" | "left" {
-  return level === ExperienceLevel.EXPERT ? "both" : "left";
-}

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -5,6 +5,7 @@ import {
   type OnboardingState,
   OnboardingStepId,
   OnboardingStepStatus,
+  SecretsEditorLayout,
   type UserPreferences,
 } from "../../../src/api/types/system.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
@@ -92,7 +93,7 @@ describe("loadPreferences (post-wizard context refresh)", () => {
     theme: "dark" as UserPreferences["theme"],
     navigator_visible: true,
     device_editor_layout: EditorLayout.BOTH,
-    secrets_editor_layout: EditorLayout.VISUAL,
+    secrets_editor_layout: SecretsEditorLayout.VISUAL,
     table_page_size: 25,
     table_column_visibility: {},
     table_sort_column: null,

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  EditorLayout,
   ExperienceLevel,
   type OnboardingState,
   OnboardingStepId,
@@ -90,6 +91,8 @@ describe("loadPreferences (post-wizard context refresh)", () => {
     dashboard_view: "cards" as UserPreferences["dashboard_view"],
     theme: "dark" as UserPreferences["theme"],
     navigator_visible: true,
+    device_editor_layout: EditorLayout.BOTH,
+    secrets_editor_layout: EditorLayout.VISUAL,
     table_page_size: 25,
     table_column_visibility: {},
     table_sort_column: null,

--- a/test/components/app-shell/events-initial-state-prefs.test.ts
+++ b/test/components/app-shell/events-initial-state-prefs.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   EditorLayout,
   ExperienceLevel,
+  SecretsEditorLayout,
   type UserPreferences,
 } from "../../../src/api/types/system.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
@@ -17,7 +18,7 @@ function prefs(over: Partial<UserPreferences> = {}): UserPreferences {
     theme: "dark" as UserPreferences["theme"],
     navigator_visible: true,
     device_editor_layout: EditorLayout.BOTH,
-    secrets_editor_layout: EditorLayout.VISUAL,
+    secrets_editor_layout: SecretsEditorLayout.VISUAL,
     table_page_size: 25,
     table_column_visibility: {},
     table_sort_column: null,

--- a/test/components/app-shell/events-initial-state-prefs.test.ts
+++ b/test/components/app-shell/events-initial-state-prefs.test.ts
@@ -3,7 +3,11 @@ import {
   DeviceEventType,
   type InitialStateEventData,
 } from "../../../src/api/types/event-subscription.js";
-import { ExperienceLevel, type UserPreferences } from "../../../src/api/types/system.js";
+import {
+  EditorLayout,
+  ExperienceLevel,
+  type UserPreferences,
+} from "../../../src/api/types/system.js";
 import type { ESPHomeApp } from "../../../src/components/app-shell.js";
 import { handleEvent } from "../../../src/components/app-shell/events.js";
 
@@ -12,6 +16,8 @@ function prefs(over: Partial<UserPreferences> = {}): UserPreferences {
     dashboard_view: "cards" as UserPreferences["dashboard_view"],
     theme: "dark" as UserPreferences["theme"],
     navigator_visible: true,
+    device_editor_layout: EditorLayout.BOTH,
+    secrets_editor_layout: EditorLayout.VISUAL,
     table_page_size: 25,
     table_column_visibility: {},
     table_sort_column: null,

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
+import { ESPHomePageDevice } from "../../src/pages/device.js";
+
+/**
+ * Pin the device-editor layout persistence: backend seed when localStorage
+ * is empty, an in-flight toggle winning over the seed, and the
+ * cache-only vs cache-plus-backend writer split.
+ */
+
+interface PageView {
+  _layout: DeviceLayoutMode;
+  _navCollapsed: boolean;
+  _api: ESPHomeAPI;
+  _loadPreferences(): Promise<void>;
+  _cacheLayout(mode: DeviceLayoutMode): void;
+  _persistLayout(mode: DeviceLayoutMode): void;
+}
+
+function makePage(overrides: Partial<PageView> = {}): PageView {
+  const page = new ESPHomePageDevice() as unknown as PageView;
+  Object.assign(page, overrides);
+  return page;
+}
+
+describe("esphome-page-device layout persistence", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  test("seeds the layout from the backend pref when localStorage is empty", async () => {
+    const getPreferences = vi.fn(() =>
+      Promise.resolve({ navigator_visible: true, device_editor_layout: "yaml" })
+    );
+    const page = makePage({ _layout: "both" });
+    page._api = { getPreferences } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("right");
+  });
+
+  test("defers to a layout the user toggled while the seed fetch was in flight", async () => {
+    const getPreferences = vi.fn(() => {
+      // The user toggled mid-fetch, so _persistLayout wrote localStorage.
+      localStorage.setItem("esphome-editor-layout", "left");
+      return Promise.resolve({ navigator_visible: true, device_editor_layout: "yaml" });
+    });
+    const page = makePage({ _layout: "left" });
+    page._api = { getPreferences } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("left");
+  });
+
+  test("_persistLayout caches locally and records the cross-browser pref", () => {
+    const updatePreferences = vi.fn(() => Promise.resolve());
+    const page = makePage();
+    page._api = { updatePreferences } as unknown as ESPHomeAPI;
+    page._persistLayout("right");
+    expect(page._layout).toBe("right");
+    expect(localStorage.getItem("esphome-editor-layout")).toBe("right");
+    expect(updatePreferences).toHaveBeenCalledWith({ device_editor_layout: "yaml" });
+  });
+
+  test("_cacheLayout persists locally without recording a backend pref", () => {
+    const updatePreferences = vi.fn(() => Promise.resolve());
+    const page = makePage();
+    page._api = { updatePreferences } as unknown as ESPHomeAPI;
+    page._cacheLayout("both");
+    expect(page._layout).toBe("both");
+    expect(localStorage.getItem("esphome-editor-layout")).toBe("both");
+    expect(updatePreferences).not.toHaveBeenCalled();
+  });
+});

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -39,6 +39,17 @@ describe("esphome-page-device layout persistence", () => {
     expect(page._layout).toBe("right");
   });
 
+  test("seeds from the backend when localStorage holds an invalid value", async () => {
+    localStorage.setItem("esphome-editor-layout", "garbage");
+    const getPreferences = vi.fn(() =>
+      Promise.resolve({ navigator_visible: true, device_editor_layout: "yaml" })
+    );
+    const page = makePage({ _layout: "both" });
+    page._api = { getPreferences } as unknown as ESPHomeAPI;
+    await page._loadPreferences();
+    expect(page._layout).toBe("right");
+  });
+
   test("defers to a layout the user toggled while the seed fetch was in flight", async () => {
     const getPreferences = vi.fn(() => {
       // The user toggled mid-fetch, so _persistLayout wrote localStorage.

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -333,6 +333,19 @@ describe("esphome-page-secrets layout persistence", () => {
     expect(page._layout).toBe("yaml");
   });
 
+  test("_seedLayoutFromBackend defers to a layout the user toggled mid-fetch", async () => {
+    // The user clicked the toggle while getPreferences() was in flight, so a
+    // local choice now exists; the resolving seed must not clobber it.
+    const getPreferences = vi.fn(() => {
+      localStorage.setItem("esphome-secrets-layout", "form");
+      return Promise.resolve({ secrets_editor_layout: "yaml" });
+    });
+    const page = makePage({ _layout: "form" });
+    page._api = { getPreferences } as unknown as ESPHomeAPI;
+    await page._seedLayoutFromBackend();
+    expect(page._layout).toBe("form");
+  });
+
   test("both panes bind the same buffer and either change advances it", () => {
     const page = makePage({
       _loaded: true,

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -28,7 +28,8 @@ interface PageView {
   _saving: boolean;
   _api: ESPHomeAPI;
   _layout: "form" | "yaml";
-  _readStoredLayout(): "form" | "yaml";
+  _readStoredLayout(): "form" | "yaml" | null;
+  _seedLayoutFromBackend(): Promise<void>;
   _setLayout(layout: "form" | "yaml"): void;
   _onYamlChange(e: CustomEvent<{ value: string }>): void;
   _confirmLeave(): Promise<boolean>;
@@ -298,13 +299,13 @@ describe("esphome-page-secrets layout persistence", () => {
   beforeEach(() => localStorage.clear());
   afterEach(() => localStorage.clear());
 
-  test("defaults to the structured form when nothing is stored", () => {
-    expect(makePage()._readStoredLayout()).toBe("form");
+  test("returns null when nothing is stored", () => {
+    expect(makePage()._readStoredLayout()).toBeNull();
   });
 
-  test("falls back to form for an unrecognized stored value", () => {
+  test("returns null for an unrecognized stored value", () => {
     localStorage.setItem("esphome-secrets-layout", "bogus");
-    expect(makePage()._readStoredLayout()).toBe("form");
+    expect(makePage()._readStoredLayout()).toBeNull();
   });
 
   test("reads a stored valid layout", () => {
@@ -312,11 +313,24 @@ describe("esphome-page-secrets layout persistence", () => {
     expect(makePage()._readStoredLayout()).toBe("yaml");
   });
 
-  test("_setLayout updates state and persists the choice", () => {
+  test("_setLayout updates state, persists locally, and writes the backend pref", () => {
+    const updatePreferences = vi.fn(() => Promise.resolve());
     const page = makePage();
+    page._api = { updatePreferences } as unknown as ESPHomeAPI;
     page._setLayout("yaml");
     expect(page._layout).toBe("yaml");
     expect(localStorage.getItem("esphome-secrets-layout")).toBe("yaml");
+    expect(updatePreferences).toHaveBeenCalledWith({ secrets_editor_layout: "yaml" });
+  });
+
+  test("_seedLayoutFromBackend restores the layout from the backend pref", async () => {
+    const getPreferences = vi.fn(() =>
+      Promise.resolve({ secrets_editor_layout: "yaml" })
+    );
+    const page = makePage();
+    page._api = { getPreferences } as unknown as ESPHomeAPI;
+    await page._seedLayoutFromBackend();
+    expect(page._layout).toBe("yaml");
   });
 
   test("both panes bind the same buffer and either change advances it", () => {

--- a/test/util/editor-layout.test.ts
+++ b/test/util/editor-layout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { EditorLayout } from "../../src/api/types/system.js";
+import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
+import {
+  deviceLayoutToPref,
+  prefToDeviceLayout,
+  prefToSecretsLayout,
+  secretsLayoutToPref,
+  type SecretsLayout,
+} from "../../src/util/editor-layout.js";
+
+describe("device layout mapping", () => {
+  it("round-trips every device layout mode through the pref enum", () => {
+    const modes: DeviceLayoutMode[] = ["left", "both", "right"];
+    for (const mode of modes) {
+      expect(prefToDeviceLayout(deviceLayoutToPref(mode))).toBe(mode);
+    }
+  });
+
+  it("maps panes to the shared enum", () => {
+    expect(deviceLayoutToPref("left")).toBe(EditorLayout.VISUAL);
+    expect(deviceLayoutToPref("right")).toBe(EditorLayout.YAML);
+    expect(deviceLayoutToPref("both")).toBe(EditorLayout.BOTH);
+  });
+});
+
+describe("secrets layout mapping", () => {
+  it("round-trips the two secrets layouts through the pref enum", () => {
+    const layouts: SecretsLayout[] = ["form", "yaml"];
+    for (const layout of layouts) {
+      expect(prefToSecretsLayout(secretsLayoutToPref(layout))).toBe(layout);
+    }
+  });
+
+  it("never produces BOTH and falls back to yaml for a stray BOTH", () => {
+    expect(secretsLayoutToPref("form")).toBe(EditorLayout.VISUAL);
+    expect(secretsLayoutToPref("yaml")).toBe(EditorLayout.YAML);
+    expect(prefToSecretsLayout(EditorLayout.BOTH)).toBe("yaml");
+  });
+});

--- a/test/util/editor-layout.test.ts
+++ b/test/util/editor-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EditorLayout } from "../../src/api/types/system.js";
+import { EditorLayout, SecretsEditorLayout } from "../../src/api/types/system.js";
 import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
 import {
   deviceLayoutToPref,
@@ -32,9 +32,10 @@ describe("secrets layout mapping", () => {
     }
   });
 
-  it("never produces BOTH and falls back to yaml for a stray BOTH", () => {
-    expect(secretsLayoutToPref("form")).toBe(EditorLayout.VISUAL);
-    expect(secretsLayoutToPref("yaml")).toBe(EditorLayout.YAML);
-    expect(prefToSecretsLayout(EditorLayout.BOTH)).toBe("yaml");
+  it("maps onto the two-value secrets enum", () => {
+    expect(secretsLayoutToPref("form")).toBe(SecretsEditorLayout.VISUAL);
+    expect(secretsLayoutToPref("yaml")).toBe(SecretsEditorLayout.YAML);
+    expect(prefToSecretsLayout(SecretsEditorLayout.VISUAL)).toBe("form");
+    expect(prefToSecretsLayout(SecretsEditorLayout.YAML)).toBe("yaml");
   });
 });

--- a/test/util/editor-layout.test.ts
+++ b/test/util/editor-layout.test.ts
@@ -22,6 +22,10 @@ describe("device layout mapping", () => {
     expect(deviceLayoutToPref("right")).toBe(EditorLayout.YAML);
     expect(deviceLayoutToPref("both")).toBe(EditorLayout.BOTH);
   });
+
+  it("defaults an unexpected pref value to the split view", () => {
+    expect(prefToDeviceLayout("bogus" as EditorLayout)).toBe("both");
+  });
 });
 
 describe("secrets layout mapping", () => {

--- a/test/util/experience.test.ts
+++ b/test/util/experience.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ExperienceLevel } from "../../src/api/types/system.js";
-import {
-  editorLayoutForExperience,
-  EXPERIENCE_OPTIONS,
-  isExpert,
-} from "../../src/util/experience.js";
+import { EXPERIENCE_OPTIONS, isExpert } from "../../src/util/experience.js";
 
 describe("isExpert", () => {
   it("is true only for EXPERT", () => {
@@ -14,14 +10,6 @@ describe("isExpert", () => {
 
   it("treats an unchosen level (null) as not expert", () => {
     expect(isExpert(null)).toBe(false);
-  });
-});
-
-describe("editorLayoutForExperience", () => {
-  it("opens the split view for experts and the navigator otherwise", () => {
-    expect(editorLayoutForExperience(ExperienceLevel.EXPERT)).toBe("both");
-    expect(editorLayoutForExperience(ExperienceLevel.BEGINNER)).toBe("left");
-    expect(editorLayoutForExperience(null)).toBe("left");
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Persists which editor panes a user keeps open so the choice survives a new browser, and gives the backend a signal of who prefers working in YAML.

Each editor's layout toggle now mirrors to the backend `device_editor_layout` / `secrets_editor_layout` preferences; localStorage stays the instant per-browser seed and the backend pref is restored when localStorage is empty. A small `editor-layout` util maps the device editor's three-way layout (`left` / `both` / `right`) and the secrets editor's two-way layout (`form` / `yaml`) onto the shared `EditorLayout` enum (`visual` / `yaml` / `both`); secrets never stores `both`. Writes are fire-and-forget like `navigator_visible`. The device editor's first-open layout now comes from the backend default (`both`) rather than the experience level, so `editorLayoutForExperience` is removed.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

Backend companion: esphome/device-builder#1481 (adds the `EditorLayout` enum and the two preference fields).
