### PR TITLE
Follow the caret into a block typed on the current line

### DIFF
--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -30,6 +30,7 @@ import { idleCompletion } from "../util/idle-completion.js";
 import { getKeyPath } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
+import { blankLineContext, keyPathByIndent } from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
@@ -144,6 +145,12 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    *  We only emit on line transitions so a horizontal mouse / arrow
    *  movement inside the same line doesn't churn the page state. */
   private _lastReportedCursorLine = 0;
+
+  /** Last top-level key we emitted with `yaml-cursor-line`. Typing or
+   *  completing a new block (`http_re` → `http_request:`) changes the
+   *  section without changing the line number, so we also emit when this
+   *  changes; otherwise the structured panel stays on the old section. */
+  private _lastReportedTopKey: string | null = null;
 
   static styles = css`
     :host {
@@ -412,20 +419,46 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
             })
           );
         }
-        // Cursor moved (click, arrow keys, find-jump). Emit the
-        // 1-indexed line so the page can switch the visual
-        // section editor to match. Throttle to line transitions:
-        // moving within the same line is irrelevant for section
-        // attribution, and emitting on every column change would
-        // churn page state.
+        // Cursor moved (click, arrow keys, find-jump) or a user edit
+        // moved it. Emit the 1-indexed line + key path so the page can
+        // switch the visual section editor to match. Gate on
+        // `selectionSet` only: every user edit (typing, completion
+        // accept) also moves the caret, so this still catches them, but
+        // a programmatic host doc patch (the `value` prop sync) carries
+        // no selection and must not switch sections on an unfocused
+        // editor. Throttle so a mere column move within the same line
+        // and section is ignored, but emit when EITHER the line OR the
+        // top-level key changes: typing/completing a new block (`http_re`
+        // → `http_request:`) changes the section without changing the
+        // line number, and must still re-attribute the panel.
         if (update.selectionSet) {
           const head = update.state.selection.main.head;
           const line = update.state.doc.lineAt(head).number;
-          if (line !== this._lastReportedCursorLine) {
+          // A pure horizontal move within an unchanged line can't change the
+          // line or the top-level key (only a doc edit moves the key), so skip
+          // the key-path walk on same-line cursor moves with no edit.
+          if (line === this._lastReportedCursorLine && !update.docChanged) return;
+          // Full key path; the page derives the form-relative path
+          // (it knows whether the section keys fields under its key).
+          let path = getKeyPath(update.state, head);
+          // The AST yields no Pair on a blank line, so resolve the
+          // enclosing key chain from the caret's indentation instead.
+          // This lets the page attribute a blank, indented child line —
+          // the line under a just-typed `http_request:` with no children
+          // yet — to its section. A column-0 caret resolves to [], so a
+          // true inter-section gap stays unattributed.
+          if (path.length === 0) {
+            const blank = blankLineContext(update.state.doc, head);
+            if (blank)
+              path = keyPathByIndent(update.state.doc, blank.lineIdx, blank.indent);
+          }
+          const topKey = path[0] ?? null;
+          if (
+            line !== this._lastReportedCursorLine ||
+            topKey !== this._lastReportedTopKey
+          ) {
             this._lastReportedCursorLine = line;
-            // Full key path; the page derives the form-relative path
-            // (it knows whether the section keys fields under its key).
-            const path = getKeyPath(update.state, head);
+            this._lastReportedTopKey = topKey;
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
                 detail: { line, path },
@@ -524,6 +557,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     this._destroyView();
     this._container.innerHTML = "";
     this._lastReportedCursorLine = 0;
+    this._lastReportedTopKey = null;
     this._mountEditor();
   }
 

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -42,7 +42,7 @@ import { getLastValidatedResult } from "../util/yaml-lint-backend.js";
 import {
   findFieldLine,
   parseYamlTopLevelSections,
-  sectionAtLine,
+  sectionForCursor,
   sectionKeyOf,
   type YamlSection,
 } from "../util/yaml-sections.js";
@@ -1240,16 +1240,18 @@ export class ESPHomePageDevice extends LitElement {
     // The user is driving from the YAML pane now — drop any pending
     // form-field retry so it can't re-highlight after they've moved on.
     this._clearPendingFieldLine();
-    const match = sectionAtLine(this._yaml, e.detail.line);
+    const full = e.detail.path ?? [];
+    // `sectionForCursor` falls back to the caret's key path when no section
+    // range covers the line, so the panel follows the caret into a blank,
+    // indented child line under a just-typed top-level block.
+    const match = sectionForCursor(this._yaml, e.detail.line, full);
     if (!match) return;
     // Drop the top-level key to get the form-relative path. LIST_SECTIONS
-    // (globals) are the exception: their form keys fields under the
-    // section key, so keep it. (MAP sections like substitutions render at
-    // an empty path, so their fields are section-relative — slice as usual.)
-    const full = e.detail.path ?? [];
-    // LIST_SECTIONS (globals) key fields under the section key, so keep it —
-    // but only with a child segment; a bare ``["globals"]`` header reduces
-    // to [] (a non-field line), not a whole-section field highlight.
+    // (globals) are the exception: their form keys fields under the section
+    // key, so keep it — but only with a child segment; a bare
+    // ``["globals"]`` header reduces to [] (a non-field line), not a
+    // whole-section field highlight. MAP sections like substitutions render
+    // at an empty path, so their fields are section-relative — slice as usual.
     const rel = full.length > 1 && LIST_SECTIONS.has(full[0]) ? full : full.slice(1);
     const sectionKey = sectionKeyOf(match);
     if (

--- a/src/util/yaml-completion-catalog.ts
+++ b/src/util/yaml-completion-catalog.ts
@@ -326,7 +326,8 @@ export function nestedPathForParent(
   // stay on the AST: a missing parentKey there means the walkers disagree
   // (e.g. a list-item context), where the indent walk could synthesise a
   // sibling-laden path. (The fallback is kept here, not inside ``getKeyPath``,
-  // so its AST-only callers — hover, the cursor-line event — still get ``[]``.)
+  // so hover — which wants the raw AST result — still gets ``[]``. The
+  // cursor-line event applies the same blank-line fallback on its own.)
   const blank = blankLineContext(state.doc, pos);
   const path = blank
     ? keyPathByIndent(state.doc, blank.lineIdx, blank.indent)

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -136,7 +136,7 @@ export function findAddedSection(
   // Top-level (non-platform) component — match the bare key, e.g.
   // adding "wifi" navigates to the `wifi:` block.
   if (!componentId.includes(".")) {
-    const match = sections.find((s) => s.key === componentId && !s.platform);
+    const match = _topLevelBlockByKey(sections, componentId);
     if (match) return { sectionKey: match.key, fromLine: match.fromLine };
   }
 
@@ -237,6 +237,39 @@ export function sectionAtLine(yaml: string, line: number): YamlSection | null {
   // by nothing. When the click lands exactly on such a header, select the
   // section's first instance instead of leaving the selection unchanged.
   return _firstItemForListHeader(tops, yaml, line);
+}
+
+/**
+ * Resolve the section the caret belongs to from its line and key path.
+ *
+ * Layers a path-based fallback over `sectionAtLine`: when no section range
+ * covers the line, attribute it to the path's top-level key. That happens on
+ * a blank, indented child line directly under a just-typed top-level block
+ * (`http_request:` then a blank child line) — `sectionAtLine` leaves it
+ * unattributed because the range is trimmed to the last non-blank child. The
+ * caret indent disambiguates: the editor only fills `path` from indentation
+ * for an indented caret, so a column-0 inter-section gap keeps an empty path
+ * and still resolves to null.
+ */
+export function sectionForCursor(
+  yaml: string,
+  line: number,
+  path: readonly string[]
+): YamlSection | null {
+  const hit = sectionAtLine(yaml, line);
+  if (hit) return hit;
+  const topKey = path[0];
+  if (!topKey) return null;
+  return _topLevelBlockByKey(parseYamlTopLevelSections(yaml), topKey);
+}
+
+/**
+ * The bare top-level `<key>:` block (never a platform list item sharing the
+ * key as a catalog id). The `!platform` guard keeps a platform value like
+ * `dht` from matching a `sensor.dht` item.
+ */
+function _topLevelBlockByKey(sections: YamlSection[], key: string): YamlSection | null {
+  return sections.find((s) => s.key === key && !s.platform) ?? null;
 }
 
 function _firstItemForListHeader(

--- a/test/components/yaml-editor-cursor-line.test.ts
+++ b/test/components/yaml-editor-cursor-line.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression for #946: the structured editor follows the caret into a
+ * block typed/completed on the current line. The editor emits
+ * `yaml-cursor-line` on a line change OR a top-level-key change, so
+ * turning a blank/partial line into `http_request:` re-attributes the
+ * section even though the line number never changes.
+ */
+import { forceParsing } from "@codemirror/language";
+import { EditorSelection } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
+
+interface CursorLineDetail {
+  line: number;
+  path: string[];
+}
+
+async function mount(value: string): Promise<ESPHomeYamlEditor> {
+  const el = new ESPHomeYamlEditor();
+  document.body.appendChild(el);
+  await el.updateComplete; // mounts empty
+  el.value = value; // content arrives async (baselined, no event)
+  await el.updateComplete;
+  return el;
+}
+
+const viewOf = (el: ESPHomeYamlEditor): EditorView =>
+  (el as unknown as { _view: EditorView })._view;
+
+const parseAll = (view: EditorView) => forceParsing(view, view.state.doc.length, 60000);
+
+/** Capture every `yaml-cursor-line` the editor emits from now on. */
+function record(el: ESPHomeYamlEditor): CursorLineDetail[] {
+  const seen: CursorLineDetail[] = [];
+  el.addEventListener("yaml-cursor-line", (e) =>
+    seen.push((e as CustomEvent<CursorLineDetail>).detail)
+  );
+  return seen;
+}
+
+const caretToLineEnd = (view: EditorView, line: number) =>
+  view.dispatch({ selection: EditorSelection.single(view.state.doc.line(line).to) });
+
+describe("yaml-editor cursor-line emission (#946)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("re-emits on a same-line top-level-key change (typing a new block)", async () => {
+    // Line 3 starts blank; typing `http_request:` into it keeps line 3 but
+    // changes the top-level key from none to http_request.
+    const el = await mount("esp32:\n  board: a\n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    // Caret rests on the blank top-level line 3 → first emit, no section.
+    caretToLineEnd(view, 3);
+    parseAll(view);
+    expect(events).toHaveLength(1);
+    expect(events[0].line).toBe(3);
+    expect(events[0].path[0]).toBeUndefined();
+
+    // Type the block header on the same line in one transaction — a real
+    // keystroke carries both the edit and the caret move. The same-line
+    // top-level-key change must still re-attribute the section.
+    const at = view.state.doc.length;
+    view.dispatch({
+      changes: { from: at, insert: "http_request:" },
+      selection: EditorSelection.single(at + "http_request:".length),
+    });
+
+    // One more emit, still line 3, now attributed to http_request.
+    expect(events).toHaveLength(2);
+    expect(events[1].line).toBe(3);
+    expect(events[1].path[0]).toBe("http_request");
+  });
+
+  it("does not re-emit while typing within the same section", async () => {
+    const el = await mount("logger:\n  level: DEBUG\n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    // Settle on the value line → one emit under logger.
+    caretToLineEnd(view, 2);
+    parseAll(view);
+    expect(events).toHaveLength(1);
+    expect(events[0].path[0]).toBe("logger");
+
+    // Keep typing in the same value in one transaction (edit + caret move):
+    // same line, same top-level key.
+    const at = view.state.doc.line(2).to;
+    view.dispatch({
+      changes: { from: at, insert: "X" },
+      selection: EditorSelection.single(at + 1),
+    });
+
+    // No churn — the page already shows logger.
+    expect(events).toHaveLength(1);
+  });
+
+  it("attributes an indented blank child line to its block (indent fallback)", async () => {
+    // The AST yields no Pair on the blank line 4; the emitted path comes from
+    // the caret's indentation so the page can follow the caret into the block.
+    const el = await mount("esp32:\n  board: a\nhttp_request:\n  \n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 4); // the "  " line under http_request
+    expect(events).toHaveLength(1);
+    expect(events[0].line).toBe(4);
+    expect(events[0].path[0]).toBe("http_request");
+  });
+
+  it("does not emit on a programmatic doc patch with no selection", async () => {
+    // A host `value`-prop sync into an unfocused split-view editor dispatches
+    // a changes-only transaction (no selection). The gate is `selectionSet`
+    // only, so it must not switch sections off the editor's stale caret.
+    const el = await mount("logger:\n  level: DEBUG\n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    const at = view.state.doc.line(2).to;
+    view.dispatch({ changes: { from: at, insert: "G" } }); // no selection
+    parseAll(view);
+    expect(events).toHaveLength(0);
+  });
+
+  it("still emits on an ordinary line change", async () => {
+    const el = await mount("esphome:\n  name: x\nlogger:\n  level: INFO\n");
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 2); // esphome.name
+    caretToLineEnd(view, 4); // logger.level
+    expect(events).toHaveLength(2);
+    expect(events[0].path[0]).toBe("esphome");
+    expect(events[1].path[0]).toBe("logger");
+  });
+});

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -8,6 +8,7 @@ import {
   parseYamlTopLevelSections,
   resolveCurrentFromLine,
   sectionAtLine,
+  sectionForCursor,
   sectionKeyOf,
   type YamlSection,
 } from "../../src/util/yaml-sections.js";
@@ -434,6 +435,39 @@ script:
     // ``- id: my_routine`` is line 4; the ``then:`` body lives on 6-7.
     const m = sectionAtLine(yaml, 6);
     expect(m?.key).toBe("automation:script:my_routine");
+  });
+});
+
+describe("sectionForCursor", () => {
+  // A just-typed top-level block whose only child line is still blank:
+  // `http_request:` on line 3, an indented blank line 4 under it.
+  const yaml = "esphome:\n  name: x\nhttp_request:\n  \n";
+
+  it("delegates to sectionAtLine when a range covers the line", () => {
+    expect(sectionForCursor(yaml, 2, ["esphome", "name"])?.key).toBe("esphome");
+  });
+
+  it("attributes an uncovered indented child line to its top-level section", () => {
+    // sectionAtLine alone leaves line 4 unattributed (the http_request range
+    // is trimmed to its last non-blank child, i.e. just the header).
+    expect(sectionAtLine(yaml, 4)).toBeNull();
+    expect(sectionForCursor(yaml, 4, ["http_request"])?.key).toBe("http_request");
+  });
+
+  it("stays null on an uncovered line with an empty path (column-0 gap)", () => {
+    expect(sectionForCursor(yaml, 4, [])).toBeNull();
+  });
+
+  it("does not resolve a platform-variant block by its bare key", () => {
+    // The legacy bare-mapping form keys this section "ota" WITH a platform
+    // ("ota.esphome"); the fallback's !platform guard refuses to resolve it
+    // by the bare "ota" key (which would yield the wrong sectionKey). Dropping
+    // the guard would return this section, so this exercises it, not triviality.
+    const platformYaml = "esphome:\n  name: x\nota:\n  platform: esphome\n  \n";
+    const ota = parseYamlTopLevelSections(platformYaml).find((s) => s.key === "ota");
+    expect(ota?.platform).toBe("esphome"); // precondition: the guard's target exists
+    expect(sectionAtLine(platformYaml, 5)).toBeNull();
+    expect(sectionForCursor(platformYaml, 5, ["ota"])).toBeNull();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

The structured editor switches sections by listening to the editor's `yaml-cursor-line` event, which was emitted only when the caret's line number changed. Typing or completing a new top-level block (for example `http_re` becoming `http_request:`) keeps the caret on the same line, so the event never re-fired and the structured panel stayed on the previous section (esp32 framework in the report).

The editor now also emits when the top-level key at the caret changes, not just on a line change, so the section follows the caret as soon as the new block resolves. Mid-field typing within the same section still does not re-fire, so there is no extra churn.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/946

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
