### PR TITLE
Send empty wifi credentials when reusing secrets in the wizard

### DIFF
--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -365,7 +365,8 @@ export class ESPHomeWizardStepSetup extends LitElement {
   private _onNext() {
     if (this._stage === "name") {
       if (this._hasSecretWifi) {
-        this._finish("!secret wifi_ssid", "!secret wifi_password");
+        // Empty ssid/psk tells the backend to emit unquoted !secret tags.
+        this._finish("", "");
         return;
       }
       if (this._secretWifiSsid && !this._wifiSsid) {
@@ -378,15 +379,15 @@ export class ESPHomeWizardStepSetup extends LitElement {
       return;
     }
 
-    // If the user kept the value from secrets, emit !secret references
-    // so the generated YAML uses secrets instead of hardcoded values.
+    // If the user kept the value from secrets, send empty so the backend
+    // emits the !secret reference instead of a hardcoded value.
     const ssid =
       this._wifiSsid === this._secretWifiSsid && this._secretWifiSsid
-        ? "!secret wifi_ssid"
+        ? ""
         : this._wifiSsid;
     const password =
       this._wifiPassword === this._secretWifiPassword && this._secretWifiPassword
-        ? "!secret wifi_password"
+        ? ""
         : this._wifiPassword;
 
     this._finish(ssid, password);

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -43,7 +43,51 @@ describe("wizard-step-setup ENTER", () => {
     el.addEventListener("finish-setup", onFinish as EventListener);
     pressEnter();
     expect(onFinish).toHaveBeenCalledTimes(1);
-    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.name).toBe("kitchen");
+    const detail = (onFinish.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.name).toBe("kitchen");
+    // Empty so the backend emits unquoted !secret tags, not a literal string.
+    expect(detail.wifiSsid).toBe("");
+    expect(detail.wifiPassword).toBe("");
+  });
+
+  it("sends empty ssid when the prefilled secret value is kept on the wifi stage", async () => {
+    const el = await mount();
+    // SSID-only secret prefills the ssid field and lands on the wifi stage
+    // (both secrets would skip it via _hasSecretWifi).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._secretWifiSsid = "homessid";
+    await setName(el, "kitchen");
+    pressEnter(); // advance to wifi; ssid prefilled from the secret
+    await el.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._stage).toBe("wifi");
+
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter(); // keep the prefilled ssid
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    const detail = (onFinish.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.wifiSsid).toBe("");
+  });
+
+  it("passes a typed wifi value through unchanged (not a secret reference)", async () => {
+    const el = await mount();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._secretWifiSsid = "homessid";
+    await setName(el, "kitchen");
+    pressEnter(); // advance to wifi
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector<HTMLInputElement>("#wifi-ssid")!;
+    input.value = "typed-network";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect((onFinish.mock.calls[0][0] as CustomEvent).detail.wifiSsid).toBe(
+      "typed-network"
+    );
   });
 
   it("advances to the wifi stage on Enter when there is no secret wifi", async () => {


### PR DESCRIPTION
# What does this implement/fix?

When a device is created with an existing secrets.yaml, the wizard reused the wifi secret by sending the literal string "!secret wifi_ssid" as the ssid value; the backend treats a non-empty ssid as a real credential and quotes it, so the generated YAML became ssid: "!secret wifi_ssid", a plain string that silently fails to join wifi.

The wizard now sends empty ssid/psk in that case; the backend already emits the proper unquoted !secret tags when those fields are empty, see https://github.com/esphome/device-builder/blob/5238bfadd3421631327850bac9343ef7ee7a2762/esphome_device_builder/helpers/device_yaml/_generation.py#L240-L248. This covers both the secrets-present path (wifi screen skipped) and the kept-the-prefilled-value path on the wifi screen; a typed wifi value still passes through unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1490

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
