### PR TITLE
Fix shared-backlog link to use the correct project filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create-device wizard's board picker — searchable, filterable by chip family, w
 
 ## Backlog
 
-Before filing anything, take a look at the **[shared backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22)** — it lists everything that's already planned, in progress, or shipped for the dashboard. Saves duplicates and gives you a feel for where the project is heading.
+Before filing anything, take a look at the **[shared backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22)** — it lists everything that's already planned, in progress, or shipped for the dashboard. Saves duplicates and gives you a feel for where the project is heading.
 
 ## Issues and feature requests
 


### PR DESCRIPTION
# What does this implement/fix?

The README's shared-backlog link filtered on project `device-builder-dashboard`, which no longer matches the board's project field, so it opened an empty view. Switch the filter to `device-builder` to match the backend README and land on the populated board.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1533

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
