### PR TITLE
Warn to keep the window visible during a Web Serial flash

### DIFF
--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -134,6 +134,9 @@ export function cardStatusDetail(host: ESPHomeFirmwareInstallDialog): string {
   }
   if (host._step === "download-ready") return downloadReadyDetail(host);
   if (host._step === "error") return host._errorMessage;
+  // Hidden tabs throttle timers, which can stall the Web Serial write and fail
+  // the flash; there's no API to opt out, so warn the user to stay on the page.
+  if (host._step === "flashing") return host._localize("firmware.flashing_keep_visible");
   return "";
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -405,6 +405,7 @@
     "status_installing": "Compiling and installing firmware…",
     "status_downloading": "Downloading firmware…",
     "status_flashing": "Flashing firmware to device…",
+    "flashing_keep_visible": "Keep this window visible — switching to another tab or window can interrupt the flash.",
     "status_resetting": "Restarting device…",
     "status_done": "Installation complete!",
     "status_failed": "Installation failed",

--- a/test/components/firmware-install-dialog-flashing-warning.test.ts
+++ b/test/components/firmware-install-dialog-flashing-warning.test.ts
@@ -1,0 +1,30 @@
+/**
+ * During a Web Serial flash (the `flashing` step) the status subtext warns the
+ * user to keep the window visible — a hidden tab throttles timers and can stall
+ * the write. Other steps carry no such warning.
+ */
+import { describe, expect, it } from "vitest";
+import { defaultLocalize } from "../../src/common/localize.js";
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { cardStatusDetail } from "../../src/components/firmware-install-dialog/renderers.js";
+
+const host = (step: string): ESPHomeFirmwareInstallDialog =>
+  ({
+    _step: step,
+    _errorMessage: "",
+    _localize: defaultLocalize,
+  }) as unknown as ESPHomeFirmwareInstallDialog;
+
+describe("cardStatusDetail flashing warning", () => {
+  it("warns to keep the window visible during a Web Serial flash", () => {
+    const detail = cardStatusDetail(host("flashing"));
+    expect(detail).toBe(defaultLocalize("firmware.flashing_keep_visible"));
+    expect(detail).toContain("Keep this window visible");
+  });
+
+  it("adds no warning on non-flashing steps", () => {
+    expect(cardStatusDetail(host("queued"))).toBe("");
+    expect(cardStatusDetail(host("downloading"))).toBe("");
+    expect(cardStatusDetail(host("resetting"))).toBe("");
+  });
+});

--- a/test/components/firmware-install-dialog-flashing-warning.test.ts
+++ b/test/components/firmware-install-dialog-flashing-warning.test.ts
@@ -23,8 +23,11 @@ describe("cardStatusDetail flashing warning", () => {
   });
 
   it("adds no warning on non-flashing steps", () => {
+    // The restart phase keeps _step === "flashing" (only the status message
+    // changes), so the warning correctly persists there; test genuine
+    // non-flashing steps instead.
+    expect(cardStatusDetail(host("connecting"))).toBe("");
     expect(cardStatusDetail(host("queued"))).toBe("");
     expect(cardStatusDetail(host("downloading"))).toBe("");
-    expect(cardStatusDetail(host("resetting"))).toBe("");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Navigating away from the tab/window during a browser (Web Serial) flash sometimes fails the flash. Browsers throttle `setTimeout`/`setInterval` to ≥1s in hidden tabs, which disrupts esptool-js's timing-sensitive serial writes — and there's no JS API to opt a normal page out of that throttling, so it can't be prevented technically. The correct mitigation is a user warning, which is what the legacy dashboard did ("Keep this page visible to prevent slow down", shown during the writing phase).

This shows a "Keep this window visible …" note in the install dialog's status subtext during the `flashing` step. That step is the **Web Serial** path only — OTA / server-serial flash on the backend and aren't affected by browser visibility — so the warning is correctly scoped (it doesn't appear for those install methods).

A Screen Wake Lock was considered and rejected: it only prevents display sleep, not hidden-tab timer throttling (the actual failure), so it wouldn't fix the "navigated away" case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
