### PR TITLE
Stop the board picker clipping its list on a phone-height sheet

### DIFF
--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -330,6 +330,17 @@ export const wizardStepBoardStyles = css`
      with the base rules left align-items / width / height
      silently overridden. #41 */
   @media (max-width: 480px) {
+    /* The board list's inner scroller is a fixed 500px on desktop so the
+       filter chips stay pinned while only the grid scrolls. On a phone the
+       step renders inside a full-screen sheet, and that fixed height runs
+       past the viewport — the featured card's bottom is clipped and
+       unreachable (iPhone XR repro). Collapse the inner scroller so the
+       dialog body scrolls as one. */
+    .boards-scroll {
+      height: auto;
+      overflow-y: visible;
+    }
+
     .boards-grid {
       grid-template-columns: 1fr;
     }

--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
+
 /**
  * Styles for <esphome-wizard-step-board>. Extracted from the
  * component file to keep it under the repo's file-size cap (see
@@ -329,18 +331,20 @@ export const wizardStepBoardStyles = css`
      Copilot review on PR #400 — the prior placement inline
      with the base rules left align-items / width / height
      silently overridden. #41 */
-  @media (max-width: 480px) {
-    /* The board list's inner scroller is a fixed 500px on desktop so the
-       filter chips stay pinned while only the grid scrolls. On a phone the
-       step renders inside a full-screen sheet, and that fixed height runs
-       past the viewport — the featured card's bottom is clipped and
-       unreachable (iPhone XR repro). Collapse the inner scroller so the
-       dialog body scrolls as one. */
+  /* The board list's inner scroller is a fixed 500px on desktop so the
+     filter chips stay pinned while only the grid scrolls. The wizard goes
+     full-screen at MOBILE_BREAKPOINT, and at that width the fixed height runs
+     past the viewport — the featured card's bottom is clipped and unreachable
+     (iPhone XR repro). Collapse the inner scroller at the same cutoff the
+     sheet uses so the dialog body scrolls as one. */
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
     .boards-scroll {
       height: auto;
       overflow-y: visible;
     }
+  }
 
+  @media (max-width: 480px) {
     .boards-grid {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
# What does this implement/fix?

The wizard's board picker wraps its featured card and board grid in an inner scroller with a fixed `height: 500px`. That keeps the filter chips pinned while the grid scrolls on desktop, but inside the full-screen sheet on a phone the header, search, and chip rows push that fixed 500px region past the viewport, so the bottom of the featured card is clipped and unreachable (reproduced on iPhone XR). On mobile the inner scroller now collapses to `height: auto` with `overflow: visible`, so the dialog body scrolls as one and the whole card is reachable. Desktop is unchanged.

**Related issue or feature (if applicable):**

- 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
