### PR TITLE
Extract shared settings toggle-row and status-row render helpers

### DIFF
--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -12,6 +12,7 @@ import {
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { renderToggleRow } from "./settings-rows.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -173,44 +174,25 @@ export class ESPHomeSettingsAppearance extends LitElement {
   }
 
   private _renderRemoteCompute() {
-    return html`
-      <div class="row">
-        <div class="row-label">
-          <span id="remote-compute-title" class="row-title">
-            ${this._localize("settings.remote_compute_only")}
-          </span>
-          <span class="row-desc">
-            ${this._localize("settings.remote_compute_only_desc")}
-          </span>
-        </div>
-        <button
-          class="toggle"
-          role="switch"
-          aria-labelledby="remote-compute-title"
-          aria-checked=${this._remoteComputeOnly}
-          @click=${this._onToggleRemoteCompute}
-        ></button>
-      </div>
-    `;
+    return renderToggleRow(this._localize, {
+      titleId: "remote-compute-title",
+      titleKey: "settings.remote_compute_only",
+      descKey: "settings.remote_compute_only_desc",
+      checked: this._remoteComputeOnly,
+      onToggle: this._onToggleRemoteCompute,
+    });
   }
 
   private _renderExpertMode() {
     return html`
-      <div class="row expert-row">
-        <div class="row-label">
-          <span id="expert-mode-title" class="row-title">
-            ${this._localize("settings.expert_mode")}
-          </span>
-          <span class="row-desc">${this._localize("settings.expert_mode_desc")}</span>
-        </div>
-        <button
-          class="toggle"
-          role="switch"
-          aria-labelledby="expert-mode-title"
-          aria-checked=${this._expertMode}
-          @click=${this._onToggleExpertMode}
-        ></button>
-      </div>
+      ${renderToggleRow(this._localize, {
+        titleId: "expert-mode-title",
+        titleKey: "settings.expert_mode",
+        descKey: "settings.expert_mode_desc",
+        checked: this._expertMode,
+        onToggle: this._onToggleExpertMode,
+        rowClass: "expert-row",
+      })}
       <div class="expert-features">
         <button
           class="expert-features-toggle"

--- a/src/components/settings-dialog/build-offload-advanced.ts
+++ b/src/components/settings-dialog/build-offload-advanced.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, html } from "lit";
+import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -8,6 +8,7 @@ import {
   offloaderIncludeLocalInPoolContext,
 } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { renderToggleRow } from "./settings-rows.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
 /**
@@ -31,39 +32,14 @@ export class ESPHomeSettingsBuildOffloadAdvanced extends LitElement {
   static styles = [espHomeStyles, settingsSharedStyles, settingsRowStyles];
 
   protected render() {
-    if (this._includeLocalInPool === null) {
-      return html`
-        <div class="row" role="status">
-          <div class="row-label">
-            <span class="row-title">
-              ${this._localize("settings.offloader_include_local")}
-            </span>
-            <span class="row-desc">
-              ${this._localize("settings.offloader_include_local_loading")}
-            </span>
-          </div>
-        </div>
-      `;
-    }
-    return html`
-      <div class="row">
-        <div class="row-label">
-          <span id="offloader-include-local-title" class="row-title">
-            ${this._localize("settings.offloader_include_local")}
-          </span>
-          <span class="row-desc">
-            ${this._localize("settings.offloader_include_local_desc")}
-          </span>
-        </div>
-        <button
-          class="toggle"
-          role="switch"
-          aria-labelledby="offloader-include-local-title"
-          aria-checked=${this._includeLocalInPool}
-          @click=${this._onToggleIncludeLocal}
-        ></button>
-      </div>
-    `;
+    return renderToggleRow(this._localize, {
+      titleId: "offloader-include-local-title",
+      titleKey: "settings.offloader_include_local",
+      descKey: "settings.offloader_include_local_desc",
+      loadingDescKey: "settings.offloader_include_local_loading",
+      checked: this._includeLocalInPool,
+      onToggle: this._onToggleIncludeLocal,
+    });
   }
 
   private _onToggleIncludeLocal = () => {

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -32,6 +32,7 @@ import type { ESPHomeRemoteBuildJobDialog } from "../remote-build-job-dialog.js"
 import { renderOffloaderAlert } from "./build-offload-alert.js";
 import { latestJobForPin, renderPairingRow } from "./build-offload-pairing-row.js";
 import { offloaderAlertStyles, pairingRowStyles } from "./offload-styles.js";
+import { renderStatusRow, renderToggleRow } from "./settings-rows.js";
 import {
   peerRowStyles,
   settingsRowStyles,
@@ -204,39 +205,14 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
   }
 
   private _renderRemoteBuildsToggle() {
-    if (this._remoteBuildsEnabled === null) {
-      return html`
-        <div class="row" role="status">
-          <div class="row-label">
-            <span class="row-title">
-              ${this._localize("settings.offloader_remote_builds_enabled")}
-            </span>
-            <span class="row-desc">
-              ${this._localize("settings.offloader_remote_builds_enabled_loading")}
-            </span>
-          </div>
-        </div>
-      `;
-    }
-    return html`
-      <div class="row">
-        <div class="row-label">
-          <span id="offloader-remote-builds-enabled-title" class="row-title">
-            ${this._localize("settings.offloader_remote_builds_enabled")}
-          </span>
-          <span class="row-desc">
-            ${this._localize("settings.offloader_remote_builds_enabled_desc")}
-          </span>
-        </div>
-        <button
-          class="toggle"
-          role="switch"
-          aria-labelledby="offloader-remote-builds-enabled-title"
-          aria-checked=${this._remoteBuildsEnabled}
-          @click=${this._onToggleRemoteBuilds}
-        ></button>
-      </div>
-    `;
+    return renderToggleRow(this._localize, {
+      titleId: "offloader-remote-builds-enabled-title",
+      titleKey: "settings.offloader_remote_builds_enabled",
+      descKey: "settings.offloader_remote_builds_enabled_desc",
+      loadingDescKey: "settings.offloader_remote_builds_enabled_loading",
+      checked: this._remoteBuildsEnabled,
+      onToggle: this._onToggleRemoteBuilds,
+    });
   }
 
   private _renderVersionMatchPolicyPicker() {
@@ -282,10 +258,10 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
 
   private _renderPairings() {
     if (this._pairings === null) {
-      return this._statusRow("settings.paired_build_servers_loading");
+      return renderStatusRow(this._localize, "settings.paired_build_servers_loading");
     }
     if (this._pairings.size === 0) {
-      return this._statusRow("settings.paired_build_servers_empty");
+      return renderStatusRow(this._localize, "settings.paired_build_servers_empty");
     }
     return Array.from(this._pairings.values()).map((p) =>
       renderPairingRow(p, {
@@ -301,19 +277,9 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     );
   }
 
-  private _statusRow(key: string) {
-    return html`
-      <div class="row" role="status">
-        <div class="row-label">
-          <span class="row-desc">${this._localize(key)}</span>
-        </div>
-      </div>
-    `;
-  }
-
   private _renderDiscoveredHosts() {
     if (this._discoveredHosts === null) {
-      return this._statusRow("settings.remote_build_peers_loading");
+      return renderStatusRow(this._localize, "settings.remote_build_peers_loading");
     }
     // remote_build_port === 0 means no peer-link receiver, so the dashboard
     // can't accept builds (e.g. an HA addon); hide it from this list.
@@ -321,7 +287,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       (peer) => peer.remote_build_port > 0 && !this._hasPairingFor(peer.hostname)
     );
     if (peers.length === 0) {
-      return this._statusRow("settings.remote_build_peers_empty");
+      return renderStatusRow(this._localize, "settings.remote_build_peers_empty");
     }
     return peers.map((peer) => this._renderDiscoveredRow(peer));
   }

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -31,6 +31,7 @@ import { registerMdiIcons } from "../../util/register-icons.js";
 import { formatSecondsAgo } from "../../util/relative-time.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import { buildServerCardStyles, cleanupTtlStyles } from "./build-server-styles.js";
+import { renderStatusRow, renderToggleRow } from "./settings-rows.js";
 import {
   peerRowStyles,
   settingsRowStyles,
@@ -118,24 +119,13 @@ export class ESPHomeSettingsBuildServer extends LitElement {
 
   protected render() {
     return html`
-      <div class="row">
-        <div class="row-label">
-          <span id="remote-build-enable-title" class="row-title">
-            ${this._localize("settings.remote_build_enable")}
-          </span>
-          <span class="row-desc">
-            ${this._localize("settings.remote_build_enable_desc")}
-          </span>
-        </div>
-        <button
-          class="toggle"
-          role="switch"
-          aria-labelledby="remote-build-enable-title"
-          aria-checked=${this._remoteBuildEnabled}
-          @click=${this._onToggleEnabled}
-        ></button>
-      </div>
-
+      ${renderToggleRow(this._localize, {
+        titleId: "remote-build-enable-title",
+        titleKey: "settings.remote_build_enable",
+        descKey: "settings.remote_build_enable_desc",
+        checked: this._remoteBuildEnabled,
+        onToggle: this._onToggleEnabled,
+      })}
       ${this._renderApprovedPeers()} ${this._renderPeerRemoveConfirmDialog()}
 
       <div class="section-heading">
@@ -159,20 +149,10 @@ export class ESPHomeSettingsBuildServer extends LitElement {
         ${this._localize("settings.build_server_paired_senders_desc")}
       </div>
       ${peers === null
-        ? this._loadingRow("settings.build_server_paired_senders_loading")
+        ? renderStatusRow(this._localize, "settings.build_server_paired_senders_loading")
         : approved.length === 0
-          ? this._loadingRow("settings.build_server_paired_senders_empty")
+          ? renderStatusRow(this._localize, "settings.build_server_paired_senders_empty")
           : approved.map((p) => this._renderApprovedPeerRow(p))}
-    `;
-  }
-
-  private _loadingRow(key: string) {
-    return html`
-      <div class="row" role="status">
-        <div class="row-label">
-          <span class="row-desc">${this._localize(key)}</span>
-        </div>
-      </div>
     `;
   }
 
@@ -273,18 +253,14 @@ export class ESPHomeSettingsBuildServer extends LitElement {
 
   private _renderCard() {
     if (this._identityLoadFailed) {
-      return html`
-        <div class="row" role="alert">
-          <div class="row-label">
-            <span class="row-desc">
-              ${this._localize("settings.remote_build_identity_load_failed")}
-            </span>
-          </div>
-        </div>
-      `;
+      return renderStatusRow(
+        this._localize,
+        "settings.remote_build_identity_load_failed",
+        "alert"
+      );
     }
     if (this._identity === null) {
-      return this._loadingRow("settings.remote_build_identity_loading");
+      return renderStatusRow(this._localize, "settings.remote_build_identity_loading");
     }
     const identity = this._identity;
     const formattedPin = formatPinSha256(identity.pin_sha256);

--- a/src/components/settings-dialog/pairing-requests-section.ts
+++ b/src/components/settings-dialog/pairing-requests-section.ts
@@ -18,6 +18,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { remainingOf } from "../../util/relative-time.js";
 import type { ESPHomeAcceptPeerDialog } from "../accept-peer-dialog.js";
 import { pairingWindowStyles } from "./pairing-styles.js";
+import { renderStatusRow } from "./settings-rows.js";
 import {
   peerRowStyles,
   settingsRowStyles,
@@ -113,24 +114,20 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
         ${this._localize("settings.build_server_pairing_requests_desc")}
       </div>
       ${peers === null
-        ? this._statusRow("settings.build_server_pairing_requests_loading")
+        ? renderStatusRow(
+            this._localize,
+            "settings.build_server_pairing_requests_loading"
+          )
         : pending.length === 0
-          ? this._statusRow("settings.build_server_pairing_requests_empty")
+          ? renderStatusRow(
+              this._localize,
+              "settings.build_server_pairing_requests_empty"
+            )
           : pending.map((p) => this._renderPendingRow(p))}
       <esphome-accept-peer-dialog
         @confirm=${this._onAcceptConfirm}
         @reject=${this._onRejectFromDialog}
       ></esphome-accept-peer-dialog>
-    `;
-  }
-
-  private _statusRow(key: string) {
-    return html`
-      <div class="row" role="status">
-        <div class="row-label">
-          <span class="row-desc">${this._localize(key)}</span>
-        </div>
-      </div>
     `;
   }
 

--- a/src/components/settings-dialog/settings-rows.ts
+++ b/src/components/settings-dialog/settings-rows.ts
@@ -17,7 +17,7 @@ export interface ToggleRowOptions {
 
 /**
  * Settings toggle row: title + description and a `role=switch` button.
-
+ *
  * A `null` `checked` renders the button-less loading variant (title +
  * `loadingDescKey`) instead.
  */

--- a/src/components/settings-dialog/settings-rows.ts
+++ b/src/components/settings-dialog/settings-rows.ts
@@ -1,0 +1,71 @@
+import { html, type TemplateResult } from "lit";
+import { classMap } from "lit/directives/class-map.js";
+
+import type { LocalizeFunc } from "../../common/localize.js";
+
+export interface ToggleRowOptions {
+  titleId: string;
+  titleKey: string;
+  descKey: string;
+  checked: boolean | null;
+  onToggle: () => void;
+  /** Loading-row description key; required when `checked` can be `null`. */
+  loadingDescKey?: string;
+  /** Extra class on the live `.row` (e.g. ``expert-row``). */
+  rowClass?: string;
+}
+
+/**
+ * Settings toggle row: title + description and a `role=switch` button.
+
+ * A `null` `checked` renders the desc-only loading variant instead.
+ */
+export function renderToggleRow(
+  localize: LocalizeFunc,
+  opts: ToggleRowOptions
+): TemplateResult {
+  if (opts.checked === null) {
+    return html`
+      <div class="row" role="status">
+        <div class="row-label">
+          <span class="row-title">${localize(opts.titleKey)}</span>
+          <span class="row-desc"> ${localize(opts.loadingDescKey ?? opts.descKey)} </span>
+        </div>
+      </div>
+    `;
+  }
+  const rowClasses = classMap({
+    row: true,
+    ...(opts.rowClass ? { [opts.rowClass]: true } : {}),
+  });
+  return html`
+    <div class=${rowClasses}>
+      <div class="row-label">
+        <span id=${opts.titleId} class="row-title"> ${localize(opts.titleKey)} </span>
+        <span class="row-desc">${localize(opts.descKey)}</span>
+      </div>
+      <button
+        class="toggle"
+        role="switch"
+        aria-labelledby=${opts.titleId}
+        aria-checked=${opts.checked}
+        @click=${opts.onToggle}
+      ></button>
+    </div>
+  `;
+}
+
+/** Desc-only status row (loading / empty / failure messages). */
+export function renderStatusRow(
+  localize: LocalizeFunc,
+  key: string,
+  role: "status" | "alert" = "status"
+): TemplateResult {
+  return html`
+    <div class="row" role=${role}>
+      <div class="row-label">
+        <span class="row-desc">${localize(key)}</span>
+      </div>
+    </div>
+  `;
+}

--- a/src/components/settings-dialog/settings-rows.ts
+++ b/src/components/settings-dialog/settings-rows.ts
@@ -3,17 +3,28 @@ import { classMap } from "lit/directives/class-map.js";
 
 import type { LocalizeFunc } from "../../common/localize.js";
 
-export interface ToggleRowOptions {
+interface ToggleRowBase {
   titleId: string;
   titleKey: string;
   descKey: string;
-  checked: boolean | null;
   onToggle: () => void;
-  /** Loading-row description key; required when `checked` can be `null`. */
-  loadingDescKey?: string;
   /** Extra class on the live `.row` (e.g. ``expert-row``). */
   rowClass?: string;
 }
+
+/** Always-live toggle: `checked` is a settled boolean, no loading row. */
+interface LiveToggleRowOptions extends ToggleRowBase {
+  checked: boolean;
+  loadingDescKey?: never;
+}
+
+/** Toggle whose state can be unresolved; `null` renders the loading row. */
+interface LoadableToggleRowOptions extends ToggleRowBase {
+  checked: boolean | null;
+  loadingDescKey: string;
+}
+
+export type ToggleRowOptions = LiveToggleRowOptions | LoadableToggleRowOptions;
 
 /**
  * Settings toggle row: title + description and a `role=switch` button.
@@ -30,7 +41,7 @@ export function renderToggleRow(
       <div class="row" role="status">
         <div class="row-label">
           <span class="row-title">${localize(opts.titleKey)}</span>
-          <span class="row-desc"> ${localize(opts.loadingDescKey ?? opts.descKey)} </span>
+          <span class="row-desc">${localize(opts.loadingDescKey)}</span>
         </div>
       </div>
     `;

--- a/src/components/settings-dialog/settings-rows.ts
+++ b/src/components/settings-dialog/settings-rows.ts
@@ -18,7 +18,8 @@ export interface ToggleRowOptions {
 /**
  * Settings toggle row: title + description and a `role=switch` button.
 
- * A `null` `checked` renders the desc-only loading variant instead.
+ * A `null` `checked` renders the button-less loading variant (title +
+ * `loadingDescKey`) instead.
  */
 export function renderToggleRow(
   localize: LocalizeFunc,

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -6,6 +6,7 @@
  * only for the component import (WebAwesome touches ``CSSStyleSheet`` at load);
  * the render call uses stubbed sentinels, no DOM.
  */
+import { render, type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
 import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";
 import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
@@ -28,9 +29,9 @@ type Row = { row: string };
 
 function makeHost(peers: RemoteBuildPeer[]) {
   return {
+    _localize: (key: string) => key,
     _discoveredHosts: new Map(peers.map((p) => [p.name, p])),
     _hasPairingFor: () => false,
-    _statusRow: (key: string) => ({ status: key }),
     _renderDiscoveredRow: (p: RemoteBuildPeer): Row => ({ row: p.name }),
   };
 }
@@ -43,13 +44,22 @@ function renderDiscoveredHosts(host: ReturnType<typeof makeHost>): unknown {
   return fn.call(host);
 }
 
+// The empty / loading branch returns a single status-row TemplateResult; render
+// it and read back the localize key the row shows.
+function statusRowKey(result: unknown): string | null {
+  if (Array.isArray(result)) return null;
+  const el = document.createElement("div");
+  render(result as TemplateResult, el);
+  return el.querySelector(".row-desc")?.textContent?.trim() ?? null;
+}
+
 describe("_renderDiscoveredHosts", () => {
   it("hides dashboards with no peer-link receiver (remote_build_port === 0)", () => {
     const host = makeHost([peer("addon", 0)]);
     // Every discovered host filtered out → the empty status row, not rows.
-    expect(renderDiscoveredHosts(host)).toEqual({
-      status: "settings.remote_build_peers_empty",
-    });
+    expect(statusRowKey(renderDiscoveredHosts(host))).toBe(
+      "settings.remote_build_peers_empty"
+    );
   });
 
   it("keeps build servers that bound a peer-link receiver", () => {

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -3,8 +3,8 @@
  *
  * Pins that ``_renderDiscoveredHosts`` hides un-buildable dashboards
  * (``remote_build_port === 0``) and keeps real build servers. ``happy-dom`` is
- * only for the component import (WebAwesome touches ``CSSStyleSheet`` at load);
- * the render call uses stubbed sentinels, no DOM.
+ * needed both for the component import (WebAwesome touches ``CSSStyleSheet`` at
+ * load) and to render the empty/loading status-row template back to its key.
  */
 import { render, type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";

--- a/test/components/settings-dialog/settings-rows.test.ts
+++ b/test/components/settings-dialog/settings-rows.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the shared settings row helpers: live toggle markup + a11y wiring, the
+ * `null` loading variant, the `expert-row` class pass-through, and the status /
+ * alert role.
+ */
+import { render, type TemplateResult } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  renderStatusRow,
+  renderToggleRow,
+} from "../../../src/components/settings-dialog/settings-rows.js";
+
+const localize = (key: string) => key;
+
+function mount(result: TemplateResult): HTMLElement {
+  const el = document.createElement("div");
+  render(result, el);
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("renderToggleRow", () => {
+  it("renders the live toggle with a11y wiring and fires onToggle", () => {
+    const onToggle = vi.fn();
+    const el = mount(
+      renderToggleRow(localize, {
+        titleId: "my-title",
+        titleKey: "settings.my_title",
+        descKey: "settings.my_desc",
+        checked: true,
+        onToggle,
+      })
+    );
+
+    const title = el.querySelector(".row-title")!;
+    expect(title.id).toBe("my-title");
+    expect(title.textContent?.trim()).toBe("settings.my_title");
+    expect(el.querySelector(".row-desc")?.textContent?.trim()).toBe("settings.my_desc");
+
+    const btn = el.querySelector<HTMLButtonElement>('button.toggle[role="switch"]')!;
+    expect(btn.getAttribute("aria-labelledby")).toBe("my-title");
+    expect(btn.getAttribute("aria-checked")).toBe("true");
+
+    btn.click();
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("applies an extra row class", () => {
+    const el = mount(
+      renderToggleRow(localize, {
+        titleId: "x",
+        titleKey: "k",
+        descKey: "d",
+        checked: false,
+        onToggle: () => {},
+        rowClass: "expert-row",
+      })
+    );
+    const row = el.querySelector(".row")!;
+    expect(row.classList.contains("expert-row")).toBe(true);
+  });
+
+  it("renders the loading variant (no button) when checked is null", () => {
+    const el = mount(
+      renderToggleRow(localize, {
+        titleId: "x",
+        titleKey: "settings.loading_title",
+        descKey: "settings.loaded_desc",
+        loadingDescKey: "settings.loading_desc",
+        checked: null,
+        onToggle: () => {},
+      })
+    );
+    expect(el.querySelector("button.toggle")).toBeNull();
+    expect(el.querySelector('.row[role="status"]')).not.toBeNull();
+    expect(el.querySelector(".row-title")?.textContent?.trim()).toBe(
+      "settings.loading_title"
+    );
+    expect(el.querySelector(".row-desc")?.textContent?.trim()).toBe(
+      "settings.loading_desc"
+    );
+  });
+});
+
+describe("renderStatusRow", () => {
+  it("defaults to role=status with the localized key", () => {
+    const el = mount(renderStatusRow(localize, "settings.empty"));
+    const row = el.querySelector(".row")!;
+    expect(row.getAttribute("role")).toBe("status");
+    expect(el.querySelector(".row-desc")?.textContent?.trim()).toBe("settings.empty");
+    expect(el.querySelector("button")).toBeNull();
+  });
+
+  it("supports role=alert", () => {
+    const el = mount(renderStatusRow(localize, "settings.failed", "alert"));
+    expect(el.querySelector(".row")!.getAttribute("role")).toBe("alert");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The settings toggle row (`.row` with a title, a description, and a `role=switch` button) was hand-rolled inline in five sections, and the desc-only status row was duplicated as three private helpers plus two inline loading variants; only the string keys and the bound field differed.

This adds two module-level helpers in `settings-rows.ts`, `renderToggleRow` and `renderStatusRow`, and routes every call site through them. `renderToggleRow` also folds in the `value === null` loading variant, and `renderStatusRow` takes an optional role so the build-server failure row (`role="alert"`) reuses it too.

No behaviour change; the emitted markup, classes, and a11y wiring are identical, so the existing section tests still pass. A focused test pins the new helpers.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/891

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
