### PR TITLE
Reset checkbox display state when reusing a dialog

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -328,7 +328,7 @@ export class ESPHomeAdoptDialog extends LitElement {
               <label class="checkbox-row">
                 <input
                   type="checkbox"
-                  ?checked=${this._encryption}
+                  .checked=${this._encryption}
                   ?disabled=${this._busy}
                   @change=${(e: Event) => {
                     this._encryption = (e.target as HTMLInputElement).checked;

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -222,7 +222,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
         </div>
         <div class="install-row">
           <wa-checkbox
-            ?checked=${this._install}
+            .checked=${this._install}
             @change=${(e: Event) => {
               this._install = (e.target as HTMLInputElement).checked;
             }}

--- a/test/components/adopt-dialog-checkbox-reset.test.ts
+++ b/test/components/adopt-dialog-checkbox-reset.test.ts
@@ -5,7 +5,7 @@
  * the reused dialog is reopened: a prior user uncheck must not leave the box
  * visually unchecked while `_encryption` is back to true (issue #1535).
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 
@@ -30,6 +30,10 @@ const checkbox = (el: ESPHomeAdoptDialog) =>
   el.shadowRoot!.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
 
 describe("adopt-dialog encryption checkbox reset", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
   it("re-checks the box on reopen after a prior uncheck", async () => {
     const el = await mount();
 

--- a/test/components/adopt-dialog-checkbox-reset.test.ts
+++ b/test/components/adopt-dialog-checkbox-reset.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins that the encryption checkbox tracks the reset `_encryption` state when
+ * the reused dialog is reopened: a prior user uncheck must not leave the box
+ * visually unchecked while `_encryption` is back to true (issue #1535).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/components/base-dialog.js", () => ({}));
+
+import type { AdoptableDevice } from "../../src/api/types/devices.js";
+import { ESPHomeAdoptDialog } from "../../src/components/adopt-dialog.js";
+
+const DEVICE = {
+  name: "foo-1234",
+  friendly_name: "Foo",
+  project_name: "acme.widget",
+  package_import_url: "github://acme/widget/widget.yaml@main",
+} as unknown as AdoptableDevice;
+
+async function mount(): Promise<ESPHomeAdoptDialog> {
+  const el = new ESPHomeAdoptDialog();
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const checkbox = (el: ESPHomeAdoptDialog) =>
+  el.shadowRoot!.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+
+describe("adopt-dialog encryption checkbox reset", () => {
+  it("re-checks the box on reopen after a prior uncheck", async () => {
+    const el = await mount();
+
+    el.open(DEVICE);
+    await el.updateComplete;
+    const box = checkbox(el);
+    box.checked = false;
+    box.dispatchEvent(new Event("change"));
+    await el.updateComplete;
+    expect(checkbox(el).checked).toBe(false);
+
+    el.close();
+    await el.updateComplete;
+
+    el.open(DEVICE);
+    await el.updateComplete;
+    expect(checkbox(el).checked).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Fixes a checkbox state desync in two reused singleton dialogs. The "Install immediately" box in Edit friendly name and the encryption box in the adopt dialog were bound with an attribute binding (`?checked`), which only feeds the checkbox's `defaultChecked`; once the user clicks the box it latches its own dirty state and ignores the attribute. So reopening the dialog after an uncheck left the box visually unchecked while the backing state had already reset to checked, and Edit friendly name then fired the install flow even though the box looked unchecked. Switching both to a property binding (`.checked`) makes the box track the reset state on every reopen.

Added a regression test for the adopt dialog; the friendly-name dialog mocks out the WebAwesome checkbox in tests so the sticky state can't be reproduced there, verified that path in the browser instead.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1535

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
