### PR TITLE
Pin language-picker option labels so the collapsed value drops the % badge

### DIFF
--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -74,16 +74,18 @@ export class ESPHomeSettingsLanguage extends LitElement {
           <span class="row-desc">${this._localize("settings.language_desc")}</span>
         </div>
         <wa-select value=${this._language} @change=${this._onChange}>
-          ${LANGUAGES.map(
-            (l) => html`
-              <wa-option value=${l.value}
-                >${l.flag}
-                ${languageLabel(l, this._localize)}${this._renderCompleteness(
-                  l
-                )}</wa-option
+          ${LANGUAGES.map((l) => {
+            const name = languageLabel(l, this._localize);
+            // wa-select derives the collapsed display label from the option's
+            // text content, which would include the slot="end" completeness
+            // badge ("99%"). Pin an explicit flag-plus-name label so the
+            // collapsed value reads "Deutsch", not "Deutsch99%" (issue #1650).
+            return html`
+              <wa-option value=${l.value} label="${l.flag} ${name}"
+                >${l.flag} ${name}${this._renderCompleteness(l)}</wa-option
               >
-            `
-          )}
+            `;
+          })}
         </wa-select>
         <p class="language-note">
           ${this._localize("settings.language_completeness_note")}

--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -79,7 +79,8 @@ export class ESPHomeSettingsLanguage extends LitElement {
             // wa-select derives the collapsed display label from the option's
             // text content, which would include the slot="end" completeness
             // badge ("99%"). Pin an explicit flag-plus-name label so the
-            // collapsed value reads "Deutsch", not "Deutsch99%" (issue #1650).
+            // collapsed value reads the flag plus "Deutsch", not "Deutsch99%"
+            // (issue #1650).
             const optionLabel = `${l.flag} ${name}`;
             return html`
               <wa-option value=${l.value} .label=${optionLabel}

--- a/src/components/settings-dialog/language-section.ts
+++ b/src/components/settings-dialog/language-section.ts
@@ -80,8 +80,9 @@ export class ESPHomeSettingsLanguage extends LitElement {
             // text content, which would include the slot="end" completeness
             // badge ("99%"). Pin an explicit flag-plus-name label so the
             // collapsed value reads "Deutsch", not "Deutsch99%" (issue #1650).
+            const optionLabel = `${l.flag} ${name}`;
             return html`
-              <wa-option value=${l.value} label="${l.flag} ${name}"
+              <wa-option value=${l.value} .label=${optionLabel}
                 >${l.flag} ${name}${this._renderCompleteness(l)}</wa-option
               >
             `;

--- a/test/components/settings-dialog/language-section.test.ts
+++ b/test/components/settings-dialog/language-section.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it } from "vitest";
 
 import type { LanguageOption, LocalizeFunc } from "../../../src/common/localize.js";
 import { ESPHomeSettingsLanguage } from "../../../src/components/settings-dialog/language-section.js";
-import { visitTemplates } from "../../_lit-template-walker.js";
+import {
+  extractAttributeBindings,
+  findTemplatesByAnchor,
+  visitTemplates,
+} from "../../_lit-template-walker.js";
 
 const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
 
@@ -62,11 +66,19 @@ describe("esphome-settings-language completeness badge", () => {
     expect(text).toContain("%");
   });
 
-  it("pins an explicit option label so the collapsed value drops the badge", () => {
+  it("pins an explicit per-option label that excludes the completeness badge", () => {
     // Without an explicit label, wa-select derives the collapsed display from
     // the option's text content, gluing the slot="end" badge onto the name
-    // ("Deutsch99%"). The render must carry a label= attribute (issue #1650).
-    expect(renderedText(render())).toContain('label="');
+    // ("Deutsch99%"). Every wa-option must bind a non-empty .label whose value
+    // carries the name but never the percent badge (issue #1650).
+    const options = findTemplatesByAnchor(render(), "<wa-option");
+    expect(options.length).toBeGreaterThan(0);
+    for (const option of options) {
+      const label = extractAttributeBindings(option)[".label"];
+      expect(typeof label).toBe("string");
+      expect(label as string).not.toContain("%");
+      expect((label as string).length).toBeGreaterThan(0);
+    }
   });
 
   it("omits the badge for a fully translated locale", () => {

--- a/test/components/settings-dialog/language-section.test.ts
+++ b/test/components/settings-dialog/language-section.test.ts
@@ -62,6 +62,13 @@ describe("esphome-settings-language completeness badge", () => {
     expect(text).toContain("%");
   });
 
+  it("pins an explicit option label so the collapsed value drops the badge", () => {
+    // Without an explicit label, wa-select derives the collapsed display from
+    // the option's text content, gluing the slot="end" badge onto the name
+    // ("Deutsch99%"). The render must carry a label= attribute (issue #1650).
+    expect(renderedText(render())).toContain('label="');
+  });
+
   it("omits the badge for a fully translated locale", () => {
     expect(
       renderCompleteness({


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

In Settings, Language, the collapsed dropdown showed the selected language with the translation percentage stuck onto it, like "Deutsch99%". The percentage is a slot="end" badge on each option; wa-select builds the collapsed value from the option's text content, which swallows that badge. This pins an explicit flag plus name label on each option, so the collapsed value reads "Deutsch" while the expanded list keeps the percentage badge.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1650

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
