### PR TITLE
Offer actions, not component keys, at an empty "- " in a then: block

### DIFF
--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -128,6 +128,14 @@ export function isUnderThenItem(state: EditorState, pos: number): boolean {
  *  legacy ``then``-only carve-out. */
 const RE_AUTOMATION_KEY = /^(?:then|else|on_[a-z0-9_]*|[a-z0-9_]+_action)$/;
 
+/** True for pair keys whose value is a list of actions: ``then`` /
+ *  ``else`` / ``on_*`` / ``*_action``. The indent-based completion
+ *  fallback uses this when the Lezer parse mis-nests an empty trailing
+ *  ``- `` and ``isUnderAutomationItem`` can't see the enclosing key. */
+export function isAutomationKey(key: string): boolean {
+  return RE_AUTOMATION_KEY.test(key);
+}
+
 /**
  * True when *pos* is inside a list ``Item`` whose enclosing Pair
  * is an automation-shaped key. Generalised from the legacy
@@ -149,7 +157,7 @@ export function isUnderAutomationItem(state: EditorState, pos: number): boolean 
         const pair = seq.parent;
         if (pair?.name === "Pair") {
           const key = getPairKey(state, pair);
-          if (key && RE_AUTOMATION_KEY.test(key)) return true;
+          if (key && isAutomationKey(key)) return true;
         }
       }
     }

--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -31,6 +31,7 @@ import { getConfigVarValueOptions } from "./esphome-schema.js";
 import {
   collectSiblingKeys,
   collectSubstitutionKeys,
+  isAutomationKey,
   isUnderAutomationItem,
 } from "./yaml-ast.js";
 import {
@@ -346,7 +347,11 @@ export function createYamlCompletionSource(
       // and ``*_action:`` (cover ``open_action`` / ``close_action`` /
       // ``stop_action``, lock ``unlock_action``, etc.) all surface
       // the action registry at list-item position.
-      inAutomation: isListItem && isUnderAutomationItem(state, pos),
+      // ``isUnderAutomationItem`` reads the Lezer tree, which mis-nests an
+      // empty trailing ``- `` so the enclosing ``then:``/``on_*:`` is lost;
+      // the indent-derived ``parent`` survives that, so OR it in.
+      inAutomation:
+        isListItem && (isUnderAutomationItem(state, pos) || isAutomationKey(parent.key)),
       // Triggers all start with ``on_``; gate the schema fetch on
       // the partial's prefix so non-trigger keystrokes don't burn
       // a round-trip.

--- a/test/util/yaml-ast.test.ts
+++ b/test/util/yaml-ast.test.ts
@@ -6,6 +6,7 @@ import {
   collectTopLevelKeys,
   getPlatformValue,
   getTopLevelKey,
+  isAutomationKey,
   isUnderThenItem,
   resolveBundleContext,
 } from "../../src/util/yaml-ast.js";
@@ -243,6 +244,30 @@ describe("isUnderThenItem", () => {
     const state = makeState(yaml);
     // Cursor on the ``- delay: 2s`` line under ``else:``.
     expect(isUnderThenItem(state, posAt(yaml, 10, 14))).toBe(true);
+  });
+});
+
+describe("isAutomationKey", () => {
+  // The completion source ORs this against isUnderAutomationItem so the
+  // action registry still fires on an empty trailing "- " (where the
+  // Lezer parse mis-nests and the AST can't see the enclosing key).
+  it("matches action-list keys", () => {
+    for (const key of [
+      "then",
+      "else",
+      "on_press",
+      "on_multi_click",
+      "open_action",
+      "unlock_action",
+    ]) {
+      expect(isAutomationKey(key)).toBe(true);
+    }
+  });
+
+  it("rejects ordinary config / trigger-host keys", () => {
+    for (const key of ["web_server", "platform", "zigbee_id", "filters", "pin"]) {
+      expect(isAutomationKey(key)).toBe(false);
+    }
   });
 });
 

--- a/test/util/yaml-completion-automation.test.ts
+++ b/test/util/yaml-completion-automation.test.ts
@@ -89,14 +89,16 @@ describe("createYamlCompletionSource (automation action list)", () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it("offers actions, not component keys, at an empty trailing '- ' under then:", async () => {
+  // The action registry only fires when the source resolves `inAutomation`,
+  // and every other key provider bails when it does — so on a regression
+  // (the bug: `inAutomation` false at the empty dash) the action labels
+  // vanish entirely. These `toContain` assertions are therefore the
+  // regression guard; a vacuous `not.toContain("web_server")` would add
+  // nothing here since the hermetic fixtures never serve component keys.
+  it("offers actions at an empty trailing '- ' under then:", async () => {
     const labels = await labelsAt([...DEVICE, "        - "].join("\n"));
     expect(labels).toContain("delay");
     expect(labels).toContain("switch.turn_on");
-    // The bug: the enclosing binary_sensor's config keys / triggers leaked in.
-    expect(labels).not.toContain("web_server");
-    expect(labels).not.toContain("zigbee_binary_sensor");
-    expect(labels).not.toContain("on_press");
   });
 
   it("still offers actions for a partial-key list item (AST path, no regression)", async () => {
@@ -105,6 +107,5 @@ describe("createYamlCompletionSource (automation action list)", () => {
     const labels = await labelsAt([...DEVICE, "        - s"].join("\n"));
     expect(labels).toContain("delay");
     expect(labels).toContain("switch.turn_on");
-    expect(labels).not.toContain("zigbee_binary_sensor");
   });
 });

--- a/test/util/yaml-completion-automation.test.ts
+++ b/test/util/yaml-completion-automation.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+//
+// Pins that completion inside an automation action body offers the
+// action registry — not the enclosing component's config keys/triggers —
+// including at an empty trailing "- ", where the Lezer parse mis-nests
+// the dash and the AST-only context check used to fall back to the
+// component schema (the zigbee_binary_sensor-under-on_press bug).
+import { CompletionContext } from "@codemirror/autocomplete";
+import { forceParsing } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComponentCategory } from "../../src/api/types/components.js";
+import { _clearComponentCache } from "../../src/util/component-name-cache.js";
+import { _resetSchemaCacheForTests } from "../../src/util/esphome-schema.js";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
+import { makeComponentEntry } from "./_make-component-entry.js";
+
+const SLIM = [
+  makeComponentEntry("esphome", { category: ComponentCategory.CORE }),
+  makeComponentEntry("binary_sensor.gpio", { category: ComponentCategory.BINARY_SENSOR }),
+  makeComponentEntry("switch.gpio", { category: ComponentCategory.SWITCH }),
+];
+
+const fakeApi = {
+  getVersion: async () => ({ esphome_version: "2026.5.1" }),
+  getComponents: async () => ({ components: SLIM }),
+  getComponentBodies: async () => ({}),
+  getComponent: async () => null,
+} as never;
+
+// The action registry reads each present component's bundle and pulls its
+// `action` map (core actions live under the `esphome` bundle's `core`).
+function bundleFor(url: string): Response {
+  if (url.endsWith("/esphome.json")) {
+    // Doubles as the version probe and the core-action bundle.
+    return new Response(
+      JSON.stringify({ core: { action: { delay: {}, lambda: {}, if: {} } } }),
+      { status: 200 }
+    );
+  }
+  if (url.endsWith("/switch.json")) {
+    return new Response(
+      JSON.stringify({ switch: { action: { turn_on: {}, turn_off: {} } } }),
+      { status: 200 }
+    );
+  }
+  return new Response("{}", { status: 200 });
+}
+
+async function labelsAt(yaml: string, explicit = false): Promise<string[]> {
+  const view = new EditorView({
+    state: EditorState.create({ doc: yaml, extensions: [esphomeYaml()] }),
+  });
+  try {
+    forceParsing(view, yaml.length, 60000);
+    const ctx = new CompletionContext(view.state, yaml.length, explicit);
+    const result = await createYamlCompletionSource(fakeApi)(ctx);
+    return (result?.options ?? []).map((o) => o.label);
+  } finally {
+    view.destroy();
+  }
+}
+
+const DEVICE = [
+  "switch:",
+  "  - platform: gpio",
+  "    id: relay1",
+  "    pin: GPIO33",
+  "binary_sensor:",
+  "  - platform: gpio",
+  "    id: button",
+  "    name: Gate",
+  "    pin: GPIO34",
+  "    on_press:",
+  "      then:",
+  "        - switch.turn_on: relay1",
+];
+
+describe("createYamlCompletionSource (automation action list)", () => {
+  beforeEach(() => {
+    _clearComponentCache();
+    _resetSchemaCacheForTests();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => bundleFor(url))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("offers actions, not component keys, at an empty trailing '- ' under then:", async () => {
+    const labels = await labelsAt([...DEVICE, "        - "].join("\n"));
+    expect(labels).toContain("delay");
+    expect(labels).toContain("switch.turn_on");
+    // The bug: the enclosing binary_sensor's config keys / triggers leaked in.
+    expect(labels).not.toContain("web_server");
+    expect(labels).not.toContain("zigbee_binary_sensor");
+    expect(labels).not.toContain("on_press");
+  });
+
+  it("still offers actions for a partial-key list item (AST path, no regression)", async () => {
+    // A non-empty dash parses cleanly, so the AST context check already
+    // fires here; assert the fix didn't disturb that path.
+    const labels = await labelsAt([...DEVICE, "        - s"].join("\n"));
+    expect(labels).toContain("delay");
+    expect(labels).toContain("switch.turn_on");
+    expect(labels).not.toContain("zigbee_binary_sensor");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Inside an automation action body (`on_press:` then `then:`), typing on a fresh `- ` list item offered the enclosing component's config keys and triggers (`web_server`, `zigbee_binary_sensor`, `on_press`, ...) instead of actions like `switch.turn_on`, `delay`, `lambda`.

The cause is the YAML parser; an empty trailing `- ` can't be placed by Lezer's error recovery, so the AST-based check that decides "are we in an action list" loses the enclosing `then:` and the completion falls back to the component schema. The indent-based parent key already resolves to `then` at that spot, so I OR that into the in-automation check; once it's true the action registry fires and the config key / trigger providers correctly bail. A content-bearing `- ` already parsed fine and keeps working.

**Related issue or feature (if applicable):**

- N/A (reported directly)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
