### PR TITLE
Add the missing ESP32 variant chips to the board picker

### DIFF
--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -29,6 +29,7 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
   { platform: "esp32", variant: "esp32c3", label: "ESP32-C3" },
   { platform: "esp32", variant: "esp32c6", label: "ESP32-C6" },
   { platform: "esp32", variant: "esp32h2", label: "ESP32-H2" },
+  { platform: "esp32", variant: "esp32p4", label: "ESP32-P4" },
   { platform: "esp8266", variant: "", label: "ESP8266" },
   // ESPHome's 'rp2040' platform covers both the original RP2040 and
   // the newer RP2350; split into two chips (mirroring the per-variant


### PR DESCRIPTION
# What does this implement/fix?

ESP32-P4 was missing from the board picker's platform filter chips, so the ESP32-P4 boards already in the catalog (esp32-p4, esp32-p4-evboard, generic-esp32p4, m5stack-tab5-p4, and the rev.300 variants) couldn't be filtered to or surfaced under a P4 chip. This adds the `esp32p4` entry to `WIZARD_BOARD_PLATFORMS`, alongside the other ESP32 variants. The variant was already known to `chip-variant.ts` and the translations, so this one line is all that was missing.

**Related issue or feature (if applicable):**

- 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
