### PR TITLE
Fix USB hand-off error banner and pop-up-blocked recovery

### DIFF
--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -459,16 +459,25 @@ export function handOffToFlasher(host: ESPHomeFirmwareInstallDialog): void {
   host._step = "flashing";
   host._flashPercent = 0;
   host._statusMessage = host._localize("firmware.usb_flashing");
+  host._errorMessage = "";
   const deviceName = host._device ? host._device.friendly_name || host._device.name : "";
+  // An in-tab retry after a failure resumes via progress/status frames; leave
+  // the error view and clear the failure banner so it doesn't headline a flash
+  // that's already running (a progress frame often lands before a status one).
+  const resumeFromError = () => {
+    if (host._step !== "error") return;
+    host._step = "flashing";
+    host._errorMessage = "";
+    host._statusMessage = host._localize("firmware.usb_flashing");
+  };
   const teardown = openFlasher(firmware, host._usbFirmwareName, deviceName, {
     onProgress: (pct) => {
+      resumeFromError();
       host._flashPercent = pct;
-      // An in-tab retry after a failure resumes flashing; leave the error view.
-      if (host._step === "error") host._step = "flashing";
     },
     onStatus: (detail) => {
+      resumeFromError();
       host._statusMessage = detail;
-      if (host._step === "error") host._step = "flashing";
     },
     onState: (state, detail) => {
       if (state === "done") {
@@ -490,7 +499,12 @@ export function handOffToFlasher(host: ESPHomeFirmwareInstallDialog): void {
     },
   });
   if (!teardown) {
-    host._fail(host._localize("firmware.usb_popup_blocked"));
+    // Pop-up blocked: stay on download-ready with the firmware still in hand so
+    // the user can allow pop-ups and click Open again, rather than being forced
+    // through a full recompile. The message surfaces in the ready-screen detail.
+    host._step = "download-ready";
+    host._statusMessage = "";
+    host._errorMessage = host._localize("firmware.usb_popup_blocked");
     return;
   }
   // The openFlasher session now holds the bytes (in its closure) and transfers

--- a/src/components/firmware-install-dialog/renderers.ts
+++ b/src/components/firmware-install-dialog/renderers.ts
@@ -112,6 +112,9 @@ function downloadReadyTitle(host: ESPHomeFirmwareInstallDialog): string {
 
 function downloadReadyDetail(host: ESPHomeFirmwareInstallDialog): string {
   if (host._installer === "web-flash") {
+    // A blocked pop-up parks here with the firmware still built; show why so the
+    // user can allow pop-ups and click Open again (handOffToFlasher clears it).
+    if (host._errorMessage) return host._errorMessage;
     return host._localize("firmware.usb_built_body", { host: FLASHER_HOST });
   }
   // binary-download

--- a/test/components/firmware-install-dialog-usb-handoff.test.ts
+++ b/test/components/firmware-install-dialog-usb-handoff.test.ts
@@ -4,8 +4,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const { openFlasher } = vi.hoisted(() => ({ openFlasher: vi.fn() }));
 vi.mock("../../src/util/usb-flasher.js", () => ({ openFlasher }));
 
+import { FLASHER_HOST } from "../../src/common/docs.js";
+import { defaultLocalize } from "../../src/common/localize.js";
 import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { handOffToFlasher } from "../../src/components/firmware-install-dialog/install-flow.js";
+import { cardStatusDetail } from "../../src/components/firmware-install-dialog/renderers.js";
 import type { FlasherCallbacks } from "../../src/util/usb-flasher.js";
 
 function makeHost() {
@@ -64,5 +67,27 @@ describe("handOffToFlasher", () => {
     expect(host._errorMessage).toBe("");
     expect(host._statusMessage).toBe("firmware.usb_flashing");
     expect(host._flashPercent).toBe(10);
+  });
+});
+
+describe("download-ready detail (web-flash)", () => {
+  const detailHost = (errorMessage: string) =>
+    ({
+      _step: "download-ready",
+      _installer: "web-flash",
+      _errorMessage: errorMessage,
+      _downloadedFilename: "",
+      _localize: defaultLocalize,
+    }) as unknown as ESPHomeFirmwareInstallDialog;
+
+  it("surfaces the pop-up-blocked message when _errorMessage is set", () => {
+    const message = defaultLocalize("firmware.usb_popup_blocked");
+    expect(cardStatusDetail(detailHost(message))).toBe(message);
+  });
+
+  it("falls back to the built-firmware body when there's no error", () => {
+    expect(cardStatusDetail(detailHost(""))).toBe(
+      defaultLocalize("firmware.usb_built_body", { host: FLASHER_HOST })
+    );
   });
 });

--- a/test/components/firmware-install-dialog-usb-handoff.test.ts
+++ b/test/components/firmware-install-dialog-usb-handoff.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { openFlasher } = vi.hoisted(() => ({ openFlasher: vi.fn() }));
+vi.mock("../../src/util/usb-flasher.js", () => ({ openFlasher }));
+
+import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
+import { handOffToFlasher } from "../../src/components/firmware-install-dialog/install-flow.js";
+import type { FlasherCallbacks } from "../../src/util/usb-flasher.js";
+
+function makeHost() {
+  const host = {
+    _usbFirmware: new ArrayBuffer(16) as ArrayBuffer | null,
+    _usbFirmwareName: "firmware.factory.bin",
+    _device: { name: "dev", friendly_name: "Dev" },
+    _step: "download-ready",
+    _statusMessage: "",
+    _errorMessage: "",
+    _flashPercent: 0,
+    _usbFlashTeardown: null as (() => void) | null,
+    _localize: (k: string) => k,
+    _fail(title: string, detail = "") {
+      this._step = "error";
+      this._statusMessage = title;
+      this._errorMessage = detail;
+    },
+  };
+  return host;
+}
+
+const asHost = (h: ReturnType<typeof makeHost>) =>
+  h as unknown as ESPHomeFirmwareInstallDialog;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("handOffToFlasher", () => {
+  it("parks on download-ready and keeps the firmware when the pop-up is blocked", () => {
+    openFlasher.mockReturnValue(null);
+    const host = makeHost();
+    handOffToFlasher(asHost(host));
+    expect(host._step).toBe("download-ready");
+    expect(host._errorMessage).toBe("firmware.usb_popup_blocked");
+    // Still in hand so the user can allow pop-ups and click Open again.
+    expect(host._usbFirmware).not.toBeNull();
+  });
+
+  it("clears the failure banner when an in-tab retry resumes flashing", () => {
+    let cbs: FlasherCallbacks | undefined;
+    openFlasher.mockImplementation(
+      (_fw: ArrayBuffer, _n: string, _d: string, callbacks: FlasherCallbacks) => {
+        cbs = callbacks;
+        return () => {};
+      }
+    );
+    const host = makeHost();
+    handOffToFlasher(asHost(host));
+    // The flasher reports a non-terminal error, then the user retries in-tab and
+    // the first frame back is progress (no status detail).
+    cbs!.onState("error", "boom");
+    expect(host._step).toBe("error");
+    expect(host._errorMessage).toBe("boom");
+    cbs!.onProgress(10);
+    expect(host._step).toBe("flashing");
+    expect(host._errorMessage).toBe("");
+    expect(host._statusMessage).toBe("firmware.usb_flashing");
+    expect(host._flashPercent).toBe(10);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Addresses the two Copilot review comments that landed on #904 right after it merged. Both are on the external USB flash hand-off (`install-flow.ts` / `renderers.ts`):

1. **Stale failure banner during an in-tab retry.** After a non-terminal flasher `error`, an in-tab retry resumes through `progress` / `status` frames, but `_statusMessage` stayed "USB install failed" (set by `_fail`) until a `status` frame arrived. A `progress` frame usually lands first, so the UI showed a failure headline over a flash that was actually running. Resuming from error now also clears `_errorMessage` and restores the flashing status.

2. **Pop-up blocked forced a full recompile.** When the browser blocked the flasher pop-up, the dialog went to a terminal error, so retrying meant recompiling/redownloading. It now stays on download-ready with the firmware still in hand and surfaces the pop-up-blocked message in the ready-screen detail, so the user can allow pop-ups and click Open again.

The third post-merge comment (a `#904` / `#907` PR-number deprecation marker on `installWebDownload`) is already resolved: #919 deleted that method entirely.

Added `firmware-install-dialog-usb-handoff.test.ts` covering both: pop-up-blocked parks on download-ready and keeps the firmware; an in-tab progress frame after an error clears the banner.

**Related issue or feature (if applicable):**

- Follow-up to #904

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
