### PR TITLE
Split RP2040 and RP2350 into per-chip picker filters and badges

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -1320,6 +1320,7 @@ export class ESPHomeAPI {
     query?: string;
     platform?: string;
     variant?: string;
+    mcu?: string;
     tag?: string;
     offset?: number;
     limit?: number;

--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -13,6 +13,8 @@ export interface BoardEsphomeConfig {
   board: string;
   variant: string | null;
   framework: string | null;
+  // rp2040-only chip series ('rp2040' / 'rp2350'); null on other platforms.
+  mcu: string | null;
 }
 
 export interface BoardHardware {

--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -11,14 +11,14 @@
  *   this value verbatim.
  * - ``variant`` narrows ESP32 chips into their families (S2 / S3 /
  *   C3 / C6 / H2). Empty for non-ESP32 platforms.
- * - ``label`` is the user-facing chip text. The RP2040 chip's
- *   label is ``RP2040 / RP2350`` because ESPHome's ``rp2040``
- *   platform covers both chip generations; users searching for
- *   either chip name need to recognise the filter as theirs.
+ * - ``mcu`` narrows ESPHome's single ``rp2040`` platform into its
+ *   two chip series (RP2040 / RP2350). Absent for other platforms.
+ * - ``label`` is the user-facing chip text.
  */
 export interface WizardBoardPlatform {
   readonly platform: string;
   readonly variant: string;
+  readonly mcu?: string;
   readonly label: string;
 }
 
@@ -30,11 +30,12 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
   { platform: "esp32", variant: "esp32c6", label: "ESP32-C6" },
   { platform: "esp32", variant: "esp32h2", label: "ESP32-H2" },
   { platform: "esp8266", variant: "", label: "ESP8266" },
-  // ESPHome's ``rp2040`` platform covers both the original
-  // RP2040 and the newer RP2350; the label calls out both
-  // chip names so a user searching for either one sees the
-  // filter chip that owns them.
-  { platform: "rp2040", variant: "", label: "RP2040 / RP2350" },
+  // ESPHome's 'rp2040' platform covers both the original RP2040 and
+  // the newer RP2350; split into two chips (mirroring the per-variant
+  // ESP32 chips) so users pick their actual silicon. The backend
+  // filters the shared platform by 'mcu'.
+  { platform: "rp2040", variant: "", mcu: "rp2040", label: "RP2040" },
+  { platform: "rp2040", variant: "", mcu: "rp2350", label: "RP2350" },
   { platform: "bk72xx", variant: "", label: "BK72xx" },
   { platform: "rtl87xx", variant: "", label: "RTL87xx" },
   { platform: "ln882x", variant: "", label: "LN882x" },
@@ -55,6 +56,9 @@ export function chipNameToFilterLabel(chipName: string): string | null {
   const family = chipName.split("(")[0].trim().toLowerCase().replace(/-/g, "");
   const byVariant = WIZARD_BOARD_PLATFORMS.find((p) => p.variant === family);
   if (byVariant) return byVariant.label;
+  // rp2040 / rp2350 share one platform; match on the chip series.
+  const byMcu = WIZARD_BOARD_PLATFORMS.find((p) => p.mcu === family);
+  if (byMcu) return byMcu.label;
   const byPlatform = WIZARD_BOARD_PLATFORMS.find(
     (p) => p.platform === family && !p.variant
   );

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -164,7 +164,14 @@ export class ESPHomeWizardStepBoard extends LitElement {
       );
       const platform = filter?.platform || undefined;
       const variant = filter?.variant || undefined;
-      const response = await this._api.getBoards({ query, platform, variant, limit: 50 });
+      const mcu = filter?.mcu || undefined;
+      const response = await this._api.getBoards({
+        query,
+        platform,
+        variant,
+        mcu,
+        limit: 50,
+      });
       this._boards = response.boards;
     } catch (e) {
       console.error("Failed to load board catalog:", e);
@@ -298,7 +305,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
           <div class="tags">
             <wa-badge variant="neutral" pill style="font-size: var(--wa-font-size-s);"
               >${this._localizeTag(
-                board.esphome.variant || board.esphome.platform
+                board.esphome.mcu || board.esphome.variant || board.esphome.platform
               )}</wa-badge
             >
             ${board.tags.map(
@@ -356,7 +363,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
         <div class="tags">
           <wa-badge style="font-size: var(--wa-font-size-xs);" variant="neutral" pill
             >${this._localizeTag(
-              board.esphome.variant || board.esphome.platform
+              board.esphome.mcu || board.esphome.variant || board.esphome.platform
             )}</wa-badge
           >
           ${board.tags.map(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -522,6 +522,7 @@
       "esp32p4": "ESP32-P4",
       "esp8266": "ESP8266",
       "rp2040": "RP2040",
+      "rp2350": "RP2350",
       "bk72xx": "BK72xx",
       "rtl87xx": "RTL87xx",
       "compact": "Compact",

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -63,6 +63,7 @@ function _hydrateEsphome(esphome: BoardEsphomeConfig): BoardEsphomeConfig {
     ...esphome,
     variant: esphome.variant ?? null,
     framework: esphome.framework ?? null,
+    mcu: esphome.mcu ?? null,
   };
 }
 

--- a/test/components/device/config-entry-variant-default.test.ts
+++ b/test/components/device/config-entry-variant-default.test.ts
@@ -70,6 +70,7 @@ describe("renderSelectField — esp32 variant default from board", () => {
           board: "esp32-c6-devkitm-1",
           variant: "esp32c6",
           framework: null,
+          mcu: null,
         },
       },
     });

--- a/test/components/device/config-entry-variant-options.test.ts
+++ b/test/components/device/config-entry-variant-options.test.ts
@@ -21,7 +21,9 @@ const MODE: ConfigValueOption[] = [
 
 function boardWithVariant(variant: string): BoardCatalogEntry {
   return makeTestBoard({
-    overrides: { esphome: { platform: "esp32", board: "b", variant, framework: null } },
+    overrides: {
+      esphome: { platform: "esp32", board: "b", variant, framework: null, mcu: null },
+    },
   });
 }
 

--- a/test/components/wizard/wizard-step-board-platforms.test.ts
+++ b/test/components/wizard/wizard-step-board-platforms.test.ts
@@ -30,17 +30,18 @@ describe("wizard step-board platform chips", () => {
     expect(nrf52?.variant).toBe("");
   });
 
-  it("labels the rp2040 platform 'RP2040 / RP2350' so users searching for either chip name see it", () => {
-    // ESPHome's `rp2040` platform key covers both the original
-    // RP2040 and the newer RP2350 (Raspberry Pi Pico 2). A plain
-    // "RP2040" label hides the filter from anyone searching for
-    // their RP2350 board. The platform key stays `rp2040` —
-    // this is a label-only contract.
-    const labels = WIZARD_BOARD_PLATFORMS.map((p) => p.label);
-    expect(labels).toContain("RP2040 / RP2350");
-    expect(labels).not.toContain("RP2040");
-    const rp = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "RP2040 / RP2350");
-    expect(rp?.platform).toBe("rp2040");
+  it("splits the rp2040 platform into separate RP2040 and RP2350 chips", () => {
+    // ESPHome's `rp2040` platform key covers both the original RP2040
+    // and the newer RP2350 (Raspberry Pi Pico 2). Each gets its own
+    // filter chip (mirroring the per-variant ESP32 chips); both keep
+    // platform `rp2040` and are told apart by `mcu`, which the backend
+    // filters on.
+    const rp2040 = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "RP2040");
+    const rp2350 = WIZARD_BOARD_PLATFORMS.find((p) => p.label === "RP2350");
+    expect(rp2040?.platform).toBe("rp2040");
+    expect(rp2040?.mcu).toBe("rp2040");
+    expect(rp2350?.platform).toBe("rp2040");
+    expect(rp2350?.mcu).toBe("rp2350");
   });
 
   it("groups the libretiny-family chips (BK72xx / RTL87xx / LN882x) adjacent", () => {
@@ -78,11 +79,17 @@ describe("wizard step-board platform chips", () => {
     });
 
     it("maps a platform-only chip (variant === '') via the platform fallback", () => {
-      // ESP8266 / RP2040 / BK72xx / RTL87xx / LN882x / nRF52 don't have
-      // variants in WIZARD_BOARD_PLATFORMS — the function must fall back
-      // to a platform match when the variant lookup misses.
+      // ESP8266 / BK72xx / RTL87xx / LN882x / nRF52 don't have variants
+      // in WIZARD_BOARD_PLATFORMS — the function must fall back to a
+      // platform match when the variant lookup misses.
       expect(chipNameToFilterLabel("ESP8266")).toBe("ESP8266");
-      expect(chipNameToFilterLabel("RP2040")).toBe("RP2040 / RP2350");
+    });
+
+    it("maps the rp2040 / rp2350 chip series to their split filter labels", () => {
+      // The two rp2040-platform chips are distinguished by `mcu`, so the
+      // chip-series name must resolve to its own label.
+      expect(chipNameToFilterLabel("RP2040")).toBe("RP2040");
+      expect(chipNameToFilterLabel("RP2350")).toBe("RP2350");
     });
 
     it("returns null for a chip name with no matching platform or variant", () => {

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -172,6 +172,7 @@ describe("hydrateBoard", () => {
         board: "esp32dev",
         variant: "esp32",
         framework: "arduino",
+        mcu: null,
       },
       hardware: {
         flash_size: "4 MB",


### PR DESCRIPTION
# What does this implement/fix?

The board picker treated RP2040 and RP2350 as one chip: a single "RP2040 / RP2350" filter chip, and every card badged "RP2040" even for RP2350 boards (Pico 2 / Pico 2 W, Plasma2350W, NULA RP2350). We should have modeled this the way ESP32 already models its chip variants (a per-chip discriminator on the shared platform); we did not, so users could not tell the two chips apart in the picker.

This splits the one chip into separate "RP2040" and "RP2350" filters (mirroring the per-variant ESP32 chips) and badges each card with its real chip. ESPHome lumps both under the `rp2040` platform, so the backend now carries the chip series as `esphome.mcu` and filters on it (companion backend PR below); the filter passes `mcu` through and the badge prefers `mcu` over `variant`/`platform`.

The `mcu` field is generic: it can be reused to split the libretiny families (e.g. bk72xx chips) the same way if we want chip-level filters there in the future.

**Related issue or feature (if applicable):**

- Companion backend PR: esphome/device-builder#1499

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
