### PR TITLE
Hint the canonical option when a custom combobox value differs by case only

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -40,6 +40,12 @@ export const configEntryFormStyles = css`
     margin-top: var(--wa-space-2xs);
   }
 
+  .field-warning {
+    color: var(--esphome-warning, #d97706);
+    font-size: var(--wa-font-size-2xs);
+    margin-top: var(--wa-space-2xs);
+  }
+
   .field-description {
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -183,7 +183,7 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
         ></esphome-options-combobox>
         ${renderFieldError(path, ctx)}
         ${suggestion
-          ? html`<span class="field-warning"
+          ? html`<span class="field-warning" role="status"
               >${ctx.localize("validation.did_you_mean", { suggestion })}</span
             >`
           : nothing}

--- a/src/components/device/config-entry-renderers/primitives.ts
+++ b/src/components/device/config-entry-renderers/primitives.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { chipNameToVariant } from "../../../util/chip-variant.js";
+import { nearCanonicalOption } from "../../../util/config-validation.js";
 import { parseYamlBoolean, YamlRawValue } from "../../../util/yaml-serialize.js";
 import type { OptionsComboboxValueChange } from "../../options-combobox-event.js";
 import {
@@ -158,6 +159,10 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
   // the esp32 variant default below); resolved once per render.
   const variant = resolveEsp32Variant(ctx);
   if (entry.allow_custom_value && entry.options && entry.options.length > 0) {
+    // A custom value that matches a canonical option by case only (`l` vs the
+    // catalog's `L`) compiles but breaks downstream unit recognition; nudge
+    // toward the canonical spelling without blocking submit.
+    const suggestion = nearCanonicalOption(value, entry.options);
     // ``label`` only names the combobox's shadow-DOM input (renderLabel's
     // visible label isn't associated via for=); the combobox draws no label
     // chrome of its own, so this isn't a duplicate visible label.
@@ -177,6 +182,11 @@ export function renderSelectField(entry: ConfigEntry, path: string[], ctx: Rende
             ctx.emitChange(path, coerceValueToEntryType(entry, e.detail.value))}
         ></esphome-options-combobox>
         ${renderFieldError(path, ctx)}
+        ${suggestion
+          ? html`<span class="field-warning"
+              >${ctx.localize("validation.did_you_mean", { suggestion })}</span
+            >`
+          : nothing}
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -894,7 +894,8 @@
     "invalid_encryption_key": "Must be a 32-byte base64 key",
     "invalid_device_name": "Only lowercase letters, digits, hyphens and underscores",
     "device_name_underscore": "Underscores work but aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks",
-    "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks"
+    "device_name_edge_hyphen": "Names starting or ending with a hyphen aren't valid mDNS hostnames — the device may not resolve on RFC-strict networks",
+    "did_you_mean": "Did you mean \"{suggestion}\"?"
   },
   "onboarding": {
     "menu_item_setup_wifi": "Set up Wi-Fi",

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -1,4 +1,8 @@
-import type { ConfigEntry, ConfigPrimitive } from "../api/types/config-entries.js";
+import type {
+  ConfigEntry,
+  ConfigPrimitive,
+  ConfigValueOption,
+} from "../api/types/config-entries.js";
 import { ConfigEntryType } from "../api/types/config-entries.js";
 import {
   isApiEncryptionKeyField,
@@ -125,6 +129,25 @@ export function getDeviceNameWarning(name: string): ValidationError | null {
     return { key: "name", code: "validation.device_name_edge_hyphen" };
   }
   return null;
+}
+
+/** The canonical option whose value matches `value` case-insensitively but not
+ *  exactly, else null. Drives a soft "did you mean" hint for custom-value
+ *  comboboxes — a user who typed `l` where the catalog only offers `L`. Matches
+ *  on option value only (never label), and yields nothing when an exact-case
+ *  option exists, so a deliberately case-distinct custom value never nags. */
+export function nearCanonicalOption(
+  value: string,
+  options: readonly ConfigValueOption[] | null
+): string | null {
+  if (!value || !options || options.length === 0) return null;
+  const lower = value.toLowerCase();
+  let near: string | null = null;
+  for (const opt of options) {
+    if (opt.value === value) return null;
+    if (near === null && opt.value.toLowerCase() === lower) near = opt.value;
+  }
+  return near;
 }
 
 /**

--- a/test/components/device/config-entry-combobox.test.ts
+++ b/test/components/device/config-entry-combobox.test.ts
@@ -117,6 +117,13 @@ describe("renderSelectField — did-you-mean hint", () => {
   it("renders no hint for a genuinely custom unit", () => {
     expect(hintText("L/min")).toBeNull();
   });
+
+  it("marks the hint as a polite status region so it announces to screen readers", () => {
+    const ctx = makeRenderCtx({ unit_of_measurement: "l" });
+    const tpl = renderSelectField(unitEntry(), ["unit_of_measurement"], ctx);
+    const [span] = findTemplatesByAnchor(tpl, '<span class="field-warning"');
+    expect(span.strings.join("")).toContain('role="status"');
+  });
 });
 
 const BAUD_RATES: ConfigValueOption[] = [

--- a/test/components/device/config-entry-combobox.test.ts
+++ b/test/components/device/config-entry-combobox.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ConfigValueOption } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderSelectField } from "../../../src/components/device/config-entry-renderers/primitives.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { findElementBindings, makeEntry, makeRenderCtx } from "./_renderer-fixtures.js";
 
 const BOARDS: ConfigValueOption[] = [
@@ -74,6 +75,47 @@ describe("renderSelectField — allow_custom_value combobox", () => {
     const tpl = renderSelectField(entry, ["board"], makeRenderCtx({ board: "bw15" }));
     expect(findElementBindings(tpl, "esphome-options-combobox")).toHaveLength(0);
     expect(findElementBindings(tpl, "wa-select")).toHaveLength(1);
+  });
+});
+
+const UNITS: ConfigValueOption[] = [
+  { value: "L", label: "L" },
+  { value: "L/s", label: "L/s" },
+];
+
+function unitEntry() {
+  return makeEntry(ConfigEntryType.STRING, {
+    key: "unit_of_measurement",
+    label: "Unit",
+    options: UNITS,
+    allow_custom_value: true,
+  });
+}
+
+// Render the combobox for *value* and return the did-you-mean hint's localized
+// text, or null when no hint renders. The ctx localize echoes the suggestion
+// param so the assertion can see which canonical spelling was offered.
+function hintText(value: string): string | null {
+  const ctx = makeRenderCtx(
+    { unit_of_measurement: value },
+    { overrides: { localize: (k, v) => (v ? `${k}:${v.suggestion}` : k) } }
+  );
+  const tpl = renderSelectField(unitEntry(), ["unit_of_measurement"], ctx);
+  const [span] = findTemplatesByAnchor(tpl, '<span class="field-warning"');
+  return span ? String(span.values[0]) : null;
+}
+
+describe("renderSelectField — did-you-mean hint", () => {
+  it("offers the canonical spelling for a case-only custom value", () => {
+    expect(hintText("l")).toBe("validation.did_you_mean:L");
+  });
+
+  it("renders no hint for the canonical value", () => {
+    expect(hintText("L")).toBeNull();
+  });
+
+  it("renders no hint for a genuinely custom unit", () => {
+    expect(hintText("L/min")).toBeNull();
   });
 });
 

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { ConfigValueOption } from "../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import {
   getDeviceNameWarning,
+  nearCanonicalOption,
   validateDeviceName,
   validateEntries,
   validateEntry,
@@ -58,6 +60,39 @@ describe("getDeviceNameWarning", () => {
   it("returns null for clean hyphenated names", () => {
     expect(getDeviceNameWarning("my-device")).toBeNull();
     expect(getDeviceNameWarning("device42")).toBeNull();
+  });
+});
+
+describe("nearCanonicalOption", () => {
+  const opt = (value: string, label = value): ConfigValueOption => ({ label, value });
+  const units = [opt("L"), opt("L/s"), opt("m³")];
+
+  it("suggests the canonical value for a case-only mismatch", () => {
+    expect(nearCanonicalOption("l", units)).toBe("L");
+    expect(nearCanonicalOption("l/S", units)).toBe("L/s");
+  });
+
+  it("returns null when the value exactly matches an option", () => {
+    expect(nearCanonicalOption("L", units)).toBeNull();
+    expect(nearCanonicalOption("L/s", units)).toBeNull();
+  });
+
+  it("returns null for a genuinely custom value", () => {
+    expect(nearCanonicalOption("L/min", units)).toBeNull();
+  });
+
+  it("matches the first case-insensitive option when several collide", () => {
+    expect(nearCanonicalOption("foo", [opt("FOO"), opt("Foo")])).toBe("FOO");
+  });
+
+  it("never matches on the label alone", () => {
+    expect(nearCanonicalOption("litre", [opt("L", "litre")])).toBeNull();
+  });
+
+  it("returns null for empty value or empty/null options", () => {
+    expect(nearCanonicalOption("", units)).toBeNull();
+    expect(nearCanonicalOption("l", [])).toBeNull();
+    expect(nearCanonicalOption("l", null)).toBeNull();
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

A custom unit like `l` (lowercase) is accepted everywhere upstream but breaks downstream in Home Assistant, which only recognizes the canonical `L`; the unit dropdown only ever offers `L`, so a typed `l` slips through with no nudge and the user finds out much later when a feature does not work. Now any custom combobox value that matches a known option by case only shows a soft hint suggesting the canonical spelling, e.g. typing `l` shows "Did you mean "L"?". The hint is advisory; it never blocks submit, never rewrites the value (units are genuinely case sensitive, mV vs MV), and applies to every allow_custom_value combobox rather than special casing one unit.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1666

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
