### PR TITLE
Use one secret-name convention across both creation flows

### DIFF
--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -372,7 +372,8 @@ export function renderStringField(
         ctx.sectionKey,
         entry.key,
         ctx.deviceName ?? "",
-        inputType === "password"
+        inputType === "password",
+        path
       )
     : [];
   const secretPicker = secretEligible

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -18,6 +18,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { navigate } from "../../util/navigation.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { secretHostSlug } from "../../util/secret-eligibility.js";
 import {
   addSecret,
   groupSecretsByDevice,
@@ -334,7 +335,12 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
   };
 
   private _addKey(): string {
-    return (this._addTarget ? `${this._addTarget}__` : "") + this._addName.trim();
+    // Slug the device prefix so a hyphenated name (`temp-sensor`) lands under
+    // the same `temp_sensor__` namespace the field picker uses, instead of a
+    // second hyphenated group.
+    const host = this._addTarget ? secretHostSlug(this._addTarget) : "";
+    const name = this._addName.trim();
+    return host ? `${host}__${name}` : name;
   }
 
   // Validate the dialog's name against the chosen target; null when valid.

--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -48,7 +48,11 @@ export function isSecretEligible(sectionKey: string, key: string): boolean {
  */
 export function isSharedSecret(key: string, hostname: string): boolean {
   const host = secretHostSlug(hostname);
-  return !host || !key.startsWith(`${host}__`);
+  if (!host) return true;
+  const sep = key.indexOf("__");
+  // Slug the stored prefix too, so a legacy hyphenated key (`temp-sensor__…`)
+  // still reads as this device's own rather than triggering the shared warning.
+  return sep <= 0 || secretHostSlug(key.slice(0, sep)) !== host;
 }
 
 /** Lowercase + collapse anything outside ``[a-z0-9_]`` so a hostname or
@@ -84,7 +88,9 @@ export function withoutForeignDeviceSecrets(
   if (others.size === 0) return [...keys];
   return keys.filter((k) => {
     const i = k.indexOf("__");
-    return i <= 0 || !others.has(k.slice(0, i));
+    // Slug the stored prefix so a legacy hyphenated key matches the slugged
+    // device set and is correctly recognized as another device's secret.
+    return i <= 0 || !others.has(secretHostSlug(k.slice(0, i)));
   });
 }
 

--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -169,6 +169,9 @@ export function recommendedSecretKeys(
     }
   }
 
+  // A nested concealed wifi leaf not in DEVICE_BASE (e.g. `wifi.eap.password`)
+  // intentionally falls through here and resolves to the shared `wifi_password`;
+  // only the fallback-AP fields get their own scoped key.
   const shared = SHARED[sectionKey]?.[key];
   if (shared) return [shared];
 

--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -19,13 +19,18 @@ const FIELD_BOUND_SHARED = new Set(
 );
 
 /** Per-device base names for the well-known credential fields, joined to the
- *  hostname as ``<hostname>__<base>``. Keyed by ``sectionKey`` then key. */
+ *  hostname as ``<hostname>__<base>``. Keyed by ``sectionKey`` then the field's
+ *  *lookup key*: the leaf ``entry.key`` by default, or the dotted field path
+ *  (``ap.password``) when a leaf alone is ambiguous within the section. */
 const DEVICE_BASE: Readonly<Record<string, Readonly<Record<string, string>>>> = {
   // Keyed by the editor sectionKey (the OTA esphome platform is `ota.esphome`),
   // so the field picker and the security notice agree on the secret name.
   "ota.esphome": { password: "ota_password" },
   api: { key: "encryption_key" },
   web_server: { password: "web_password" },
+  // The fallback-hotspot password is `wifi.ap.password`; key it by its dotted
+  // path so it doesn't collide with the STA `wifi.password` (`wifi_password`).
+  wifi: { "ap.password": "ap_password" },
 };
 
 /** True when a non-concealed *key* under *sectionKey* still wants the picker. */
@@ -41,13 +46,15 @@ export function isSecretEligible(sectionKey: string, key: string): boolean {
  * value warns. An unknown hostname can't prove scoping → shared.
  */
 export function isSharedSecret(key: string, hostname: string): boolean {
-  const host = slug(hostname);
+  const host = secretHostSlug(hostname);
   return !host || !key.startsWith(`${host}__`);
 }
 
 /** Lowercase + collapse anything outside ``[a-z0-9_]`` so a hostname or
- *  field name is safe to embed in a secret key. */
-function slug(s: string): string {
+ *  field name is safe to embed in a secret key. The single normalization both
+ *  write paths (field picker and Secrets-menu add) share so a device's secret
+ *  prefix is identical however the secret was created. */
+export function secretHostSlug(s: string): string {
   return s
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, "_")
@@ -65,13 +72,13 @@ export function withoutForeignDeviceSecrets(
   currentHostname: string,
   allDeviceNames: readonly string[]
 ): string[] {
-  const current = slug(currentHostname);
+  const current = secretHostSlug(currentHostname);
   // Without the current host we can't tell ours from theirs — don't filter, or
   // we'd hide the current device's own keys (and the migrate target) during the
   // brief window before the device name resolves.
   if (!current) return [...keys];
   const others = new Set(
-    allDeviceNames.map((n) => slug(n)).filter((h) => h && h !== current)
+    allDeviceNames.map((n) => secretHostSlug(n)).filter((h) => h && h !== current)
   );
   if (others.size === 0) return [...keys];
   return keys.filter((k) => {
@@ -130,18 +137,35 @@ function scoped(host: string, base: string): string[] {
  * - Any other concealed field → ``<hostname>__<section>_<key>``.
  *
  * *hostname* is the backend-resolved ESPHome node name (substitutions already
- * expanded), threaded through the render context.
+ * expanded), threaded through the render context. *path* is the field's full
+ * path within the section; a nested leaf (``wifi.ap.password``) is looked up by
+ * its dotted path first so it doesn't collapse onto a sibling leaf of the same
+ * name (the STA ``wifi.password``), then falls back to the leaf-key logic.
  */
 export function recommendedSecretKeys(
   sectionKey: string,
   key: string,
   hostname: string,
-  concealed: boolean
+  concealed: boolean,
+  path?: readonly string[]
 ): string[] {
+  // Dotted-path lookup wins for nested leaves so `ap.password` resolves before
+  // the leaf `password` short-circuits onto the shared `wifi_password`.
+  const qualified = path && path.length > 1 ? path.join(".") : undefined;
+  if (qualified) {
+    const sharedQ = SHARED[sectionKey]?.[qualified];
+    if (sharedQ) return [sharedQ];
+    const baseQ = DEVICE_BASE[sectionKey]?.[qualified];
+    if (baseQ) {
+      const hostQ = secretHostSlug(hostname);
+      return hostQ ? scoped(hostQ, baseQ) : [];
+    }
+  }
+
   const shared = SHARED[sectionKey]?.[key];
   if (shared) return [shared];
 
-  const host = slug(hostname);
+  const host = secretHostSlug(hostname);
   if (!host) return [];
 
   const base = DEVICE_BASE[sectionKey]?.[key];
@@ -149,7 +173,7 @@ export function recommendedSecretKeys(
 
   // Generic per-device fallback for any other concealed credential field.
   if (concealed) {
-    const tail = slug(`${sectionKey}_${key}`);
+    const tail = secretHostSlug(`${sectionKey}_${key}`);
     return tail ? scoped(host, tail) : [];
   }
   return [];

--- a/src/util/secret-eligibility.ts
+++ b/src/util/secret-eligibility.ts
@@ -28,9 +28,10 @@ const DEVICE_BASE: Readonly<Record<string, Readonly<Record<string, string>>>> = 
   "ota.esphome": { password: "ota_password" },
   api: { key: "encryption_key" },
   web_server: { password: "web_password" },
-  // The fallback-hotspot password is `wifi.ap.password`; key it by its dotted
-  // path so it doesn't collide with the STA `wifi.password` (`wifi_password`).
-  wifi: { "ap.password": "ap_password" },
+  // The fallback-hotspot credentials are nested under `wifi.ap`; key them by
+  // their dotted path so they don't collapse onto the STA `wifi.ssid` /
+  // `wifi.password` shared secrets (the AP is a different network).
+  wifi: { "ap.ssid": "ap_ssid", "ap.password": "ap_password" },
 };
 
 /** True when a non-concealed *key* under *sectionKey* still wants the picker. */

--- a/src/util/secrets-entries.ts
+++ b/src/util/secrets-entries.ts
@@ -6,6 +6,7 @@
  * keys, block / flow collections and nested mappings are read-only.
  */
 
+import { secretHostSlug } from "./secret-eligibility.js";
 import { escapeYamlDoubleQuoted } from "./yaml-escape.js";
 import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
 import { formatYamlScalar } from "./yaml-serialize.js";
@@ -53,13 +54,17 @@ export function isValidSecretKey(key: string): boolean {
   return VALID_KEY.test(key);
 }
 
-/** Group entries into shared-then-per-device runs by the ``<device>__`` key prefix. */
+/** Group entries into shared-then-per-device runs by the ``<device>__`` key prefix.
+ *  The prefix is slugged so a device's hyphenated and underscored secrets
+ *  (created by different flows before the names converged) collapse into one
+ *  group instead of two. */
 export function groupSecretsByDevice(entries: SecretEntry[]): SecretGroup[] {
   const order: (string | null)[] = [];
   const byDevice = new Map<string | null, SecretEntry[]>();
   for (const entry of entries) {
     const sep = entry.key.indexOf("__");
-    const device = sep > 0 ? entry.key.slice(0, sep) : null;
+    const raw = sep > 0 ? entry.key.slice(0, sep) : null;
+    const device = raw ? secretHostSlug(raw) || raw : null;
     if (!byDevice.has(device)) {
       byDevice.set(device, []);
       order.push(device);

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -222,6 +222,25 @@ describe("esphome-secrets-structured-editor", () => {
     expect(captured.value).toBe("wifi_ssid: home\nbw15__api: xyz\n");
   });
 
+  test("a hyphenated device target is slugged so the prefix matches the field picker", async () => {
+    const el = await mount("wifi_ssid: home\n", false, [
+      {
+        name: "temp-sensor",
+        configuration: "temp-sensor.yaml",
+        friendly_name: "Temp Sensor",
+      },
+    ]);
+    const captured = onChange(el);
+    const view = el as unknown as AddView;
+    view._openAdd();
+    view._addTarget = "temp-sensor";
+    view._addName = "ap_password";
+    view._addValue = "xyz";
+    view._confirmAdd();
+    expect(view._addOpen).toBe(false);
+    expect(captured.value).toBe("wifi_ssid: home\ntemp_sensor__ap_password: xyz\n");
+  });
+
   test("the add dialog rejects an invalid name and stays open", async () => {
     const el = await mount("wifi_ssid: home\n");
     const captured = onChange(el);

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -70,6 +70,32 @@ describe("recommendedSecretKeys", () => {
   it("recommends nothing for a non-concealed unknown field", () => {
     expect(recommendedSecretKeys("sensor", "name", "kitchen", false)).toEqual([]);
   });
+
+  it("scopes the nested AP password by its path, not the shared wifi_password", () => {
+    // `wifi.ap.password` and the STA `wifi.password` share the leaf `password`;
+    // the dotted path disambiguates so the AP field gets its own scoped key.
+    expect(
+      recommendedSecretKeys("wifi", "password", "kitchen", true, ["ap", "password"])
+    ).toEqual(["kitchen__ap_password", "kitchen_ap_password"]);
+  });
+
+  it("still resolves the STA wifi password to the shared key when path is passed", () => {
+    expect(
+      recommendedSecretKeys("wifi", "password", "kitchen", true, ["password"])
+    ).toEqual(["wifi_password"]);
+  });
+
+  it("leaves api / web_server keys unchanged when their nested paths are passed", () => {
+    expect(
+      recommendedSecretKeys("api", "key", "kitchen", true, ["encryption", "key"])
+    ).toEqual(["kitchen__encryption_key", "kitchen_encryption_key"]);
+    expect(
+      recommendedSecretKeys("web_server", "password", "kitchen", true, [
+        "auth",
+        "password",
+      ])
+    ).toEqual(["kitchen__web_password", "kitchen_web_password"]);
+  });
 });
 
 describe("withoutForeignDeviceSecrets", () => {

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isSecretEligible,
+  isSharedSecret,
   recommendedSecretKeys,
   secretValueFromYaml,
   visibleSecretKeys,
@@ -135,6 +136,18 @@ describe("withoutForeignDeviceSecrets", () => {
     ).toEqual(["apollo_r_pro_1_eth_5938e0__encryption_key"]);
   });
 
+  it("filters a legacy hyphenated foreign key by slugging the stored prefix", () => {
+    // The key was stored before names converged (`porch-light__…`); it must
+    // still be recognized as another device's and dropped.
+    expect(
+      withoutForeignDeviceSecrets(
+        ["porch-light__encryption_key", "kitchen__ota_password"],
+        "kitchen",
+        ["kitchen", "porch-light"]
+      )
+    ).toEqual(["kitchen__ota_password"]);
+  });
+
   it("keeps everything when there are no other devices", () => {
     expect(withoutForeignDeviceSecrets(keys, "kitchen", ["kitchen"])).toEqual(keys);
   });
@@ -149,6 +162,29 @@ describe("withoutForeignDeviceSecrets", () => {
     expect(withoutForeignDeviceSecrets(["myapp__token"], "kitchen", devices)).toEqual([
       "myapp__token",
     ]);
+  });
+});
+
+describe("isSharedSecret", () => {
+  it("treats wifi_* and unscoped names as shared", () => {
+    expect(isSharedSecret("wifi_password", "kitchen")).toBe(true);
+    expect(isSharedSecret("some_token", "kitchen")).toBe(true);
+  });
+
+  it("treats this device's own scoped key as not shared", () => {
+    expect(isSharedSecret("kitchen__ota_password", "kitchen")).toBe(false);
+  });
+
+  it("recognizes a legacy hyphenated own-device key as not shared", () => {
+    expect(isSharedSecret("temp-sensor__ota_password", "temp-sensor")).toBe(false);
+  });
+
+  it("treats another device's scoped key as shared", () => {
+    expect(isSharedSecret("porch__encryption_key", "kitchen")).toBe(true);
+  });
+
+  it("is shared when the hostname is unresolved", () => {
+    expect(isSharedSecret("kitchen__ota_password", "")).toBe(true);
   });
 });
 

--- a/test/util/secret-eligibility.test.ts
+++ b/test/util/secret-eligibility.test.ts
@@ -71,18 +71,25 @@ describe("recommendedSecretKeys", () => {
     expect(recommendedSecretKeys("sensor", "name", "kitchen", false)).toEqual([]);
   });
 
-  it("scopes the nested AP password by its path, not the shared wifi_password", () => {
-    // `wifi.ap.password` and the STA `wifi.password` share the leaf `password`;
-    // the dotted path disambiguates so the AP field gets its own scoped key.
+  it("scopes the nested AP credentials by path, not the shared wifi_* keys", () => {
+    // `wifi.ap.{ssid,password}` share their leaf with the STA `wifi.{ssid,password}`;
+    // the dotted path disambiguates so each AP field gets its own scoped key
+    // instead of pointing at the home-network secret.
     expect(
       recommendedSecretKeys("wifi", "password", "kitchen", true, ["ap", "password"])
     ).toEqual(["kitchen__ap_password", "kitchen_ap_password"]);
+    expect(
+      recommendedSecretKeys("wifi", "ssid", "kitchen", false, ["ap", "ssid"])
+    ).toEqual(["kitchen__ap_ssid", "kitchen_ap_ssid"]);
   });
 
-  it("still resolves the STA wifi password to the shared key when path is passed", () => {
+  it("still resolves the STA wifi ssid/password to the shared keys when path is passed", () => {
     expect(
       recommendedSecretKeys("wifi", "password", "kitchen", true, ["password"])
     ).toEqual(["wifi_password"]);
+    expect(recommendedSecretKeys("wifi", "ssid", "kitchen", false, ["ssid"])).toEqual([
+      "wifi_ssid",
+    ]);
   });
 
   it("leaves api / web_server keys unchanged when their nested paths are passed", () => {

--- a/test/util/secrets-entries.test.ts
+++ b/test/util/secrets-entries.test.ts
@@ -200,6 +200,17 @@ describe("groupSecretsByDevice", () => {
     );
     expect(groups.map((g) => g.device)).toEqual([null, "bw15"]);
   });
+
+  test("collapses hyphen and underscore spellings of the same device into one group", () => {
+    const groups = groupSecretsByDevice(
+      parseSecretsEntries("temp_sensor__api: a\ntemp-sensor__ota: b\n")
+    );
+    expect(groups.map((g) => g.device)).toEqual(["temp_sensor"]);
+    expect(groups[0].entries.map((e) => e.key)).toEqual([
+      "temp_sensor__api",
+      "temp-sensor__ota",
+    ]);
+  });
 });
 
 describe("isValidSecretKey", () => {


### PR DESCRIPTION
# What does this implement/fix?

Secrets got two different names depending on where they were created. The device editor's field picker and security notice slug the device name to underscores (`temperature_sensor_livingroom__ota_password`), but the Secrets menu's "Add secret" flow kept the raw name with dashes (`temperature-sensor-livingroom__ap_pw`); the same device then showed up as two rows in the Secrets menu.

This routes the Secrets-menu Add flow and the Secrets-menu device grouping through the same `secretHostSlug` the field picker already uses, so a device's secrets share one prefix however they were created. Grouping is normalized too, so secrets already on disk with the two spellings collapse back into one device row (display only, nothing is renamed).

It also fixes the WiFi AP / fallback-hotspot password, which the issue notes had no usable secret option. Its field picker collided with the main WiFi password because secret keying looked only at the section and leaf key (`wifi`, `password`) and dropped the nested path, so it offered the shared `wifi_password`. `recommendedSecretKeys` now takes the field path and resolves `wifi.ap.password` to `<host>__ap_password` via a dotted-path lookup; every other field's name is unchanged.

Canonical form is underscores, matching what the rest of the secrets code already assumes and what the backend's `config/set_secret` accepts (it rejects dashed keys).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1573

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
