### PR TITLE
Reconnect Web Serial logs with a fresh port after a flash reset

### DIFF
--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -211,7 +211,6 @@ export async function openLogsWithMethod(
       return;
     }
     if (!serialPort) return; // User dismissed the port picker.
-    const port = serialPort;
     host._logsDialog.configuration = device.configuration;
     host._logsDialog.name = device.friendly_name || device.name;
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
@@ -222,7 +221,7 @@ export async function openLogsWithMethod(
     // attach toasts the reopen-retry failure itself; cover any other rejection
     // so it can't escape this fire-and-forget call as an unhandled rejection.
     try {
-      await attachSerialLogStream(port, host._logsDialog, host._localize);
+      await attachSerialLogStream(serialPort, host._logsDialog, host._localize);
     } catch {
       toast.error(host._localize("dashboard.logs_web_serial_open_failed"), {
         richColors: true,

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -10,7 +10,11 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { clearJustCreated } from "../../util/just-created.js";
-import { attachSerialLogStream } from "../../util/post-install-logs.js";
+import {
+  attachSerialLogStream,
+  reconnectWebSerialLogs,
+  requestAndOpenSerialPort,
+} from "../../util/post-install-logs.js";
 
 export async function executeFriendlyName(
   host: ESPHomePageDashboard,
@@ -195,18 +199,9 @@ export async function openLogsWithMethod(
       });
       return;
     }
-    let serialPort: SerialPort;
+    let serialPort: SerialPort | null;
     try {
-      serialPort = await (
-        navigator as unknown as {
-          serial: { requestPort: () => Promise<SerialPort> };
-        }
-      ).serial.requestPort();
-    } catch {
-      return; // User dismissed the port picker.
-    }
-    try {
-      await serialPort.open({ baudRate: 115200 });
+      serialPort = await requestAndOpenSerialPort();
     } catch {
       // The user picked a port but it couldn't open (claimed by another tab,
       // driver error); unlike a picker dismissal this needs feedback.
@@ -215,16 +210,19 @@ export async function openLogsWithMethod(
       });
       return;
     }
+    if (!serialPort) return; // User dismissed the port picker.
+    const port = serialPort;
     host._logsDialog.configuration = device.configuration;
     host._logsDialog.name = device.friendly_name || device.name;
-    // Reconnect hook drives the dialog's "click Start to reconnect" path.
-    const reconnect = () =>
-      attachSerialLogStream(serialPort, host._logsDialog, host._localize);
-    host._logsDialog.openPassive({ onReconnect: reconnect });
+    // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
+    // port via the picker — the cached handle can be dead after a device reset.
+    host._logsDialog.openPassive({
+      onReconnect: () => reconnectWebSerialLogs(host._logsDialog, host._localize),
+    });
     // attach toasts the reopen-retry failure itself; cover any other rejection
     // so it can't escape this fire-and-forget call as an unhandled rejection.
     try {
-      await reconnect();
+      await attachSerialLogStream(port, host._logsDialog, host._localize);
     } catch {
       toast.error(host._localize("dashboard.logs_web_serial_open_failed"), {
         richColors: true,

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -225,6 +225,16 @@ export class ESPHomeLogsDialog extends LitElement {
     this._session = { kind: "dead" };
   }
 
+  /**
+   * Return a reconnect attempt to ``dead`` without surfacing an error — for
+   * when the user dismisses the Web Serial port picker. The ``Start`` button
+   * stays available; no log line or toast (a cancel isn't a failure).
+   */
+  public abortSerialReconnect() {
+    if (!this._open || !isPassive(this._session)) return;
+    this._session = { kind: "dead" };
+  }
+
   /** Stop whatever the session is running (Web Serial reader -> closes the
    *  port; backend WS -> kills the subprocess) and return to ``idle``. The
    *  cancel from `streamSerialToDialog` releases the reader lock before closing

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -216,9 +216,9 @@ export class ESPHomeLogsDialog extends LitElement {
    * with a ``toast.error``.
    */
   public setSerialOpenFailed(message: string) {
-    // Same guard as setSerialStream: the reopen retries for ~5s, so a late
-    // failure can land after the dialog closed or switched to an OTA session —
-    // don't tear that unrelated session down or flip it into a passive `dead`.
+    // Same guard as setSerialStream: the reopen retries across the re-enum
+    // window, so a late failure can land after the dialog closed or switched to
+    // an OTA session — don't tear that unrelated session down or flip it dead.
     if (!this._open || !isPassive(this._session)) return;
     void this._teardownSession();
     this._lines = [...this._lines, message];

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -226,12 +226,14 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   /**
-   * Return a reconnect attempt to ``dead`` without surfacing an error — for
+   * Return an in-flight reconnect to ``dead`` without surfacing an error — for
    * when the user dismisses the Web Serial port picker. The ``Start`` button
-   * stays available; no log line or toast (a cancel isn't a failure).
+   * stays available; no log line or toast (a cancel isn't a failure). Only acts
+   * while ``reconnecting`` — never on a live ``serial`` session, which holds an
+   * open reader/port that flipping to ``dead`` would leak.
    */
   public abortSerialReconnect() {
-    if (!this._open || !isPassive(this._session)) return;
+    if (this._session.kind !== "reconnecting") return;
     this._session = { kind: "dead" };
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -62,7 +62,7 @@
     "logs_show_states": "Show states",
     "logs_back_to_install": "Back to install",
     "logs_back_to_install_tooltip": "Return to the install output",
-    "logs_port_reopen_failed": "Failed to reopen the serial port for logs. The device may still be restarting — click Start to reconnect.",
+    "logs_port_reopen_failed": "Failed to reopen the serial port for logs ({port}). The device may still be restarting — click Start to reconnect.",
     "select_all": "Select all",
     "deselect_all": "Deselect all",
     "selected_count": "{count} selected",

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -149,57 +149,75 @@ export function postInstallShowLogsHandler(
   return (e) => handlePostInstallShowLogs(e, getLogsDialog(), getLocalize());
 }
 
+const matchesDevice = (a: SerialPortInfo, b: SerialPortInfo): boolean =>
+  a.usbVendorId === b.usbVendorId && a.usbProductId === b.usbProductId;
+
 /**
- * Reopen a SerialPort that the post-install hard-reset just closed,
- * retrying through the brief native-USB re-enumeration window.
+ * Open the live SerialPort for a device the post-install hard-reset just
+ * closed, retrying through the native-USB re-enumeration window. Returns the
+ * open port, or ``null`` if none opened inside ``timeoutMs``.
  *
- * ESP32-S3 / C3 / C6 (USB-Serial/JTAG) drop their USB device for a
- * few hundred ms after the EN-pulse reset, so a synchronous
- * ``port.open()`` immediately after ``transport.disconnect()`` races
- * the re-enumeration and throws ``NetworkError``. UART-bridge chips
- * (CP2102 / CH340) don't re-enumerate and the first attempt succeeds.
- *
- * Returns ``true`` on success (or "already open" — a race that left
- * the port usable). Returns ``false`` if no attempt succeeded inside
- * ``timeoutMs``.
+ * ESP32-S3 / C3 / C6 (USB-Serial/JTAG) drop their USB device after the reset
+ * and re-enumerate. On Chrome the *cached* handle esptool used stays dead
+ * (``open()`` throws ``NetworkError`` forever) while ``navigator.serial.
+ * getPorts()`` returns a fresh, openable handle for the same authorized
+ * device — so each attempt prefers a live granted port, falling back to the
+ * cached handle (which Firefox and non-re-enumerating UART bridges reopen
+ * directly). No re-prompt: every candidate is already permitted.
  */
-async function openSerialWithRetry(
-  port: SerialPort,
+async function openLiveSerialPort(
+  cachedPort: SerialPort,
   baudRate: number,
   timeoutMs: number
-): Promise<boolean> {
+): Promise<SerialPort | null> {
+  const want = cachedPort.getInfo();
   const deadline = Date.now() + timeoutMs;
-  let lastErr: unknown = null;
   while (true) {
+    let granted: SerialPort[] = [];
     try {
-      await port.open({ baudRate });
-      return true;
-    } catch (err) {
-      lastErr = err;
-      const name = err instanceof DOMException ? err.name : "";
-      const message = err instanceof Error ? err.message : "";
-      // Chrome's message for "InvalidStateError: The port is already
-      // open." has no specific DOMException code; string-match is
-      // unavoidable. Web Serial is Chromium-only today so the surface
-      // is one-browser — acceptable.
-      if (name === "InvalidStateError" && /already open/i.test(message)) {
-        return true;
-      }
-      if (name !== "NetworkError" || Date.now() >= deadline) {
-        console.error("[Web Serial] Failed to reopen port for logs:", lastErr);
-        return false;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      granted = await navigator.serial.getPorts();
+    } catch {
+      /* getPorts can transiently reject mid-re-enumeration; treat as empty
+         and retry (the cached handle is still tried below). */
     }
+    // Prefer a freshly-granted handle for the same device (Chrome's live
+    // re-enumerated port), then any other granted port, then the cached handle
+    // (Firefox / UART bridges reopen it in place). Dedup so the dead cached
+    // handle isn't retried twice per round.
+    const candidates = [
+      ...granted.filter((p) => p !== cachedPort && matchesDevice(p.getInfo(), want)),
+      ...granted.filter((p) => p !== cachedPort && !matchesDevice(p.getInfo(), want)),
+      cachedPort,
+    ];
+    for (const p of candidates) {
+      if (p.readable) return p; // already open (a reset race left it usable)
+      try {
+        await p.open({ baudRate });
+        return p;
+      } catch (err) {
+        const name = err instanceof DOMException ? err.name : "";
+        const message = err instanceof Error ? err.message : "";
+        if (name === "InvalidStateError" && /already open/i.test(message)) {
+          return p;
+        }
+        // Anything else (NetworkError while the device is still gone, a stale
+        // handle) — try the next candidate / next round.
+      }
+    }
+    if (Date.now() >= deadline) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
 }
 
 /**
  * Start a Web Serial read loop and hand the dialog its port + loop-cancel.
  * Begins a passive session (user-initiated logs, post-install hand-off, or
- * the dialog's reconnect-after-failure). A closed port is reopened through
- * the re-enumeration window (the ``requestPort()`` grant persists, so no
- * re-prompt) with DTR/RTS cleared; an already-open port skips the reopen.
+ * the dialog's reconnect-after-failure). A closed port is reopened through the
+ * re-enumeration window — resolving the live granted handle, since a native-USB
+ * chip's cached handle can be dead after the reset — with DTR/RTS cleared; an
+ * already-open port streams as-is.
  */
 export async function attachSerialLogStream(
   port: SerialPort,
@@ -207,8 +225,8 @@ export async function attachSerialLogStream(
   localize: LocalizeFunc
 ): Promise<void> {
   if (!port.readable) {
-    const opened = await openSerialWithRetry(port, 115200, SERIAL_REOPEN_TIMEOUT_MS);
-    if (!opened) {
+    const live = await openLiveSerialPort(port, 115200, SERIAL_REOPEN_TIMEOUT_MS);
+    if (!live) {
       const message = localize("dashboard.logs_port_reopen_failed", {
         port: formatSerialPortLabel(port),
       });
@@ -216,6 +234,7 @@ export async function attachSerialLogStream(
       toast.error(message, { richColors: true });
       return;
     }
+    port = live;
     try {
       await port.setSignals({ dataTerminalReady: false, requestToSend: false });
     } catch {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -181,12 +181,11 @@ async function openLiveSerialPort(
          and retry (the cached handle is still tried below). */
     }
     // Prefer a freshly-granted handle for the same device (Chrome's live
-    // re-enumerated port), then any other granted port, then the cached handle
-    // (Firefox / UART bridges reopen it in place). Dedup so the dead cached
-    // handle isn't retried twice per round.
+    // re-enumerated port), then the cached handle (Firefox / UART bridges
+    // reopen it in place). The cached handle is dropped from the granted list
+    // so it isn't tried twice per round.
     const candidates = [
       ...granted.filter((p) => p !== cachedPort && matchesDevice(p.getInfo(), want)),
-      ...granted.filter((p) => p !== cachedPort && !matchesDevice(p.getInfo(), want)),
       cachedPort,
     ];
     for (const p of candidates) {
@@ -194,14 +193,9 @@ async function openLiveSerialPort(
       try {
         await p.open({ baudRate });
         return p;
-      } catch (err) {
-        const name = err instanceof DOMException ? err.name : "";
-        const message = err instanceof Error ? err.message : "";
-        if (name === "InvalidStateError" && /already open/i.test(message)) {
-          return p;
-        }
-        // Anything else (NetworkError while the device is still gone, a stale
-        // handle) — try the next candidate / next round.
+      } catch {
+        // Device still gone (NetworkError) or a stale handle — try the next
+        // candidate / next round.
       }
     }
     if (Date.now() >= deadline) {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -154,6 +154,9 @@ export function postInstallShowLogsHandler(
 
 // Same USB device by vendor/product id. Requires both ids present so two
 // non-USB ports (``undefined === undefined``) aren't treated as a match.
+// VID:PID isn't a unique device id — two identical boards both match and
+// getPorts() order picks one; Web Serial exposes no per-device serial to
+// disambiguate, and the post-install flow is single-device anyway.
 const matchesDevice = (a: SerialPortInfo, b: SerialPortInfo): boolean =>
   a.usbVendorId !== undefined &&
   a.usbProductId !== undefined &&
@@ -180,6 +183,7 @@ async function openLiveSerialPort(
 ): Promise<SerialPort | null> {
   const want = cachedPort.getInfo();
   const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown = null;
   while (true) {
     let granted: SerialPort[] = [];
     try {
@@ -201,12 +205,14 @@ async function openLiveSerialPort(
       try {
         await p.open({ baudRate });
         return p;
-      } catch {
-        // Device still gone (NetworkError) or a stale handle — try the next
-        // candidate / next round.
+      } catch (err) {
+        // Device still gone (NetworkError) or a stale handle — keep the last
+        // error for the timeout breadcrumb and try the next candidate / round.
+        lastErr = err;
       }
     }
     if (Date.now() >= deadline) {
+      console.error("[Web Serial] Failed to reopen port for logs:", lastErr);
       return null;
     }
     await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -3,6 +3,73 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
+import { SERIAL_ACTIVITY_WINDOW_MS } from "./web-serial.js";
+
+// Reopen budget for a port closed by the post-install reset: covers the
+// native-USB re-enumeration window (``SERIAL_ACTIVITY_WINDOW_MS``) with margin
+// for a slower first enumeration on a brand-new board.
+const SERIAL_REOPEN_TIMEOUT_MS = SERIAL_ACTIVITY_WINDOW_MS + 2000;
+
+/**
+ * Human label for a Web Serial port, for error messages. Web Serial exposes
+ * no device path/name, only the USB vendor/product ids; fall back to a generic
+ * label when those are absent (non-USB ports).
+ */
+export function formatSerialPortLabel(port: SerialPort): string {
+  const { usbVendorId, usbProductId } = port.getInfo();
+  if (usbVendorId === undefined || usbProductId === undefined) {
+    return "USB serial device";
+  }
+  const hex = (n: number) => n.toString(16).padStart(4, "0");
+  return `USB ${hex(usbVendorId)}:${hex(usbProductId)}`;
+}
+
+/**
+ * Prompt for a Web Serial port and open it at log baud. Returns the open port,
+ * or ``null`` if the user dismissed the picker. Throws if a picked port can't
+ * be opened (claimed by another tab, driver error) — the caller surfaces that.
+ */
+export async function requestAndOpenSerialPort(): Promise<SerialPort | null> {
+  let port: SerialPort;
+  try {
+    port = await navigator.serial.requestPort();
+  } catch {
+    return null; // User dismissed the port picker.
+  }
+  await port.open({ baudRate: 115200 });
+  return port;
+}
+
+/**
+ * Reconnect a dead Web Serial logs session by acquiring a FRESH port via the
+ * picker, not reopening the cached handle.
+ *
+ * The post-install handoff caches the ``SerialPort`` esptool used for flashing;
+ * on a native-USB chip (C3 / S3 / C6) the post-flash reset re-enumerates the
+ * USB device and that download-mode handle never reopens. Re-running the picker
+ * (the dialog's "Start" runs inside the click's user activation, so
+ * ``requestPort()`` is allowed) grabs the running firmware's live CDC — the
+ * same thing a manual "Logs → Web Serial" does, which is why that works.
+ */
+export async function reconnectWebSerialLogs(
+  logsDialog: ESPHomeLogsDialog,
+  localize: LocalizeFunc
+): Promise<void> {
+  let port: SerialPort | null;
+  try {
+    port = await requestAndOpenSerialPort();
+  } catch {
+    const message = localize("dashboard.logs_web_serial_open_failed");
+    logsDialog.setSerialOpenFailed(message);
+    toast.error(message, { richColors: true });
+    return;
+  }
+  if (!port) {
+    logsDialog.abortSerialReconnect(); // Picker dismissed — back to "Start", quietly.
+    return;
+  }
+  await attachSerialLogStream(port, logsDialog, localize);
+}
 
 /**
  * Detail shape of the cancelable ``request-show-logs-after-install``
@@ -140,9 +207,11 @@ export async function attachSerialLogStream(
   localize: LocalizeFunc
 ): Promise<void> {
   if (!port.readable) {
-    const opened = await openSerialWithRetry(port, 115200, 5000);
+    const opened = await openSerialWithRetry(port, 115200, SERIAL_REOPEN_TIMEOUT_MS);
     if (!opened) {
-      const message = localize("dashboard.logs_port_reopen_failed");
+      const message = localize("dashboard.logs_port_reopen_failed", {
+        port: formatSerialPortLabel(port),
+      });
       logsDialog.setSerialOpenFailed(message);
       toast.error(message, { richColors: true });
       return;
@@ -170,8 +239,10 @@ export async function handlePostInstallShowLogs(
   if (webSerialPort) {
     logsDialog.openPassive({
       onBackToInstall: reopenInstall,
-      // "click Start to reconnect" after a reopen failure (#636).
-      onReconnect: () => attachSerialLogStream(webSerialPort, logsDialog, localize),
+      // "click Start to reconnect" after a reopen failure (#636). Re-acquire a
+      // fresh port via the picker rather than reopening the cached esptool
+      // handle, which a native-USB chip's post-flash re-enumeration leaves dead.
+      onReconnect: () => reconnectWebSerialLogs(logsDialog, localize),
     });
     /* Settling delay — some USB-UART bridges (notably the CH9102F on
        M5Stamp boards) don't resync their internal CDC state cleanly

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -18,7 +18,7 @@ const SERIAL_REOPEN_TIMEOUT_MS = SERIAL_ACTIVITY_WINDOW_MS + 2000;
 export function formatSerialPortLabel(port: SerialPort): string {
   const { usbVendorId, usbProductId } = port.getInfo();
   if (usbVendorId === undefined || usbProductId === undefined) {
-    return "the serial port";
+    return "unknown device";
   }
   const hex = (n: number) => n.toString(16).padStart(4, "0");
   return `USB ${hex(usbVendorId)}:${hex(usbProductId)}`;
@@ -206,9 +206,22 @@ async function openLiveSerialPort(
         await p.open({ baudRate });
         return p;
       } catch (err) {
-        // Device still gone (NetworkError) or a stale handle — keep the last
-        // error for the timeout breadcrumb and try the next candidate / round.
         lastErr = err;
+        const name = err instanceof DOMException ? err.name : "";
+        const message = err instanceof Error ? err.message : "";
+        // Already open (a reset race / another candidate) — usable as-is.
+        if (name === "InvalidStateError" && /already open/i.test(message)) {
+          return p;
+        }
+        // NetworkError means the device is still gone mid-re-enumeration: keep
+        // retrying the next candidate / round. Anything else (claimed by
+        // another app, driver / security error) won't fix itself by waiting —
+        // fail fast rather than stall the whole window behind a misleading
+        // "still restarting" message.
+        if (name !== "NetworkError") {
+          console.error("[Web Serial] Failed to reopen port for logs:", err);
+          return null;
+        }
       }
     }
     if (Date.now() >= deadline) {

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -3,7 +3,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
-import { SERIAL_ACTIVITY_WINDOW_MS } from "./web-serial.js";
+import { isPortPickerCancel, SERIAL_ACTIVITY_WINDOW_MS } from "./web-serial.js";
 
 // Reopen budget for a port closed by the post-install reset: covers the
 // native-USB re-enumeration window (``SERIAL_ACTIVITY_WINDOW_MS``) with margin
@@ -18,7 +18,7 @@ const SERIAL_REOPEN_TIMEOUT_MS = SERIAL_ACTIVITY_WINDOW_MS + 2000;
 export function formatSerialPortLabel(port: SerialPort): string {
   const { usbVendorId, usbProductId } = port.getInfo();
   if (usbVendorId === undefined || usbProductId === undefined) {
-    return "USB serial device";
+    return "the serial port";
   }
   const hex = (n: number) => n.toString(16).padStart(4, "0");
   return `USB ${hex(usbVendorId)}:${hex(usbProductId)}`;
@@ -33,8 +33,11 @@ export async function requestAndOpenSerialPort(): Promise<SerialPort | null> {
   let port: SerialPort;
   try {
     port = await navigator.serial.requestPort();
-  } catch {
-    return null; // User dismissed the port picker.
+  } catch (err) {
+    if (isPortPickerCancel(err)) {
+      return null; // User dismissed the port picker.
+    }
+    throw err; // A real requestPort failure — let the caller surface it.
   }
   await port.open({ baudRate: 115200 });
   return port;
@@ -149,8 +152,13 @@ export function postInstallShowLogsHandler(
   return (e) => handlePostInstallShowLogs(e, getLogsDialog(), getLocalize());
 }
 
+// Same USB device by vendor/product id. Requires both ids present so two
+// non-USB ports (``undefined === undefined``) aren't treated as a match.
 const matchesDevice = (a: SerialPortInfo, b: SerialPortInfo): boolean =>
-  a.usbVendorId === b.usbVendorId && a.usbProductId === b.usbProductId;
+  a.usbVendorId !== undefined &&
+  a.usbProductId !== undefined &&
+  a.usbVendorId === b.usbVendorId &&
+  a.usbProductId === b.usbProductId;
 
 /**
  * Open the live SerialPort for a device the post-install hard-reset just

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -99,7 +99,7 @@ let _lastSerialActivityMs = 0;
 // plus our internal disconnect → port.close → optional hard_reset
 // chain. Bursts of re-enum events extend the window further (see
 // the handler in ``app-shell``), so this is just the floor.
-const SERIAL_ACTIVITY_WINDOW_MS = 6000;
+export const SERIAL_ACTIVITY_WINDOW_MS = 6000;
 
 export function markSerialActivity(): void {
   _lastSerialActivityMs = Date.now();

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../src/util/web-serial.js", () => ({
   disconnect: vi.fn(),
   flashFirmware: vi.fn(),
   resetAndDisconnect: vi.fn(),
+  SERIAL_ACTIVITY_WINDOW_MS: 6000,
 }));
 
 import {

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/util/web-serial.js", () => ({
   disconnect: vi.fn(),
   flashFirmware: vi.fn(),
   resetAndDisconnect: vi.fn(),
+  SERIAL_ACTIVITY_WINDOW_MS: 6000,
 }));
 
 import {

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -377,5 +377,20 @@ describe("logs-dialog passive Web Serial session (#526)", () => {
     el.setSerialOpenFailed("gone");
     expect(hasSerialPort(session(el))).toBe(false);
   });
+
+  it("abortSerialReconnect drops to dead with no error line or toast", () => {
+    el.openPassive({ onReconnect: () => Promise.resolve() });
+    expect(session(el).kind).toBe("reconnecting");
+    el.abortSerialReconnect();
+    expect(session(el).kind).toBe("dead");
+    expect((el as any)._lines).toEqual([]); // a cancel isn't a failure
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("abortSerialReconnect is a no-op for a non-passive (OTA) session", () => {
+    el.open("OTA");
+    el.abortSerialReconnect();
+    expect(session(el).kind).toBe("ota");
+  });
 });
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -63,6 +63,16 @@ function withRequestPort(impl: () => Promise<SerialPort>): () => void {
   return () =>
     Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
 }
+
+function withGetPorts(impl: () => Promise<SerialPort[]>): () => void {
+  const prev = (navigator as any).serial;
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    value: { getPorts: vi.fn(impl) },
+  });
+  return () =>
+    Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
+}
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 afterEach(() => {
@@ -125,13 +135,38 @@ describe("reconnectWebSerialLogs", () => {
   });
 });
 
-describe("attachSerialLogStream reopen failure", () => {
-  it("names the port being tried in the failure message", async () => {
+describe("attachSerialLogStream reopen", () => {
+  it("opens a fresh getPorts() handle when the cached one is dead (Chrome re-enum)", async () => {
+    // The cached esptool handle won't reopen, but getPorts() yields a live one
+    // for the same device — the auto path must recover with no picker.
+    const live = openPort();
+    const restore = withGetPorts(async () => [live]);
     const dialog = stubDialog();
-    await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
-    expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
-    const message = dialog.setSerialOpenFailed.mock.calls[0][0] as string;
-    expect(message).toContain("USB 303a:1001");
-    expect(toastError).toHaveBeenCalledTimes(1);
+    try {
+      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialStream.mock.calls[0][0]).toBe(live); // streamed the live handle
+      expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("names the port in the failure message when nothing opens in the window", async () => {
+    vi.useFakeTimers();
+    const restore = withGetPorts(async () => []); // device never reappears
+    const dialog = stubDialog();
+    try {
+      const done = attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      await vi.advanceTimersByTimeAsync(8100);
+      await done;
+      expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
+      const message = dialog.setSerialOpenFailed.mock.calls[0][0] as string;
+      expect(message).toContain("USB 303a:1001");
+      expect(toastError).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The post-install Web Serial logs handoff: reconnect must re-acquire a FRESH
+ * port via the picker (the cached esptool handle is dead after a native-USB
+ * chip's post-flash re-enumeration), and the reopen-failure message names the
+ * port being tried.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/components/dashboard/actions.js", () => ({
+  streamSerialToDialog: () => () => {},
+}));
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+vi.mock("sonner-js", () => ({ default: { error: toastError } }));
+
+import { defaultLocalize } from "../../src/common/localize.js";
+import {
+  attachSerialLogStream,
+  formatSerialPortLabel,
+  reconnectWebSerialLogs,
+} from "../../src/util/post-install-logs.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function openPort(
+  info: SerialPortInfo = { usbVendorId: 0x303a, usbProductId: 0x1001 }
+): SerialPort {
+  return {
+    readable: {} as ReadableStream,
+    getInfo: () => info,
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    setSignals: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SerialPort;
+}
+
+// A closed port whose open() rejects with a non-NetworkError, so the reopen
+// retry bails immediately (no fake timers needed).
+function deadPort(): SerialPort {
+  return {
+    readable: null,
+    getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+    open: vi.fn().mockRejectedValue(new Error("nope")),
+    setSignals: vi.fn(),
+  } as unknown as SerialPort;
+}
+
+function stubDialog() {
+  return {
+    setSerialStream: vi.fn(),
+    setSerialOpenFailed: vi.fn(),
+    abortSerialReconnect: vi.fn(),
+  };
+}
+
+function withRequestPort(impl: () => Promise<SerialPort>): () => void {
+  const prev = (navigator as any).serial;
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    value: { requestPort: vi.fn(impl) },
+  });
+  return () =>
+    Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("formatSerialPortLabel", () => {
+  it("formats USB vendor:product as 4-digit hex", () => {
+    expect(formatSerialPortLabel(openPort())).toBe("USB 303a:1001");
+  });
+
+  it("falls back to a generic label when USB ids are absent", () => {
+    expect(formatSerialPortLabel(openPort({}))).toBe("USB serial device");
+  });
+});
+
+describe("reconnectWebSerialLogs", () => {
+  it("acquires a fresh port via requestPort and streams it", async () => {
+    const restore = withRequestPort(async () => openPort());
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((navigator as any).serial.requestPort).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns to dead without an error when the picker is dismissed", async () => {
+    const restore = withRequestPort(async () => {
+      throw new Error("dismissed");
+    });
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      expect(dialog.abortSerialReconnect).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+      expect(toastError).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an open failure when the picked port won't open", async () => {
+    const port = openPort();
+    (port.open as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("claimed"));
+    const restore = withRequestPort(async () => port);
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("attachSerialLogStream reopen failure", () => {
+  it("names the port being tried in the failure message", async () => {
+    const dialog = stubDialog();
+    await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+    expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
+    const message = dialog.setSerialOpenFailed.mock.calls[0][0] as string;
+    expect(message).toContain("USB 303a:1001");
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -1,10 +1,11 @@
 /**
  * @vitest-environment happy-dom
  *
- * The post-install Web Serial logs handoff: reconnect must re-acquire a FRESH
- * port via the picker (the cached esptool handle is dead after a native-USB
- * chip's post-flash re-enumeration), and the reopen-failure message names the
- * port being tried.
+ * The post-install Web Serial logs handoff. After a native-USB chip's
+ * post-flash re-enumeration the cached esptool handle is dead, so the auto
+ * reopen prefers a fresh navigator.serial.getPorts() handle (no picker); only
+ * the user-gesture "Start" reconnect re-prompts via requestPort(). The
+ * reopen-failure message names the port being tried.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -56,24 +57,35 @@ function stubDialog() {
   };
 }
 
+// Restore the original `navigator.serial`, deleting the injected property when
+// it didn't exist before (happy-dom has none) so a leaked `"serial" in
+// navigator` can't make later tests order-dependent.
+function restoreSerial(had: boolean, prev: unknown): () => void {
+  return () => {
+    if (had) {
+      Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
+    } else {
+      delete (navigator as any).serial;
+    }
+  };
+}
+
 function withRequestPort(impl: () => Promise<SerialPort>): () => void {
-  const prev = (navigator as any).serial;
+  const restore = restoreSerial("serial" in navigator, (navigator as any).serial);
   Object.defineProperty(navigator, "serial", {
     configurable: true,
     value: { requestPort: vi.fn(impl) },
   });
-  return () =>
-    Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
+  return restore;
 }
 
 function withGetPorts(impl: () => Promise<SerialPort[]>): () => void {
-  const prev = (navigator as any).serial;
+  const restore = restoreSerial("serial" in navigator, (navigator as any).serial);
   Object.defineProperty(navigator, "serial", {
     configurable: true,
     value: { getPorts: vi.fn(impl) },
   });
-  return () =>
-    Object.defineProperty(navigator, "serial", { configurable: true, value: prev });
+  return restore;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -35,13 +35,15 @@ function openPort(
   } as unknown as SerialPort;
 }
 
-// A closed port whose open() rejects with a non-NetworkError, so the reopen
-// retry bails immediately (no fake timers needed).
-function deadPort(): SerialPort {
+// A closed port whose open() always rejects. Defaults to a non-NetworkError
+// (the reopen bails fast); pass a NetworkError to exercise the retry window.
+function deadPort(
+  error: unknown = new DOMException("blocked", "SecurityError")
+): SerialPort {
   return {
     readable: null,
     getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
-    open: vi.fn().mockRejectedValue(new Error("nope")),
+    open: vi.fn().mockRejectedValue(error),
     setSignals: vi.fn(),
   } as unknown as SerialPort;
 }
@@ -85,7 +87,7 @@ describe("formatSerialPortLabel", () => {
   });
 
   it("falls back to a neutral label when USB ids are absent", () => {
-    expect(formatSerialPortLabel(openPort({}))).toBe("the serial port");
+    expect(formatSerialPortLabel(openPort({}))).toBe("unknown device");
   });
 });
 
@@ -168,18 +170,39 @@ describe("attachSerialLogStream reopen", () => {
     }
   });
 
-  it("names the port in the failure message and logs a breadcrumb when nothing opens", async () => {
+  it("fails fast on a non-recoverable open error (no waiting out the window)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const restore = withGetPorts(async () => []);
+    const dialog = stubDialog();
+    try {
+      // SecurityError won't fix itself by waiting — bail without fake timers.
+      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialOpenFailed.mock.calls[0][0] as string).toContain(
+        "USB 303a:1001"
+      );
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+      restore();
+    }
+  });
+
+  it("retries NetworkError across the window, then names the port and logs a breadcrumb", async () => {
     vi.useFakeTimers();
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const restore = withGetPorts(async () => []); // device never reappears
     const dialog = stubDialog();
     try {
-      const done = attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      const port = deadPort(new DOMException("gone", "NetworkError"));
+      const done = attachSerialLogStream(port, dialog as never, defaultLocalize);
       await vi.advanceTimersByTimeAsync(8100);
       await done;
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
-      const message = dialog.setSerialOpenFailed.mock.calls[0][0] as string;
-      expect(message).toContain("USB 303a:1001");
+      expect(dialog.setSerialOpenFailed.mock.calls[0][0] as string).toContain(
+        "USB 303a:1001"
+      );
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(errSpy).toHaveBeenCalled(); // last open error logged for field debugging
     } finally {

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -84,8 +84,8 @@ describe("formatSerialPortLabel", () => {
     expect(formatSerialPortLabel(openPort())).toBe("USB 303a:1001");
   });
 
-  it("falls back to a generic label when USB ids are absent", () => {
-    expect(formatSerialPortLabel(openPort({}))).toBe("USB serial device");
+  it("falls back to a neutral label when USB ids are absent", () => {
+    expect(formatSerialPortLabel(openPort({}))).toBe("the serial port");
   });
 });
 
@@ -105,8 +105,9 @@ describe("reconnectWebSerialLogs", () => {
   });
 
   it("returns to dead without an error when the picker is dismissed", async () => {
+    // A dismissed picker rejects with DOMException NotFoundError.
     const restore = withRequestPort(async () => {
-      throw new Error("dismissed");
+      throw new DOMException("dismissed", "NotFoundError");
     });
     const dialog = stubDialog();
     try {
@@ -114,6 +115,21 @@ describe("reconnectWebSerialLogs", () => {
       expect(dialog.abortSerialReconnect).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
       expect(toastError).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces a non-cancel requestPort failure instead of swallowing it", async () => {
+    const restore = withRequestPort(async () => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();
     } finally {
       restore();
     }

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -168,8 +168,9 @@ describe("attachSerialLogStream reopen", () => {
     }
   });
 
-  it("names the port in the failure message when nothing opens in the window", async () => {
+  it("names the port in the failure message and logs a breadcrumb when nothing opens", async () => {
     vi.useFakeTimers();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const restore = withGetPorts(async () => []); // device never reappears
     const dialog = stubDialog();
     try {
@@ -180,7 +181,9 @@ describe("attachSerialLogStream reopen", () => {
       const message = dialog.setSerialOpenFailed.mock.calls[0][0] as string;
       expect(message).toContain("USB 303a:1001");
       expect(toastError).toHaveBeenCalledTimes(1);
+      expect(errSpy).toHaveBeenCalled(); // last open error logged for field debugging
     } finally {
+      errSpy.mockRestore();
       restore();
       vi.useRealTimers();
     }


### PR DESCRIPTION
# What does this implement/fix?

After flashing a native-USB ESP32 (C3 / S3 / C6) over Web Serial, the post-install "Logs" viewer failed to attach on **Chrome** ("Failed to reopen the serial port for logs…") and clicking Start did nothing useful, while **Firefox** showed the full boot log.

Root cause: the install→logs handoff reopened the same `SerialPort` esptool used for flashing. The post-flash reset re-enumerates the USB device. On Chrome the cached handle then stays dead (`open()` throws `NetworkError` indefinitely), whereas `navigator.serial.getPorts()` returns a fresh, openable handle for the same authorized device. Firefox reopens the cached handle directly, which is why it worked there.

Fix: when a closed port is reopened for logs, resolve the **live** port from `getPorts()` (matching the device's USB vendor/product, falling back to the cached handle for Firefox and non-re-enumerating UART bridges) and open that, retrying every 200 ms across the re-enumeration window. The logs now reconnect automatically on both browsers with no picker. A user-gesture reconnect via `requestPort()` on "Start" remains the last resort if the device is truly gone (a picker needs a click; `getPorts()` does not). The reopen-failure message now names the port (USB vendor:product).

Confirmed on hardware: on Chrome, `getPorts()` returns one port that opens after the C3 re-enumerates, while the cached handle's `open()` throws at the same time.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
