### PR TITLE
Name the included file when a save error lives outside the open config

### DIFF
--- a/src/api/types/editor.ts
+++ b/src/api/types/editor.ts
@@ -8,6 +8,8 @@
 
 /** Range emitted by the upstream `esphome vscode --ace` validator. 0-indexed. */
 export interface EditorRange {
+  /** Source file the range came from; differs from the open config when the error is in an `!include`d file. */
+  document?: string;
   start_line: number;
   start_col: number;
   end_line: number;

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -50,6 +50,9 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   /** First error's message, used as a hint under the count. */
   @property() firstErrorMessage = "";
 
+  /** Included file the first error lives in, or "" when it's in the open config. */
+  @property() firstErrorFile = "";
+
   @state() private _open = false;
 
   static styles = [
@@ -63,6 +66,11 @@ export class ESPHomeYamlValidationDialog extends LitElement {
       .icon-wrap {
         background: color-mix(in srgb, var(--esphome-error), transparent 88%);
         color: var(--esphome-error);
+      }
+
+      .included-file {
+        margin-top: var(--wa-space-xs);
+        color: var(--wa-color-text-normal);
       }
 
       .first-error {
@@ -102,8 +110,13 @@ export class ESPHomeYamlValidationDialog extends LitElement {
 
   // Enter goes to the first error (the safe path), never force-save.
   private _enter = new EnterController(this, () => {
-    if (this.firstErrorLine > 0) this._goto();
+    if (this._canGoToError) this._goto();
   });
+
+  /** Navigation only works when the error is in the open buffer at a known line. */
+  private get _canGoToError(): boolean {
+    return this.firstErrorLine > 0 && !this.firstErrorFile;
+  }
 
   open() {
     this._resolvedExit = null;
@@ -127,7 +140,12 @@ export class ESPHomeYamlValidationDialog extends LitElement {
     const message = this._localize("device.yaml_invalid_message", {
       count: this.errorCount,
     });
-    const canGoToError = this.firstErrorLine > 0;
+    const includedFileNote = this.firstErrorFile
+      ? this._localize("device.yaml_invalid_in_included_file", {
+          file: this.firstErrorFile,
+          line: this.firstErrorLine,
+        })
+      : "";
     return html`
       <esphome-base-dialog
         ?open=${this._open}
@@ -141,6 +159,9 @@ export class ESPHomeYamlValidationDialog extends LitElement {
           </div>
           <div class="text">
             ${message}
+            ${includedFileNote
+              ? html`<div class="included-file">${includedFileNote}</div>`
+              : nothing}
             ${this.firstErrorMessage
               ? html`<div class="first-error">${this.firstErrorMessage}</div>`
               : nothing}
@@ -150,7 +171,11 @@ export class ESPHomeYamlValidationDialog extends LitElement {
           <button class="btn btn--cancel" @click=${this.close}>
             ${this._localize("layout.cancel")}
           </button>
-          <button class="btn btn--goto" ?disabled=${!canGoToError} @click=${this._goto}>
+          <button
+            class="btn btn--goto"
+            ?disabled=${!this._canGoToError}
+            @click=${this._goto}
+          >
             ${this._localize("device.yaml_invalid_go_to_error")}
           </button>
           <button class="btn btn--save-anyway" @click=${this._saveAnyway}>
@@ -162,6 +187,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   }
 
   private _goto() {
+    if (!this._canGoToError) return; // error is in an included file we can't open here
     if (this._resolvedExit !== null) return; // a repeated Enter must not dispatch twice
     this._resolvedExit = "goto";
     this.close();

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -46,7 +46,11 @@ import {
   sectionKeyOf,
   type YamlSection,
 } from "../util/yaml-sections.js";
-import { summarizeValidation } from "../util/yaml-validation-summary.js";
+import {
+  basename,
+  isOpenConfigFile,
+  summarizeValidation,
+} from "../util/yaml-validation-summary.js";
 import { devicePageStyles } from "./device-styles.js";
 import {
   buildDeviceUrl,
@@ -263,6 +267,9 @@ export class ESPHomePageDevice extends LitElement {
 
   @state()
   private _validationFirstMessage = "";
+
+  @state()
+  private _validationFirstFile = "";
 
   private _onPostInstallShowLogs = postInstallShowLogsHandler(
     () => this._logsDialog,
@@ -726,6 +733,14 @@ export class ESPHomePageDevice extends LitElement {
           this._validationFirstLine = summary.first?.line ?? 0;
           this._validationFirstCol = summary.first?.col ?? 0;
           this._validationFirstMessage = summary.first?.message ?? "";
+          // The reported line is meaningless against the open buffer when
+          // the error is inside an `!include`d file; name that file instead
+          // of leaving the editor to navigate nowhere.
+          const errorFile = summary.first?.file ?? null;
+          this._validationFirstFile =
+            errorFile && this.id && !isOpenConfigFile(errorFile, this.id)
+              ? basename(errorFile)
+              : "";
           // A previous prompt that's somehow still pending (the
           // unsaved-guard already prevents overlapping page-leave
           // dialogs, but a manual Save click reaches this branch
@@ -1015,6 +1030,7 @@ export class ESPHomePageDevice extends LitElement {
           .firstErrorLine=${this._validationFirstLine}
           .firstErrorCol=${this._validationFirstCol}
           .firstErrorMessage=${this._validationFirstMessage}
+          .firstErrorFile=${this._validationFirstFile}
           @save-anyway=${this._onValidationSaveAnyway}
           @goto=${this._onValidationGoTo}
           @cancel=${this._onValidationCancel}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -592,6 +592,7 @@
     "yaml_invalid_title": "Configuration has errors",
     "yaml_invalid_message": "{count, plural, one {ESPHome reported # error in this configuration. Save anyway, jump to it to fix it, or cancel.} other {ESPHome reported # errors in this configuration. Save anyway, jump to the first one to fix it, or cancel.}}",
     "yaml_invalid_go_to_error": "Go to error",
+    "yaml_invalid_in_included_file": "The first error is in {file} (line {line}), an included file that can't be opened here; open that file to fix it.",
     "yaml_invalid_save_anyway": "Save anyway",
     "more_info": "More info",
     "change_board_link": "Change board",

--- a/src/util/yaml-validation-summary.ts
+++ b/src/util/yaml-validation-summary.ts
@@ -21,6 +21,8 @@ import type { EditorValidateResponse } from "../api/types/editor.js";
 
 const YAML_LINE_COL_RE = /line\s+(\d+)\s*,\s*column\s+(\d+)/i;
 const YAML_LINE_RE = /line\s+(\d+)/i;
+/** Windows path separators, normalized to ``/`` before comparison. */
+const BACKSLASH_RE = /\\/g;
 
 export interface ValidationFirstError {
   /** 1-indexed line, or 0 if the error has no resolvable line. */
@@ -85,26 +87,24 @@ export function summarizeValidation(res: EditorValidateResponse): ValidationSumm
 
 /** Last path segment of a ``/``- or ``\``-separated path. */
 export function basename(path: string): string {
-  const normalized = path.replace(/\\/g, "/");
+  const normalized = path.replace(BACKSLASH_RE, "/");
   const idx = normalized.lastIndexOf("/");
   return idx === -1 ? normalized : normalized.slice(idx + 1);
 }
 
 /**
- * Whether a validator ``document`` path refers to the currently open
- * configuration rather than an ``!include``d file. The ``--ace`` loader
- * leaves the main file's stream unnamed, so its nodes report the
- * ``"<file>"`` sentinel (and a missing document means the same thing);
- * only ``!include``d files carry a real path, resolved to
- * ``<config_dir>/<configuration>``. A suffix match on the full
- * configuration path identifies the open file; a plain basename match is
- * deliberately avoided so an included file sharing the open file's name
- * (open ``sub/light.yaml``, error in ``common/light.yaml``) isn't
- * mistaken for the open buffer.
+ * Whether a validator ``document`` refers to the currently open
+ * configuration rather than an ``!include``d file.
+
+ * The ``esphome vscode --ace`` loader leaves the main file's stream
+ * unnamed, so its nodes report the ``"<file>"`` sentinel (a missing
+ * document means the same thing) while every ``!include``d file carries a
+ * real resolved path — so the sentinel is the open file. A suffix match
+ * on ``configuration`` is deliberately NOT used: it is usually a bare
+ * filename, and an included ``packages/light.yaml`` would masquerade as
+ * an open ``light.yaml`` and re-enable navigation into the wrong file.
  */
 export function isOpenConfigFile(document: string, configuration: string): boolean {
   if (!document || document === "<file>") return true;
-  const doc = document.replace(/\\/g, "/");
-  const cfg = configuration.replace(/\\/g, "/");
-  return doc === cfg || doc.endsWith(`/${cfg}`);
+  return document.replace(BACKSLASH_RE, "/") === configuration.replace(BACKSLASH_RE, "/");
 }

--- a/src/util/yaml-validation-summary.ts
+++ b/src/util/yaml-validation-summary.ts
@@ -92,12 +92,19 @@ export function basename(path: string): string {
 
 /**
  * Whether a validator ``document`` path refers to the currently open
- * configuration rather than an ``!include``d file. The main file's
- * document is ``<config_dir>/<configuration>``; an include resolves to a
- * different path.
+ * configuration rather than an ``!include``d file. The ``--ace`` loader
+ * leaves the main file's stream unnamed, so its nodes report the
+ * ``"<file>"`` sentinel (and a missing document means the same thing);
+ * only ``!include``d files carry a real path, resolved to
+ * ``<config_dir>/<configuration>``. A suffix match on the full
+ * configuration path identifies the open file; a plain basename match is
+ * deliberately avoided so an included file sharing the open file's name
+ * (open ``sub/light.yaml``, error in ``common/light.yaml``) isn't
+ * mistaken for the open buffer.
  */
 export function isOpenConfigFile(document: string, configuration: string): boolean {
+  if (!document || document === "<file>") return true;
   const doc = document.replace(/\\/g, "/");
   const cfg = configuration.replace(/\\/g, "/");
-  return doc === cfg || doc.endsWith(`/${cfg}`) || basename(doc) === basename(cfg);
+  return doc === cfg || doc.endsWith(`/${cfg}`);
 }

--- a/src/util/yaml-validation-summary.ts
+++ b/src/util/yaml-validation-summary.ts
@@ -29,6 +29,8 @@ export interface ValidationFirstError {
   col: number;
   /** Trimmed message — feeds the dialog's "first error" hint. */
   message: string;
+  /** Source file the error came from, or null when the validator didn't report one. */
+  file: string | null;
 }
 
 export interface ValidationSummary {
@@ -66,7 +68,10 @@ export function summarizeValidation(res: EditorValidateResponse): ValidationSumm
     }
     if (!Number.isFinite(line) || line < 1) line = 0;
     if (!Number.isFinite(col) || col < 1) col = 0;
-    return { count, first: { line, col, message: message || "Invalid YAML" } };
+    return {
+      count,
+      first: { line, col, message: message || "Invalid YAML", file: null },
+    };
   }
 
   const err = validationErrors[0];
@@ -75,5 +80,24 @@ export function summarizeValidation(res: EditorValidateResponse): ValidationSumm
   const line = Math.max(1, (err.range?.start_line ?? 0) + 1);
   const col = Math.max(1, (err.range?.start_col ?? 0) + 1);
   const message = (err.message ?? "Invalid configuration").trim();
-  return { count, first: { line, col, message } };
+  return { count, first: { line, col, message, file: err.range?.document ?? null } };
+}
+
+/** Last path segment of a ``/``- or ``\``-separated path. */
+export function basename(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const idx = normalized.lastIndexOf("/");
+  return idx === -1 ? normalized : normalized.slice(idx + 1);
+}
+
+/**
+ * Whether a validator ``document`` path refers to the currently open
+ * configuration rather than an ``!include``d file. The main file's
+ * document is ``<config_dir>/<configuration>``; an include resolves to a
+ * different path.
+ */
+export function isOpenConfigFile(document: string, configuration: string): boolean {
+  const doc = document.replace(/\\/g, "/");
+  const cfg = configuration.replace(/\\/g, "/");
+  return doc === cfg || doc.endsWith(`/${cfg}`) || basename(doc) === basename(cfg);
 }

--- a/test/components/yaml-validation-dialog.test.ts
+++ b/test/components/yaml-validation-dialog.test.ts
@@ -79,6 +79,48 @@ describe("yaml-validation-dialog ENTER", () => {
   });
 });
 
+// When the first error lives in an `!include`d file the reported line is
+// meaningless against the open buffer, so "Go to error" must disable rather
+// than navigate nowhere, and the dialog names the offending file instead.
+describe("yaml-validation-dialog included-file error", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const gotoButton = (el: ESPHomeYamlValidationDialog): HTMLButtonElement =>
+    el.shadowRoot!.querySelector(".btn--goto")!;
+
+  it("disables Go to error when the error is in an included file", async () => {
+    const el = await mount();
+    el.firstErrorLine = 42;
+    el.firstErrorFile = "base.yaml";
+    await el.updateComplete;
+    expect(gotoButton(el).disabled).toBe(true);
+    expect(el.shadowRoot!.querySelector(".included-file")).not.toBeNull();
+  });
+
+  it("does not fire goto on Enter when the error is in an included file", async () => {
+    const el = await mount();
+    el.firstErrorLine = 42;
+    el.firstErrorFile = "base.yaml";
+    await el.updateComplete;
+    const onGoto = vi.fn();
+    el.addEventListener("goto", onGoto);
+    el.open();
+    pressEnter();
+    expect(onGoto).not.toHaveBeenCalled();
+  });
+
+  it("keeps Go to error enabled when the error is in the open file", async () => {
+    const el = await mount();
+    el.firstErrorLine = 42;
+    el.firstErrorFile = "";
+    await el.updateComplete;
+    expect(gotoButton(el).disabled).toBe(false);
+    expect(el.shadowRoot!.querySelector(".included-file")).toBeNull();
+  });
+});
+
 // The migration onto esphome-base-dialog introduced the reactive ?open binding,
 // the request-close handler, and the after-hide -> cancel path. Pin them so the
 // dismiss-cancels contract (the page-leave guard depends on it) can't regress.

--- a/test/util/yaml-validation-summary.test.ts
+++ b/test/util/yaml-validation-summary.test.ts
@@ -19,7 +19,11 @@
 
 import { describe, expect, it } from "vitest";
 import type { EditorValidateResponse } from "../../src/api/types/editor.js";
-import { summarizeValidation } from "../../src/util/yaml-validation-summary.js";
+import {
+  basename,
+  isOpenConfigFile,
+  summarizeValidation,
+} from "../../src/util/yaml-validation-summary.js";
 
 function res(
   yaml_errors: EditorValidateResponse["yaml_errors"] = [],
@@ -108,6 +112,47 @@ describe("summarizeValidation", () => {
     );
   });
 
+  it("carries the validation-error source document as first.file", () => {
+    const summary = summarizeValidation(
+      res(
+        [],
+        [
+          {
+            message: "'foo' is an invalid option for [sensor]",
+            range: {
+              document: "/config/esphome/common/base.yaml",
+              start_line: 41,
+              start_col: 2,
+              end_line: 41,
+              end_col: 5,
+            },
+          },
+        ]
+      )
+    );
+    expect(summary.first?.file).toBe("/config/esphome/common/base.yaml");
+  });
+
+  it("leaves first.file null when the validator reports no document", () => {
+    const summary = summarizeValidation(
+      res(
+        [],
+        [
+          {
+            message: "Invalid value",
+            range: { start_line: 1, start_col: 0, end_line: 1, end_col: 1 },
+          },
+        ]
+      )
+    );
+    expect(summary.first?.file).toBeNull();
+  });
+
+  it("leaves first.file null for yaml parse errors", () => {
+    const summary = summarizeValidation(res([{ message: "boom at line 3, column 1" }]));
+    expect(summary.first?.file).toBeNull();
+  });
+
   it("counts every error across both buckets", () => {
     const summary = summarizeValidation(
       res(
@@ -125,5 +170,41 @@ describe("summarizeValidation", () => {
       )
     );
     expect(summary.count).toBe(3);
+  });
+});
+
+describe("basename", () => {
+  it("returns the last segment of a posix path", () => {
+    expect(basename("/config/esphome/common/base.yaml")).toBe("base.yaml");
+  });
+
+  it("returns the last segment of a windows path", () => {
+    expect(basename("C:\\config\\esphome\\base.yaml")).toBe("base.yaml");
+  });
+
+  it("returns the input when there is no separator", () => {
+    expect(basename("base.yaml")).toBe("base.yaml");
+  });
+});
+
+describe("isOpenConfigFile", () => {
+  it("matches the open config by full document path", () => {
+    expect(isOpenConfigFile("/config/esphome/light.yaml", "light.yaml")).toBe(true);
+  });
+
+  it("matches when the configuration carries a subpath", () => {
+    expect(isOpenConfigFile("/config/esphome/sub/light.yaml", "sub/light.yaml")).toBe(
+      true
+    );
+  });
+
+  it("matches a windows document path by basename", () => {
+    expect(isOpenConfigFile("C:\\config\\esphome\\light.yaml", "light.yaml")).toBe(true);
+  });
+
+  it("treats an included file as not the open config", () => {
+    expect(isOpenConfigFile("/config/esphome/common/base.yaml", "light.yaml")).toBe(
+      false
+    );
   });
 });

--- a/test/util/yaml-validation-summary.test.ts
+++ b/test/util/yaml-validation-summary.test.ts
@@ -198,12 +198,30 @@ describe("isOpenConfigFile", () => {
     );
   });
 
-  it("matches a windows document path by basename", () => {
+  it("matches a normalized windows document path", () => {
     expect(isOpenConfigFile("C:\\config\\esphome\\light.yaml", "light.yaml")).toBe(true);
+  });
+
+  it("treats the --ace main-file sentinel as the open config", () => {
+    // The `esphome vscode --ace` loader leaves the main stream unnamed,
+    // so main-file errors report "<file>" rather than a real path.
+    expect(isOpenConfigFile("<file>", "light.yaml")).toBe(true);
+  });
+
+  it("treats a missing document as the open config", () => {
+    expect(isOpenConfigFile("", "light.yaml")).toBe(true);
   });
 
   it("treats an included file as not the open config", () => {
     expect(isOpenConfigFile("/config/esphome/common/base.yaml", "light.yaml")).toBe(
+      false
+    );
+  });
+
+  it("does not match an included file that merely shares the open file's name", () => {
+    // open sub/light.yaml, error in common/light.yaml — same basename,
+    // different file; a basename match would navigate the wrong document.
+    expect(isOpenConfigFile("/config/esphome/common/light.yaml", "sub/light.yaml")).toBe(
       false
     );
   });

--- a/test/util/yaml-validation-summary.test.ts
+++ b/test/util/yaml-validation-summary.test.ts
@@ -188,28 +188,22 @@ describe("basename", () => {
 });
 
 describe("isOpenConfigFile", () => {
-  it("matches the open config by full document path", () => {
-    expect(isOpenConfigFile("/config/esphome/light.yaml", "light.yaml")).toBe(true);
-  });
-
-  it("matches when the configuration carries a subpath", () => {
-    expect(isOpenConfigFile("/config/esphome/sub/light.yaml", "sub/light.yaml")).toBe(
-      true
-    );
-  });
-
-  it("matches a normalized windows document path", () => {
-    expect(isOpenConfigFile("C:\\config\\esphome\\light.yaml", "light.yaml")).toBe(true);
-  });
-
   it("treats the --ace main-file sentinel as the open config", () => {
     // The `esphome vscode --ace` loader leaves the main stream unnamed,
-    // so main-file errors report "<file>" rather than a real path.
+    // so main-file errors report "<file>"; only includes carry a real path.
     expect(isOpenConfigFile("<file>", "light.yaml")).toBe(true);
   });
 
   it("treats a missing document as the open config", () => {
     expect(isOpenConfigFile("", "light.yaml")).toBe(true);
+  });
+
+  it("matches an exact document path", () => {
+    expect(isOpenConfigFile("light.yaml", "light.yaml")).toBe(true);
+  });
+
+  it("matches an exact document path after normalizing separators", () => {
+    expect(isOpenConfigFile("sub\\light.yaml", "sub/light.yaml")).toBe(true);
   });
 
   it("treats an included file as not the open config", () => {
@@ -219,9 +213,9 @@ describe("isOpenConfigFile", () => {
   });
 
   it("does not match an included file that merely shares the open file's name", () => {
-    // open sub/light.yaml, error in common/light.yaml — same basename,
-    // different file; a basename match would navigate the wrong document.
-    expect(isOpenConfigFile("/config/esphome/common/light.yaml", "sub/light.yaml")).toBe(
+    // open light.yaml, error in packages/light.yaml — same basename,
+    // different file; a suffix match would navigate the wrong document.
+    expect(isOpenConfigFile("/config/esphome/packages/light.yaml", "light.yaml")).toBe(
       false
     );
   });


### PR DESCRIPTION
# What does this implement/fix?

When you include a file with `<<: !include common/base.yaml` and the validation error is inside that included file, the save dialog showed a "Go to error" button that did nothing; the reported line points into the included file, not the open config, so the editor had nowhere to jump.

The validator already tells us which file the error came from in `range.document`, we just dropped it. Now we read it, and when the first error is not in the open config we name the included file and the line in the dialog and disable the "Go to error" button instead of jumping nowhere. When the error is in the open file the button works exactly as before.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1655

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
