### PR TITLE
Keep the serial logs viewer responsive under a flood

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -6,7 +6,7 @@ import type { ArchivedDevice, BulkActionResult } from "../../api/types/system.js
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
 import { getErrorMessage } from "../../util/error-message.js";
-import { ESPHomeLogParser } from "../../util/esphome-log-parser.js";
+import { ESPHomeLogParser, isLikelyGarbageLine } from "../../util/esphome-log-parser.js";
 import {
   connectToPort,
   detectChip,
@@ -459,6 +459,12 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
                replaces it in place — so a stream of CRLF-terminated
                boot lines would collapse to just the last one. */
             const cleaned = line.endsWith("\r") ? line.slice(0, -1) : line;
+            // Drop mis-sampled UART garbage (e.g. an ESP8266's 74880-baud boot
+            // banner read at the app's baud) before it reaches the parser, so it
+            // neither pollutes the carried prefix/color nor floods the view.
+            if (isLikelyGarbageLine(cleaned)) {
+              continue;
+            }
             /* Stamp every line — including blanks — at receive time
                so the log pane shows the same ``[HH:MM:SS]`` anchor it
                does for WS-fed sessions. esphome/dashboard's
@@ -470,7 +476,7 @@ export function streamSerialToDialog(port: any, dialog: any): () => void {
             // Keep draining while paused (Stop) but don't display, so resume
             // needs no port reopen / device reset (#526).
             if (!dialog._serialPaused) {
-              dialog._lines = [...dialog._lines, stamped];
+              dialog._enqueueLine(stamped);
             }
           }
         }

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -235,7 +235,7 @@ export class ESPHomeLogsDialog extends LitElement {
     if (!this._open || !isPassive(this._session)) return;
     void this._teardownSession();
     this._resetPendingLines();
-    this._lines = [...this._lines, message];
+    this._appendCapped([message]);
     this._session = { kind: "dead" };
   }
 
@@ -527,13 +527,20 @@ export class ESPHomeLogsDialog extends LitElement {
     });
   }
 
+  // Append to the visible buffer, trimmed to the newest MAX_LOG_LINES. The
+  // single place the cap is enforced, shared by the batched flush and the
+  // direct recovery-path append (setSerialOpenFailed).
+  private _appendCapped(lines: string[]): void {
+    const merged = [...this._lines, ...lines];
+    this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
+  }
+
   // Drain pending lines into ``_lines`` now, trimmed to the newest
   // MAX_LOG_LINES. Called from teardown / clear / download so consumers
   // don't race the rAF.
   _flushPendingLines(): void {
     if (this._pendingLines.length === 0) return;
-    const merged = [...this._lines, ...this._pendingLines];
-    this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
+    this._appendCapped(this._pendingLines);
     this._pendingLines = [];
   }
 

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -56,6 +56,11 @@ registerMdiIcons({
   restart: mdiRestart,
 });
 
+// Hard cap on retained log lines. A verbose (or garbage-flooding) device can
+// emit faster than the view renders; without a bound the line array and its
+// DOM grow until the tab locks up. Trimmed to the newest on every flush.
+const MAX_LOG_LINES = 5000;
+
 @customElement("esphome-logs-dialog")
 export class ESPHomeLogsDialog extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
@@ -106,6 +111,13 @@ export class ESPHomeLogsDialog extends LitElement {
 
   @state()
   _lines: string[] = [];
+
+  // rAF batch buffer: coalesce per-line appends into one render per frame
+  // instead of one per line (mirrors command-dialog, #348). A fast serial
+  // stream would otherwise schedule a full re-render of the whole list per
+  // line and freeze the tab.
+  private _pendingLines: string[] = [];
+  private _flushScheduled = 0;
 
   @state()
   private _open = false;
@@ -172,6 +184,7 @@ export class ESPHomeLogsDialog extends LitElement {
    *  behaves the same way every time unless the user flips it this session. */
   private _beginSession(onBackToInstall?: () => void) {
     void this._teardownSession();
+    this._resetPendingLines();
     this._lines = [];
     this._expanded = false;
     this._showStates = true;
@@ -221,6 +234,7 @@ export class ESPHomeLogsDialog extends LitElement {
     // an OTA session — don't tear that unrelated session down or flip it dead.
     if (!this._open || !isPassive(this._session)) return;
     void this._teardownSession();
+    this._resetPendingLines();
     this._lines = [...this._lines, message];
     this._session = { kind: "dead" };
   }
@@ -243,6 +257,9 @@ export class ESPHomeLogsDialog extends LitElement {
    *  so the next open() isn't blocked by a still-open port. A Stop *pause*
    *  doesn't call this — it keeps the reader + port alive (#526). */
   private _teardownSession(): Promise<void> {
+    // Drain any batched lines into the visible buffer before the session ends
+    // so a stop/close doesn't drop what was buffered for the next frame.
+    this._flushPendingLines();
     const s = this._session;
     this._session = { kind: "idle" };
     if (s.kind === "serial") {
@@ -436,7 +453,7 @@ export class ESPHomeLogsDialog extends LitElement {
       s.port,
       {
         onOutput: (line: string) => {
-          this._lines = [...this._lines, line];
+          this._enqueueLine(line);
         },
         onResult: () => this._markOtaStopped(streamId),
         onError: () => this._markOtaStopped(streamId),
@@ -470,6 +487,7 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _downloadLogs() {
+    this._flushPendingLines();
     const stem = configurationStem(this.configuration, "logs");
     downloadAnsiText(this._lines, `${stem}-logs.txt`);
   }
@@ -494,7 +512,39 @@ export class ESPHomeLogsDialog extends LitElement {
   }
 
   private _clearLogs() {
+    this._resetPendingLines();
     this._lines = [];
+  }
+
+  // Buffer a streamed line; flushed on the next animation frame. The serial
+  // reader (streamSerialToDialog) and the OTA stream both feed through here.
+  _enqueueLine(line: string): void {
+    this._pendingLines.push(line);
+    if (this._flushScheduled) return;
+    this._flushScheduled = requestAnimationFrame(() => {
+      this._flushScheduled = 0;
+      this._flushPendingLines();
+    });
+  }
+
+  // Drain pending lines into ``_lines`` now, trimmed to the newest
+  // MAX_LOG_LINES. Called from teardown / clear / download so consumers
+  // don't race the rAF.
+  _flushPendingLines(): void {
+    if (this._pendingLines.length === 0) return;
+    const merged = [...this._lines, ...this._pendingLines];
+    this._lines = merged.length > MAX_LOG_LINES ? merged.slice(-MAX_LOG_LINES) : merged;
+    this._pendingLines = [];
+  }
+
+  // Drop the pending batch and cancel any scheduled flush. Paired with every
+  // ``_lines = []`` reset.
+  _resetPendingLines(): void {
+    this._pendingLines = [];
+    if (this._flushScheduled) {
+      cancelAnimationFrame(this._flushScheduled);
+      this._flushScheduled = 0;
+    }
   }
 
   // Reset Device button (Web Serial only). Pulses RTS (wired to EN on the

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -520,6 +520,12 @@ export class ESPHomeLogsDialog extends LitElement {
   // reader (streamSerialToDialog) and the OTA stream both feed through here.
   _enqueueLine(line: string): void {
     this._pendingLines.push(line);
+    // rAF doesn't fire while the tab is hidden, so a flood can pile up here
+    // unflushed. Trim with headroom (so we slice once per MAX_LOG_LINES pushes,
+    // not every push) to keep the pending buffer bounded too.
+    if (this._pendingLines.length > 2 * MAX_LOG_LINES) {
+      this._pendingLines = this._pendingLines.slice(-MAX_LOG_LINES);
+    }
     if (this._flushScheduled) return;
     this._flushScheduled = requestAnimationFrame(() => {
       this._flushScheduled = 0;

--- a/src/util/esphome-log-parser.ts
+++ b/src/util/esphome-log-parser.ts
@@ -36,6 +36,30 @@ const LEADING_COLOR_RE = /^(?:\u001b|\\033)\[[0-9;]*m/;
 // trailing reset is needed so color can't bleed past the line.
 const HAS_ANSI_RE = /(?:\u001b|\\033)\[/;
 
+// Strip CSI escape sequences (both ESC-byte and literal \033 forms) so the
+// garbage heuristic counts content bytes, not color codes.
+const ANSI_STRIP_RE = /(?:\u001b|\\033)\[[0-9;?]*[ -\/]*[@-~]/g;
+
+/**
+ * True when a decoded UART line looks like baud-mismatch garbage rather than a
+ * real log line. An ESP8266 prints its boot/reset banner at 74880 baud; read at
+ * the app's (lower) configured baud it mis-samples into mojibake: U+FFFD
+ * replacement chars and non-printable control bytes. Clean ESPHome logs are
+ * printable ASCII plus ANSI escapes, so they never trip this. Short lines are
+ * never flagged (too little signal; the line cap bounds any that slip by).
+ */
+export function isLikelyGarbageLine(line: string): boolean {
+  const stripped = line.replace(ANSI_STRIP_RE, "").replace(/\u001b/g, "");
+  if (stripped.length < 2) return false;
+  let bad = 0;
+  for (const ch of stripped) {
+    const code = ch.codePointAt(0) ?? 0;
+    // Tab is fine; U+FFFD, DEL, and other C0 controls signal corruption.
+    if (ch === "\ufffd" || code === 0x7f || (code < 0x20 && code !== 0x09)) bad++;
+  }
+  return bad / stripped.length > 0.3;
+}
+
 /** Already ends in a reset (either escape form)? */
 function endsWithReset(line: string): boolean {
   return line.endsWith("\u001b[0m") || line.endsWith("\\033[0m");

--- a/test/components/dashboard/stream-serial-to-dialog.test.ts
+++ b/test/components/dashboard/stream-serial-to-dialog.test.ts
@@ -14,6 +14,19 @@ import { streamSerialToDialog } from "../../../src/components/dashboard/actions.
 
 interface MockDialog {
   _lines: string[];
+  _enqueueLine(line: string): void;
+}
+
+// The real dialog batches via requestAnimationFrame; for these decode-focused
+// tests a synchronous push keeps the existing _lines assertions intact.
+function mockDialog(): MockDialog {
+  const d: MockDialog = {
+    _lines: [],
+    _enqueueLine(line: string) {
+      d._lines.push(line);
+    },
+  };
+  return d;
 }
 
 function encode(str: string): Uint8Array {
@@ -75,7 +88,7 @@ describe("streamSerialToDialog", () => {
     const port = createMockPort([
       encode("[I][app:100]: Booting\n[W][gpio:5]: strapping\n"),
     ]);
-    const dialog: MockDialog = { _lines: [] };
+    const dialog = mockDialog();
     const cancel = streamSerialToDialog(port, dialog);
     await flush();
     cancel();
@@ -87,7 +100,7 @@ describe("streamSerialToDialog", () => {
 
   it("strips trailing CR before prepending the timestamp", async () => {
     const port = createMockPort([encode("[I][app:100]: Hello\r\n")]);
-    const dialog: MockDialog = { _lines: [] };
+    const dialog = mockDialog();
     const cancel = streamSerialToDialog(port, dialog);
     await flush();
     cancel();
@@ -102,7 +115,7 @@ describe("streamSerialToDialog", () => {
        line still carries a [HH:MM:SS] anchor so the two web serial
        paths render identically when viewed side by side. */
     const port = createMockPort([encode("[I][a:1]: hi\n\n[I][a:2]: bye\n")]);
-    const dialog: MockDialog = { _lines: [] };
+    const dialog = mockDialog();
     const cancel = streamSerialToDialog(port, dialog);
     await flush();
     cancel();
@@ -112,9 +125,22 @@ describe("streamSerialToDialog", () => {
     expect(dialog._lines[2]).toMatch(/^\[\d{2}:\d{2}:\d{2}\]\[I\]\[a:2\]: bye$/);
   });
 
+  it("drops a mis-sampled garbage line but keeps the clean lines around it", async () => {
+    // Invalid UTF-8 bytes decode to U+FFFD replacement chars — the shape of an
+    // ESP8266 boot banner read at the wrong baud. A clean line follows.
+    const garbage = new Uint8Array([0x80, 0x81, 0xfe, 0xff, 0x80, 0x81, 0x0a]);
+    const port = createMockPort([garbage, encode("[I][app:1]: ok\n")]);
+    const dialog = mockDialog();
+    const cancel = streamSerialToDialog(port, dialog);
+    await flush();
+    cancel();
+    expect(dialog._lines).toHaveLength(1);
+    expect(dialog._lines[0]).toMatch(/\[I\]\[app:1\]: ok$/);
+  });
+
   it("buffers a partial line across chunks and stamps it once on completion", async () => {
     const port = createMockPort([encode("[I][app:100]: par"), encode("tial\n")]);
-    const dialog: MockDialog = { _lines: [] };
+    const dialog = mockDialog();
     const cancel = streamSerialToDialog(port, dialog);
     await flush();
     cancel();
@@ -127,7 +153,7 @@ describe("streamSerialToDialog", () => {
     // later open() throws "already open" and the logs dialog never reopens.
     // The lock must be released before close().
     const port = createMockPort([encode("[I][a:1]: hi\n")]);
-    const dialog: MockDialog = { _lines: [] };
+    const dialog = mockDialog();
     const cancel = streamSerialToDialog(port, dialog);
     await flush();
     cancel();

--- a/test/components/logs-dialog-batching.test.ts
+++ b/test/components/logs-dialog-batching.test.ts
@@ -52,6 +52,24 @@ describe("logs-dialog line batching + cap", () => {
     expect(d._lines[d._lines.length - 1]).toBe(String(total - 1));
   });
 
+  it("caps the buffer on the recovery-path append (setSerialOpenFailed)", () => {
+    const d = new ESPHomeLogsDialog();
+    for (let i = 0; i < 5000; i++) d._enqueueLine(String(i));
+    fireFrame();
+    expect(d._lines).toHaveLength(5000);
+    // Drive the reconnect-failure append with the dialog open + a passive
+    // session so the guard passes; it must stay capped, not grow to 5001.
+    const internal = d as unknown as {
+      _open: boolean;
+      _session: { kind: string; paused: boolean };
+    };
+    internal._open = true;
+    internal._session = { kind: "reconnecting", paused: false };
+    d.setSerialOpenFailed("reopen failed");
+    expect(d._lines).toHaveLength(5000);
+    expect(d._lines[d._lines.length - 1]).toBe("reopen failed");
+  });
+
   it("resetPendingLines drops the batch and a late frame can't resurrect it", () => {
     const d = new ESPHomeLogsDialog();
     d._enqueueLine("x");

--- a/test/components/logs-dialog-batching.test.ts
+++ b/test/components/logs-dialog-batching.test.ts
@@ -52,6 +52,20 @@ describe("logs-dialog line batching + cap", () => {
     expect(d._lines[d._lines.length - 1]).toBe(String(total - 1));
   });
 
+  it("bounds the pending buffer when frames never fire (hidden tab)", () => {
+    // rAF is captured but never invoked, simulating a backgrounded tab; the
+    // pending buffer must not grow without bound during a flood.
+    const d = new ESPHomeLogsDialog();
+    for (let i = 0; i < 12000; i++) d._enqueueLine(String(i));
+    const pending = (d as unknown as { _pendingLines: string[] })._pendingLines;
+    expect(d._lines).toHaveLength(0); // nothing flushed without a frame
+    expect(pending.length).toBeLessThanOrEqual(10000); // 2 * MAX_LOG_LINES
+    expect(pending[pending.length - 1]).toBe("11999"); // newest retained
+    fireFrame();
+    expect(d._lines).toHaveLength(5000);
+    expect(d._lines[d._lines.length - 1]).toBe("11999");
+  });
+
   it("caps the buffer on the recovery-path append (setSerialOpenFailed)", () => {
     const d = new ESPHomeLogsDialog();
     for (let i = 0; i < 5000; i++) d._enqueueLine(String(i));

--- a/test/components/logs-dialog-batching.test.ts
+++ b/test/components/logs-dialog-batching.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The logs dialog coalesces per-line appends into one render per animation
+ * frame and caps the retained buffer, so a verbose / garbage-flooding device
+ * can't freeze the tab with unbounded per-line re-renders.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ESPHomeLogsDialog } from "../../src/components/logs-dialog.js";
+
+let rafCb: FrameRequestCallback | null = null;
+let raf: ReturnType<typeof vi.fn>;
+let caf: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  rafCb = null;
+  raf = vi.fn((cb: FrameRequestCallback) => {
+    rafCb = cb;
+    return 1;
+  });
+  caf = vi.fn();
+  vi.stubGlobal("requestAnimationFrame", raf);
+  vi.stubGlobal("cancelAnimationFrame", caf);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function fireFrame(): void {
+  rafCb?.(0);
+}
+
+describe("logs-dialog line batching + cap", () => {
+  it("coalesces many enqueues into a single flush per frame", () => {
+    const d = new ESPHomeLogsDialog();
+    for (let i = 0; i < 100; i++) d._enqueueLine(`line ${i}`);
+    expect(d._lines).toHaveLength(0); // nothing visible until the frame fires
+    expect(raf).toHaveBeenCalledTimes(1); // one frame for the whole burst
+    fireFrame();
+    expect(d._lines).toHaveLength(100);
+    expect(d._lines[0]).toBe("line 0");
+  });
+
+  it("caps the buffer to the newest 5000 lines", () => {
+    const d = new ESPHomeLogsDialog();
+    const total = 5005;
+    for (let i = 0; i < total; i++) d._enqueueLine(String(i));
+    fireFrame();
+    expect(d._lines).toHaveLength(5000);
+    expect(d._lines[0]).toBe("5"); // oldest five dropped
+    expect(d._lines[d._lines.length - 1]).toBe(String(total - 1));
+  });
+
+  it("resetPendingLines drops the batch and a late frame can't resurrect it", () => {
+    const d = new ESPHomeLogsDialog();
+    d._enqueueLine("x");
+    d._resetPendingLines();
+    expect(caf).toHaveBeenCalledWith(1);
+    fireFrame();
+    expect(d._lines).toHaveLength(0);
+  });
+});

--- a/test/util/esphome-log-parser.test.ts
+++ b/test/util/esphome-log-parser.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { ESPHomeLogParser } from "../../src/util/esphome-log-parser.js";
+import {
+  ESPHomeLogParser,
+  isLikelyGarbageLine,
+} from "../../src/util/esphome-log-parser.js";
 
 // Build the ESC byte at runtime so the test source stays free of raw
 // control characters (the device sends real ESC; the renderer accepts it).
 const ESC = String.fromCharCode(0x1b);
 const RESET = `${ESC}[0m`;
 const MAGENTA = `${ESC}[0;35m`; // [C] config color
+const FFFD = "\ufffd"; // U+FFFD, what TextDecoder emits for invalid UTF-8
 
 describe("ESPHomeLogParser", () => {
   it("appends a reset to an entry line that opened color but never closed it", () => {
@@ -89,5 +93,30 @@ describe("ESPHomeLogParser", () => {
     expect(p.parseLine("  Hostname: 'ol'")).toBe(
       `${MAGENTA}[C][wifi:1248]:   Hostname: 'ol'${RESET}`
     );
+  });
+});
+
+describe("isLikelyGarbageLine", () => {
+  it("flags a line that is mostly replacement chars", () => {
+    expect(isLikelyGarbageLine(FFFD.repeat(8))).toBe(true);
+  });
+
+  it("flags a line dominated by control bytes", () => {
+    const ctrl = String.fromCharCode(0x01, 0x02, 0x00, 0x1f, 0x7f);
+    expect(isLikelyGarbageLine(`${ctrl}ab`)).toBe(true);
+  });
+
+  it("passes a clean ESPHome log line, color codes and all", () => {
+    expect(isLikelyGarbageLine(`${MAGENTA}[C][wifi:1248]: WiFi:${RESET}`)).toBe(false);
+    expect(isLikelyGarbageLine("[I][app:100]: Booting")).toBe(false);
+  });
+
+  it("keeps tab-indented continuation lines", () => {
+    expect(isLikelyGarbageLine("\t  Hostname: slowlogs")).toBe(false);
+  });
+
+  it("never flags a short line — too little signal, the cap bounds it", () => {
+    expect(isLikelyGarbageLine("m")).toBe(false);
+    expect(isLikelyGarbageLine(FFFD)).toBe(false);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Flashing a verbose device over Web Serial (an ESP8266 with `logger: baud_rate: 19200`) could fill the logs viewer with pages of fragmented garbage and lock up the browser tab until the device was reset. Two distinct problems:

1. **Resilience.** The serial path appended one line at a time (`dialog._lines = [...dialog._lines, line]`), each triggering a full re-render of an unbounded list, so a fast stream froze the tab. This batches appends into one render per animation frame (mirroring the existing `command-dialog` batcher) and caps the retained buffer to the newest 5000 lines. The view now stays responsive regardless of input rate.

2. **Garbage source.** An ESP8266 prints its boot/reset banner at a fixed 74880 baud; read at the app's configured baud it mis-samples into mojibake (U+FFFD replacement chars, control bytes), which recurs on every reset. Lines that are mostly such bytes are now dropped before reaching the parser, so they neither pollute the carried color/prefix state nor flood the view. Clean ESPHome logs are printable ASCII plus ANSI and pass through untouched.

Note: the filter removes the bulk of the mojibake, but an occasional clean-looking fragment (a bare `m` from a split reset, a short tail) can still slip through; the cap and batching make whatever slips through harmless. Fully eliminating ESP8266 boot-baud garbage would mean reading the boot at 74880 then switching to the app baud, which most tools don't do; out of scope here.

**Related issue or feature (if applicable):**

Found while testing serial logs on an ESP8266 with a non-default logger baud.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
