### PR TITLE
Note that component library docs are English-only on the language page

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1046,7 +1046,7 @@
     "language_desc": "Choose the language used across the interface.",
     "language_system": "System",
     "language_completeness": "{percent}% translated",
-    "language_completeness_note": "Percentages show how much of each language is translated. Untranslated text falls back to English.",
+    "language_completeness_note": "Percentages show how much of each language is translated. Untranslated text falls back to English. Component library documentation is only available in English.",
     "language_help": "Is your language missing or incomplete?",
     "language_help_link": "Help translate ESPHome",
     "theme_desc": "Choose between light, dark, or follow your system preference.",


### PR DESCRIPTION
# What does this implement/fix?

Adds a short note on the language settings page that the component library documentation is only available in English; the UI translation percentages can suggest everything localizes, so this sets the expectation. The note is appended to the existing translation-completeness line, no new field or layout. The feedback dialog is intentionally left unchanged; it is just a link list and a disclaimer there would be noise.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1669

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
