### PR TITLE
Factor optimistic-update-with-revert settings handlers into a helper

### DIFF
--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -16,6 +16,41 @@ import {
 import type { ESPHomeApp } from "../app-shell.js";
 import { patchOffloadPairing } from "./events.js";
 
+interface OptimisticSetting<T> {
+  get: () => T;
+  set: (value: T) => void;
+  write: () => Promise<unknown>;
+  value: T;
+  toastKey?: string;
+  inFlight?: (active: boolean) => void;
+  warn?: string;
+  onSuccess?: () => void;
+}
+
+// Capture previous, optimistic set, await write, revert + toast on failure.
+// ``set`` and ``inFlight`` run before the first await, so the optimistic value
+// and the in-flight guard take effect synchronously for the caller.
+async function optimisticSetting<T>(
+  host: ESPHomeApp,
+  { get, set, write, value, toastKey, inFlight, warn, onSuccess }: OptimisticSetting<T>
+): Promise<void> {
+  const previous = get();
+  set(value);
+  inFlight?.(true);
+  try {
+    await write();
+    onSuccess?.();
+  } catch (err) {
+    set(previous);
+    if (warn) console.warn(warn, err);
+    if (toastKey) {
+      toast.error(host._localize(toastKey), { richColors: true });
+    }
+  } finally {
+    inFlight?.(false);
+  }
+}
+
 export function onSetTheme(host: ESPHomeApp, e: CustomEvent<string>): void {
   const theme = e.detail as Theme;
   host.applyTheme(theme);
@@ -34,44 +69,38 @@ export function onSetTheme(host: ESPHomeApp, e: CustomEvent<string>): void {
 
 // experience_level is the single source of truth; EXPERT unlocks the power-user
 // surfaces and the editor's first-open layout. Revert + toast on failure so the
-// stored level can't silently diverge from the UI.
+// stored level can't silently diverge from the UI. The in-flight count stops a
+// reconnect's INITIAL_STATE snapshot reloading the pre-write value mid-flight.
 function setExperienceLevel(host: ESPHomeApp, level: ExperienceLevel): void {
-  const previousLevel = host._experienceLevel;
-  host._experienceLevel = level;
-  // Count the write so a reconnect's INITIAL_STATE snapshot can't reload the
-  // pre-write values over the optimistic ones mid-flight.
-  host._prefsWritesInFlight += 1;
-  host._api
-    .updatePreferences({ experience_level: level })
-    .catch((err) => {
-      console.warn("Failed to save experience level:", err);
-      host._experienceLevel = previousLevel;
-      toast.error(host._localize("settings.experience_save_failed"), {
-        richColors: true,
-      });
-    })
-    .finally(() => {
-      host._prefsWritesInFlight -= 1;
-    });
+  void optimisticSetting(host, {
+    get: () => host._experienceLevel,
+    set: (v) => {
+      host._experienceLevel = v;
+    },
+    write: () => host._api.updatePreferences({ experience_level: level }),
+    value: level,
+    toastKey: "settings.experience_save_failed",
+    warn: "Failed to save experience level:",
+    inFlight: (active) => {
+      host._prefsWritesInFlight += active ? 1 : -1;
+    },
+  });
 }
 
 export function onSetRemoteComputeOnly(host: ESPHomeApp, e: CustomEvent<boolean>): void {
-  const enabled = e.detail;
-  const previous = host._remoteComputeOnly;
-  host._remoteComputeOnly = enabled;
-  host._prefsWritesInFlight += 1;
-  host._api
-    .updatePreferences({ remote_compute_only: enabled })
-    .catch((err) => {
-      console.warn("Failed to save remote-compute-only:", err);
-      host._remoteComputeOnly = previous;
-      toast.error(host._localize("settings.experience_save_failed"), {
-        richColors: true,
-      });
-    })
-    .finally(() => {
-      host._prefsWritesInFlight -= 1;
-    });
+  void optimisticSetting(host, {
+    get: () => host._remoteComputeOnly,
+    set: (v) => {
+      host._remoteComputeOnly = v;
+    },
+    write: () => host._api.updatePreferences({ remote_compute_only: e.detail }),
+    value: e.detail,
+    toastKey: "settings.experience_save_failed",
+    warn: "Failed to save remote-compute-only:",
+    inFlight: (active) => {
+      host._prefsWritesInFlight += active ? 1 : -1;
+    },
+  });
 }
 
 // Expert Mode is just experience_level === EXPERT; the Appearance/command-palette
@@ -83,28 +112,28 @@ export function onSetExpertMode(host: ESPHomeApp, e: CustomEvent<boolean>): void
 // Optimistic flip with revert-on-failure for security-sensitive toggles.
 // _remoteBuildSetInFlight gates loadRemoteBuildSettings so a reconnect
 // racing the write can't clobber the optimistic value.
-export async function onSetRemoteBuildEnabled(
+export function onSetRemoteBuildEnabled(
   host: ESPHomeApp,
   e: CustomEvent<boolean>
 ): Promise<void> {
-  const enabled = e.detail;
-  const previous = host._remoteBuildEnabled;
-  host._remoteBuildEnabled = enabled;
-  host._remoteBuildSetInFlight = true;
-  try {
+  return optimisticSetting(host, {
+    get: () => host._remoteBuildEnabled,
+    set: (v) => {
+      host._remoteBuildEnabled = v;
+    },
     // Omit cleanup_ttl_seconds so this path doesn't clobber a TTL another tab set.
-    await host._api.setRemoteBuildSettings({ enabled });
+    write: () => host._api.setRemoteBuildSettings({ enabled: e.detail }),
+    value: e.detail,
+    toastKey: "settings.remote_build_save_failed",
+    inFlight: (active) => {
+      host._remoteBuildSetInFlight = active;
+    },
     // Toggling enabled tears down / re-binds the peer-link runner;
     // bump the counter so settings-dialog re-fetches identity.
-    host._buildServerIdentityRotationCounter += 1;
-  } catch {
-    host._remoteBuildEnabled = previous;
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
-  } finally {
-    host._remoteBuildSetInFlight = false;
-  }
+    onSuccess: () => {
+      host._buildServerIdentityRotationCounter += 1;
+    },
+  });
 }
 
 export async function onSetRemoteBuildCleanupTtl(
@@ -141,48 +170,42 @@ export async function onSetRemoteBuildCleanupTtl(
   }
 }
 
-export async function onSetOffloaderRemoteBuildsEnabled(
+export function onSetOffloaderRemoteBuildsEnabled(
   host: ESPHomeApp,
   e: CustomEvent<boolean>
 ): Promise<void> {
-  const enabled = e.detail;
-  const previous = host._offloaderRemoteBuildsEnabled;
-  host._offloaderRemoteBuildsEnabled = enabled;
-  host._offloaderWritesInFlight += 1;
-  try {
-    await host._api.setOffloaderRemoteBuildSettings({
-      remote_builds_enabled: enabled,
-    });
-  } catch {
-    host._offloaderRemoteBuildsEnabled = previous;
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
-  } finally {
-    host._offloaderWritesInFlight -= 1;
-  }
+  return optimisticSetting(host, {
+    get: () => host._offloaderRemoteBuildsEnabled,
+    set: (v) => {
+      host._offloaderRemoteBuildsEnabled = v;
+    },
+    write: () =>
+      host._api.setOffloaderRemoteBuildSettings({ remote_builds_enabled: e.detail }),
+    value: e.detail,
+    toastKey: "settings.remote_build_save_failed",
+    inFlight: (active) => {
+      host._offloaderWritesInFlight += active ? 1 : -1;
+    },
+  });
 }
 
-export async function onSetOffloaderIncludeLocal(
+export function onSetOffloaderIncludeLocal(
   host: ESPHomeApp,
   e: CustomEvent<boolean>
 ): Promise<void> {
-  const enabled = e.detail;
-  const previous = host._offloaderIncludeLocalInPool;
-  host._offloaderIncludeLocalInPool = enabled;
-  host._offloaderWritesInFlight += 1;
-  try {
-    await host._api.setOffloaderRemoteBuildSettings({
-      include_local_in_pool: enabled,
-    });
-  } catch {
-    host._offloaderIncludeLocalInPool = previous;
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
-  } finally {
-    host._offloaderWritesInFlight -= 1;
-  }
+  return optimisticSetting(host, {
+    get: () => host._offloaderIncludeLocalInPool,
+    set: (v) => {
+      host._offloaderIncludeLocalInPool = v;
+    },
+    write: () =>
+      host._api.setOffloaderRemoteBuildSettings({ include_local_in_pool: e.detail }),
+    value: e.detail,
+    toastKey: "settings.remote_build_save_failed",
+    inFlight: (active) => {
+      host._offloaderWritesInFlight += active ? 1 : -1;
+    },
+  });
 }
 
 export async function onSetOffloaderPairingEnabled(
@@ -204,26 +227,23 @@ export async function onSetOffloaderPairingEnabled(
   }
 }
 
-export async function onSetOffloaderVersionMatchPolicy(
+export function onSetOffloaderVersionMatchPolicy(
   host: ESPHomeApp,
   e: CustomEvent<VersionMatchPolicy>
 ): Promise<void> {
-  const policy = e.detail;
-  const previous = host._offloaderVersionMatchPolicy;
-  host._offloaderVersionMatchPolicy = policy;
-  host._offloaderWritesInFlight += 1;
-  try {
-    await host._api.setOffloaderRemoteBuildSettings({
-      version_match_policy: policy,
-    });
-  } catch {
-    host._offloaderVersionMatchPolicy = previous;
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
-  } finally {
-    host._offloaderWritesInFlight -= 1;
-  }
+  return optimisticSetting(host, {
+    get: () => host._offloaderVersionMatchPolicy,
+    set: (v) => {
+      host._offloaderVersionMatchPolicy = v;
+    },
+    write: () =>
+      host._api.setOffloaderRemoteBuildSettings({ version_match_policy: e.detail }),
+    value: e.detail,
+    toastKey: "settings.remote_build_save_failed",
+    inFlight: (active) => {
+      host._offloaderWritesInFlight += active ? 1 : -1;
+    },
+  });
 }
 
 export function onPairRequestSent(

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -6,6 +6,7 @@ import {
   onSetExpertMode,
   onSetOffloaderIncludeLocal,
   onSetOffloaderVersionMatchPolicy,
+  onSetRemoteBuildEnabled,
   onSetRemoteComputeOnly,
   onSetTheme,
 } from "../../../src/components/app-shell/settings-actions.js";
@@ -254,6 +255,70 @@ describe("onSetTheme", () => {
     expect(host._prefsWritesInFlight).toBe(0);
     expect(warn).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
+  });
+});
+
+type RemoteBuildHost = Pick<
+  ESPHomeApp,
+  | "_remoteBuildEnabled"
+  | "_remoteBuildSetInFlight"
+  | "_buildServerIdentityRotationCounter"
+  | "_localize"
+> & {
+  _api: { setRemoteBuildSettings: (args: Record<string, unknown>) => Promise<unknown> };
+};
+
+function makeRemoteBuildHost(
+  setRemoteBuildSettings: RemoteBuildHost["_api"]["setRemoteBuildSettings"]
+): RemoteBuildHost {
+  return {
+    _remoteBuildEnabled: false,
+    _remoteBuildSetInFlight: false,
+    _buildServerIdentityRotationCounter: 0,
+    _localize: ((key: string) => key) as ESPHomeApp["_localize"],
+    _api: { setRemoteBuildSettings },
+  };
+}
+
+describe("onSetRemoteBuildEnabled", () => {
+  beforeEach(() => toastError.mockClear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("flips optimistically, gates the write, and rotates identity on success", async () => {
+    const setApi = vi.fn(async () => ({}));
+    const host = makeRemoteBuildHost(setApi);
+
+    const pending = onSetRemoteBuildEnabled(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: true })
+    );
+    // Optimistic value + in-flight gate apply synchronously, before the await.
+    expect(host._remoteBuildEnabled).toBe(true);
+    expect(host._remoteBuildSetInFlight).toBe(true);
+
+    await pending;
+    expect(setApi).toHaveBeenCalledWith({ enabled: true });
+    expect(host._buildServerIdentityRotationCounter).toBe(1);
+    expect(host._remoteBuildSetInFlight).toBe(false);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("reverts and toasts on rejection without rotating identity", async () => {
+    const host = makeRemoteBuildHost(
+      vi.fn(async () => {
+        throw new Error("no");
+      })
+    );
+
+    await onSetRemoteBuildEnabled(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: true })
+    );
+
+    expect(host._remoteBuildEnabled).toBe(false);
+    expect(host._buildServerIdentityRotationCounter).toBe(0);
+    expect(host._remoteBuildSetInFlight).toBe(false);
+    expect(toastError).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The offloader trio, the prefs pair (remote-compute-only and experience level), and onSetRemoteBuildEnabled all shared the same body; capture previous, optimistic set, await write, revert plus toast on failure, manage an in-flight guard. This adds a small optimisticSetting helper that collapses them, with optional inFlight, warn, and onSuccess hooks folding in the prefs and remote-build variants. set and inFlight still run before the first await, so the optimistic value and the in-flight guard apply synchronously to the caller. onSetTheme (no revert), onSetRemoteBuildCleanupTtl (range validation), and onSetOffloaderPairingEnabled (map-based revert) stay standalone. No behavior change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/892

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
