### PR TITLE
Show ESPHome version on paired build server rows

### DIFF
--- a/src/api/types/event-subscription.ts
+++ b/src/api/types/event-subscription.ts
@@ -68,8 +68,8 @@ export enum DeviceEventType {
   // to the receiver enters / leaves the post-handshake parked
   // state. Drives the PairingSummary.connected indicator on
   // the offloader-side Paired-build-servers list. Both events
-  // share the same OffloaderPeerLinkSessionEventData shape;
-  // the discriminator is the event type itself.
+  // share the OffloaderPeerLinkSessionEventData identity base;
+  // OPENED adds esphome_version, CLOSED adds reason/error_detail.
   OFFLOADER_PEER_LINK_OPENED = "offloader_peer_link_opened",
   OFFLOADER_PEER_LINK_CLOSED = "offloader_peer_link_closed",
   // Offloader-side remote-build job lifecycle. Fired by the

--- a/src/api/types/remote-build-events.ts
+++ b/src/api/types/remote-build-events.ts
@@ -149,22 +149,30 @@ export interface ReceiverPeerLinkSessionEventData {
 }
 
 /**
- * Data payload for offloader_peer_link_opened.
+ * Shared identity base for the peer-link session events
+ * (OPENED / CLOSED).
  *
- * Fires on the offloader-side bus when the long-lived
- * PeerLinkClient enters its post-handshake parked state.
- * Drives the PairingSummary.connected indicator: app-shell
- * flips the matching row's connected flag in the local
- * _buildOffloadPairings map keyed by pin_sha256. Receiver
- * coords are carried as display fields the renderer can use
- * without a follow-up lookup, but they're ignored when keying
- * the map (4a-o part 6; pin_sha256 is the canonical row
- * identity).
+ * pin_sha256 is the canonical row key in the local
+ * _buildOffloadPairings map; receiver coords are display fields
+ * the renderer can use without a follow-up lookup (4a-o part 6).
  */
 export interface OffloaderPeerLinkSessionEventData {
   receiver_hostname: string;
   receiver_port: number;
   pin_sha256: string;
+}
+
+/**
+ * Data payload for offloader_peer_link_opened.
+ *
+ * The OPENED counterpart of the shared identity base, plus the
+ * receiver's freshly-handshaked esphome_version. App-shell merges
+ * it into the matching row keyed by pin_sha256 so a receiver
+ * upgrade surfaces on the next reconnect without a page reload.
+ * Empty until the first handshake fills it in.
+ */
+export interface OffloaderPeerLinkOpenedEventData extends OffloaderPeerLinkSessionEventData {
+  esphome_version: string;
 }
 
 /**

--- a/src/components/app-shell/events.ts
+++ b/src/components/app-shell/events.ts
@@ -19,7 +19,7 @@ import type {
   OffloaderPairPinMismatchEventData,
   OffloaderPairStatusChangedEventData,
   OffloaderPeerLinkClosedEventData,
-  OffloaderPeerLinkSessionEventData,
+  OffloaderPeerLinkOpenedEventData,
   OffloaderRemoteBuildsToggledEventData,
   OffloaderVersionMatchPolicyChangedEventData,
   ReceiverPeerLinkSessionEventData,
@@ -281,11 +281,12 @@ export function handleEvent(host: ESPHomeApp, event: string, data: unknown): voi
     case DeviceEventType.OFFLOADER_PEER_LINK_OPENED: {
       // OPENED clears the failure record: a successful session-open
       // invalidates whatever caused the previous close.
-      const evt = data as OffloaderPeerLinkSessionEventData;
+      const evt = data as OffloaderPeerLinkOpenedEventData;
       patchOffloadPairing(host, evt.pin_sha256, {
         connected: true,
         connecting: false,
         last_connect_error: "",
+        esphome_version: evt.esphome_version,
       });
       break;
     }

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -85,6 +85,12 @@ export function renderPairingRow(
         </span>
         <span class="row-desc">
           ${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}
+          ${pairing.esphome_version &&
+          classifyVersionMismatch(appVersion, pairing.esphome_version) === null
+            ? localize("settings.remote_build_peer_version_line", {
+                esphome: pairing.esphome_version,
+              })
+            : nothing}
         </span>
         ${pairing.status === "approved" &&
         !pairing.connected &&

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -4,10 +4,7 @@ import type { PairingSummary } from "../../api/types/remote-build.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { RemoteBuildJobState } from "../../context/index.js";
 import { trimTrailingDot } from "../../util/hostname.js";
-import {
-  classifyVersionMismatch,
-  type VersionMismatchKind,
-} from "../../util/version-mismatch.js";
+import { classifyVersionMismatch } from "../../util/version-mismatch.js";
 
 interface PillResult {
   pillClass: string;
@@ -65,10 +62,6 @@ export function renderPairingRow(
     onUnpair,
   } = ctx;
   const { pillClass, pillLabel } = pillFor(pairing, localize);
-  // Computed once and threaded into both version helpers: the plain
-  // line shows only when versions match, the mismatch note only when
-  // they don't, so they never double up.
-  const versionMismatch = classifyVersionMismatch(appVersion, pairing.esphome_version);
   return html`
     <div class="row peer-row row--stacked">
       <div class="row-label">
@@ -92,7 +85,6 @@ export function renderPairingRow(
         </span>
         <span class="row-desc">
           ${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}
-          ${renderPeerVersionLine(pairing, localize, versionMismatch)}
         </span>
         ${pairing.status === "approved" &&
         !pairing.connected &&
@@ -105,7 +97,7 @@ export function renderPairingRow(
               </span>
             `
           : nothing}
-        ${renderVersionMismatch(pairing, localize, appVersion, versionMismatch)}
+        ${renderPeerVersion(pairing, localize, appVersion)}
       </div>
       <div class="pairing-actions">
         ${pairing.status === "approved" && pairing.connected
@@ -167,33 +159,25 @@ export function renderPairingRow(
   `;
 }
 
-function renderPeerVersionLine(
+function renderPeerVersion(
   pairing: PairingSummary,
   localize: LocalizeFunc,
-  versionMismatch: VersionMismatchKind
-): string | typeof nothing {
-  // Mirror of renderVersionMismatch: scoped to approved rows, the
-  // plain version line is the match case, so it yields when there's
-  // a mismatch note to show (or no version yet).
-  if (
-    pairing.status !== "approved" ||
-    !pairing.esphome_version ||
-    versionMismatch !== null
-  ) {
-    return nothing;
-  }
-  return localize("settings.remote_build_peer_version_line", {
-    esphome: pairing.esphome_version,
-  });
-}
-
-function renderVersionMismatch(
-  pairing: PairingSummary,
-  localize: LocalizeFunc,
-  appVersion: string,
-  kind: VersionMismatchKind
+  appVersion: string
 ): TemplateResult | typeof nothing {
-  if (pairing.status !== "approved" || kind === null) return nothing;
+  // One sub-line for an approved row's version: a plain "ESPHome X"
+  // when it matches the local version, or the cautionary note when it
+  // doesn't. Hidden until the first handshake fills in esphome_version.
+  if (pairing.status !== "approved" || !pairing.esphome_version) return nothing;
+  const kind = classifyVersionMismatch(appVersion, pairing.esphome_version);
+  if (kind === null) {
+    return html`
+      <span class="row-desc">
+        ${localize("settings.remote_build_peer_version_line", {
+          esphome: pairing.esphome_version,
+        })}
+      </span>
+    `;
+  }
   const key =
     kind === "release"
       ? "settings.build_offload_pairing_version_mismatch_release"

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -172,10 +172,16 @@ function renderPeerVersionLine(
   localize: LocalizeFunc,
   versionMismatch: VersionMismatchKind
 ): string | typeof nothing {
-  // Mirror of renderVersionMismatch: the plain version line is the
-  // match case, so it yields when there's a mismatch note to show
-  // (or no version yet).
-  if (!pairing.esphome_version || versionMismatch !== null) return nothing;
+  // Mirror of renderVersionMismatch: scoped to approved rows, the
+  // plain version line is the match case, so it yields when there's
+  // a mismatch note to show (or no version yet).
+  if (
+    pairing.status !== "approved" ||
+    !pairing.esphome_version ||
+    versionMismatch !== null
+  ) {
+    return nothing;
+  }
   return localize("settings.remote_build_peer_version_line", {
     esphome: pairing.esphome_version,
   });

--- a/src/components/settings-dialog/build-offload-pairing-row.ts
+++ b/src/components/settings-dialog/build-offload-pairing-row.ts
@@ -4,7 +4,10 @@ import type { PairingSummary } from "../../api/types/remote-build.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import type { RemoteBuildJobState } from "../../context/index.js";
 import { trimTrailingDot } from "../../util/hostname.js";
-import { classifyVersionMismatch } from "../../util/version-mismatch.js";
+import {
+  classifyVersionMismatch,
+  type VersionMismatchKind,
+} from "../../util/version-mismatch.js";
 
 interface PillResult {
   pillClass: string;
@@ -62,6 +65,10 @@ export function renderPairingRow(
     onUnpair,
   } = ctx;
   const { pillClass, pillLabel } = pillFor(pairing, localize);
+  // Computed once and threaded into both version helpers: the plain
+  // line shows only when versions match, the mismatch note only when
+  // they don't, so they never double up.
+  const versionMismatch = classifyVersionMismatch(appVersion, pairing.esphome_version);
   return html`
     <div class="row peer-row row--stacked">
       <div class="row-label">
@@ -85,12 +92,7 @@ export function renderPairingRow(
         </span>
         <span class="row-desc">
           ${trimTrailingDot(pairing.receiver_hostname)}:${pairing.receiver_port}
-          ${pairing.esphome_version &&
-          classifyVersionMismatch(appVersion, pairing.esphome_version) === null
-            ? localize("settings.remote_build_peer_version_line", {
-                esphome: pairing.esphome_version,
-              })
-            : nothing}
+          ${renderPeerVersionLine(pairing, localize, versionMismatch)}
         </span>
         ${pairing.status === "approved" &&
         !pairing.connected &&
@@ -103,7 +105,7 @@ export function renderPairingRow(
               </span>
             `
           : nothing}
-        ${renderVersionMismatch(pairing, localize, appVersion)}
+        ${renderVersionMismatch(pairing, localize, appVersion, versionMismatch)}
       </div>
       <div class="pairing-actions">
         ${pairing.status === "approved" && pairing.connected
@@ -165,14 +167,27 @@ export function renderPairingRow(
   `;
 }
 
+function renderPeerVersionLine(
+  pairing: PairingSummary,
+  localize: LocalizeFunc,
+  versionMismatch: VersionMismatchKind
+): string | typeof nothing {
+  // Mirror of renderVersionMismatch: the plain version line is the
+  // match case, so it yields when there's a mismatch note to show
+  // (or no version yet).
+  if (!pairing.esphome_version || versionMismatch !== null) return nothing;
+  return localize("settings.remote_build_peer_version_line", {
+    esphome: pairing.esphome_version,
+  });
+}
+
 function renderVersionMismatch(
   pairing: PairingSummary,
   localize: LocalizeFunc,
-  appVersion: string
+  appVersion: string,
+  kind: VersionMismatchKind
 ): TemplateResult | typeof nothing {
-  if (pairing.status !== "approved") return nothing;
-  const kind = classifyVersionMismatch(appVersion, pairing.esphome_version);
-  if (kind === null) return nothing;
+  if (pairing.status !== "approved" || kind === null) return nothing;
   const key =
     kind === "release"
       ? "settings.build_offload_pairing_version_mismatch_release"

--- a/test/components/app-shell/events-peer-link-opened.test.ts
+++ b/test/components/app-shell/events-peer-link-opened.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { DeviceEventType } from "../../../src/api/types/event-subscription.js";
+import type { OffloaderPeerLinkOpenedEventData } from "../../../src/api/types/remote-build-events.js";
+import type { PairingSummary } from "../../../src/api/types/remote-build.js";
+import type { ESPHomeApp } from "../../../src/components/app-shell.js";
+import { handleEvent } from "../../../src/components/app-shell/events.js";
+
+function makeSummary(pin: string, esphome_version: string): PairingSummary {
+  return {
+    receiver_hostname: "192.168.1.50",
+    receiver_port: 6052,
+    pin_sha256: pin,
+    label: "lab-receiver",
+    paired_at: 1,
+    status: "approved",
+    connected: false,
+    connecting: true,
+    last_connect_error: "boom",
+    esphome_version,
+    enabled: true,
+  };
+}
+
+function opened(pin: string, esphome_version: string): OffloaderPeerLinkOpenedEventData {
+  return {
+    receiver_hostname: "192.168.1.50",
+    receiver_port: 6052,
+    pin_sha256: pin,
+    esphome_version,
+  };
+}
+
+type Host = Pick<ESPHomeApp, "_buildOffloadPairings">;
+
+function dispatch(host: Host, evt: OffloaderPeerLinkOpenedEventData): void {
+  handleEvent(host as ESPHomeApp, DeviceEventType.OFFLOADER_PEER_LINK_OPENED, evt);
+}
+
+describe("handleEvent OFFLOADER_PEER_LINK_OPENED", () => {
+  it("merges the freshly-handshaked esphome_version into the row", () => {
+    const pin = "a".repeat(64);
+    const host: Host = {
+      _buildOffloadPairings: new Map([[pin, makeSummary(pin, "2026.5.0")]]),
+    };
+
+    dispatch(host, opened(pin, "2026.6.0"));
+
+    const row = host._buildOffloadPairings?.get(pin);
+    expect(row?.esphome_version).toBe("2026.6.0");
+    expect(row?.connected).toBe(true);
+    expect(row?.connecting).toBe(false);
+    expect(row?.last_connect_error).toBe("");
+  });
+
+  it("no-ops when the row is not in the map", () => {
+    const host: Host = { _buildOffloadPairings: new Map() };
+
+    dispatch(host, opened("b".repeat(64), "2026.6.0"));
+
+    expect(host._buildOffloadPairings?.size).toBe(0);
+  });
+});

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -1,0 +1,70 @@
+import type { TemplateResult } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { PairingSummary } from "../../../src/api/types/remote-build.js";
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { renderPairingRow } from "../../../src/components/settings-dialog/build-offload-pairing-row.js";
+import { visitTemplates } from "../../_lit-template-walker.js";
+
+const localize: LocalizeFunc = ((key: string, values?: Record<string, unknown>) =>
+  values ? `${key} ${JSON.stringify(values)}` : key) as LocalizeFunc;
+
+function makeSummary(esphome_version: string): PairingSummary {
+  return {
+    receiver_hostname: "mac.local",
+    receiver_port: 6055,
+    pin_sha256: "a".repeat(64),
+    label: "macbook",
+    paired_at: 1,
+    status: "approved",
+    connected: true,
+    connecting: false,
+    last_connect_error: "",
+    esphome_version,
+    enabled: true,
+  };
+}
+
+function ctx() {
+  return {
+    localize,
+    // Equal to the peer version so renderVersionMismatch stays silent
+    // and the plain version line is the only version text.
+    appVersion: "2026.6.0",
+    latestJob: undefined,
+    onToggleEnabled: vi.fn(),
+    onBuildRemote: vi.fn(),
+    onViewBuild: vi.fn(),
+    onEditEndpoint: vi.fn(),
+    onUnpair: vi.fn(),
+  };
+}
+
+/** Flatten the static strings + string values across the template tree. */
+function renderedText(root: TemplateResult): string {
+  const parts: string[] = [];
+  visitTemplates(root, (t) => {
+    parts.push(...t.strings);
+    for (const v of t.values) if (typeof v === "string") parts.push(v);
+  });
+  return parts.join(" ");
+}
+
+describe("renderPairingRow version line", () => {
+  it("renders the ESPHome version when the peer has reported one", () => {
+    const text = renderedText(renderPairingRow(makeSummary("2026.6.0"), ctx()));
+    expect(text).toContain("settings.remote_build_peer_version_line");
+    expect(text).toContain("2026.6.0");
+  });
+
+  it("omits the version line before the first handshake (empty version)", () => {
+    const text = renderedText(renderPairingRow(makeSummary(""), ctx()));
+    expect(text).not.toContain("settings.remote_build_peer_version_line");
+  });
+
+  it("omits the version line on a mismatch (the mismatch note already states it)", () => {
+    // appVersion 2026.6.0 vs peer 2026.5.0 -> release mismatch.
+    const text = renderedText(renderPairingRow(makeSummary("2026.5.0"), ctx()));
+    expect(text).not.toContain("settings.remote_build_peer_version_line");
+    expect(text).toContain("settings.build_offload_pairing_version_mismatch_release");
+  });
+});

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -27,8 +27,8 @@ function makeSummary(esphome_version: string): PairingSummary {
 function ctx() {
   return {
     localize,
-    // Equal to the peer version so renderVersionMismatch stays silent
-    // and the plain version line is the only version text.
+    // Equal to the peer version so renderPeerVersion emits the plain
+    // line, not the mismatch note.
     appVersion: "2026.6.0",
     latestJob: undefined,
     onToggleEnabled: vi.fn(),

--- a/test/components/settings-dialog/render-pairing-row.test.ts
+++ b/test/components/settings-dialog/render-pairing-row.test.ts
@@ -67,4 +67,10 @@ describe("renderPairingRow version line", () => {
     expect(text).not.toContain("settings.remote_build_peer_version_line");
     expect(text).toContain("settings.build_offload_pairing_version_mismatch_release");
   });
+
+  it("omits the version line on a non-approved row even with a retained version", () => {
+    const pending = { ...makeSummary("2026.6.0"), status: "pending" as const };
+    const text = renderedText(renderPairingRow(pending, ctx()));
+    expect(text).not.toContain("settings.remote_build_peer_version_line");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The paired build server rows in Settings only showed the host and port, so there was no way to tell which ESPHome version a connected build server runs; the Known Dashboards list right below it already shows that. This adds the version to each paired row, reusing the same line. It only renders once the receiver has handshaked, and it stays out of the way when the versions differ since the existing mismatch note already states both versions.

It also keeps the shown version fresh. The backend already sends `esphome_version` on `offloader_peer_link_opened`, but the frontend dropped it, so a row kept its snapshot value until a full reload. The event payload now carries it and the handler merges it, so an upgraded build server shows up on the next reconnect without a reload.

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/device-builder/issues/1545

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
