### PR TITLE
Link footer version numbers to their release notes

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -15,6 +15,10 @@ import { stripBase, withBase } from "../util/base-path.js";
 import { deviceBuilderChannel } from "../util/device-builder-channel.js";
 import { navigate, runLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import {
+  deviceBuilderReleaseUrl,
+  esphomeChangelogUrl,
+} from "../util/release-notes-url.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -78,6 +82,20 @@ export class ESPHomeLayout extends LitElement {
     // Reflect the consumed context to a host attribute so the slim-header
     // CSS (`:host([ingress])`) can key off it.
     this.toggleAttribute("ingress", this._isHaIngress);
+  }
+
+  // Footer version, linked to its release notes when a URL exists, else plain
+  // text. The anchor inherits the footer style so it reads as ordinary text.
+  private _footerVersion(text: string, href: string | null) {
+    return href
+      ? html`<a
+          href=${href}
+          target="_blank"
+          rel="noopener noreferrer"
+          title=${this._localize("layout.release_notes")}
+          >${text}</a
+        >`
+      : html`${text}`;
   }
 
   static styles = [
@@ -302,6 +320,14 @@ export class ESPHomeLayout extends LitElement {
         color: color-mix(in srgb, var(--wa-color-text-quiet), transparent 30%);
         user-select: text;
       }
+
+      /* Version links read as plain footer text; only the cursor and the
+         title tooltip hint that they are clickable. */
+      .app-footer a {
+        color: inherit;
+        text-decoration: none;
+        cursor: pointer;
+      }
     `,
   ];
 
@@ -363,10 +389,20 @@ export class ESPHomeLayout extends LitElement {
       <slot></slot>
       <div class="app-footer">
         ${this._serverVersion
-          ? html`<span>ESPHome Device Builder v${this._serverVersion}</span>`
+          ? html`<span
+              >${this._footerVersion(
+                `ESPHome Device Builder v${this._serverVersion}`,
+                deviceBuilderReleaseUrl(this._serverVersion)
+              )}</span
+            >`
           : nothing}
         ${this._esphomeVersion
-          ? html`<span>ESPHome ${this._esphomeVersion}</span>`
+          ? html`<span
+              >${this._footerVersion(
+                `ESPHome ${this._esphomeVersion}`,
+                esphomeChangelogUrl(this._esphomeVersion)
+              )}</span
+            >`
           : nothing}
       </div>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -942,6 +942,7 @@
     }
   },
   "layout": {
+    "release_notes": "View release notes",
     "secrets": "Secrets",
     "update_all_started": "{count, plural, one {# device update started} other {# device updates started}}",
     "update_all_none": "No online devices to update",

--- a/src/util/release-notes-url.ts
+++ b/src/util/release-notes-url.ts
@@ -11,13 +11,18 @@ export function deviceBuilderReleaseUrl(version: string): string | null {
 }
 
 /**
- * Changelog URL for an ESPHome version, or null for a dev build. ESPHome
- * publishes one page per minor; patch and pre-release versions normalize to
- * the YYYY.M.0 page (e.g. 2026.5.3 and 2026.5.0b1 both map to 2026.5.0).
+ * Docs URL for an ESPHome version, routed by channel. Stable links to the
+ * per-minor changelog on esphome.io; patch and pre-release versions normalize
+ * to the YYYY.M.0 page (e.g. 2026.6.3 and 2026.6.0b3 both map to 2026.6.0).
+ * Beta (bN) uses the beta docs site, whose page exists before the stable one.
+ * A dev build links to the next docs root, since its changelog is unpublished.
+ * Returns null when the version cannot be parsed.
  */
 export function esphomeChangelogUrl(version: string): string | null {
   const v = version.trim();
-  if (/dev/i.test(v)) return null;
+  if (/dev/i.test(v)) return "https://next.esphome.io/";
   const m = v.match(/^(\d{4})\.(\d{1,2})\b/);
-  return m ? `https://esphome.io/changelog/${m[1]}.${m[2]}.0/` : null;
+  if (!m) return null;
+  const host = /b\d/.test(v) ? "beta.esphome.io" : "esphome.io";
+  return `https://${host}/changelog/${m[1]}.${m[2]}.0/`;
 }

--- a/src/util/release-notes-url.ts
+++ b/src/util/release-notes-url.ts
@@ -2,7 +2,8 @@ import { deviceBuilderChannel } from "./device-builder-channel.js";
 
 /**
  * Release-notes URL for a Device Builder version, or null for a dev build
- * (which has no published tag). The release tag is the version verbatim.
+ * (which has no published tag). The release tag is the trimmed version with
+ * any leading v removed.
  */
 export function deviceBuilderReleaseUrl(version: string): string | null {
   if (deviceBuilderChannel(version) === "dev") return null;

--- a/src/util/release-notes-url.ts
+++ b/src/util/release-notes-url.ts
@@ -1,0 +1,23 @@
+import { deviceBuilderChannel } from "./device-builder-channel.js";
+
+/**
+ * Release-notes URL for a Device Builder version, or null for a dev build
+ * (which has no published tag). The release tag is the version verbatim.
+ */
+export function deviceBuilderReleaseUrl(version: string): string | null {
+  if (deviceBuilderChannel(version) === "dev") return null;
+  const v = version.trim().replace(/^v/, "");
+  return `https://github.com/esphome/device-builder/releases/tag/${v}`;
+}
+
+/**
+ * Changelog URL for an ESPHome version, or null for a dev build. ESPHome
+ * publishes one page per minor; patch and pre-release versions normalize to
+ * the YYYY.M.0 page (e.g. 2026.5.3 and 2026.5.0b1 both map to 2026.5.0).
+ */
+export function esphomeChangelogUrl(version: string): string | null {
+  const v = version.trim();
+  if (/dev/i.test(v)) return null;
+  const m = v.match(/^(\d{4})\.(\d{1,2})\b/);
+  return m ? `https://esphome.io/changelog/${m[1]}.${m[2]}.0/` : null;
+}

--- a/test/components/esphome-layout-footer.test.ts
+++ b/test/components/esphome-layout-footer.test.ts
@@ -49,11 +49,13 @@ describe("esphome-layout footer version links", () => {
     }
   });
 
-  test("renders dev versions as plain text without a link", async () => {
-    el = await renderFooter("0.0.0", "2026.5.0-dev");
-    expect(footerLinks(el)).toHaveLength(0);
+  test("dev Device Builder stays plain text; dev ESPHome links to the next docs root", async () => {
+    el = await renderFooter("0.0.0", "2026.7.0-dev");
+    const links = footerLinks(el);
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("https://next.esphome.io/");
+    expect(links[0].textContent?.trim()).toBe("ESPHome 2026.7.0-dev");
     const footer = el.shadowRoot!.querySelector(".app-footer")?.textContent;
     expect(footer).toContain("ESPHome Device Builder v0.0.0");
-    expect(footer).toContain("ESPHome 2026.5.0-dev");
   });
 });

--- a/test/components/esphome-layout-footer.test.ts
+++ b/test/components/esphome-layout-footer.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test } from "vitest";
+
+import { ESPHomeLayout } from "../../src/components/esphome-layout.js";
+
+interface FooterVersions {
+  _serverVersion: string;
+  _esphomeVersion: string;
+}
+
+async function renderFooter(
+  serverVersion: string,
+  esphomeVersion: string
+): Promise<ESPHomeLayout> {
+  const el = new ESPHomeLayout();
+  const view = el as unknown as FooterVersions;
+  view._serverVersion = serverVersion;
+  view._esphomeVersion = esphomeVersion;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function footerLinks(el: ESPHomeLayout): HTMLAnchorElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll(".app-footer a"));
+}
+
+describe("esphome-layout footer version links", () => {
+  let el: ESPHomeLayout | undefined;
+
+  afterEach(() => {
+    el?.remove();
+    el = undefined;
+  });
+
+  test("links stable versions to their release notes", async () => {
+    el = await renderFooter("1.0.3", "2026.5.3");
+    const links = footerLinks(el);
+    expect(links).toHaveLength(2);
+    expect(links[0].getAttribute("href")).toBe(
+      "https://github.com/esphome/device-builder/releases/tag/1.0.3"
+    );
+    expect(links[0].textContent?.trim()).toBe("ESPHome Device Builder v1.0.3");
+    expect(links[1].getAttribute("href")).toBe("https://esphome.io/changelog/2026.5.0/");
+    expect(links[1].textContent?.trim()).toBe("ESPHome 2026.5.3");
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
+  test("renders dev versions as plain text without a link", async () => {
+    el = await renderFooter("0.0.0", "2026.5.0-dev");
+    expect(footerLinks(el)).toHaveLength(0);
+    const footer = el.shadowRoot!.querySelector(".app-footer")?.textContent;
+    expect(footer).toContain("ESPHome Device Builder v0.0.0");
+    expect(footer).toContain("ESPHome 2026.5.0-dev");
+  });
+});

--- a/test/util/release-notes-url.test.ts
+++ b/test/util/release-notes-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  deviceBuilderReleaseUrl,
+  esphomeChangelogUrl,
+} from "../../src/util/release-notes-url.js";
+
+describe("deviceBuilderReleaseUrl", () => {
+  it("links a stable version to its release tag", () => {
+    expect(deviceBuilderReleaseUrl("1.0.3")).toBe(
+      "https://github.com/esphome/device-builder/releases/tag/1.0.3"
+    );
+    expect(deviceBuilderReleaseUrl("v1.0.3")).toBe(
+      "https://github.com/esphome/device-builder/releases/tag/1.0.3"
+    );
+  });
+
+  it("links a beta version to its release tag", () => {
+    expect(deviceBuilderReleaseUrl("1.0.2b4")).toBe(
+      "https://github.com/esphome/device-builder/releases/tag/1.0.2b4"
+    );
+  });
+
+  it("returns null for a dev build", () => {
+    expect(deviceBuilderReleaseUrl("0.0.0")).toBeNull();
+    expect(deviceBuilderReleaseUrl("")).toBeNull();
+    expect(deviceBuilderReleaseUrl("0.1.0.dev5+g1234")).toBeNull();
+  });
+});
+
+describe("esphomeChangelogUrl", () => {
+  it("links a stable version to its minor changelog page", () => {
+    expect(esphomeChangelogUrl("2026.5.0")).toBe(
+      "https://esphome.io/changelog/2026.5.0/"
+    );
+  });
+
+  it("normalizes a patch version to the minor page", () => {
+    expect(esphomeChangelogUrl("2026.5.3")).toBe(
+      "https://esphome.io/changelog/2026.5.0/"
+    );
+  });
+
+  it("normalizes a pre-release version to the minor page", () => {
+    expect(esphomeChangelogUrl("2026.5.0b1")).toBe(
+      "https://esphome.io/changelog/2026.5.0/"
+    );
+    expect(esphomeChangelogUrl("2026.12.0b2")).toBe(
+      "https://esphome.io/changelog/2026.12.0/"
+    );
+  });
+
+  it("returns null for a dev build or an unparseable version", () => {
+    expect(esphomeChangelogUrl("2026.5.0-dev")).toBeNull();
+    expect(esphomeChangelogUrl("")).toBeNull();
+    expect(esphomeChangelogUrl("not-a-version")).toBeNull();
+  });
+});

--- a/test/util/release-notes-url.test.ts
+++ b/test/util/release-notes-url.test.ts
@@ -40,17 +40,20 @@ describe("esphomeChangelogUrl", () => {
     );
   });
 
-  it("normalizes a pre-release version to the minor page", () => {
-    expect(esphomeChangelogUrl("2026.5.0b1")).toBe(
-      "https://esphome.io/changelog/2026.5.0/"
+  it("routes a beta version to the beta docs site", () => {
+    expect(esphomeChangelogUrl("2026.6.0b3")).toBe(
+      "https://beta.esphome.io/changelog/2026.6.0/"
     );
     expect(esphomeChangelogUrl("2026.12.0b2")).toBe(
-      "https://esphome.io/changelog/2026.12.0/"
+      "https://beta.esphome.io/changelog/2026.12.0/"
     );
   });
 
-  it("returns null for a dev build or an unparseable version", () => {
-    expect(esphomeChangelogUrl("2026.5.0-dev")).toBeNull();
+  it("links a dev build to the next docs root", () => {
+    expect(esphomeChangelogUrl("2026.7.0-dev")).toBe("https://next.esphome.io/");
+  });
+
+  it("returns null for an unparseable version", () => {
     expect(esphomeChangelogUrl("")).toBeNull();
     expect(esphomeChangelogUrl("not-a-version")).toBeNull();
   });


### PR DESCRIPTION
# What does this implement/fix?

The two footer version numbers are now links to their release notes; the ESPHome Device Builder version opens its GitHub release page, and the ESPHome version opens its esphome.io changelog. Both URLs are derived from the version string, so nothing needs updating each release; patch and beta versions resolve to the right changelog page, and dev builds, which have no published notes, stay as plain text. The links inherit the footer style so the design is untouched; only a pointer cursor and a tooltip hint that they are clickable.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/863

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
