### PR TITLE
Identify classic ESP32 and ESP8266 in board-picker chip detection

### DIFF
--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -15,6 +15,8 @@
  *   two chip series (RP2040 / RP2350). Absent for other platforms.
  * - ``label`` is the user-facing chip text.
  */
+import { chipNameToVariant } from "../../util/chip-variant.js";
+
 export interface WizardBoardPlatform {
   readonly platform: string;
   readonly variant: string;
@@ -46,22 +48,21 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
 /**
  * Map an esptool-js chip name (e.g. ``"ESP32-C6 (QFN32) (revision
  * v0.2)"``) to the platform-filter label the board picker uses
- * (e.g. ``"ESP32-C6"``). Strips the parenthesised chip-package /
- * revision suffix, normalises to lowercase, drops dashes, then
- * looks the family up in ``WIZARD_BOARD_PLATFORMS`` — that's the
- * same shape the picker's filter chips use, so callers can hand
- * the result straight to ``_selectedFilter`` /
- * ``openAtBoardStep``.
+ * (e.g. ``"ESP32-C6"``). Normalises through ``chipNameToVariant``
+ * (handles package-specific descriptions like ``ESP32-D0WD`` →
+ * ``esp32`` and ``ESP8266EX`` → ``esp8266``), then matches an
+ * existing filter chip. Returns ``null`` when no chip represents the
+ * variant (e.g. ESP32-S31/C31/H21) so the caller shows the full
+ * picker rather than narrowing to the wrong family.
  */
 export function chipNameToFilterLabel(chipName: string): string | null {
-  const family = chipName.split("(")[0].trim().toLowerCase().replace(/-/g, "");
-  const byVariant = WIZARD_BOARD_PLATFORMS.find((p) => p.variant === family);
-  if (byVariant) return byVariant.label;
-  // rp2040 / rp2350 share one platform; match on the chip series.
-  const byMcu = WIZARD_BOARD_PLATFORMS.find((p) => p.mcu === family);
-  if (byMcu) return byMcu.label;
-  const byPlatform = WIZARD_BOARD_PLATFORMS.find(
-    (p) => p.platform === family && !p.variant
+  let family = chipNameToVariant(chipName);
+  if (family.startsWith("esp82")) family = "esp8266"; // esp8266 / esp8285
+  const match = WIZARD_BOARD_PLATFORMS.find(
+    (p) =>
+      (p.variant && p.variant === family) ||
+      p.mcu === family ||
+      (!p.variant && !p.mcu && p.platform === family)
   );
-  return byPlatform?.label ?? null;
+  return match?.label ?? null;
 }

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -479,13 +479,8 @@ export class ESPHomeWizardStepBoard extends LitElement {
       // filtered picker is the better UX: they can still pick the
       // generic board explicitly, or one of several boards for
       // their chip.
-      const label = chipNameToFilterLabel(chipName);
-      if (label) {
-        this._selectedFilter = label;
-        this._filterFromDetection = true;
-        this._search = "";
-        void this._fetchBoards();
-      }
+      this._applyDetectedFilter(chipNameToFilterLabel(chipName));
+      void this._fetchBoards();
     } catch (err) {
       if (isPortPickerCancel(err)) return;
       this._detectError = this._extractErrorDetail(
@@ -530,13 +525,10 @@ export class ESPHomeWizardStepBoard extends LitElement {
 
       // Resolve to an existing filter chip (same as the WebSerial path);
       // a recognised-but-unfiltered variant (e.g. ESP32-S31) yields null,
-      // so we leave the picker unfiltered instead of setting a dead filter.
-      const label = result.chip_family && chipNameToFilterLabel(result.chip_family);
-      if (label) {
-        this._selectedFilter = label;
-        this._filterFromDetection = true;
-        this._search = "";
-      }
+      // so the picker is left unfiltered instead of keeping a dead filter.
+      this._applyDetectedFilter(
+        result.chip_family ? chipNameToFilterLabel(result.chip_family) : null
+      );
       this._view = "boards";
       void this._fetchBoards();
     } catch (err) {
@@ -578,6 +570,15 @@ export class ESPHomeWizardStepBoard extends LitElement {
     this._view = "boards";
     this._detectError = "";
   };
+
+  // Apply a detected chip's filter, clearing any prior filter when the
+  // chip maps to no picker chip (null) so the picker is genuinely
+  // unfiltered rather than keeping a stale manual/preset selection.
+  private _applyDetectedFilter(label: string | null) {
+    this._selectedFilter = label ?? "";
+    this._filterFromDetection = label !== null;
+    this._search = "";
+  }
 
   private _exitDetectionMode() {
     this._selectedFilter = "";

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -528,8 +528,12 @@ export class ESPHomeWizardStepBoard extends LitElement {
         }
       }
 
-      if (result.chip_family) {
-        this._selectedFilter = result.chip_family;
+      // Resolve to an existing filter chip (same as the WebSerial path);
+      // a recognised-but-unfiltered variant (e.g. ESP32-S31) yields null,
+      // so we leave the picker unfiltered instead of setting a dead filter.
+      const label = result.chip_family && chipNameToFilterLabel(result.chip_family);
+      if (label) {
+        this._selectedFilter = label;
         this._filterFromDetection = true;
         this._search = "";
       }

--- a/src/util/chip-variant.ts
+++ b/src/util/chip-variant.ts
@@ -5,22 +5,29 @@
  * esptool-js returns specific descriptions like ``ESP32-PICO-D4``,
  * ``ESP32-D0WD``, or ``ESP32-S3-PICO-1``. ESPHome groups all
  * non-sub-variant ESP32 chips under the plain ``esp32`` variant; sub
- * variants (S2/S3, C2/C3/C5/C6/C61, H2, P4) are their own variants and
- * must be matched exactly. ESP8266 has no sub-variants.
+ * variants (S2/S3/S31, C2/C3/C31/C5/C6/C61, H2/H4/H21, P4) are their
+ * own variants and must be matched exactly. ESP8266 has no sub-variants.
  *
- * Sub-variant prefixes are listed longest-first so e.g. ``esp32c61``
- * isn't swallowed by ``esp32c6``.
+ * Sub-variant prefixes are listed longest-first so a longer number
+ * isn't swallowed by a shorter sibling (``esp32s31`` before ``esp32s3``,
+ * ``esp32c61``/``esp32c31`` before ``esp32c6``/``esp32c3``, ``esp32h21``
+ * before ``esp32h2``). C31 has shipping hardware but no esphome variant
+ * yet; recognised here so it can't be mis-read as C3.
  */
 export function chipNameToVariant(name: string): string {
   const n = name.split("(")[0].trim().toLowerCase().replace(/-/g, "");
   const subVariants = [
     "esp32c61",
+    "esp32c31",
     "esp32c2",
     "esp32c3",
     "esp32c5",
     "esp32c6",
+    "esp32h21",
     "esp32h2",
+    "esp32h4",
     "esp32p4",
+    "esp32s31",
     "esp32s2",
     "esp32s3",
     "esp8266",

--- a/test/components/wizard/wizard-step-board-platforms.test.ts
+++ b/test/components/wizard/wizard-step-board-platforms.test.ts
@@ -85,6 +85,34 @@ describe("wizard step-board platform chips", () => {
       expect(chipNameToFilterLabel("ESP8266")).toBe("ESP8266");
     });
 
+    it("identifies classic ESP32 from its package-specific description", () => {
+      // esptool reports classic ESP32 as ESP32-D0WD / ESP32-PICO-D4 etc.,
+      // never the bare "ESP32" — the exact-match version returned null.
+      expect(chipNameToFilterLabel("ESP32-D0WD (revision 1)")).toBe("ESP32");
+      expect(chipNameToFilterLabel("ESP32-PICO-D4")).toBe("ESP32");
+      expect(chipNameToFilterLabel("ESP32-U4WDH")).toBe("ESP32");
+    });
+
+    it("identifies ESP8266 / ESP8285 from their package descriptions", () => {
+      expect(chipNameToFilterLabel("ESP8266EX")).toBe("ESP8266");
+      expect(chipNameToFilterLabel("ESP8285")).toBe("ESP8266");
+    });
+
+    it("keeps ESP32-S3 packages on the S3 filter (not classic ESP32)", () => {
+      expect(chipNameToFilterLabel("ESP32-S3 (QFN56)")).toBe("ESP32-S3");
+      expect(chipNameToFilterLabel("ESP32-S3-PICO-1")).toBe("ESP32-S3");
+    });
+
+    it("returns null for variants with no filter chip (no mis-narrowing)", () => {
+      // S31/C31/H21/H4 have no catalog filter — narrowing to the shorter
+      // sibling (S3/C3/H2) or to classic ESP32 would show the wrong boards,
+      // so the caller falls back to the full picker.
+      expect(chipNameToFilterLabel("ESP32-S31")).toBeNull();
+      expect(chipNameToFilterLabel("ESP32-C31")).toBeNull();
+      expect(chipNameToFilterLabel("ESP32-H21")).toBeNull();
+      expect(chipNameToFilterLabel("ESP32-H4")).toBeNull();
+    });
+
     it("maps the rp2040 / rp2350 chip series to their split filter labels", () => {
       // The two rp2040-platform chips are distinguished by `mcu`, so the
       // chip-series name must resolve to its own label.

--- a/test/util/chip-variant.test.ts
+++ b/test/util/chip-variant.test.ts
@@ -16,6 +16,13 @@ describe("chipNameToVariant", () => {
     expect(chipNameToVariant("ESP32-U4WDH")).toBe("esp32");
   });
 
+  it("maps classic S0WD packages to esp32, not a phantom s-variant", () => {
+    // ESP32-S0WD / S0WDQ6 are classic ESP32 SKUs, not sub-variants — they
+    // must not be caught by the esp32s2/s3/s31 entries.
+    expect(chipNameToVariant("ESP32-S0WD")).toBe("esp32");
+    expect(chipNameToVariant("ESP32-S0WDQ6")).toBe("esp32");
+  });
+
   it("maps PICO-V3 variants to esp32", () => {
     expect(chipNameToVariant("ESP32-PICO-V3")).toBe("esp32");
     expect(chipNameToVariant("ESP32-PICO-V3-02")).toBe("esp32");
@@ -24,19 +31,29 @@ describe("chipNameToVariant", () => {
   it("maps each ESP32 sub-variant to its own variant", () => {
     expect(chipNameToVariant("ESP32-S2")).toBe("esp32s2");
     expect(chipNameToVariant("ESP32-S3")).toBe("esp32s3");
+    expect(chipNameToVariant("ESP32-S31")).toBe("esp32s31");
     expect(chipNameToVariant("ESP32-C2")).toBe("esp32c2");
     expect(chipNameToVariant("ESP32-C3")).toBe("esp32c3");
+    expect(chipNameToVariant("ESP32-C31")).toBe("esp32c31");
     expect(chipNameToVariant("ESP32-C5")).toBe("esp32c5");
     expect(chipNameToVariant("ESP32-C6")).toBe("esp32c6");
     expect(chipNameToVariant("ESP32-C61")).toBe("esp32c61");
     expect(chipNameToVariant("ESP32-H2")).toBe("esp32h2");
+    expect(chipNameToVariant("ESP32-H4")).toBe("esp32h4");
+    expect(chipNameToVariant("ESP32-H21")).toBe("esp32h21");
     expect(chipNameToVariant("ESP32-P4")).toBe("esp32p4");
   });
 
-  it("does not let esp32c6 swallow esp32c61", () => {
-    // Order in the prefix list matters: c61 must be checked before c6.
+  it("does not let a shorter sibling swallow a longer-numbered variant", () => {
+    // Order in the prefix list matters: the longer number is checked first.
     expect(chipNameToVariant("ESP32-C61")).toBe("esp32c61");
     expect(chipNameToVariant("ESP32-C6")).toBe("esp32c6");
+    expect(chipNameToVariant("ESP32-C31")).toBe("esp32c31");
+    expect(chipNameToVariant("ESP32-C3")).toBe("esp32c3");
+    expect(chipNameToVariant("ESP32-S31")).toBe("esp32s31");
+    expect(chipNameToVariant("ESP32-S3")).toBe("esp32s3");
+    expect(chipNameToVariant("ESP32-H21")).toBe("esp32h21");
+    expect(chipNameToVariant("ESP32-H2")).toBe("esp32h2");
   });
 
   it("maps sub-variant packages to the sub-variant family", () => {
@@ -48,6 +65,13 @@ describe("chipNameToVariant", () => {
   it("maps ESP8266 chips to esp8266", () => {
     expect(chipNameToVariant("ESP8266")).toBe("esp8266");
     expect(chipNameToVariant("ESP8266EX")).toBe("esp8266");
+  });
+
+  it("returns esp8285 verbatim (callers collapse the esp82 family)", () => {
+    // esp8285 shares esphome's esp8266 platform, but chipNameToVariant
+    // keeps the token distinct; install-flow / chipNameToFilterLabel
+    // collapse it via the `esp82` prefix.
+    expect(chipNameToVariant("ESP8285")).toBe("esp8285");
   });
 
   it("strips parenthetical revision info", () => {


### PR DESCRIPTION
# What does this implement/fix?

"Connect your board" in the create wizard could not identify classic ESP32 or ESP8266 boards, so the picker stayed unfiltered after a successful chip detect.

esptool reports package-specific chip descriptions (ESP32-D0WD, ESP8266EX, ESP8285), but the picker matched them by exact equality and they resolved to nothing. `chipNameToFilterLabel` now normalizes through the existing `chipNameToVariant`, which also gains the full ESP32 variant set in collision-safe order, so ESP32-S31/C31/H21 are not mis-read as S3/C3/H2 and a variant with no filter chip falls back to the full picker instead of the wrong family. The server-side detect path resolves `chip_family` through the same function.

Tested on real hardware: ESP32-S3, classic ESP32, and ESP8266 all narrow correctly.

**Related issue or feature (if applicable):**

Reported via the dashboard; no tracking issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
