### PR TITLE
Add a help-translate link to the language settings

### DIFF
--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -1,5 +1,6 @@
 import { consume } from "@lit/context";
-import { LitElement, html } from "lit";
+import { mdiOpenInNew } from "@mdi/js";
+import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { LanguageChoice, LocalizeFunc } from "../../common/localize.js";
@@ -7,10 +8,17 @@ import { LANGUAGES, languageLabel, readStoredLocale } from "../../common/localiz
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/option/option.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
+
+registerMdiIcons({ "open-in-new": mdiOpenInNew });
+
+// The ESPHome translations guide, which links on to Lokalise; see issue #888.
+const TRANSLATIONS_GUIDE_URL = "https://developers.esphome.io/contributing/translations/";
 
 @customElement("esphome-settings-language")
 export class ESPHomeSettingsLanguage extends LitElement {
@@ -21,7 +29,32 @@ export class ESPHomeSettingsLanguage extends LitElement {
   @state()
   private _language: LanguageChoice = readStoredLocale() ?? "system";
 
-  static styles = [espHomeStyles, inputStyles, settingsSharedStyles, settingsRowStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    settingsSharedStyles,
+    settingsRowStyles,
+    css`
+      .language-help {
+        margin: var(--wa-space-xs) 0 0;
+        font-size: var(--wa-font-size-xs);
+        color: var(--wa-color-text-quiet);
+        line-height: 1.4;
+      }
+      .language-help-link {
+        color: var(--esphome-primary);
+        text-decoration: none;
+        white-space: nowrap;
+      }
+      .language-help-link:hover {
+        text-decoration: underline;
+      }
+      .language-help-link wa-icon {
+        font-size: 1em;
+        vertical-align: -0.15em;
+      }
+    `,
+  ];
 
   protected render() {
     return html`
@@ -39,6 +72,19 @@ export class ESPHomeSettingsLanguage extends LitElement {
             `
           )}
         </wa-select>
+        <p class="language-help">
+          <span aria-hidden="true">💡</span>
+          ${this._localize("settings.language_help")}
+          <a
+            class="language-help-link"
+            href=${TRANSLATIONS_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ${this._localize("settings.language_help_link")}
+            <wa-icon library="mdi" name="open-in-new"></wa-icon>
+          </a>
+        </p>
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1044,6 +1044,8 @@
     "language": "Language",
     "language_desc": "Choose the language used across the interface.",
     "language_system": "System",
+    "language_help": "Is your language missing or incomplete?",
+    "language_help_link": "Help translate ESPHome",
     "theme_desc": "Choose between light, dark, or follow your system preference.",
     "expert_mode": "Expert Mode",
     "expert_mode_desc": "Enabling Expert Mode will unlock some additional powerful options in the Device Builder for experienced power users of ESPHome.",

--- a/test/common/localize.test.ts
+++ b/test/common/localize.test.ts
@@ -10,6 +10,13 @@ describe("defaultLocalize", () => {
     expect(defaultLocalize("wizard.tag.esp32")).toBe("ESP32");
   });
 
+  it("resolves the language translation-help keys", () => {
+    expect(defaultLocalize("settings.language_help")).toBe(
+      "Is your language missing or incomplete?"
+    );
+    expect(defaultLocalize("settings.language_help_link")).toBe("Help translate ESPHome");
+  });
+
   it("returns the key unchanged when missing", () => {
     expect(defaultLocalize("does.not.exist")).toBe("does.not.exist");
   });

--- a/test/components/settings-dialog/language-section.test.ts
+++ b/test/components/settings-dialog/language-section.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import type { TemplateResult } from "lit";
+import { describe, expect, it } from "vitest";
+
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { ESPHomeSettingsLanguage } from "../../../src/components/settings-dialog/language-section.js";
+import { visitTemplates } from "../../_lit-template-walker.js";
+
+const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+
+// Flatten the static strings + string values across the template tree.
+// wa-select can't mount under happy-dom (form association), so inspect the
+// rendered template directly instead of appending the component to the DOM.
+function renderedText(root: TemplateResult): string {
+  const parts: string[] = [];
+  visitTemplates(root, (t) => {
+    parts.push(...t.strings);
+    for (const v of t.values) if (typeof v === "string") parts.push(v);
+  });
+  return parts.join(" ");
+}
+
+function render(): TemplateResult {
+  const el = new ESPHomeSettingsLanguage();
+  (el as unknown as { _localize: LocalizeFunc })._localize = localize;
+  return (el as unknown as { render(): TemplateResult }).render();
+}
+
+describe("esphome-settings-language translation help", () => {
+  it("renders an external link to the ESPHome translations guide", () => {
+    const text = renderedText(render());
+    expect(text).toContain("https://developers.esphome.io/contributing/translations/");
+    expect(text).toContain('target="_blank"');
+    expect(text).toContain('rel="noopener noreferrer"');
+    expect(text).toContain("settings.language_help");
+    expect(text).toContain("settings.language_help_link");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The language section in Settings now shows a quiet tip below the selector inviting people to help when their language is missing or incomplete; it links to the ESPHome translations guide, which in turn links to Lokalise. This mirrors the "Help translating" affordance Home Assistant has. The strings are English only for now; other locales fall back per key.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/888

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
