### PR TITLE
Add WiFi chip label for WiFi-capable RP2040 boards

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -538,6 +538,7 @@
       "microphone": "Microphone",
       "speaker": "Speaker",
       "imu": "IMU",
+      "wifi": "WiFi",
       "lipo": "LiPo",
       "poe": "PoE",
       "usb-c": "USB-C",


### PR DESCRIPTION
# What does this implement/fix?

The backend now tags WiFi-capable RP2040 boards (Pico W, Pico 2 W, and the Pimoroni/SparkFun/Waveshare W variants) with a `wifi` board tag. This adds the `wizard.tag.wifi` translation so the picker chip reads `WiFi` instead of the raw tag, matching the existing feature chips (`USB-C`, `LiPo`, …). No render code changes; the board card already maps tags to chips.

**Related issue or feature (if applicable):**

- Companion to esphome/device-builder#1496 (injects the WiFi board tag).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).

