### PR TITLE
Save with Cmd/Ctrl+S in the secrets editor

### DIFF
--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -19,6 +19,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { expertModeContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { SaveShortcutController } from "../../util/save-shortcut-controller.js";
 import {
   clampSplitRatio,
   loadSplitRatio,
@@ -96,29 +97,22 @@ export class ESPHomeDeviceEditor extends LitElement {
     this._isMobile = e.matches;
   };
 
-  /** Cmd/Ctrl+S → save the YAML if there are unsaved changes.
-   *  Listens at the window level so the shortcut works regardless of
-   *  which child (CodeMirror, navigator, etc.) currently has focus. */
-  private _onGlobalKeyDown = (e: KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "s") {
-      e.preventDefault();
-      if (this.hasUnsavedEdits) {
-        this._onSave();
-      }
+  // Cmd/Ctrl+S → save the YAML if there are unsaved changes.
+  private _saveShortcut = new SaveShortcutController(this, () => {
+    if (this.hasUnsavedEdits) {
+      this._onSave();
     }
-  };
+  });
 
   connectedCallback() {
     super.connectedCallback();
     this._isMobile = this._mql.matches;
     this._mql.addEventListener("change", this._onMqlChange);
-    window.addEventListener("keydown", this._onGlobalKeyDown);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._mql.removeEventListener("change", this._onMqlChange);
-    window.removeEventListener("keydown", this._onGlobalKeyDown);
   }
 
   @property({ attribute: false })

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -18,6 +18,7 @@ import {
 } from "../util/editor-layout.js";
 import { setLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
 import { UnsavedGuard } from "../util/unsaved-guard.js";
 import { secretsStyles } from "./secrets.styles.js";
@@ -82,6 +83,14 @@ export class ESPHomePageSecrets extends LitElement {
   private _wipeDialog?: ESPHomeConfirmDialog;
 
   private _unsavedGuard = new UnsavedGuard();
+
+  // Cmd/Ctrl+S → save when there's something to save. Covers both the
+  // structured and YAML views, which share the single _yaml buffer.
+  private _saveShortcut = new SaveShortcutController(this, () => {
+    if (this._isDirty && !this._saving && this._yaml.trim() !== "") {
+      void this._save();
+    }
+  });
 
   // Set true once the leave guard has cleared a navigation, so the
   // synthetic popstate it triggers isn't re-intercepted.

--- a/src/util/save-shortcut-controller.ts
+++ b/src/util/save-shortcut-controller.ts
@@ -1,0 +1,52 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+export interface SaveShortcutControllerOptions {
+  /** Where to bind the keydown listener. Defaults to ``window`` so the
+   *  shortcut fires regardless of which child (CodeMirror, form inputs)
+   *  holds focus. Accepts any ``EventTarget`` so tests can inject a stub. */
+  target?: EventTarget;
+}
+
+/**
+ * Reactive controller that runs ``onSave`` on Cmd/Ctrl+S, swallowing the
+ * browser's "save page" default while the host is connected.
+
+ * ``preventDefault`` fires on every match (so the browser dialog never
+ * appears on an editor page); ``onSave`` decides whether anything is dirty.
+ */
+export class SaveShortcutController implements ReactiveController {
+  private _bound = false;
+  private readonly _target: EventTarget;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly onSave: () => void,
+    options: SaveShortcutControllerOptions = {}
+  ) {
+    this._target = options.target ?? window;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    if (this._bound) return;
+    this._target.addEventListener("keydown", this._handler);
+    this._bound = true;
+  }
+
+  hostDisconnected() {
+    if (!this._bound) return;
+    this._target.removeEventListener("keydown", this._handler);
+    this._bound = false;
+  }
+
+  /* Typed as EventListener so the union of Window | Document accepts the
+     registration; the cast is local and callers get a real KeyboardEvent. */
+  private _handler: EventListener = (e) => {
+    const ke = e as KeyboardEvent;
+    if (!(ke.metaKey || ke.ctrlKey) || ke.shiftKey || ke.key.toLowerCase() !== "s") {
+      return;
+    }
+    ke.preventDefault();
+    this.onSave();
+  };
+}

--- a/src/util/save-shortcut-controller.ts
+++ b/src/util/save-shortcut-controller.ts
@@ -43,7 +43,12 @@ export class SaveShortcutController implements ReactiveController {
      registration; the cast is local and callers get a real KeyboardEvent. */
   private _handler: EventListener = (e) => {
     const ke = e as KeyboardEvent;
-    if (!(ke.metaKey || ke.ctrlKey) || ke.shiftKey || ke.key.toLowerCase() !== "s") {
+    if (
+      !(ke.metaKey || ke.ctrlKey) ||
+      ke.altKey ||
+      ke.shiftKey ||
+      ke.key.toLowerCase() !== "s"
+    ) {
       return;
     }
     // Bail if a deeper handler already claimed this Cmd+S, so two co-active

--- a/src/util/save-shortcut-controller.ts
+++ b/src/util/save-shortcut-controller.ts
@@ -10,7 +10,7 @@ export interface SaveShortcutControllerOptions {
 /**
  * Reactive controller that runs ``onSave`` on Cmd/Ctrl+S, swallowing the
  * browser's "save page" default while the host is connected.
-
+ *
  * ``preventDefault`` fires on every match (so the browser dialog never
  * appears on an editor page); ``onSave`` decides whether anything is dirty.
  */
@@ -46,6 +46,9 @@ export class SaveShortcutController implements ReactiveController {
     if (!(ke.metaKey || ke.ctrlKey) || ke.shiftKey || ke.key.toLowerCase() !== "s") {
       return;
     }
+    // Bail if a deeper handler already claimed this Cmd+S, so two co-active
+    // controllers on the same target don't both fire (mirrors EnterController).
+    if (ke.defaultPrevented) return;
     ke.preventDefault();
     this.onSave();
   };

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -423,6 +423,9 @@ describe("esphome-page-secrets Cmd/Ctrl+S save shortcut wiring", () => {
     updateConfig: ReturnType<typeof vi.fn>;
     save: () => void;
   } {
+    // Reset first so the assertion proves THIS construction wired the
+    // shortcut, not a stale callback captured by an earlier test.
+    capturedRef.onSave = undefined;
     const page = makePage({ _loaded: true, ...overrides });
     const updateConfig = vi.fn().mockResolvedValue(undefined);
     page._api = { updateConfig } as unknown as ESPHomeAPI;

--- a/test/pages/secrets.test.ts
+++ b/test/pages/secrets.test.ts
@@ -15,6 +15,21 @@ vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
+// Capture the save-shortcut callback the page wires so the gating closure
+// can be exercised without mounting (and binding a real window listener).
+const { capturedRef } = vi.hoisted(() => ({
+  capturedRef: { onSave: undefined as (() => void) | undefined },
+}));
+vi.mock("../../src/util/save-shortcut-controller.js", () => ({
+  SaveShortcutController: class {
+    constructor(_host: unknown, onSave: () => void) {
+      capturedRef.onSave = onSave;
+    }
+    hostConnected() {}
+    hostDisconnected() {}
+  },
+}));
+
 /**
  * Pin the secrets-page data-loss guards: don't render an editor
  * with empty content while loading, and keep Save disabled when
@@ -400,6 +415,61 @@ describe("esphome-page-secrets save toast ordering", () => {
     window.removeEventListener("secrets-saved", onSaved);
 
     expect(onSaved).not.toHaveBeenCalled();
+  });
+});
+
+describe("esphome-page-secrets Cmd/Ctrl+S save shortcut wiring", () => {
+  function pageWith(overrides: Partial<PageView>): {
+    updateConfig: ReturnType<typeof vi.fn>;
+    save: () => void;
+  } {
+    const page = makePage({ _loaded: true, ...overrides });
+    const updateConfig = vi.fn().mockResolvedValue(undefined);
+    page._api = { updateConfig } as unknown as ESPHomeAPI;
+    // The page's field initializer constructed the (mocked) controller and
+    // handed us its callback — that is the gating closure the shortcut runs.
+    expect(capturedRef.onSave).toBeTypeOf("function");
+    return { updateConfig, save: capturedRef.onSave! };
+  }
+
+  test("saves a dirty, non-empty buffer", async () => {
+    const { updateConfig, save } = pageWith({
+      _yaml: "wifi_password: new\n",
+      _savedYaml: "wifi_password: old\n",
+    });
+    save();
+    await Promise.resolve();
+    expect(updateConfig).toHaveBeenCalledWith("secrets.yaml", "wifi_password: new\n");
+  });
+
+  test("no-ops on a clean buffer", () => {
+    const { updateConfig, save } = pageWith({
+      _yaml: "wifi_password: same\n",
+      _savedYaml: "wifi_password: same\n",
+    });
+    save();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("no-ops while a save is already in flight", () => {
+    const { updateConfig, save } = pageWith({
+      _yaml: "wifi_password: new\n",
+      _savedYaml: "wifi_password: old\n",
+      _saving: true,
+    });
+    save();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("does not trigger the destructive wipe path on an empty buffer", () => {
+    // The Save button stays enabled at zero secrets to allow a confirmed wipe,
+    // but the keyboard shortcut must not fire that destructive path.
+    const { updateConfig, save } = pageWith({
+      _yaml: "",
+      _savedYaml: "wifi_password: old\n",
+    });
+    save();
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/test/util/save-shortcut-controller.test.ts
+++ b/test/util/save-shortcut-controller.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { SaveShortcutController } from "../../src/util/save-shortcut-controller.js";
+import { FakeHost } from "../_fake-host.js";
+
+/* Plain Node test env (no jsdom): feed the controller our own
+   EventTarget and dispatch raw ``Event``s with the modifier/key props
+   the handler reads. */
+function makeKey(
+  key: string,
+  mods: { meta?: boolean; ctrl?: boolean; shift?: boolean } = {}
+): Event {
+  const e = new Event("keydown", { cancelable: true });
+  Object.defineProperty(e, "key", { value: key });
+  Object.defineProperty(e, "metaKey", { value: !!mods.meta });
+  Object.defineProperty(e, "ctrlKey", { value: !!mods.ctrl });
+  Object.defineProperty(e, "shiftKey", { value: !!mods.shift });
+  return e;
+}
+
+describe("SaveShortcutController", () => {
+  it("invokes the callback on Cmd+S and Ctrl+S once connected, and preventDefaults", () => {
+    const target = new EventTarget();
+    const host = new FakeHost();
+    const cb = vi.fn();
+    const ctrl = new SaveShortcutController(host, cb, { target });
+    ctrl.hostConnected();
+
+    const cmd = makeKey("s", { meta: true });
+    target.dispatchEvent(cmd);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cmd.defaultPrevented).toBe(true);
+
+    target.dispatchEvent(makeKey("s", { ctrl: true }));
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    // Uppercase (Shift not pressed but caps/layout) still matches.
+    target.dispatchEvent(makeKey("S", { meta: true }));
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not fire before the host is connected", () => {
+    const target = new EventTarget();
+    const cb = vi.fn();
+    new SaveShortcutController(new FakeHost(), cb, { target });
+
+    target.dispatchEvent(makeKey("s", { meta: true }));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("ignores Shift+Cmd+S, plain s, and other modified keys", () => {
+    const target = new EventTarget();
+    const cb = vi.fn();
+    const ctrl = new SaveShortcutController(new FakeHost(), cb, { target });
+    ctrl.hostConnected();
+
+    target.dispatchEvent(makeKey("s", { meta: true, shift: true }));
+    target.dispatchEvent(makeKey("s"));
+    target.dispatchEvent(makeKey("k", { meta: true }));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("detaches on hostDisconnected", () => {
+    const target = new EventTarget();
+    const cb = vi.fn();
+    const ctrl = new SaveShortcutController(new FakeHost(), cb, { target });
+    ctrl.hostConnected();
+    ctrl.hostDisconnected();
+
+    target.dispatchEvent(makeKey("s", { meta: true }));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("attaches only one listener for repeated hostConnected calls", () => {
+    const target = new EventTarget();
+    const cb = vi.fn();
+    const ctrl = new SaveShortcutController(new FakeHost(), cb, { target });
+    ctrl.hostConnected();
+    ctrl.hostConnected();
+
+    target.dispatchEvent(makeKey("s", { meta: true }));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-registers as a controller on the host", () => {
+    const host = new FakeHost();
+    const ctrl = new SaveShortcutController(host, () => {}, {
+      target: new EventTarget(),
+    });
+    expect(host.controllers).toContain(ctrl);
+  });
+});

--- a/test/util/save-shortcut-controller.test.ts
+++ b/test/util/save-shortcut-controller.test.ts
@@ -70,6 +70,18 @@ describe("SaveShortcutController", () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
+  it("skips when the event was already defaultPrevented", () => {
+    const target = new EventTarget();
+    const cb = vi.fn();
+    const ctrl = new SaveShortcutController(new FakeHost(), cb, { target });
+    ctrl.hostConnected();
+
+    const e = makeKey("s", { meta: true });
+    e.preventDefault();
+    target.dispatchEvent(e);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
   it("attaches only one listener for repeated hostConnected calls", () => {
     const target = new EventTarget();
     const cb = vi.fn();

--- a/test/util/save-shortcut-controller.test.ts
+++ b/test/util/save-shortcut-controller.test.ts
@@ -7,18 +7,19 @@ import { FakeHost } from "../_fake-host.js";
    the handler reads. */
 function makeKey(
   key: string,
-  mods: { meta?: boolean; ctrl?: boolean; shift?: boolean } = {}
+  mods: { meta?: boolean; ctrl?: boolean; shift?: boolean; alt?: boolean } = {}
 ): Event {
   const e = new Event("keydown", { cancelable: true });
   Object.defineProperty(e, "key", { value: key });
   Object.defineProperty(e, "metaKey", { value: !!mods.meta });
   Object.defineProperty(e, "ctrlKey", { value: !!mods.ctrl });
   Object.defineProperty(e, "shiftKey", { value: !!mods.shift });
+  Object.defineProperty(e, "altKey", { value: !!mods.alt });
   return e;
 }
 
 describe("SaveShortcutController", () => {
-  it("invokes the callback on Cmd+S and Ctrl+S once connected, and preventDefaults", () => {
+  it("invokes the callback on Cmd+S and Ctrl+S once connected, and calls preventDefault", () => {
     const target = new EventTarget();
     const host = new FakeHost();
     const cb = vi.fn();
@@ -47,13 +48,15 @@ describe("SaveShortcutController", () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it("ignores Shift+Cmd+S, plain s, and other modified keys", () => {
+  it("ignores Shift/Alt-modified Cmd+S, plain s, and other modified keys", () => {
     const target = new EventTarget();
     const cb = vi.fn();
     const ctrl = new SaveShortcutController(new FakeHost(), cb, { target });
     ctrl.hostConnected();
 
     target.dispatchEvent(makeKey("s", { meta: true, shift: true }));
+    target.dispatchEvent(makeKey("s", { meta: true, alt: true }));
+    target.dispatchEvent(makeKey("s", { ctrl: true, alt: true }));
     target.dispatchEvent(makeKey("s"));
     target.dispatchEvent(makeKey("k", { meta: true }));
     expect(cb).not.toHaveBeenCalled();


### PR DESCRIPTION
# What does this implement/fix?

In the device configuration editor, Cmd/Ctrl+S saves. In the Secrets editor (both the structured form view and the YAML view) it did nothing; the browser's "save webpage" download dialog appeared instead, because the secrets page registered no keydown handler.

This extracts the save shortcut into a `SaveShortcutController` reactive controller (matching the existing `EnterController` / `EscapeController` pattern in `src/util/`) and wires it on the Secrets page. Both secrets views share one `_yaml` buffer and one save path, so the single page-level controller covers them both. The device editor is migrated onto the same controller so there is one implementation instead of a second inline copy. Its behavior is unchanged except that the controller also ignores Alt, so Cmd+Alt+S / Ctrl+Alt+S no longer saves and falls through to the browser; the old inline handler only excluded Shift. This is intentional, since those chords are often OS/browser shortcuts.

The shortcut always calls `preventDefault()` on a Cmd/Ctrl+S match so the browser dialog never appears on these editor pages, and saves only when there is something to save (dirty, not already saving, non-empty buffer). A truly empty or whitespace-only buffer is skipped, so the shortcut never fires the wipe-everything path on an accidental select-all-delete; a buffer that still has text but clears every secret routes through the same confirm dialog the Save button uses.

Verified in a browser: the secrets page and device editor both intercept Cmd/Ctrl+S, and a page without the controller (the dashboard) does not.

**Related issue or feature (if applicable):**

- Fixes esphome/device-builder#1585

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).



