### PR TITLE
Hide browser Web Serial install for non-ESP platforms (RP2040 / RP2350, nrf52, libretiny)

### DIFF
--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -112,14 +112,19 @@ export class ESPHomeInstallMethodDialog extends LitElement {
   }
 
   /**
-   * web.esphome.io / esp-web-tools only supports ESP32 (all variants)
-   * and ESP8266. UF2 platforms (RP2040, nrf52, libretiny) ship a
-   * different binary format that the browser flasher can't handle, so
-   * we hide the option entirely for those.
+   * ESP32 (all variants) and ESP8266 / ESP8285 — the only chips the browser
+   * flashers can handle. Both Web Serial (esptool-js) and web.esphome.io /
+   * esp-web-tools speak the esptool ROM protocol. Non-ESP targets can't be
+   * flashed from the browser: RP2040 / RP2350 and nrf52 use a BOOTSEL /
+   * 1200-baud touch + UF2 mass-storage copy, and libretiny (bk72xx / rtl87xx /
+   * ln882x) uses ltchiptool's own serial protocol — only the backend
+   * (`esphome run` / server-serial) flashes those. So the Web Serial and
+   * web-download rows are hidden for them.
    */
-  private get _supportsWebDownload(): boolean {
+  private get _isEsptoolPlatform(): boolean {
     const p = this.deviceTargetPlatform.toLowerCase();
-    return p.startsWith("esp32") || p === "esp8266";
+    // esp82… covers esp8266 and esp8285.
+    return p.startsWith("esp32") || p.startsWith("esp82");
   }
 
   protected willUpdate(changed: Map<string, unknown>) {
@@ -174,8 +179,12 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     // Replaces the disabled WebSerial row with web-download when
     // not online (offline or unknown) and no Web Serial. OTA is
     // offered above but may fail; web-download always works.
+    // Browser flashers (Web Serial esptool-js, web.esphome.io) are ESP-only.
+    // Non-ESP targets (RP2040 / RP2350, nrf52, libretiny) flash over serial
+    // only via the backend (`esphome run` / server-serial), never the browser.
+    const isEsptool = this._isEsptoolPlatform;
     const swapInWebDownload =
-      this.mode === "install" && !hasWebSerial && !isOnline && this._supportsWebDownload;
+      this.mode === "install" && !hasWebSerial && !isOnline && isEsptool;
     // On localhost the WebSerial option and the server-serial option
     // target the same physical USB stack. There are two collapse cases:
     //
@@ -191,7 +200,10 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     // KEEP the disabled row — it carries an actionable "open at 127.0.0.1 /
     // https" fix, so it isn't dead weight. On HA / remote both rows point at
     // different machines, so both always stay.
-    const showServerSerialRow = !(env === "localhost" && hasWebSerial);
+    // Only collapse the server-serial row in favour of Web Serial when Web
+    // Serial is actually shown (esptool platform) — otherwise a non-ESP device
+    // on localhost would lose its only working serial path.
+    const showServerSerialRow = !(env === "localhost" && hasWebSerial && isEsptool);
     const dropDisabledWebSerial =
       env === "localhost" && availability === "unsupported" && !swapInWebDownload;
     const serverSerialKeys = this._serverSerialCopyKeys(env);
@@ -201,9 +213,9 @@ export class ESPHomeInstallMethodDialog extends LitElement {
         ${this._renderOtaOption(isOnline)}
         ${swapInWebDownload
           ? this._renderWebDownloadOption()
-          : dropDisabledWebSerial
-            ? nothing
-            : this._renderWebSerialOption(availability)}
+          : isEsptool && !dropDisabledWebSerial
+            ? this._renderWebSerialOption(availability)
+            : nothing}
         ${showServerSerialRow
           ? html`<div class="option" @click=${this._onServerSerial}>
               <wa-icon library="mdi" name="serial-port"></wa-icon>

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -120,6 +120,11 @@ export class ESPHomeInstallMethodDialog extends LitElement {
    * ln882x) uses ltchiptool's own serial protocol — only the backend
    * (`esphome run` / server-serial) flashes those. So the Web Serial and
    * web-download rows are hidden for them.
+   *
+   * Fail-closed: an empty / unknown platform returns false, so we never offer a
+   * browser flasher that won't work (server-serial / OTA stay). target_platform
+   * is reliably populated for configured devices, so this only ever hides Web
+   * Serial transiently before metadata loads.
    */
   private get _isEsptoolPlatform(): boolean {
     const p = this.deviceTargetPlatform.toLowerCase();

--- a/test/components/install-method-dialog-web-serial-availability.test.ts
+++ b/test/components/install-method-dialog-web-serial-availability.test.ts
@@ -43,6 +43,9 @@ async function mount(): Promise<ESPHomeInstallMethodDialog> {
   (dialog as any)._localize = defaultLocalize;
   (dialog as any)._api = {}; // detectEnvironment only needs serverInfo?.ha_addon
   dialog.deviceState = DeviceState.ONLINE;
+  // Web Serial availability messaging only applies to ESP (esptool) platforms;
+  // the row is hidden for non-ESP targets.
+  dialog.deviceTargetPlatform = "esp32";
   document.body.appendChild(dialog);
   await dialog.updateComplete;
   return dialog;

--- a/test/components/install-method-dialog-web-serial-platform.test.ts
+++ b/test/components/install-method-dialog-web-serial-platform.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Browser Web Serial (esptool-js) is ESP-only. Non-ESP targets — RP2040 /
+ * RP2350, nrf52, libretiny (bk72xx / rtl87xx / ln882x) — can't be flashed from
+ * the browser, so the Web Serial install row is hidden for them; server-serial
+ * (`esphome run`) stays available, even on localhost where it's normally
+ * collapsed into Web Serial.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { DeviceState } from "../../src/api/types/devices.js";
+import { defaultLocalize } from "../../src/common/localize.js";
+import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const origSerial = Object.getOwnPropertyDescriptor(navigator, "serial");
+const origSecure = Object.getOwnPropertyDescriptor(window, "isSecureContext");
+const origLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+// Localhost, secure, Web Serial available — the case where server-serial is
+// normally dropped in favour of Web Serial.
+function setLocalhostWithWebSerial() {
+  Object.defineProperty(navigator, "serial", { configurable: true, value: {} });
+  Object.defineProperty(window, "isSecureContext", { configurable: true, value: true });
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { hostname: "localhost", href: "http://localhost:6052/" },
+  });
+}
+
+async function mount(platform: string): Promise<ESPHomeInstallMethodDialog> {
+  const dialog = new ESPHomeInstallMethodDialog();
+  (dialog as any)._localize = defaultLocalize;
+  (dialog as any)._api = {};
+  dialog.deviceState = DeviceState.ONLINE;
+  dialog.deviceTargetPlatform = platform;
+  document.body.appendChild(dialog);
+  await dialog.updateComplete;
+  return dialog;
+}
+
+// Rows are identified by their leading icon: Web Serial uses "usb",
+// server-serial uses "serial-port".
+const hasWebSerialRow = (d: ESPHomeInstallMethodDialog): boolean =>
+  !!d.shadowRoot!.querySelector('wa-icon[name="usb"]');
+const hasServerSerialRow = (d: ESPHomeInstallMethodDialog): boolean =>
+  !!d.shadowRoot!.querySelector('wa-icon[name="serial-port"]');
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+beforeEach(() => {
+  setLocalhostWithWebSerial();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  if (origSerial) Object.defineProperty(navigator, "serial", origSerial);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  else if ("serial" in navigator) delete (navigator as any).serial;
+  if (origSecure) Object.defineProperty(window, "isSecureContext", origSecure);
+  if (origLocation) Object.defineProperty(window, "location", origLocation);
+  vi.restoreAllMocks();
+});
+
+describe("install-method-dialog platform gating", () => {
+  // ESPHome's platform key for RP2350 is "rp2040"; "rp2350" included defensively.
+  it.each(["rp2040", "rp2350", "nrf52", "bk72xx", "rtl87xx", "ln882x"])(
+    "hides Web Serial and keeps server-serial for non-ESP platform %s",
+    async (platform) => {
+      const d = await mount(platform);
+      expect(hasWebSerialRow(d)).toBe(false);
+      expect(hasServerSerialRow(d)).toBe(true);
+    }
+  );
+
+  it.each(["esp32", "esp32c3", "esp32s3", "esp8266", "esp8285"])(
+    "shows Web Serial for ESP platform %s",
+    async (platform) => {
+      const d = await mount(platform);
+      expect(hasWebSerialRow(d)).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
# What does this implement/fix?

The install dialog offered the **browser Web Serial** flash option for an RP2350/RP2040 device — the user saw the RP2350B in the browser's serial-port picker, and flashing failed.

Browser Web Serial uses esptool-js, which speaks only the esptool ROM protocol. It can't flash:
- **RP2040 / RP2350** — enter the bootloader via a BOOTSEL / 1200-baud touch and flash by UF2 mass-storage copy;
- **nrf52** — UF2 / serial-DFU;
- **libretiny** (bk72xx / rtl87xx / ln882x) — ltchiptool's own serial protocol.

These flash over serial only via the **backend** (`esphome run` / the dialog's server-serial method), never the browser. So the Web Serial row was dead for them.

This gates the Web Serial row on the platform: the existing ESP-only check (used for the web.esphome.io download row) is generalized into `_isEsptoolPlatform` (`esp32*` / `esp82*` — covers esp8266 and esp8285), and Web Serial renders only for those. Server-serial stays available for non-ESP platforms, including on localhost where it would otherwise collapse into the now-hidden Web Serial row. OTA (when online) and the UF2 download (advanced section) are unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
