### PR TITLE
Show the build server friendly_name in the discovered-host picker

### DIFF
--- a/src/api/types/remote-build.ts
+++ b/src/api/types/remote-build.ts
@@ -262,6 +262,12 @@ export interface RemoteBuildPeer {
   server_version: string;
   esphome_version: string;
   /**
+   * Human machine label from the mDNS TXT `friendly_name` key, used as
+   * the display label. Empty for older receivers that don't broadcast
+   * it; callers fall back to `name`.
+   */
+  friendly_name: string;
+  /**
    * SHA-256 of the receiver's static X25519 peer-link pubkey,
    * lowercase hex, parsed off the mDNS TXT record. Empty string
    * for receivers that haven't bound the peer-link listener at

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -116,7 +116,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // immediately and land on the confirm step. A failed preview drops back to
   // the pre-filled input form (onPreviewSubmit's error branch).
   open(
-    prefill?: { hostname?: string; port?: number },
+    prefill?: { hostname?: string; port?: number; receiverLabel?: string },
     opts?: { autoPreview?: boolean }
   ): void {
     // Supersede any preview still in flight from a previous open().
@@ -127,11 +127,11 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     this._hostname = prefill?.hostname ?? "";
     this._port = prefill?.port !== undefined ? String(prefill.port) : "6055";
     this._previewedPin = "";
-    // Pre-fill labels from known hostnames. The offloader label is sourced
-    // from window.location.hostname (the URL used to reach this dashboard)
-    // and doesn't auto-update afterwards — the page can't reload mid-dialog
-    // without losing form state anyway.
-    this._receiverLabel = friendlyHostname(this._hostname);
+    // Pre-fill the receiver label from the caller-supplied friendly_name,
+    // falling back to one derived from the hostname. The offloader label is
+    // sourced from window.location.hostname and doesn't auto-update afterwards.
+    this._receiverLabel =
+      prefill?.receiverLabel?.trim() || friendlyHostname(this._hostname);
     this._receiverLabelTouched = false;
     this._offloaderLabel = friendlyHostname(window.location.hostname);
     this._error = null;

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -299,7 +299,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
         })
       : nothing;
     // Prefer the friendly_name label; fall back to the instance name.
-    const displayName = trimTrailingDot(peer.friendly_name || peer.name);
+    const displayName = trimTrailingDot(peer.friendly_name.trim() || peer.name);
     return html`
       <div class="row peer-row">
         <div class="row-label">

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -298,10 +298,12 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
           esphome: peer.esphome_version,
         })
       : nothing;
+    // Prefer the friendly_name label; fall back to the instance name.
+    const displayName = trimTrailingDot(peer.friendly_name || peer.name);
     return html`
       <div class="row peer-row">
         <div class="row-label">
-          <span class="row-title">${trimTrailingDot(peer.name)}</span>
+          <span class="row-title">${displayName}</span>
           <span class="row-desc">
             ${trimTrailingDot(peer.hostname)}:${peer.port} ${versionLine}
           </span>
@@ -310,7 +312,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
           type="button"
           class="btn-pair-build-server btn-pair-row"
           aria-label=${this._localize("settings.pair_build_server_row_aria", {
-            name: trimTrailingDot(peer.name),
+            name: displayName,
           })}
           @click=${() => this._onPairDiscovered(peer)}
         >
@@ -398,6 +400,8 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
       {
         hostname: peer.hostname,
         port: peer.remote_build_port > 0 ? peer.remote_build_port : undefined,
+        // Seed the receiver label from the friendly_name.
+        receiverLabel: peer.friendly_name || undefined,
       },
       // Host + peer-link port are known from mDNS — skip the manual entry step
       // and preview the fingerprint straight away.

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -11,7 +11,11 @@ import { describe, expect, it } from "vitest";
 import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";
 import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
 
-function peer(name: string, remote_build_port: number): RemoteBuildPeer {
+function peer(
+  name: string,
+  remote_build_port: number,
+  friendly_name = ""
+): RemoteBuildPeer {
   return {
     name,
     hostname: `${name}.local`,
@@ -20,6 +24,7 @@ function peer(name: string, remote_build_port: number): RemoteBuildPeer {
     addresses: ["192.168.1.10"],
     server_version: "0.1.0",
     esphome_version: "2026.5.0",
+    friendly_name,
     pin_sha256: remote_build_port > 0 ? "abc" : "",
     remote_build_port,
   };
@@ -70,5 +75,32 @@ describe("_renderDiscoveredHosts", () => {
   it("renders only the buildable peers from a mixed set", () => {
     const host = makeHost([peer("addon", 0), peer("buildbox", 6055)]);
     expect(renderDiscoveredHosts(host)).toEqual([{ row: "buildbox" }]);
+  });
+});
+
+function rowTitle(peerInfo: RemoteBuildPeer): string | null {
+  const fn = (
+    ESPHomeSettingsBuildOffload.prototype as unknown as Record<
+      string,
+      (p: RemoteBuildPeer) => TemplateResult
+    >
+  )._renderDiscoveredRow;
+  const result = fn.call({ _localize: (key: string) => key }, peerInfo);
+  const el = document.createElement("div");
+  render(result, el);
+  return el.querySelector(".row-title")?.textContent?.trim() ?? null;
+}
+
+describe("_renderDiscoveredRow display name", () => {
+  it("prefers the friendly_name label over the opaque instance name", () => {
+    expect(rowTitle(peer("esphome-builder-jwywnve", 6055, "MacBook-Pro"))).toBe(
+      "MacBook-Pro"
+    );
+  });
+
+  it("falls back to the instance name when friendly_name is empty", () => {
+    expect(rowTitle(peer("esphome-builder-jwywnve", 6055))).toBe(
+      "esphome-builder-jwywnve"
+    );
   });
 });

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -103,4 +103,10 @@ describe("_renderDiscoveredRow display name", () => {
       "esphome-builder-jwywnve"
     );
   });
+
+  it("falls back to the instance name for a whitespace-only friendly_name", () => {
+    expect(rowTitle(peer("esphome-builder-jwywnve", 6055, "   "))).toBe(
+      "esphome-builder-jwywnve"
+    );
+  });
 });

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -104,4 +104,18 @@ describe("pair dialog open() auto-preview orchestration", () => {
     expect(d._skippedInput).toBe(false);
     expect(api.previewRemoteBuildPair).not.toHaveBeenCalled();
   });
+
+  it("seeds the receiver label from the prefill (the discovered friendly_name)", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "esphome-builder-jwywnve.local", receiverLabel: "MacBook-Pro" });
+    expect(d._receiverLabel).toBe("MacBook-Pro");
+  });
+
+  it("falls back to a hostname-derived receiver label without a prefill label", () => {
+    const api = makeApi();
+    const d = makeDialog(api);
+    d.open({ hostname: "buildbox.local", port: 6055 });
+    expect(d._receiverLabel).toBe("buildbox");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

The backend now advertises a stable, opaque mDNS identity for each dashboard (`esphome-builder-<id>`) instead of one derived from the OS hostname, and carries the human machine label in a new `friendly_name` TXT entry. Without a matching frontend change the discovered-build-server picker would show that opaque identifier instead of the machine name.

This surfaces `friendly_name` on `RemoteBuildPeer` and prefers it for the discovered-host row title and aria label, falling back to the instance name for older receivers that don't broadcast it. The pair wizard's receiver label is seeded from it too, so pairing a discovered host no longer prefills the opaque hostname.

Companion to the backend change esphome/device-builder#1632; must land lockstep with it. That PR makes `name` an opaque `esphome-builder-<id>` identifier, so without this change the discovered-build-server picker shows the opaque id instead of the machine name. The frontend ships prebuilt in the backend wheel, so both must be in the same release.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

