### PR TITLE
Return to the method chooser when cancelling empty-config

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -62,6 +62,12 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   @state()
   private _step: WizardStep = "method";
 
+  // Owned here, not in the method step, so the "Advanced" disclosure stays
+  // open when the user navigates into an advanced option (empty-config /
+  // import) and back — the step element is unmounted across that transition.
+  @state()
+  private _advancedOpen = false;
+
   // Drives the step components' Enter listeners: the steps stay mounted in
   // the wa-dialog while it's merely hidden (light-dismiss / Escape / close),
   // so they must deactivate on hide, not just on unmount.
@@ -168,6 +174,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
    * here. */
   private _resetTransientState(): void {
     this._creationMethod = "basic";
+    this._advancedOpen = false;
     this._import.reset();
     this._submitting = false;
     this._resetCreateErrors();
@@ -254,6 +261,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         @request-close=${this._onRequestClose}
         @after-hide=${this._onHide}
         @next-step=${this._onNextStep}
+        @toggle-advanced=${this._onToggleAdvanced}
         @finish-setup=${this._onFinishSetup}
         @create-empty-config=${this._onCreateEmptyConfig}
         @import-file=${this._onImportFile}
@@ -291,7 +299,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
 
     switch (this._step) {
       case "method":
-        return html`<esphome-wizard-step-method></esphome-wizard-step-method>`;
+        return html`<esphome-wizard-step-method
+          .advancedOpen=${this._advancedOpen}
+        ></esphome-wizard-step-method>`;
       case "board":
         return html`<esphome-wizard-step-board
           .presetFilterLabel=${this._initialBoardFilter}
@@ -342,6 +352,10 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     }
 
     this._step = detail.step;
+  }
+
+  private _onToggleAdvanced() {
+    this._advancedOpen = !this._advancedOpen;
   }
 
   private _onImportFile(e: CustomEvent<{ file: File }>) {

--- a/src/components/wizard/wizard-step-empty-config.ts
+++ b/src/components/wizard/wizard-step-empty-config.ts
@@ -129,7 +129,7 @@ export class ESPHomeWizardStepEmptyConfig extends LitElement {
 
   private _cancel() {
     this.dispatchEvent(
-      new CustomEvent("next-step", { detail: "board", bubbles: true, composed: true })
+      new CustomEvent("next-step", { detail: "method", bubbles: true, composed: true })
     );
   }
 

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { mdiChevronDown, mdiChevronRight, mdiCog } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
@@ -27,8 +27,10 @@ export class ESPHomeWizardStepMethod extends LitElement {
   @query("#file-input")
   private _fileInput!: HTMLInputElement;
 
-  @state()
-  private _advancedOpen = false;
+  // Owned by the parent dialog so it survives step changes (the dialog
+  // unmounts this element when navigating away and back).
+  @property({ type: Boolean })
+  advancedOpen = false;
 
   private _drop = new FileDropController(this, (file) => this._sendImportFile(file));
 
@@ -192,14 +194,14 @@ export class ESPHomeWizardStepMethod extends LitElement {
 
           <button
             class="advanced-toggle"
-            aria-expanded=${this._advancedOpen}
+            aria-expanded=${this.advancedOpen}
             @click=${this._toggleAdvanced}
           >
             ${this._localize("wizard.advanced_options")}
             <wa-icon library="mdi" name="chevron-down"></wa-icon>
           </button>
 
-          ${this._advancedOpen
+          ${this.advancedOpen
             ? html`<div class="option-cards">${this._renderAdvancedOptions()}</div>`
             : nothing}
         </div>
@@ -238,7 +240,11 @@ export class ESPHomeWizardStepMethod extends LitElement {
   }
 
   private _toggleAdvanced() {
-    this._advancedOpen = !this._advancedOpen;
+    // Just signal intent; the dialog owns the flag (it outlives this element)
+    // and flips it.
+    this.dispatchEvent(
+      new CustomEvent("toggle-advanced", { bubbles: true, composed: true })
+    );
   }
 
   private _goToBoard() {

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -496,3 +496,57 @@ describe("create-config-dialog upload overwrite", () => {
     expect(createDevice).toHaveBeenCalledTimes(1);
   });
 });
+
+// The "Advanced" disclosure flag lives on the dialog (not the method step) so
+// it survives the method element being unmounted and re-created when the user
+// navigates into an advanced option (empty-config / import) and back.
+describe("create-config-dialog advanced disclosure persistence", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const methodEl = (el: ESPHomeCreateConfigDialog): HTMLElement | null =>
+    el.shadowRoot!.querySelector("esphome-wizard-step-method");
+
+  const advancedOpen = (el: ESPHomeCreateConfigDialog): boolean | undefined =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (methodEl(el) as any)?.advancedOpen;
+
+  function toggleAdvanced(el: ESPHomeCreateConfigDialog): void {
+    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
+      new CustomEvent("toggle-advanced", { bubbles: true, composed: true })
+    );
+  }
+
+  it("keeps Advanced open when navigating into empty-config and back", async () => {
+    const el = await mount({});
+    expect(advancedOpen(el)).toBe(false);
+
+    toggleAdvanced(el);
+    await el.updateComplete;
+    expect(advancedOpen(el)).toBe(true);
+
+    // Into the advanced option — the method element unmounts.
+    emitNextStep(el, "empty-config");
+    await el.updateComplete;
+    expect(methodEl(el)).toBeNull();
+
+    // Back to the chooser — the re-mounted method step still gets it open.
+    emitNextStep(el, "method");
+    await el.updateComplete;
+    expect(advancedOpen(el)).toBe(true);
+  });
+
+  it("starts collapsed again after the dialog is reopened", async () => {
+    const el = await mount({});
+    toggleAdvanced(el);
+    await el.updateComplete;
+    expect(advancedOpen(el)).toBe(true);
+
+    el.close();
+    await el.updateComplete;
+    el.open();
+    await el.updateComplete;
+    expect(advancedOpen(el)).toBe(false);
+  });
+});

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -67,4 +67,16 @@ describe("wizard-step-empty-config ENTER", () => {
     pressEnter();
     expect(onCreate).not.toHaveBeenCalled();
   });
+
+  it("Cancel returns to the method chooser, not the board picker", async () => {
+    // This step is reached directly from the method chooser (no board is
+    // picked), so Cancel must go back there, matching the dialog's header
+    // back arrow.
+    const el = await mount();
+    const onNext = vi.fn();
+    el.addEventListener("next-step", onNext as EventListener);
+    (el.shadowRoot!.querySelector(".btn-cancel") as HTMLButtonElement).click();
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect((onNext.mock.calls[0][0] as CustomEvent).detail).toBe("method");
+  });
 });

--- a/test/components/wizard/wizard-step-method-advanced.test.ts
+++ b/test/components/wizard/wizard-step-method-advanced.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "Advanced" disclosure is driven by the parent dialog's ``advancedOpen``
+ * property (so it survives navigating into an advanced option and back); the
+ * toggle signals intent via a ``toggle-advanced`` event rather than flipping
+ * local state.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { defaultLocalize } from "../../../src/common/localize.js";
+import { ESPHomeWizardStepMethod } from "../../../src/components/wizard/wizard-step-method.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+async function mount(advancedOpen = false): Promise<ESPHomeWizardStepMethod> {
+  const el = new ESPHomeWizardStepMethod();
+  (el as any)._localize = defaultLocalize;
+  el.advancedOpen = advancedOpen;
+  document.body.appendChild(el);
+  el.checkVisibility = () => true;
+  await el.updateComplete;
+  return el;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("wizard-step-method advanced disclosure", () => {
+  it("renders advanced options only when advancedOpen is set", async () => {
+    // Closed: just the primary "create new" card; the advanced disclosure
+    // (a second .option-cards block) is absent and the toggle reads collapsed.
+    const closed = await mount(false);
+    expect(closed.shadowRoot!.querySelectorAll(".option-cards")).toHaveLength(1);
+    expect(
+      closed.shadowRoot!.querySelector(".advanced-toggle")!.getAttribute("aria-expanded")
+    ).toBe("false");
+
+    // Open: the advanced block is rendered (import + empty-config cards).
+    const open = await mount(true);
+    expect(open.shadowRoot!.querySelectorAll(".option-cards")).toHaveLength(2);
+    expect(
+      open.shadowRoot!.querySelector(".advanced-toggle")!.getAttribute("aria-expanded")
+    ).toBe("true");
+  });
+
+  it("signals intent via toggle-advanced instead of flipping locally", async () => {
+    const el = await mount(false);
+    const onToggle = vi.fn();
+    el.addEventListener("toggle-advanced", onToggle as EventListener);
+    (el.shadowRoot!.querySelector(".advanced-toggle") as HTMLButtonElement).click();
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // The step doesn't own the state — it just signals and stays put until the
+    // parent feeds advancedOpen back down.
+    expect(el.advancedOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Two related fixes to the new-device wizard.

**Cancel routing.** "Create empty configuration" (an advanced option on the "How would you like to create your project?" chooser) goes straight to the empty-config step; no board is picked on that path. Its Cancel button dispatched `next-step` with `"board"`, so cancelling dropped the user on the board picker. Dispatch `"method"` instead, so Cancel returns to the method chooser, matching the dialog's header back arrow which already maps `empty-config` to `method`.

**Advanced disclosure persistence.** Once Cancel returns to the method chooser, the user lands on a freshly re-mounted method step (the dialog swaps step elements via a switch), so the "Advanced" section they had opened was collapsed again. The open state is per-session, not per-mount, so it now lives on the dialog: `_advancedOpen` is owned by `create-config-dialog`, passed down as `.advancedOpen`, toggled via a `toggle-advanced` event the step emits, and reset on dialog open so a fresh wizard still starts collapsed.

Tests: empty-config Cancel routing; the method step renders advanced options from the prop and signals via the event rather than flipping local state; and a dialog-level round trip (open, toggle advanced, into empty-config, back) that pins the disclosure stays open, plus reset-on-reopen.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
