### PR TITLE
Prefer the dotted platform impl over a same-named component

### DIFF
--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -220,10 +220,13 @@ export async function resolveAvailableEntries(
   const componentEntries = async (componentId: string): Promise<ConfigEntry[]> => {
     let mergeId: string | null = null;
     if (platformValue) {
-      if (catalog.byId.has(platformValue)) {
-        mergeId = platformValue;
-      } else if (catalog.byId.has(`${componentId}.${platformValue}`)) {
+      // Prefer the dotted per-domain impl (``ota.esphome``) over a bare
+      // component that happens to share the platform's name (``esphome``);
+      // otherwise ``ota: - platform: esphome`` merges the core esphome fields.
+      if (catalog.byId.has(`${componentId}.${platformValue}`)) {
         mergeId = `${componentId}.${platformValue}`;
+      } else if (catalog.byId.has(platformValue)) {
+        mergeId = platformValue;
       }
     }
     if (mergeId) {

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -207,7 +207,9 @@ describe("resolveAvailableEntries (nested descent)", () => {
     const fakeApi = {
       getComponentBodies: async (ids: string[]) =>
         Object.fromEntries(
-          ids.filter((id) => id in bodies).map((id) => [id, bodies[id]])
+          ids
+            .filter((id) => Object.prototype.hasOwnProperty.call(bodies, id))
+            .map((id) => [id, bodies[id]])
         ),
     } as never;
     const keys = (

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -172,4 +172,50 @@ describe("resolveAvailableEntries (nested descent)", () => {
     );
     expect(out.map((e) => e.key)).toEqual(["sorting_weight"]);
   });
+
+  it("merges the dotted platform impl, not a bare component sharing its name", async () => {
+    // ``ota: - platform: esphome`` must merge ``ota.esphome`` (password/port),
+    // not the core ``esphome`` component (name/areas) whose id collides with
+    // the platform value.
+    const ota = makeComponentEntry("ota", { category: ComponentCategory.CORE });
+    const otaEsphome = makeComponentEntry("ota.esphome", {
+      category: ComponentCategory.CORE,
+    });
+    const esphome = makeComponentEntry("esphome", { category: ComponentCategory.CORE });
+    const bodies: Record<string, ComponentCatalogEntry> = {
+      ota: { ...ota, config_entries: [makeConfigEntry({ key: "platform" })] },
+      "ota.esphome": {
+        ...otaEsphome,
+        config_entries: [
+          makeConfigEntry({ key: "password" }),
+          makeConfigEntry({ key: "port" }),
+        ],
+      },
+      esphome: {
+        ...esphome,
+        config_entries: [
+          makeConfigEntry({ key: "name" }),
+          makeConfigEntry({ key: "areas" }),
+        ],
+      },
+    };
+    const catalog = {
+      components: [ota, otaEsphome, esphome],
+      byId: new Map(Object.entries({ ota, "ota.esphome": otaEsphome, esphome })),
+      byCategory: new Map(),
+    };
+    const fakeApi = {
+      getComponentBodies: async (ids: string[]) =>
+        Object.fromEntries(
+          ids.filter((id) => id in bodies).map((id) => [id, bodies[id]])
+        ),
+    } as never;
+    const keys = (
+      await resolveAvailableEntries(fakeApi, catalog, "ota", "esphome", "ota", () => [])
+    ).map((e) => e.key);
+    expect(keys).toContain("password");
+    expect(keys).toContain("port");
+    expect(keys).not.toContain("name");
+    expect(keys).not.toContain("areas");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

In the YAML editor, completing under `ota:` with `platform: esphome` offered the core `esphome:` component's fields (`name`, `area`, `areas`, `friendly_name`, `build_flags`, ...) instead of OTA's (`password`, `port`, `id`, ...).

Root cause: the platform merge in `resolveAvailableEntries` checked the bare platform value (`esphome`) before the dotted per-domain impl (`ota.esphome`). Both are catalog ids, so the bare core component won and its fields were merged in. The fix checks the dotted `<domain>.<platform>` id first; the bare lookup stays as the fallback. Every other platform (e.g. `sensor: - platform: dht` -> `sensor.dht`) is unaffected since the dotted id was already the match.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
