### PR TITLE
Offer Retry after a failed Web Serial flash

### DIFF
--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -297,6 +297,13 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
     if (this._detected) flipToLogs(this, this._detected.port);
   };
 
+  // Re-run the Web Serial install after a flash failure: a full reset (_init) +
+  // fresh connect/flash, so a transient serial error (noise, dropped port) can
+  // be retried without closing and reopening the dialog.
+  _retry = () => {
+    if (this._device) this.installWebSerial(this._device);
+  };
+
   _cancel = async () => {
     if (this._jobId) {
       try {

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -313,6 +313,26 @@ export function renderFooter(host: ESPHomeFirmwareInstallDialog): TemplateResult
       </div>
     `;
   }
+  // A failed Web Serial flash can be retried in place — re-run the install.
+  // Excludes compile / validate failures, which surface the reset-build hint
+  // (renderResetSuggestion) instead; re-flashing wouldn't address those.
+  const canRetry =
+    host._step === "error" &&
+    host._installer === "web-serial" &&
+    !host._failedDuringCompile &&
+    !host._failedDuringValidate;
+  if (canRetry) {
+    return html`
+      <div class="footer">
+        <button class="btn btn--ghost" @click=${host._close}>
+          ${host._localize("command.close")}
+        </button>
+        <button class="btn btn--primary" @click=${host._retry}>
+          ${host._localize("command.retry")}
+        </button>
+      </div>
+    `;
+  }
   // Web Serial install success — surface "Logs" so users can flip back after
   // they've clicked logs-dialog's "Back to install". _detected survives
   // _onClose but not _close, so the button only renders while the SerialPort

--- a/test/components/firmware-install-dialog-footer.test.ts
+++ b/test/components/firmware-install-dialog-footer.test.ts
@@ -18,6 +18,11 @@ function footerHost(step: string) {
     _localize: (key: string) => key,
     _close: vi.fn(),
     _cancel: vi.fn(),
+    _retry: vi.fn(),
+    _showLogsAgain: vi.fn(),
+    _detected: null,
+    _failedDuringCompile: false,
+    _failedDuringValidate: false,
     _showLogsAfterInstall: false,
     _toggleShowLogsAfterInstall: vi.fn(),
   };
@@ -44,5 +49,29 @@ describe("firmware-install-dialog footer", () => {
     const host = footerHost("compiling");
     const values = footerValues(host);
     expect(values).toContain(host._cancel);
+  });
+
+  it("offers Retry and Close on a Web Serial flash failure", () => {
+    const host = footerHost("error");
+    host._installer = "web-serial";
+    const values = footerValues(host);
+    expect(values).toContain(host._retry);
+    expect(values).toContain(host._close);
+  });
+
+  it("does not offer Retry when the Web Serial failure was during compile", () => {
+    // Compile/validate failures show the reset-build hint instead; re-flashing
+    // wouldn't address them, so it falls through to the plain Close footer.
+    const host = footerHost("error");
+    host._installer = "web-serial";
+    host._failedDuringCompile = true;
+    const values = footerValues(host);
+    expect(values).not.toContain(host._retry);
+  });
+
+  it("does not offer Retry on a non-Web-Serial error", () => {
+    const host = footerHost("error"); // binary-download
+    const values = footerValues(host);
+    expect(values).not.toContain(host._retry);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A failed Web Serial flash (e.g. "Serial data stream stopped: Possible serial noise or corruption.") only offered **Close** — there was no way to retry without closing the dialog and starting the whole install over.

Add a **Retry** button to the error footer for Web Serial flash failures. It calls a bound `_retry` that re-runs `installWebSerial(this._device)`, which does a full `_init` reset and a fresh connect + flash — so a transient serial error (noise, dropped port) can be retried in place.

Scope: Retry shows only for a Web Serial install error that was **not** a compile/validate failure. Those surface the reset-build hint (`renderResetSuggestion`) instead — re-flashing wouldn't address a broken build. Non-Web-Serial errors are unaffected. Reuses the existing `command.retry` string.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
