### PR TITLE
Follow the caret to the right field, revealing advanced fields

### DIFF
--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -17,7 +17,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { actionFieldLabel } from "../../util/action-field-label.js";
 import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.js";
-import { anyAdvancedEntry } from "../../util/config-entry-tree.js";
+import { anyAdvancedEntry, pathIsAdvanced } from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -136,6 +136,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
   @state() _advancedShownSections = new Set<string>();
   @state() _presentComponents: Set<string> = new Set();
 
+  // Sections whose advanced fields we've auto-revealed for caret-follow once.
+  // Not reactive — bookkeeping so a later deliberate collapse isn't reopened.
+  private readonly _autoRevealedSections = new Set<string>();
+
   // Section's resolved fromLine against the *current* yaml. Forwarded to the
   // form so its conflict-detection stays aligned with read/write paths.
   // undefined when not found — form treats that as "no exclusion".
@@ -194,6 +198,29 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     ) {
       void loadConfig(this);
     }
+    this._revealAdvancedForFocus(changedProperties);
+  }
+
+  /**
+   * When the caret follows to an advanced field that's currently hidden (Show
+   * advanced off and the field has no value yet, so it isn't rendered), reveal
+   * the section's advanced fields here in willUpdate so the field renders this
+   * pass and the form's scroll-to-field can reach it. Revealed at most once per
+   * section so a later deliberate collapse sticks (mirrors config-entry-form's
+   * seed-once nested-disclosure behaviour — caret-follow shouldn't fight the
+   * user's choice).
+   */
+  private _revealAdvancedForFocus(changedProperties: Map<string, unknown>): void {
+    if (!changedProperties.has("focusFieldPath") && !changedProperties.has("_config")) {
+      return;
+    }
+    const path = this.focusFieldPath;
+    if (!path?.length || this._showAdvanced || !this._config) return;
+    if (this._autoRevealedSections.has(this.sectionKey)) return;
+    const entries = resolveSectionEntries(this.sectionKey, this._config.entries);
+    if (!pathIsAdvanced(entries, path)) return;
+    this._autoRevealedSections.add(this.sectionKey);
+    this._setShowAdvanced(true);
   }
 
   updated() {

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -27,10 +27,14 @@ import {
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
-import { getKeyPath } from "../util/yaml-ast.js";
+import { getKeyPath, isInsideBlockScalar } from "../util/yaml-ast.js";
 import { createYamlCompletionSource } from "../util/yaml-completion.js";
 import { createYamlHoverTooltip } from "../util/yaml-hover.js";
-import { blankLineContext, keyPathByIndent } from "../util/yaml-line-walker.js";
+import {
+  blankLineContext,
+  fieldPathByIndent,
+  keyPathByIndent,
+} from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
   lintErrorLineGutter,
@@ -146,11 +150,13 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    *  movement inside the same line doesn't churn the page state. */
   private _lastReportedCursorLine = 0;
 
-  /** Last top-level key we emitted with `yaml-cursor-line`. Typing or
-   *  completing a new block (`http_re` → `http_request:`) changes the
-   *  section without changing the line number, so we also emit when this
-   *  changes; otherwise the structured panel stays on the old section. */
-  private _lastReportedTopKey: string | null = null;
+  /** Joined key path last emitted with `yaml-cursor-line`. We re-emit when the
+   *  resolved path changes — a different section OR a different field on the
+   *  same line (typing/completing a new block, or moving between fields of a
+   *  list item, where the line and top-level key stay put). Throttling on the
+   *  whole path keeps both section- and field-following in sync without
+   *  churning on plain column moves. */
+  private _lastReportedPathKey = "";
 
   static styles = css`
     :host {
@@ -426,39 +432,50 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         // accept) also moves the caret, so this still catches them, but
         // a programmatic host doc patch (the `value` prop sync) carries
         // no selection and must not switch sections on an unfocused
-        // editor. Throttle so a mere column move within the same line
-        // and section is ignored, but emit when EITHER the line OR the
-        // top-level key changes: typing/completing a new block (`http_re`
-        // → `http_request:`) changes the section without changing the
-        // line number, and must still re-attribute the panel.
+        // editor. Throttle so a mere column move within the same line and
+        // field is ignored, but emit whenever the resolved path changes —
+        // a new section OR a new field on the same line (typing a block or
+        // moving between a list item's fields).
         if (update.selectionSet) {
           const head = update.state.selection.main.head;
           const line = update.state.doc.lineAt(head).number;
           // A pure horizontal move within an unchanged line can't change the
-          // line or the top-level key (only a doc edit moves the key), so skip
-          // the key-path walk on same-line cursor moves with no edit.
+          // path (only a doc edit can), so skip the walk on same-line cursor
+          // moves with no edit.
           if (line === this._lastReportedCursorLine && !update.docChanged) return;
-          // Full key path; the page derives the form-relative path
-          // (it knows whether the section keys fields under its key).
-          let path = getKeyPath(update.state, head);
-          // The AST yields no Pair on a blank line, so resolve the
-          // enclosing key chain from the caret's indentation instead.
-          // This lets the page attribute a blank, indented child line —
-          // the line under a just-typed `http_request:` with no children
-          // yet — to its section. A column-0 caret resolves to [], so a
-          // true inter-section gap stays unattributed.
-          if (path.length === 0) {
-            const blank = blankLineContext(update.state.doc, head);
-            if (blank)
-              path = keyPathByIndent(update.state.doc, blank.lineIdx, blank.indent);
+          // Resolve the caret's key path field-first (the page derives the
+          // form-relative path from it). The AST can't anchor an empty-value
+          // `key:` (Lezer leaves the Pair open) and yields nothing on a blank
+          // line, so prefer the indent walkers there: fieldPathByIndent gives
+          // the field path including the leaf key for an empty-value pair, else
+          // fall back to the AST, else the ancestor chain from a blank line.
+          // `skipListItems` keeps an anonymous `- ` dash from masquerading as a
+          // container key.
+          let path = fieldPathByIndent(update.state.doc, line - 1);
+          // Inside a block scalar (a `lambda: |-` body) a `key:`-looking
+          // content line is literal text, not a field; the regex can't tell,
+          // so defer to the AST there.
+          if (path && isInsideBlockScalar(update.state, head)) path = null;
+          if (!path) {
+            path = getKeyPath(update.state, head);
+            if (path.length === 0) {
+              const blank = blankLineContext(update.state.doc, head);
+              if (blank)
+                path = keyPathByIndent(
+                  update.state.doc,
+                  blank.lineIdx,
+                  blank.indent,
+                  true
+                );
+            }
           }
-          const topKey = path[0] ?? null;
+          const pathKey = JSON.stringify(path);
           if (
             line !== this._lastReportedCursorLine ||
-            topKey !== this._lastReportedTopKey
+            pathKey !== this._lastReportedPathKey
           ) {
             this._lastReportedCursorLine = line;
-            this._lastReportedTopKey = topKey;
+            this._lastReportedPathKey = pathKey;
             this.dispatchEvent(
               new CustomEvent("yaml-cursor-line", {
                 detail: { line, path },
@@ -557,7 +574,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     this._destroyView();
     this._container.innerHTML = "";
     this._lastReportedCursorLine = 0;
-    this._lastReportedTopKey = null;
+    this._lastReportedPathKey = "";
     this._mountEditor();
   }
 

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -39,6 +39,23 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
 }
 
 /**
+ * Whether the entry at *path* — or any NESTED ancestor along it — is
+ * `advanced`. Used to reveal a section's hidden advanced fields when the
+ * caret follows to one. Returns false if the path doesn't resolve.
+ */
+export function pathIsAdvanced(entries: ConfigEntry[], path: string[]): boolean {
+  let level = entries;
+  let advanced = false;
+  for (const key of path) {
+    const entry = level.find((e) => e.key === key);
+    if (!entry) return false;
+    if (entry.advanced) advanced = true;
+    level = entry.config_entries ?? [];
+  }
+  return advanced;
+}
+
+/**
  * Walk the entries in render order and return the first error target.
  * `path` is the dotted path of the failing leaf field;
  * `hasAdvancedAncestor` is true when the leaf itself or any

--- a/src/util/yaml-ast.ts
+++ b/src/util/yaml-ast.ts
@@ -209,6 +209,23 @@ export function getKeyPath(state: EditorState, pos: number): string[] {
 }
 
 /**
+ * Whether *pos* sits inside a block scalar's content (a ``key: |`` / ``>``
+ * body), where an indented ``key:``-looking line is literal text, not a real
+ * pair. Indent-based path resolvers (which the regex can't tell apart from a
+ * field) must defer to the AST here — Lezer parses the body as ``BlockLiteral``.
+ */
+export function isInsideBlockScalar(state: EditorState, pos: number): boolean {
+  let node: SyntaxNode | null = syntaxTree(state).resolveInner(pos, -1);
+  while (node) {
+    if (node.name === "BlockLiteral" || node.name === "BlockLiteralContent") {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
+}
+
+/**
  * Read the ``platform:`` value of the enclosing list-item, if any
  * (``binary_sensor: - platform: gpio`` → ``"gpio"``). Returns
  * ``null`` when the cursor isn't inside a list-item that declares

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -34,6 +34,11 @@ export const RE_PAIR_LINE = /^\s*(?:-\s+)?([A-Za-z0-9_.]+)\s*:\s*(.*)$/;
  *  top-level component blocks when walking up from the cursor. */
 export const RE_TOP_LEVEL_KEY = /^([A-Za-z0-9_]+)\s*:/;
 
+/** A list-item line — optional indent then a ``- `` dash. The item is an
+ *  anonymous container, so an indent walk treating list items as parentless
+ *  uses this to skip the dash line's inline key. */
+export const RE_LIST_ITEM = /^\s*-\s/;
+
 /** ``platform: gpio`` sibling reader. Same shape as
  *  ``RE_PAIR_LINE`` but constrains the key to literal
  *  ``platform``. Accepts unquoted (``platform: gpio``),
@@ -75,12 +80,17 @@ export interface ParentKey {
 /**
  * Walk back from *lineIdx* to find the nearest key-line whose
  * indent is strictly less than *belowIndent*. The parent block of
- * the cursor.
+ * the cursor. With *skipListItems*, an inline ``- key: value`` list item
+ * contributes no key (its inline key is a sibling field, not a container),
+ * so walking continues to the named container. An empty-value ``- key:``
+ * IS a container (e.g. ``- logger.log:`` whose args nest under it), so its
+ * key is kept — matching what the AST ``getKeyPath`` yields.
  */
 export function findParentKey(
   doc: Text,
   lineIdx: number,
-  belowIndent: number
+  belowIndent: number,
+  skipListItems = false
 ): ParentKey | null {
   for (let i = lineIdx - 1; i >= 0; i--) {
     const stripped = stripComment(doc.line(i + 1).text);
@@ -88,7 +98,9 @@ export function findParentKey(
     const ind = indentOf(stripped);
     if (ind >= belowIndent) continue;
     const m = stripped.match(RE_PAIR_LINE);
-    if (m) return { key: m[1], indent: ind, lineIdx: i };
+    if (!m) continue;
+    if (skipListItems && m[2] !== "" && RE_LIST_ITEM.test(stripped)) continue;
+    return { key: m[1], indent: ind, lineIdx: i };
   }
   return null;
 }
@@ -121,18 +133,39 @@ export function blankLineContext(
  * nested context of an empty indented line (which has no Pair to anchor
  * on). Returns ``[]`` at the top level.
  */
-export function keyPathByIndent(doc: Text, lineIdx: number, indent: number): string[] {
+export function keyPathByIndent(
+  doc: Text,
+  lineIdx: number,
+  indent: number,
+  skipListItems = false
+): string[] {
   const chain: string[] = [];
   let below = indent;
   let from = lineIdx;
   for (;;) {
-    const p = findParentKey(doc, from, below);
+    const p = findParentKey(doc, from, below, skipListItems);
     if (!p) break;
     chain.push(p.key);
     below = p.indent;
     from = p.lineIdx;
   }
   return chain.reverse();
+}
+
+/**
+ * Field key path — named containers plus the caret line's own key — for a
+ * value-position caret on an empty-value ``key:`` the AST can't anchor (Lezer
+ * leaves the Pair open when the value is empty and a populated sibling
+ * precedes it, so ``getKeyPath`` drops the leaf). List items are anonymous
+ * containers, so a ``- `` line contributes no key — only named ``key:``
+ * containers above do, matching what ``getKeyPath`` yields when the parse
+ * succeeds. Returns ``null`` unless the caret line is an empty-value pair.
+ */
+export function fieldPathByIndent(doc: Text, lineIdx: number): string[] | null {
+  const stripped = stripComment(doc.line(lineIdx + 1).text);
+  const m = stripped.match(RE_PAIR_LINE);
+  if (!m || m[2] !== "") return null;
+  return [...keyPathByIndent(doc, lineIdx, indentOf(stripped), true), m[1]];
 }
 
 /**

--- a/test/components/device/section-config-advanced-reveal.test.ts
+++ b/test/components/device/section-config-advanced-reveal.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins `device-section-config`'s caret-follow advanced reveal: when the
+ * structured panel's `focusFieldPath` lands on a hidden advanced field, the
+ * section reveals its advanced settings once (so the field renders and the
+ * scroll-to-field can reach it) — honouring a later deliberate collapse.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+
+const entry = (key: string, advanced: boolean): ConfigEntry =>
+  ({ key, type: ConfigEntryType.STRING, label: key, advanced }) as ConfigEntry;
+
+/** Bare instance with a config that has one plain and one advanced field. */
+function makeHost(focusFieldPath: string[]) {
+  const c = new ESPHomeDeviceSectionConfig();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = c as any;
+  inner.sectionKey = "text_sensor.version";
+  inner._config = { entries: [entry("name", false), entry("hide_timestamp", true)] };
+  inner.focusFieldPath = focusFieldPath;
+  return inner;
+}
+
+// willUpdate passes the changed-property map; the reveal only runs when
+// focusFieldPath or _config changed.
+const focusChanged = () => new Map([["focusFieldPath", undefined]]);
+
+describe("device-section-config — advanced reveal on caret-follow", () => {
+  it("reveals advanced settings when the caret lands on a hidden advanced field", () => {
+    const inner = makeHost(["hide_timestamp"]);
+    expect(inner._showAdvanced).toBe(false);
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(true);
+  });
+
+  it("does not reveal for a plain field", () => {
+    const inner = makeHost(["name"]);
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(false);
+  });
+
+  it("does not reopen after a deliberate collapse (revealed once)", () => {
+    const inner = makeHost(["hide_timestamp"]);
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(true);
+    inner._setShowAdvanced(false); // user collapses
+    inner._revealAdvancedForFocus(focusChanged());
+    expect(inner._showAdvanced).toBe(false);
+  });
+
+  it("ignores updates where neither focusFieldPath nor _config changed", () => {
+    const inner = makeHost(["hide_timestamp"]);
+    inner._revealAdvancedForFocus(new Map()); // e.g. an unrelated re-render
+    expect(inner._showAdvanced).toBe(false);
+  });
+});

--- a/test/components/yaml-editor-cursor-line.test.ts
+++ b/test/components/yaml-editor-cursor-line.test.ts
@@ -118,6 +118,65 @@ describe("yaml-editor cursor-line emission (#946)", () => {
     expect(events[0].path[0]).toBe("http_request");
   });
 
+  it("attributes a value-position empty-value field via the indent fallback", async () => {
+    // On `device_class:` (empty value) below a populated sibling in a list
+    // item, the AST drops the leaf; the emitted path must still end with
+    // device_class so the structured panel focuses that field, not state_class.
+    const el = await mount(
+      "sensor:\n  - platform: template\n    state_class: measurement\n    device_class:\n"
+    );
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 4); // the `device_class:` line
+    expect(events).toHaveLength(1);
+    expect(events[0].path).toEqual(["sensor", "device_class"]);
+  });
+
+  it("re-emits when the field changes on the same line in a list item", async () => {
+    // Typing a field onto a blank child line of a list item changes the field
+    // but not the line or the top-level key ("sensor"). The panel must follow
+    // into the new field, so the throttle keys on the whole path, not just the
+    // top-level key. The blank line first resolves to ["sensor"] (the dash is
+    // an anonymous container, never "platform").
+    const el = await mount(
+      "sensor:\n  - platform: template\n    state_class: measurement\n    \n"
+    );
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 4); // the blank "    " child line
+    expect(events).toHaveLength(1);
+    expect(events[0].path).toEqual(["sensor"]);
+
+    // Type device_class: onto the same line (line 4) in one transaction.
+    const at = view.state.doc.line(4).to;
+    view.dispatch({
+      changes: { from: at, insert: "device_class:" },
+      selection: EditorSelection.single(at + "device_class:".length),
+    });
+    expect(events).toHaveLength(2);
+    expect(events[1].line).toBe(4);
+    expect(events[1].path).toEqual(["sensor", "device_class"]);
+  });
+
+  it("does not mistake block-scalar content for a field", async () => {
+    // `done:` is a C++ label inside a lambda body — literal text. The path must
+    // come from the AST (lambda), not the indent resolver (a phantom field).
+    const el = await mount(
+      "sensor:\n  - platform: template\n    lambda: |-\n      done:\n      return 0;\n"
+    );
+    const view = viewOf(el);
+    parseAll(view);
+    const events = record(el);
+
+    caretToLineEnd(view, 4); // the `      done:` line, inside the block scalar
+    expect(events).toHaveLength(1);
+    expect(events[0].path).toEqual(["sensor", "lambda"]);
+  });
+
   it("does not emit on a programmatic doc patch with no selection", async () => {
     // A host `value`-prop sync into an unfocused split-view editor dispatches
     // a changes-only transaction (no selection). The gate is `selectionSet`

--- a/test/util/config-entry-tree.test.ts
+++ b/test/util/config-entry-tree.test.ts
@@ -3,10 +3,20 @@ import { describe, expect, it } from "vitest";
 
 import type { ConfigEntry } from "../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
-import { actionAdvancedState } from "../../src/util/config-entry-tree.js";
+import { actionAdvancedState, pathIsAdvanced } from "../../src/util/config-entry-tree.js";
 
 function entry(key: string, advanced: boolean): ConfigEntry {
   return { key, type: ConfigEntryType.STRING, label: key, advanced } as ConfigEntry;
+}
+
+function nested(key: string, advanced: boolean, children: ConfigEntry[]): ConfigEntry {
+  return {
+    key,
+    type: ConfigEntryType.NESTED,
+    label: key,
+    advanced,
+    config_entries: children,
+  } as ConfigEntry;
 }
 
 describe("actionAdvancedState", () => {
@@ -44,5 +54,35 @@ describe("actionAdvancedState", () => {
       showAdvanced: false,
       showToggle: false,
     });
+  });
+});
+
+describe("pathIsAdvanced", () => {
+  const entries = [
+    entry("name", false),
+    entry("hide_timestamp", true),
+    nested("filters", false, [entry("multiply", true)]),
+    nested("calibrate", true, [entry("method", false)]),
+  ];
+
+  it("is true for an advanced leaf", () => {
+    expect(pathIsAdvanced(entries, ["hide_timestamp"])).toBe(true);
+  });
+
+  it("is false for a plain leaf", () => {
+    expect(pathIsAdvanced(entries, ["name"])).toBe(false);
+  });
+
+  it("is true when an advanced ancestor gates a plain leaf", () => {
+    expect(pathIsAdvanced(entries, ["calibrate", "method"])).toBe(true);
+  });
+
+  it("is true for an advanced leaf under a plain ancestor", () => {
+    expect(pathIsAdvanced(entries, ["filters", "multiply"])).toBe(true);
+  });
+
+  it("is false when the path doesn't resolve", () => {
+    expect(pathIsAdvanced(entries, ["bogus"])).toBe(false);
+    expect(pathIsAdvanced(entries, [])).toBe(false);
   });
 });

--- a/test/util/yaml-ast-keypath.test.ts
+++ b/test/util/yaml-ast-keypath.test.ts
@@ -2,7 +2,7 @@ import { ensureSyntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
-import { getKeyPath } from "../../src/util/yaml-ast.js";
+import { getKeyPath, isInsideBlockScalar } from "../../src/util/yaml-ast.js";
 
 function pathAt(doc: string, token: string): string[] {
   const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
@@ -50,5 +50,25 @@ describe("getKeyPath", () => {
 
   it("returns [] outside any mapping pair", () => {
     expect(pathAt("# comment\n", "comment")).toEqual([]);
+  });
+});
+
+describe("isInsideBlockScalar", () => {
+  const at = (doc: string, token: string): boolean => {
+    const state = EditorState.create({ doc, extensions: [esphomeYaml()] });
+    ensureSyntaxTree(state, state.doc.length);
+    return isInsideBlockScalar(state, doc.indexOf(token) + token.length);
+  };
+
+  it("is true for a `key:`-looking line inside a block scalar body", () => {
+    // `done:` is a C++ label in a lambda body — literal text, not a YAML pair.
+    const doc =
+      "sensor:\n  - platform: template\n    lambda: |-\n      done:\n      return 0;\n";
+    expect(at(doc, "done:")).toBe(true);
+  });
+
+  it("is false on a real empty-value key line", () => {
+    const doc = "sensor:\n  - platform: template\n    device_class:\n";
+    expect(at(doc, "device_class:")).toBe(false);
   });
 });

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   blankLineContext,
   collectSiblingKeysByIndent,
+  fieldPathByIndent,
   findParentKey,
   findTopLevelBlock,
   indentOf,
@@ -213,6 +214,65 @@ describe("collectSiblingKeysByIndent", () => {
       "advanced",
       "version",
     ]);
+  });
+});
+
+describe("fieldPathByIndent", () => {
+  it("resolves a flat list-item field, skipping the anonymous dash key", () => {
+    // keyPathByIndent would wrongly include `platform` from the dash line; the
+    // field path treats the list item as anonymous and yields just the parent.
+    const lines = [
+      "sensor:",
+      "  - platform: template",
+      "    state_class: measurement",
+      "    device_class:",
+    ];
+    expect(fieldPathByIndent(t(lines), 3)).toEqual(["sensor", "device_class"]);
+  });
+
+  it("keeps an empty-value dash container key (action args), drops inline ones", () => {
+    // `- logger.log:` is a container (its args nest under it) so its key stays
+    // in the path; `- platform: gpio` is an inline item whose key is a sibling
+    // field and is dropped — matching what getKeyPath yields.
+    const lines = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    on_press:",
+      "      then:",
+      "        - logger.log:",
+      "            format:",
+    ];
+    expect(fieldPathByIndent(t(lines), 5)).toEqual([
+      "binary_sensor",
+      "on_press",
+      "then",
+      "logger.log",
+      "format",
+    ]);
+  });
+
+  it("resolves a nested map field through named containers", () => {
+    const lines = ["esp32:", "  framework:", "    advanced:", "      x:"];
+    expect(fieldPathByIndent(t(lines), 3)).toEqual([
+      "esp32",
+      "framework",
+      "advanced",
+      "x",
+    ]);
+  });
+
+  it("resolves a top-level empty-value field", () => {
+    expect(fieldPathByIndent(t(["esphome:", "  name: x", "http_request:"]), 2)).toEqual([
+      "http_request",
+    ]);
+  });
+
+  it("returns null on a valued pair, a blank line, and a comment", () => {
+    const lines = ["sensor:", "  - platform: template", "    name: x", "", "# c"];
+    expect(fieldPathByIndent(t(lines), 2)).toBeNull(); // name: x has a value
+    expect(fieldPathByIndent(t(lines), 1)).toBeNull(); // dash line with a value
+    expect(fieldPathByIndent(t(lines), 3)).toBeNull(); // blank
+    expect(fieldPathByIndent(t(lines), 4)).toBeNull(); // comment-only
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

Makes the structured editor follow the YAML caret to the right field. Moving the caret to (or autocompleting) a field on the same line of a list item left the panel focused on the previous field, and an empty advanced field never appeared at all. Confirmed by driving the live editor headlessly.

Three causes:

- The `yaml-cursor-line` throttle keyed on `(line, top-level key)`. Within a list item the field changes while the line and top-level key (`sensor`) stay put, so it never re-emitted. It now throttles on the whole resolved path, so it follows the caret between fields without churning on plain column moves.
- An empty-value `key:` (Lezer leaves the Pair open) and a blank child line both leave `getKeyPath` unable to anchor, so the emitted path lost the field. The path is now resolved from indentation via a new dash-aware `fieldPathByIndent` (and `skipListItems` on the blank-line fallback): a list item's field keeps its leaf key, an inline `- key: value` dash is treated as a sibling field while an empty-value `- key:` container (e.g. `- logger.log:`) keeps its key, and a `key:`-looking line inside a `lambda: |-` block scalar is left to the AST (new `isInsideBlockScalar` guard) so it can't resolve to a phantom field. `getKeyPath`, hover, and completion are untouched.
- An advanced field with no value isn't rendered while "Show advanced settings" is off, so the caret couldn't reach it (e.g. autocompleting `hide_timestamp:`). When the caret follows to an advanced field (or one with an advanced ancestor), the section now reveals its advanced settings once — honouring a later deliberate collapse so it doesn't fight the user.

Verified live: typing `device_class:` focuses Device Class, and autocompleting the advanced `hide_timestamp:` reveals advanced settings, renders the field, scrolls to it and pulses it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
