### PR TITLE
Auto-offer completion at a fresh list-item dash

### DIFF
--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -277,7 +277,11 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
     const indent = leading.length;
     const keyFrom = pos - partial.length;
 
-    if (!ctx.explicit && partial.length === 0) return null;
+    // A fresh ``- `` is itself the signal to offer list-item keys
+    // (``platform:``, the action registry), the same way ``key:`` auto-fires
+    // value completion. A plain blank key line still waits for a partial or
+    // an explicit/idle trigger.
+    if (!ctx.explicit && partial.length === 0 && !isListItem) return null;
 
     const catalog = await loadCatalog(api);
 

--- a/test/util/yaml-completion-filter.test.ts
+++ b/test/util/yaml-completion-filter.test.ts
@@ -166,4 +166,11 @@ describe("createYamlCompletionSource (already-set key filtering)", () => {
     );
     expect(labels).toEqual(["true", "false"]);
   });
+
+  it("auto-offers platform at a fresh list-item dash (no partial typed)", async () => {
+    // Typing ``- `` under a platform domain should immediately offer
+    // ``platform:`` rather than wait for a partial or ctrl-space.
+    const labels = await labelsAt(["sensor:", "  - "].join("\n"));
+    expect(labels).toContain("platform");
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Typing a fresh list item (`- `) under a platform domain produced no suggestions: e.g. under `ota:` adding a second `  - ` offered nothing, so there was no `platform:` prompt until you typed a character. The key-position completion bailed on an empty partial for implicit (typing) completion.

Now a list-item dash auto-opens the popup, the same way `key:` already auto-fires value completion, so `platform:` (and the action registry inside automation bodies) appears as soon as you type `- `. A plain blank key line still waits for a partial or an explicit trigger, so this doesn't make ordinary key editing noisier.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
