### PR TITLE
Remove redundant height:100% from device-card host

### DIFF
--- a/src/components/device-card/styles.ts
+++ b/src/components/device-card/styles.ts
@@ -17,7 +17,12 @@ export const deviceCardStyles = [
     :host {
       display: block;
       outline: none;
-      height: 100%;
+      /* Intentionally no height: 100%. The .devices-grid already equalizes
+         card heights via align-items: stretch (its default) and the inner
+         .device-card fills this host, so a height here is redundant. It is
+         also fragile: a percentage height on a grid item resolves against the
+         track, which WebKit can compute as the viewport-tall grid box instead
+         of the auto content track, stretching the card to full-window height. */
     }
 
     .device-card {


### PR DESCRIPTION
# What does this implement/fix?

Remove the redundant `height: 100%` from the `<esphome-device-card>` `:host`.

The device grid (`.devices-grid`) already equalizes card heights via
`align-items: stretch` (the grid default), and the inner `.device-card` fills
the host, so a height on the host adds nothing. It is also fragile: a percentage
height on a grid item resolves against the row track, and WebKit can compute that
as the viewport-tall grid box rather than the auto content track, stretching each
card to nearly the full window height with a large empty gap below the content.

Reported on Safari 17.6, which is below the supported baseline (`browserslist`
"last 2 Safari versions" currently resolves to 26.3/26.4), but the rule was
redundant and fragile, so removing it is correct regardless. Layout is identical
in Chromium with and without the rule (measured 169px both ways at the reporter's
viewport), so there is no behaviour change in supported browsers.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1581

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
