### PR TITLE
Restore the board filter chip padding

### DIFF
--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -294,7 +294,7 @@ export const wizardStepBoardStyles = css`
   .platform-chip {
     display: inline-flex;
     align-items: center;
-    padding: 4px 8px;
+    padding: 4px 12px;
     border-radius: 999px;
     font-size: var(--wa-font-size-2xs);
     font-weight: var(--wa-font-weight-bold);


### PR DESCRIPTION
# What does this implement/fix?

#915 tightened the board-picker filter chips (chip gap 6px to 4px, chip padding 12px to 8px) to fit the extra ESP32 variant chips on fewer lines, and they ended up looking cramped. #917 has since fixed the underlying mobile cause, so the squeeze is no longer needed. This restores the chip horizontal padding to 12px while keeping the tighter 4px gap, which still lands every chip on two rows but reads less cramped. It is good enough until the filter row gets a proper redesign.

**Related issue or feature (if applicable):**

- 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
