### PR TITLE
Fix Web Serial flashing of ESP8266 (flash at 0x0, boot-mode reset)

### DIFF
--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -34,6 +34,33 @@ export function compileFailureDetail(err: unknown): string {
   return err instanceof Error ? err.message.trim() : String(err ?? "").trim();
 }
 
+/**
+ * Choose which binary to flash over Web Serial and its flash offset.
+ *
+ * ESP8266 / ESP8285 flash a single complete ``firmware.bin`` at 0x0; ESP32 uses
+ * a merged ``*.factory.bin`` (bootloader + partitions + app) at 0x0, falling
+ * back to the app image at 0x10000. Flashing an ESP8266 image at 0x10000 leaves
+ * the boot address empty so the chip never boots (#1529). Returns ``null`` when
+ * there's no binary to flash.
+ *
+ * ``chipName`` is esptool-js's chip *description* (``loader.main()`` returns
+ * ``getChipDescription()`` — e.g. ``ESP8266EX`` / ``ESP8285``, not ``ESP8266``),
+ * so normalize it via ``chipNameToVariant`` and match the ``esp82`` family.
+ */
+export function pickFlashTarget(
+  chipName: string,
+  binaries: FirmwareBinary[]
+): { binary: FirmwareBinary; address: number } | null {
+  const factory = binaries.find((b) => b.file.includes("factory"));
+  const binary = factory ?? binaries[0];
+  if (!binary) return null;
+  // ESP8266 / ESP8285 are the only "esp82…" family — both flash a single
+  // complete image at 0x0, unlike ESP32's app-at-0x10000 layout.
+  const isEsp8266 = chipNameToVariant(chipName).startsWith("esp82");
+  const atZero = factory !== undefined || isEsp8266;
+  return { binary, address: atZero ? 0x0 : 0x10000 };
+}
+
 export async function startWebSerialInstall(
   host: ESPHomeFirmwareInstallDialog
 ): Promise<void> {
@@ -122,19 +149,17 @@ export async function startWebSerialInstall(
   // 4. Download binary
   host._statusMessage = host._localize("firmware.status_downloading");
   let firmwareBytes: Uint8Array;
-  let flashAddress = 0x10000;
+  let flashAddress: number;
   try {
     const binaries = await host._api.firmwareGetBinaries(device.configuration);
-    // Prefer factory binary (flashes at 0x0, includes bootloader).
-    const factory = binaries.find((b) => b.file.includes("factory"));
-    const binary = factory || binaries[0];
-    if (!binary) {
+    const target = pickFlashTarget(detected.chipName, binaries);
+    if (!target) {
       host._fail(host._localize("serial.no_firmware"));
       return;
     }
-    if (factory) flashAddress = 0x0;
+    flashAddress = target.address;
     firmwareBytes = new Uint8Array(
-      await host._api.firmwareDownloadBytes(device.configuration, binary.file)
+      await host._api.firmwareDownloadBytes(device.configuration, target.binary.file)
     );
   } catch {
     host._fail(host._localize("firmware.download_failed"));

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -5,7 +5,7 @@
  * Web Serial API. No backend involvement — talks directly to the
  * USB-connected ESP device.
  */
-import { ClassicReset, ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
+import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
 
 /** Espressif's USB Vendor ID — chips with native USB-Serial/JTAG. */
 const ESPRESSIF_USB_VID = 0x303a;
@@ -284,7 +284,7 @@ export async function flashFirmware(
  * trick precisely because DTR/RTS-based resets are unreliable on
  * native-USB / USB-Serial-JTAG chips and on boards whose auto-reset
  * circuit doesn't have the cross-coupled "cancellation" behaviour the
- * standard ClassicReset sequence assumes (M5Stamp C3 with CH9102F is
+ * standard DTR/RTS reset sequence assumes (M5Stamp C3 with CH9102F is
  * one such combination — the user-reported repro of this fix).
  *
  * Disabled on ESP32-C6 (causes full system freeze per Espressif docs)
@@ -373,6 +373,19 @@ async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<b
 }
 
 /**
+ * Boot the just-flashed firmware on a classic ESP32 / ESP8266 behind a UART
+ * bridge: pulse EN (RTS) low→high while leaving GPIO0 (DTR) released, so the
+ * chip resets out of the bootloader and runs the app. Mirrors esptool's
+ * ``--after hard-reset`` and the legacy dashboard's ``resetSerialDevice``.
+ */
+async function classicHardReset(transport: Transport): Promise<void> {
+  await transport.setDTR(false); // GPIO0 high → boot from flash, not download mode
+  await transport.setRTS(true); // EN low (hold in reset)
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await transport.setRTS(false); // EN high → boot the app
+}
+
+/**
  * Pick a reset strategy based on the chip and how it's connected.
  *
  * esptool-js's ``loader.after("hard_reset")`` resolves to its
@@ -391,8 +404,11 @@ async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<b
  *   list (mostly fall-through; safety net): esptool-js's
  *   ``UsbJtagSerialReset``.
  * - Everything else (classic ESP32 / ESP8266 via CP210x / CH340 /
- *   FTDI / etc. bridges): the standard DTR/RTS pulse esptool's
- *   ``--after hard-reset`` uses (``ClassicReset``).
+ *   FTDI / etc. bridges): an EN pulse with GPIO0 released
+ *   (``classicHardReset``), matching esptool's ``--after hard-reset``.
+ *   esptool-js's ``ClassicReset`` is NOT this — it's the
+ *   *enter-bootloader* sequence (drives GPIO0 low as EN releases), which
+ *   left the just-flashed chip stuck in the serial bootloader (#1529).
  */
 async function hardResetChip(
   loader: ESPLoader,
@@ -404,7 +420,7 @@ async function hardResetChip(
   if (vendorId === ESPRESSIF_USB_VID) {
     await new UsbJtagSerialReset(transport).reset();
   } else {
-    await new ClassicReset(transport, 50).reset();
+    await classicHardReset(transport);
   }
 }
 

--- a/test/components/firmware-install-flash-target.test.ts
+++ b/test/components/firmware-install-flash-target.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Web Serial flash-target selection. ESP8266's firmware.bin is a complete image
+ * at 0x0; flashing it at the ESP32 app offset (0x10000) leaves the boot address
+ * empty so the chip never boots (#1529).
+ */
+import { describe, expect, it } from "vitest";
+import type { FirmwareBinary } from "../../src/api/types/firmware-jobs.js";
+import { pickFlashTarget } from "../../src/components/firmware-install-dialog/install-flow.js";
+
+const bin = (file: string): FirmwareBinary => ({ title: file, file });
+
+describe("pickFlashTarget", () => {
+  // esptool-js reports the chip *description*, not the bare family name.
+  it("flashes an ESP8266EX firmware.bin at 0x0 (no factory variant exists)", () => {
+    const target = pickFlashTarget("ESP8266EX", [
+      bin("firmware.bin"),
+      bin("firmware.elf"),
+    ]);
+    expect(target).toEqual({ binary: bin("firmware.bin"), address: 0x0 });
+  });
+
+  it("flashes an ESP8285 firmware.bin at 0x0", () => {
+    const target = pickFlashTarget("ESP8285", [bin("firmware.bin")]);
+    expect(target).toEqual({ binary: bin("firmware.bin"), address: 0x0 });
+  });
+
+  it("flashes an ESP32 merged factory image at 0x0", () => {
+    const target = pickFlashTarget("ESP32-C3", [
+      bin("firmware.bin"),
+      bin("firmware.factory.bin"),
+    ]);
+    expect(target).toEqual({ binary: bin("firmware.factory.bin"), address: 0x0 });
+  });
+
+  it("flashes an ESP32 app image at 0x10000 when there's no factory image", () => {
+    const target = pickFlashTarget("ESP32-C3", [bin("firmware.bin")]);
+    expect(target).toEqual({ binary: bin("firmware.bin"), address: 0x10000 });
+  });
+
+  it("returns null when there are no binaries", () => {
+    expect(pickFlashTarget("ESP8266", [])).toBeNull();
+  });
+});

--- a/test/util/web-serial-reset.test.ts
+++ b/test/util/web-serial-reset.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The post-flash reset must boot the firmware, not re-enter the bootloader.
+ * For a classic ESP32 / ESP8266 behind a UART bridge that means an EN (RTS)
+ * pulse with GPIO0 (DTR) released — esptool-js's ClassicReset would instead
+ * drive GPIO0 low and strand the chip in the serial bootloader (#1529).
+ */
+import type { ESPLoader, Transport } from "esptool-js";
+import { describe, expect, it, vi } from "vitest";
+import { resetAndDisconnect } from "../../src/util/web-serial.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function fakeTransport() {
+  return {
+    setDTR: vi.fn().mockResolvedValue(undefined),
+    setRTS: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// An ESP8266 (no RTC watchdog) behind a CP210x bridge — the classic path.
+const esp8266Loader = { chip: { CHIP_NAME: "ESP8266" } } as unknown as ESPLoader;
+const cp210xPort = { getInfo: () => ({ usbVendorId: 0x10c4 }) } as unknown as SerialPort;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe("resetAndDisconnect — classic ESP32 / ESP8266 over a UART bridge", () => {
+  it("pulses EN and leaves GPIO0 released, then disconnects", async () => {
+    const transport = fakeTransport();
+    await resetAndDisconnect(
+      esp8266Loader,
+      transport as unknown as Transport,
+      cp210xPort
+    );
+
+    // EN pulse: RTS true (reset) then false (boot).
+    expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    // GPIO0/DTR is only ever released — never driven low (which would re-enter
+    // the download bootloader, the #1529 regression).
+    expect(transport.setDTR.mock.calls.every((c) => c[0] === false)).toBe(true);
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/util/web-serial-reset.test.ts
+++ b/test/util/web-serial-reset.test.ts
@@ -10,7 +10,6 @@ import type { ESPLoader, Transport } from "esptool-js";
 import { describe, expect, it, vi } from "vitest";
 import { resetAndDisconnect } from "../../src/util/web-serial.js";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 function fakeTransport() {
   return {
     setDTR: vi.fn().mockResolvedValue(undefined),
@@ -22,7 +21,6 @@ function fakeTransport() {
 // An ESP8266 (no RTC watchdog) behind a CP210x bridge — the classic path.
 const esp8266Loader = { chip: { CHIP_NAME: "ESP8266" } } as unknown as ESPLoader;
 const cp210xPort = { getInfo: () => ({ usbVendorId: 0x10c4 }) } as unknown as SerialPort;
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 describe("resetAndDisconnect — classic ESP32 / ESP8266 over a UART bridge", () => {
   it("pulses EN and leaves GPIO0 released, then disconnects", async () => {
@@ -35,8 +33,9 @@ describe("resetAndDisconnect — classic ESP32 / ESP8266 over a UART bridge", ()
 
     // EN pulse: RTS true (reset) then false (boot).
     expect(transport.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
-    // GPIO0/DTR is only ever released — never driven low (which would re-enter
+    // GPIO0/DTR is actively released and never driven low (which would re-enter
     // the download bootloader, the #1529 regression).
+    expect(transport.setDTR).toHaveBeenCalledWith(false);
     expect(transport.setDTR.mock.calls.every((c) => c[0] === false)).toBe(true);
     expect(transport.disconnect).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
# What does this implement/fix?

Flashing an ESP8266 over Web Serial completed but the chip never booted; downloading the binary and flashing via web.esphome.io or the classic backend worked. Two root causes, both ESP8266/UART-bridge specific:

**1. Wrong flash address (primary).** The install flow defaulted to `0x10000` (the ESP32 app partition) and only used `0x0` when a binary's filename contained `"factory"`. ESP8266 ships a single complete `firmware.bin` (PlatformIO's `esp8266_copy_factory_bin` output) with no `"factory"` variant, so it was written at `0x10000` — leaving the boot address empty. The serial log confirmed it: `Wrote 455760 bytes ... at 0x10000`. New `pickFlashTarget` flashes a merged `*factory*` image or any **esp82xx** (ESP8266 / ESP8285) `firmware.bin` at `0x0`; an ESP32 app-only image stays at `0x10000`. `chipName` is esptool-js's *description* (`loader.main()` returns `getChipDescription()` → `ESP8266EX` / `ESP8285`, not `ESP8266`), so it's normalized via `chipNameToVariant` and matched on the `esp82` family.

**2. Wrong post-flash reset.** The classic/UART-bridge branch used esptool-js's `ClassicReset`, which is the *enter-bootloader* sequence (drives GPIO0 low as it releases EN), leaving the chip in the serial bootloader. Replaced with `classicHardReset` — an EN pulse with GPIO0 released — matching esptool's `--after hard-reset`.

Both match the legacy dashboard (`esphome/dashboard`): its web-serial flasher always wrote a complete image at **`address: 0`** for every chip, and its `resetSerialDevice` is the same RTS pulse. The watchdog-reset path (ESP32-S2/S3/C2/C3) and native USB-Serial/JTAG path are unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1529

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
