### PR TITLE
Prefix board image URLs with the deployment base

### DIFF
--- a/src/util/board-image.ts
+++ b/src/util/board-image.ts
@@ -8,9 +8,13 @@ export function defaultBoardImageUrl(): string {
   return withBase(DEFAULT_BOARD_IMAGE);
 }
 
-/** First catalog image for a board, or the bundled placeholder. */
+/** First catalog image for a board, or the bundled placeholder.
+ *  Local board images (generic SVGs) are root-relative `/boards/images/...`
+ *  paths the backend serves; `withBase` adds the deployment prefix so they
+ *  resolve under HA ingress / a reverse-proxy subpath. External `https://`
+ *  URLs (curated boards) pass through unchanged. */
 export function boardImageUrl(board: BoardCatalogEntry): string {
-  if (board.images.length > 0) return board.images[0];
+  if (board.images.length > 0) return withBase(board.images[0]);
   return defaultBoardImageUrl();
 }
 

--- a/test/util/board-image.test.ts
+++ b/test/util/board-image.test.ts
@@ -1,17 +1,29 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
-import {
-  boardImageUrl,
-  defaultBoardImageUrl,
-  onBoardImageError,
-} from "../../src/util/board-image.js";
+
+// Simulate a non-root deployment base (HA ingress / reverse-proxy subpath) so
+// the prefixing of root-relative board images is observable.
+vi.mock("../../src/util/base-path.js", () => ({
+  withBase: (p: string) => (p.startsWith("/") ? `/api/hassio_ingress/tok${p}` : p),
+}));
+
+const { boardImageUrl, defaultBoardImageUrl, onBoardImageError } =
+  await import("../../src/util/board-image.js");
 
 const board = (images: string[]): BoardCatalogEntry =>
   ({ id: "b", name: "B", images }) as BoardCatalogEntry;
 
 describe("boardImageUrl", () => {
-  it("returns the first catalog image when present", () => {
+  it("prefixes a root-relative local board image with the deployment base", () => {
+    // Generic board SVGs are served from the backend at /boards/images/...;
+    // under ingress they must carry the base prefix or they 404 against origin.
+    expect(boardImageUrl(board(["/boards/images/_generic/bk72xx.svg"]))).toBe(
+      "/api/hassio_ingress/tok/boards/images/_generic/bk72xx.svg"
+    );
+  });
+
+  it("leaves an external image URL unchanged", () => {
     expect(boardImageUrl(board(["https://example.com/a.png", "b.png"]))).toBe(
       "https://example.com/a.png"
     );


### PR DESCRIPTION
# What does this implement/fix?

Under the Home Assistant add-on (ingress), the board picker showed broken images for the generic boards (Generic ESP32-C6, Generic RP2040, Generic BK7231x, …). They link to a root path like `https://<host>:8123/boards/images/_generic/bk72xx.svg`, which resolves against the origin and drops the `/api/hassio_ingress/<token>/` prefix, so the request bypasses the add-on and 404s. The same breaks behind any reverse-proxy subpath.

Generic boards' images are local, root-relative `/boards/images/_generic/<variant>.svg` paths the backend serves; curated boards use external `https://` URLs and were fine. `boardImageUrl` returned the catalog image raw, unlike its sibling `defaultBoardImageUrl` which already wraps the path in `withBase`. Wrap it the same way: `withBase` prefixes the deployment base for root-relative paths and passes external URLs through unchanged. Every board-image consumer (wizard, change-board dialog, device board info) goes through this one function.

**Related issue or feature (if applicable):**

- Fixes broken generic-board images under HA ingress

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] Tests added/updated (`test/util/board-image.test.ts`).
- [x] `npm run lint` (tsc) and `npm test` pass.
- [x] Prettier-formatted.
