### PR TITLE
Disable browser autofill on the wizard setup inputs

### DIFF
--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -300,6 +300,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
           <input
             id="device-name"
             type="text"
+            autocomplete="off"
             .value=${this._deviceName}
             placeholder=${this._localize("wizard.device_name_placeholder")}
             @input=${(e: InputEvent) => {
@@ -326,6 +327,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
           <input
             id="wifi-ssid"
             type="text"
+            autocomplete="off"
             .value=${this._wifiSsid}
             @input=${(e: InputEvent) => {
               this._wifiSsid = (e.target as HTMLInputElement).value;
@@ -338,6 +340,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
           <input
             id="wifi-password"
             type="password"
+            autocomplete="off"
             .value=${this._wifiPassword}
             @input=${(e: InputEvent) => {
               this._wifiPassword = (e.target as HTMLInputElement).value;

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -149,4 +149,18 @@ describe("wizard-step-setup ENTER", () => {
     expect(onFinish).toHaveBeenCalledTimes(1);
     expect((onFinish.mock.calls[0][0] as CustomEvent).detail.wifiSsid).toBe("home");
   });
+
+  it("disables browser autofill on the name and wifi inputs", async () => {
+    const el = await mount();
+    const deviceName = el.shadowRoot!.querySelector<HTMLInputElement>("#device-name");
+    expect(deviceName?.getAttribute("autocomplete")).toBe("off");
+
+    await setName(el, "kitchen");
+    pressEnter(); // advance to the wifi stage so its inputs render
+    await el.updateComplete;
+    for (const id of ["wifi-ssid", "wifi-password"]) {
+      const input = el.shadowRoot!.querySelector<HTMLInputElement>(`#${id}`);
+      expect(input?.getAttribute("autocomplete")).toBe("off");
+    }
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The board setup wizard's Device name field popped the browser/password-manager autofill dropdown offering saved usernames and emails, because the input had no `autocomplete` attribute and the browser treated the generic text field as a username field. This adds `autocomplete="off"` to the Device name input and the Wi-Fi SSID/password inputs in the same step, matching the convention already used across the app; the autofill suggestions no longer appear.

**Related issue or feature (if applicable):**

Found during manual testing of the board setup wizard.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
