### PR TITLE
Note Edge and Firefox 151+ support for web-serial flashing

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -162,7 +162,7 @@
     "install_method_usb_server_ha_desc": "For devices connected via USB to your Home Assistant server",
     "install_method_web_download": "Flash on this computer via {link}",
     "install_method_web_download_link": "web.esphome.io",
-    "install_method_web_download_desc": "Requires a browser with Web Serial support (e.g. Chrome)",
+    "install_method_web_download_desc": "Requires a browser with Web Serial support (e.g. Chrome, Edge, or Firefox 151+)",
     "install_method_manual_download": "Download firmware binary",
     "install_method_manual_download_desc": "Compile here and download the binary, then flash it manually with your preferred tool",
     "install": "Install",


### PR DESCRIPTION
# What does this implement/fix?

Updates the install-method description for in-browser flashing. Web Serial is no longer Chrome-only, so the copy now mentions Edge and Firefox 151+ alongside Chrome, instead of implying Chrome is the only supported browser.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).