### PR TITLE
Make lvgl YAML-only and stop hydrating its 14 MB body

### DIFF
--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -24,6 +24,7 @@ import {
   subscribeComponentCache,
 } from "../../util/component-name-cache.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { loadCatalog } from "../../util/yaml-completion-catalog.js";
 import {
   type YamlSection,
   categorizeSections,
@@ -40,6 +41,7 @@ import { type NavRow, resolveBucketLabels } from "./navigator-labels.js";
 import { type NavAction, renderNavSection } from "./navigator-render.js";
 import { NavigatorRevealController } from "./navigator-reveal-controller.js";
 import { navItemMatches } from "./navigator-search-match.js";
+import { YAML_ONLY_SECTIONS } from "./yaml-only-sections.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./add-automation-dialog.js";
@@ -532,11 +534,18 @@ export class ESPHomeDeviceNavigator extends LitElement {
    */
   private _kickoffNameResolves(): void {
     if (!this._api) return;
+    // The slim catalog carries every section's friendly name; navigator-labels
+    // falls back to it, so load it once rather than depending solely on per-id
+    // body fetches for names.
+    void loadCatalog(this._api).catch(() => {});
     const sections = parseYamlTopLevelSections(this.yaml);
     const { core, components } = categorizeSections(sections);
     const platform = this.platform || undefined;
     for (const item of [...core, ...components]) {
       const id = sectionKeyOf(item);
+      // YAML-only sections (lvgl) render no form; don't pull their per-id body
+      // (lvgl's is ~14 MB) just to resolve a name the slim index already has.
+      if (YAML_ONLY_SECTIONS.has(id)) continue;
       if (getCachedComponent(id, platform) !== undefined) continue;
       void fetchComponent(this._api, id, platform).catch(() => {
         // Swallow — the navigator falls back to the raw id when no

--- a/src/components/device/device-navigator.ts
+++ b/src/components/device/device-navigator.ts
@@ -536,8 +536,11 @@ export class ESPHomeDeviceNavigator extends LitElement {
     if (!this._api) return;
     // The slim catalog carries every section's friendly name; navigator-labels
     // falls back to it, so load it once rather than depending solely on per-id
-    // body fetches for names.
-    void loadCatalog(this._api).catch(() => {});
+    // body fetches for names. Re-render when it lands so a YAML-only section's
+    // friendly name replaces the raw key on first paint.
+    void loadCatalog(this._api)
+      .then(() => this.requestUpdate())
+      .catch(() => {});
     const sections = parseYamlTopLevelSections(this.yaml);
     const { core, components } = categorizeSections(sections);
     const platform = this.platform || undefined;

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -42,9 +42,11 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
     // (editor/validate_yaml's post-render refresh) doesn't re-issue the round
     // trip.
     const yamlOnly = YAML_ONLY_SECTIONS.has(host.sectionKey);
+    // loadCatalog degrades to an empty index (logged) rather than rejecting, so
+    // a genuine load failure surfaces as a raw-id YAML-only header, not a throw;
+    // a real throw still reaches loadConfig's catch below.
     const component = yamlOnly
-      ? ((await loadCatalog(host._api).catch(() => null))?.byId.get(host.sectionKey) ??
-        null)
+      ? ((await loadCatalog(host._api)).byId.get(host.sectionKey) ?? null)
       : await fetchComponent(host._api, host.sectionKey, platform);
 
     if (id !== host._loadId) return;

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -1,10 +1,12 @@
 import type { ConfigEntry, RequiredGroup } from "../../../api/types/config-entries.js";
 import { fetchComponent } from "../../../util/component-name-cache.js";
 import { normalizeHexValues } from "../../../util/hex-int.js";
+import { loadCatalog } from "../../../util/yaml-completion-catalog.js";
 import { parseYamlSectionValues } from "../../../util/yaml-section-reader.js";
 import { resolveCurrentFromLine } from "../../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../../util/yaml-serialize.js";
 import type { ESPHomeDeviceSectionConfig } from "../device-section-config.js";
+import { YAML_ONLY_SECTIONS } from "../yaml-only-sections.js";
 
 export interface SectionConfigResponse {
   section_key: string;
@@ -33,10 +35,17 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
 
   try {
     const platform = host.board?.esphome.platform;
-    // Session-scoped cache: a section that re-loads on every keystroke
-    // (editor/validate_yaml's post-render refresh) doesn't re-issue the
-    // same backend round-trip. Catalog is static JSON, entries immutable.
-    const component = await fetchComponent(host._api, host.sectionKey, platform);
+    // YAML-only sections (recursive/complex shapes like lvgl) render no form,
+    // so source the header from the slim catalog index and never fetch the
+    // full per-id body — lvgl's is ~14 MB. Other sections hydrate the body
+    // through the session-scoped cache so a re-load per keystroke
+    // (editor/validate_yaml's post-render refresh) doesn't re-issue the round
+    // trip.
+    const yamlOnly = YAML_ONLY_SECTIONS.has(host.sectionKey);
+    const component = yamlOnly
+      ? ((await loadCatalog(host._api).catch(() => null))?.byId.get(host.sectionKey) ??
+        null)
+      : await fetchComponent(host._api, host.sectionKey, platform);
 
     if (id !== host._loadId) return;
 
@@ -72,8 +81,10 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
         docs_url: component.docs_url,
         icon: "",
         image_url: component.image_url,
-        entries: component.config_entries,
-        required_groups: component.required_groups ?? [],
+        // YAML-only sections drop entries so the "edit in YAML" notice fires;
+        // the slim index carries no config_entries to render anyway.
+        entries: yamlOnly ? [] : component.config_entries,
+        required_groups: yamlOnly ? [] : (component.required_groups ?? []),
       };
     }
     // Asymmetric with save/delete paths: undefined here means "section

--- a/src/components/device/navigator-labels.ts
+++ b/src/components/device/navigator-labels.ts
@@ -3,6 +3,7 @@ import { actionFieldLabel } from "../../util/action-field-label.js";
 import { getCachedComponent } from "../../util/component-name-cache.js";
 import { stripRedundantComponentSuffix } from "../../util/component-title.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
+import { getLoadedCatalog } from "../../util/yaml-completion-catalog.js";
 import { type YamlSection, sectionKeyOf } from "../../util/yaml-sections.js";
 import type { NavigatorBuckets } from "./navigator-buckets.js";
 import type { TriggerCatalogController } from "./trigger-catalog-controller.js";
@@ -56,7 +57,13 @@ export function resolveNavItemLabels(
 
   let primary = raw;
   const cached = getCachedComponent(raw, ctx.platform || undefined);
+  // YAML-only sections (lvgl) never hydrate the per-id body, so fall back to
+  // the slim index's friendly name rather than the raw key.
   if (cached?.name) primary = cached.name;
+  else {
+    const slim = getLoadedCatalog()?.byId.get(raw);
+    if (slim?.name) primary = slim.name;
+  }
   if (category === "core") primary = stripRedundantComponentSuffix(primary);
 
   // Prefer the backend-resolved node name for the esphome core section

--- a/src/components/device/yaml-only-sections.ts
+++ b/src/components/device/yaml-only-sections.ts
@@ -24,12 +24,21 @@
  * so route the whole section to YAML-only — both shapes round-
  * trip cleanly through the YAML pane.
  *
+ * `lvgl` is a recursive widget tree (`pages:` -> `widgets:` -> widgets that
+ * themselves contain `widgets:`). The catalog model can't express the
+ * recursion, so the structured form can't round-trip it (`pages:` renders an
+ * empty list even when the YAML has pages) and editing in the form silently
+ * drops config. Route the whole section to the YAML pane, which round-trips
+ * losslessly. Its per-id catalog body is also ~14 MB; YAML-only sections skip
+ * the body fetch (see `loadConfig`), so the section never pulls it.
+ *
  * Lives in its own module so the unit test can import without
  * dragging Lit / DOM into the vitest Node environment.
  */
 export const YAML_ONLY_SECTIONS: ReadonlySet<string> = new Set([
   "external_components",
   "packages",
+  "lvgl",
 ]);
 
 /** True when the section should fall back to the YAML notice — either

--- a/src/util/component-name-resolver-controller.ts
+++ b/src/util/component-name-resolver-controller.ts
@@ -61,8 +61,11 @@ export class ComponentNameResolverController implements ReactiveController {
   kickoff(ids: Iterable<string>): void {
     const api = this._getApi();
     if (!api) return;
-    // The slim index supplies names for YAML-only sections without a body fetch.
-    void loadCatalog(api).catch(() => {});
+    // The slim index supplies names for YAML-only sections without a body fetch;
+    // re-render when it lands so the friendly name replaces the raw id.
+    void loadCatalog(api)
+      .then(() => this._host.requestUpdate())
+      .catch(() => {});
     const platform = this._getPlatform();
     for (const id of ids) {
       // YAML-only sections (lvgl) render no form; don't pull their per-id body

--- a/src/util/component-name-resolver-controller.ts
+++ b/src/util/component-name-resolver-controller.ts
@@ -1,10 +1,12 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ESPHomeAPI } from "../api/index.js";
+import { YAML_ONLY_SECTIONS } from "../components/device/yaml-only-sections.js";
 import {
   fetchComponent,
   getCachedComponent,
   subscribeComponentCache,
 } from "./component-name-cache.js";
+import { getLoadedCatalog, loadCatalog } from "./yaml-completion-catalog.js";
 
 /**
  * Reactive controller that resolves raw component ids (e.g.
@@ -44,17 +46,28 @@ export class ComponentNameResolverController implements ReactiveController {
     this._unsubscribe = undefined;
   }
 
-  /** Friendly catalog name for ``id`` if cached, else the raw id. */
+  /** Friendly catalog name for ``id`` if cached, else the raw id.
+   *  Falls back to the slim index so YAML-only sections (whose bodies are
+   *  never hydrated) still resolve a friendly name. */
   resolve(id: string): string {
-    return getCachedComponent(id, this._getPlatform())?.name ?? id;
+    return (
+      getCachedComponent(id, this._getPlatform())?.name ??
+      getLoadedCatalog()?.byId.get(id)?.name ??
+      id
+    );
   }
 
   /** Fire-and-forget catalog lookups for any ids not yet cached. */
   kickoff(ids: Iterable<string>): void {
     const api = this._getApi();
     if (!api) return;
+    // The slim index supplies names for YAML-only sections without a body fetch.
+    void loadCatalog(api).catch(() => {});
     const platform = this._getPlatform();
     for (const id of ids) {
+      // YAML-only sections (lvgl) render no form; don't pull their per-id body
+      // (lvgl's is ~14 MB) just for a name the slim index already has.
+      if (YAML_ONLY_SECTIONS.has(id)) continue;
       if (getCachedComponent(id, platform) !== undefined) continue;
       void fetchComponent(api, id, platform).catch(() => {
         // Swallow — callers fall back to the raw id on miss, so a

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -14,6 +14,7 @@ import type { EditorState } from "@codemirror/state";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
+import { YAML_ONLY_SECTIONS } from "../components/device/yaml-only-sections.js";
 import { fetchComponent } from "./component-name-cache.js";
 import { resolveBundleContext } from "./yaml-ast.js";
 import { findTopLevelBlock, readPlatformSibling } from "./yaml-line-walker.js";
@@ -108,6 +109,14 @@ export interface CatalogIndex {
 }
 
 let catalogPromise: Promise<CatalogIndex> | null = null;
+let loadedCatalog: CatalogIndex | null = null;
+
+/** The slim catalog if `loadCatalog` has already resolved, else `null`.
+ *  Lets sync callers (navigator label resolution) read a component's
+ *  friendly name from the slim index without the per-id body fetch. */
+export function getLoadedCatalog(): CatalogIndex | null {
+  return loadedCatalog;
+}
 
 /**
  * Load the component catalog once per session. The list is small enough
@@ -126,7 +135,8 @@ export function loadCatalog(api: ESPHomeAPI): Promise<CatalogIndex> {
       list.push(c);
       byCategory.set(c.category, list);
     }
-    return { components: res.components, byId, byCategory };
+    loadedCatalog = { components: res.components, byId, byCategory };
+    return loadedCatalog;
   })().catch((err) => {
     console.debug("[yaml-completion] failed to load catalog:", err);
     catalogPromise = null;
@@ -191,6 +201,9 @@ export async function resolveAvailableEntries(
   platformValue: string | null,
   topLevelKey: string | null
 ): Promise<ConfigEntry[]> {
+  // YAML-only sections (lvgl) have no structured form; skip completions so we
+  // never hydrate their per-id body (lvgl's is ~14 MB) just to suggest fields.
+  if (topLevelKey && YAML_ONLY_SECTIONS.has(topLevelKey)) return [];
   // The slim ``getComponents`` index carries no ``config_entries``
   // (those hydrate lazily through ``components/get_component_bodies``),
   // so the catalog tells us only *which* ids exist — never their

--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -19,7 +19,10 @@ import { html, nothing, render } from "lit";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
-import { isYamlOnlySection } from "../components/device/yaml-only-sections.js";
+import {
+  isYamlOnlySection,
+  YAML_ONLY_SECTIONS,
+} from "../components/device/yaml-only-sections.js";
 import { fetchComponent } from "./component-name-cache.js";
 import {
   getActions,
@@ -134,6 +137,9 @@ async function isYamlOnlyComponent(
   topLevelKey: string,
   platformValue: string | null
 ): Promise<boolean> {
+  // Always-YAML sections (lvgl, packages, ...) are YAML-only regardless of
+  // their body — short-circuit so hover never hydrates it (lvgl's is ~14 MB).
+  if (YAML_ONLY_SECTIONS.has(topLevelKey)) return true;
   const componentId = platformValue ? `${topLevelKey}.${platformValue}` : topLevelKey;
   const comp = await fetchComponent(api, componentId);
   // `config_entries` is absent (not []) on form-less components like ethernet.

--- a/test/components/device/yaml-only-section.test.ts
+++ b/test/components/device/yaml-only-section.test.ts
@@ -45,6 +45,14 @@ describe("YAML_ONLY_SECTIONS", () => {
     expect(MAP_SECTIONS.has("packages")).toBe(false);
   });
 
+  it("contains lvgl — recursive widget tree, no structured form", () => {
+    // lvgl is pages -> widgets -> widgets (recursive); the catalog can't
+    // express it and its per-id body is ~14 MB, so it's always YAML-only.
+    expect(YAML_ONLY_SECTIONS.has("lvgl")).toBe(true);
+    expect(isYamlOnlySection("lvgl", 200)).toBe(true);
+    expect(MAP_SECTIONS.has("lvgl")).toBe(false);
+  });
+
   it("YAML_ONLY_SECTIONS and MAP_SECTIONS are mutually exclusive", () => {
     // YAML-only takes precedence — an entry in both would silently
     // demote a MAP section to a YAML notice.

--- a/test/util/yaml-completion-top-level.test.ts
+++ b/test/util/yaml-completion-top-level.test.ts
@@ -230,6 +230,29 @@ describe("resolveAvailableEntries (platform-merged)", () => {
     );
     expect(out.map((e: { key: string }) => e.key)).toContain("ssid");
   });
+
+  it("returns [] for a YAML-only section without fetching the body (lvgl)", async () => {
+    // lvgl renders YAML-only; completion under it must never hydrate the
+    // (~14 MB) per-id body. Guard short-circuits before any getComponentBodies.
+    const { resolveAvailableEntries } = await import("../../src/util/yaml-completion.js");
+    const c = catalog([entry("lvgl", ComponentCategory.CORE)]);
+    let fetched = false;
+    const fakeApi = {
+      getComponentBodies: async () => {
+        fetched = true;
+        return {};
+      },
+    } as never;
+    const out = await (resolveAvailableEntries as unknown as Function)(
+      fakeApi,
+      c,
+      "lvgl", // parentKey
+      null, // platformValue
+      "lvgl" // topLevelKey
+    );
+    expect(out).toEqual([]);
+    expect(fetched).toBe(false);
+  });
 });
 
 describe("matchKeyPosition", () => {


### PR DESCRIPTION
# What does this implement/fix?

Editing an `lvgl:` block in the Visual Editor is broken and unsafe. lvgl is a recursive widget tree (`pages:` -> `widgets:` -> widgets that contain `widgets:`); the catalog can't express the recursion, so the structured form can't round-trip it (`pages:` renders an empty list even when the YAML has pages) and editing in the form silently drops config. Add `lvgl` to `YAML_ONLY_SECTIONS` so the section renders the existing "edit in YAML" notice and round-trips losslessly through the YAML pane.

lvgl's per-id catalog body is also ~14 MB, and it was being fetched just to show a name or classify the section. Source YAML-only sections' metadata from the slim index instead of the body:

- `loadConfig` skips the body fetch for YAML-only sections and builds the header from the slim catalog (`entries: []` drives the notice).
- The navigator and the name-resolver controller resolve display names from the slim catalog (new `getLoadedCatalog`) and skip the body fetch for YAML-only sections.
- `yaml-hover` and autocomplete short-circuit on YAML-only sections so hovering or typing under `lvgl:` never hydrates the body.

The lvgl body is never requested. Companion backend PR fixes the bare `lvgl` catalog entry's borrowed "LVGL Number" name so the slim title reads "LVGL".

**Related issue or feature (if applicable):**

- fixes the lvgl Visual Editor breakage on the 2026.6 beta catalog

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] Tests added/updated (`test/components/device/yaml-only-section.test.ts`).
- [x] `npm run lint` (tsc) and `npm test` (3363) pass.
- [x] Prettier-formatted.
