### PR TITLE
Drop redundant .btn-unpair; .peer-remove is the single destructive icon button

### DIFF
--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -147,7 +147,7 @@ export function renderPairingRow(
           : nothing}
         <button
           type="button"
-          class="peer-remove btn-unpair"
+          class="peer-remove"
           aria-label=${localize("settings.unpair_aria", { label: pairing.label })}
           title=${localize("settings.unpair_action")}
           @click=${() => onUnpair(pairing)}

--- a/src/components/settings-dialog/offload-styles.ts
+++ b/src/components/settings-dialog/offload-styles.ts
@@ -108,11 +108,11 @@ export const pairingRowStyles = css`
   }
 
   /* Shared chrome for the section's secondary action buttons: the
-     pairing row's icon-only squares, its Build-remote / View-build
+     pairing row's icon Edit square, its Build-remote / View-build
      text actions, and the alert's text Unpair (.offloader-alert-unpair
      markup lives in build-offload-alert.ts; its chrome stays here with
-     its siblings). */
-  .btn-unpair,
+     its siblings). The pairing row's trash button is the shared
+     .peer-remove in shared-styles.ts. */
   .btn-edit-endpoint,
   .btn-build-remote,
   .btn-view-remote-build,
@@ -128,19 +128,16 @@ export const pairingRowStyles = css`
     flex-shrink: 0;
   }
 
-  .btn-unpair,
   .btn-edit-endpoint {
     width: 32px;
     border-radius: var(--wa-border-radius-s);
   }
 
-  .btn-unpair wa-icon,
   .btn-edit-endpoint wa-icon {
     font-size: 16px;
   }
 
   /* Destructive actions tint error on hover; edit tints primary. */
-  .btn-unpair:hover,
   .offloader-alert-unpair:hover {
     background: color-mix(in srgb, var(--esphome-error), white 90%);
     color: var(--esphome-error);
@@ -168,7 +165,6 @@ export const pairingRowStyles = css`
     font-weight: var(--wa-font-weight-semibold);
   }
 
-  .btn-unpair:focus-visible,
   .btn-edit-endpoint:focus-visible,
   .btn-build-remote:focus-visible,
   .btn-view-remote-build:focus-visible,

--- a/src/components/settings-dialog/shared-styles.ts
+++ b/src/components/settings-dialog/shared-styles.ts
@@ -252,7 +252,9 @@ export const peerRowStyles = css`
   }
 
   /* Destructive remove/unpair icon button: neutral bordered square at
-     rest, error tint on hover/focus. */
+     rest, error tint on hover/focus. Single source for both the
+     approved-senders Remove (build-server-section) and the offloader
+     unpair trash (build-offload-pairing-row). */
   .peer-remove {
     display: inline-flex;
     align-items: center;

--- a/test/components/build-offload-section/render-offloader-alert.test.ts
+++ b/test/components/build-offload-section/render-offloader-alert.test.ts
@@ -1,6 +1,6 @@
 /**
  * The alert's Unpair action is a text button and must use the padded
- * text style, never the pairing row's 32×32 icon-only ``btn-unpair``
+ * text style, never the pairing row's 32×32 icon-only ``peer-remove``
  * (text overflowed the square and read as an unstyled button, #766).
  */
 import { describe, expect, it, vi } from "vitest";
@@ -45,12 +45,12 @@ describe("renderOffloaderAlert", () => {
     const tokens = classTokens(renderOffloaderAlert(pinMismatch, ctx()).strings.join(""));
     expect(tokens).toContain("btn-pair-build-server");
     expect(tokens).toContain("offloader-alert-unpair");
-    expect(tokens).not.toContain("btn-unpair");
+    expect(tokens).not.toContain("peer-remove");
   });
 
   it("styles the peer-revoked Unpair as a text button", () => {
     const tokens = classTokens(renderOffloaderAlert(peerRevoked, ctx()).strings.join(""));
     expect(tokens).toContain("offloader-alert-unpair");
-    expect(tokens).not.toContain("btn-unpair");
+    expect(tokens).not.toContain("peer-remove");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #867. That PR promoted the shared `.peer-remove` into the destructive icon button, which left it restating, byte-for-byte, the chrome `.btn-unpair` already defined in `offload-styles.ts`; the same look lived in two stylesheets and could drift. `.btn-unpair` was only ever used on the offloader trash button, which already carries `.peer-remove`, so this drops the redundant class and its rules and leaves `.peer-remove` as the single source. No visual change; the trash button, the Edit pencil, and the Paired Senders Remove all render exactly as before.

**Related issue or feature (if applicable):**

Follow-up to #867 (addresses the duplication noted in review).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
