### PR TITLE
Build pairing UI cleanup

### DIFF
--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -83,6 +83,13 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // secondary button: Cancel (close) rather than Back (to the skipped form).
   @state() _skippedInput = false;
 
+  // Bumped on every open(). The dialog is a reused singleton and a dismissable
+  // preview can still be in flight (offline host), so onPreviewSubmit captures
+  // this and drops its result if a later open() superseded the session — else a
+  // late preview would clobber the fresh session with a stale host/fingerprint.
+  // Not reactive: it gates a write, it doesn't drive render.
+  _previewGeneration = 0;
+
   // ${hostname}:${port} of the submitted request — null outside the sent step.
   @state() _sentKey: string | null = null;
 
@@ -112,6 +119,8 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     prefill?: { hostname?: string; port?: number },
     opts?: { autoPreview?: boolean }
   ): void {
+    // Supersede any preview still in flight from a previous open().
+    this._previewGeneration += 1;
     this._step = "input";
     this._busy = false;
     this._sending = false;

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -127,7 +127,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     if (
       opts?.autoPreview &&
       this._api !== undefined &&
-      this._hostname &&
+      this._hostname.trim() &&
       parsePortInput(this._port) !== null
     ) {
       this._step = "confirm";

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -60,7 +60,13 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   _buildOffloadPairings: Map<string, PairingSummary> | null = null;
 
   @state() _step: "input" | "confirm" | "sent" = "input";
+  // Any round-trip in flight (preview or send): gates re-entry, the submit
+  // button, and the inputs, and drives the progress label/spinner.
   @state() _busy = false;
+  // The mutating request_pair send specifically. Only this vetoes dismissal
+  // (base-dialog busy gate) — the read-only fingerprint preview must stay
+  // cancellable, so a stale/offline discovered host doesn't trap the user.
+  @state() _sending = false;
   @state() _hostname = "";
   @state() _port = "6055";
   @state() _previewedPin = "";
@@ -108,6 +114,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   ): void {
     this._step = "input";
     this._busy = false;
+    this._sending = false;
     this._hostname = prefill?.hostname ?? "";
     this._port = prefill?.port !== undefined ? String(prefill.port) : "6055";
     this._previewedPin = "";
@@ -166,7 +173,9 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   _onPreviewSubmit = () => onPreviewSubmit(this);
   _onConfirmSubmit = () => onConfirmSubmit(this);
   _onConfirmBack = (): void => {
-    if (this._busy) return;
+    // Allowed during the read-only preview (connecting) so the user can bail on
+    // a stale host; only blocked once the request_pair send is in flight.
+    if (this._sending) return;
     // Drop captured pin — user is going back, possibly to a different host.
     // Re-previewing refills it on the next forward step.
     this._previewedPin = "";
@@ -182,14 +191,15 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   };
 
   protected render() {
-    // ?busy gates outside-click + Esc + close-button while a round-trip is
-    // in flight. Base-dialog vetoes wa-hide when busy — without
-    // this, a successful request_pair could fire pair-request-sent against
-    // an already-closed dialog.
+    // ?busy gates outside-click + Esc + close-button while the request_pair
+    // send is in flight (so a successful send can't fire pair-request-sent
+    // against an already-closed dialog). The read-only preview deliberately
+    // does NOT veto dismissal — it has no side effect to orphan, and trapping
+    // the user behind a spinner for an unreachable host is worse.
     return html`
       <esphome-base-dialog
         ?open=${this._open}
-        ?busy=${this._busy}
+        ?busy=${this._sending}
         .label=${this._dialogTitle()}
         @after-hide=${this._onAfterHide}
       >

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -1,3 +1,5 @@
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
+
 import { consume } from "@lit/context";
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
@@ -15,7 +17,7 @@ import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { friendlyHostname } from "../util/hostname.js";
+import { friendlyHostname, parsePortInput } from "../util/hostname.js";
 import "./base-dialog.js";
 import {
   onConfirmSubmit,
@@ -90,7 +92,14 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     pairBuildServerDialogStyles,
   ];
 
-  open(prefill?: { hostname?: string; port?: number }): void {
+  // autoPreview skips the hostname/port input step: when the host+port are
+  // already known (mDNS-discovered dashboard), preview the fingerprint
+  // immediately and land on the confirm step. A failed preview drops back to
+  // the pre-filled input form (onPreviewSubmit's error branch).
+  open(
+    prefill?: { hostname?: string; port?: number },
+    opts?: { autoPreview?: boolean }
+  ): void {
     this._step = "input";
     this._busy = false;
     this._hostname = prefill?.hostname ?? "";
@@ -108,6 +117,15 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     this._offloaderIdentity = null;
     void this._loadOffloaderIdentity();
     this._open = true;
+    if (
+      opts?.autoPreview &&
+      this._api !== undefined &&
+      this._hostname &&
+      parsePortInput(this._port) !== null
+    ) {
+      this._step = "confirm";
+      void onPreviewSubmit(this);
+    }
   }
 
   // Read this dashboard's own identity for the sent-step fingerprint. The

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -72,6 +72,11 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // Resets on open() so the next pair attempt re-derives from hostname.
   @state() _receiverLabelTouched = false;
 
+  // True when the confirm step was reached by auto-preview (mDNS-discovered
+  // host), so the input step was never shown. Drives the confirm step's
+  // secondary button: Cancel (close) rather than Back (to the skipped form).
+  @state() _skippedInput = false;
+
   // ${hostname}:${port} of the submitted request — null outside the sent step.
   @state() _sentKey: string | null = null;
 
@@ -115,6 +120,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     this._error = null;
     this._sentKey = null;
     this._offloaderIdentity = null;
+    this._skippedInput = false;
     void this._loadOffloaderIdentity();
     this._open = true;
     if (
@@ -124,6 +130,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
       parsePortInput(this._port) !== null
     ) {
       this._step = "confirm";
+      this._skippedInput = true;
       void onPreviewSubmit(this);
     }
   }
@@ -162,8 +169,15 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     // Drop captured pin — user is going back, possibly to a different host.
     // Re-previewing refills it on the next forward step.
     this._previewedPin = "";
-    this._step = "input";
     this._error = null;
+    // Reached confirm straight from the discovered list — there's no input
+    // step to return to, so dismiss back to that list instead of revealing the
+    // skipped hostname form.
+    if (this._skippedInput) {
+      this.close();
+      return;
+    }
+    this._step = "input";
   };
 
   protected render() {

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -14,6 +14,7 @@ import {
 } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
+import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { inputStyles } from "../styles/inputs.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -95,6 +96,9 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     // Neutral header + title + footer (shared) — dialog-chrome.ts.
     dialogChromeStyles,
     pairBuildServerDialogStyles,
+    // Full-screen sheet on mobile (overrides base-dialog's centered default;
+    // the outer-tree ::part rule wins the cascade).
+    fullscreenMobileDialog("esphome-base-dialog"),
   ];
 
   // autoPreview skips the hostname/port input step: when the host+port are

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -13,7 +13,6 @@ import {
   localizeContext,
 } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
-import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { inputStyles } from "../styles/inputs.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
@@ -93,8 +92,6 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     inputStyles,
     pinHexStyles,
     dialogActionButtonStyles,
-    // Neutral header + title + footer (shared) — dialog-chrome.ts.
-    dialogChromeStyles,
     pairBuildServerDialogStyles,
     // Full-screen sheet on mobile (overrides base-dialog's centered default;
     // the outer-tree ::part rule wins the cascade).

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -56,6 +56,10 @@ export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promi
   const port = parsePortInput(host._port);
   if (!hostname || port === null) {
     host._error = host._localize("settings.pair_build_server_input_invalid");
+    // Recover to a usable form, mirroring the catch below — keeps both failure
+    // exits consistent if the open() guard ever loosens.
+    host._step = "input";
+    host._skippedInput = false;
     return;
   }
   host._busy = true;
@@ -89,6 +93,8 @@ export async function onConfirmSubmit(host: ESPHomePairBuildServerDialog): Promi
     return;
   }
   host._busy = true;
+  // The mutating send: veto dismissal until it resolves (don't orphan it).
+  host._sending = true;
   host._error = null;
   try {
     const summary = await host._api.requestRemoteBuildPair({
@@ -119,6 +125,7 @@ export async function onConfirmSubmit(host: ESPHomePairBuildServerDialog): Promi
     host._error = requestErrorMessage(host, err);
   } finally {
     host._busy = false;
+    host._sending = false;
   }
 }
 

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -68,8 +68,10 @@ export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promi
     host._error = previewErrorMessage(host, err);
     // Drop back to the input form so the user can fix the host/port. No-op in
     // the manual flow (already on input); matters for an auto-preview that
-    // jumped straight to confirm.
+    // jumped straight to confirm. Once the form is shown, a later Back from
+    // confirm should behave normally (go to input, not close).
     host._step = "input";
+    host._skippedInput = false;
   } finally {
     host._busy = false;
   }

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -66,6 +66,10 @@ export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promi
     host._step = "confirm";
   } catch (err) {
     host._error = previewErrorMessage(host, err);
+    // Drop back to the input form so the user can fix the host/port. No-op in
+    // the manual flow (already on input); matters for an auto-preview that
+    // jumped straight to confirm.
+    host._step = "input";
   } finally {
     host._busy = false;
   }

--- a/src/components/pair-build-server-dialog/actions.ts
+++ b/src/components/pair-build-server-dialog/actions.ts
@@ -62,13 +62,19 @@ export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promi
     host._skippedInput = false;
     return;
   }
+  // The dialog is a reused singleton and this preview is dismissable, so a
+  // later open() can supersede us mid-flight; drop a stale result rather than
+  // clobber the fresh session with the wrong host/fingerprint.
+  const generation = host._previewGeneration;
   host._busy = true;
   host._error = null;
   try {
     const response = await host._api.previewRemoteBuildPair({ hostname, port });
+    if (host._previewGeneration !== generation) return;
     host._previewedPin = response.pin_sha256;
     host._step = "confirm";
   } catch (err) {
+    if (host._previewGeneration !== generation) return;
     host._error = previewErrorMessage(host, err);
     // Drop back to the input form so the user can fix the host/port. No-op in
     // the manual flow (already on input); matters for an auto-preview that
@@ -77,7 +83,8 @@ export async function onPreviewSubmit(host: ESPHomePairBuildServerDialog): Promi
     host._step = "input";
     host._skippedInput = false;
   } finally {
-    host._busy = false;
+    // Only clear busy for the live session; a superseded open() owns it now.
+    if (host._previewGeneration === generation) host._busy = false;
   }
 }
 

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -75,22 +75,24 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
       </div>
     </div>
     <div class="helper">${host._localize("settings.pair_build_server_port_helper")}</div>
-    ${host._error
-      ? html`<div class="step-error" role="alert">${host._error}</div>`
-      : nothing}
-    <div slot="footer" class="actions">
-      <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
-        ${host._localize("layout.cancel")}
-      </button>
-      <button
-        class="btn btn--primary"
-        ?disabled=${!canSubmit}
-        @click=${host._onPreviewSubmit}
-      >
-        ${host._busy
-          ? host._localize("settings.pair_build_server_previewing")
-          : host._localize("settings.pair_build_server_preview_action")}
-      </button>
+    <div slot="footer" class="dialog-footer">
+      ${host._error
+        ? html`<div class="step-error" role="alert">${host._error}</div>`
+        : nothing}
+      <div class="actions">
+        <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
+          ${host._localize("layout.cancel")}
+        </button>
+        <button
+          class="btn btn--primary"
+          ?disabled=${!canSubmit}
+          @click=${host._onPreviewSubmit}
+        >
+          ${host._busy
+            ? host._localize("settings.pair_build_server_previewing")
+            : host._localize("settings.pair_build_server_preview_action")}
+        </button>
+      </div>
     </div>
   `;
 }
@@ -182,26 +184,30 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
         ${host._localize("settings.pair_build_server_offloader_label_helper")}
       </span>
     </div>
-    ${host._error
-      ? html`<div class="step-error" role="alert">${host._error}</div>`
-      : nothing}
-    <div slot="footer" class="actions">
-      <button
-        class="btn btn--cancel"
-        ?disabled=${host._busy}
-        @click=${host._onConfirmBack}
-      >
-        ${host._localize("layout.back")}
-      </button>
-      <button
-        class="btn btn--primary"
-        ?disabled=${!canSubmit}
-        @click=${host._onConfirmSubmit}
-      >
-        ${host._busy
-          ? host._localize("settings.pair_build_server_sending")
-          : host._localize("settings.pair_build_server_request_action")}
-      </button>
+    <div slot="footer" class="dialog-footer">
+      ${host._error
+        ? html`<div class="step-error" role="alert">${host._error}</div>`
+        : nothing}
+      <div class="actions">
+        <button
+          class="btn btn--cancel"
+          ?disabled=${host._busy}
+          @click=${host._onConfirmBack}
+        >
+          ${host._skippedInput
+            ? host._localize("layout.cancel")
+            : host._localize("layout.back")}
+        </button>
+        <button
+          class="btn btn--primary"
+          ?disabled=${!canSubmit}
+          @click=${host._onConfirmSubmit}
+        >
+          ${host._busy
+            ? host._localize("settings.pair_build_server_sending")
+            : host._localize("settings.pair_build_server_request_action")}
+        </button>
+      </div>
     </div>
   `;
 }

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -112,12 +112,14 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
 }
 
 export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateResult {
-  // Empty pin = auto-preview still in flight (mDNS-discovered host jumped
-  // straight here); show a connecting state until the fingerprint lands.
-  const connecting = host._previewedPin === "";
+  // Busy with no pin yet = auto-preview still in flight (mDNS-discovered host
+  // jumped straight here); show a connecting state until the fingerprint lands.
+  // Gating on _busy means a degenerate empty pin from the backend renders the
+  // landed branch rather than an unresolving spinner.
+  const connecting = host._busy && host._previewedPin === "";
   const canSubmit =
     !host._busy &&
-    !connecting &&
+    host._previewedPin !== "" &&
     host._receiverLabel.trim().length > 0 &&
     host._offloaderLabel.trim().length > 0;
   return html`
@@ -215,7 +217,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
           ?disabled=${!canSubmit}
           @click=${host._onConfirmSubmit}
         >
-          ${host._busy
+          ${host._busy && !connecting
             ? host._localize("settings.pair_build_server_sending")
             : host._localize("settings.pair_build_server_request_action")}
         </button>

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -94,7 +94,7 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
     ${renderFooter(
       host,
       html`
-        <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
+        <button class="btn btn--cancel" ?disabled=${host._sending} @click=${host.close}>
           ${host._localize("layout.cancel")}
         </button>
         <button
@@ -205,7 +205,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
       html`
         <button
           class="btn btn--cancel"
-          ?disabled=${host._busy}
+          ?disabled=${host._sending}
           @click=${host._onConfirmBack}
         >
           ${host._skippedInput

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -127,7 +127,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
     <div class="pin-card">
       ${connecting
         ? html`
-            <div class="pin-connecting">
+            <div class="pin-connecting" role="status">
               <wa-spinner></wa-spinner>
               <span>
                 ${host._localize("settings.pair_build_server_connecting", {

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -78,7 +78,7 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
     ${host._error
       ? html`<div class="step-error" role="alert">${host._error}</div>`
       : nothing}
-    <div class="actions">
+    <div slot="footer" class="actions">
       <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
         ${host._localize("layout.cancel")}
       </button>
@@ -96,8 +96,12 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
 }
 
 export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateResult {
+  // Empty pin = auto-preview still in flight (mDNS-discovered host jumped
+  // straight here); show a connecting state until the fingerprint lands.
+  const connecting = host._previewedPin === "";
   const canSubmit =
     !host._busy &&
+    !connecting &&
     host._receiverLabel.trim().length > 0 &&
     host._offloaderLabel.trim().length > 0;
   return html`
@@ -105,16 +109,30 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
       ${host._localize("settings.pair_build_server_confirm_desc")}
     </div>
     <div class="pin-card">
-      <span class="pin-card-label">
-        ${host._localize("settings.pair_build_server_pin_label")}
-      </span>
-      ${renderFingerprint(host, host._previewedPin)}
-      <span class="pin-card-target">
-        ${host._localize("settings.pair_build_server_target", {
-          hostname: trimTrailingDot(host._hostname),
-          port: host._port,
-        })}
-      </span>
+      ${connecting
+        ? html`
+            <div class="pin-connecting">
+              <wa-spinner></wa-spinner>
+              <span>
+                ${host._localize("settings.pair_build_server_connecting", {
+                  hostname: trimTrailingDot(host._hostname),
+                  port: host._port,
+                })}
+              </span>
+            </div>
+          `
+        : html`
+            <span class="pin-card-label">
+              ${host._localize("settings.pair_build_server_pin_label")}
+            </span>
+            ${renderFingerprint(host, host._previewedPin)}
+            <span class="pin-card-target">
+              ${host._localize("settings.pair_build_server_target", {
+                hostname: trimTrailingDot(host._hostname),
+                port: host._port,
+              })}
+            </span>
+          `}
     </div>
     <div class="trust-warning" role="alert">
       ${host._localize("settings.pair_build_server_trust_warning")}
@@ -167,7 +185,7 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
     ${host._error
       ? html`<div class="step-error" role="alert">${host._error}</div>`
       : nothing}
-    <div class="actions">
+    <div slot="footer" class="actions">
       <button
         class="btn btn--cancel"
         ?disabled=${host._busy}
@@ -211,7 +229,7 @@ export function renderSentStep(host: ESPHomePairBuildServerDialog): TemplateResu
           </div>
         `
       : nothing}
-    <div class="actions">
+    <div slot="footer" class="actions">
       <button class="btn btn--primary" @click=${host.close}>
         ${host._localize("layout.close")}
       </button>

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -126,10 +126,13 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
     <div class="description">
       ${host._localize("settings.pair_build_server_confirm_desc")}
     </div>
-    <div class="pin-card">
+    <!-- role="status" on the card (not the inner connecting div) makes one
+         polite live region cover both states, so a screen reader hears
+         "connecting…" and then the fingerprint when the auto-preview lands. -->
+    <div class="pin-card" role="status">
       ${connecting
         ? html`
-            <div class="pin-connecting" role="status">
+            <div class="pin-connecting">
               <wa-spinner></wa-spinner>
               <span>
                 ${host._localize("settings.pair_build_server_connecting", {

--- a/src/components/pair-build-server-dialog/renderers.ts
+++ b/src/components/pair-build-server-dialog/renderers.ts
@@ -23,6 +23,22 @@ function renderFingerprint(
   `;
 }
 
+// Footer slot shared by the input + confirm steps: the step error (when set)
+// stacked above the actions row, pinned outside the scrolling body.
+function renderFooter(
+  host: ESPHomePairBuildServerDialog,
+  actions: TemplateResult
+): TemplateResult {
+  return html`
+    <div slot="footer" class="dialog-footer">
+      ${host._error
+        ? html`<div class="step-error" role="alert">${host._error}</div>`
+        : nothing}
+      <div class="actions">${actions}</div>
+    </div>
+  `;
+}
+
 export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateResult {
   const portValid = parsePortInput(host._port) !== null;
   const canSubmit = !host._busy && host._hostname.trim().length > 0 && portValid;
@@ -75,11 +91,9 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
       </div>
     </div>
     <div class="helper">${host._localize("settings.pair_build_server_port_helper")}</div>
-    <div slot="footer" class="dialog-footer">
-      ${host._error
-        ? html`<div class="step-error" role="alert">${host._error}</div>`
-        : nothing}
-      <div class="actions">
+    ${renderFooter(
+      host,
+      html`
         <button class="btn btn--cancel" ?disabled=${host._busy} @click=${host.close}>
           ${host._localize("layout.cancel")}
         </button>
@@ -92,8 +106,8 @@ export function renderInputStep(host: ESPHomePairBuildServerDialog): TemplateRes
             ? host._localize("settings.pair_build_server_previewing")
             : host._localize("settings.pair_build_server_preview_action")}
         </button>
-      </div>
-    </div>
+      `
+    )}
   `;
 }
 
@@ -184,11 +198,9 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
         ${host._localize("settings.pair_build_server_offloader_label_helper")}
       </span>
     </div>
-    <div slot="footer" class="dialog-footer">
-      ${host._error
-        ? html`<div class="step-error" role="alert">${host._error}</div>`
-        : nothing}
-      <div class="actions">
+    ${renderFooter(
+      host,
+      html`
         <button
           class="btn btn--cancel"
           ?disabled=${host._busy}
@@ -207,8 +219,8 @@ export function renderConfirmStep(host: ESPHomePairBuildServerDialog): TemplateR
             ? host._localize("settings.pair_build_server_sending")
             : host._localize("settings.pair_build_server_request_action")}
         </button>
-      </div>
-    </div>
+      `
+    )}
   `;
 }
 

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -80,11 +80,21 @@ export const pairBuildServerDialogStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
+  /* Rendered into wa-dialog's footer slot (pinned outside the scrolling
+     body), which supplies its own padding — so the row carries none. */
   .actions {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
     gap: var(--wa-space-s);
-    padding: var(--wa-space-m) 0 var(--wa-space-l);
+  }
+
+  .pin-connecting {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-s);
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-text-quiet);
   }
 
   .field-error {

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -89,7 +89,13 @@ export const pairBuildServerDialogStyles = css`
   }
 
   /* Rendered into wa-dialog's footer slot (pinned outside the scrolling
-     body), which supplies its own padding — so the row carries none. */
+     body) so the error + actions stay visible regardless of body scroll. */
+  .dialog-footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-s);
+  }
+
   .actions {
     display: flex;
     align-items: center;
@@ -114,7 +120,6 @@ export const pairBuildServerDialogStyles = css`
   .step-error {
     color: var(--esphome-error);
     font-size: var(--wa-font-size-s);
-    padding: var(--wa-space-s) 0;
   }
 
   .trust-warning {

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -5,18 +5,22 @@ export const pairBuildServerDialogStyles = css`
     --width: 500px;
   }
 
-  /* Neutral header + title + footer come from dialogChromeStyles
-     (added in pair-build-server-dialog.ts's static styles). */
-  esphome-base-dialog::part(body) {
-    padding: 0 var(--wa-space-l);
+  /* Neutral header + title chrome, inlined rather than composed from
+     dialogChromeStyles: that shared block also hides the footer part, and this
+     wizard renders its actions in the footer so they stay pinned while a tall
+     confirm step scrolls. */
+  esphome-base-dialog::part(header) {
+    padding: var(--wa-space-l) var(--wa-space-l) var(--wa-space-s);
   }
 
-  /* dialogChromeStyles hides the footer part (this dialog historically kept
-     its actions inside the scrolling body). We render the wizard actions in
-     the footer so they stay pinned while a tall confirm step scrolls, so
-     re-enable it — this rule comes after dialogChromeStyles in the cascade. */
-  esphome-base-dialog::part(footer) {
-    display: block;
+  esphome-base-dialog::part(title) {
+    font-size: var(--wa-font-size-m);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-normal);
+  }
+
+  esphome-base-dialog::part(body) {
+    padding: 0 var(--wa-space-l);
   }
 
   .description {

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -1,5 +1,7 @@
 import { css } from "lit";
 
+import { MOBILE_BREAKPOINT } from "../../styles/breakpoints.js";
+
 export const pairBuildServerDialogStyles = css`
   esphome-base-dialog {
     --width: 500px;
@@ -143,5 +145,13 @@ export const pairBuildServerDialogStyles = css`
   .sent-body code {
     font-family: var(--wa-font-family-mono, monospace);
     font-size: var(--wa-font-size-xs);
+  }
+
+  /* On the mobile full-screen sheet the desktop header breathing room wastes
+     vertical space; tighten the top padding there only. */
+  @media (max-width: ${MOBILE_BREAKPOINT}px) {
+    esphome-base-dialog::part(header) {
+      padding-top: var(--wa-space-s);
+    }
   }
 `;

--- a/src/components/pair-build-server-dialog/styles.ts
+++ b/src/components/pair-build-server-dialog/styles.ts
@@ -11,6 +11,14 @@ export const pairBuildServerDialogStyles = css`
     padding: 0 var(--wa-space-l);
   }
 
+  /* dialogChromeStyles hides the footer part (this dialog historically kept
+     its actions inside the scrolling body). We render the wizard actions in
+     the footer so they stay pinned while a tall confirm step scrolls, so
+     re-enable it — this rule comes after dialogChromeStyles in the cascade. */
+  esphome-base-dialog::part(footer) {
+    display: block;
+  }
+
   .description {
     font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-quiet);

--- a/src/components/pin-emoji-grid.ts
+++ b/src/components/pin-emoji-grid.ts
@@ -35,13 +35,14 @@ export class ESPHomePinEmojiGrid extends LitElement {
     }
 
     /* Emoji-only row, evenly distributed across the card width. Wraps rather
-       than overflowing in a narrow host (e.g. the build-server identity card's
-       label/value row on mobile); with no name labels the seven glyphs fit one
-       line wherever there's room (the pair-confirm card). */
+       than overflowing in a narrow host; space-evenly (not space-between) keeps
+       inter-glyph spacing consistent if it wraps, so the fingerprint reads as
+       one cohesive strip instead of a ragged last row. With no name labels the
+       seven glyphs fit one line wherever there's room (the pair-confirm card). */
     .grid {
       display: flex;
       flex-wrap: wrap;
-      justify-content: space-between;
+      justify-content: space-evenly;
       align-items: center;
       gap: var(--wa-space-xs);
     }

--- a/src/components/pin-emoji-grid.ts
+++ b/src/components/pin-emoji-grid.ts
@@ -3,9 +3,11 @@ import { customElement, property } from "lit/decorators.js";
 import { pinSha256ToEmojis } from "../util/pin-emoji.js";
 
 /**
- * Render a SHA-256 pin as a row of large emojis with their
- * names underneath; the visualisation each side of an OOB
- * verification compares.
+ * Render a SHA-256 pin as a row of evenly-spaced emojis; the
+ * visualisation each side of an OOB verification compares. The
+ * emoji glyph is the canonical signal, so the names show only as
+ * per-emoji ``title`` tooltips and the grid's combined
+ * ``aria-label`` (screen readers), not as visible labels.
  *
  * The mapping itself lives in `util/pin-emoji.ts`; this
  * component is just the visual frame, kept as a Lit element
@@ -32,25 +34,13 @@ export class ESPHomePinEmojiGrid extends LitElement {
       display: block;
     }
 
+    /* Emoji-only row, evenly distributed across the card width. With no
+       name labels the seven glyphs fit one line in every host context. */
     .grid {
       display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-    }
-
-    /* Cells are sized to fit a 4+3 layout inside a ~280px host
-       (the typical width once the surrounding dialog padding +
-       icon column eats into 420px); cell background is
-       intentionally transparent so the row reads as a single
-       fingerprint rather than a strip of buttons that invite
-       clicking. */
-    .cell {
-      display: flex;
-      flex-direction: column;
+      justify-content: space-between;
       align-items: center;
-      gap: 1px;
-      min-width: 48px;
-      padding: 2px 4px;
+      gap: var(--wa-space-xs);
     }
 
     /* Lean on the platform emoji font; overriding font-family
@@ -61,33 +51,21 @@ export class ESPHomePinEmojiGrid extends LitElement {
       font-size: 1.5rem;
       line-height: 1;
     }
-
-    .name {
-      font-size: var(--wa-font-size-xs, 11px);
-      color: var(--wa-color-text-quiet);
-      text-transform: lowercase;
-      letter-spacing: 0.02em;
-    }
   `;
 
   protected render() {
     const slots = pinSha256ToEmojis(this.pin);
     if (slots.length === 0) return null;
-    // ``lang="en"`` because the emoji names are English; screen
-    // readers in non-English locales use it to pick the right
-    // pronunciation while the visible text serves sighted users
-    // identically across locales. Per-cell name spans are
-    // ``aria-hidden`` so screen readers announce the
-    // fingerprint once via the grid's aria-label rather than
-    // repeating each name twice (container label + cell text).
+    // ``lang="en"`` because the emoji names are English; screen readers in
+    // non-English locales use it to pick the right pronunciation for the
+    // combined aria-label. Each emoji is ``aria-hidden`` so the fingerprint
+    // is announced once via the grid's aria-label, not per-glyph; the
+    // ``title`` gives sighted users the name on hover.
     return html`
       <div class="grid" role="img" lang="en" aria-label=${this._ariaLabel(slots)}>
         ${slots.map(
           (slot) => html`
-            <div class="cell">
-              <span class="emoji" aria-hidden="true">${slot.emoji}</span>
-              <span class="name" aria-hidden="true">${slot.name}</span>
-            </div>
+            <span class="emoji" title=${slot.name} aria-hidden="true">${slot.emoji}</span>
           `
         )}
       </div>
@@ -96,10 +74,7 @@ export class ESPHomePinEmojiGrid extends LitElement {
 
   private _ariaLabel(slots: ReadonlyArray<{ name: string }>): string {
     // Single combined label so screen readers announce the
-    // sequence as one fingerprint instead of N separate
-    // images; the per-cell .name text remains the visual
-    // identifier for sighted users (with aria-hidden so it
-    // doesn't get double-announced via the container label).
+    // sequence as one fingerprint instead of N separate images.
     return slots.map((s) => s.name).join(", ");
   }
 }

--- a/src/components/pin-emoji-grid.ts
+++ b/src/components/pin-emoji-grid.ts
@@ -34,10 +34,13 @@ export class ESPHomePinEmojiGrid extends LitElement {
       display: block;
     }
 
-    /* Emoji-only row, evenly distributed across the card width. With no
-       name labels the seven glyphs fit one line in every host context. */
+    /* Emoji-only row, evenly distributed across the card width. Wraps rather
+       than overflowing in a narrow host (e.g. the build-server identity card's
+       label/value row on mobile); with no name labels the seven glyphs fit one
+       line wherever there's room (the pair-confirm card). */
     .grid {
       display: flex;
+      flex-wrap: wrap;
       justify-content: space-between;
       align-items: center;
       gap: var(--wa-space-xs);

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -394,10 +394,15 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     // peer.port is the SRV dashboard HTTP port and would land an
     // UNAVAILABLE on preview_pair. 0 means the receiver didn't
     // publish the key — let the wizard fall back to its default.
-    this._pairDialog?.open({
-      hostname: peer.hostname,
-      port: peer.remote_build_port > 0 ? peer.remote_build_port : undefined,
-    });
+    this._pairDialog?.open(
+      {
+        hostname: peer.hostname,
+        port: peer.remote_build_port > 0 ? peer.remote_build_port : undefined,
+      },
+      // Host + peer-link port are known from mDNS — skip the manual entry step
+      // and preview the fingerprint straight away.
+      { autoPreview: true }
+    );
   };
 
   private _onAlertRepair = (alert: OffloaderAlertSnapshotEntry): void => {

--- a/src/components/settings-dialog/build-server-styles.ts
+++ b/src/components/settings-dialog/build-server-styles.ts
@@ -33,9 +33,11 @@ export const buildServerCardStyles = css`
     flex: 1;
   }
 
-  /* Pin row stacks vertically so the emoji grid gets its own line. */
+  /* Pin row stacks vertically so the emoji grid gets the full card width
+     (beside the 110px label it shrinks and the fingerprint wraps cramped). */
   .build-server-row--pin {
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .build-server-pin-display {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1082,6 +1082,7 @@
     "pair_build_server_pin_label": "Receiver fingerprint (SHA-256)",
     "pair_build_server_pin_hex_summary": "Show hex bytes",
     "pair_build_server_target": "Connected to {hostname}:{port}",
+    "pair_build_server_connecting": "Connecting to {hostname}:{port}…",
     "pair_build_server_receiver_label_label": "Name for this receiver",
     "pair_build_server_receiver_label_placeholder": "e.g. desktop, lab-pc",
     "pair_build_server_receiver_label_helper": "Shown to you in the paired-receivers list. Local to this dashboard.",

--- a/test/components/pair-build-server-dialog/on-preview-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-preview-submit.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for ``onPreviewSubmit`` step routing. A successful preview captures
+ * the pin and advances to ``confirm``; a failed preview drops back to
+ * ``input`` (so an auto-preview that jumped straight to ``confirm`` returns
+ * the user to the pre-filled form to retry).
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import { onPreviewSubmit } from "../../../src/components/pair-build-server-dialog/actions.js";
+
+function makeHost(
+  preview: () => Promise<{ pin_sha256: string }>
+): ESPHomePairBuildServerDialog {
+  return {
+    _localize: (key: string) => key,
+    _api: { previewRemoteBuildPair: preview },
+    _busy: false,
+    _hostname: "buildbox.local",
+    _port: "6055",
+    _previewedPin: "",
+    _error: null,
+    _step: "confirm",
+  } as unknown as ESPHomePairBuildServerDialog;
+}
+
+describe("onPreviewSubmit", () => {
+  it("captures the pin and advances to the confirm step on success", async () => {
+    const host = makeHost(async () => ({ pin_sha256: "abc123" }));
+    await onPreviewSubmit(host);
+
+    expect(host._previewedPin).toBe("abc123");
+    expect(host._step).toBe("confirm");
+    expect(host._error).toBeNull();
+  });
+
+  it("falls back to the input step on a failed preview", async () => {
+    const host = makeHost(() => Promise.reject(new Error("unreachable")));
+    await onPreviewSubmit(host);
+
+    expect(host._step).toBe("input");
+    expect(host._previewedPin).toBe("");
+    expect(host._error).not.toBeNull();
+  });
+
+  it("ignores invalid input without calling the API", async () => {
+    const preview = vi.fn(async () => ({ pin_sha256: "x" }));
+    const host = makeHost(preview);
+    host._hostname = "";
+    await onPreviewSubmit(host);
+
+    expect(preview).not.toHaveBeenCalled();
+    expect(host._step).toBe("confirm");
+    expect(host._error).toBe("settings.pair_build_server_input_invalid");
+  });
+});

--- a/test/components/pair-build-server-dialog/on-preview-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-preview-submit.test.ts
@@ -45,14 +45,15 @@ describe("onPreviewSubmit", () => {
     expect(host._skippedInput).toBe(false);
   });
 
-  it("ignores invalid input without calling the API", async () => {
+  it("recovers to the input step on invalid input without calling the API", async () => {
     const preview = vi.fn(async () => ({ pin_sha256: "x" }));
     const host = makeHost(preview);
     host._hostname = "";
     await onPreviewSubmit(host);
 
     expect(preview).not.toHaveBeenCalled();
-    expect(host._step).toBe("confirm");
+    expect(host._step).toBe("input");
+    expect(host._skippedInput).toBe(false);
     expect(host._error).toBe("settings.pair_build_server_input_invalid");
   });
 });

--- a/test/components/pair-build-server-dialog/on-preview-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-preview-submit.test.ts
@@ -20,6 +20,7 @@ function makeHost(
     _previewedPin: "",
     _error: null,
     _step: "confirm",
+    _skippedInput: true,
   } as unknown as ESPHomePairBuildServerDialog;
 }
 
@@ -40,6 +41,8 @@ describe("onPreviewSubmit", () => {
     expect(host._step).toBe("input");
     expect(host._previewedPin).toBe("");
     expect(host._error).not.toBeNull();
+    // Form is now shown, so a later Back from confirm goes to input, not close.
+    expect(host._skippedInput).toBe(false);
   });
 
   it("ignores invalid input without calling the API", async () => {

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins open()'s auto-preview orchestration: with the guard satisfied it jumps
+ * to the confirm step, marks the input step skipped, and dispatches the
+ * fingerprint preview; otherwise (no api, no/blank hostname, or no autoPreview)
+ * it stays on the input step.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+
+function makeApi() {
+  return {
+    getRemoteBuildIdentity: vi.fn(async () => ({
+      dashboard_id: "x",
+      pin_sha256: "p",
+      server_version: "1",
+      esphome_version: "1",
+      listener_bound: true,
+    })),
+    previewRemoteBuildPair: vi.fn(async () => ({ pin_sha256: "abc" })),
+  };
+}
+
+function makeDialog(api: unknown): ESPHomePairBuildServerDialog {
+  const d = new ESPHomePairBuildServerDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (d as any)._localize = (k: string) => k;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (d as any)._api = api;
+  return d;
+}
+
+describe("pair dialog open() auto-preview orchestration", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("jumps to confirm, skips input, and previews when the guard passes", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "buildbox.local", port: 6055 }, { autoPreview: true });
+    expect(d._step).toBe("confirm");
+    expect(d._skippedInput).toBe(true);
+    expect(api.previewRemoteBuildPair).toHaveBeenCalledOnce();
+  });
+
+  it("stays on input when the api is undefined", () => {
+    const d = makeDialog(undefined);
+    d.open({ hostname: "buildbox.local", port: 6055 }, { autoPreview: true });
+    expect(d._step).toBe("input");
+    expect(d._skippedInput).toBe(false);
+  });
+
+  it("stays on input for a blank/whitespace hostname", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "   ", port: 6055 }, { autoPreview: true });
+    expect(d._step).toBe("input");
+    expect(d._skippedInput).toBe(false);
+    expect(api.previewRemoteBuildPair).not.toHaveBeenCalled();
+  });
+
+  it("stays on input without autoPreview even with a valid prefill", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "buildbox.local", port: 6055 });
+    expect(d._step).toBe("input");
+    expect(d._skippedInput).toBe(false);
+    expect(api.previewRemoteBuildPair).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -61,6 +61,25 @@ describe("pair dialog open() auto-preview orchestration", () => {
     expect(d._sending).toBe(false);
   });
 
+  it("drops a stale preview result after the dialog is reopened", async () => {
+    const api = makeApi();
+    let resolvePreview: (v: { pin_sha256: string }) => void = () => {};
+    api.previewRemoteBuildPair = vi.fn(() => new Promise((r) => (resolvePreview = r)));
+    const d = makeDialog(api);
+    // Pair host A: auto-preview starts and hangs (offline host).
+    d.open({ hostname: "hostA.local", port: 6055 }, { autoPreview: true });
+    // User dismisses and reopens the singleton for a fresh session.
+    d.open();
+    expect(d._step).toBe("input");
+    // Host A's preview finally resolves, late.
+    resolvePreview({ pin_sha256: "stale-a-pin" });
+    await Promise.resolve();
+    await Promise.resolve();
+    // The stale result must not yank the fresh session to confirm.
+    expect(d._step).toBe("input");
+    expect(d._previewedPin).toBe("");
+  });
+
   it("stays on input when the api is undefined", () => {
     const d = makeDialog(undefined);
     d.open({ hostname: "buildbox.local", port: 6055 }, { autoPreview: true });

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -51,6 +51,16 @@ describe("pair dialog open() auto-preview orchestration", () => {
     expect(api.previewRemoteBuildPair).toHaveBeenCalledOnce();
   });
 
+  it("connecting state is busy but not sending, so the dialog stays dismissable", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "buildbox.local", port: 6055 }, { autoPreview: true });
+    // The read-only preview marks _busy (spinner/submit-gate) but not _sending,
+    // so base-dialog's busy gate doesn't veto Escape/outside-click/Cancel.
+    expect(d._busy).toBe(true);
+    expect(d._sending).toBe(false);
+  });
+
   it("stays on input when the api is undefined", () => {
     const d = makeDialog(undefined);
     d.open({ hostname: "buildbox.local", port: 6055 }, { autoPreview: true });

--- a/test/components/pair-build-server-dialog/render-confirm-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-confirm-step.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Targeted tests for ``renderConfirmStep`` — pins the connecting state used
+ * when an mDNS-discovered host auto-previews straight into the confirm step.
+ *
+ * While ``_previewedPin`` is empty the step shows a ``<wa-spinner>`` +
+ * "connecting" line (no fingerprint); once the pin lands it shows the emoji
+ * grid + "connected" target. Walks the returned ``TemplateResult`` tree via
+ * the shared ``test/_lit-template-walker.ts`` helpers (node env, no DOM).
+ */
+import { describe, expect, it } from "vitest";
+import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import { renderConfirmStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
+import { findTemplatesByAnchor, visitTemplates } from "../../_lit-template-walker.js";
+
+function makeHost(pin: string): ESPHomePairBuildServerDialog {
+  return {
+    _localize: (key: string) => key,
+    _busy: false,
+    _previewedPin: pin,
+    _hostname: "buildbox.local",
+    _port: "6055",
+    _receiverLabel: "buildbox",
+    _offloaderLabel: "ha-green",
+    _error: null,
+    _onConfirmBack: () => {},
+    _onConfirmSubmit: () => {},
+    close: () => {},
+  } as unknown as ESPHomePairBuildServerDialog;
+}
+
+/** Every interpolated value across the template tree, in render order. */
+function allValues(root: unknown): unknown[] {
+  const out: unknown[] = [];
+  visitTemplates(root, (t) => out.push(...t.values));
+  return out;
+}
+
+describe("renderConfirmStep", () => {
+  it("shows a connecting spinner (no fingerprint) while the pin is empty", () => {
+    const tree = renderConfirmStep(makeHost(""));
+
+    expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(1);
+    expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(0);
+    expect(allValues(tree)).toContain("settings.pair_build_server_connecting");
+  });
+
+  it("shows the fingerprint and target once the pin has landed", () => {
+    const tree = renderConfirmStep(makeHost("9f86d081884c7d659a2feaa0c55ad015"));
+
+    expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(0);
+    expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(1);
+    expect(allValues(tree)).toContain("settings.pair_build_server_target");
+  });
+});

--- a/test/components/pair-build-server-dialog/render-confirm-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-confirm-step.test.ts
@@ -12,16 +12,19 @@ import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-
 import { renderConfirmStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
 import { findTemplatesByAnchor, visitTemplates } from "../../_lit-template-walker.js";
 
-function makeHost(pin: string): ESPHomePairBuildServerDialog {
+function makeHost(
+  opts: { pin?: string; skippedInput?: boolean; error?: string | null } = {}
+): ESPHomePairBuildServerDialog {
   return {
     _localize: (key: string) => key,
     _busy: false,
-    _previewedPin: pin,
+    _previewedPin: opts.pin ?? "",
     _hostname: "buildbox.local",
     _port: "6055",
     _receiverLabel: "buildbox",
     _offloaderLabel: "ha-green",
-    _error: null,
+    _error: opts.error ?? null,
+    _skippedInput: opts.skippedInput ?? false,
     _onConfirmBack: () => {},
     _onConfirmSubmit: () => {},
     close: () => {},
@@ -37,7 +40,7 @@ function allValues(root: unknown): unknown[] {
 
 describe("renderConfirmStep", () => {
   it("shows a connecting spinner (no fingerprint) while the pin is empty", () => {
-    const tree = renderConfirmStep(makeHost(""));
+    const tree = renderConfirmStep(makeHost({ pin: "" }));
 
     expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(1);
     expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(0);
@@ -45,10 +48,27 @@ describe("renderConfirmStep", () => {
   });
 
   it("shows the fingerprint and target once the pin has landed", () => {
-    const tree = renderConfirmStep(makeHost("9f86d081884c7d659a2feaa0c55ad015"));
+    const tree = renderConfirmStep(makeHost({ pin: "9f86d081884c7d659a2feaa0c55ad015" }));
 
     expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(0);
     expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(1);
     expect(allValues(tree)).toContain("settings.pair_build_server_target");
+  });
+
+  it("labels the secondary button Back in the manual flow", () => {
+    const tree = renderConfirmStep(makeHost({ pin: "abc", skippedInput: false }));
+    expect(allValues(tree)).toContain("layout.back");
+    expect(allValues(tree)).not.toContain("layout.cancel");
+  });
+
+  it("labels the secondary button Cancel when the input step was skipped", () => {
+    const tree = renderConfirmStep(makeHost({ pin: "abc", skippedInput: true }));
+    expect(allValues(tree)).toContain("layout.cancel");
+    expect(allValues(tree)).not.toContain("layout.back");
+  });
+
+  it("renders the error banner when an error is set", () => {
+    const tree = renderConfirmStep(makeHost({ pin: "abc", error: "boom" }));
+    expect(allValues(tree)).toContain("boom");
   });
 });

--- a/test/components/pair-build-server-dialog/render-confirm-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-confirm-step.test.ts
@@ -18,11 +18,13 @@ function makeHost(
     skippedInput?: boolean;
     error?: string | null;
     busy?: boolean;
+    sending?: boolean;
   } = {}
 ): ESPHomePairBuildServerDialog {
   return {
     _localize: (key: string) => key,
     _busy: opts.busy ?? false,
+    _sending: opts.sending ?? false,
     _previewedPin: opts.pin ?? "",
     _hostname: "buildbox.local",
     _port: "6055",

--- a/test/components/pair-build-server-dialog/render-confirm-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-confirm-step.test.ts
@@ -13,11 +13,16 @@ import { renderConfirmStep } from "../../../src/components/pair-build-server-dia
 import { findTemplatesByAnchor, visitTemplates } from "../../_lit-template-walker.js";
 
 function makeHost(
-  opts: { pin?: string; skippedInput?: boolean; error?: string | null } = {}
+  opts: {
+    pin?: string;
+    skippedInput?: boolean;
+    error?: string | null;
+    busy?: boolean;
+  } = {}
 ): ESPHomePairBuildServerDialog {
   return {
     _localize: (key: string) => key,
-    _busy: false,
+    _busy: opts.busy ?? false,
     _previewedPin: opts.pin ?? "",
     _hostname: "buildbox.local",
     _port: "6055",
@@ -39,12 +44,19 @@ function allValues(root: unknown): unknown[] {
 }
 
 describe("renderConfirmStep", () => {
-  it("shows a connecting spinner (no fingerprint) while the pin is empty", () => {
-    const tree = renderConfirmStep(makeHost({ pin: "" }));
+  it("shows a connecting spinner (no fingerprint) while busy with no pin", () => {
+    const tree = renderConfirmStep(makeHost({ pin: "", busy: true }));
 
     expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(1);
     expect(findTemplatesByAnchor(tree, "<esphome-pin-emoji-grid")).toHaveLength(0);
     expect(allValues(tree)).toContain("settings.pair_build_server_connecting");
+  });
+
+  it("renders the landed branch (no spinner) for an empty pin when not busy", () => {
+    // Degenerate backend pin: don't strand an unresolving spinner.
+    const tree = renderConfirmStep(makeHost({ pin: "", busy: false }));
+
+    expect(findTemplatesByAnchor(tree, "<wa-spinner")).toHaveLength(0);
   });
 
   it("shows the fingerprint and target once the pin has landed", () => {


### PR DESCRIPTION
# What does this implement/fix?

Cleans up the build-server pairing UI, mostly for mobile.

When you Pair an mDNS-discovered dashboard, the wizard now skips the redundant hostname/port form (the host and peer-link port are already known) and previews the fingerprint straight away, landing on the Confirm receiver step with a connecting spinner until it arrives; a failed preview drops back to the pre-filled form. Back on that auto-previewed step returns you to the discovered list instead of revealing the form you never saw.

The wizard action buttons are pinned in the dialog footer with the step error shown above them, so neither falls below the scroll fold on a tall confirm step. The dialog goes full-screen on mobile, with tighter header padding there. The fingerprint renders as evenly-spaced emoji (names move to per-emoji tooltips and the grid's screen-reader label) and wraps instead of overflowing in the narrow build-server identity card, whose pin row now stacks so the grid gets full width.

Also a small refactor: the footer markup shared by the input and confirm steps is extracted into a helper.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
