### PR TITLE
Validate and regenerate the API encryption key in the structured editor

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -152,7 +152,6 @@ export const configEntryFormStyles = css`
   }
 
   .generate-key:hover {
-    color: var(--esphome-primary);
     text-decoration: underline;
   }
 

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -135,6 +135,31 @@ export const configEntryFormStyles = css`
     color: var(--esphome-primary);
   }
 
+  /* Inline "generate a key" action stacked under the API encryption-key
+     input — a quiet link-style button, not a heavy form control. */
+  .generate-key {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--esphome-primary);
+    font-size: var(--wa-font-size-2xs);
+    transition: color 0.12s;
+  }
+
+  .generate-key:hover {
+    color: var(--esphome-primary);
+    text-decoration: underline;
+  }
+
+  .generate-key wa-icon {
+    font-size: 14px;
+  }
+
   /* ─── Nested group ──────────────────────────────────────── */
   .nested-group {
     display: flex;

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -22,6 +22,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import {
   generateApiEncryptionKey,
   isApiEncryptionKeyField,
+  isValidApiEncryptionKey,
 } from "../../util/api-encryption-key.js";
 import { stripConstraintProse } from "../../util/constraint-groups.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
@@ -362,13 +363,16 @@ export function renderStringField(
           ctx.emitChange(path, e.detail.value)}
       ></esphome-secret-picker>`
     : nothing;
-  // The API encryption key is a base64 Noise PSK — offer an inline generator
-  // so the user needn't leave for the docs page to mint a valid one. Only with
-  // a literal value (in secret mode the picker owns the field); generating
-  // replaces the literal, and the typed value can still be migrated to a
-  // secret afterwards via the picker.
+  // The API encryption key is a base64 Noise PSK — offer an inline generator so
+  // the user needn't leave for the docs page to mint a valid one. Shown only
+  // when the field doesn't already hold a valid key, so one click can't clobber
+  // a working key (clear the field to deliberately rotate); suppressed in secret
+  // mode, where the picker owns the field.
   const showGenerate =
-    isApiEncryptionKeyField(ctx.sectionKey, path) && !secretMode && !disabled;
+    isApiEncryptionKeyField(ctx.sectionKey, path) &&
+    !secretMode &&
+    !disabled &&
+    !isValidApiEncryptionKey(value);
   const generateAffordance = showGenerate
     ? html`<button
         type="button"

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -7,6 +7,7 @@
 
 import {
   mdiAlertCircleOutline,
+  mdiAutoFix,
   mdiCodeBraces,
   mdiKeyVariant,
   mdiLockOutline,
@@ -18,6 +19,10 @@ import { warningBannerStyles } from "../../styles/banners.js";
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import {
+  generateApiEncryptionKey,
+  isApiEncryptionKeyField,
+} from "../../util/api-encryption-key.js";
 import { stripConstraintProse } from "../../util/constraint-groups.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
 import { coerceIntFieldValue } from "../../util/int-input.js";
@@ -29,6 +34,7 @@ import {
   isSecretEligible,
   recommendedSecretKeys,
 } from "../../util/secret-eligibility.js";
+import { secretRefKey } from "../../util/secret-ref.js";
 import {
   hasSubstitutionReference,
   resolveSubstitutions,
@@ -70,6 +76,7 @@ export const fieldRendererStyles = [
 
 registerMdiIcons({
   "alert-circle-outline": mdiAlertCircleOutline,
+  "auto-fix": mdiAutoFix,
   "code-braces": mdiCodeBraces,
   "key-variant": mdiKeyVariant,
   "lock-outline": mdiLockOutline,
@@ -120,26 +127,16 @@ export const parseFieldKey = (attr: string): string[] => {
   return attr ? attr.split(".") : [];
 };
 
-/** ESPHome stores secret references as `!secret <key>` literal strings
- *  in the YAML — match that shape so any string-shaped field can flag
- *  values that point at the secrets store. */
-const SECRET_REF_RE = /^!secret\s+(\S+)\s*$/;
-
-/** The key a `!secret <key>` value points at, or ``null`` if not a ref. */
-export function secretRefKey(value: string): string | null {
-  return value.match(SECRET_REF_RE)?.[1] ?? null;
-}
-
 /** Render a small "Using stored secret: <name>" hint when the value
  *  is a `!secret <key>` reference. Returns `nothing` otherwise so
  *  callers can drop it inline without conditional wrapping. */
 export function renderSecretHint(value: string, ctx: RenderCtx) {
-  const match = value.match(SECRET_REF_RE);
-  if (!match) return nothing;
+  const key = secretRefKey(value);
+  if (key === null) return nothing;
   return html`<span class="secret-note">
     <wa-icon library="mdi" name="key-variant"></wa-icon>
     <span>${ctx.localize("device.value_from_secret")}</span>
-    <code>${match[1]}</code>
+    <code>${key}</code>
   </span>`;
 }
 
@@ -365,14 +362,34 @@ export function renderStringField(
           ctx.emitChange(path, e.detail.value)}
       ></esphome-secret-picker>`
     : nothing;
-  // Wrap an input with the picker beside it, or swap it out entirely in
-  // secret mode. Plain input when the field isn't secret-eligible.
+  // The API encryption key is a base64 Noise PSK — offer an inline generator
+  // so the user needn't leave for the docs page to mint a valid one. Only with
+  // a literal value (in secret mode the picker owns the field); generating
+  // replaces the literal, and the typed value can still be migrated to a
+  // secret afterwards via the picker.
+  const showGenerate =
+    isApiEncryptionKeyField(ctx.sectionKey, path) && !secretMode && !disabled;
+  const generateAffordance = showGenerate
+    ? html`<button
+        type="button"
+        class="generate-key"
+        @click=${() => ctx.emitChange(path, generateApiEncryptionKey())}
+      >
+        <wa-icon library="mdi" name="auto-fix"></wa-icon>
+        <span>${ctx.localize("device.generate_encryption_key")}</span>
+      </button>`
+    : nothing;
+  // Wrap an input with the picker (and any inline affordance) stacked below,
+  // or swap it out entirely in secret mode. Plain input when the field is
+  // neither secret-eligible nor carrying an affordance.
   const withPicker = (input: unknown) =>
-    !secretEligible
-      ? input
-      : secretMode
-        ? secretPicker
-        : html`<div class="field-input-row">${input}${secretPicker}</div>`;
+    secretMode
+      ? secretPicker
+      : !secretEligible && !showGenerate
+        ? input
+        : html`<div class="field-input-row">
+            ${input}${secretPicker}${generateAffordance}
+          </div>`;
   // Picker doubles as the secret indicator; only the no-picker path hints.
   const secretHint = secretPicker === nothing ? renderSecretHint(value, ctx) : nothing;
   // Never preview the resolved value for concealed fields — a secret kept

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -38,6 +38,7 @@ import {
 import { secretRefKey } from "../../util/secret-ref.js";
 import {
   hasSubstitutionReference,
+  looksLikeSubstitution,
   resolveSubstitutions,
 } from "../../util/substitutions.js";
 import {
@@ -365,13 +366,15 @@ export function renderStringField(
     : nothing;
   // The API encryption key is a base64 Noise PSK — offer an inline generator so
   // the user needn't leave for the docs page to mint a valid one. Shown only
-  // when the field doesn't already hold a valid key, so one click can't clobber
-  // a working key (clear the field to deliberately rotate); suppressed in secret
-  // mode, where the picker owns the field.
+  // when the field holds nothing worth keeping, so one click can't clobber a
+  // working key, a `!secret` ref (suppressed via secretMode, where the picker
+  // owns the field), or a `${substitution}` that resolves at build time. Clear
+  // the field to deliberately rotate.
   const showGenerate =
     isApiEncryptionKeyField(ctx.sectionKey, path) &&
     !secretMode &&
     !disabled &&
+    !looksLikeSubstitution(value) &&
     !isValidApiEncryptionKey(value);
   const generateAffordance = showGenerate
     ? html`<button

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -26,7 +26,8 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
     renderEntries,
     host._values,
     host._presentComponents,
-    host.board?.esphome.platform ?? null
+    host.board?.esphome.platform ?? null,
+    host.sectionKey
   );
 
   const fromLine = resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -658,6 +658,7 @@
     "password_reveal": "Show password",
     "password_hide": "Hide password",
     "value_from_secret": "Using stored secret:",
+    "generate_encryption_key": "Generate a new key",
     "default_option_tag": "default",
     "constraint_exactly_one": "Set exactly one of: {keys}",
     "constraint_exactly_one_radio": "Set exactly one of:",
@@ -890,6 +891,7 @@
     "not_a_number": "Must be a number",
     "not_an_integer": "Must be a whole number",
     "invalid_option": "Not a valid option",
+    "invalid_encryption_key": "Must be a 32-byte base64 key",
     "invalid_device_name": "Only lowercase letters, digits, hyphens and underscores",
     "device_name_underscore": "Underscores work but aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks",
     "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks"

--- a/src/util/api-encryption-key.ts
+++ b/src/util/api-encryption-key.ts
@@ -9,3 +9,26 @@ import { arrayBufferToBase64 } from "./base64.js";
 export function generateApiEncryptionKey(): string {
   return arrayBufferToBase64(crypto.getRandomValues(new Uint8Array(32)).buffer);
 }
+
+/** A Noise PSK is exactly 32 bytes, base64-encoded: 43 base64 chars + one `=`
+ *  pad (32 mod 3 === 2). Matches what `generateApiEncryptionKey` emits and
+ *  what the docs generator / backend `key` validator accept. */
+const API_ENCRYPTION_KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
+
+/** Whether *value* is a well-formed 32-byte base64 API encryption key. */
+export function isValidApiEncryptionKey(value: string): boolean {
+  return API_ENCRYPTION_KEY_RE.test(value);
+}
+
+/**
+ * Whether a structured-editor field is the `api:` → `encryption:` → `key:`
+ * Noise PSK — the one field that wants format validation and a generate
+ * affordance. The same path triplet is referenced by `SECURITY_SETTINGS.api`
+ * (security-notice.ts) and `DEVICE_BASE.api.key` (secret-eligibility.ts).
+ */
+export function isApiEncryptionKeyField(
+  sectionKey: string,
+  path: readonly string[]
+): boolean {
+  return sectionKey === "api" && path.join(".") === "encryption.key";
+}

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,9 +1,14 @@
 import type { ConfigEntry, ConfigPrimitive } from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
+import {
+  isApiEncryptionKeyField,
+  isValidApiEncryptionKey,
+} from "./api-encryption-key.js";
 import { parseFloatWithUnit } from "./float-with-unit.js";
 import { parseHexInt } from "./hex-int.js";
 import { parseIntInput } from "./int-input.js";
 import { asMappingList, asRecord } from "./nested-values.js";
+import { isSecretRef } from "./secret-ref.js";
 import { looksLikeSubstitution } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
@@ -260,7 +265,8 @@ export function validateEntries(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   presentComponents?: Set<string>,
-  targetPlatform?: string | null
+  targetPlatform?: string | null,
+  sectionKey?: string
 ): Map<string, ValidationError> {
   const errors = new Map<string, ValidationError>();
   _validateEntriesRecursive(
@@ -269,7 +275,8 @@ export function validateEntries(
     presentComponents,
     targetPlatform,
     [],
-    errors
+    errors,
+    sectionKey
   );
   return errors;
 }
@@ -286,7 +293,8 @@ function _validateEntriesRecursive(
   presentComponents: Set<string> | undefined,
   targetPlatform: string | null | undefined,
   pathPrefix: string[],
-  errors: Map<string, ValidationError>
+  errors: Map<string, ValidationError>,
+  sectionKey: string | undefined
 ): void {
   for (const entry of entries) {
     // Skip hidden entries and those whose visibility predicates fail —
@@ -329,7 +337,8 @@ function _validateEntriesRecursive(
             presentComponents,
             targetPlatform,
             [...pathPrefix, entry.key, String(idx)],
-            errors
+            errors,
+            sectionKey
           );
         });
         continue;
@@ -352,7 +361,8 @@ function _validateEntriesRecursive(
         presentComponents,
         targetPlatform,
         [...pathPrefix, entry.key],
-        errors
+        errors,
+        sectionKey
       );
       continue;
     }
@@ -393,6 +403,20 @@ function _validateEntriesRecursive(
     if (err) {
       const fullPath = [...pathPrefix, entry.key].join(".");
       errors.set(fullPath, { ...err, key: fullPath });
+    } else if (
+      // Cheap section gate first so non-api leaves never build the path array.
+      sectionKey === "api" &&
+      typeof raw === "string" &&
+      isApiEncryptionKeyField(sectionKey, [...pathPrefix, entry.key]) &&
+      isValuePresent(raw) &&
+      !looksLikeSubstitution(raw) &&
+      !isSecretRef(raw) &&
+      !isValidApiEncryptionKey(raw)
+    ) {
+      // Format-check only the api.encryption.key Noise PSK; a `!secret` ref or
+      // a `${substitution}` resolves elsewhere, so neither is base64-checkable.
+      const fullPath = [...pathPrefix, entry.key].join(".");
+      errors.set(fullPath, { key: fullPath, code: "validation.invalid_encryption_key" });
     }
   }
 }

--- a/src/util/secret-ref.ts
+++ b/src/util/secret-ref.ts
@@ -1,0 +1,13 @@
+/** A `!secret <key>` value points the field at an entry in the secrets store
+ *  rather than holding a literal. */
+const SECRET_REF_RE = /^!secret\s+(\S+)\s*$/;
+
+/** The key a `!secret <key>` value points at, or `null` if not a ref. */
+export function secretRefKey(value: string): string | null {
+  return value.match(SECRET_REF_RE)?.[1] ?? null;
+}
+
+/** Whether *value* is a `!secret <key>` reference. */
+export function isSecretRef(value: string): boolean {
+  return SECRET_REF_RE.test(value);
+}

--- a/test/components/device/config-entry-encryption-key.test.ts
+++ b/test/components/device/config-entry-encryption-key.test.ts
@@ -52,4 +52,9 @@ describe("api encryption key field", () => {
     const { tpl } = renderKeyField("!secret api_encryption_key");
     expect(findElementBindings(tpl, "button")).toHaveLength(0);
   });
+
+  it("omits the affordance once a valid key is present, so a click can't clobber it", () => {
+    const { tpl } = renderKeyField("a".repeat(43) + "=");
+    expect(findElementBindings(tpl, "button")).toHaveLength(0);
+  });
 });

--- a/test/components/device/config-entry-encryption-key.test.ts
+++ b/test/components/device/config-entry-encryption-key.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the api.encryption.key field's inline generate affordance: it renders
+ * for the encryption key, emits a valid key on click, and stays absent for an
+ * ordinary password field or when the value references a secret.
+ */
+import { describe, expect, it, type Mock } from "vitest";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderStringField } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { isValidApiEncryptionKey } from "../../../src/util/api-encryption-key.js";
+import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
+
+const KEY_PATH = ["encryption", "key"];
+
+const keyEntry = () =>
+  makeEntry(ConfigEntryType.SECURE_STRING, { key: "key", label: "Encryption key" });
+
+function renderKeyField(value: string) {
+  const ctx = makeRenderCtx(
+    { encryption: { key: value } },
+    { overrides: { sectionKey: "api" } }
+  );
+  return { ctx, tpl: renderStringField(keyEntry(), "password", KEY_PATH, ctx) };
+}
+
+describe("api encryption key field", () => {
+  it("renders a generate affordance that emits a valid key", () => {
+    const { ctx, tpl } = renderKeyField("");
+    const buttons = findElementBindings(tpl, "button");
+    expect(buttons).toHaveLength(1);
+    (buttons[0]["@click"] as () => void)();
+    expect(ctx.emitChange).toHaveBeenCalledTimes(1);
+    const [path, value] = (ctx.emitChange as Mock).mock.calls[0];
+    expect(path).toEqual(KEY_PATH);
+    expect(isValidApiEncryptionKey(value as string)).toBe(true);
+  });
+
+  it("omits the affordance for an ordinary password field", () => {
+    const ctx = makeRenderCtx(
+      { password: "" },
+      { overrides: { sectionKey: "ota.esphome" } }
+    );
+    const tpl = renderStringField(
+      makeEntry(ConfigEntryType.SECURE_STRING, { key: "password" }),
+      "password",
+      ["password"],
+      ctx
+    );
+    expect(findElementBindings(tpl, "button")).toHaveLength(0);
+  });
+
+  it("omits the affordance when the key references a secret", () => {
+    const { tpl } = renderKeyField("!secret api_encryption_key");
+    expect(findElementBindings(tpl, "button")).toHaveLength(0);
+  });
+});

--- a/test/components/device/config-entry-encryption-key.test.ts
+++ b/test/components/device/config-entry-encryption-key.test.ts
@@ -57,4 +57,9 @@ describe("api encryption key field", () => {
     const { tpl } = renderKeyField("a".repeat(43) + "=");
     expect(findElementBindings(tpl, "button")).toHaveLength(0);
   });
+
+  it("omits the affordance over a ${substitution}, so a click can't clobber the reference", () => {
+    const { tpl } = renderKeyField("${api_key}");
+    expect(findElementBindings(tpl, "button")).toHaveLength(0);
+  });
 });

--- a/test/util/api-encryption-key.test.ts
+++ b/test/util/api-encryption-key.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { generateApiEncryptionKey } from "../../src/util/api-encryption-key.js";
+import {
+  generateApiEncryptionKey,
+  isApiEncryptionKeyField,
+  isValidApiEncryptionKey,
+} from "../../src/util/api-encryption-key.js";
 
 describe("generateApiEncryptionKey", () => {
   it("returns a 44-char base64 string that decodes to 32 bytes", () => {
@@ -12,5 +16,30 @@ describe("generateApiEncryptionKey", () => {
     const a = generateApiEncryptionKey();
     const b = generateApiEncryptionKey();
     expect(a).not.toBe(b);
+  });
+});
+
+describe("isValidApiEncryptionKey", () => {
+  it("accepts a freshly generated key", () => {
+    expect(isValidApiEncryptionKey(generateApiEncryptionKey())).toBe(true);
+  });
+
+  it("rejects wrong length, non-base64, and empty values", () => {
+    expect(isValidApiEncryptionKey("")).toBe(false);
+    expect(isValidApiEncryptionKey("too-short")).toBe(false);
+    // 31 bytes (missing pad) and 33 bytes are both wrong byte counts.
+    expect(isValidApiEncryptionKey("a".repeat(44))).toBe(false);
+    expect(isValidApiEncryptionKey("a".repeat(43) + "=")).toBe(true);
+    // A `!` isn't in the base64 alphabet.
+    expect(isValidApiEncryptionKey("a".repeat(42) + "!=")).toBe(false);
+  });
+});
+
+describe("isApiEncryptionKeyField", () => {
+  it("is true only for api -> encryption.key", () => {
+    expect(isApiEncryptionKeyField("api", ["encryption", "key"])).toBe(true);
+    expect(isApiEncryptionKeyField("api", ["encryption", "port"])).toBe(false);
+    expect(isApiEncryptionKeyField("wifi", ["encryption", "key"])).toBe(false);
+    expect(isApiEncryptionKeyField("api", ["key"])).toBe(false);
   });
 });

--- a/test/util/api-encryption-key.test.ts
+++ b/test/util/api-encryption-key.test.ts
@@ -27,8 +27,11 @@ describe("isValidApiEncryptionKey", () => {
   it("rejects wrong length, non-base64, and empty values", () => {
     expect(isValidApiEncryptionKey("")).toBe(false);
     expect(isValidApiEncryptionKey("too-short")).toBe(false);
-    // 31 bytes (missing pad) and 33 bytes are both wrong byte counts.
+    // 44 unpadded base64 chars decode to 33 bytes (one too many).
     expect(isValidApiEncryptionKey("a".repeat(44))).toBe(false);
+    // 42 chars plus "==" is a 31-byte key (one too few).
+    expect(isValidApiEncryptionKey("a".repeat(42) + "==")).toBe(false);
+    // Exactly 32 bytes: 43 chars plus a single "=".
     expect(isValidApiEncryptionKey("a".repeat(43) + "=")).toBe(true);
     // A `!` isn't in the base64 alphabet.
     expect(isValidApiEncryptionKey("a".repeat(42) + "!=")).toBe(false);

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -602,3 +602,38 @@ describe("validateEntries", () => {
     ).toBe("validation.required");
   });
 });
+
+describe("validateEntries — api encryption key format", () => {
+  // `api:` → `encryption:` → `key:`, the shape the structured editor passes.
+  const entries = [
+    makeEntry({
+      key: "encryption",
+      type: ConfigEntryType.NESTED,
+      config_entries: [makeEntry({ key: "key", type: ConfigEntryType.SECURE_STRING })],
+    }),
+  ];
+  const validate = (key: unknown) =>
+    validateEntries(entries, { encryption: { key } }, undefined, null, "api");
+
+  it("flags a malformed key", () => {
+    expect(validate("not-a-real-key").get("encryption.key")?.code).toBe(
+      "validation.invalid_encryption_key"
+    );
+  });
+
+  it("accepts a well-formed 32-byte base64 key", () => {
+    expect(validate("a".repeat(43) + "=").size).toBe(0);
+  });
+
+  it("skips empty, substitution, and !secret values", () => {
+    expect(validate("").size).toBe(0);
+    expect(validate("${api_key}").size).toBe(0);
+    expect(validate("!secret api_encryption_key").size).toBe(0);
+  });
+
+  it("does not format-check when the section isn't api", () => {
+    expect(
+      validateEntries(entries, { encryption: { key: "bad" } }, undefined, null).size
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

ESPHome does validate the API encryption key, but only at compile time, and the error it surfaces is non-obvious; the structured editor gave no inline feedback while you were editing, and there was no way to mint a valid key without leaving for the docs page. This adds inline validation of the key (32 bytes, base64) right in the field, plus a "Generate a new key" action that fills in a fresh valid key. It reuses the `generateApiEncryptionKey` helper we already ship, the same generator the docs page uses. The `!secret` detector moves into a small util so the renderer and the validator share one source of truth, and a `!secret` reference or a `${substitution}` is skipped rather than wrongly flagged.

Frontend only; no backend change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/952

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
