### PR TITLE
Warn in the drawer when a device is reachable but not on mDNS

### DIFF
--- a/src/components/dashboard/device-drawer-content/reachability.ts
+++ b/src/components/dashboard/device-drawer-content/reachability.ts
@@ -11,7 +11,7 @@ import {
   getNumberFormatter,
 } from "../../../util/relative-time.js";
 import type { ESPHomeDeviceDrawerContent } from "../device-drawer-content.js";
-import { renderMdnsTxtRecords } from "../device-drawer-render.js";
+import { renderMdnsStaleWarning, renderMdnsTxtRecords } from "../device-drawer-render.js";
 
 interface ReachabilityRowSpec {
   source: "mdns" | "ping" | "mqtt";
@@ -69,6 +69,7 @@ export function renderReachabilitySection(
         : rows.map((row) =>
             renderReachabilityRow(row, r.active_source, lang, host._localize)
           )}
+      ${renderMdnsStaleWarning(r, host._localize)}
     </div>
   `;
 }

--- a/src/components/dashboard/device-drawer-content/styles.ts
+++ b/src/components/dashboard/device-drawer-content/styles.ts
@@ -208,7 +208,8 @@ export const deviceDrawerContentStyles = css`
   }
 
   .auto-loaded-details > summary,
-  .mdns-txt-details > summary {
+  .mdns-txt-details > summary,
+  .reachability-warning > summary {
     cursor: pointer;
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);
@@ -349,6 +350,31 @@ export const deviceDrawerContentStyles = css`
   }
 
   .reachability-rtt {
+    color: var(--wa-color-text-quiet);
+  }
+
+  .reachability-warning {
+    margin-top: var(--wa-space-s);
+  }
+
+  /* Shares cursor / padding / sizing with the other drawer disclosures
+     above; only the warning emphasis + icon layout are specific here. */
+  .reachability-warning > summary {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--esphome-warning, #d97706);
+  }
+
+  .reachability-warning > summary wa-icon {
+    font-size: 14px;
+  }
+
+  .reachability-warning-body {
+    margin-top: var(--wa-space-2xs);
+    font-size: var(--wa-font-size-2xs);
+    line-height: 1.45;
     color: var(--wa-color-text-quiet);
   }
 `;

--- a/src/components/dashboard/device-drawer-render.ts
+++ b/src/components/dashboard/device-drawer-render.ts
@@ -9,6 +9,8 @@
  * and the localize signature.
  */
 import { html, nothing } from "lit";
+import { DeviceState } from "../../api/types/devices.js";
+import type { ReachabilityStateEvent } from "../../api/types/reachability.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 
@@ -88,6 +90,65 @@ export function renderMdnsTxtRecords(
           `
         )}
       </dl>
+    </details>
+  `;
+}
+
+/**
+ * Render the collapsible warning shown when a device is reachable but
+ * the dashboard can't see it over mDNS (different subnet, no mDNS
+ * reflector, …) — not an assertion the device stopped announcing.
+ *
+ * MAC address, ESPHome version, and config hash are read from the mDNS
+ * TXT payload, so on a Ping/MQTT-only device the cached values (and the
+ * Modified / Update-available indicators derived from them) may be
+ * stale. The drawer's per-row "Waiting for mDNS discovery…" text doesn't
+ * explain why; this surfaces the reason once, in the same `<details>`
+ * chevron idiom as ``renderMdnsTxtRecords`` so it sits naturally in the
+ * section.
+ *
+ * Returns ``nothing`` unless mDNS has never been seen
+ * (``mdns_last_seen_seconds_ago === null``) while another source is
+ * live and the device is not OFFLINE. UNKNOWN counts: a Ping/MQTT-only
+ * device's online state is mDNS-driven, so it sits at UNKNOWN even while
+ * reachable — exactly the case this warns about. OFFLINE is excluded
+ * because the Ping/MQTT timestamps linger as stale history once a device
+ * drops; a fully-offline device gets the existing "Waiting for first
+ * signal…" line, and a device heard over mDNS isn't stale.
+ */
+export function renderMdnsStaleWarning(
+  reachability: ReachabilityStateEvent | null,
+  localize: LocalizeFunc
+) {
+  if (reachability === null) return nothing;
+  // Exclude only OFFLINE, not "not ONLINE": a device reachable solely over
+  // Ping/MQTT reports UNKNOWN (the online state is mDNS-driven), and that is
+  // exactly the case this warns about. OFFLINE is excluded because the
+  // *_last_seen_seconds_ago stamps linger as stale history once a device
+  // drops, and "reachable over {source}" must not show for a dead device.
+  if (reachability.state === DeviceState.OFFLINE) return nothing;
+  const mdnsSeen = reachability.mdns_last_seen_seconds_ago !== null;
+  const mqttSeen = reachability.mqtt_last_seen_seconds_ago !== null;
+  const pingSeen = reachability.ping_last_seen_seconds_ago !== null;
+  if (mdnsSeen || (!mqttSeen && !pingSeen)) return nothing;
+  // Name the channel the device IS reachable on. active_source is the
+  // priority winner (MQTT > Ping while mDNS is dark); fall back to
+  // whichever is live if it isn't already one of those two.
+  const viaMqtt =
+    reachability.active_source === "mqtt" ||
+    (reachability.active_source !== "ping" && mqttSeen);
+  const source = localize(
+    viaMqtt ? "dashboard.drawer_source_mqtt" : "dashboard.drawer_source_ping"
+  );
+  return html`
+    <details class="reachability-warning">
+      <summary>
+        <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
+        ${localize("dashboard.drawer_mdns_stale_warning")}
+      </summary>
+      <div class="reachability-warning-body">
+        ${localize("dashboard.drawer_mdns_stale_detail", { source })}
+      </div>
     </details>
   `;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -231,6 +231,8 @@
     "drawer_waiting_for_signal": "Waiting for first signal…",
     "drawer_waiting_for_mdns": "Waiting for mDNS discovery…",
     "drawer_show_mdns_txt_records": "{count, plural, one {Show # mDNS TXT record} other {Show # mDNS TXT records}}",
+    "drawer_mdns_stale_warning": "Not reachable via mDNS, some details may be stale",
+    "drawer_mdns_stale_detail": "This device is reachable over {source} but not via mDNS; the MAC address, ESPHome version, and config hash are read from mDNS, so those values and the Modified and Update available indicators may be stale, for example if the dashboard and the device are on different subnets.",
     "drawer_ip_address": "IP Address",
     "drawer_ip_show_more": "Show {n} more",
     "drawer_ip_hide_extra": "Hide",

--- a/test/components/dashboard/render-mdns-stale-warning.test.ts
+++ b/test/components/dashboard/render-mdns-stale-warning.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the drawer's "not reachable via mDNS" warning.
+ *
+ * Pins ``renderMdnsStaleWarning`` — the collapsible the reachability
+ * section mounts when a device is up over Ping/MQTT but isn't announcing
+ * on mDNS, so the user knows why MAC / version / config-hash (and the
+ * Modified / Update-available indicators) aren't refreshing. Only the
+ * render condition and the localize keys are observable here; the live
+ * mDNS state can't be toggled on the bench.
+ */
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import { DeviceState } from "../../../src/api/types/devices.js";
+import type { ReachabilityStateEvent } from "../../../src/api/types/reachability.js";
+import { renderMdnsStaleWarning } from "../../../src/components/dashboard/device-drawer-render.js";
+import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-walker.js";
+
+const _identityLocalize: (key: string) => string = (key) => key;
+
+function reachability(
+  overrides: Partial<ReachabilityStateEvent> = {}
+): ReachabilityStateEvent {
+  return {
+    device: "dev",
+    state: DeviceState.ONLINE,
+    active_source: "ping",
+    ip: "192.168.1.10",
+    mdns_last_seen_seconds_ago: null,
+    mdns_ttl_remaining_seconds: null,
+    ping_last_seen_seconds_ago: 5,
+    mqtt_last_seen_seconds_ago: null,
+    ping_rtt_ms: 4.2,
+    ...overrides,
+  };
+}
+
+describe("renderMdnsStaleWarning", () => {
+  it("warns when mDNS is dark but Ping is live", () => {
+    const result = renderMdnsStaleWarning(reachability(), _identityLocalize);
+    expect(isTemplateResult(result)).toBe(true);
+    expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
+  });
+
+  it("warns for an UNKNOWN-state device reachable over Ping", () => {
+    // A Ping/MQTT-only device's online state is mDNS-driven, so it stays
+    // UNKNOWN while reachable; the warning must still show (regression: a
+    // strict ONLINE gate hid it until a reload caught a later snapshot).
+    const result = renderMdnsStaleWarning(
+      reachability({ state: DeviceState.UNKNOWN, active_source: "ping" }),
+      _identityLocalize
+    );
+    expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
+  });
+
+  it("warns when mDNS is dark but only MQTT is live", () => {
+    const result = renderMdnsStaleWarning(
+      reachability({
+        active_source: "mqtt",
+        ping_last_seen_seconds_ago: null,
+        mqtt_last_seen_seconds_ago: 9,
+        ping_rtt_ms: null,
+      }),
+      _identityLocalize
+    );
+    expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
+  });
+
+  it("stays silent once mDNS has been seen", () => {
+    const result = renderMdnsStaleWarning(
+      reachability({ active_source: "mdns", mdns_last_seen_seconds_ago: 3 }),
+      _identityLocalize
+    );
+    expect(result).toBe(nothing);
+  });
+
+  it("stays silent when no source is live (offline gets the waiting line)", () => {
+    const result = renderMdnsStaleWarning(
+      reachability({ ping_last_seen_seconds_ago: null, ping_rtt_ms: null }),
+      _identityLocalize
+    );
+    expect(result).toBe(nothing);
+  });
+
+  it("stays silent for an offline snapshot with stale Ping/MQTT timestamps", () => {
+    // *_last_seen_seconds_ago can carry historical timestamps after a
+    // device goes offline; the "online over {source}" copy must not show.
+    const result = renderMdnsStaleWarning(
+      reachability({ state: DeviceState.OFFLINE, ping_last_seen_seconds_ago: 300 }),
+      _identityLocalize
+    );
+    expect(result).toBe(nothing);
+  });
+
+  it("renders nothing for a null snapshot", () => {
+    expect(renderMdnsStaleWarning(null, _identityLocalize)).toBe(nothing);
+  });
+
+  it("uses the summary and detail localize keys", () => {
+    const keys: string[] = [];
+    renderMdnsStaleWarning(reachability(), (key) => {
+      keys.push(key);
+      return key;
+    });
+    expect(keys).toContain("dashboard.drawer_mdns_stale_warning");
+    expect(keys).toContain("dashboard.drawer_mdns_stale_detail");
+  });
+
+  // The detail string names the live channel via a {source} arg so it
+  // reads "online over Ping/MQTT", not a generic "Ping or MQTT".
+  function detailSourceArg(r: ReachabilityStateEvent): unknown {
+    const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+    renderMdnsStaleWarning(r, (key, args) => {
+      calls.push([key, args]);
+      return key;
+    });
+    const detail = calls.find(([key]) => key === "dashboard.drawer_mdns_stale_detail");
+    return detail?.[1]?.source;
+  }
+
+  it("names Ping as the source when the device is reachable over Ping", () => {
+    expect(detailSourceArg(reachability({ active_source: "ping" }))).toBe(
+      "dashboard.drawer_source_ping"
+    );
+  });
+
+  it("names MQTT as the source when the device is reachable over MQTT", () => {
+    expect(
+      detailSourceArg(
+        reachability({
+          active_source: "mqtt",
+          ping_last_seen_seconds_ago: null,
+          mqtt_last_seen_seconds_ago: 9,
+          ping_rtt_ms: null,
+        })
+      )
+    ).toBe("dashboard.drawer_source_mqtt");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

When a device is online over Ping or MQTT but is not announcing on mDNS, the dashboard cannot read the mDNS TXT payload, so the MAC address, ESPHome version, and config hash come up blank or stale; the config hash in particular never updates without mDNS, so the Modified and Update available indicators stay on. The drawer already shows per row "Waiting for mDNS discovery…" text, but nothing explains why or what is affected, and people keep filing it as a bug.

This adds a small collapsible warning under the Reachability section, using the same chevron dropdown idiom as the existing mDNS TXT records list; the summary says the device is not reachable via mDNS, and the expanded body explains which details stay stale until mDNS works. It only shows when mDNS has never been seen while another source (Ping or MQTT) is live, so a fully offline device still gets the existing "Waiting for first signal" line.

**Related issue or feature (if applicable):**

- addresses the recurring "MAC address / ESPHome version missing" confusion in esphome/device-builder#1453, esphome/device-builder#1575, esphome/device-builder#1577

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
