### PR TITLE
Extract a shared "advanced options" disclosure helper

### DIFF
--- a/src/components/device/config-entry-form-extra.styles.ts
+++ b/src/components/device/config-entry-form-extra.styles.ts
@@ -128,6 +128,11 @@ export const configEntryFormExtraStyles = css`
     margin-top: var(--wa-space-2xs);
   }
 
+  /* Keep the toggle's original vertical hit area (the shared base is flush). */
+  .pin-advanced .disclosure-toggle {
+    padding: 2px 0;
+  }
+
   /* The shared disclosure renders the quiet toggle + panel; the bordered indent
      rail for the long-form fields is pin-specific, scoped to this disclosure's
      panel so it overrides the shared margin-only default. */

--- a/src/components/device/config-entry-form-extra.styles.ts
+++ b/src/components/device/config-entry-form-extra.styles.ts
@@ -128,23 +128,10 @@ export const configEntryFormExtraStyles = css`
     margin-top: var(--wa-space-2xs);
   }
 
-  .pin-advanced-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    background: none;
-    border: none;
-    padding: 2px 0;
-    color: var(--wa-color-text-quiet);
-    font-size: var(--wa-font-size-2xs);
-    cursor: pointer;
-  }
-
-  .pin-advanced-toggle:hover {
-    color: var(--wa-color-text-normal);
-  }
-
-  .pin-advanced-fields {
+  /* The shared disclosure renders the quiet toggle + panel; the bordered indent
+     rail for the long-form fields is pin-specific, scoped to this disclosure's
+     panel so it overrides the shared margin-only default. */
+  .pin-advanced .disclosure-panel {
     margin-top: var(--wa-space-xs);
     padding-left: var(--wa-space-s);
     border-left: 2px solid var(--wa-color-surface-border);

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -13,6 +13,7 @@ import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
 import { formatPinValue, parsePinGpio } from "../../util/pin-gpio.js";
 import { expandPinModeShorthand } from "../../util/pin-mode.js";
+import { renderDisclosure } from "../shared/disclosure.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -401,21 +402,17 @@ function renderPinAdvanced(
       data-field-key="${advancedKey}"
       data-reveal-for="${fieldKeyAttr(path)}"
     >
-      <button
-        type="button"
-        class="pin-advanced-toggle"
-        aria-expanded=${isOpen}
-        ?disabled=${fieldDisabled}
-        @click=${onAdvancedToggle}
-      >
-        <wa-icon library="mdi" name=${isOpen ? "chevron-up" : "chevron-down"}></wa-icon>
-        <span>${ctx.localize("device.pin_advanced")}</span>
-      </button>
-      ${isOpen
-        ? html`<div class="pin-advanced-fields">
-            ${longFormFields.map((child) => renderLongFormChild(child, path, ctx))}
-          </div>`
-        : nothing}
+      ${renderDisclosure({
+        open: isOpen,
+        onToggle: onAdvancedToggle,
+        localize: ctx.localize,
+        labelKey: "device.pin_advanced",
+        variant: "quiet",
+        iconBefore: true,
+        disabled: fieldDisabled,
+        body: () =>
+          html`${longFormFields.map((child) => renderLongFormChild(child, path, ctx))}`,
+      })}
     </div>
   `;
 }

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -16,6 +16,7 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { warningBannerStyles } from "../../styles/banners.js";
+import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { stripConstraintProse } from "../../util/constraint-groups.js";
@@ -61,6 +62,7 @@ export const fieldRendererStyles = [
   warningBannerStyles,
   configEntryFormStyles,
   configEntryFormExtraStyles,
+  disclosureStyles,
   literalLambdaToggleStyles,
   constraintClusterStyles,
   fieldHighlightStyles,

--- a/src/components/install-method-dialog.styles.ts
+++ b/src/components/install-method-dialog.styles.ts
@@ -71,50 +71,18 @@ export const installMethodDialogStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
-  /* "Advanced options" disclosure rendered below the method
-     list. Holds the OTA address-override form and the manual
-     binary-download option — paths that aren't part of the
-     everyday install flow. Styled as an underlined inline
-     link rather than a button card so it doesn't compete
-     visually with the main method options above. */
-  .advanced-toggle {
-    display: inline-flex;
-    align-items: center;
+  /* "Advanced options" disclosure (shared renderDisclosure helper) rendered
+     below the method list. Separate it from the method cards above; the panel
+     content stacks the OTA address form and the manual-download option with the
+     same gap as the main list so the visual rhythm stays uniform when expanded. */
+  .disclosure-toggle {
     margin-top: var(--wa-space-m);
-    padding: 0;
-    background: none;
-    border: none;
-    font-family: inherit;
-    font-size: var(--wa-font-size-xs);
-    font-weight: var(--wa-font-weight-bold);
-    color: var(--esphome-primary);
-    cursor: pointer;
-    /* Underline targets the text only (via text-underline-offset);
-       the chevron is excluded from text-decoration below so it
-       doesn't sit on the underline rail. */
-    text-decoration: underline;
-    text-underline-offset: 2px;
   }
 
-  .advanced-toggle__chevron {
-    font-size: 16px;
-    text-decoration: none;
-  }
-
-  .advanced-toggle:focus-visible {
-    outline: 2px solid var(--esphome-primary);
-    outline-offset: 2px;
-  }
-
-  /* Container for the disclosed advanced controls. Stacks
-     the OTA address form and the manual-download option with
-     the same gap as the main list so the visual rhythm
-     stays uniform when expanded. */
-  .advanced-panel {
+  .advanced-panel-content {
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-s);
-    margin-top: var(--wa-space-s);
   }
 
   /* Trailing chevron on option cards. chevron-right on

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -19,6 +19,7 @@ import { DeviceState } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
+import { disclosureStyles } from "../styles/disclosure.js";
 import { inputStyles } from "../styles/inputs.js";
 import { newItemHighlightStyles } from "../styles/new-item-highlight.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -31,6 +32,7 @@ import {
   type WebSerialAvailability,
 } from "../util/web-serial.js";
 import { installMethodDialogStyles } from "./install-method-dialog.styles.js";
+import { renderDisclosure } from "./shared/disclosure.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -149,6 +151,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    disclosureStyles,
     primaryDialogHeaderStyles,
     inputStyles,
     newItemHighlightStyles,
@@ -486,31 +489,20 @@ export class ESPHomeInstallMethodDialog extends LitElement {
    * option (compile here, flash with an external tool).
    */
   private _renderAdvancedSection() {
-    const expanded = this._advancedExpanded;
-    return html`
-      <button
-        type="button"
-        class="advanced-toggle"
-        aria-expanded=${expanded ? "true" : "false"}
-        aria-controls=${expanded ? "advanced-panel" : nothing}
-        @click=${this._onToggleAdvanced}
-      >
-        ${this._localize("dashboard.install_method_advanced_toggle")}
-        <wa-icon
-          class="advanced-toggle__chevron"
-          library="mdi"
-          name=${expanded ? "chevron-up" : "chevron-down"}
-        ></wa-icon>
-      </button>
-      ${expanded
-        ? html`
-            <div id="advanced-panel" class="advanced-panel">
-              ${this._renderOtaAddressCard()}
-              ${this.mode === "install" ? this._renderManualDownloadOption() : nothing}
-            </div>
-          `
-        : nothing}
-    `;
+    return renderDisclosure({
+      open: this._advancedExpanded,
+      onToggle: () => this._onToggleAdvanced(),
+      localize: this._localize,
+      labelKey: "dashboard.install_method_advanced_toggle",
+      variant: "link",
+      panelId: "advanced-panel",
+      body: () => html`
+        <div class="advanced-panel-content">
+          ${this._renderOtaAddressCard()}
+          ${this.mode === "install" ? this._renderManualDownloadOption() : nothing}
+        </div>
+      `,
+    });
   }
 
   /**

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
-import { mdiChevronDown, mdiCodeBraces, mdiMagnify, mdiVectorDifference } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { mdiCodeBraces, mdiMagnify, mdiVectorDifference } from "@mdi/js";
+import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -9,9 +9,11 @@ import {
   localizeContext,
   remoteComputeOnlyContext,
 } from "../../context/index.js";
+import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { renderDisclosure } from "../shared/disclosure.js";
 import { settingsRowStyles, settingsSharedStyles } from "./shared-styles.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -19,7 +21,6 @@ import "@home-assistant/webawesome/dist/components/option/option.js";
 import "@home-assistant/webawesome/dist/components/select/select.js";
 
 registerMdiIcons({
-  "chevron-down": mdiChevronDown,
   "code-braces": mdiCodeBraces,
   magnify: mdiMagnify,
   "vector-difference": mdiVectorDifference,
@@ -69,6 +70,7 @@ export class ESPHomeSettingsAppearance extends LitElement {
     inputStyles,
     settingsSharedStyles,
     settingsRowStyles,
+    disclosureStyles,
     css`
       .expert-row {
         border-bottom: none;
@@ -82,40 +84,9 @@ export class ESPHomeSettingsAppearance extends LitElement {
         border-radius: var(--wa-border-radius-m);
       }
 
-      .expert-features-toggle {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        width: 100%;
-        padding: 0;
-        background: none;
-        border: none;
-        cursor: pointer;
-        color: inherit;
-      }
-
-      .expert-features-heading {
-        font-size: var(--wa-font-size-2xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-      }
-
-      .expert-features-chevron {
-        font-size: 18px;
-        color: var(--wa-color-text-quiet);
-        flex-shrink: 0;
-        transition: transform 0.15s;
-      }
-
-      .expert-features-toggle[aria-expanded="true"] .expert-features-chevron {
-        transform: rotate(180deg);
-      }
-
       .expert-feature-list {
         list-style: none;
-        margin: var(--wa-space-s) 0 0;
+        margin: 0;
         padding: 0;
         display: flex;
         flex-direction: column;
@@ -212,43 +183,32 @@ export class ESPHomeSettingsAppearance extends LitElement {
         ></button>
       </div>
       <div class="expert-features">
-        <button
-          class="expert-features-toggle"
-          type="button"
-          aria-expanded=${this._featuresOpen ? "true" : "false"}
-          @click=${this._onToggleFeatures}
-        >
-          <span class="expert-features-heading">
-            ${this._localize("settings.expert_mode_features_title")}
-          </span>
-          <wa-icon
-            class="expert-features-chevron"
-            library="mdi"
-            name="chevron-down"
-            aria-hidden="true"
-          ></wa-icon>
-        </button>
-        ${this._featuresOpen
-          ? html`
-              <ul class="expert-feature-list">
-                ${EXPERT_FEATURES.map(
-                  (f) => html`
-                    <li class="expert-feature">
-                      <wa-icon library="mdi" name=${f.icon}></wa-icon>
-                      <div class="expert-feature-text">
-                        <span class="expert-feature-title">
-                          ${this._localize(f.titleKey)}
-                        </span>
-                        <span class="expert-feature-desc">
-                          ${this._localize(f.descKey)}
-                        </span>
-                      </div>
-                    </li>
-                  `
-                )}
-              </ul>
-            `
-          : nothing}
+        ${renderDisclosure({
+          open: this._featuresOpen,
+          onToggle: () => this._onToggleFeatures(),
+          localize: this._localize,
+          labelKey: "settings.expert_mode_features_title",
+          variant: "heading",
+          body: () => html`
+            <ul class="expert-feature-list">
+              ${EXPERT_FEATURES.map(
+                (f) => html`
+                  <li class="expert-feature">
+                    <wa-icon library="mdi" name=${f.icon}></wa-icon>
+                    <div class="expert-feature-text">
+                      <span class="expert-feature-title">
+                        ${this._localize(f.titleKey)}
+                      </span>
+                      <span class="expert-feature-desc">
+                        ${this._localize(f.descKey)}
+                      </span>
+                    </div>
+                  </li>
+                `
+              )}
+            </ul>
+          `,
+        })}
       </div>
     `;
   }

--- a/src/components/shared/disclosure.ts
+++ b/src/components/shared/disclosure.ts
@@ -1,0 +1,67 @@
+import { mdiChevronDown } from "@mdi/js";
+import { type TemplateResult, html, nothing } from "lit";
+
+import type { LocalizeFunc } from "../../common/localize.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+
+// The `<wa-icon>` element itself is registered by the consuming component
+// (every caller already imports it); a pure render helper must not pull the
+// element's side-effect import, which would break node-env renderer tests.
+registerMdiIcons({ "chevron-down": mdiChevronDown });
+
+export interface DisclosureOptions {
+  /** Whether the panel is shown. The caller owns this state. */
+  open: boolean;
+  /** Fired on toggle-button click; the caller flips its own `open`. */
+  onToggle: () => void;
+  localize: LocalizeFunc;
+  /** Translation key for the toggle label. */
+  labelKey: string;
+  /** Panel content; called (and built) only while `open`, so a collapsed
+   *  disclosure never constructs its body or runs its render side effects. */
+  body: () => TemplateResult;
+  /** Label styling; see `disclosureStyles`. Defaults to `"link"`. */
+  variant?: "link" | "heading" | "quiet";
+  /** Render the chevron before the label instead of after. */
+  iconBefore?: boolean;
+  disabled?: boolean;
+  /** When set, ids the panel and wires `aria-controls` while open. */
+  panelId?: string;
+}
+
+/**
+ * Shared "advanced options" disclosure: a button + rotating chevron that
+ * toggles `aria-expanded` and reveals `body`.
+ *
+ * Controlled — the caller passes `open` + `onToggle`, so it fits
+ * component-local, parent-owned, and external (context-set) open-state alike.
+ * Pair with `disclosureStyles` (src/styles/disclosure.ts) in the consumer's
+ * `static styles`.
+ */
+export function renderDisclosure(opts: DisclosureOptions): TemplateResult {
+  const { open, variant = "link", iconBefore = false, panelId } = opts;
+  const label = html`<span class="disclosure-toggle__label">
+    ${opts.localize(opts.labelKey)}
+  </span>`;
+  const chevron = html`<wa-icon
+    class="disclosure-toggle__chevron"
+    library="mdi"
+    name="chevron-down"
+    aria-hidden="true"
+  ></wa-icon>`;
+  return html`
+    <button
+      type="button"
+      class="disclosure-toggle disclosure-toggle--${variant}"
+      aria-expanded=${open ? "true" : "false"}
+      aria-controls=${open && panelId ? panelId : nothing}
+      ?disabled=${opts.disabled ?? false}
+      @click=${opts.onToggle}
+    >
+      ${iconBefore ? html`${chevron}${label}` : html`${label}${chevron}`}
+    </button>
+    ${open
+      ? html`<div id=${panelId ?? nothing} class="disclosure-panel">${opts.body()}</div>`
+      : nothing}
+  `;
+}

--- a/src/components/shared/disclosure.ts
+++ b/src/components/shared/disclosure.ts
@@ -12,8 +12,10 @@ registerMdiIcons({ "chevron-down": mdiChevronDown });
 export interface DisclosureOptions {
   /** Whether the panel is shown. The caller owns this state. */
   open: boolean;
-  /** Fired on toggle-button click; the caller flips its own `open`. */
-  onToggle: () => void;
+  /** Fired on toggle-button click; the caller flips its own `open`. Receives
+   *  the click event so an existing event handler can be passed directly; a
+   *  zero-arg arrow is also fine (extra params are ignored). */
+  onToggle: (event: Event) => void;
   localize: LocalizeFunc;
   /** Translation key for the toggle label. */
   labelKey: string;

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -49,6 +49,12 @@ export class ESPHomeWizardStepMethod extends LitElement {
         padding: var(--wa-space-s);
       }
 
+      /* The old advanced block sat flush under the toggle; drop the shared
+         panel's default top margin to keep that spacing. */
+      .disclosure-panel {
+        margin-top: 0;
+      }
+
       .step-heading {
         display: flex;
         align-items: center;

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -1,21 +1,22 @@
 import { consume } from "@lit/context";
-import { mdiChevronDown, mdiChevronRight, mdiCog } from "@mdi/js";
-import { LitElement, css, html, nothing } from "lit";
+import { mdiChevronRight, mdiCog } from "@mdi/js";
+import { LitElement, css, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { disclosureStyles } from "../../styles/disclosure.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { FileDropController } from "../../util/file-drop-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { ACCEPTED_UPLOAD_EXTENSIONS } from "../../util/upload-file-types.js";
+import { renderDisclosure } from "../shared/disclosure.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 
 registerMdiIcons({
   cog: mdiCog,
   "chevron-right": mdiChevronRight,
-  "chevron-down": mdiChevronDown,
 });
 
 @customElement("esphome-wizard-step-method")
@@ -36,6 +37,7 @@ export class ESPHomeWizardStepMethod extends LitElement {
 
   static styles = [
     espHomeStyles,
+    disclosureStyles,
     css`
       :host {
         display: block;
@@ -115,34 +117,6 @@ export class ESPHomeWizardStepMethod extends LitElement {
         flex-shrink: 0;
       }
 
-      .advanced-toggle {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--wa-space-2xs);
-        color: var(--esphome-primary);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        cursor: pointer;
-        text-decoration: underline;
-        background: none;
-        border: none;
-        padding: var(--wa-space-s);
-      }
-
-      .advanced-toggle:hover {
-        text-decoration: none;
-      }
-
-      .advanced-toggle wa-icon {
-        font-size: var(--wa-font-size-s);
-        color: var(--esphome-primary);
-        transition: transform var(--wa-transition-normal) var(--wa-transition-easing);
-      }
-
-      .advanced-toggle[aria-expanded="true"] wa-icon {
-        transform: rotate(180deg);
-      }
-
       .drop-hint {
         margin-top: var(--wa-space-xl);
         text-align: center;
@@ -192,18 +166,15 @@ export class ESPHomeWizardStepMethod extends LitElement {
             </button>
           </div>
 
-          <button
-            class="advanced-toggle"
-            aria-expanded=${this.advancedOpen}
-            @click=${this._toggleAdvanced}
-          >
-            ${this._localize("wizard.advanced_options")}
-            <wa-icon library="mdi" name="chevron-down"></wa-icon>
-          </button>
-
-          ${this.advancedOpen
-            ? html`<div class="option-cards">${this._renderAdvancedOptions()}</div>`
-            : nothing}
+          ${renderDisclosure({
+            open: this.advancedOpen,
+            onToggle: () => this._toggleAdvanced(),
+            localize: this._localize,
+            labelKey: "wizard.advanced_options",
+            variant: "link",
+            body: () =>
+              html`<div class="option-cards">${this._renderAdvancedOptions()}</div>`,
+          })}
         </div>
 
         <p class="drop-hint">${this._localize("wizard.drop_yaml")}</p>

--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -43,6 +43,12 @@ export class ESPHomeWizardStepMethod extends LitElement {
         display: block;
       }
 
+      /* Restore the pre-shared-helper padding so the advanced toggle keeps its
+         comfortable touch target (the shared base is flush, padding: 0). */
+      .disclosure-toggle {
+        padding: var(--wa-space-s);
+      }
+
       .step-heading {
         display: flex;
         align-items: center;

--- a/src/styles/disclosure.ts
+++ b/src/styles/disclosure.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared "advanced options" disclosure styling.
+ *
+ * A button + rotating chevron that toggles `aria-expanded` and reveals a
+ * panel, rendered by `renderDisclosure` (src/components/shared/disclosure.ts).
+ * Three label looks via the `--link` / `--heading` / `--quiet` modifier:
+ *
+ * - `--link`: underlined inline link (install-method dialog, create-config wizard)
+ * - `--heading`: uppercase quiet row, chevron right-justified (settings expert features)
+ * - `--quiet`: small quiet text (per-pin advanced fields)
+ *
+ * Adding a site? Add this fragment to the consumer's `static styles` and call
+ * `renderDisclosure`; keep call-site-specific spacing (toggle `margin-top`,
+ * panel-content layout) inline at the call site rather than baking it in here.
+ * Cross-site drift is the failure mode this fragment exists to prevent.
+ */
+import { css } from "lit";
+
+export const disclosureStyles = css`
+  .disclosure-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    padding: 0;
+    background: none;
+    border: none;
+    font-family: inherit;
+    cursor: pointer;
+    color: var(--esphome-primary);
+  }
+
+  .disclosure-toggle:focus-visible {
+    outline: 2px solid var(--esphome-primary);
+    outline-offset: 2px;
+  }
+
+  .disclosure-toggle[disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  /* Chevron inherits the button's color (currentColor) and rotates on open.
+     Single icon rotated via CSS rather than swapping chevron-up/down names. */
+  .disclosure-toggle__chevron {
+    font-size: 16px;
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+  }
+
+  .disclosure-toggle[aria-expanded="true"] .disclosure-toggle__chevron {
+    transform: rotate(180deg);
+  }
+
+  /* link — underlined inline link; underline targets the label only so the
+     chevron doesn't sit on the underline rail. */
+  .disclosure-toggle--link {
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-bold);
+  }
+
+  .disclosure-toggle--link .disclosure-toggle__label {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .disclosure-toggle--link:hover .disclosure-toggle__label {
+    text-decoration: none;
+  }
+
+  /* heading — full-width uppercase quiet row with the chevron pushed right. */
+  .disclosure-toggle--heading {
+    width: 100%;
+    justify-content: space-between;
+    color: var(--wa-color-text-quiet);
+  }
+
+  .disclosure-toggle--heading .disclosure-toggle__label {
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  /* quiet — small quiet text that brightens on hover. */
+  .disclosure-toggle--quiet {
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .disclosure-toggle--quiet:hover {
+    color: var(--wa-color-text-normal);
+  }
+
+  .disclosure-panel {
+    margin-top: var(--wa-space-s);
+  }
+`;

--- a/src/styles/disclosure.ts
+++ b/src/styles/disclosure.ts
@@ -63,7 +63,7 @@ export const disclosureStyles = css`
     text-underline-offset: 2px;
   }
 
-  .disclosure-toggle--link:hover .disclosure-toggle__label {
+  .disclosure-toggle--link:not([disabled]):hover .disclosure-toggle__label {
     text-decoration: none;
   }
 
@@ -93,7 +93,7 @@ export const disclosureStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
-  .disclosure-toggle--quiet:hover {
+  .disclosure-toggle--quiet:not([disabled]):hover {
     color: var(--wa-color-text-normal);
   }
 

--- a/src/styles/disclosure.ts
+++ b/src/styles/disclosure.ts
@@ -81,6 +81,12 @@ export const disclosureStyles = css`
     letter-spacing: 0.04em;
   }
 
+  /* Heading rows carry a slightly larger chevron than the inline link/quiet
+     variants (matches the pre-refactor expert-features disclosure). */
+  .disclosure-toggle--heading .disclosure-toggle__chevron {
+    font-size: 18px;
+  }
+
   /* quiet — small quiet text that brightens on hover. */
   .disclosure-toggle--quiet {
     font-size: var(--wa-font-size-2xs);

--- a/test/components/settings-dialog/appearance-expert-mode.test.ts
+++ b/test/components/settings-dialog/appearance-expert-mode.test.ts
@@ -36,9 +36,8 @@ describe("appearance Expert Mode toggle", () => {
 
   it("hides the feature list until the chevron is opened", async () => {
     const el = await mount(false);
-    const disclosure = el.shadowRoot!.querySelector<HTMLButtonElement>(
-      ".expert-features-toggle"
-    )!;
+    const disclosure =
+      el.shadowRoot!.querySelector<HTMLButtonElement>(".disclosure-toggle")!;
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
     expect(el.shadowRoot!.querySelectorAll(".expert-feature").length).toBe(0);
 

--- a/test/components/shared/render-disclosure.test.ts
+++ b/test/components/shared/render-disclosure.test.ts
@@ -1,6 +1,13 @@
 import { html } from "lit";
 import { describe, expect, it, vi } from "vitest";
 
+// renderDisclosure's module-level registerMdiIcons() reaches webawesome's
+// icon-library registry; stub it so this node-environment test stays hermetic
+// and doesn't pull the DOM-dependent real implementation.
+vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
+  registerIconLibrary: () => {},
+}));
+
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { renderDisclosure } from "../../../src/components/shared/disclosure.js";
 import {

--- a/test/components/shared/render-disclosure.test.ts
+++ b/test/components/shared/render-disclosure.test.ts
@@ -1,0 +1,101 @@
+import { html } from "lit";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LocalizeFunc } from "../../../src/common/localize.js";
+import { renderDisclosure } from "../../../src/components/shared/disclosure.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+  visitTemplates,
+} from "../../_lit-template-walker.js";
+
+const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+
+const button = (result: unknown) => findTemplatesByAnchor(result, "<button")[0];
+
+function renderedText(result: unknown): string {
+  const parts: string[] = [];
+  visitTemplates(result, (t) => {
+    parts.push(...t.strings);
+    for (const v of t.values) if (typeof v === "string") parts.push(v);
+  });
+  return parts.join(" ");
+}
+
+describe("renderDisclosure", () => {
+  it("is collapsed when closed: no panel, body never built", () => {
+    const body = vi.fn(() => html`<p>x</p>`);
+    const result = renderDisclosure({
+      open: false,
+      onToggle: () => {},
+      localize,
+      labelKey: "settings.label",
+      body,
+    });
+    expect(extractAttributeBindings(button(result))["aria-expanded"]).toBe("false");
+    expect(findTemplatesByAnchor(result, 'class="disclosure-panel"')).toHaveLength(0);
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it("is expanded when open: panel rendered, body built once", () => {
+    const body = vi.fn(() => html`<p>x</p>`);
+    const result = renderDisclosure({
+      open: true,
+      onToggle: () => {},
+      localize,
+      labelKey: "settings.label",
+      panelId: "advanced-panel",
+      body,
+    });
+    expect(extractAttributeBindings(button(result))["aria-expanded"]).toBe("true");
+    expect(findTemplatesByAnchor(result, 'class="disclosure-panel"')).toHaveLength(1);
+    expect(body).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the localized label and a decorative chevron", () => {
+    const result = renderDisclosure({
+      open: false,
+      onToggle: () => {},
+      localize,
+      labelKey: "settings.my_label",
+      body: () => html``,
+    });
+    expect(renderedText(result)).toContain("settings.my_label");
+    const chevrons = findTemplatesByAnchor(result, "<wa-icon");
+    expect(chevrons).toHaveLength(1);
+    expect(chevrons[0].strings.join("")).toContain('aria-hidden="true"');
+  });
+
+  it("applies the variant class and the disabled binding", () => {
+    const result = renderDisclosure({
+      open: false,
+      onToggle: () => {},
+      localize,
+      labelKey: "k",
+      body: () => html``,
+      variant: "quiet",
+      disabled: true,
+    });
+    const btn = button(result);
+    expect(btn.values).toContain("quiet");
+    expect(extractAttributeBindings(btn)["?disabled"]).toBe(true);
+  });
+
+  it("places the chevron before the label when iconBefore is set", () => {
+    const order: string[] = [];
+    const result = renderDisclosure({
+      open: false,
+      onToggle: () => {},
+      localize,
+      labelKey: "k",
+      body: () => html``,
+      iconBefore: true,
+    });
+    visitTemplates(result, (t) => {
+      const s = t.strings.join("");
+      if (s.includes("<wa-icon")) order.push("icon");
+      else if (s.includes("disclosure-toggle__label")) order.push("label");
+    });
+    expect(order).toEqual(["icon", "label"]);
+  });
+});

--- a/test/components/wizard/wizard-step-method-advanced.test.ts
+++ b/test/components/wizard/wizard-step-method-advanced.test.ts
@@ -36,14 +36,16 @@ describe("wizard-step-method advanced disclosure", () => {
     const closed = await mount(false);
     expect(closed.shadowRoot!.querySelectorAll(".option-cards")).toHaveLength(1);
     expect(
-      closed.shadowRoot!.querySelector(".advanced-toggle")!.getAttribute("aria-expanded")
+      closed
+        .shadowRoot!.querySelector(".disclosure-toggle")!
+        .getAttribute("aria-expanded")
     ).toBe("false");
 
     // Open: the advanced block is rendered (import + empty-config cards).
     const open = await mount(true);
     expect(open.shadowRoot!.querySelectorAll(".option-cards")).toHaveLength(2);
     expect(
-      open.shadowRoot!.querySelector(".advanced-toggle")!.getAttribute("aria-expanded")
+      open.shadowRoot!.querySelector(".disclosure-toggle")!.getAttribute("aria-expanded")
     ).toBe("true");
   });
 
@@ -51,7 +53,7 @@ describe("wizard-step-method advanced disclosure", () => {
     const el = await mount(false);
     const onToggle = vi.fn();
     el.addEventListener("toggle-advanced", onToggle as EventListener);
-    (el.shadowRoot!.querySelector(".advanced-toggle") as HTMLButtonElement).click();
+    (el.shadowRoot!.querySelector(".disclosure-toggle") as HTMLButtonElement).click();
     expect(onToggle).toHaveBeenCalledTimes(1);
     // The step doesn't own the state — it just signals and stays put until the
     // parent feeds advancedOpen back down.


### PR DESCRIPTION
# What does this implement/fix?

The collapsible "advanced options" disclosure (a button, a chevron, and a panel that toggles `aria-expanded`) was hand-rolled in four places with near-duplicate markup and CSS. This adds one shared `renderDisclosure` helper (`src/components/shared/`, a new folder) plus a `disclosureStyles` fragment, and migrates all four call sites: the install-method dialog, the create-config wizard, the settings expert features, and the per-pin advanced fields.

The helper is controlled; the caller passes `open` and `onToggle`, so it fits component-local, parent-owned, and context-set open state alike. A `variant` selects the link, heading, or quiet look, and the panel body is built lazily so a collapsed disclosure never runs its content. The chevron now rotates via CSS rather than swapping icon names, which converges the two slightly different link looks into one; this is a small intentional visual normalization.

The fifth copy the issue lists was already converted to a plain toggle, so four remained. The OTA card disclosure inside the install dialog, the nested-section toggle, and the filter-section header are the same shape but carry extra concerns; they are noted as follow-ups rather than migrated here.

**Related issue or feature (if applicable):**

- closes esphome/device-builder-frontend#890

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
