### PR TITLE
Fix misaligned Paired Senders Remove button

### DIFF
--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -248,9 +248,10 @@ export class ESPHomeSettingsBuildServer extends LitElement {
           aria-label=${this._localize("settings.build_server_peer_remove_aria", {
             label: peer.label,
           })}
+          title=${this._localize("settings.build_server_peer_remove")}
           @click=${() => this._onRemovePeerRequest(peer.dashboard_id)}
         >
-          ${this._localize("settings.build_server_peer_remove")}
+          <wa-icon library="mdi" name="delete"></wa-icon>
         </button>
       </div>
     `;

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -251,24 +251,36 @@ export const peerRowStyles = css`
     gap: var(--wa-space-xs);
   }
 
+  /* Destructive remove/unpair icon button: neutral bordered square at
+     rest, error tint on hover/focus. */
   .peer-remove {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 32px;
     height: 32px;
-    border: none;
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     border-radius: var(--wa-border-radius-s);
-    background: transparent;
+    background: var(--wa-color-surface-default);
     color: var(--wa-color-text-quiet);
     cursor: pointer;
     flex-shrink: 0;
   }
 
+  .peer-remove wa-icon {
+    font-size: 16px;
+  }
+
   .peer-remove:hover,
   .peer-remove:focus-visible {
-    background: var(--wa-color-surface-border);
-    color: var(--wa-color-text);
+    background: color-mix(in srgb, var(--esphome-error), white 90%);
+    color: var(--esphome-error);
+    border-color: var(--esphome-error);
+  }
+
+  .peer-remove:focus-visible {
+    outline: none;
+    box-shadow: var(--esphome-focus-ring);
   }
 
   .peer-connection-pill {


### PR DESCRIPTION
# What does this implement/fix?

The Remove control on each Paired Senders row was a text button reusing the shared `.peer-remove` class, which is sized as a 32px icon square; the text overflowed the box, so the hover background sat offset behind the text and clipped at the panel edge. This makes it the same delete icon button the offloader pairing row uses; a neutral bordered square at rest that tints red on hover, since removing a sender is destructive. The shared `.peer-remove` now carries that destructive icon-button chrome, so the offloader trash button is unchanged.

**Related issue or feature (if applicable):**

Found during manual testing of the Build server settings.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
