### PR TITLE
Filter already-set keys and complete nested mappings in the YAML editor

### DIFF
--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -244,6 +244,28 @@ export function resolveBundleContext(
   return { topLevelKey, platformValue: getPlatformValue(state, pos) };
 }
 
+/** Iterate the direct ``Pair`` children of a ``BlockMapping`` node — the
+ *  shared primitive behind the mapping-key collectors below. */
+function* mappingPairs(map: SyntaxNode): Generator<SyntaxNode> {
+  for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
+    if (pair.name === "Pair") yield pair;
+  }
+}
+
+/** Ordered, de-duplicated keys of a ``BlockMapping``'s direct pairs. */
+function uniqueMappingKeys(state: EditorState, map: SyntaxNode): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const pair of mappingPairs(map)) {
+    const k = getPairKey(state, pair);
+    if (k && !seen.has(k)) {
+      seen.add(k);
+      out.push(k);
+    }
+  }
+  return out;
+}
+
 /** Memoise substitution-key collection by Lezer ``Tree`` identity.
  *  Same incremental-tree reuse as ``collectTopLevelKeys`` —
  *  unchanged ``substitutions:`` mapping shouldn't re-walk on every
@@ -261,28 +283,13 @@ export function collectSubstitutionKeys(state: EditorState): string[] {
   const cached = substitutionKeysMemo.get(tree);
   if (cached) return cached;
   const out: string[] = [];
-  const seen = new Set<string>();
-  const doc = tree.topNode.getChild("Document");
-  const map = doc?.getChild("BlockMapping");
-  if (!map) {
-    substitutionKeysMemo.set(tree, out);
-    return out;
-  }
-  for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
-    if (pair.name !== "Pair") continue;
+  const map = tree.topNode.getChild("Document")?.getChild("BlockMapping");
+  for (const pair of map ? mappingPairs(map) : []) {
     if (getPairKey(state, pair) !== "substitutions") continue;
     // ``substitutions:`` value is a BlockMapping of leaf pairs.
     let val: SyntaxNode | null = pair.lastChild;
     while (val && val.name !== "BlockMapping") val = val.prevSibling;
-    if (!val) break;
-    for (let inner = val.firstChild; inner; inner = inner.nextSibling) {
-      if (inner.name !== "Pair") continue;
-      const k = getPairKey(state, inner);
-      if (k && !seen.has(k)) {
-        seen.add(k);
-        out.push(k);
-      }
-    }
+    if (val) out.push(...uniqueMappingKeys(state, val));
     break;
   }
   substitutionKeysMemo.set(tree, out);
@@ -309,18 +316,13 @@ export function collectSiblingKeys(state: EditorState, pos: number): Set<string>
   // a new sibling typed beneath one would otherwise wrongly exclude that
   // key (and re-suggest it).
   const ownPair = findEnclosingPair(inner);
-  const cursorLine = state.doc.lineAt(pos).number;
-  let ownKeyOnCursorLine = false;
-  if (ownPair) {
-    const k = ownPair.getChild("Key");
-    ownKeyOnCursorLine = !!k && state.doc.lineAt(k.from).number === cursorLine;
-  }
-  for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
-    if (pair.name !== "Pair") continue;
-    // Lezer nodes aren't reference-equal across traversals; compare by span.
-    if (ownKeyOnCursorLine && pair.from === ownPair!.from && pair.to === ownPair!.to) {
-      continue;
-    }
+  const ownKey = ownPair?.getChild("Key");
+  const ownKeyOnCursorLine =
+    !!ownKey && state.doc.lineAt(ownKey.from).number === state.doc.lineAt(pos).number;
+  for (const pair of mappingPairs(map)) {
+    // Lezer nodes aren't reference-equal across traversals; a Pair is
+    // uniquely identified by its start within one mapping.
+    if (ownKeyOnCursorLine && pair.from === ownPair!.from) continue;
     const k = getPairKey(state, pair);
     if (k) out.add(k);
   }
@@ -346,27 +348,9 @@ export function collectTopLevelKeys(state: EditorState): string[] {
   const tree = syntaxTree(state);
   const cached = topLevelKeysMemo.get(tree);
   if (cached) return cached;
-  const out: string[] = [];
-  const seen = new Set<string>();
   // Stream → Document → BlockMapping → Pair*
-  const doc = tree.topNode.getChild("Document");
-  if (!doc) {
-    topLevelKeysMemo.set(tree, out);
-    return out;
-  }
-  const map = doc.getChild("BlockMapping");
-  if (!map) {
-    topLevelKeysMemo.set(tree, out);
-    return out;
-  }
-  for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
-    if (pair.name !== "Pair") continue;
-    const k = getPairKey(state, pair);
-    if (k && !seen.has(k)) {
-      seen.add(k);
-      out.push(k);
-    }
-  }
+  const map = tree.topNode.getChild("Document")?.getChild("BlockMapping");
+  const out = map ? uniqueMappingKeys(state, map) : [];
   topLevelKeysMemo.set(tree, out);
   return out;
 }

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -289,6 +289,35 @@ export function collectSubstitutionKeys(state: EditorState): string[] {
   return out;
 }
 
+/**
+ * Collect the keys of the block mapping the cursor sits in, excluding
+ * the pair the cursor is editing. The new editor's equivalent of the
+ * legacy ``mapHasScalarKey`` filter — drives "don't re-suggest a key
+ * that's already set in this mapping". Returns an empty set when the
+ * cursor isn't inside a mapping (no filtering, matching prior
+ * behaviour).
+ */
+export function collectSiblingKeys(state: EditorState, pos: number): Set<string> {
+  const out = new Set<string>();
+  const inner = syntaxTree(state).resolveInner(pos, -1);
+  let map: SyntaxNode | null = inner;
+  while (map && map.name !== "BlockMapping") map = map.parent;
+  if (!map) return out;
+  // The pair being edited stays out of the set so an in-place key edit
+  // still completes itself. A bare partial line that didn't parse as a
+  // Pair yields an ``ownPair`` outside this mapping, which simply never
+  // matches a child below.
+  const ownPair = findEnclosingPair(inner);
+  for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
+    if (pair.name !== "Pair") continue;
+    // Lezer nodes aren't reference-equal across traversals; compare by span.
+    if (ownPair && pair.from === ownPair.from && pair.to === ownPair.to) continue;
+    const k = getPairKey(state, pair);
+    if (k) out.add(k);
+  }
+  return out;
+}
+
 /** Memoise top-level-key collection by Lezer ``Tree`` identity.
  *  Lezer's incremental parsing reuses the same ``Tree`` object
  *  across edits that don't touch the relevant subtree, so a

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -304,14 +304,23 @@ export function collectSiblingKeys(state: EditorState, pos: number): Set<string>
   while (map && map.name !== "BlockMapping") map = map.parent;
   if (!map) return out;
   // The pair being edited stays out of the set so an in-place key edit
-  // still completes itself. A bare partial line that didn't parse as a
-  // Pair yields an ``ownPair`` outside this mapping, which simply never
-  // matches a child below.
+  // still completes itself — but only when its key sits on the cursor's
+  // line. An empty ``key:`` opener absorbs the line below as its value, so
+  // a new sibling typed beneath one would otherwise wrongly exclude that
+  // key (and re-suggest it).
   const ownPair = findEnclosingPair(inner);
+  const cursorLine = state.doc.lineAt(pos).number;
+  let ownKeyOnCursorLine = false;
+  if (ownPair) {
+    const k = ownPair.getChild("Key");
+    ownKeyOnCursorLine = !!k && state.doc.lineAt(k.from).number === cursorLine;
+  }
   for (let pair = map.firstChild; pair; pair = pair.nextSibling) {
     if (pair.name !== "Pair") continue;
     // Lezer nodes aren't reference-equal across traversals; compare by span.
-    if (ownPair && pair.from === ownPair.from && pair.to === ownPair.to) continue;
+    if (ownKeyOnCursorLine && pair.from === ownPair!.from && pair.to === ownPair!.to) {
+      continue;
+    }
     const k = getPairKey(state, pair);
     if (k) out.add(k);
   }

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -243,7 +243,16 @@ export async function resolveAvailableEntries(
     if (!topLevelKey || !platformValue) return [];
     return entriesFor(`${topLevelKey}.${platformValue}`);
   }
-  if (catalog.byId.has(parentKey)) {
+  // Treat the parent as a top-level component only when it actually *is* the
+  // top-level block. A nested group key can collide with a component id
+  // (``web_server``, ``uart``, ``time``, …); preferring the component would
+  // shadow the descent and surface the wrong fields. When the AST is silent
+  // (``topLevelKey`` null) keep the direct lookup — the descent can't run
+  // without it anyway.
+  if (
+    catalog.byId.has(parentKey) &&
+    (topLevelKey === null || parentKey === topLevelKey)
+  ) {
     return componentEntries(parentKey);
   }
   // Nested mapping (``esp32: framework:`` → parentKey="framework", not a

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -15,7 +15,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
-import { resolveBundleContext } from "./yaml-ast.js";
+import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
 import { findTopLevelBlock, readPlatformSibling } from "./yaml-line-walker.js";
 
 // ``validFor`` regex constants — consumed by CodeMirror to decide
@@ -189,7 +189,8 @@ export async function resolveAvailableEntries(
   catalog: CatalogIndex,
   parentKey: string,
   platformValue: string | null,
-  topLevelKey: string | null
+  topLevelKey: string | null,
+  nestedPath: string[] = []
 ): Promise<ConfigEntry[]> {
   // The slim ``getComponents`` index carries no ``config_entries``
   // (those hydrate lazily through ``components/get_component_bodies``),
@@ -211,6 +212,30 @@ export async function resolveAvailableEntries(
     }
   };
 
+  // Resolve a top-level component's fields, merging the platform
+  // implementation's fields when a ``platform:`` value is set (the
+  // catalog keys per-platform entries as ``<domain>.<stem>``). The merge
+  // id is resolved up front so both bodies register before the microtask
+  // flush and batch into a single ``get_component_bodies`` round trip.
+  const componentEntries = async (componentId: string): Promise<ConfigEntry[]> => {
+    let mergeId: string | null = null;
+    if (platformValue) {
+      if (catalog.byId.has(platformValue)) {
+        mergeId = platformValue;
+      } else if (catalog.byId.has(`${componentId}.${platformValue}`)) {
+        mergeId = `${componentId}.${platformValue}`;
+      }
+    }
+    if (mergeId) {
+      const [own, extra] = await Promise.all([
+        entriesFor(componentId),
+        entriesFor(mergeId),
+      ]);
+      return [...own, ...extra];
+    }
+    return entriesFor(componentId);
+  };
+
   // Cursor nested under a list-item header (``- platform: template``
   // → parentKey="platform"). The form fields live on the dotted
   // catalog id ``<domain>.<platformValue>`` (``binary_sensor.template``).
@@ -219,27 +244,19 @@ export async function resolveAvailableEntries(
     return entriesFor(`${topLevelKey}.${platformValue}`);
   }
   if (catalog.byId.has(parentKey)) {
-    // Top-level component directly. If a platform value is set, merge
-    // the platform implementation's fields in (the catalog keys
-    // per-platform entries as ``<domain>.<stem>``). Resolve the merge
-    // id up front so both bodies register before the microtask flush
-    // and batch into a single ``get_component_bodies`` round trip.
-    let mergeId: string | null = null;
-    if (platformValue) {
-      if (catalog.byId.has(platformValue)) {
-        mergeId = platformValue;
-      } else if (topLevelKey && catalog.byId.has(`${topLevelKey}.${platformValue}`)) {
-        mergeId = `${topLevelKey}.${platformValue}`;
-      }
-    }
-    if (mergeId) {
-      const [own, extra] = await Promise.all([
-        entriesFor(parentKey),
-        entriesFor(mergeId),
-      ]);
-      return [...own, ...extra];
-    }
-    return entriesFor(parentKey);
+    return componentEntries(parentKey);
+  }
+  // Nested mapping (``esp32: framework:`` → parentKey="framework", not a
+  // catalog id). Descend the top-level component's nested
+  // ``config_entries`` along the key path; the catalog models nested
+  // groups (``framework`` → ``advanced`` → …) the same way the visual
+  // form renders them.
+  if (topLevelKey && nestedPath.length > 0) {
+    const descended = descendNestedEntries(
+      await componentEntries(topLevelKey),
+      nestedPath
+    );
+    if (descended.length > 0) return descended;
   }
   // No direct hit — try fetching the component (handles aliases the
   // catalog list call doesn't return). Routes through the session-
@@ -253,6 +270,42 @@ export async function resolveAvailableEntries(
     /* ignore */
   }
   return [];
+}
+
+/**
+ * Compute the nested-group descent path for ``resolveAvailableEntries``:
+ * the key chain from just under the top-level component down to and
+ * including *parentKey*. Returns ``[]`` when *parentKey* is the top-level
+ * key itself or doesn't appear on the cursor's AST key path (safe
+ * no-descent fallback when the AST and the regex walker disagree).
+ */
+export function nestedPathForParent(
+  state: EditorState,
+  pos: number,
+  parentKey: string
+): string[] {
+  const path = getKeyPath(state, pos);
+  const idx = path.lastIndexOf(parentKey);
+  if (idx < 1) return [];
+  return path.slice(1, idx + 1);
+}
+
+/**
+ * Walk *entries* down *path*, descending into each matching entry's
+ * nested ``config_entries``. Returns the deepest level reached, or
+ * ``[]`` when any step has no nested group for that key.
+ */
+export function descendNestedEntries(
+  entries: ConfigEntry[],
+  path: string[]
+): ConfigEntry[] {
+  let cur = entries;
+  for (const key of path) {
+    const next = cur.find((e) => e.key === key && e.config_entries);
+    if (!next?.config_entries) return [];
+    cur = next.config_entries;
+  }
+  return cur;
 }
 
 /**

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -254,11 +254,14 @@ export async function resolveAvailableEntries(
   // path's AST walk stays off the common (cursor-under-a-component) path.
   const nestedPath = topLevelKey ? resolveNestedPath() : [];
   if (nestedPath.length > 0) {
+    // ``null`` means the path didn't resolve (fall through to the alias
+    // fetch); an empty array means a real but childless nested group, which
+    // should surface no suggestions rather than trigger the network fallback.
     const descended = descendNestedEntries(
       await componentEntries(topLevelKey!),
       nestedPath
     );
-    if (descended.length > 0) return descended;
+    if (descended !== null) return descended;
   }
   // No direct hit — try fetching the component (handles aliases the
   // catalog list call doesn't return). Routes through the session-
@@ -294,17 +297,19 @@ export function nestedPathForParent(
 
 /**
  * Walk *entries* down *path*, descending into each matching entry's
- * nested ``config_entries``. Returns the deepest level reached, or
- * ``[]`` when any step has no nested group for that key.
+ * nested ``config_entries``. Returns the deepest level reached (possibly
+ * empty for a childless nested group), or ``null`` when any step has no
+ * nested group for that key — letting the caller tell "resolved but empty"
+ * apart from "path missing".
  */
 export function descendNestedEntries(
   entries: ConfigEntry[],
   path: string[]
-): ConfigEntry[] {
+): ConfigEntry[] | null {
   let cur = entries;
   for (const key of path) {
     const next = cur.find((e) => e.key === key && e.config_entries);
-    if (!next?.config_entries) return [];
+    if (!next?.config_entries) return null;
     cur = next.config_entries;
   }
   return cur;

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -13,7 +13,7 @@
 import type { EditorState } from "@codemirror/state";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { ComponentCatalogEntry } from "../api/types/components.js";
-import type { ConfigEntry } from "../api/types/config-entries.js";
+import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
 import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
 import { findTopLevelBlock, readPlatformSibling } from "./yaml-line-walker.js";
@@ -317,9 +317,16 @@ export function descendNestedEntries(
 ): ConfigEntry[] | null {
   let cur = entries;
   for (const key of path) {
-    const next = cur.find((e) => e.key === key && e.config_entries);
-    if (!next?.config_entries) return null;
-    cur = next.config_entries;
+    // Descend into any entry that carries child entries (``nested`` / ``pin``
+    // / ``map``); a ``nested`` group can legitimately have ``null`` children
+    // (treated as empty), so match it by type too rather than only by a
+    // truthy ``config_entries``.
+    const next = cur.find(
+      (e) =>
+        e.key === key && (e.config_entries != null || e.type === ConfigEntryType.NESTED)
+    );
+    if (!next) return null;
+    cur = next.config_entries ?? [];
   }
   return cur;
 }

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -190,7 +190,7 @@ export async function resolveAvailableEntries(
   parentKey: string,
   platformValue: string | null,
   topLevelKey: string | null,
-  nestedPath: string[] = []
+  resolveNestedPath: () => string[] = () => []
 ): Promise<ConfigEntry[]> {
   // The slim ``getComponents`` index carries no ``config_entries``
   // (those hydrate lazily through ``components/get_component_bodies``),
@@ -250,10 +250,12 @@ export async function resolveAvailableEntries(
   // catalog id). Descend the top-level component's nested
   // ``config_entries`` along the key path; the catalog models nested
   // groups (``framework`` → ``advanced`` → …) the same way the visual
-  // form renders them.
-  if (topLevelKey && nestedPath.length > 0) {
+  // form renders them. Only reached once the cheaper branches miss, so the
+  // path's AST walk stays off the common (cursor-under-a-component) path.
+  const nestedPath = topLevelKey ? resolveNestedPath() : [];
+  if (nestedPath.length > 0) {
     const descended = descendNestedEntries(
-      await componentEntries(topLevelKey),
+      await componentEntries(topLevelKey!),
       nestedPath
     );
     if (descended.length > 0) return descended;

--- a/src/util/yaml-completion-providers.ts
+++ b/src/util/yaml-completion-providers.ts
@@ -25,6 +25,7 @@ import { collectTopLevelKeys } from "./yaml-ast.js";
 import {
   bundleFor,
   type CatalogIndex,
+  nestedPathForParent,
   resolveAvailableEntries,
 } from "./yaml-completion-catalog.js";
 import {
@@ -110,7 +111,8 @@ async function resolveCatalogEntries(k: KeyPositionCtx): Promise<ConfigEntry[]> 
       k.catalog,
       k.parent.key,
       k.platformValue,
-      k.topLevelKey
+      k.topLevelKey,
+      nestedPathForParent(k.state, k.pos, k.parent.key)
     );
   }
   return k._cachedCatalogEntries;

--- a/src/util/yaml-completion-providers.ts
+++ b/src/util/yaml-completion-providers.ts
@@ -112,7 +112,7 @@ async function resolveCatalogEntries(k: KeyPositionCtx): Promise<ConfigEntry[]> 
       k.parent.key,
       k.platformValue,
       k.topLevelKey,
-      nestedPathForParent(k.state, k.pos, k.parent.key)
+      () => nestedPathForParent(k.state, k.pos, k.parent.key)
     );
   }
   return k._cachedCatalogEntries;

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -27,11 +27,16 @@ import {
   findReferenceCandidates,
 } from "./config-entry-yaml-scan.js";
 import { getConfigVarValueOptions } from "./esphome-schema.js";
-import { collectSubstitutionKeys, isUnderAutomationItem } from "./yaml-ast.js";
+import {
+  collectSiblingKeys,
+  collectSubstitutionKeys,
+  isUnderAutomationItem,
+} from "./yaml-ast.js";
 import {
   bundleFor,
   loadCatalog,
   matchKeyPosition,
+  nestedPathForParent,
   RE_BOOLEAN_VALUE,
   RE_ENUM_VALUE,
   RE_KEY,
@@ -170,7 +175,8 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         catalog,
         parent.key,
         completionCtx.platformValue,
-        completionCtx.topLevelKey
+        completionCtx.topLevelKey,
+        nestedPathForParent(state, pos, parent.key)
       );
       const entry = entries.find((e) => e.key === key);
 
@@ -280,9 +286,10 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     // components (catalog entries whose id has no dot). See
     // ``buildTopLevelCompletions`` for the rationale.
     if (indent === 0) {
+      const present = collectSiblingKeys(state, pos);
       return {
         from: keyFrom,
-        options: buildTopLevelCompletions(catalog),
+        options: buildTopLevelCompletions(catalog).filter((c) => !present.has(c.label)),
         validFor: RE_KEY,
       };
     }
@@ -322,7 +329,13 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     };
 
     const buckets = await Promise.all(KEY_POSITION_PROVIDERS.map((p) => p.fetch(keyCtx)));
-    const options = buckets.flat();
+    let options = buckets.flat();
+    // Drop keys already set in this mapping (plain key position only —
+    // list items like automation actions / filters are repeatable).
+    if (!isListItem) {
+      const present = collectSiblingKeys(state, pos);
+      if (present.size > 0) options = options.filter((o) => !present.has(o.label));
+    }
     if (options.length === 0) return null;
 
     // ``RE_KEY_OR_ACTION`` allows ``.`` because dotted action

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -176,7 +176,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         parent.key,
         completionCtx.platformValue,
         completionCtx.topLevelKey,
-        nestedPathForParent(state, pos, parent.key)
+        () => nestedPathForParent(state, pos, parent.key)
       );
       const entry = entries.find((e) => e.key === key);
 

--- a/test/util/yaml-ast-sibling-keys.test.ts
+++ b/test/util/yaml-ast-sibling-keys.test.ts
@@ -1,0 +1,45 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { collectSiblingKeys } from "../../src/util/yaml-ast.js";
+
+function siblingsAt(yaml: string, pos: number): string[] {
+  const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
+  return [...collectSiblingKeys(state, pos)].sort();
+}
+
+describe("collectSiblingKeys", () => {
+  it("returns the sibling keys of the cursor's mapping", () => {
+    const yaml = ["esphome:", "  name: foo", "  friendly_name: bar", "  c"].join("\n");
+    expect(siblingsAt(yaml, yaml.length)).toEqual(["friendly_name", "name"]);
+  });
+
+  it("returns the top-level keys when the cursor is at column 0", () => {
+    const yaml = ["esphome:", "  name: foo", "wifi:", "  ssid: x", "l"].join("\n");
+    expect(siblingsAt(yaml, yaml.length)).toEqual(["esphome", "wifi"]);
+  });
+
+  it("excludes the pair the cursor is editing in place", () => {
+    const yaml = ["esphome:", "  name: foo"].join("\n");
+    const pos = yaml.indexOf("name") + 2;
+    expect(siblingsAt(yaml, pos)).toEqual([]);
+  });
+
+  it("is scoped to the current list-item mapping, not sibling items", () => {
+    // Each ``- `` starts its own mapping, so a repeated field in a
+    // second item must not see the first item's keys (list items are
+    // legitimately repeatable).
+    const yaml = [
+      "sensor:",
+      "  - platform: dht",
+      "    name: a",
+      "  - platform: dht",
+      "    n",
+    ].join("\n");
+    expect(siblingsAt(yaml, yaml.length)).toEqual(["platform"]);
+  });
+
+  it("returns an empty set when the cursor isn't inside a mapping", () => {
+    expect(siblingsAt("", 0)).toEqual([]);
+  });
+});

--- a/test/util/yaml-ast-sibling-keys.test.ts
+++ b/test/util/yaml-ast-sibling-keys.test.ts
@@ -39,6 +39,14 @@ describe("collectSiblingKeys", () => {
     expect(siblingsAt(yaml, yaml.length)).toEqual(["platform"]);
   });
 
+  it("includes an empty block opener above the cursor", () => {
+    // ``captive_portal:`` / ``debug:`` etc. with no children absorb the
+    // line below as their value; the new sibling key beneath must still
+    // see them so they aren't re-suggested.
+    const yaml = ["wifi:", "  ssid: x", "captive_portal:", "d"].join("\n");
+    expect(siblingsAt(yaml, yaml.length)).toEqual(["captive_portal", "wifi"]);
+  });
+
   it("returns an empty set when the cursor isn't inside a mapping", () => {
     expect(siblingsAt("", 0)).toEqual([]);
   });

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment happy-dom
 import { CompletionContext } from "@codemirror/autocomplete";
+import { forceParsing } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComponentCategory } from "../../src/api/types/components.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
@@ -36,7 +39,9 @@ const BODIES: Record<
         makeConfigEntry({
           key: "advanced",
           type: ConfigEntryType.NESTED,
-          config_entries: [],
+          config_entries: [
+            makeConfigEntry({ key: "verbose", type: ConfigEntryType.BOOLEAN }),
+          ],
         }),
         makeConfigEntry({ key: "version" }),
       ]),
@@ -52,10 +57,19 @@ const fakeApi = {
 } as never;
 
 async function labelsAt(yaml: string): Promise<string[]> {
-  const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
-  const ctx = new CompletionContext(state, yaml.length, false);
-  const result = await createYamlCompletionSource(fakeApi)(ctx);
-  return (result?.options ?? []).map((o) => o.label);
+  // Drive a real view + full parse so the AST helpers see the same tree a
+  // live editor does (a bare state parses lazily and misses the cursor's tail).
+  const view = new EditorView({
+    state: EditorState.create({ doc: yaml, extensions: [esphomeYaml()] }),
+  });
+  try {
+    forceParsing(view, yaml.length, 60000);
+    const ctx = new CompletionContext(view.state, yaml.length, false);
+    const result = await createYamlCompletionSource(fakeApi)(ctx);
+    return (result?.options ?? []).map((o) => o.label);
+  } finally {
+    view.destroy();
+  }
 }
 
 describe("createYamlCompletionSource (already-set key filtering)", () => {
@@ -95,5 +109,16 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     );
     expect(labels).toContain("advanced");
     expect(labels).toContain("version");
+  });
+
+  it("completes a value inside a deeply nested mapping", async () => {
+    // Value position two levels deep (``framework: advanced: verbose:``)
+    // exercises the value-position nested descent end to end. A partial
+    // value is present so the AST resolves the key path (an empty ``key: ``
+    // resolves to the document root and falls back to the schema lookup).
+    const labels = await labelsAt(
+      ["esp32:", "  framework:", "    advanced:", "      verbose: t"].join("\n")
+    );
+    expect(labels).toEqual(["true", "false"]);
   });
 });

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -1,0 +1,99 @@
+import { CompletionContext } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComponentCategory } from "../../src/api/types/components.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
+  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+
+const SLIM = ["esphome", "wifi", "logger", "esp32"].map((id) =>
+  makeComponentEntry(id, { category: ComponentCategory.CORE })
+);
+
+const BODIES: Record<
+  string,
+  { id: string; config_entries: ReturnType<typeof makeConfigEntry>[] }
+> = {
+  esphome: {
+    id: "esphome",
+    config_entries: [
+      makeConfigEntry({ key: "name" }),
+      makeConfigEntry({ key: "friendly_name" }),
+      makeConfigEntry({ key: "comment" }),
+    ],
+  },
+  esp32: {
+    id: "esp32",
+    config_entries: [
+      nested("framework", [
+        makeConfigEntry({
+          key: "advanced",
+          type: ConfigEntryType.NESTED,
+          config_entries: [],
+        }),
+        makeConfigEntry({ key: "version" }),
+      ]),
+    ],
+  },
+};
+
+const fakeApi = {
+  getComponents: async () => ({ components: SLIM }),
+  getComponentBodies: async (ids: string[]) =>
+    Object.fromEntries(ids.filter((id) => id in BODIES).map((id) => [id, BODIES[id]])),
+  getComponent: async () => null,
+} as never;
+
+async function labelsAt(yaml: string): Promise<string[]> {
+  const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
+  const ctx = new CompletionContext(state, yaml.length, false);
+  const result = await createYamlCompletionSource(fakeApi)(ctx);
+  return (result?.options ?? []).map((o) => o.label);
+}
+
+describe("createYamlCompletionSource (already-set key filtering)", () => {
+  beforeEach(() => {
+    _clearComponentCache();
+    _resetSchemaCacheForTests();
+    // Keep the schema-bundle providers hermetic — they shouldn't fire
+    // here (the catalog answers every position), but stub fetch so a
+    // stray call resolves to an empty bundle instead of hitting the net.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("drops nested keys already set in the mapping", async () => {
+    const labels = await labelsAt(["esphome:", "  name: foo", "  c"].join("\n"));
+    expect(labels).not.toContain("name");
+    expect(labels).toContain("friendly_name");
+    expect(labels).toContain("comment");
+  });
+
+  it("drops top-level blocks already present", async () => {
+    const labels = await labelsAt(
+      ["esphome:", "  name: foo", "wifi:", "  ssid: x", "e"].join("\n")
+    );
+    expect(labels).not.toContain("esphome");
+    expect(labels).not.toContain("wifi");
+    expect(labels).toContain("logger");
+    expect(labels).toContain("esp32");
+  });
+
+  it("completes nested-mapping keys (esp32 framework), the missing-suggestions case", async () => {
+    const labels = await labelsAt(
+      ["esp32:", "  board: esp32-poe-iso", "  framework:", "    a"].join("\n")
+    );
+    expect(labels).toContain("advanced");
+    expect(labels).toContain("version");
+  });
+});

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -16,9 +16,12 @@ import { makeConfigEntry } from "./_make-config-entry.js";
 const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
   makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
 
-const SLIM = ["esphome", "wifi", "logger", "esp32"].map((id) =>
-  makeComponentEntry(id, { category: ComponentCategory.CORE })
-);
+const SLIM = [
+  ...["esphome", "wifi", "logger", "esp32"].map((id) =>
+    makeComponentEntry(id, { category: ComponentCategory.CORE })
+  ),
+  makeComponentEntry("sensor.template", { category: ComponentCategory.SENSOR }),
+];
 
 const BODIES: Record<
   string,
@@ -45,6 +48,14 @@ const BODIES: Record<
         }),
         makeConfigEntry({ key: "version" }),
       ]),
+    ],
+  },
+  "sensor.template": {
+    id: "sensor.template",
+    config_entries: [
+      makeConfigEntry({ key: "name" }),
+      makeConfigEntry({ key: "lambda" }),
+      makeConfigEntry({ key: "update_interval" }),
     ],
   },
 };
@@ -109,6 +120,32 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     );
     expect(labels).toContain("advanced");
     expect(labels).toContain("version");
+  });
+
+  it("offers each list item's own fields without cross-item filtering", async () => {
+    // Two ``- platform: template`` sensors: ``name`` is set in the first
+    // item only, so the second item must still offer it (list items are
+    // separate mappings), along with the rest of the platform's fields.
+    const labels = await labelsAt(
+      [
+        "sensor:",
+        "  - platform: template",
+        "    name: First",
+        "  - platform: template",
+        "    n",
+      ].join("\n")
+    );
+    expect(labels).toContain("name");
+    expect(labels).toContain("lambda");
+    expect(labels).toContain("update_interval");
+  });
+
+  it("filters a key already set within the same list item", async () => {
+    const labels = await labelsAt(
+      ["sensor:", "  - platform: template", "    name: Second", "    u"].join("\n")
+    );
+    expect(labels).not.toContain("name");
+    expect(labels).toContain("update_interval");
   });
 
   it("completes a value inside a deeply nested mapping", async () => {

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -29,7 +29,7 @@ describe("descendNestedEntries", () => {
   const entries = [FRAMEWORK];
 
   it("descends one level into a nested group", () => {
-    expect(descendNestedEntries(entries, ["framework"]).map((e) => e.key)).toEqual([
+    expect(descendNestedEntries(entries, ["framework"])!.map((e) => e.key)).toEqual([
       "advanced",
       "version",
       "type",
@@ -38,13 +38,18 @@ describe("descendNestedEntries", () => {
 
   it("descends multiple levels", () => {
     expect(
-      descendNestedEntries(entries, ["framework", "advanced"]).map((e) => e.key)
+      descendNestedEntries(entries, ["framework", "advanced"])!.map((e) => e.key)
     ).toEqual(["compiler_optimization"]);
   });
 
-  it("returns [] when a path step has no nested group", () => {
-    expect(descendNestedEntries(entries, ["framework", "bogus"])).toEqual([]);
-    expect(descendNestedEntries(entries, ["version"])).toEqual([]);
+  it("returns an empty array for a real but childless nested group", () => {
+    const empty = [nested("framework", [nested("advanced", [])])];
+    expect(descendNestedEntries(empty, ["framework", "advanced"])).toEqual([]);
+  });
+
+  it("returns null when a path step has no nested group", () => {
+    expect(descendNestedEntries(entries, ["framework", "bogus"])).toBeNull();
+    expect(descendNestedEntries(entries, ["version"])).toBeNull();
   });
 
   it("returns the input level for an empty path", () => {

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -1,0 +1,107 @@
+import { EditorState } from "@codemirror/state";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type ComponentCatalogEntry,
+  ComponentCategory,
+} from "../../src/api/types/components.js";
+import { ConfigEntryType } from "../../src/api/types/config-entries.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import {
+  descendNestedEntries,
+  nestedPathForParent,
+  resolveAvailableEntries,
+} from "../../src/util/yaml-completion-catalog.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+import { makeConfigEntry } from "./_make-config-entry.js";
+
+const nested = (key: string, children: ReturnType<typeof makeConfigEntry>[]) =>
+  makeConfigEntry({ key, type: ConfigEntryType.NESTED, config_entries: children });
+
+// esp32 → framework (nested) → advanced (nested) → compiler_optimization.
+const FRAMEWORK = nested("framework", [
+  nested("advanced", [makeConfigEntry({ key: "compiler_optimization" })]),
+  makeConfigEntry({ key: "version" }),
+  makeConfigEntry({ key: "type" }),
+]);
+
+describe("descendNestedEntries", () => {
+  const entries = [FRAMEWORK];
+
+  it("descends one level into a nested group", () => {
+    expect(descendNestedEntries(entries, ["framework"]).map((e) => e.key)).toEqual([
+      "advanced",
+      "version",
+      "type",
+    ]);
+  });
+
+  it("descends multiple levels", () => {
+    expect(
+      descendNestedEntries(entries, ["framework", "advanced"]).map((e) => e.key)
+    ).toEqual(["compiler_optimization"]);
+  });
+
+  it("returns [] when a path step has no nested group", () => {
+    expect(descendNestedEntries(entries, ["framework", "bogus"])).toEqual([]);
+    expect(descendNestedEntries(entries, ["version"])).toEqual([]);
+  });
+
+  it("returns the input level for an empty path", () => {
+    expect(descendNestedEntries(entries, [])).toBe(entries);
+  });
+});
+
+describe("nestedPathForParent", () => {
+  const pathAt = (yaml: string, parentKey: string) => {
+    const state = EditorState.create({ doc: yaml, extensions: [esphomeYaml()] });
+    return nestedPathForParent(state, yaml.length, parentKey);
+  };
+
+  it("yields the chain under the top-level component", () => {
+    const yaml = ["esp32:", "  framework:", "    a"].join("\n");
+    expect(pathAt(yaml, "framework")).toEqual(["framework"]);
+  });
+
+  it("yields a multi-level chain", () => {
+    const yaml = ["esp32:", "  framework:", "    advanced:", "      x"].join("\n");
+    expect(pathAt(yaml, "advanced")).toEqual(["framework", "advanced"]);
+  });
+
+  it("returns [] for the top-level key itself", () => {
+    const yaml = ["esp32:", "  a"].join("\n");
+    expect(pathAt(yaml, "esp32")).toEqual([]);
+  });
+
+  it("returns [] when the parent isn't on the key path", () => {
+    const yaml = ["esp32:", "  framework:", "    a"].join("\n");
+    expect(pathAt(yaml, "platform")).toEqual([]);
+  });
+});
+
+describe("resolveAvailableEntries (nested descent)", () => {
+  beforeEach(() => _clearComponentCache());
+
+  it("descends a top-level component's nested config_entries", async () => {
+    const slim = makeComponentEntry("esp32", { category: ComponentCategory.CORE });
+    const body: ComponentCatalogEntry = { ...slim, config_entries: [FRAMEWORK] };
+    const catalog = {
+      components: [slim],
+      byId: new Map([["esp32", slim]]),
+      byCategory: new Map([[ComponentCategory.CORE, [slim]]]),
+    };
+    const fakeApi = {
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(ids.filter((id) => id === "esp32").map((id) => [id, body])),
+    } as never;
+    const out = await resolveAvailableEntries(
+      fakeApi,
+      catalog,
+      "framework", // parentKey from the indent walker (not a catalog id)
+      null,
+      "esp32",
+      ["framework"]
+    );
+    expect(out.map((e) => e.key)).toEqual(["advanced", "version", "type"]);
+  });
+});

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -100,7 +100,7 @@ describe("resolveAvailableEntries (nested descent)", () => {
       "framework", // parentKey from the indent walker (not a catalog id)
       null,
       "esp32",
-      ["framework"]
+      () => ["framework"]
     );
     expect(out.map((e) => e.key)).toEqual(["advanced", "version", "type"]);
   });

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -109,4 +109,56 @@ describe("resolveAvailableEntries (nested descent)", () => {
     );
     expect(out.map((e) => e.key)).toEqual(["advanced", "version", "type"]);
   });
+
+  it("descends a nested group whose key collides with a component id", async () => {
+    // ``web_server`` is both a top-level component and a per-entity nested
+    // group; the descent must win over the same-named component so the user
+    // gets the nested group's fields, not the component's.
+    const ws = makeComponentEntry("web_server", { category: ComponentCategory.CORE });
+    const wsBody: ComponentCatalogEntry = {
+      ...ws,
+      config_entries: [
+        makeConfigEntry({ key: "port" }),
+        makeConfigEntry({ key: "auth" }),
+      ],
+    };
+    const host = makeComponentEntry("esphome", { category: ComponentCategory.CORE });
+    const hostBody: ComponentCatalogEntry = {
+      ...host,
+      config_entries: [
+        nested("web_server", [makeConfigEntry({ key: "sorting_weight" })]),
+      ],
+    };
+    const catalog = {
+      components: [ws, host],
+      byId: new Map([
+        ["web_server", ws],
+        ["esphome", host],
+      ]),
+      byCategory: new Map(),
+    };
+    const fakeApi = {
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(
+          ids
+            .map((id) =>
+              id === "web_server"
+                ? [id, wsBody]
+                : id === "esphome"
+                  ? [id, hostBody]
+                  : null
+            )
+            .filter((e): e is [string, ComponentCatalogEntry] => e !== null)
+        ),
+    } as never;
+    const out = await resolveAvailableEntries(
+      fakeApi,
+      catalog,
+      "web_server", // parentKey collides with a component id
+      null,
+      "esphome", // but the top-level block is esphome, so descend
+      () => ["web_server"]
+    );
+    expect(out.map((e) => e.key)).toEqual(["sorting_weight"]);
+  });
 });

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -47,6 +47,17 @@ describe("descendNestedEntries", () => {
     expect(descendNestedEntries(empty, ["framework", "advanced"])).toEqual([]);
   });
 
+  it("descends a nested group whose children are null", () => {
+    // ``config_entries`` is ``ConfigEntry[] | null``; a nested group with
+    // null children resolves to an empty level, not a missing path.
+    const nullChildren = makeConfigEntry({
+      key: "framework",
+      type: ConfigEntryType.NESTED,
+      config_entries: null,
+    });
+    expect(descendNestedEntries([nullChildren], ["framework"])).toEqual([]);
+  });
+
   it("returns null when a path step has no nested group", () => {
     expect(descendNestedEntries(entries, ["framework", "bogus"])).toBeNull();
     expect(descendNestedEntries(entries, ["version"])).toBeNull();


### PR DESCRIPTION
# What does this implement/fix?

The YAML editor's autocomplete had regressed against the legacy dashboard in two ways:

1. It re-suggested keys that are already set in the surrounding mapping (fields already written under a block, or top-level blocks like `wifi:`/`api:` that already exist). The legacy editor filtered these out.
2. It offered nothing inside nested mappings; typing under `esp32:` then `framework:` returned no suggestions, where the legacy editor offered `advanced` and the rest of the framework fields.

Both behaviours are client-side; completion is computed in the frontend from the component catalog, so this is a frontend-only fix.

Changes:

- Add `collectSiblingKeys` (AST) and drop completions whose key is already present in the cursor's mapping, at plain key positions only. List-item positions (automation actions, filters) stay unfiltered since they are legitimately repeatable, and YAML map-key uniqueness is what makes the plain-key filter safe.
- Descend the catalog's nested `config_entries` along the cursor's AST key path (`getKeyPath`), so nested groups like `framework` and `framework: advanced:` complete. The catalog already models the nesting the visual form uses, so no schema or backend change is needed.

**Related issue or feature (if applicable):**

- Reported with editor autocomplete screenshots; no issue filed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
