### PR TITLE
Show value completion at an empty trailing-space value

### DIFF
--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -182,7 +182,16 @@ export function getTopLevelKey(state: EditorState, pos: number): string | null {
  */
 export function getKeyPath(state: EditorState, pos: number): string[] {
   const keys: string[] = [];
-  let cur = findEnclosingPair(syntaxTree(state).resolveInner(pos, -1));
+  const tree = syntaxTree(state);
+  let cur = findEnclosingPair(tree.resolveInner(pos, -1));
+  if (!cur) {
+    // A cursor in an empty value / trailing whitespace (``key: ``) resolves to
+    // the document root, not the pair. Re-anchor on the line's last non-space
+    // char (the ``:`` or key) so a nested ``key: `` still yields its path.
+    const line = state.doc.lineAt(pos);
+    const upto = line.text.slice(0, pos - line.from).trimEnd();
+    if (upto) cur = findEnclosingPair(tree.resolveInner(line.from + upto.length - 1, -1));
+  }
   while (cur) {
     const k = getPairKey(state, cur);
     if (k) keys.push(k);

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -31,6 +31,23 @@ describe("getKeyPath", () => {
     expect(pathAt(doc, "number").slice(1)).toEqual(["pin", "number"]);
   });
 
+  it("resolves a nested empty value at a trailing space (key: )", () => {
+    // ``minimum_chip_revision: `` with the cursor after the space resolves to
+    // the document root; re-anchoring on the line's last non-space char must
+    // still yield the full path so value completion fires.
+    const doc = "esp32:\n  framework:\n    advanced:\n      minimum_chip_revision: \n";
+    const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+    ensureSyntaxTree(state, state.doc.length);
+    const marker = "minimum_chip_revision: ";
+    const pos = doc.indexOf(marker) + marker.length;
+    expect(getKeyPath(state, pos)).toEqual([
+      "esp32",
+      "framework",
+      "advanced",
+      "minimum_chip_revision",
+    ]);
+  });
+
   it("returns [] outside any mapping pair", () => {
     expect(pathAt("# comment\n", "comment")).toEqual([]);
   });

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -150,11 +150,19 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
 
   it("completes a value inside a deeply nested mapping", async () => {
     // Value position two levels deep (``framework: advanced: verbose:``)
-    // exercises the value-position nested descent end to end. A partial
-    // value is present so the AST resolves the key path (an empty ``key: ``
-    // resolves to the document root and falls back to the schema lookup).
+    // exercises the value-position nested descent end to end.
     const labels = await labelsAt(
       ["esp32:", "  framework:", "    advanced:", "      verbose: t"].join("\n")
+    );
+    expect(labels).toEqual(["true", "false"]);
+  });
+
+  it("completes a nested value at a trailing space (empty partial)", async () => {
+    // Cursor after ``verbose: `` with no value typed yet: the empty value
+    // resolves to the document root, so getKeyPath re-anchors on the line to
+    // still surface the options instead of going silent.
+    const labels = await labelsAt(
+      ["esp32:", "  framework:", "    advanced:", "      verbose: "].join("\n")
     );
     expect(labels).toEqual(["true", "false"]);
   });


### PR DESCRIPTION
# What does this implement/fix?

In the YAML editor, value completion appeared at `key:` but vanished as soon as you typed the space (`key: `). It was most visible on nested fields; e.g. under `esp32: framework:` typing `type: ` offered nothing, and `framework: advanced: minimum_chip_revision: ` showed no value options.

Root cause: a cursor in an empty trailing-space value resolves to the document root, so `getKeyPath` returned `[]` and the nested value descent could not find the entry. The fix re-anchors `getKeyPath` on the line's last non-space character (the `:` or key) when the cursor sits in empty trailing whitespace, so the key path (and the value options) still resolve.

This is a follow-up to #939.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
