### PR TITLE
Drop min-height: 2lh to improve alignment

### DIFF
--- a/src/components/wizard/wizard-step-method.ts
+++ b/src/components/wizard/wizard-step-method.ts
@@ -120,7 +120,6 @@ export class ESPHomeWizardStepMethod extends LitElement {
         margin: 0;
         font-size: var(--wa-font-size-s);
         color: var(--wa-color-text-quiet);
-        min-height: 2lh;
       }
 
       .option-card wa-icon {


### PR DESCRIPTION
# What does this implement/fix?

Right now `min-height: 2lh;` forces the empty configuration card to be really misaligned:
<img width="970" height="478" alt="image" src="https://github.com/user-attachments/assets/88e1bc25-d615-4272-b04b-47962cc25053" />
Removing it lets it be naturally centered:
<img width="954" height="474" alt="image" src="https://github.com/user-attachments/assets/b43be891-f103-439a-ac06-d15814571e41" />

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes. there's a ton of preexisting errors 
<img width="748" height="254" alt="image" src="https://github.com/user-attachments/assets/656e86f9-ea54-488b-b3a3-7e48ede0736b" />

- [ ] Tests have been added to verify that the new code works (where applicable).
