### PR TITLE
Keep the watchdog-reset config0 value an unsigned u32

### DIFF
--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -352,11 +352,12 @@ async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<b
      Order: unlock → set timeout → enable+arm → re-lock. The
      ``(1<<31) | (5<<28) | (1<<8) | 2`` config0 bit pattern is what
      esptool ships — exact bit semantics aren't documented per-chip;
-     trust the authoritative source. */
+     trust the authoritative source. ``>>> 0`` keeps it an unsigned
+     u32 (``1 << 31`` alone is negative in JS). */
   try {
     await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
     await loader.writeReg(regs.wdtConfig1, 2000);
-    await loader.writeReg(regs.wdtConfig0, (1 << 31) | (5 << 28) | (1 << 8) | 2);
+    await loader.writeReg(regs.wdtConfig0, ((1 << 31) | (5 << 28) | (1 << 8) | 2) >>> 0);
     await loader.writeReg(regs.wdtWProtect, 0);
   } catch {
     /* A writeReg may race the actual reset firing — the chip is


### PR DESCRIPTION
# What does this implement/fix?

`(1 << 31)` evaluates to a negative signed int32 in JavaScript, so the
`wdtConfig0` write in `watchdogReset` (the ESP32-S2/S3/C2/C3 RTC-WDT
reset path) was passing a negative value where the ROM expects the
unsigned `0xD0000102`. Masking with `>>> 0` keeps it an unsigned u32 and
documents why in the comment.

No behaviour change: `loader.writeReg` coerces to u32 on the wire either
way. This is a readability fix so the constant reads as the value it
actually is. The same nit was raised on the dashboard's ported copy
(esphome/dashboard#923); this fixes the canonical source here.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
