### PR TITLE
Extract bulk-update orchestration into a shared helper

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -16,11 +16,9 @@ import { LitElement, html, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import toast from "sonner-js";
-import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { AdoptableDevice, ConfiguredDevice, Label } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
-import { ErrorCode } from "../api/types/protocol.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { ArchivedDevice } from "../api/types/system.js";
 import { DashboardView } from "../api/types/system.js";
@@ -99,6 +97,7 @@ import {
 } from "../context/index.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { runBulkUpdate } from "../util/bulk-update.js";
 import { readDashboardUrl, writeDashboardUrl } from "../util/dashboard-url.js";
 import {
   activeFacetCount,
@@ -116,7 +115,6 @@ import { consumePendingHighlight } from "../util/pending-highlight.js";
 import { consumePendingSerialSetup } from "../util/pending-serial-setup.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
-import { classifyNoCompatiblePeerReason } from "../util/version-mismatch.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../components/adopt-dialog.js";
@@ -213,9 +211,9 @@ export class ESPHomePageDashboard extends LitElement {
     return this._remoteComputeOnly || !this._prefsLoaded;
   }
 
-  // Used by the NO_COMPATIBLE_PEER toast classifier — see
-  // classifyNoCompatiblePeerReason. Same context the settings
-  // dialog reads; null until the subscribe_events seed lands.
+  // Passed to runBulkUpdate for the NO_COMPATIBLE_PEER toast
+  // classifier. Same context the settings dialog reads; null until
+  // the subscribe_events seed lands.
   @consume({ context: buildOffloadPairingsContext, subscribe: true })
   @state()
   _pairings: Map<string, PairingSummary> | null = null;
@@ -873,38 +871,12 @@ export class ESPHomePageDashboard extends LitElement {
     const selected = [...this._selectedDevices];
     this._selectMode = false;
     this._selectedDevices = new Set();
-    if (selected.length === 0) {
-      toast.info(this._localize("layout.update_all_none"), { richColors: true });
-      return;
-    }
-    toast.info(this._localize("layout.update_all_started", { count: selected.length }), {
-      richColors: true,
+    await runBulkUpdate(selected, {
+      api: this._api,
+      localize: this._localize,
+      appVersion: this._appVersion,
+      pairings: this._pairings?.values() ?? [],
     });
-    try {
-      await this._api.firmwareInstallBulk(selected);
-    } catch (err) {
-      if (
-        err instanceof APIError &&
-        err.errorCode === ErrorCode.NO_COMPATIBLE_PEER &&
-        this._appVersion
-      ) {
-        // ``_appVersion`` empty during a reconnect race would leak
-        // into the ``{local}`` placeholder and misattribute the
-        // bucket; fall through to the generic toast.
-        const reason = classifyNoCompatiblePeerReason(
-          this._pairings?.values() ?? [],
-          this._appVersion
-        );
-        toast.error(
-          this._localize(`layout.update_all_no_compatible_peer_${reason}`, {
-            local: this._appVersion,
-          }),
-          { richColors: true }
-        );
-      } else {
-        toast.error(this._localize("layout.update_all_error"), { richColors: true });
-      }
-    }
   };
 
   _openConfirm(pending: PendingConfirm) {

--- a/src/util/bulk-update.ts
+++ b/src/util/bulk-update.ts
@@ -1,0 +1,58 @@
+import toast from "sonner-js";
+
+import { APIError } from "../api/api-error.js";
+import type { ESPHomeAPI } from "../api/index.js";
+import { ErrorCode } from "../api/types/protocol.js";
+import type { PairingSummary } from "../api/types/remote-build.js";
+import type { LocalizeFunc } from "../common/localize.js";
+
+import { classifyNoCompatiblePeerReason } from "./version-mismatch.js";
+
+export interface BulkUpdateContext {
+  api: ESPHomeAPI;
+  localize: LocalizeFunc;
+  appVersion: string;
+  pairings: Iterable<PairingSummary>;
+}
+
+/**
+ * Bulk-install firmware to *configurations*, surfacing start/error toasts.
+ * No-op (info toast) on an empty list. A NO_COMPATIBLE_PEER failure is
+ * classified into the offline/version/mixed bucket; everything else gets
+ * the generic error toast.
+ */
+export async function runBulkUpdate(
+  configurations: string[],
+  ctx: BulkUpdateContext
+): Promise<void> {
+  if (configurations.length === 0) {
+    toast.info(ctx.localize("layout.update_all_none"), { richColors: true });
+    return;
+  }
+  toast.info(
+    ctx.localize("layout.update_all_started", { count: configurations.length }),
+    { richColors: true }
+  );
+  try {
+    await ctx.api.firmwareInstallBulk(configurations);
+  } catch (err) {
+    if (
+      err instanceof APIError &&
+      err.errorCode === ErrorCode.NO_COMPATIBLE_PEER &&
+      ctx.appVersion
+    ) {
+      // ``appVersion`` empty during a reconnect race would leak into the
+      // ``{local}`` placeholder and misattribute the bucket; fall through
+      // to the generic toast.
+      const reason = classifyNoCompatiblePeerReason(ctx.pairings, ctx.appVersion);
+      toast.error(
+        ctx.localize(`layout.update_all_no_compatible_peer_${reason}`, {
+          local: ctx.appVersion,
+        }),
+        { richColors: true }
+      );
+    } else {
+      toast.error(ctx.localize("layout.update_all_error"), { richColors: true });
+    }
+  }
+}

--- a/test/util/bulk-update.test.ts
+++ b/test/util/bulk-update.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Pins runBulkUpdate: empty list → info toast + no API call, success → start
+ * toast + one firmwareInstallBulk call, NO_COMPATIBLE_PEER → bucketed error
+ * toast, any other error → generic error toast.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import toast from "sonner-js";
+import { APIError } from "../../src/api/api-error.js";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import { ErrorCode } from "../../src/api/types/protocol.js";
+import type { PairingSummary } from "../../src/api/types/remote-build.js";
+import { runBulkUpdate } from "../../src/util/bulk-update.js";
+
+const localize = vi.fn((key: string, _args?: unknown) => key);
+
+function pairing(overrides: Partial<PairingSummary>): PairingSummary {
+  return {
+    receiver_hostname: "build.local",
+    receiver_port: 6055,
+    pin_sha256: "a".repeat(64),
+    label: "desktop",
+    paired_at: 1,
+    status: "approved",
+    connected: true,
+    connecting: false,
+    last_connect_error: "",
+    esphome_version: "2026.5.0",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function apiWith(impl: () => Promise<unknown>) {
+  const firmwareInstallBulk = vi.fn(impl);
+  return {
+    api: { firmwareInstallBulk } as unknown as ESPHomeAPI,
+    firmwareInstallBulk,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runBulkUpdate", () => {
+  it("info-toasts and skips the API call on an empty list", async () => {
+    const { api, firmwareInstallBulk } = apiWith(async () => []);
+    await runBulkUpdate([], { api, localize, appVersion: "2026.5.0", pairings: [] });
+    expect(firmwareInstallBulk).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith("layout.update_all_none", {
+      richColors: true,
+    });
+  });
+
+  it("start-toasts and installs the given configurations", async () => {
+    const { api, firmwareInstallBulk } = apiWith(async () => []);
+    await runBulkUpdate(["a.yaml", "b.yaml"], {
+      api,
+      localize,
+      appVersion: "2026.5.0",
+      pairings: [],
+    });
+    expect(toast.info).toHaveBeenCalledWith("layout.update_all_started", {
+      richColors: true,
+    });
+    // Pin the device count handed to the plural string, not just the key.
+    expect(localize).toHaveBeenCalledWith("layout.update_all_started", { count: 2 });
+    expect(firmwareInstallBulk).toHaveBeenCalledWith(["a.yaml", "b.yaml"]);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("classifies a NO_COMPATIBLE_PEER failure into the offline bucket", async () => {
+    const { api } = apiWith(async () => {
+      throw new APIError(ErrorCode.NO_COMPATIBLE_PEER, "");
+    });
+    await runBulkUpdate(["a.yaml"], {
+      api,
+      localize,
+      appVersion: "2026.5.0",
+      pairings: [pairing({ connected: false })],
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      "layout.update_all_no_compatible_peer_offline",
+      { richColors: true }
+    );
+  });
+
+  it("falls back to the generic toast on any other error", async () => {
+    const { api } = apiWith(async () => {
+      throw new Error("boom");
+    });
+    await runBulkUpdate(["a.yaml"], {
+      api,
+      localize,
+      appVersion: "2026.5.0",
+      pairings: [],
+    });
+    expect(toast.error).toHaveBeenCalledWith("layout.update_all_error", {
+      richColors: true,
+    });
+  });
+
+  it("uses the generic toast when appVersion is empty during a reconnect race", async () => {
+    const { api } = apiWith(async () => {
+      throw new APIError(ErrorCode.NO_COMPATIBLE_PEER, "");
+    });
+    await runBulkUpdate(["a.yaml"], {
+      api,
+      localize,
+      appVersion: "",
+      pairings: [pairing({ connected: false })],
+    });
+    expect(toast.error).toHaveBeenCalledWith("layout.update_all_error", {
+      richColors: true,
+    });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Lifts the bulk firmware-update orchestration — the start/error toasts and the `NO_COMPATIBLE_PEER` reason classification — out of the dashboard page's `_updateSelected` into a shared `runBulkUpdate` helper in `src/util/bulk-update.ts`. The dashboard's select-mode update now calls the helper; behaviour is unchanged.

This is a behaviour-free refactor that lets a second caller (the upcoming "Update All" command-palette dialog) reuse the exact same toast/error handling instead of duplicating it.

**Related issue or feature (if applicable):**

- First of three stacked PRs adding an "Update All" command-palette entry. Followed by the facet-accordion extraction and the feature itself.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
