### PR TITLE
Offer idle autocomplete for key/value discovery

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -25,6 +25,7 @@ import {
 } from "../util/codemirror-theme.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
+import { idleCompletion } from "../util/idle-completion.js";
 import { getKeyPath } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
@@ -42,6 +43,9 @@ import { yamlStickyScroll } from "../util/yaml-sticky-scroll.js";
 import { CodeMirrorEditorElement } from "./codemirror-editor-element.js";
 
 export type HighlightRange = Pick<YamlSection, "fromLine" | "toLine">;
+
+// Delay before an at-rest caret opens the completion popup for discovery.
+const IDLE_COMPLETION_DELAY_MS = 1500;
 
 // `#` must be percent-encoded (`%23`) inside a data-URI background-image.
 const errorDot = (fill: string, stroke: string): string =>
@@ -449,7 +453,10 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           icons: true,
           closeOnBlur: true,
           maxRenderedOptions: 60,
-        })
+        }),
+        // Open the popup when the caret idles on a blank/empty line, so
+        // keys/values are discoverable without typing a partial first.
+        idleCompletion(IDLE_COMPLETION_DELAY_MS)
       );
       // Catalog-backed hover docs (description + "See also" link).
       extensions.push(

--- a/src/util/idle-completion.ts
+++ b/src/util/idle-completion.ts
@@ -1,0 +1,63 @@
+/**
+ * Idle autocompletion trigger for the YAML editor.
+ *
+ * The completion source only fires while typing (or on Ctrl-Space), so a
+ * caret resting on a blank indented line or an empty ``key:`` offers no
+ * discovery of what's allowed there. This extension opens the popup after
+ * the caret idles. ``startCompletion`` triggers an *explicit* completion,
+ * which the source answers even with an empty partial, so no change to the
+ * source's typing-time gate is needed.
+ */
+import { completionStatus, startCompletion } from "@codemirror/autocomplete";
+import type { EditorState } from "@codemirror/state";
+import { ViewPlugin, type EditorView, type ViewUpdate } from "@codemirror/view";
+import { matchKeyPosition, matchValuePosition } from "./yaml-completion-catalog.js";
+
+/**
+ * Whether an idle trigger should open the popup at the caret: a settled
+ * single caret at end of line, in a key or value discovery position, with
+ * no popup already open.
+ */
+export function shouldIdleComplete(state: EditorState): boolean {
+  if (completionStatus(state) !== null) return false;
+  const sel = state.selection.main;
+  if (!sel.empty) return false;
+  const line = state.doc.lineAt(sel.head);
+  if (sel.head !== line.to) return false;
+  const before = line.text.slice(0, sel.head - line.from);
+  return matchKeyPosition(before) !== null || matchValuePosition(before) !== null;
+}
+
+/** Open the completion popup *delayMs* after the caret last moved or the
+ *  doc last changed, for at-rest key/value discovery. */
+export function idleCompletion(delayMs: number) {
+  return ViewPlugin.fromClass(
+    class {
+      private timer: ReturnType<typeof setTimeout> | null = null;
+
+      update(update: ViewUpdate): void {
+        if (!update.docChanged && !update.selectionSet) return;
+        this.arm(update.view);
+      }
+
+      destroy(): void {
+        this.clear();
+      }
+
+      private arm(view: EditorView): void {
+        this.clear();
+        this.timer = setTimeout(() => {
+          this.timer = null;
+          if (shouldIdleComplete(view.state)) startCompletion(view);
+        }, delayMs);
+      }
+
+      private clear(): void {
+        if (this.timer !== null) {
+          clearTimeout(this.timer);
+          this.timer = null;
+        }
+      }
+    }
+  );
+}

--- a/src/util/idle-completion.ts
+++ b/src/util/idle-completion.ts
@@ -42,6 +42,14 @@ export function idleCompletion(delayMs: number) {
       private timer: ReturnType<typeof setTimeout> | null = null;
 
       update(update: ViewUpdate): void {
+        // While a popup is open (or pending), cancel any idle timer — checked
+        // on every update so the popup-open transaction clears the timer that
+        // the preceding keystroke armed. Otherwise dismissing with Esc (which
+        // fires no doc/selection update) could leave that timer to re-open it.
+        if (completionStatus(update.state) !== null) {
+          this.clear();
+          return;
+        }
         if (!update.docChanged && !update.selectionSet) return;
         this.arm(update.view);
       }

--- a/src/util/idle-completion.ts
+++ b/src/util/idle-completion.ts
@@ -15,10 +15,11 @@ import { matchKeyPosition, matchValuePosition } from "./yaml-completion-catalog.
 
 /**
  * Whether an idle trigger should open the popup at the caret: a settled
- * single caret at end of line, at an *empty* discovery position (a blank
- * indented key line or an empty ``key: `` value), with no popup already
- * open. Empty-only so it doesn't re-pop over a partial still being typed or
- * a value the user already chose.
+ * single caret at end of line, at an *empty, indented* discovery position (a
+ * blank nested key line or an empty ``key: `` value), with no popup already
+ * open. Empty-only so it doesn't re-pop over a partial still being typed or a
+ * value the user already chose; indented-only so it doesn't surface the whole
+ * top-level component list when the caret merely rests at column 0.
  */
 export function shouldIdleComplete(state: EditorState): boolean {
   if (completionStatus(state) !== null) return false;
@@ -28,9 +29,9 @@ export function shouldIdleComplete(state: EditorState): boolean {
   if (sel.head !== line.to) return false;
   const before = line.text.slice(0, sel.head - line.from);
   const valuePos = matchValuePosition(before);
-  if (valuePos) return valuePos.partial === "";
+  if (valuePos) return valuePos.partial === "" && valuePos.leading.length > 0;
   const keyPos = matchKeyPosition(before);
-  return keyPos !== null && keyPos.partial === "";
+  return keyPos !== null && keyPos.partial === "" && keyPos.leading.length > 0;
 }
 
 /** Open the completion popup *delayMs* after the caret last moved or the

--- a/src/util/idle-completion.ts
+++ b/src/util/idle-completion.ts
@@ -15,8 +15,10 @@ import { matchKeyPosition, matchValuePosition } from "./yaml-completion-catalog.
 
 /**
  * Whether an idle trigger should open the popup at the caret: a settled
- * single caret at end of line, in a key or value discovery position, with
- * no popup already open.
+ * single caret at end of line, at an *empty* discovery position (a blank
+ * indented key line or an empty ``key: `` value), with no popup already
+ * open. Empty-only so it doesn't re-pop over a partial still being typed or
+ * a value the user already chose.
  */
 export function shouldIdleComplete(state: EditorState): boolean {
   if (completionStatus(state) !== null) return false;
@@ -25,7 +27,10 @@ export function shouldIdleComplete(state: EditorState): boolean {
   const line = state.doc.lineAt(sel.head);
   if (sel.head !== line.to) return false;
   const before = line.text.slice(0, sel.head - line.from);
-  return matchKeyPosition(before) !== null || matchValuePosition(before) !== null;
+  const valuePos = matchValuePosition(before);
+  if (valuePos) return valuePos.partial === "";
+  const keyPos = matchKeyPosition(before);
+  return keyPos !== null && keyPos.partial === "";
 }
 
 /** Open the completion popup *delayMs* after the caret last moved or the
@@ -48,7 +53,8 @@ export function idleCompletion(delayMs: number) {
         this.clear();
         this.timer = setTimeout(() => {
           this.timer = null;
-          if (shouldIdleComplete(view.state)) startCompletion(view);
+          // Don't pop up on an editor the user has since clicked away from.
+          if (view.hasFocus && shouldIdleComplete(view.state)) startCompletion(view);
         }, delayMs);
       }
 

--- a/src/util/idle-completion.ts
+++ b/src/util/idle-completion.ts
@@ -28,10 +28,10 @@ export function shouldIdleComplete(state: EditorState): boolean {
   const line = state.doc.lineAt(sel.head);
   if (sel.head !== line.to) return false;
   const before = line.text.slice(0, sel.head - line.from);
-  const valuePos = matchValuePosition(before);
-  if (valuePos) return valuePos.partial === "" && valuePos.leading.length > 0;
-  const keyPos = matchKeyPosition(before);
-  return keyPos !== null && keyPos.partial === "" && keyPos.leading.length > 0;
+  // An empty partial at an indented position (a blank nested key line or an
+  // empty ``key: `` value). Value position wins where both could match.
+  const match = matchValuePosition(before) ?? matchKeyPosition(before);
+  return match !== null && match.partial === "" && match.leading.length > 0;
 }
 
 /** Open the completion popup *delayMs* after the caret last moved or the

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -16,7 +16,12 @@ import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.js";
 import { fetchComponent } from "./component-name-cache.js";
 import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
-import { findTopLevelBlock, readPlatformSibling } from "./yaml-line-walker.js";
+import {
+  findTopLevelBlock,
+  indentOf,
+  keyPathByIndent,
+  readPlatformSibling,
+} from "./yaml-line-walker.js";
 
 // ``validFor`` regex constants — consumed by CodeMirror to decide
 // whether cached completion options stay valid as the user types.
@@ -293,16 +298,23 @@ export async function resolveAvailableEntries(
  * Compute the nested-group descent path for ``resolveAvailableEntries``:
  * the key chain from just under the top-level component down to and
  * including *parentKey*. Returns ``[]`` when *parentKey* is the top-level
- * key itself or doesn't appear on the cursor's AST key path (safe
- * no-descent fallback when the AST and the regex walker disagree).
+ * key itself or doesn't appear on the cursor's key path (safe no-descent
+ * fallback).
  */
 export function nestedPathForParent(
   state: EditorState,
   pos: number,
   parentKey: string
 ): string[] {
-  const path = getKeyPath(state, pos);
-  const idx = path.lastIndexOf(parentKey);
+  let path = getKeyPath(state, pos);
+  let idx = path.lastIndexOf(parentKey);
+  if (idx < 1) {
+    // The AST can't anchor on a blank indented line (no Pair). Rebuild the
+    // chain from indentation so nested discovery still resolves there.
+    const line = state.doc.lineAt(pos);
+    path = keyPathByIndent(state.doc, line.number - 1, indentOf(line.text));
+    idx = path.lastIndexOf(parentKey);
+  }
   if (idx < 1) return [];
   return path.slice(1, idx + 1);
 }

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -17,8 +17,8 @@ import { ConfigEntryType, type ConfigEntry } from "../api/types/config-entries.j
 import { fetchComponent } from "./component-name-cache.js";
 import { getKeyPath, resolveBundleContext } from "./yaml-ast.js";
 import {
+  blankLineContext,
   findTopLevelBlock,
-  indentOf,
   keyPathByIndent,
   readPlatformSibling,
 } from "./yaml-line-walker.js";
@@ -306,17 +306,17 @@ export function nestedPathForParent(
   pos: number,
   parentKey: string
 ): string[] {
-  let path = getKeyPath(state, pos);
-  let idx = path.lastIndexOf(parentKey);
-  const line = state.doc.lineAt(pos);
-  // Only rebuild from indentation on a genuinely blank line, where the AST
-  // has no Pair to anchor on. Elsewhere a missing parentKey means the AST and
-  // regex walkers disagree (e.g. a list-item context), and the indent walk
-  // could synthesise a sibling-laden path — keep the safe no-descent result.
-  if (idx < 1 && line.text.slice(0, pos - line.from).trim() === "") {
-    path = keyPathByIndent(state.doc, line.number - 1, indentOf(line.text));
-    idx = path.lastIndexOf(parentKey);
-  }
+  // On a genuinely blank line the AST has no Pair to anchor on (``getKeyPath``
+  // returns ``[]``), so build the chain from indentation instead. Elsewhere
+  // stay on the AST: a missing parentKey there means the walkers disagree
+  // (e.g. a list-item context), where the indent walk could synthesise a
+  // sibling-laden path. (The fallback is kept here, not inside ``getKeyPath``,
+  // so its AST-only callers — hover, the cursor-line event — still get ``[]``.)
+  const blank = blankLineContext(state.doc, pos);
+  const path = blank
+    ? keyPathByIndent(state.doc, blank.lineIdx, blank.indent)
+    : getKeyPath(state, pos);
+  const idx = path.lastIndexOf(parentKey);
   if (idx < 1) return [];
   return path.slice(1, idx + 1);
 }

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -308,10 +308,12 @@ export function nestedPathForParent(
 ): string[] {
   let path = getKeyPath(state, pos);
   let idx = path.lastIndexOf(parentKey);
-  if (idx < 1) {
-    // The AST can't anchor on a blank indented line (no Pair). Rebuild the
-    // chain from indentation so nested discovery still resolves there.
-    const line = state.doc.lineAt(pos);
+  const line = state.doc.lineAt(pos);
+  // Only rebuild from indentation on a genuinely blank line, where the AST
+  // has no Pair to anchor on. Elsewhere a missing parentKey means the AST and
+  // regex walkers disagree (e.g. a list-item context), and the indent walk
+  // could synthesise a sibling-laden path — keep the safe no-descent result.
+  if (idx < 1 && line.text.slice(0, pos - line.from).trim() === "") {
     path = keyPathByIndent(state.doc, line.number - 1, indentOf(line.text));
     idx = path.lastIndexOf(parentKey);
   }

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -20,6 +20,7 @@
  *      block (e.g. inside `sensor:` we suggest sensor platforms).
  */
 import { type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
+import type { EditorState } from "@codemirror/state";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import {
@@ -55,10 +56,21 @@ import {
   type KeyPositionCtx,
 } from "./yaml-completion-providers.js";
 import {
+  blankLineContext,
+  collectSiblingKeysByIndent,
   findParentKey,
   findTopLevelBlock,
   RE_INLINE_COMMENT_BOUNDARY,
 } from "./yaml-line-walker.js";
+
+/** Keys already set in the cursor's mapping, for the already-set filter.
+ *  On a blank line the AST has no Pair to anchor on, so scan by indent. */
+function siblingKeysAt(state: EditorState, pos: number): Set<string> {
+  const blank = blankLineContext(state.doc, pos);
+  return blank
+    ? collectSiblingKeysByIndent(state.doc, blank.lineIdx, blank.indent)
+    : collectSiblingKeys(state, pos);
+}
 
 // ── Public surface preserved across the catalog / provider split ──
 // Consumers (``yaml-hover``, ``yaml-completion-items``, the
@@ -290,7 +302,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     // components (catalog entries whose id has no dot). See
     // ``buildTopLevelCompletions`` for the rationale.
     if (indent === 0) {
-      const present = collectSiblingKeys(state, pos);
+      const present = siblingKeysAt(state, pos);
       return {
         from: keyFrom,
         options: buildTopLevelCompletions(catalog).filter((c) => !present.has(c.label)),
@@ -337,7 +349,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     // Drop keys already set in this mapping (plain key position only —
     // list items like automation actions / filters are repeatable).
     if (!isListItem) {
-      const present = collectSiblingKeys(state, pos);
+      const present = siblingKeysAt(state, pos);
       if (present.size > 0) options = options.filter((o) => !present.has(o.label));
     }
     if (options.length === 0) return null;

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -93,6 +93,28 @@ export function findParentKey(
   return null;
 }
 
+/**
+ * Build the full ancestor key chain (top-down) for a line by walking
+ * outward through strictly-decreasing indents — e.g. a line under
+ * ``esp32:`` → ``framework:`` yields ``["esp32", "framework"]``. Unlike
+ * the AST ``getKeyPath``, this is blank-line tolerant, so it resolves the
+ * nested context of an empty indented line (which has no Pair to anchor
+ * on). Returns ``[]`` at the top level.
+ */
+export function keyPathByIndent(doc: Text, lineIdx: number, indent: number): string[] {
+  const chain: string[] = [];
+  let below = indent;
+  let from = lineIdx;
+  for (;;) {
+    const p = findParentKey(doc, from, below);
+    if (!p) break;
+    chain.push(p.key);
+    below = p.indent;
+    from = p.lineIdx;
+  }
+  return chain.reverse();
+}
+
 /** Walk back from *lineIdx* to the first column-0 ``key:`` line. */
 export function findTopLevelBlock(doc: Text, lineIdx: number): string | null {
   for (let i = lineIdx - 1; i >= 0; i--) {

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -94,18 +94,23 @@ export function findParentKey(
 }
 
 /**
- * When everything before *pos* on its line is whitespace (a blank line the
- * caret sits on), return that line's 0-based index and indent — the inputs
- * the indent walkers need. The AST can't anchor on such a line (no Pair), so
- * callers fall back to the indent-based walkers. ``null`` otherwise.
+ * When the caret sits on a wholly blank line, return that line's 0-based
+ * index and the caret's indent — the inputs the indent walkers need. The AST
+ * can't anchor on such a line (no Pair), so callers fall back to the
+ * indent-based walkers. ``null`` otherwise (including a caret in the
+ * indentation of a non-blank ``key:`` line, which the AST resolves fine).
  */
 export function blankLineContext(
   doc: Text,
   pos: number
 ): { lineIdx: number; indent: number } | null {
   const line = doc.lineAt(pos);
-  if (line.text.slice(0, pos - line.from).trim() !== "") return null;
-  return { lineIdx: line.number - 1, indent: indentOf(line.text) };
+  // The whole line must be blank, not just the text before the caret — a
+  // caret in the indentation of an existing ``key:`` line is not a blank line
+  // (the AST resolves it fine), and treating it as blank would switch callers
+  // to the indent scan and miss that line's key.
+  if (line.text.trim() !== "") return null;
+  return { lineIdx: line.number - 1, indent: pos - line.from };
 }
 
 /**

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -94,6 +94,21 @@ export function findParentKey(
 }
 
 /**
+ * When everything before *pos* on its line is whitespace (a blank line the
+ * caret sits on), return that line's 0-based index and indent — the inputs
+ * the indent walkers need. The AST can't anchor on such a line (no Pair), so
+ * callers fall back to the indent-based walkers. ``null`` otherwise.
+ */
+export function blankLineContext(
+  doc: Text,
+  pos: number
+): { lineIdx: number; indent: number } | null {
+  const line = doc.lineAt(pos);
+  if (line.text.slice(0, pos - line.from).trim() !== "") return null;
+  return { lineIdx: line.number - 1, indent: indentOf(line.text) };
+}
+
+/**
  * Build the full ancestor key chain (top-down) for a line by walking
  * outward through strictly-decreasing indents — e.g. a line under
  * ``esp32:`` → ``framework:`` yields ``["esp32", "framework"]``. Unlike
@@ -113,6 +128,37 @@ export function keyPathByIndent(doc: Text, lineIdx: number, indent: number): str
     from = p.lineIdx;
   }
   return chain.reverse();
+}
+
+/**
+ * Collect the keys of the mapping at *indent* surrounding *lineIdx* by
+ * scanning lines, not the AST. Used when the cursor is on a blank line —
+ * where the AST has no Pair to anchor on — so the already-set-key filter
+ * still works. Bounded to the enclosing block: stops at the first line that
+ * dedents below *indent* in each direction; deeper lines (children of a
+ * sibling) are skipped.
+ */
+export function collectSiblingKeysByIndent(
+  doc: Text,
+  lineIdx: number,
+  indent: number
+): Set<string> {
+  const out = new Set<string>();
+  const scan = (from: number, step: number): void => {
+    for (let i = from; i >= 0 && i < doc.lines; i += step) {
+      const stripped = stripComment(doc.line(i + 1).text);
+      if (!stripped.trim()) continue;
+      const ind = indentOf(stripped);
+      if (ind < indent) break;
+      if (ind === indent) {
+        const m = stripped.match(RE_PAIR_LINE);
+        if (m) out.add(m[1]);
+      }
+    }
+  };
+  scan(lineIdx - 1, -1);
+  scan(lineIdx + 1, 1);
+  return out;
 }
 
 /** Walk back from *lineIdx* to the first column-0 ``key:`` line. */

--- a/test/util/idle-completion.test.ts
+++ b/test/util/idle-completion.test.ts
@@ -1,17 +1,21 @@
 // @vitest-environment happy-dom
-import { startCompletion } from "@codemirror/autocomplete";
+import { completionStatus, startCompletion } from "@codemirror/autocomplete";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
 import { idleCompletion, shouldIdleComplete } from "../../src/util/idle-completion.js";
 
-// Spy on startCompletion (keep everything else real) so the timer tests can
-// assert when the plugin would open the popup without standing up the full
-// completion machinery.
+// Spy on startCompletion and make completionStatus controllable, so the timer
+// tests can assert when the plugin would open the popup (and that an active
+// popup cancels a pending timer) without standing up the completion machinery.
 vi.mock("@codemirror/autocomplete", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codemirror/autocomplete")>();
-  return { ...actual, startCompletion: vi.fn(() => true) };
+  return {
+    ...actual,
+    startCompletion: vi.fn(() => true),
+    completionStatus: vi.fn(actual.completionStatus),
+  };
 });
 
 function stateAt(doc: string, head = doc.length, anchor = head): EditorState {
@@ -60,9 +64,12 @@ describe("shouldIdleComplete", () => {
 
 describe("idleCompletion (timer)", () => {
   const spy = vi.mocked(startCompletion);
+  const status = vi.mocked(completionStatus);
+  const realStatus = status.getMockImplementation()!;
   beforeEach(() => {
     vi.useFakeTimers();
     spy.mockClear();
+    status.mockImplementation(realStatus);
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -127,5 +134,16 @@ describe("idleCompletion (timer)", () => {
     view.destroy();
     vi.advanceTimersByTime(1000);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending timer once a completion is active (no reopen after Esc)", () => {
+    const view = mkView();
+    toEnd(view); // armed while no popup is open
+    status.mockReturnValue("active"); // popup opened
+    view.dispatch({ selection: EditorSelection.single(view.state.doc.length - 1) });
+    status.mockReturnValue(null); // dismissed with Esc (no doc/selection update)
+    vi.advanceTimersByTime(2000);
+    expect(spy).not.toHaveBeenCalled();
+    view.destroy();
   });
 });

--- a/test/util/idle-completion.test.ts
+++ b/test/util/idle-completion.test.ts
@@ -1,7 +1,18 @@
+// @vitest-environment happy-dom
+import { startCompletion } from "@codemirror/autocomplete";
 import { EditorSelection, EditorState } from "@codemirror/state";
-import { describe, expect, it } from "vitest";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
-import { shouldIdleComplete } from "../../src/util/idle-completion.js";
+import { idleCompletion, shouldIdleComplete } from "../../src/util/idle-completion.js";
+
+// Spy on startCompletion (keep everything else real) so the timer tests can
+// assert when the plugin would open the popup without standing up the full
+// completion machinery.
+vi.mock("@codemirror/autocomplete", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codemirror/autocomplete")>();
+  return { ...actual, startCompletion: vi.fn(() => true) };
+});
 
 function stateAt(doc: string, head = doc.length, anchor = head): EditorState {
   return EditorState.create({
@@ -20,8 +31,12 @@ describe("shouldIdleComplete", () => {
     expect(shouldIdleComplete(stateAt("esp32:\n  framework:\n    type: "))).toBe(true);
   });
 
-  it("fires at a key partial", () => {
-    expect(shouldIdleComplete(stateAt("esp32:\n  fra"))).toBe(true);
+  it("does not fire at a key partial (typing already drives that)", () => {
+    expect(shouldIdleComplete(stateAt("esp32:\n  fra"))).toBe(false);
+  });
+
+  it("does not fire on a chosen value (no re-pop after accepting)", () => {
+    expect(shouldIdleComplete(stateAt("logger:\n  baud_rate: 115200"))).toBe(false);
   });
 
   it("does not fire mid-line", () => {
@@ -40,5 +55,71 @@ describe("shouldIdleComplete", () => {
   it("does not fire with a non-empty selection", () => {
     const doc = "esp32:\n  framework:\n    ";
     expect(shouldIdleComplete(stateAt(doc, doc.length, doc.length - 4))).toBe(false);
+  });
+});
+
+describe("idleCompletion (timer)", () => {
+  const spy = vi.mocked(startCompletion);
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spy.mockClear();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // Blank indented line under a block; caret starts at column 0 so the first
+  // dispatch is a real selection move (arms the timer). Mounted + focused so
+  // the focus guard passes.
+  const mkView = (focus = true) => {
+    const view = new EditorView({
+      parent: document.body,
+      state: EditorState.create({
+        doc: "esp32:\n  framework:\n    ",
+        selection: EditorSelection.single(0),
+        extensions: [esphomeYaml(), idleCompletion(1000)],
+      }),
+    });
+    if (focus) view.focus();
+    return view;
+  };
+  const toEnd = (view: EditorView) =>
+    view.dispatch({ selection: EditorSelection.single(view.state.doc.length) });
+
+  it("opens the popup once after the idle delay", () => {
+    const view = mkView();
+    toEnd(view);
+    expect(spy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalledTimes(1);
+    view.destroy();
+  });
+
+  it("debounces rapid updates into a single fire", () => {
+    const view = mkView();
+    toEnd(view);
+    vi.advanceTimersByTime(600);
+    view.dispatch({ selection: EditorSelection.single(view.state.doc.length - 1) });
+    vi.advanceTimersByTime(600); // re-armed, not yet elapsed
+    expect(spy).not.toHaveBeenCalled();
+    view.dispatch({ selection: EditorSelection.single(view.state.doc.length) });
+    vi.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalledTimes(1);
+    view.destroy();
+  });
+
+  it("does not fire when the editor is not focused", () => {
+    const view = mkView(false);
+    view.contentDOM.blur();
+    toEnd(view);
+    vi.advanceTimersByTime(1000);
+    expect(spy).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it("clears the timer on destroy", () => {
+    const view = mkView();
+    toEnd(view);
+    view.destroy();
+    vi.advanceTimersByTime(1000);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/test/util/idle-completion.test.ts
+++ b/test/util/idle-completion.test.ts
@@ -1,0 +1,44 @@
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { shouldIdleComplete } from "../../src/util/idle-completion.js";
+
+function stateAt(doc: string, head = doc.length, anchor = head): EditorState {
+  return EditorState.create({
+    doc,
+    selection: EditorSelection.single(anchor, head),
+    extensions: [esphomeYaml()],
+  });
+}
+
+describe("shouldIdleComplete", () => {
+  it("fires on a blank indented line at end of line", () => {
+    expect(shouldIdleComplete(stateAt("esp32:\n  framework:\n    "))).toBe(true);
+  });
+
+  it("fires at an empty value (key: )", () => {
+    expect(shouldIdleComplete(stateAt("esp32:\n  framework:\n    type: "))).toBe(true);
+  });
+
+  it("fires at a key partial", () => {
+    expect(shouldIdleComplete(stateAt("esp32:\n  fra"))).toBe(true);
+  });
+
+  it("does not fire mid-line", () => {
+    const doc = "esphome:\n  name: My Device";
+    expect(shouldIdleComplete(stateAt(doc, doc.indexOf("My")))).toBe(false);
+  });
+
+  it("does not fire on a completed multi-word value", () => {
+    expect(shouldIdleComplete(stateAt("esphome:\n  name: My Device"))).toBe(false);
+  });
+
+  it("does not fire inside a comment", () => {
+    expect(shouldIdleComplete(stateAt("esp32:\n  # a comment"))).toBe(false);
+  });
+
+  it("does not fire with a non-empty selection", () => {
+    const doc = "esp32:\n  framework:\n    ";
+    expect(shouldIdleComplete(stateAt(doc, doc.length, doc.length - 4))).toBe(false);
+  });
+});

--- a/test/util/idle-completion.test.ts
+++ b/test/util/idle-completion.test.ts
@@ -64,7 +64,13 @@ describe("idleCompletion (timer)", () => {
     vi.useFakeTimers();
     spy.mockClear();
   });
-  afterEach(() => vi.useRealTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    // ``view.destroy()`` leaves the mounted DOM node in ``document.body``;
+    // clear it so editors don't accumulate and ``activeElement`` can't stay
+    // on a stale node across tests (would make the focus checks flaky).
+    document.body.replaceChildren();
+  });
 
   // Blank indented line under a block; caret starts at column 0 so the first
   // dispatch is a real selection move (arms the timer). Mounted + focused so

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -67,7 +67,7 @@ const fakeApi = {
   getComponent: async () => null,
 } as never;
 
-async function labelsAt(yaml: string): Promise<string[]> {
+async function labelsAt(yaml: string, explicit = false): Promise<string[]> {
   // Drive a real view + full parse so the AST helpers see the same tree a
   // live editor does (a bare state parses lazily and misses the cursor's tail).
   const view = new EditorView({
@@ -75,7 +75,7 @@ async function labelsAt(yaml: string): Promise<string[]> {
   });
   try {
     forceParsing(view, yaml.length, 60000);
-    const ctx = new CompletionContext(view.state, yaml.length, false);
+    const ctx = new CompletionContext(view.state, yaml.length, explicit);
     const result = await createYamlCompletionSource(fakeApi)(ctx);
     return (result?.options ?? []).map((o) => o.label);
   } finally {
@@ -118,6 +118,14 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     const labels = await labelsAt(
       ["esp32:", "  board: esp32-poe-iso", "  framework:", "    a"].join("\n")
     );
+    expect(labels).toContain("advanced");
+    expect(labels).toContain("version");
+  });
+
+  it("offers nested keys on a blank indented line when triggered explicitly (idle)", async () => {
+    // The caret rests on a blank line under ``framework:`` with no partial;
+    // an explicit (idle) trigger must still surface the framework fields.
+    const labels = await labelsAt(["esp32:", "  framework:", "    "].join("\n"), true);
     expect(labels).toContain("advanced");
     expect(labels).toContain("version");
   });

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -130,6 +130,17 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     expect(labels).toContain("version");
   });
 
+  it("filters already-set siblings on a blank indented line", async () => {
+    // The AST can't read siblings on a blank line; an indent scan must still
+    // drop a key already set in the mapping (``version`` here).
+    const labels = await labelsAt(
+      ["esp32:", "  framework:", "    version: 5.0", "    "].join("\n"),
+      true
+    );
+    expect(labels).toContain("advanced");
+    expect(labels).not.toContain("version");
+  });
+
   it("offers each list item's own fields without cross-item filtering", async () => {
     // Two ``- platform: template`` sensors: ``name`` is set in the first
     // item only, so the second item must still offer it (list items are

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -93,6 +93,16 @@ describe("nestedPathForParent", () => {
     const yaml = ["esp32:", "  framework:", "    a"].join("\n");
     expect(pathAt(yaml, "platform")).toEqual([]);
   });
+
+  it("resolves a blank indented line via indentation (AST is silent there)", () => {
+    const yaml = ["esp32:", "  framework:", "    "].join("\n");
+    expect(pathAt(yaml, "framework")).toEqual(["framework"]);
+  });
+
+  it("resolves a deep blank line via indentation", () => {
+    const yaml = ["esp32:", "  framework:", "    advanced:", "      "].join("\n");
+    expect(pathAt(yaml, "advanced")).toEqual(["framework", "advanced"]);
+  });
 });
 
 describe("resolveAvailableEntries (nested descent)", () => {

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -4,6 +4,7 @@ import {
   findParentKey,
   findTopLevelBlock,
   indentOf,
+  keyPathByIndent,
   readPlatformSibling,
   stripComment,
 } from "../../src/util/yaml-line-walker.js";
@@ -163,5 +164,27 @@ describe("readPlatformSibling (regex fallback)", () => {
   it("returns null when there's no platform sibling", () => {
     const lines = ["wifi:", "  ssid: x", "  password: y"];
     expect(readPlatformSibling(t(lines), 2, 2)).toBeNull();
+  });
+});
+
+describe("keyPathByIndent", () => {
+  it("builds the full ancestor chain for a blank nested line", () => {
+    const lines = ["esp32:", "  framework:", "    type: esp-idf", "    "];
+    expect(keyPathByIndent(t(lines), 3, 4)).toEqual(["esp32", "framework"]);
+  });
+
+  it("descends two nested levels", () => {
+    const lines = ["esp32:", "  framework:", "    advanced:", "      "];
+    expect(keyPathByIndent(t(lines), 3, 6)).toEqual(["esp32", "framework", "advanced"]);
+  });
+
+  it("returns [] at the top level", () => {
+    const lines = ["esp32:", "  board: x", ""];
+    expect(keyPathByIndent(t(lines), 2, 0)).toEqual([]);
+  });
+
+  it("skips blank lines between siblings", () => {
+    const lines = ["esp32:", "  framework:", "", "    type: a", "    "];
+    expect(keyPathByIndent(t(lines), 4, 4)).toEqual(["esp32", "framework"]);
   });
 });

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -1,6 +1,8 @@
 import { Text } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import {
+  blankLineContext,
+  collectSiblingKeysByIndent,
   findParentKey,
   findTopLevelBlock,
   indentOf,
@@ -181,6 +183,36 @@ describe("keyPathByIndent", () => {
   it("returns [] at the top level", () => {
     const lines = ["esp32:", "  board: x", ""];
     expect(keyPathByIndent(t(lines), 2, 0)).toEqual([]);
+  });
+
+  it("collectSiblingKeysByIndent collects the mapping's keys at the cursor indent", () => {
+    const lines = ["ethernet:", "  clk:", "    mode: CLK_EXT_IN", "    pin: 0", "    "];
+    expect([...collectSiblingKeysByIndent(t(lines), 4, 4)].sort()).toEqual([
+      "mode",
+      "pin",
+    ]);
+  });
+
+  it("collectSiblingKeysByIndent skips deeper descendants and other blocks", () => {
+    const lines = [
+      "esp32:",
+      "  framework:",
+      "    advanced:",
+      "      x: 1",
+      "    version: 5",
+      "    ",
+    ];
+    expect([...collectSiblingKeysByIndent(t(lines), 5, 4)].sort()).toEqual([
+      "advanced",
+      "version",
+    ]);
+  });
+
+  it("blankLineContext reports a blank indented line, else null", () => {
+    const blank = t(["esp32:", "  framework:", "    "]);
+    expect(blankLineContext(blank, blank.length)).toEqual({ lineIdx: 2, indent: 4 });
+    const filled = t(["esp32:", "  board: x"]);
+    expect(blankLineContext(filled, filled.length)).toBeNull();
   });
 
   it("skips blank lines between siblings", () => {

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -223,4 +223,12 @@ describe("blankLineContext", () => {
     const filled = t(["esp32:", "  board: x"]);
     expect(blankLineContext(filled, filled.length)).toBeNull();
   });
+
+  it("returns null for a caret in the indentation of a non-blank line", () => {
+    // Whole-line check: a caret at column 2 of ``  board: x`` is not a blank
+    // line, even though the text before the caret is whitespace.
+    const doc = t(["esp32:", "  board: x"]);
+    const line2 = doc.line(2);
+    expect(blankLineContext(doc, line2.from + 2)).toBeNull();
+  });
 });

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -185,7 +185,14 @@ describe("keyPathByIndent", () => {
     expect(keyPathByIndent(t(lines), 2, 0)).toEqual([]);
   });
 
-  it("collectSiblingKeysByIndent collects the mapping's keys at the cursor indent", () => {
+  it("skips blank lines between siblings", () => {
+    const lines = ["esp32:", "  framework:", "", "    type: a", "    "];
+    expect(keyPathByIndent(t(lines), 4, 4)).toEqual(["esp32", "framework"]);
+  });
+});
+
+describe("collectSiblingKeysByIndent", () => {
+  it("collects the mapping's keys at the cursor indent", () => {
     const lines = ["ethernet:", "  clk:", "    mode: CLK_EXT_IN", "    pin: 0", "    "];
     expect([...collectSiblingKeysByIndent(t(lines), 4, 4)].sort()).toEqual([
       "mode",
@@ -193,7 +200,7 @@ describe("keyPathByIndent", () => {
     ]);
   });
 
-  it("collectSiblingKeysByIndent skips deeper descendants and other blocks", () => {
+  it("skips deeper descendants and other blocks", () => {
     const lines = [
       "esp32:",
       "  framework:",
@@ -207,16 +214,13 @@ describe("keyPathByIndent", () => {
       "version",
     ]);
   });
+});
 
-  it("blankLineContext reports a blank indented line, else null", () => {
+describe("blankLineContext", () => {
+  it("reports a blank indented line, else null", () => {
     const blank = t(["esp32:", "  framework:", "    "]);
     expect(blankLineContext(blank, blank.length)).toEqual({ lineIdx: 2, indent: 4 });
     const filled = t(["esp32:", "  board: x"]);
     expect(blankLineContext(filled, filled.length)).toBeNull();
-  });
-
-  it("skips blank lines between siblings", () => {
-    const lines = ["esp32:", "  framework:", "", "    type: a", "    "];
-    expect(keyPathByIndent(t(lines), 4, 4)).toEqual(["esp32", "framework"]);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The YAML editor only offered completion once you started typing a partial, so on a blank indented line or an empty `key:` there was no way to discover what was allowed. Now the popup opens when the caret idles (~1.5s) on a blank/indented line or an empty key/value, so keys and values are discoverable without typing first.

How it works:

- A small `idleCompletion` editor extension opens the popup after the caret settles, only when no popup is already open, the selection is an empty caret at end of line, and the position is a key or value spot (reusing the existing `matchKeyPosition` / `matchValuePosition` matchers). It calls `startCompletion`, which is an explicit completion, so the source's typing-time gate is untouched and ordinary typing behaves exactly as before.
- A new `keyPathByIndent` walker lets nested discovery resolve on a blank line, where the AST has no pair to anchor on; `nestedPathForParent` falls back to it so a blank line under `esp32: framework:` still offers the framework fields.

This is a follow-up to #939.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
