### PR TITLE
Guard the version badge against a null server version

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -73,6 +73,7 @@ export class ESPHomeLayout extends LitElement {
 
   /** Hardcoded (untranslated) badge label for a non-stable backend, else null. */
   private get _versionBadge(): string | null {
+    if (!this._serverVersion) return null;
     const channel = deviceBuilderChannel(this._serverVersion);
     if (!channel) return null;
     return channel === "dev" ? "Dev" : "Beta";

--- a/src/util/device-builder-channel.ts
+++ b/src/util/device-builder-channel.ts
@@ -8,8 +8,10 @@ export type DeviceBuilderChannel = "dev" | "beta";
  * ``0.0.0`` version, or any ``dev`` marker, is ``"dev"``; anything else
  * with a non-numeric suffix (``0.1.0b117``, ``0.2.0rc1``) is ``"beta"``.
  */
-export function deviceBuilderChannel(version: string): DeviceBuilderChannel | null {
-  const v = version.trim().replace(/^v/, "");
+export function deviceBuilderChannel(
+  version: string | null | undefined
+): DeviceBuilderChannel | null {
+  const v = (version ?? "").trim().replace(/^v/, "");
   if (!v || v === "0.0.0" || /dev/i.test(v)) return "dev";
   if (!/^\d+(\.\d+)*$/.test(v)) return "beta";
   return null;

--- a/src/util/device-builder-channel.ts
+++ b/src/util/device-builder-channel.ts
@@ -1,17 +1,19 @@
 export type DeviceBuilderChannel = "dev" | "beta";
 
 /**
- * Classify the Device Builder backend version's release channel, or
- * ``null`` for a stable release.
+ * Classify the Device Builder backend version's release channel.
  *
- * Stable versions are pure dotted digits (``1.0.0``). An empty or
- * ``0.0.0`` version, or any ``dev`` marker, is ``"dev"``; anything else
- * with a non-numeric suffix (``0.1.0b117``, ``0.2.0rc1``) is ``"beta"``.
+ * Returns ``null`` for a stable release (pure dotted digits like
+ * ``1.0.0``) and for an unknown version (``null`` / ``undefined``, i.e.
+ * no channel is determinable). An empty/whitespace or ``0.0.0`` version,
+ * or any ``dev`` marker, is ``"dev"``; anything else with a non-numeric
+ * suffix (``0.1.0b117``, ``0.2.0rc1``) is ``"beta"``.
  */
 export function deviceBuilderChannel(
   version: string | null | undefined
 ): DeviceBuilderChannel | null {
-  const v = (version ?? "").trim().replace(/^v/, "");
+  if (version == null) return null;
+  const v = version.trim().replace(/^v/, "");
   if (!v || v === "0.0.0" || /dev/i.test(v)) return "dev";
   if (!/^\d+(\.\d+)*$/.test(v)) return "beta";
   return null;

--- a/test/components/esphome-layout-version-badge.test.ts
+++ b/test/components/esphome-layout-version-badge.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test } from "vitest";
+
+import { ESPHomeLayout } from "../../src/components/esphome-layout.js";
+
+interface ServerVersionView {
+  _serverVersion: string | null;
+}
+
+async function renderWithServerVersion(
+  serverVersion: string | null
+): Promise<ESPHomeLayout> {
+  const el = new ESPHomeLayout();
+  (el as unknown as ServerVersionView)._serverVersion = serverVersion;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function badge(el: ESPHomeLayout): HTMLElement | null {
+  return el.shadowRoot!.querySelector(".preview-badge");
+}
+
+describe("esphome-layout version badge", () => {
+  let el: ESPHomeLayout | undefined;
+
+  afterEach(() => {
+    el?.remove();
+    el = undefined;
+  });
+
+  test("renders with no badge and does not throw when server version is null", async () => {
+    el = await renderWithServerVersion(null);
+    expect(badge(el)).toBeNull();
+    // Header still rendered, so the layout didn't crash mid-render.
+    expect(el.shadowRoot!.querySelector(".header-title-text")).not.toBeNull();
+  });
+
+  test("shows Dev for a dev backend", async () => {
+    el = await renderWithServerVersion("0.0.0");
+    expect(badge(el)?.textContent?.trim()).toBe("Dev");
+  });
+
+  test("shows Beta for a pre-release backend", async () => {
+    el = await renderWithServerVersion("0.1.0b117");
+    expect(badge(el)?.textContent?.trim()).toBe("Beta");
+  });
+
+  test("shows no badge for a stable backend", async () => {
+    el = await renderWithServerVersion("1.0.0");
+    expect(badge(el)).toBeNull();
+  });
+});

--- a/test/util/device-builder-channel.test.ts
+++ b/test/util/device-builder-channel.test.ts
@@ -24,8 +24,8 @@ describe("deviceBuilderChannel", () => {
     expect(deviceBuilderChannel("2026.5.0-dev")).toBe("dev");
   });
 
-  it("tolerates null/undefined without throwing", () => {
-    expect(deviceBuilderChannel(null)).toBe("dev");
-    expect(deviceBuilderChannel(undefined)).toBe("dev");
+  it("returns null for an unknown (null/undefined) version", () => {
+    expect(deviceBuilderChannel(null)).toBeNull();
+    expect(deviceBuilderChannel(undefined)).toBeNull();
   });
 });

--- a/test/util/device-builder-channel.test.ts
+++ b/test/util/device-builder-channel.test.ts
@@ -23,4 +23,9 @@ describe("deviceBuilderChannel", () => {
     expect(deviceBuilderChannel("0.1.0.dev5+g1234")).toBe("dev");
     expect(deviceBuilderChannel("2026.5.0-dev")).toBe("dev");
   });
+
+  it("tolerates null/undefined without throwing", () => {
+    expect(deviceBuilderChannel(null)).toBe("dev");
+    expect(deviceBuilderChannel(undefined)).toBe("dev");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The dashboard white-screened on load with `TypeError: can't access property "trim", e is null` from the `_versionBadge` getter. `_versionBadge` calls `deviceBuilderChannel(this._serverVersion)`, which trims the value; when `server_version` from the wire is null or missing, the getter throws during render, and because Lit evaluates it inside the header template the whole layout render aborts, not just the badge.

This returns null from `_versionBadge` when the server version is falsy (mirroring the footer and feedback-dialog guards, so the badge is just absent until a real version arrives), and makes `deviceBuilderChannel` tolerate null/undefined as defense in depth. A render test pins it; it reproduces the exact crash without the guard.

**Related issue or feature (if applicable):**

- N/A; found via the browser console during local testing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
