### PR TITLE
Resolve platform/board value options in YAML completion

### DIFF
--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -350,6 +350,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                   : html`<esphome-yaml-editor
                       .value=${this.yaml}
                       .configuration=${this.configuration}
+                      .board=${this.board}
                       .highlightRange=${this.highlightRange}
                       .scrollToHighlight=${this.scrollToHighlight}
                       .revealSensitive=${this._revealSensitive}

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -10,6 +10,7 @@ import { basicSetup, EditorView } from "codemirror";
 import { css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
+import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import {
@@ -112,6 +113,13 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    * back to plain YAML editing with no diagnostics or suggestions.
    */
   @property() configuration = "";
+
+  /**
+   * The device's resolved board catalog entry. Supplies the target
+   * platform/board so completion hydrates per-platform value options (e.g.
+   * `hardware_uart`) the same way the structured editor does.
+   */
+  @property({ attribute: false }) board: BoardCatalogEntry | null = null;
 
   @property({ attribute: false }) highlightRange: HighlightRange | null = null;
 
@@ -448,7 +456,12 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       // Schema-driven completion off the components catalog.
       extensions.push(
         autocompletion({
-          override: [createYamlCompletionSource(this._api)],
+          override: [
+            createYamlCompletionSource(this._api, () => ({
+              platform: this.board?.esphome.platform,
+              boardId: this.board?.id,
+            })),
+          ],
           activateOnTyping: true,
           icons: true,
           closeOnBlur: true,

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -112,6 +112,17 @@ export interface CatalogIndex {
   byCategory: Map<string, ComponentCatalogEntry[]>;
 }
 
+/**
+ * The device's target platform/board (e.g. `esp32` / `esp32-evb`), so body
+ * hydration resolves per-platform value options (`hardware_uart` → the
+ * board's UARTs). Distinct from the `platform:` component selector. Empty
+ * fields fall back to the generic catalog body.
+ */
+export interface CompletionTarget {
+  platform?: string;
+  boardId?: string;
+}
+
 let catalogPromise: Promise<CatalogIndex> | null = null;
 
 /**
@@ -195,7 +206,8 @@ export async function resolveAvailableEntries(
   parentKey: string,
   platformValue: string | null,
   topLevelKey: string | null,
-  resolveNestedPath: () => string[] = () => []
+  resolveNestedPath: () => string[] = () => [],
+  target?: CompletionTarget
 ): Promise<ConfigEntry[]> {
   // The slim ``getComponents`` index carries no ``config_entries``
   // (those hydrate lazily through ``components/get_component_bodies``),
@@ -210,7 +222,10 @@ export async function resolveAvailableEntries(
   const entriesFor = async (id: string): Promise<ConfigEntry[]> => {
     if (!catalog.byId.has(id)) return [];
     try {
-      const body = await fetchComponent(api, id);
+      // Pass the device target so the backend resolves per-platform value
+      // options (e.g. ``hardware_uart``); buckets the same cache the
+      // structured editor populated.
+      const body = await fetchComponent(api, id, target?.platform, target?.boardId);
       return body?.config_entries ?? [];
     } catch {
       return [];
@@ -286,7 +301,7 @@ export async function resolveAvailableEntries(
   // doesn't re-issue the backend round-trip. Tolerate failures
   // silently.
   try {
-    const comp = await fetchComponent(api, parentKey);
+    const comp = await fetchComponent(api, parentKey, target?.platform, target?.boardId);
     if (comp) return comp.config_entries ?? [];
   } catch {
     /* ignore */

--- a/src/util/yaml-completion-providers.ts
+++ b/src/util/yaml-completion-providers.ts
@@ -25,6 +25,7 @@ import { collectTopLevelKeys } from "./yaml-ast.js";
 import {
   bundleFor,
   type CatalogIndex,
+  type CompletionTarget,
   nestedPathForParent,
   resolveAvailableEntries,
 } from "./yaml-completion-catalog.js";
@@ -76,6 +77,9 @@ export interface KeyPositionCtx {
   topLevelKey: string | null;
   inAutomation: boolean;
   partialCouldBeTrigger: boolean;
+  /** Device platform/board so body hydration resolves per-platform
+   *  value options. */
+  deviceTarget?: CompletionTarget;
   /** Per-turn memo of ``resolveAvailableEntries`` so the catalog
    *  and schema-bundle providers don't re-walk the same answer.
    *  Populated lazily via ``resolveCatalogEntries``. */
@@ -112,7 +116,8 @@ async function resolveCatalogEntries(k: KeyPositionCtx): Promise<ConfigEntry[]> 
       k.parent.key,
       k.platformValue,
       k.topLevelKey,
-      () => nestedPathForParent(k.state, k.pos, k.parent.key)
+      () => nestedPathForParent(k.state, k.pos, k.parent.key),
+      k.deviceTarget
     );
   }
   return k._cachedCatalogEntries;

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -103,7 +103,7 @@ export function createYamlCompletionSource(
 ) {
   return async (ctx: CompletionContext): Promise<CompletionResult | null> => {
     const { state, pos } = ctx;
-    const target = getTarget?.();
+    const deviceTarget = getTarget?.();
     const lineInfo = state.doc.lineAt(pos);
     const lineText = lineInfo.text;
     const colInLine = pos - lineInfo.from;
@@ -197,7 +197,7 @@ export function createYamlCompletionSource(
         completionCtx.platformValue,
         completionCtx.topLevelKey,
         () => nestedPathForParent(state, pos, parent.key),
-        target
+        deviceTarget
       );
       const entry = entries.find((e) => e.key === key);
 
@@ -338,7 +338,7 @@ export function createYamlCompletionSource(
       partial,
       parent,
       isListItem,
-      deviceTarget: target,
+      deviceTarget,
       bundleCtx: completionCtx.bundleCtx,
       platformValue: completionCtx.platformValue,
       topLevelKey: completionCtx.topLevelKey,

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -35,6 +35,7 @@ import {
 } from "./yaml-ast.js";
 import {
   bundleFor,
+  type CompletionTarget,
   loadCatalog,
   matchKeyPosition,
   nestedPathForParent,
@@ -91,11 +92,18 @@ export {
 
 /**
  * Build the autocompletion source. Returned closure captures `api` so the
- * editor can wire it up once.
+ * editor can wire it up once. ``getTarget`` is read per invocation (not
+ * captured) so it tracks the device's platform/board as they load and
+ * change; passing the same target the structured editor uses reuses its
+ * already-hydrated component bodies (the body cache buckets by target).
  */
-export function createYamlCompletionSource(api: ESPHomeAPI) {
+export function createYamlCompletionSource(
+  api: ESPHomeAPI,
+  getTarget?: () => CompletionTarget
+) {
   return async (ctx: CompletionContext): Promise<CompletionResult | null> => {
     const { state, pos } = ctx;
+    const target = getTarget?.();
     const lineInfo = state.doc.lineAt(pos);
     const lineText = lineInfo.text;
     const colInLine = pos - lineInfo.from;
@@ -188,7 +196,8 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
         parent.key,
         completionCtx.platformValue,
         completionCtx.topLevelKey,
-        () => nestedPathForParent(state, pos, parent.key)
+        () => nestedPathForParent(state, pos, parent.key),
+        target
       );
       const entry = entries.find((e) => e.key === key);
 
@@ -329,6 +338,7 @@ export function createYamlCompletionSource(api: ESPHomeAPI) {
       partial,
       parent,
       isListItem,
+      deviceTarget: target,
       bundleCtx: completionCtx.bundleCtx,
       platformValue: completionCtx.platformValue,
       topLevelKey: completionCtx.topLevelKey,

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -254,11 +254,13 @@ describe("resolveAvailableEntries (nested descent)", () => {
       byCategory: new Map(),
     };
     const fakeApi = {
-      getComponentBodies: async (ids: string[], platform?: string) =>
+      // Resolve options only when BOTH platform and boardId are forwarded, so a
+      // regression that drops boardId fails this test.
+      getComponentBodies: async (ids: string[], platform?: string, boardId?: string) =>
         Object.fromEntries(
           ids
             .filter((id) => id === "logger")
-            .map((id) => [id, platform ? resolved : generic])
+            .map((id) => [id, platform && boardId ? resolved : generic])
         ),
     } as never;
     const withTarget = await resolveAvailableEntries(

--- a/test/util/yaml-completion-nested.test.ts
+++ b/test/util/yaml-completion-nested.test.ts
@@ -230,4 +230,57 @@ describe("resolveAvailableEntries (nested descent)", () => {
     expect(keys).not.toContain("name");
     expect(keys).not.toContain("areas");
   });
+
+  it("passes the device target so platform-resolved options surface", async () => {
+    // The backend only fills `options` for fields like `hardware_uart` when
+    // given the device platform/board; the completion must forward the target.
+    const slim = makeComponentEntry("logger", { category: ComponentCategory.CORE });
+    const resolved: ComponentCatalogEntry = {
+      ...slim,
+      config_entries: [
+        makeConfigEntry({
+          key: "hardware_uart",
+          options: [{ label: "UART0", value: "UART0" }],
+        }),
+      ],
+    };
+    const generic: ComponentCatalogEntry = {
+      ...slim,
+      config_entries: [makeConfigEntry({ key: "hardware_uart", options: null })],
+    };
+    const catalog = {
+      components: [slim],
+      byId: new Map([["logger", slim]]),
+      byCategory: new Map(),
+    };
+    const fakeApi = {
+      getComponentBodies: async (ids: string[], platform?: string) =>
+        Object.fromEntries(
+          ids
+            .filter((id) => id === "logger")
+            .map((id) => [id, platform ? resolved : generic])
+        ),
+    } as never;
+    const withTarget = await resolveAvailableEntries(
+      fakeApi,
+      catalog,
+      "logger",
+      null,
+      "logger",
+      () => [],
+      { platform: "esp32", boardId: "esp32-evb" }
+    );
+    expect(withTarget.find((e) => e.key === "hardware_uart")?.options).toEqual([
+      { label: "UART0", value: "UART0" },
+    ]);
+    const noTarget = await resolveAvailableEntries(
+      fakeApi,
+      catalog,
+      "logger",
+      null,
+      "logger",
+      () => []
+    );
+    expect(noTarget.find((e) => e.key === "hardware_uart")?.options).toBeNull();
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Platform/board-resolved value options were offered by the structured editor but not the YAML editor. The clearest case is `logger:` -> `hardware_uart:`: the structured form lists `UART0`/`UART1`/`UART2`, but the YAML editor offered nothing.

Those options are resolved per platform/board by the backend. The structured editor passes the device platform/board when it hydrates a component (`fetchComponent(api, id, platform, boardId)`); the YAML completion source did not, so it received the generic body where `options` is null. This threads the device's platform/board into the completion source as a live getter (so it tracks the board as it loads or changes), down to the component-body fetch.

Because `fetchComponent` buckets its cache by `(platform, boardId)`, passing the same target the structured editor uses reuses the bodies it already hydrated, so a concurrent hydration is deduped rather than double-fetched.

Fixes #945.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
