### PR TITLE
Add a mobile dialog body gutter via an inherited custom property

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -133,7 +133,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
          styles so the board picker isn't boxed into a 520px column. #41 */
 
       esphome-base-dialog::part(body) {
-        padding: var(--wa-space-l) var(--wa-space-xl);
+        /* Horizontal gutter drops to a tighter value on the mobile sheet via
+           --esphome-dialog-body-gutter (set by fullscreenMobileDialog). */
+        padding: var(--wa-space-l) var(--esphome-dialog-body-gutter, var(--wa-space-xl));
       }
 
       .error {

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -20,14 +20,14 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
-/** Consistent, tighter horizontal body gutter on the mobile sheet. Each dialog
- *  hardcodes its own desktop body padding (--wa-space-l … --wa-space-xl) with no
- *  mobile reduction, so the phone sheet looked inconsistent — some roomy, some
- *  not. ``!important`` is needed because consumers set ``::part(body)`` padding
- *  after this fragment in their styles array; only the inline (horizontal)
- *  padding is overridden so each dialog keeps its own vertical rhythm. */
+/** Custom property each dialog reads for its body's horizontal padding, e.g.
+ *  ``padding-inline: var(--esphome-dialog-body-gutter, var(--wa-space-l))``. On
+ *  the mobile sheet the fragments below set it to a tighter, consistent value;
+ *  on desktop it's unset so each dialog's own fallback applies. Driving it
+ *  through an inherited custom property (set on the host, read in the shadow
+ *  ``::part(body)``) avoids any ``::part`` specificity fight — no !important. */
 const MOBILE_DIALOG_BODY_GUTTER = css`
-  padding-inline: var(--wa-space-m) !important;
+  --esphome-dialog-body-gutter: var(--wa-space-m);
 `;
 
 /** Full-screen sheet on mobile. Pass a custom `breakpoint` for dialogs whose
@@ -52,7 +52,7 @@ export function fullscreenMobileDialog(
         margin: 0;
         border-radius: 0;
       }
-      ${sel}::part(body) {
+      ${sel} {
         ${MOBILE_DIALOG_BODY_GUTTER}
       }
     }
@@ -71,7 +71,7 @@ export function centeredMobileDialog(host: DialogHost): CSSResult {
         max-height: calc(100vh - var(--wa-space-l));
         max-height: calc(100dvh - var(--wa-space-l));
       }
-      ${sel}::part(body) {
+      ${sel} {
         ${MOBILE_DIALOG_BODY_GUTTER}
       }
     }

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -20,6 +20,16 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
   "esphome-base-dialog": css`esphome-base-dialog`,
 };
 
+/** Consistent, tighter horizontal body gutter on the mobile sheet. Each dialog
+ *  hardcodes its own desktop body padding (--wa-space-l … --wa-space-xl) with no
+ *  mobile reduction, so the phone sheet looked inconsistent — some roomy, some
+ *  not. ``!important`` is needed because consumers set ``::part(body)`` padding
+ *  after this fragment in their styles array; only the inline (horizontal)
+ *  padding is overridden so each dialog keeps its own vertical rhythm. */
+const MOBILE_DIALOG_BODY_GUTTER = css`
+  padding-inline: var(--wa-space-m) !important;
+`;
+
 /** Full-screen sheet on mobile. Pass a custom `breakpoint` for dialogs whose
  *  layout needs to go full-screen earlier than the shared phone cutoff (e.g.
  *  the settings dialog, whose stacked-nav band would otherwise float as an
@@ -42,6 +52,9 @@ export function fullscreenMobileDialog(
         margin: 0;
         border-radius: 0;
       }
+      ${sel}::part(body) {
+        ${MOBILE_DIALOG_BODY_GUTTER}
+      }
     }
   `;
 }
@@ -57,6 +70,9 @@ export function centeredMobileDialog(host: DialogHost): CSSResult {
         /* vh fallback, then dvh */
         max-height: calc(100vh - var(--wa-space-l));
         max-height: calc(100dvh - var(--wa-space-l));
+      }
+      ${sel}::part(body) {
+        ${MOBILE_DIALOG_BODY_GUTTER}
       }
     }
   `;

--- a/src/styles/dialog-mobile.ts
+++ b/src/styles/dialog-mobile.ts
@@ -21,11 +21,13 @@ const HOST_SELECTOR: Record<DialogHost, CSSResult> = {
 };
 
 /** Custom property each dialog reads for its body's horizontal padding, e.g.
- *  ``padding-inline: var(--esphome-dialog-body-gutter, var(--wa-space-l))``. On
- *  the mobile sheet the fragments below set it to a tighter, consistent value;
- *  on desktop it's unset so each dialog's own fallback applies. Driving it
- *  through an inherited custom property (set on the host, read in the shadow
- *  ``::part(body)``) avoids any ``::part`` specificity fight — no !important. */
+ *  ``padding-inline: var(--esphome-dialog-body-gutter, <desktop fallback>)``
+ *  where the fallback is that dialog's own desktop value (create-config uses
+ *  ``var(--wa-space-xl)``). On the mobile sheet the fragments below set it to a
+ *  tighter, consistent value; on desktop it's unset so each dialog's own
+ *  fallback applies. Driving it through an inherited custom property (set on the
+ *  host, read in the shadow ``::part(body)``) avoids any ``::part`` specificity
+ *  fight — no !important. */
 const MOBILE_DIALOG_BODY_GUTTER = css`
   --esphome-dialog-body-gutter: var(--wa-space-m);
 `;


### PR DESCRIPTION
# What does this implement/fix?

On mobile the wizard (`create-config`) dialog used `var(--wa-space-l) var(--wa-space-xl)` body padding with no mobile reduction, so its full-screen sheet was over-padded on a phone. This adds an inherited `--esphome-dialog-body-gutter` custom property that the mobile dialog fragments (`fullscreenMobileDialog` / `centeredMobileDialog`) set on the host inside their media query. A dialog opts in by reading it for its body's horizontal padding: `padding-inline: var(--esphome-dialog-body-gutter, <desktop fallback>)`. So the gutter tightens on the mobile sheet and keeps the desktop value otherwise.

Because it's an inherited custom property (set on the host, read in the shadow `::part(body)`), there's no `::part` specificity fight and no `!important`. It's applied to the create-config wizard here, whose primary header is already `--wa-space-m`, so header and body line up on mobile; other dialogs can opt in the same way (read the property in their `::part(body)` rule) without touching the shared header.

**Related issue or feature (if applicable):**

- 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
