### PR TITLE
Make validation-error message URLs clickable

### DIFF
--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -18,6 +18,7 @@ import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { expertModeContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { renderTextLinks } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SaveShortcutController } from "../../util/save-shortcut-controller.js";
 import {
@@ -329,7 +330,10 @@ export class ESPHomeDeviceEditor extends LitElement {
                       ${this._liveErrors
                         .slice(0, MAX_BANNER_ERRORS)
                         .map(
-                          (msg) => html`<span class="invalid-banner-error">${msg}</span>`
+                          (msg) =>
+                            html`<span class="invalid-banner-error"
+                              >${renderTextLinks(msg)}</span
+                            >`
                         )}
                       ${this._liveErrors.length > MAX_BANNER_ERRORS
                         ? html`<span class="invalid-banner-more"

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -239,6 +239,10 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         ".cm-diagnostic + .cm-diagnostic": {
           borderTop: this._darkMode ? "1px solid #2a2a32" : "1px solid #f0f1f3",
         },
+        ".cm-diagnostic a.cm-diagnostic-link": {
+          color: this._darkMode ? "#8cc2ff" : "#0b5cad",
+          textDecoration: "underline",
+        },
         ".cm-diagnostic-error": {
           borderLeftColor: this._darkMode ? "#ff6b6b" : "#d92d20",
         },

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -170,6 +170,8 @@ export function splitTextLinks(input: string): TextLinkSegment[] {
       url = url.slice(0, -1);
     }
     if (start > last) segments.push({ text: input.slice(last, start) });
+    // href is set for every match today (BARE_URL_RE is http(s)-only); the gate
+    // mirrors renderMarkdown so a broader matcher later can't emit an unsafe anchor.
     segments.push(isSafeLinkHref(url) ? { text: url, href: url } : { text: url });
     if (tail) segments.push({ text: tail });
     last = start + match[0].length;

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -131,3 +131,64 @@ export function renderMarkdown(
   const segments = parseMarkdown(input);
   return html`${segments.map(renderSegment)}`;
 }
+
+/** Bare http(s) URLs embedded in otherwise-plain text (validation messages). */
+const BARE_URL_RE = /https?:\/\/[^\s<>]+/g;
+
+/** Sentence punctuation that trails a URL in prose but isn't part of it. */
+const TRAILING_PUNCT_RE = /[.,;:!?]+$/;
+
+export interface TextLinkSegment {
+  text: string;
+  /** Present only when 'text' is a safe, clickable URL. */
+  href?: string;
+}
+
+/**
+ * Split plain text into text / URL segments, autolinking bare http(s) URLs.
+ *
+ * Trailing sentence punctuation (and an unbalanced close paren) is peeled back
+ * into the following text so the link stops at the URL. The isSafeLinkHref gate
+ * keeps this in lockstep with renderMarkdown. Plain text only, no Markdown.
+ */
+export function splitTextLinks(input: string): TextLinkSegment[] {
+  const segments: TextLinkSegment[] = [];
+  let last = 0;
+  for (const match of input.matchAll(BARE_URL_RE)) {
+    const start = match.index ?? 0;
+    let url = match[0];
+    let tail = "";
+    const punct = url.match(TRAILING_PUNCT_RE);
+    if (punct) {
+      tail = punct[0];
+      url = url.slice(0, -tail.length);
+    }
+    if (url.endsWith(")") && !url.includes("(")) {
+      tail = `)${tail}`;
+      url = url.slice(0, -1);
+    }
+    if (start > last) segments.push({ text: input.slice(last, start) });
+    segments.push(isSafeLinkHref(url) ? { text: url, href: url } : { text: url });
+    if (tail) segments.push({ text: tail });
+    last = start + match[0].length;
+  }
+  if (last < input.length) segments.push({ text: input.slice(last) });
+  return segments;
+}
+
+/**
+ * Render plain text as a Lit template, autolinking bare URLs as new-tab
+ * anchors. Returns `nothing` for empty input; output is escaped (no unsafeHTML).
+ */
+export function renderTextLinks(
+  input: string | null | undefined
+): TemplateResult | typeof nothing {
+  if (!input) return nothing;
+  return html`${splitTextLinks(input).map((seg) =>
+    seg.href
+      ? html`<a class="md-link" href=${seg.href} target="_blank" rel="noopener noreferrer"
+          >${seg.text}</a
+        >`
+      : seg.text
+  )}`;
+}

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -155,9 +155,11 @@ export function splitTextLinks(input: string): TextLinkSegment[] {
   const segments: TextLinkSegment[] = [];
   let last = 0;
   for (const match of input.matchAll(BARE_URL_RE)) {
-    const start = match.index ?? 0;
+    const start = match.index!;
     let url = match[0];
     let tail = "";
+    // Order matters: strip the punctuation run first, then the unbalanced
+    // paren, so 'Foo_(bar).' keeps ')' but drops '.'.
     const punct = url.match(TRAILING_PUNCT_RE);
     if (punct) {
       tail = punct[0];

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -23,6 +23,7 @@ import {
 import { gutterLineClass, GutterMarker, type EditorView } from "@codemirror/view";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { EditorValidateResponse } from "../api/types/editor.js";
+import { splitTextLinks } from "./markdown.js";
 
 interface BackendLinterOptions {
   api: ESPHomeAPI;
@@ -94,6 +95,25 @@ const CORE_BLOCK_KEY = "esphome";
  */
 export function sanitizeMessage(message: string): string {
   return message.replace(QUOTED_PATH_RE, '"$2"');
+}
+
+/** Lint-tooltip DOM for a message, autolinking bare URLs to new-tab anchors. */
+function renderMessageNode(message: string): HTMLSpanElement {
+  const span = document.createElement("span");
+  for (const seg of splitTextLinks(message)) {
+    if (seg.href) {
+      const link = document.createElement("a");
+      link.href = seg.href;
+      link.textContent = seg.text;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.className = "cm-diagnostic-link";
+      span.appendChild(link);
+    } else {
+      span.appendChild(document.createTextNode(seg.text));
+    }
+  }
+  return span;
 }
 
 /**
@@ -278,7 +298,14 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           continue;
         }
         const { from, to } = lineToOffsets(view, pos.line, pos.col);
-        diagnostics.push({ from, to, severity: "error", source: "yaml", message });
+        diagnostics.push({
+          from,
+          to,
+          severity: "error",
+          source: "yaml",
+          message,
+          renderMessage: () => renderMessageNode(message),
+        });
       }
 
       // Schema/validation errors carry an explicit range.
@@ -294,7 +321,14 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           bannerErrors.push(message);
           continue;
         }
-        diagnostics.push({ from, to, severity: "error", source: "esphome", message });
+        diagnostics.push({
+          from,
+          to,
+          severity: "error",
+          source: "esphome",
+          message,
+          renderMessage: () => renderMessageNode(message),
+        });
       }
 
       opts.onResult?.(bannerErrors, configuration);

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -98,7 +98,7 @@ export function sanitizeMessage(message: string): string {
 }
 
 /** Lint-tooltip DOM for a message, autolinking bare URLs to new-tab anchors. */
-function renderMessageNode(message: string): HTMLSpanElement {
+export function renderMessageNode(message: string): HTMLSpanElement {
   const span = document.createElement("span");
   for (const seg of splitTextLinks(message)) {
     if (seg.href) {

--- a/test/util/markdown.test.ts
+++ b/test/util/markdown.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isSafeLinkHref } from "../../src/util/markdown.js";
+import { isSafeLinkHref, splitTextLinks } from "../../src/util/markdown.js";
 
 describe("isSafeLinkHref — accepted schemes", () => {
   it("accepts http://", () => {
@@ -107,5 +107,62 @@ describe("isSafeLinkHref — rejected schemes", () => {
     // tweak can't accidentally widen the prefix.
     expect(isSafeLinkHref("\tjavascript:alert(1)")).toBe(false);
     expect(isSafeLinkHref("\njavascript:alert(1)")).toBe(false);
+  });
+});
+
+describe("splitTextLinks", () => {
+  it("returns a single text segment when there is no URL", () => {
+    expect(splitTextLinks("Invalid POSIX timezone string 'CDT'")).toEqual([
+      { text: "Invalid POSIX timezone string 'CDT'" },
+    ]);
+  });
+
+  it("links a bare URL and keeps a trailing period as text", () => {
+    // The real esphome timezone error: the sentence-ending period
+    // must not become part of the href.
+    expect(
+      splitTextLinks(
+        "check the list at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones."
+      )
+    ).toEqual([
+      { text: "check the list at " },
+      {
+        text: "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones",
+        href: "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones",
+      },
+      { text: "." },
+    ]);
+  });
+
+  it("links a URL embedded mid-sentence", () => {
+    expect(splitTextLinks("see https://esphome.io/foo for details")).toEqual([
+      { text: "see " },
+      { text: "https://esphome.io/foo", href: "https://esphome.io/foo" },
+      { text: " for details" },
+    ]);
+  });
+
+  it("links each of several URLs", () => {
+    const segs = splitTextLinks("https://a.example and https://b.example");
+    expect(segs.filter((s) => s.href).map((s) => s.href)).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ]);
+  });
+
+  it("keeps a paren inside the URL but peels an unbalanced trailing one", () => {
+    // Wikipedia-style '_(disambiguation)' stays in the link; a closing
+    // paren with no opener (prose wrapping) is pushed back to text.
+    expect(splitTextLinks("https://en.wikipedia.org/wiki/Foo_(bar)")).toEqual([
+      {
+        text: "https://en.wikipedia.org/wiki/Foo_(bar)",
+        href: "https://en.wikipedia.org/wiki/Foo_(bar)",
+      },
+    ]);
+    expect(splitTextLinks("(see https://esphome.io/foo)")).toEqual([
+      { text: "(see " },
+      { text: "https://esphome.io/foo", href: "https://esphome.io/foo" },
+      { text: ")" },
+    ]);
   });
 });

--- a/test/util/render-text-links.test.ts
+++ b/test/util/render-text-links.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the anchor wiring the two autolink consumers emit: the security
+ * contract (target/rel, no innerHTML) lives here, not in the splitTextLinks
+ * unit tests. renderMessageNode feeds the CodeMirror lint tooltip;
+ * renderTextLinks feeds the configuration-invalid banner.
+ */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { renderTextLinks } from "../../src/util/markdown.js";
+import { renderMessageNode } from "../../src/util/yaml-lint-backend.js";
+
+const MSG = "check the list at https://example.com/tz.";
+
+describe("renderMessageNode", () => {
+  it("wires a new-tab anchor with the noopener rel", () => {
+    const anchor = renderMessageNode(MSG).querySelector("a")!;
+    expect(anchor.getAttribute("href")).toBe("https://example.com/tz");
+    expect(anchor.textContent).toBe("https://example.com/tz");
+    expect(anchor.target).toBe("_blank");
+    expect(anchor.rel).toBe("noopener noreferrer");
+    expect(anchor.className).toBe("cm-diagnostic-link");
+  });
+
+  it("keeps surrounding prose as text nodes, not markup", () => {
+    const span = renderMessageNode(MSG);
+    // Lead text, the anchor, then the trailing period; the period must be a
+    // bare text node so a future innerHTML swap would visibly break this.
+    expect(span.childNodes[0]).toBeInstanceOf(Text);
+    expect(span.childNodes[0].textContent).toBe("check the list at ");
+    const tail = span.childNodes[span.childNodes.length - 1];
+    expect(tail).toBeInstanceOf(Text);
+    expect(tail.textContent).toBe(".");
+  });
+
+  it("emits no anchor when there is no URL", () => {
+    expect(renderMessageNode("plain text").querySelector("a")).toBeNull();
+  });
+});
+
+describe("renderTextLinks", () => {
+  it("renders a new-tab md-link anchor in a Lit template", () => {
+    const host = document.createElement("div");
+    render(renderTextLinks(MSG), host);
+    const anchor = host.querySelector("a")!;
+    expect(anchor.getAttribute("href")).toBe("https://example.com/tz");
+    expect(anchor.target).toBe("_blank");
+    expect(anchor.rel).toBe("noopener noreferrer");
+    expect(anchor.className).toBe("md-link");
+  });
+
+  it("renders nothing for empty input", () => {
+    const host = document.createElement("div");
+    render(renderTextLinks(""), host);
+    expect(host.querySelector("a")).toBeNull();
+    expect(host.textContent).toBe("");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

ESPHome validation messages frequently end with a documentation URL; the timezone error, for example, points at the tz-database wiki page. That URL rendered as plain, inert text in both the lint hover tooltip and the configuration-invalid banner, so users could not click through.

This autolinks bare `http(s)` URLs in validation messages. A new `splitTextLinks` helper in `markdown.ts` splits the text into plain and URL spans, gated through the existing `isSafeLinkHref` scheme check (no new dependency, no `unsafeHTML`). The CodeMirror tooltip path builds DOM anchors via the diagnostic's `renderMessage` callback; the banner reuses a small Lit renderer. Trailing sentence punctuation (the period after the tz-database link) is kept out of the href, and a wrapping close paren is peeled back too.

Links open in a new tab with `rel="noopener noreferrer"`, matching the existing markdown-link convention.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
