### PR TITLE
Resume USB device setup when actioned from another route

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -52,7 +52,13 @@ import {
   versionContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { stripBase } from "../util/base-path.js";
 import { isExpert } from "../util/experience.js";
+import { navigate } from "../util/navigation.js";
+import {
+  consumePendingSerialSetup,
+  markPendingSerialSetup,
+} from "../util/pending-serial-setup.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
@@ -336,15 +342,29 @@ export class ESPHomeApp extends LitElement {
       duration: 8000,
       action: {
         label: this._localize("layout.usb_device_setup"),
-        onClick: () => {
+        onClick: async () => {
           // Bridge the gap between the click and the first internal
           // markSerialActivity inside connectToPort — the chip
           // reset can fire a new connect event before that runs.
           markSerialActivity();
           toast.dismiss("esphome-usb-device-connected");
-          window.dispatchEvent(
-            new CustomEvent("esphome-serial-setup", { detail: { port } })
-          );
+          // The serial-setup handler and the wizard dialog live only on
+          // the dashboard; off-route the window event has no listener.
+          // On the dashboard, dispatch as before; elsewhere stash the
+          // port and navigate home so the dashboard resumes on mount.
+          if (stripBase(window.location.pathname) === "/") {
+            window.dispatchEvent(
+              new CustomEvent("esphome-serial-setup", { detail: { port } })
+            );
+            return;
+          }
+          markPendingSerialSetup(port);
+          await navigate("/");
+          // The editor / secrets leave guard can veto the navigation;
+          // clear the stash so a stale port can't fire on a later mount.
+          if (stripBase(window.location.pathname) !== "/") {
+            consumePendingSerialSetup();
+          }
         },
       },
     });

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -52,13 +52,7 @@ import {
   versionContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { stripBase } from "../util/base-path.js";
 import { isExpert } from "../util/experience.js";
-import { navigate } from "../util/navigation.js";
-import {
-  consumePendingSerialSetup,
-  markPendingSerialSetup,
-} from "../util/pending-serial-setup.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
@@ -75,6 +69,7 @@ import {
   subscribeToFollowJobs,
 } from "./app-shell/jobs.js";
 import { createRouter } from "./app-shell/router.js";
+import { dispatchOrStashSerialSetup } from "./app-shell/serial-setup.js";
 import {
   onPairRequestSent,
   onRemoteBuildJobDismissed,
@@ -342,29 +337,13 @@ export class ESPHomeApp extends LitElement {
       duration: 8000,
       action: {
         label: this._localize("layout.usb_device_setup"),
-        onClick: async () => {
+        onClick: () => {
           // Bridge the gap between the click and the first internal
           // markSerialActivity inside connectToPort — the chip
           // reset can fire a new connect event before that runs.
           markSerialActivity();
           toast.dismiss("esphome-usb-device-connected");
-          // The serial-setup handler and the wizard dialog live only on
-          // the dashboard; off-route the window event has no listener.
-          // On the dashboard, dispatch as before; elsewhere stash the
-          // port and navigate home so the dashboard resumes on mount.
-          if (stripBase(window.location.pathname) === "/") {
-            window.dispatchEvent(
-              new CustomEvent("esphome-serial-setup", { detail: { port } })
-            );
-            return;
-          }
-          markPendingSerialSetup(port);
-          await navigate("/");
-          // The editor / secrets leave guard can veto the navigation;
-          // clear the stash so a stale port can't fire on a later mount.
-          if (stripBase(window.location.pathname) !== "/") {
-            consumePendingSerialSetup();
-          }
+          void dispatchOrStashSerialSetup(port);
         },
       },
     });

--- a/src/components/app-shell/serial-setup.ts
+++ b/src/components/app-shell/serial-setup.ts
@@ -1,0 +1,31 @@
+import { stripBase } from "../../util/base-path.js";
+import { navigate } from "../../util/navigation.js";
+import {
+  consumePendingSerialSetup,
+  markPendingSerialSetup,
+} from "../../util/pending-serial-setup.js";
+
+/**
+ * Route the USB "Set it up" toast action to the dashboard.
+ *
+ * The serial-setup listener and the wizard live only on the dashboard;
+ * there, dispatch the live event. Elsewhere stash the port and navigate
+ * home so the dashboard resumes on mount. Clear the stash if the editor
+ * / secrets leave guard vetoes (or throws on) the navigation, so a stale
+ * port can't fire on a later, unrelated mount.
+ */
+export async function dispatchOrStashSerialSetup(port: SerialPort | null): Promise<void> {
+  if (stripBase(window.location.pathname) === "/") {
+    window.dispatchEvent(new CustomEvent("esphome-serial-setup", { detail: { port } }));
+    return;
+  }
+  markPendingSerialSetup(port);
+  try {
+    await navigate("/");
+  } catch {
+    // A misbehaving leave guard threw; the veto-clear below still runs.
+  }
+  if (stripBase(window.location.pathname) !== "/") {
+    consumePendingSerialSetup();
+  }
+}

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -389,7 +389,12 @@ export class ESPHomePageDashboard extends LitElement {
     // the prefs contexts driving _hideDeviceCreation land during it.
     const pendingSerial = consumePendingSerialSetup();
     if (pendingSerial !== null) {
-      void this.updateComplete.then(() => this._startSerialSetup(pendingSerial.port));
+      void this.updateComplete.then(() => {
+        // Bailed back off `/` before first render resolved; don't open the
+        // wizard against a torn-down host (the stash is already consumed).
+        if (!this.isConnected) return;
+        this._startSerialSetup(pendingSerial.port);
+      });
     }
   }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -106,6 +106,7 @@ import { UPDATE_FACET_BUCKETS, UPDATE_FACET_PREDICATES } from "../util/facets.js
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
+import { consumePendingSerialSetup } from "../util/pending-serial-setup.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { classifyNoCompatiblePeerReason } from "../util/version-mismatch.js";
@@ -311,10 +312,14 @@ export class ESPHomePageDashboard extends LitElement {
   ];
 
   private _onSerialSetup = (event: Event) => {
+    const port = (event as CustomEvent<{ port: SerialPort | null }>).detail?.port ?? null;
+    this._startSerialSetup(port);
+  };
+
+  private _startSerialSetup(port: SerialPort | null): void {
     // Remote-compute installs don't create devices; a plugged-in board
     // shouldn't pop the creation wizard.
     if (this._hideDeviceCreation) return;
-    const port = (event as CustomEvent<{ port: SerialPort | null }>).detail?.port ?? null;
     void detectAndOpenWizard(this._api, this._createDialog, {
       port,
       devices: this._devices,
@@ -327,7 +332,7 @@ export class ESPHomePageDashboard extends LitElement {
       },
       localize: this._localize,
     });
-  };
+  }
   private _onShowIgnoredChanged = (e: Event) => {
     this._showIgnored = (e as CustomEvent<{ value: boolean }>).detail.value;
   };
@@ -378,6 +383,13 @@ export class ESPHomePageDashboard extends LitElement {
     if (pending !== null) {
       this._highlightFreshDevice(pending);
       this._tryConsumePendingScroll();
+    }
+    // USB "Set it up" actioned from another route stashes the port and
+    // navigates here. Defer to first render: _createDialog (@query) and
+    // the prefs contexts driving _hideDeviceCreation land during it.
+    const pendingSerial = consumePendingSerialSetup();
+    if (pendingSerial !== null) {
+      void this.updateComplete.then(() => this._startSerialSetup(pendingSerial.port));
     }
   }
 

--- a/src/util/pending-serial-setup.ts
+++ b/src/util/pending-serial-setup.ts
@@ -1,0 +1,29 @@
+/**
+ * One-shot "resume USB setup on the dashboard's next mount" signal.
+ *
+ * The "USB device connected" toast is global, but the serial-setup
+ * handler and the create-config wizard live only on the dashboard. When
+ * the toast is actioned from another route (the device editor / secrets)
+ * we stash the captured ``SerialPort`` here and navigate to the
+ * dashboard, which consumes it on mount and opens the wizard.
+ *
+ * Backed by a module-level variable, not ``sessionStorage``: a live
+ * ``SerialPort`` isn't serializable, and ``navigate("/")`` is a
+ * same-document ``pushState`` so module state survives the route change.
+ * The wrapper object distinguishes a stashed ``null`` port (the toast
+ * can capture none) from "nothing pending".
+ */
+
+let pending: { port: SerialPort | null } | null = null;
+
+/** Stash *port* to be picked up by the dashboard's next mount. */
+export function markPendingSerialSetup(port: SerialPort | null): void {
+  pending = { port };
+}
+
+/** Atomically read + clear the stash; ``null`` when nothing's pending. */
+export function consumePendingSerialSetup(): { port: SerialPort | null } | null {
+  const p = pending;
+  pending = null;
+  return p;
+}

--- a/test/components/app-shell/serial-setup.test.ts
+++ b/test/components/app-shell/serial-setup.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the USB "Set it up" coordinator: dispatch on the dashboard, stash
+ * + navigate off-route, and clear the stash when the leave guard vetoes
+ * or throws (so a stale port can't fire on a later mount).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn(async () => {}) }));
+vi.mock("../../../src/util/navigation.js", async (importActual) => ({
+  ...(await importActual<typeof import("../../../src/util/navigation.js")>()),
+  navigate,
+}));
+
+import { dispatchOrStashSerialSetup } from "../../../src/components/app-shell/serial-setup.js";
+import { consumePendingSerialSetup } from "../../../src/util/pending-serial-setup.js";
+
+const fakePort = {} as SerialPort;
+
+describe("dispatchOrStashSerialSetup", () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    navigate.mockResolvedValue(undefined);
+    consumePendingSerialSetup(); // drain any stash leaked by a prior test
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("dispatches the event on the dashboard without stashing or navigating", async () => {
+    window.history.replaceState({}, "", "/");
+    const onEvent = vi.fn();
+    window.addEventListener("esphome-serial-setup", onEvent);
+    await dispatchOrStashSerialSetup(fakePort);
+    window.removeEventListener("esphome-serial-setup", onEvent);
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect((onEvent.mock.calls[0][0] as CustomEvent).detail.port).toBe(fakePort);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(consumePendingSerialSetup()).toBeNull();
+  });
+
+  it("stashes the port and navigates home from another route", async () => {
+    window.history.replaceState({}, "", "/device/foo.yaml");
+    navigate.mockImplementation(async () => {
+      window.history.replaceState({}, "", "/");
+    });
+    await dispatchOrStashSerialSetup(fakePort);
+
+    expect(navigate).toHaveBeenCalledWith("/");
+    // Navigation landed on the dashboard; the stash survives for it to consume.
+    expect(consumePendingSerialSetup()).toEqual({ port: fakePort });
+  });
+
+  it("clears the stash when the leave guard vetoes the navigation", async () => {
+    window.history.replaceState({}, "", "/device/foo.yaml");
+    navigate.mockImplementation(async () => {}); // veto: pathname unchanged
+    await dispatchOrStashSerialSetup(fakePort);
+
+    expect(consumePendingSerialSetup()).toBeNull();
+  });
+
+  it("clears the stash and never rejects when the leave guard throws", async () => {
+    window.history.replaceState({}, "", "/device/foo.yaml");
+    navigate.mockImplementation(async () => {
+      throw new Error("guard boom");
+    });
+    await expect(dispatchOrStashSerialSetup(fakePort)).resolves.toBeUndefined();
+
+    expect(consumePendingSerialSetup()).toBeNull();
+  });
+});

--- a/test/pages/dashboard-pending-serial-setup.test.ts
+++ b/test/pages/dashboard-pending-serial-setup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the dashboard resumes a USB "Set it up" stashed from another
+ * route: on mount it consumes the pending SerialPort and opens the wizard,
+ * still honouring the _hideDeviceCreation gate.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markPendingSerialSetup } from "../../src/util/pending-serial-setup.js";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+vi.mock("../../src/components/dashboard/actions.js", async (importActual) => ({
+  ...(await importActual<typeof import("../../src/components/dashboard/actions.js")>()),
+  detectAndOpenWizard: vi.fn(async () => {}),
+}));
+
+import { detectAndOpenWizard } from "../../src/components/dashboard/actions.js";
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+
+const fakePort = {} as SerialPort;
+
+async function flushPending(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+async function mountDashboard(
+  hideDeviceCreation: boolean
+): Promise<ESPHomePageDashboard> {
+  const page = new ESPHomePageDashboard();
+  // _hideDeviceCreation is `_remoteComputeOnly || !_prefsLoaded`; seed the
+  // consumed context fields directly before connectedCallback runs.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._prefsLoaded = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._remoteComputeOnly = hideDeviceCreation;
+  document.body.appendChild(page);
+  await page.updateComplete;
+  await flushPending();
+  return page;
+}
+
+describe("dashboard pending serial setup", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+    vi.mocked(detectAndOpenWizard).mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("opens the wizard with the stashed port on mount", async () => {
+    markPendingSerialSetup(fakePort);
+    await mountDashboard(false);
+    expect(detectAndOpenWizard).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(detectAndOpenWizard).mock.calls[0][2]!.port).toBe(fakePort);
+  });
+
+  it("does nothing when there is no pending port", async () => {
+    await mountDashboard(false);
+    expect(detectAndOpenWizard).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the wizard when device creation is hidden", async () => {
+    markPendingSerialSetup(fakePort);
+    await mountDashboard(true);
+    expect(detectAndOpenWizard).not.toHaveBeenCalled();
+  });
+});

--- a/test/pages/dashboard-pending-serial-setup.test.ts
+++ b/test/pages/dashboard-pending-serial-setup.test.ts
@@ -68,4 +68,18 @@ describe("dashboard pending serial setup", () => {
     await mountDashboard(true);
     expect(detectAndOpenWizard).not.toHaveBeenCalled();
   });
+
+  it("does not open the wizard if the dashboard is torn down before first render", async () => {
+    markPendingSerialSetup(fakePort);
+    const page = new ESPHomePageDashboard();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._prefsLoaded = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any)._remoteComputeOnly = false;
+    document.body.appendChild(page); // connectedCallback consumes + schedules
+    page.remove(); // disconnect before updateComplete resolves
+    await page.updateComplete;
+    await flushPending();
+    expect(detectAndOpenWizard).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/pending-serial-setup.test.ts
+++ b/test/util/pending-serial-setup.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumePendingSerialSetup,
+  markPendingSerialSetup,
+} from "../../src/util/pending-serial-setup.js";
+
+// A live SerialPort is opaque here; identity is all the stash cares about.
+const fakePort = {} as SerialPort;
+
+describe("pending-serial-setup", () => {
+  it("returns null when nothing is pending", () => {
+    expect(consumePendingSerialSetup()).toBeNull();
+  });
+
+  it("round-trips the stashed port", () => {
+    markPendingSerialSetup(fakePort);
+    expect(consumePendingSerialSetup()).toEqual({ port: fakePort });
+  });
+
+  it("clears after consumption (one-shot)", () => {
+    markPendingSerialSetup(fakePort);
+    consumePendingSerialSetup();
+    // Resumes on the dashboard's next mount only, not every mount after.
+    expect(consumePendingSerialSetup()).toBeNull();
+  });
+
+  it("distinguishes a stashed null port from nothing pending", () => {
+    // The toast can capture port === null; the wrapper keeps that
+    // distinct from the no-pending null so the wizard still opens.
+    markPendingSerialSetup(null);
+    expect(consumePendingSerialSetup()).toEqual({ port: null });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The global "USB device connected" toast's "Set it up" action did nothing when the user was inside the device editor or the secrets page; it only worked on the main dashboard. The toast is mounted app-wide, but its action dispatches a `esphome-serial-setup` window event whose only listener, and the create-config wizard it opens, live on the dashboard page; the router unmounts the dashboard on every other route, so off the dashboard the event had no handler and the dialog was not in the DOM.

Now the action branches on the current route; on the dashboard it dispatches as before, and elsewhere it stashes the live `SerialPort` and navigates home, where the dashboard consumes it on mount and resumes the same detect-and-open-wizard flow. The editor and secrets pages install a leave guard that can veto the navigation; in that case the stash is cleared so a stale port cannot fire on a later, unrelated dashboard mount.

**Related issue or feature (if applicable):**

Found during manual testing; clicking "Set it up" from inside the editor.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
