### PR TITLE
Open the Web Serial log port at the device's logger baud_rate

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -37,6 +37,10 @@ export interface ConfiguredDevice {
    *  populated. */
   ip_addresses: string[];
   web_port: number | null;
+  /** Resolved `logger: baud_rate` for the Web Serial log port. `null` means
+   *  unset (open at the 115200 default); `0` means UART logging is disabled;
+   *  a positive value is the baud to open at. */
+  logger_baud_rate: number | null;
   current_version: string;
   deployed_version: string;
   loaded_integrations: string[];

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -10,12 +10,12 @@ import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { clearJustCreated } from "../../util/just-created.js";
+import { resolveLogBaudRate } from "../../util/log-baud-rate.js";
 import {
   attachSerialLogStream,
   reconnectWebSerialLogs,
   requestAndOpenSerialPort,
 } from "../../util/post-install-logs.js";
-import { resolveLogBaudRate } from "../../util/web-serial.js";
 
 export async function executeFriendlyName(
   host: ESPHomePageDashboard,

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -15,6 +15,7 @@ import {
   reconnectWebSerialLogs,
   requestAndOpenSerialPort,
 } from "../../util/post-install-logs.js";
+import { resolveLogBaudRate } from "../../util/web-serial.js";
 
 export async function executeFriendlyName(
   host: ESPHomePageDashboard,
@@ -199,9 +200,17 @@ export async function openLogsWithMethod(
       });
       return;
     }
+    const baudRate = resolveLogBaudRate(device.logger_baud_rate);
+    if (baudRate === null) {
+      // logger: baud_rate: 0 — UART logging is disabled; serial would be silent.
+      toast.error(host._localize("dashboard.logs_serial_disabled"), {
+        richColors: true,
+      });
+      return;
+    }
     let serialPort: SerialPort | null;
     try {
-      serialPort = await requestAndOpenSerialPort();
+      serialPort = await requestAndOpenSerialPort(baudRate);
     } catch {
       // The user picked a port but it couldn't open (claimed by another tab,
       // driver error); unlike a picker dismissal this needs feedback.
@@ -216,12 +225,13 @@ export async function openLogsWithMethod(
     // Reconnect (the dialog's "click Start to reconnect") re-acquires a fresh
     // port via the picker — the cached handle can be dead after a device reset.
     host._logsDialog.openPassive({
-      onReconnect: () => reconnectWebSerialLogs(host._logsDialog, host._localize),
+      onReconnect: () =>
+        reconnectWebSerialLogs(host._logsDialog, host._localize, baudRate),
     });
     // attach toasts the reopen-retry failure itself; cover any other rejection
     // so it can't escape this fire-and-forget call as an unhandled rejection.
     try {
-      await attachSerialLogStream(serialPort, host._logsDialog, host._localize);
+      await attachSerialLogStream(serialPort, host._logsDialog, host._localize, baudRate);
     } catch {
       toast.error(host._localize("dashboard.logs_web_serial_open_failed"), {
         richColors: true,

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -14,6 +14,7 @@ import {
   flashFirmware,
   isPortPickerCancel,
   resetAndDisconnect,
+  resolveLogBaudRate,
   type DetectedChip,
 } from "../../util/web-serial.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
@@ -231,6 +232,9 @@ export function flipToLogs(
     configuration: device.configuration,
     name: device.friendly_name || device.name,
     webSerialPort,
+    // Disabled (0) is moot here — the user just flashed over serial; open at
+    // the default so any boot output still streams.
+    loggerBaudRate: resolveLogBaudRate(device.logger_baud_rate) ?? 115200,
     reopenInstall: () => host.reopen(),
   });
   if (handled) host._open = false;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -1,3 +1,4 @@
+import toast from "sonner-js";
 import {
   JobSource,
   JobStatus,
@@ -6,6 +7,7 @@ import {
 import { chipNameToVariant } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { resolveLogBaudRate } from "../../util/log-baud-rate.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import {
   connectToPort,
@@ -14,7 +16,6 @@ import {
   flashFirmware,
   isPortPickerCancel,
   resetAndDisconnect,
-  resolveLogBaudRate,
   type DetectedChip,
 } from "../../util/web-serial.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
@@ -228,13 +229,18 @@ export function flipToLogs(
 ): void {
   const device = host._device;
   if (!device) return;
+  const loggerBaudRate = resolveLogBaudRate(device.logger_baud_rate);
+  if (loggerBaudRate === null) {
+    // logger: baud_rate: 0 — UART logging is disabled, so a serial log view
+    // would be silent; tell the user instead of opening a dead port.
+    toast.info(host._localize("dashboard.logs_serial_disabled"), { richColors: true });
+    return;
+  }
   const handled = dispatchShowLogsAfterInstall(host, {
     configuration: device.configuration,
     name: device.friendly_name || device.name,
     webSerialPort,
-    // Disabled (0) is moot here — the user just flashed over serial; open at
-    // the default so any boot output still streams.
-    loggerBaudRate: resolveLogBaudRate(device.logger_baud_rate) ?? 115200,
+    loggerBaudRate,
     reopenInstall: () => host.reopen(),
   });
   if (handled) host._open = false;

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -1,4 +1,3 @@
-import toast from "sonner-js";
 import {
   JobSource,
   JobStatus,
@@ -7,7 +6,6 @@ import {
 import { chipNameToVariant } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
-import { resolveLogBaudRate } from "../../util/log-baud-rate.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import {
   connectToPort,
@@ -229,18 +227,12 @@ export function flipToLogs(
 ): void {
   const device = host._device;
   if (!device) return;
-  const loggerBaudRate = resolveLogBaudRate(device.logger_baud_rate);
-  if (loggerBaudRate === null) {
-    // logger: baud_rate: 0 — UART logging is disabled, so a serial log view
-    // would be silent; tell the user instead of opening a dead port.
-    toast.info(host._localize("dashboard.logs_serial_disabled"), { richColors: true });
-    return;
-  }
   const handled = dispatchShowLogsAfterInstall(host, {
     configuration: device.configuration,
     name: device.friendly_name || device.name,
     webSerialPort,
-    loggerBaudRate,
+    // Raw baud; the logs handler resolves it (0 ⇒ disabled, skip with a notice).
+    loggerBaudRate: device.logger_baud_rate,
     reopenInstall: () => host.reopen(),
   });
   if (handled) host._open = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -140,6 +140,7 @@
     "logs_method_wireless_desc": "Requires the device to be online",
     "logs_method_network_address_submit": "View logs over network",
     "logs_web_serial_unsupported": "Web Serial is not supported in this browser",
+    "logs_serial_disabled": "Serial logging is disabled for this device (logger baud_rate is 0).",
     "install_method_title": "How do you want to install the firmware?",
     "install_method_network": "On the network",
     "install_method_network_desc": "Compile and upload over the network",

--- a/src/util/log-baud-rate.ts
+++ b/src/util/log-baud-rate.ts
@@ -1,0 +1,12 @@
+// Baud to open the UART log stream at, or null when the device disabled
+// serial logging (logger baud_rate 0). A null / undefined wire value means
+// the YAML set no baud, so fall back to ESPHome's 115200 default.
+//
+// Pure helper kept out of web-serial.ts so non-flashing callers (and Node
+// tests) don't pull in its esptool-js dependency.
+export function resolveLogBaudRate(
+  loggerBaudRate: number | null | undefined
+): number | null {
+  if (loggerBaudRate === 0) return null;
+  return loggerBaudRate ?? 115200;
+}

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -3,6 +3,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
+import { resolveLogBaudRate } from "./log-baud-rate.js";
 import { isPortPickerCancel, SERIAL_ACTIVITY_WINDOW_MS } from "./web-serial.js";
 
 // Reopen budget for a port closed by the post-install reset: covers the
@@ -94,10 +95,10 @@ export interface PostInstallShowLogsDetail {
   name: string;
   port?: string;
   webSerialPort?: SerialPort;
-  // Baud for the Web Serial log port, resolved from the device's logger
-  // config. Set on the webSerialPort path; absent on OTA / server-serial,
-  // where the log port baud is irrelevant.
-  loggerBaudRate?: number;
+  // Raw device logger baud_rate, only meaningful on the webSerialPort path.
+  // The handler resolves it: null / absent ⇒ 115200 default, 0 ⇒ serial
+  // logging disabled (skip with a notice).
+  loggerBaudRate?: number | null;
   reopenInstall: () => void;
 }
 
@@ -286,7 +287,12 @@ export async function handlePostInstallShowLogs(
   logsDialog.configuration = configuration;
   logsDialog.name = name;
   if (webSerialPort) {
-    const baudRate = loggerBaudRate ?? 115200;
+    const baudRate = resolveLogBaudRate(loggerBaudRate);
+    if (baudRate === null) {
+      // logger: baud_rate: 0 — UART logging disabled; the port would be silent.
+      toast.error(localize("dashboard.logs_serial_disabled"), { richColors: true });
+      return;
+    }
     logsDialog.openPassive({
       onBackToInstall: reopenInstall,
       // "click Start to reconnect" after a reopen failure (#636). Re-acquire a

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -29,7 +29,9 @@ export function formatSerialPortLabel(port: SerialPort): string {
  * or ``null`` if the user dismissed the picker. Throws if a picked port can't
  * be opened (claimed by another tab, driver error) — the caller surfaces that.
  */
-export async function requestAndOpenSerialPort(): Promise<SerialPort | null> {
+export async function requestAndOpenSerialPort(
+  baudRate: number
+): Promise<SerialPort | null> {
   let port: SerialPort;
   try {
     port = await navigator.serial.requestPort();
@@ -39,7 +41,7 @@ export async function requestAndOpenSerialPort(): Promise<SerialPort | null> {
     }
     throw err; // A real requestPort failure — let the caller surface it.
   }
-  await port.open({ baudRate: 115200 });
+  await port.open({ baudRate });
   return port;
 }
 
@@ -56,11 +58,12 @@ export async function requestAndOpenSerialPort(): Promise<SerialPort | null> {
  */
 export async function reconnectWebSerialLogs(
   logsDialog: ESPHomeLogsDialog,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  baudRate: number
 ): Promise<void> {
   let port: SerialPort | null;
   try {
-    port = await requestAndOpenSerialPort();
+    port = await requestAndOpenSerialPort(baudRate);
   } catch {
     const message = localize("dashboard.logs_web_serial_open_failed");
     logsDialog.setSerialOpenFailed(message);
@@ -71,7 +74,7 @@ export async function reconnectWebSerialLogs(
     logsDialog.abortSerialReconnect(); // Picker dismissed — back to "Start", quietly.
     return;
   }
-  await attachSerialLogStream(port, logsDialog, localize);
+  await attachSerialLogStream(port, logsDialog, localize, baudRate);
 }
 
 /**
@@ -91,6 +94,10 @@ export interface PostInstallShowLogsDetail {
   name: string;
   port?: string;
   webSerialPort?: SerialPort;
+  // Baud for the Web Serial log port, resolved from the device's logger
+  // config. Set on the webSerialPort path; absent on OTA / server-serial,
+  // where the log port baud is irrelevant.
+  loggerBaudRate?: number;
   reopenInstall: () => void;
 }
 
@@ -243,10 +250,11 @@ async function openLiveSerialPort(
 export async function attachSerialLogStream(
   port: SerialPort,
   logsDialog: ESPHomeLogsDialog,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  baudRate: number
 ): Promise<void> {
   if (!port.readable) {
-    const live = await openLiveSerialPort(port, 115200, SERIAL_REOPEN_TIMEOUT_MS);
+    const live = await openLiveSerialPort(port, baudRate, SERIAL_REOPEN_TIMEOUT_MS);
     if (!live) {
       const message = localize("dashboard.logs_port_reopen_failed", {
         port: formatSerialPortLabel(port),
@@ -273,16 +281,18 @@ export async function handlePostInstallShowLogs(
   localize: LocalizeFunc
 ) {
   e.preventDefault();
-  const { configuration, name, port, webSerialPort, reopenInstall } = e.detail;
+  const { configuration, name, port, webSerialPort, loggerBaudRate, reopenInstall } =
+    e.detail;
   logsDialog.configuration = configuration;
   logsDialog.name = name;
   if (webSerialPort) {
+    const baudRate = loggerBaudRate ?? 115200;
     logsDialog.openPassive({
       onBackToInstall: reopenInstall,
       // "click Start to reconnect" after a reopen failure (#636). Re-acquire a
       // fresh port via the picker rather than reopening the cached esptool
       // handle, which a native-USB chip's post-flash re-enumeration leaves dead.
-      onReconnect: () => reconnectWebSerialLogs(logsDialog, localize),
+      onReconnect: () => reconnectWebSerialLogs(logsDialog, localize, baudRate),
     });
     /* Settling delay — some USB-UART bridges (notably the CH9102F on
        M5Stamp boards) don't resync their internal CDC state cleanly
@@ -294,7 +304,7 @@ export async function handlePostInstallShowLogs(
     /* The install just left the port closed via ``resetAndDisconnect``;
        the attach reopens the still-granted port (retrying the native-USB
        re-enumeration window) and starts reading. */
-    await attachSerialLogStream(webSerialPort, logsDialog, localize);
+    await attachSerialLogStream(webSerialPort, logsDialog, localize, baudRate);
   } else {
     logsDialog.open(port ?? OTA_PORT, { onBackToInstall: reopenInstall });
   }

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -111,6 +111,16 @@ export function isRecentSerialActivity(
   return Date.now() - _lastSerialActivityMs < windowMs;
 }
 
+// Baud to open the UART log stream at, or null when the device disabled
+// serial logging (logger baud_rate 0). A null / undefined wire value means
+// the YAML set no baud, so fall back to ESPHome's 115200 default.
+export function resolveLogBaudRate(
+  loggerBaudRate: number | null | undefined
+): number | null {
+  if (loggerBaudRate === 0) return null;
+  return loggerBaudRate ?? 115200;
+}
+
 /**
  * Open an already-authorized serial port and detect the connected chip.
  *

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -111,16 +111,6 @@ export function isRecentSerialActivity(
   return Date.now() - _lastSerialActivityMs < windowMs;
 }
 
-// Baud to open the UART log stream at, or null when the device disabled
-// serial logging (logger baud_rate 0). A null / undefined wire value means
-// the YAML set no baud, so fall back to ESPHome's 115200 default.
-export function resolveLogBaudRate(
-  loggerBaudRate: number | null | undefined
-): number | null {
-  if (loggerBaudRate === 0) return null;
-  return loggerBaudRate ?? 115200;
-}
-
 /**
  * Open an already-authorized serial port and detect the connected chip.
  *

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -34,6 +34,7 @@ const _BASE = {
   build_size_bytes: 0,
   labels: [],
   web_port: null,
+  logger_baud_rate: null,
   current_version: "",
   deployed_version: "",
   loaded_integrations: [],

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -3,7 +3,10 @@ import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import { DeviceState } from "../../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
-import { executeRename } from "../../../src/components/dashboard/actions-ui.js";
+import {
+  executeRename,
+  openLogsWithMethod,
+} from "../../../src/components/dashboard/actions-ui.js";
 import {
   confirmDialogCopy,
   executeConfirm,
@@ -17,6 +20,15 @@ vi.mock("sonner-js", () => ({
     success: vi.fn(),
     error: (...args: unknown[]) => toastError(...args),
   },
+}));
+
+const { requestAndOpenSerialPort } = vi.hoisted(() => ({
+  requestAndOpenSerialPort: vi.fn(),
+}));
+vi.mock("../../../src/util/post-install-logs.js", () => ({
+  requestAndOpenSerialPort,
+  attachSerialLogStream: vi.fn(),
+  reconnectWebSerialLogs: vi.fn(),
 }));
 
 // Append the interpolation params so the assertion sees the surfaced
@@ -48,6 +60,36 @@ function makeHost(
 function renameEvent(newName: string): CustomEvent<string> {
   return new CustomEvent("rename-confirm", { detail: newName });
 }
+
+describe("openLogsWithMethod web-serial", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    requestAndOpenSerialPort.mockClear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks serial logs and notifies when logging is disabled (baud_rate 0)", async () => {
+    vi.stubGlobal("navigator", { serial: {} });
+    const host = { _localize: localize } as unknown as ESPHomePageDashboard;
+    const device = {
+      configuration: "x.yaml",
+      name: "x",
+      friendly_name: "X",
+      logger_baud_rate: 0,
+    } as ConfiguredDevice;
+
+    await openLogsWithMethod(host, device, "web-serial");
+
+    expect(toastError).toHaveBeenCalledWith(
+      "dashboard.logs_serial_disabled",
+      expect.anything()
+    );
+    expect(requestAndOpenSerialPort).not.toHaveBeenCalled();
+  });
+});
 
 describe("executeRename", () => {
   beforeEach(() => toastError.mockClear());

--- a/test/components/firmware-install-dialog/flip-to-logs.test.ts
+++ b/test/components/firmware-install-dialog/flip-to-logs.test.ts
@@ -1,23 +1,19 @@
 /**
  * @vitest-environment happy-dom
  *
- * flipToLogs threads the device's resolved log baud into the post-install
- * handoff, and skips the serial log view (notifying instead) when logging is
- * disabled (logger baud_rate 0), where the port would be silent.
+ * flipToLogs forwards the device's raw logger baud_rate into the post-install
+ * handoff; the logs handler resolves it (0 disabled / null default).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { dispatchShowLogsAfterInstall } = vi.hoisted(() => ({
   dispatchShowLogsAfterInstall: vi.fn(
-    (_source: HTMLElement, _detail: { loggerBaudRate?: number }) => true
+    (_source: HTMLElement, _detail: { loggerBaudRate?: number | null }) => true
   ),
 }));
 vi.mock("../../../src/util/post-install-logs.js", () => ({
   dispatchShowLogsAfterInstall,
 }));
-
-const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }));
-vi.mock("sonner-js", () => ({ default: { info: toastInfo } }));
 
 import type { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmware-install-dialog.js";
 import { flipToLogs } from "../../../src/components/firmware-install-dialog/install-flow.js";
@@ -41,19 +37,9 @@ const port = {} as SerialPort;
 describe("flipToLogs", () => {
   afterEach(() => vi.clearAllMocks());
 
-  it("hands off with the device's resolved log baud", () => {
-    flipToLogs(makeHost(19200), port);
+  it.each([19200, 0, null])("forwards the raw logger baud %s", (baud) => {
+    flipToLogs(makeHost(baud), port);
     expect(dispatchShowLogsAfterInstall).toHaveBeenCalledTimes(1);
-    expect(dispatchShowLogsAfterInstall.mock.calls[0][1].loggerBaudRate).toBe(19200);
-    expect(toastInfo).not.toHaveBeenCalled();
-  });
-
-  it("notifies and skips the serial log view when logging is disabled (baud 0)", () => {
-    flipToLogs(makeHost(0), port);
-    expect(toastInfo).toHaveBeenCalledWith(
-      "dashboard.logs_serial_disabled",
-      expect.anything()
-    );
-    expect(dispatchShowLogsAfterInstall).not.toHaveBeenCalled();
+    expect(dispatchShowLogsAfterInstall.mock.calls[0][1].loggerBaudRate).toBe(baud);
   });
 });

--- a/test/components/firmware-install-dialog/flip-to-logs.test.ts
+++ b/test/components/firmware-install-dialog/flip-to-logs.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * flipToLogs threads the device's resolved log baud into the post-install
+ * handoff, and skips the serial log view (notifying instead) when logging is
+ * disabled (logger baud_rate 0), where the port would be silent.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dispatchShowLogsAfterInstall } = vi.hoisted(() => ({
+  dispatchShowLogsAfterInstall: vi.fn(
+    (_source: HTMLElement, _detail: { loggerBaudRate?: number }) => true
+  ),
+}));
+vi.mock("../../../src/util/post-install-logs.js", () => ({
+  dispatchShowLogsAfterInstall,
+}));
+
+const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }));
+vi.mock("sonner-js", () => ({ default: { info: toastInfo } }));
+
+import type { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmware-install-dialog.js";
+import { flipToLogs } from "../../../src/components/firmware-install-dialog/install-flow.js";
+
+function makeHost(loggerBaudRate: number | null): ESPHomeFirmwareInstallDialog {
+  return {
+    _device: {
+      configuration: "x.yaml",
+      name: "x",
+      friendly_name: "X",
+      logger_baud_rate: loggerBaudRate,
+    },
+    _localize: (key: string) => key,
+    _open: true,
+    reopen: vi.fn(),
+  } as unknown as ESPHomeFirmwareInstallDialog;
+}
+
+const port = {} as SerialPort;
+
+describe("flipToLogs", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("hands off with the device's resolved log baud", () => {
+    flipToLogs(makeHost(19200), port);
+    expect(dispatchShowLogsAfterInstall).toHaveBeenCalledTimes(1);
+    expect(dispatchShowLogsAfterInstall.mock.calls[0][1].loggerBaudRate).toBe(19200);
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it("notifies and skips the serial log view when logging is disabled (baud 0)", () => {
+    flipToLogs(makeHost(0), port);
+    expect(toastInfo).toHaveBeenCalledWith(
+      "dashboard.logs_serial_disabled",
+      expect.anything()
+    );
+    expect(dispatchShowLogsAfterInstall).not.toHaveBeenCalled();
+  });
+});

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -20,7 +20,9 @@ import { defaultLocalize } from "../../src/common/localize.js";
 import {
   attachSerialLogStream,
   formatSerialPortLabel,
+  handlePostInstallShowLogs,
   reconnectWebSerialLogs,
+  type PostInstallShowLogsDetail,
 } from "../../src/util/post-install-logs.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -254,5 +256,40 @@ describe("attachSerialLogStream reopen", () => {
       restore();
       vi.useRealTimers();
     }
+  });
+});
+
+describe("handlePostInstallShowLogs serial baud", () => {
+  function detail(loggerBaudRate: number | null): PostInstallShowLogsDetail {
+    return {
+      configuration: "x.yaml",
+      name: "X",
+      webSerialPort: openPort(),
+      loggerBaudRate,
+      reopenInstall: vi.fn(),
+    };
+  }
+
+  function logsDialog() {
+    return {
+      configuration: "",
+      name: "",
+      openPassive: vi.fn(),
+      setSerialStream: vi.fn(),
+      setSerialOpenFailed: vi.fn(),
+      abortSerialReconnect: vi.fn(),
+    };
+  }
+
+  it("notifies and never opens a serial session when logging is disabled (baud 0)", async () => {
+    const dialog = logsDialog();
+    const event = new CustomEvent("request-show-logs-after-install", {
+      cancelable: true,
+      detail: detail(0),
+    });
+    await handlePostInstallShowLogs(event, dialog as never, defaultLocalize);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(dialog.openPassive).not.toHaveBeenCalled();
+    expect(dialog.setSerialStream).not.toHaveBeenCalled();
   });
 });

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -108,11 +108,23 @@ describe("reconnectWebSerialLogs", () => {
     const restore = withRequestPort(async () => openPort());
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((navigator as any).serial.requestPort).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("opens the picked port at the resolved baud", async () => {
+    const port = openPort();
+    const restore = withRequestPort(async () => port);
+    const dialog = stubDialog();
+    try {
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 19200);
+      expect(port.open).toHaveBeenCalledWith({ baudRate: 19200 });
     } finally {
       restore();
     }
@@ -125,7 +137,7 @@ describe("reconnectWebSerialLogs", () => {
     });
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
       expect(dialog.abortSerialReconnect).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
       expect(toastError).not.toHaveBeenCalled();
@@ -140,7 +152,7 @@ describe("reconnectWebSerialLogs", () => {
     });
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();
@@ -155,7 +167,7 @@ describe("reconnectWebSerialLogs", () => {
     const restore = withRequestPort(async () => port);
     const dialog = stubDialog();
     try {
-      await reconnectWebSerialLogs(dialog as never, defaultLocalize);
+      await reconnectWebSerialLogs(dialog as never, defaultLocalize, 115200);
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
       expect(toastError).toHaveBeenCalledTimes(1);
       expect(dialog.abortSerialReconnect).not.toHaveBeenCalled();
@@ -173,10 +185,30 @@ describe("attachSerialLogStream reopen", () => {
     const restore = withGetPorts(async () => [live]);
     const dialog = stubDialog();
     try {
-      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize, 115200);
       expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialStream.mock.calls[0][0]).toBe(live); // streamed the live handle
       expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("reopens the live handle at the resolved baud", async () => {
+    // A closed live handle from getPorts() must be reopened at the device's
+    // configured log baud, not the flash baud.
+    const live = {
+      readable: null,
+      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+      open: vi.fn().mockResolvedValue(undefined),
+      setSignals: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const restore = withGetPorts(async () => [live]);
+    const dialog = stubDialog();
+    try {
+      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize, 19200);
+      expect(live.open).toHaveBeenCalledWith({ baudRate: 19200 });
+      expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
     } finally {
       restore();
     }
@@ -188,7 +220,7 @@ describe("attachSerialLogStream reopen", () => {
     const dialog = stubDialog();
     try {
       // SecurityError won't fix itself by waiting — bail without fake timers.
-      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize);
+      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize, 115200);
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
       expect(dialog.setSerialOpenFailed.mock.calls[0][0] as string).toContain(
         "USB 303a:1001"
@@ -208,7 +240,7 @@ describe("attachSerialLogStream reopen", () => {
     const dialog = stubDialog();
     try {
       const port = deadPort(new DOMException("gone", "NetworkError"));
-      const done = attachSerialLogStream(port, dialog as never, defaultLocalize);
+      const done = attachSerialLogStream(port, dialog as never, defaultLocalize, 115200);
       await vi.advanceTimersByTimeAsync(8100);
       await done;
       expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);

--- a/test/util/resolve-log-baud-rate.test.ts
+++ b/test/util/resolve-log-baud-rate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveLogBaudRate } from "../../src/util/web-serial.js";
+
+describe("resolveLogBaudRate", () => {
+  it("uses the device's configured baud", () => {
+    expect(resolveLogBaudRate(19200)).toBe(19200);
+  });
+
+  it("falls back to 115200 when unset on the wire", () => {
+    expect(resolveLogBaudRate(null)).toBe(115200);
+    expect(resolveLogBaudRate(undefined)).toBe(115200);
+  });
+
+  it("returns null when serial logging is disabled (baud_rate 0)", () => {
+    expect(resolveLogBaudRate(0)).toBeNull();
+  });
+});

--- a/test/util/resolve-log-baud-rate.test.ts
+++ b/test/util/resolve-log-baud-rate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveLogBaudRate } from "../../src/util/web-serial.js";
+import { resolveLogBaudRate } from "../../src/util/log-baud-rate.js";
 
 describe("resolveLogBaudRate", () => {
   it("uses the device's configured baud", () => {


### PR DESCRIPTION
# What does this implement/fix?

Web Serial log streaming opened the serial port at a hardcoded 115200, so a device configured with `logger: baud_rate: 19200` (common on ESP8266) produced no readable logs. This consumes the backend-resolved `logger_baud_rate` now on `ConfiguredDevice` and threads it through the log-open path (the picker open, the post-install reopen, and the dialog's reconnect) so the port opens at the device's configured baud. A `baud_rate` of 0 means UART logging is disabled, so we surface a notice and skip the serial stream instead of opening a silent port.

The flash path is unchanged; the ESPLoader bootloader baud (115200) is the flash protocol baud, which is separate from the UART log baud this resolves.

Needs the backend PR that resolves and emits `logger_baud_rate`: esphome/device-builder#1531

**Related issue or feature (if applicable):**

Found while testing serial logs on an ESP8266 with a non-default logger baud.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
