### PR TITLE
Try the cachedPort fallback on a non-NetworkError open failure

### DIFF
--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -221,15 +221,10 @@ async function openLiveSerialPort(
         if (name === "InvalidStateError" && /already open/i.test(message)) {
           return p;
         }
-        // NetworkError means the device is still gone mid-re-enumeration: keep
-        // retrying the next candidate / round. Anything else (claimed by
-        // another app, driver / security error) won't fix itself by waiting —
-        // fail fast rather than stall the whole window behind a misleading
-        // "still restarting" message.
-        if (name !== "NetworkError") {
-          console.error("[Web Serial] Failed to reopen port for logs:", err);
-          return null;
-        }
+        // Unusable this round — still re-enumerating (NetworkError), claimed by
+        // another app, or a transient driver / security error. Fall through to
+        // the next candidate (including the cached handle this function exists
+        // to fall back to) and only give up at the deadline below.
       }
     }
     if (Date.now() >= deadline) {

--- a/test/util/post-install-logs.test.ts
+++ b/test/util/post-install-logs.test.ts
@@ -38,8 +38,9 @@ function openPort(
   } as unknown as SerialPort;
 }
 
-// A closed port whose open() always rejects. Defaults to a non-NetworkError
-// (the reopen bails fast); pass a NetworkError to exercise the retry window.
+// A closed port whose open() always rejects. Defaults to a non-NetworkError;
+// the reopen falls through to the next candidate either way, so pass a
+// NetworkError only when a test cares about the error kind.
 function deadPort(
   error: unknown = new DOMException("blocked", "SecurityError")
 ): SerialPort {
@@ -216,21 +217,28 @@ describe("attachSerialLogStream reopen", () => {
     }
   });
 
-  it("fails fast on a non-recoverable open error (no waiting out the window)", async () => {
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const restore = withGetPorts(async () => []);
+  it("falls through a non-NetworkError fresh handle to the cached port", async () => {
+    // A re-enumerated handle that fails non-NetworkError (e.g. SecurityError on
+    // a phantom UART bridge) must not abandon the cached fallback the loop
+    // exists to provide. Resolves on the first round, so no fake timers.
+    const cached = {
+      readable: null,
+      getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }),
+      open: vi.fn().mockResolvedValue(undefined),
+      setSignals: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const restore = withGetPorts(async () => [
+      deadPort(new DOMException("blocked", "SecurityError")),
+    ]);
     const dialog = stubDialog();
     try {
-      // SecurityError won't fix itself by waiting — bail without fake timers.
-      await attachSerialLogStream(deadPort(), dialog as never, defaultLocalize, 115200);
-      expect(dialog.setSerialOpenFailed).toHaveBeenCalledTimes(1);
-      expect(dialog.setSerialOpenFailed.mock.calls[0][0] as string).toContain(
-        "USB 303a:1001"
-      );
-      expect(toastError).toHaveBeenCalledTimes(1);
-      expect(errSpy).toHaveBeenCalled();
+      await attachSerialLogStream(cached, dialog as never, defaultLocalize, 115200);
+      expect(cached.open).toHaveBeenCalledWith({ baudRate: 115200 });
+      expect(dialog.setSerialStream).toHaveBeenCalledTimes(1);
+      expect(dialog.setSerialStream.mock.calls[0][0]).toBe(cached);
+      expect(dialog.setSerialOpenFailed).not.toHaveBeenCalled();
+      expect(toastError).not.toHaveBeenCalled();
     } finally {
-      errSpy.mockRestore();
       restore();
     }
   });


### PR DESCRIPTION
# What does this implement/fix?

`openLiveSerialPort` (`src/util/post-install-logs.ts`) reopens the serial port after a post-install hard reset by walking a candidate list `[fresh re-enumerated handles…, cachedPort]`. The whole point of the loop is the `cachedPort` fallback that Firefox and UART bridges reopen in place. But the open loop early-returned `null` the moment a candidate failed to open with anything other than `NetworkError`, abandoning the rest of the list, including `cachedPort`.

So a freshly-granted handle that fails non-`NetworkError` (a `SecurityError`, or a phantom handle on a board that exposes both a native USB-CDC and a separate UART bridge) made the function give up before the cached UART port was ever tried, and post-install logs went silently unavailable even though the cached port would have opened.

The fail-fast was at the wrong granularity. This falls through to the next candidate on any open failure and gives up only at the deadline, surfacing the captured error instead of a generic timeout. It mirrors the fix already made in the dev USB flasher copy of this function (esphome/device-builder#1601); the frontend original predates that work and was not touched by it.

Trade-off, intended: a non-`NetworkError` that never recovers now waits out the re-enumeration window before failing rather than bailing immediately, which is the cost of guaranteeing the `cachedPort` fallback is always attempted.

A unit test pins the gap (fresh non-`NetworkError` handle then a good `cachedPort` streams the cached port); the existing all-`NetworkError`-to-deadline and immediate-success tests stay green.

**Related issue or feature (if applicable):**

- Fixes esphome/device-builder-frontend#909

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

