### PR TITLE
Use gap instead of margin for board-tags

### DIFF
--- a/src/components/device/device-board-info.styles.ts
+++ b/src/components/device/device-board-info.styles.ts
@@ -54,7 +54,7 @@ export const deviceBoardInfoStyles = css`
   .board-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--wa-space-2xs);
+    gap: var(--wa-space-s);
   }
 
   .board-info-link {
@@ -64,7 +64,6 @@ export const deviceBoardInfoStyles = css`
     font-size: var(--wa-font-size-xs);
     color: var(--esphome-primary);
     text-decoration: underline;
-    margin-left: var(--wa-space-s);
   }
 
   .board-info-link:hover {
@@ -80,7 +79,6 @@ export const deviceBoardInfoStyles = css`
     font-family: inherit;
     color: var(--esphome-primary);
     text-decoration: underline;
-    margin-left: var(--wa-space-s);
     padding: 0;
     border: none;
     background: none;


### PR DESCRIPTION
# What does this implement/fix?

Right now we use both `gap` and `margin-left` which looks like this
<img width="488" height="334" alt="image" src="https://github.com/user-attachments/assets/bebfaa45-c5cf-4571-be6d-9f44de195621" />
We can just use gap instead which looks a lot nicer
<img width="488" height="334" alt="image" src="https://github.com/user-attachments/assets/98937df4-367d-47d6-9fa0-b5c35bc5bad1" />

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [ ] `npm run test` passes. still fails for same reason as first pr did
- [ ] Tests have been added to verify that the new code works (where applicable).
