### PR TITLE
Lock closed issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,17 @@
+---
+name: Lock closed issues and PRs
+
+on:
+  schedule:
+    - cron: "30 0 * * *"  # Run daily at 00:30 UTC
+  workflow_dispatch:
+
+# Deny by default; the lock job opts in to exactly what the reusable workflow needs.
+permissions: {}
+
+jobs:
+  lock:
+    permissions:
+      issues: write         # issues.lock on closed issues
+      pull-requests: write  # issues.lock on closed pull requests
+    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1


### PR DESCRIPTION
# What does this implement/fix?

Adds a daily workflow that locks closed issues and PRs, same as esphome-dev; we are seeing spam on closed threads now that this repo is active. It calls the shared esphome/workflows lock workflow pinned to 2026.4.1.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `npm run lint` passes.
- [ ] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
