### PR TITLE
Satisfy a catalog dependency a present component provides

### DIFF
--- a/src/components/device/add-component-deps.ts
+++ b/src/components/device/add-component-deps.ts
@@ -1,4 +1,6 @@
+import type { ESPHomeAPI } from "../../api/index.js";
 import { ComponentCategory } from "../../api/types/components.js";
+import { providerIds } from "../../util/provides-cache.js";
 import {
   parseConfiguredPlatforms,
   parseTopLevelComponents,
@@ -43,4 +45,47 @@ export function findMissingDependencies(
     if (!PLATFORM_DOMAINS.has(dep) && platformStems.has(dep)) return false;
     return true;
   });
+}
+
+/**
+ * Of the deps `findMissingDependencies` still flags, the subset a present
+ * top-level component already *provides* under a different name.
+ *
+ * A `bk72xx:` block provides `libretiny` (the `output.libretiny_pwm` dep);
+ * a `tca9548a:` / `usb_uart:` block provides `i2c` / `uart`. The
+ * literal-name scan can't tie provider to dep, so each still-missing dep is
+ * matched against its providers from the `provides` index. Lookups are
+ * cached for the process lifetime (`providerIds`), so re-resolving on every
+ * YAML change costs one query per interface total; empty `missing`
+ * short-circuits with no round trip.
+ */
+export async function depsSatisfiedByProvides(
+  api: ESPHomeAPI,
+  missing: readonly string[],
+  present: ReadonlySet<string>,
+  ctx: { platform?: string | null; boardId?: string | null }
+): Promise<ReadonlySet<string>> {
+  const satisfied = new Set<string>();
+  // Dotted `<domain>.<platform>` deps are resolved by `findMissingDependencies`
+  // and never key the bare-id `provides` index, so a query for them always
+  // comes back empty — skip them rather than pay the round trip.
+  const resolvable = missing.filter((dep) => !dep.includes("."));
+  if (resolvable.length === 0) return satisfied;
+  await Promise.all(
+    resolvable.map(async (dep) => {
+      const providers = await providerIds(
+        api,
+        dep,
+        ctx.platform ?? undefined,
+        ctx.boardId ?? undefined
+      );
+      for (const id of providers) {
+        if (present.has(id)) {
+          satisfied.add(dep);
+          break;
+        }
+      }
+    })
+  );
+  return satisfied;
 }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -21,7 +21,10 @@ import {
   parseTopLevelComponents,
   serializeYamlValues,
 } from "../../util/yaml-serialize.js";
-import { findMissingDependencies } from "./add-component-deps.js";
+import {
+  depsSatisfiedByProvides,
+  findMissingDependencies,
+} from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
 import { overlayOptions, overlayRequired } from "./add-component-form-overlays.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
@@ -105,6 +108,15 @@ export class ESPHomeAddComponentForm extends LitElement {
   @state()
   private _showYaml = false;
 
+  /** Missing deps a present component already provides; resolved async,
+   *  subtracted from the banner. See `depsSatisfiedByProvides`. */
+  @state()
+  private _providedDeps: ReadonlySet<string> = new Set();
+
+  /** Bumps per resolution so a superseded `(component, yaml)` result can't
+   *  overwrite a newer one. */
+  private _providesSeq = 0;
+
   /** Resolves dep ids (``i2c``) to their catalog name (``I²C Bus``)
    * for the missing-deps banner. Owns the cache subscription so a
    * fresh entry triggers a re-render without bookkeeping here. */
@@ -151,6 +163,60 @@ export class ESPHomeAddComponentForm extends LitElement {
         this._depResolver.kickoff(this.component.dependencies ?? []);
       }
     }
+    // Re-resolve when the present components shift (YAML) or the query scope
+    // shifts (component deps, or a late/changed board platform/id).
+    if (
+      changedProperties.has("component") ||
+      changedProperties.has("yaml") ||
+      changedProperties.has("board")
+    ) {
+      void this._resolveProvidedDeps();
+    }
+  }
+
+  /** Net-missing deps driving the banner and submit gate: the literal-name
+   *  scan minus those a present component provides (`_providedDeps`). */
+  private _missingDeps(present: ReadonlySet<string>): string[] {
+    return findMissingDependencies(
+      this.component.dependencies ?? [],
+      this.yaml,
+      present
+    ).filter((d) => !this._providedDeps.has(d));
+  }
+
+  /** Refresh `_providedDeps` for the current `(component, yaml)`, dropping
+   *  superseded async results via `_providesSeq`. */
+  private async _resolveProvidedDeps(): Promise<void> {
+    // Drop the prior result up front so the submit gate fails closed while a
+    // fresh lookup is in flight, rather than trusting a stale `(component,
+    // yaml)` set. Empty stays empty (no needless re-render).
+    if (this._providedDeps.size) this._providedDeps = new Set();
+    const api = this._api;
+    const present = parseTopLevelComponents(this.yaml);
+    const missing = findMissingDependencies(
+      this.component?.dependencies ?? [],
+      this.yaml,
+      present
+    );
+    if (!api || missing.length === 0) return;
+    const seq = ++this._providesSeq;
+    try {
+      const satisfied = await depsSatisfiedByProvides(api, missing, present, {
+        platform: this.board?.esphome.platform ?? null,
+        boardId: this.board?.id ?? null,
+      });
+      // Skip an empty-over-empty assignment: on the common "nothing provides"
+      // path it would only flip Set identity and force an identical re-render.
+      if (seq === this._providesSeq && (satisfied.size || this._providedDeps.size)) {
+        this._providedDeps = satisfied;
+      }
+    } catch (err) {
+      // Fail closed: the up-front clear already left the deps flagged, so the
+      // banner still guides the user. Warn (not swallow) so a provides-lookup
+      // failure is observable rather than silently re-showing the original
+      // false banner — mirrors config-entry-form's provider fetch.
+      console.warn("[add-component-form] provides lookup failed", err);
+    }
   }
 
   /**
@@ -178,11 +244,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // configured platform for hub-style deps (`atm90e32` under
     // `sensor:`). Surface these instead of letting the user submit a
     // config that won't validate.
-    const missingDeps = findMissingDependencies(
-      this.component.dependencies ?? [],
-      this.yaml,
-      presentComponents
-    );
+    const missingDeps = this._missingDeps(presentComponents);
 
     // The shared form filters its own visibility — but we still need
     // to know whether everything required is filled in to enable the
@@ -410,11 +472,7 @@ export class ESPHomeAddComponentForm extends LitElement {
     // Block submit when a declared dependency isn't satisfied. The
     // button should already be disabled in that case, but defend here
     // too in case the YAML changed under us between renders.
-    const missingDeps = findMissingDependencies(
-      this.component.dependencies ?? [],
-      this.yaml,
-      presentComponents
-    );
+    const missingDeps = this._missingDeps(presentComponents);
     if (missingDeps.length > 0) {
       // Should be unreachable — the button-disabled predicate uses the
       // same check. If we get here, the YAML changed under us between

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -187,19 +187,20 @@ export class ESPHomeAddComponentForm extends LitElement {
   /** Refresh `_providedDeps` for the current `(component, yaml)`, dropping
    *  superseded async results via `_providesSeq`. */
   private async _resolveProvidedDeps(): Promise<void> {
+    // Bump first so every re-entry — even one that early-returns below —
+    // invalidates an older in-flight lookup that would otherwise pass the
+    // `seq === this._providesSeq` guard and write a stale result.
+    const seq = ++this._providesSeq;
     // Drop the prior result up front so the submit gate fails closed while a
-    // fresh lookup is in flight, rather than trusting a stale `(component,
-    // yaml)` set. Empty stays empty (no needless re-render).
+    // fresh lookup is in flight. Empty stays empty (no needless re-render).
     if (this._providedDeps.size) this._providedDeps = new Set();
     const api = this._api;
+    const deps = this.component?.dependencies ?? [];
+    // Common dep-free case: nothing to resolve, so skip the YAML parse too.
+    if (!api || deps.length === 0) return;
     const present = parseTopLevelComponents(this.yaml);
-    const missing = findMissingDependencies(
-      this.component?.dependencies ?? [],
-      this.yaml,
-      present
-    );
-    if (!api || missing.length === 0) return;
-    const seq = ++this._providesSeq;
+    const missing = findMissingDependencies(deps, this.yaml, present);
+    if (missing.length === 0) return;
     try {
       const satisfied = await depsSatisfiedByProvides(api, missing, present, {
         platform: this.board?.esphome.platform ?? null,

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,0 +1,40 @@
+import type { ESPHomeAPI } from "../api/index.js";
+
+/** Ids of the components that provide an interface, board-scoped and cached
+ *  for the process lifetime. The backend catalog is immutable for that
+ *  lifetime (see `component-name-cache`), so the same `provides` query never
+ *  needs to re-run. A rejected lookup is evicted so a later call retries. */
+const _cache = new Map<string, Promise<ReadonlySet<string>>>();
+
+/** Ids of components that provide `interfaceName` on this platform/board. */
+export function providerIds(
+  api: ESPHomeAPI,
+  interfaceName: string,
+  platform?: string,
+  boardId?: string
+): Promise<ReadonlySet<string>> {
+  const key = `${interfaceName}|${platform ?? ""}|${boardId ?? ""}`;
+  let pending = _cache.get(key);
+  if (!pending) {
+    pending = api
+      .getComponents({
+        provides: interfaceName,
+        platform: platform ?? undefined,
+        board_id: boardId ?? undefined,
+        // One page holds every provider; an interface has at most a handful,
+        // so this never truncates (mirrors config-entry-form's provider fetch).
+        limit: 200,
+      })
+      .then((resp): ReadonlySet<string> => new Set(resp.components.map((c) => c.id)))
+      .catch((err) => {
+        _cache.delete(key);
+        throw err;
+      });
+    _cache.set(key, pending);
+  }
+  return pending;
+}
+
+export function _clearProvidesCache(): void {
+  _cache.clear();
+}

--- a/test/components/device/add-component-deps.test.ts
+++ b/test/components/device/add-component-deps.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { findMissingDependencies } from "../../../src/components/device/add-component-deps.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import {
+  depsSatisfiedByProvides,
+  findMissingDependencies,
+} from "../../../src/components/device/add-component-deps.js";
+import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+
+function providersResponse(ids: string[]) {
+  return {
+    components: ids.map((id) => ({ id }) as ComponentCatalogEntry),
+    categories: [],
+    total: ids.length,
+    offset: 0,
+    limit: 200,
+  };
+}
+
+function stubApi(getComponents: ReturnType<typeof vi.fn>): ESPHomeAPI {
+  return { getComponents } as unknown as ESPHomeAPI;
+}
 
 describe("findMissingDependencies", () => {
   it("flags a top-level hub dep that isn't configured", () => {
@@ -59,5 +79,106 @@ describe("findMissingDependencies", () => {
     // Caller passes its already-parsed top-level set; the empty yaml
     // would otherwise report ld2410 missing.
     expect(findMissingDependencies(["ld2410"], "", new Set(["ld2410"]))).toEqual([]);
+  });
+});
+
+describe("depsSatisfiedByProvides", () => {
+  beforeEach(_clearProvidesCache);
+
+  it("satisfies a dep when a present component provides it", async () => {
+    // bk72xx provides libretiny; the board's `bk72xx:` block covers the
+    // libretiny_pwm dependency without the user adding anything.
+    const getComponents = vi
+      .fn()
+      .mockResolvedValue(providersResponse(["bk72xx", "rtl87xx"]));
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["libretiny"],
+      new Set(["bk72xx", "output"]),
+      { platform: "bk72xx", boardId: "generic-bk7231t" }
+    );
+    expect([...satisfied]).toEqual(["libretiny"]);
+    expect(getComponents).toHaveBeenCalledTimes(1);
+    expect(getComponents.mock.calls[0][0]).toMatchObject({
+      provides: "libretiny",
+      platform: "bk72xx",
+      board_id: "generic-bk7231t",
+    });
+  });
+
+  it("leaves a dep missing when no provider is present", async () => {
+    const getComponents = vi
+      .fn()
+      .mockResolvedValue(providersResponse(["bk72xx", "rtl87xx"]));
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["libretiny"],
+      new Set(["esp32", "output"]),
+      { platform: "esp32", boardId: null }
+    );
+    expect(satisfied.size).toBe(0);
+  });
+
+  it("leaves a dep missing when nothing provides it", async () => {
+    const getComponents = vi.fn().mockResolvedValue(providersResponse([]));
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["i2c"],
+      new Set(["sensor"]),
+      { platform: "esp32", boardId: null }
+    );
+    expect(satisfied.size).toBe(0);
+  });
+
+  it("satisfies a dep from a non-platform provider block", async () => {
+    // usb_uart provides uart; a `usb_uart:` block covers a `uart` dep
+    // without a literal `uart:` block.
+    const getComponents = vi
+      .fn()
+      .mockResolvedValue(providersResponse(["usb_uart", "ble_nus"]));
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["uart"],
+      new Set(["usb_uart", "sensor"]),
+      { platform: "esp32", boardId: null }
+    );
+    expect([...satisfied]).toEqual(["uart"]);
+  });
+
+  it("short-circuits an empty missing list without an API call", async () => {
+    const getComponents = vi.fn();
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      [],
+      new Set(["bk72xx"]),
+      { platform: "bk72xx", boardId: null }
+    );
+    expect(satisfied.size).toBe(0);
+    expect(getComponents).not.toHaveBeenCalled();
+  });
+
+  it("skips dotted deps, which never key the provides index", async () => {
+    const getComponents = vi.fn();
+    const satisfied = await depsSatisfiedByProvides(
+      stubApi(getComponents),
+      ["ota.http_request"],
+      new Set(["ota"]),
+      { platform: "esp32", boardId: null }
+    );
+    expect(satisfied.size).toBe(0);
+    expect(getComponents).not.toHaveBeenCalled();
+  });
+
+  it("caches provider lookups so a repeat resolution skips the query", async () => {
+    const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
+    const api = stubApi(getComponents);
+    const args = [
+      ["libretiny"],
+      new Set(["bk72xx"]),
+      { platform: "bk72xx", boardId: "b" },
+    ] as const;
+    await depsSatisfiedByProvides(api, ...args);
+    await depsSatisfiedByProvides(api, ...args);
+    expect(getComponents).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/components/device/add-component-form-provides-dep.test.ts
+++ b/test/components/device/add-component-form-provides-dep.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the provides-aware dependency gate: a dep the literal-name scan
+ * flags missing is cleared once a present top-level component provides it
+ * (a `bk72xx:` block provides `libretiny`, satisfying `libretiny_pwm`), so
+ * the banner clears and Submit enables without the user adding anything.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { ESPHomeAPI } from "../../../src/api/index.js";
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
+
+function providersResponse(ids: string[]) {
+  return {
+    components: ids.map((id) => ({ id }) as ComponentCatalogEntry),
+    categories: [],
+    total: ids.length,
+    offset: 0,
+    limit: 200,
+  };
+}
+
+const bk72xxBoard = {
+  id: "generic-bk7231t",
+  esphome: { platform: "bk72xx" },
+  pins: [],
+} as unknown as BoardCatalogEntry;
+
+const libretinyPwm = makeComponentEntry("output.libretiny_pwm", {
+  name: "LibreTiny PWM Output",
+  dependencies: ["libretiny"],
+});
+
+async function mountForm(
+  getComponents: ReturnType<typeof vi.fn>,
+  yaml: string
+): Promise<ESPHomeAddComponentForm> {
+  const el = new ESPHomeAddComponentForm();
+  el.component = libretinyPwm;
+  el.board = bk72xxBoard;
+  el.yaml = yaml;
+  Object.assign(el as unknown as Record<string, unknown>, {
+    _api: { getComponents } as unknown as ESPHomeAPI,
+  });
+  document.body.appendChild(el);
+  // The first paint shows the literal-missing banner; once the async
+  // provides lookup settles (a few microtask hops through the cache), a
+  // re-render clears it. Flush generously, then await the final update.
+  await el.updateComplete;
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+  await el.updateComplete;
+  return el;
+}
+
+function banner(el: ESPHomeAddComponentForm): Element | null {
+  return el.shadowRoot!.querySelector(".deps-warning");
+}
+
+function submitButton(el: ESPHomeAddComponentForm): HTMLButtonElement {
+  return el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
+}
+
+describe("add-component-form provides-satisfied dependency", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    _clearComponentCache();
+    _clearProvidesCache();
+  });
+
+  it("clears the missing-deps banner when the board platform provides the dep", async () => {
+    const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
+    const el = await mountForm(getComponents, "bk72xx:\n");
+
+    expect(getComponents).toHaveBeenCalledWith(
+      expect.objectContaining({ provides: "libretiny" })
+    );
+    expect(banner(el)).toBeNull();
+    expect(submitButton(el).disabled).toBe(false);
+  });
+
+  it("keeps blocking when no present component provides the dep", async () => {
+    // The board is esp32-like here: nothing in the YAML provides libretiny.
+    const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
+    const el = await mountForm(getComponents, "esp32:\n");
+
+    expect(banner(el)).not.toBeNull();
+    expect(submitButton(el).disabled).toBe(true);
+  });
+
+  it("fails closed and warns when the provides lookup rejects", async () => {
+    // A WS hiccup on the lookup must leave the dep flagged (banner stays,
+    // submit disabled) and surface a warning rather than swallow it.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const getComponents = vi.fn().mockRejectedValue(new Error("ws down"));
+    const el = await mountForm(getComponents, "bk72xx:\n");
+
+    expect(banner(el)).not.toBeNull();
+    expect(submitButton(el).disabled).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      "[add-component-form] provides lookup failed",
+      expect.any(Error)
+    );
+    warn.mockRestore();
+  });
+
+  it("does not re-render on the not-provided path (empty stays empty)", async () => {
+    // The provider (bk72xx) isn't present, so resolution yields an empty set.
+    // `_providedDeps` is already empty, so it must not be reassigned — a fresh
+    // empty Set would only flip identity and force an identical re-render on
+    // every YAML change.
+    const getComponents = vi.fn().mockResolvedValue(providersResponse(["bk72xx"]));
+    const el = new ESPHomeAddComponentForm();
+    el.component = libretinyPwm;
+    el.board = bk72xxBoard;
+    el.yaml = "esp32:\n";
+    Object.assign(el as unknown as Record<string, unknown>, {
+      _api: { getComponents } as unknown as ESPHomeAPI,
+    });
+
+    let renders = 0;
+    const inst = el as unknown as {
+      render: () => unknown;
+      _providedDeps: ReadonlySet<string>;
+    };
+    const origRender = inst.render.bind(el);
+    inst.render = () => {
+      renders++;
+      return origRender();
+    };
+
+    document.body.appendChild(el);
+    await el.updateComplete;
+    const rendersAfterPaint = renders;
+    const providedRef = inst._providedDeps;
+
+    // Let the provides lookup settle.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await el.updateComplete;
+
+    expect(getComponents).toHaveBeenCalled(); // the lookup did run
+    expect(renders).toBe(rendersAfterPaint); // …but produced no extra render
+    expect(inst._providedDeps).toBe(providedRef); // same Set, never reassigned
+    expect(banner(el)).not.toBeNull(); // and the dep is still correctly flagged
+  });
+});

--- a/test/components/device/add-component-form-provides-dep.test.ts
+++ b/test/components/device/add-component-form-provides-dep.test.ts
@@ -73,6 +73,8 @@ describe("add-component-form provides-satisfied dependency", () => {
     document.body.innerHTML = "";
     _clearComponentCache();
     _clearProvidesCache();
+    // Restore the console.warn spy even if a test throws before its own restore.
+    vi.restoreAllMocks();
   });
 
   it("clears the missing-deps banner when the board platform provides the dep", async () => {
@@ -108,7 +110,38 @@ describe("add-component-form provides-satisfied dependency", () => {
       "[add-component-form] provides lookup failed",
       expect.any(Error)
     );
-    warn.mockRestore();
+  });
+
+  it("discards a stale in-flight lookup after the form is retargeted", async () => {
+    // Resolution A is in flight when the component is retargeted to a dep-free
+    // one (which re-runs the resolver, bumps the seq, and early-returns). A's
+    // late result must not be written back against the new component.
+    let resolveA!: (v: unknown) => void;
+    const pending = new Promise((r) => {
+      resolveA = r;
+    });
+    const getComponents = vi.fn().mockReturnValue(pending);
+    const el = new ESPHomeAddComponentForm();
+    el.component = libretinyPwm;
+    el.board = bk72xxBoard;
+    el.yaml = "bk72xx:\n";
+    Object.assign(el as unknown as Record<string, unknown>, {
+      _api: { getComponents } as unknown as ESPHomeAPI,
+    });
+    document.body.appendChild(el);
+    await el.updateComplete; // resolution A kicked off, awaiting getComponents
+
+    // Retarget to a dep-free component: the re-resolve bumps the seq.
+    el.component = makeComponentEntry("sensor.template", { name: "Template" });
+    await el.updateComplete;
+
+    // A finally resolves with libretiny providers, after the seq moved on.
+    resolveA(providersResponse(["bk72xx"]));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await el.updateComplete;
+
+    const inst = el as unknown as { _providedDeps: ReadonlySet<string> };
+    expect(inst._providedDeps.size).toBe(0); // stale result discarded
   });
 
   it("does not re-render on the not-provided path (empty stays empty)", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adding the LibreTiny PWM output on a bk72xx board falsely reported a missing `libretiny` dependency. The dependency check matched dependency names against literal YAML keys only, so it never saw that the board's `bk72xx:` block already provides `libretiny`; following the banner's prompt then inserted an invalid `libretiny:` block that ESPHome rejected on save.

The check now treats a dependency as satisfied when a present top-level component provides it, resolved through the backend `provides` index, so on a bk72xx board the banner clears and Submit enables with nothing extra to add.

The catalog list filter in `component-catalog/filters.ts` has the same literal match blindness; it did not block this flow (the component stayed selectable), so it is tracked separately in #963.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1664

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
