### PR TITLE
Clear stale create error on wizard step navigation

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -323,6 +323,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   private _onNextStep(e: CustomEvent<WizardStepDetail>) {
+    // A new step starts clean: a failed create's error bar must not follow the
+    // user forward (e.g. Back to the board picker, then a different board).
+    this._resetCreateErrors();
     const detail = e.detail;
     if (typeof detail === "string") {
       this._step = detail;
@@ -361,6 +364,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   private _onBack() {
+    this._resetCreateErrors();
     switch (this._step) {
       case "board":
         this._step = "method";

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -197,10 +197,10 @@ describe("create-config-dialog stale error on navigation", () => {
 
   // Drive the dialog onto the setup step (where the Back button renders) by
   // dispatching the next-step a board pick would.
-  function goToSetup(el: ESPHomeCreateConfigDialog): void {
+  function goToSetup(el: ESPHomeCreateConfigDialog, boardId = "esp32dev"): void {
     el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
       new CustomEvent("next-step", {
-        detail: { step: "setup", board: { id: "esp32dev" } },
+        detail: { step: "setup", board: { id: boardId } },
         bubbles: true,
         composed: true,
       })
@@ -223,18 +223,19 @@ describe("create-config-dialog stale error on navigation", () => {
     expect(errorText(el)).toBeNull();
   });
 
-  it("clears the error when advancing into a new step", async () => {
+  it("clears the error on forward (next-step) navigation", async () => {
     const createDevice = vi.fn().mockRejectedValue(new Error("boom"));
     const el = await mount({ createDevice });
 
-    goToSetup(el);
+    goToSetup(el, "esp32dev");
     await el.updateComplete;
     emitFinish(el, "kitchen");
     await flush();
     await el.updateComplete;
     expect(errorText(el)).not.toBeNull();
 
-    goToSetup(el);
+    // Re-enter setup with a different board, as picking another board would.
+    goToSetup(el, "esp8266");
     await el.updateComplete;
     expect(errorText(el)).toBeNull();
   });

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -184,6 +184,62 @@ describe("create-config-dialog create de-dupe + retry", () => {
   });
 });
 
+// A failed create shows a dialog-level error bar that outlives step changes.
+// Navigating (Back, or forward into a new step with another board) must clear
+// it so a stale message doesn't follow the user onto the next attempt (#1487).
+describe("create-config-dialog stale error on navigation", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const errorText = (el: ESPHomeCreateConfigDialog): string | null =>
+    el.shadowRoot!.querySelector("p.error")?.textContent ?? null;
+
+  // Drive the dialog onto the setup step (where the Back button renders) by
+  // dispatching the next-step a board pick would.
+  function goToSetup(el: ESPHomeCreateConfigDialog): void {
+    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
+      new CustomEvent("next-step", {
+        detail: { step: "setup", board: { id: "esp32dev" } },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  it("clears the error when pressing Back after a failed create", async () => {
+    const createDevice = vi.fn().mockRejectedValue(new Error("boom"));
+    const el = await mount({ createDevice });
+
+    goToSetup(el);
+    await el.updateComplete;
+    emitFinish(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+    expect(errorText(el)).not.toBeNull();
+
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".back-button")!.click();
+    await el.updateComplete;
+    expect(errorText(el)).toBeNull();
+  });
+
+  it("clears the error when advancing into a new step", async () => {
+    const createDevice = vi.fn().mockRejectedValue(new Error("boom"));
+    const el = await mount({ createDevice });
+
+    goToSetup(el);
+    await el.updateComplete;
+    emitFinish(el, "kitchen");
+    await flush();
+    await el.updateComplete;
+    expect(errorText(el)).not.toBeNull();
+
+    goToSetup(el);
+    await el.updateComplete;
+    expect(errorText(el)).toBeNull();
+  });
+});
+
 // The migration onto esphome-base-dialog swapped the imperative
 // `_dialog.open = …` for a reactive `_open` flag. _onRequestClose flipping
 // _open back to false is the load-bearing part — without it a user-driven


### PR DESCRIPTION
# What does this implement/fix?

When a device create fails the wizard shows a red error bar at the dialog level, which sits outside the per-step render, so it survived step changes. Pressing Back to the board picker and choosing another board left the old error visible on the setup step. This clears the error on step navigation by reusing the existing `_resetCreateErrors()` helper in `_onBack()` and `_onNextStep()`, the two transitions that were leaking it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1487

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
