### PR TITLE
Fix lowered surface color in dark mode

### DIFF
--- a/src/styles/apply-theme.ts
+++ b/src/styles/apply-theme.ts
@@ -61,7 +61,7 @@ function applyEspHomeTokens(): void {
       --esphome-svg-filter: invert(1) hue-rotate(180deg);
       --wa-color-surface-default: var(--primary-background-color, #111111);
       --wa-color-surface-raised: var(--card-background-color, #1c1c1c);
-      --wa-color-surface-lowered: var(--secondary-background-color, #282828);
+      --wa-color-surface-lowered: color-mix(in oklch, var(--primary-background-color, #111111) 50%, black);
       --wa-color-surface-border: var(--divider-color, rgba(225, 225, 225, 0.12));
       --wa-color-text-normal: var(--primary-text-color, #e1e1e1);
       --wa-color-text-quiet: var(--secondary-text-color, #9b9b9b);


### PR DESCRIPTION
# What does this implement/fix?

In Web Awesome `--wa-color-surface-lowered` is "Background for recessed surfaces like wells and code blocks", always supposed to be darker than `--wa-color-surface-default`, whether in light or dark mode. You can read about this at https://webawesome.com/docs/tokens/color#surfaces. It's also the base color for shadows, and shadows have to be dark to look good.

Before:
<img width="484" height="226" alt="image" src="https://github.com/user-attachments/assets/b22101bc-42bc-41e4-8626-8c8c6f15ac2e" />
After:
<img width="484" height="226" alt="image" src="https://github.com/user-attachments/assets/d9194445-7ee9-4000-840c-5bc36739da1e" />


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes. same failure as last PR
- [ ] Tests have been added to verify that the new code works (where applicable).
