### PR TITLE
Submit non-destructive dialogs on Enter

### DIFF
--- a/src/components/labels/bulk-labels-dialog.ts
+++ b/src/components/labels/bulk-labels-dialog.ts
@@ -272,6 +272,12 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
     return this._pendingChanges.size > 0;
   }
 
+  /** Apply is reachable (button enabled, Enter armed) only with staged
+   *  changes and no in-flight save. */
+  get _canApply(): boolean {
+    return this._hasPendingChanges && !this._saving;
+  }
+
   static styles = [
     espHomeStyles,
     labelChipStyles,
@@ -343,6 +349,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
         .label=${this._localize("dashboard.labels_bulk_dialog_title", {
           count: targetCount,
         })}
+        .confirmOnEnter=${this._canApply ? this._apply : undefined}
         @after-hide=${this._onAfterHide}
       >
         ${this._catalog.length === 0
@@ -372,7 +379,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
           <button
             class="btn btn--primary"
             type="button"
-            ?disabled=${this._saving || !this._hasPendingChanges}
+            ?disabled=${!this._canApply}
             @click=${this._apply}
           >
             ${this._localize("dashboard.labels_bulk_apply")}
@@ -467,7 +474,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
     // two ``_apply`` calls before the Lit re-render disables the
     // button via ``_saving``. Drop the second call here so we don't
     // send two ``set_labels_bulk`` requests for the same payload.
-    if (this._saving || !this._hasPendingChanges) return;
+    if (!this._canApply) return;
     const updates = this.computeUpdates();
     const count = updates.length;
     if (count === 0) {

--- a/src/components/pair-build-server-dialog.ts
+++ b/src/components/pair-build-server-dialog.ts
@@ -17,6 +17,7 @@ import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { inputStyles } from "../styles/inputs.js";
 import { pinHexStyles } from "../styles/pin-hex.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { EnterController } from "../util/enter-controller.js";
 import { friendlyHostname, parsePortInput } from "../util/hostname.js";
 import "./base-dialog.js";
 import {
@@ -100,6 +101,16 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   // still in flight or failed).
   @state() _offloaderIdentity: IdentityView | null = null;
 
+  // Enter submits the current step. This dialog stays open across input→confirm,
+  // so it drives its own controller (rather than base-dialog's confirmOnEnter)
+  // to add the held-Enter guard: without it a single held key would carry from
+  // the input step straight through the confirm submit, sending the pair request
+  // past the unreviewed pin fingerprint.
+  private _enter = new EnterController(this, (e) => {
+    if (e.repeat) return;
+    this._enterAction()?.();
+  });
+
   static styles = [
     espHomeStyles,
     inputStyles,
@@ -177,6 +188,7 @@ export class ESPHomePairBuildServerDialog extends LitElement {
   protected willUpdate(changed: Map<string, unknown>): void {
     super.willUpdate(changed);
     watchPairingApproval(this, changed);
+    if (changed.has("_open")) this._enter.set(this._open);
   }
 
   _onPreviewSubmit = () => onPreviewSubmit(this);
@@ -231,6 +243,14 @@ export class ESPHomePairBuildServerDialog extends LitElement {
     if (this._step === "input") return renderInputStep(this);
     if (this._step === "confirm") return renderConfirmStep(this);
     return renderSentStep(this);
+  }
+
+  // Enter submits the current step; the read-only "sent" step has no action.
+  // Each handler self-guards on its own validity (empty hostname, labels).
+  private _enterAction(): (() => void) | undefined {
+    if (this._step === "input") return this._onPreviewSubmit;
+    if (this._step === "confirm") return this._onConfirmSubmit;
+    return undefined;
   }
 }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -338,6 +338,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       case "import-partial":
         return html`<esphome-wizard-step-import-partial
           .kept=${this._import.partial?.kept ?? []}
+          ?active=${this._open}
         ></esphome-wizard-step-import-partial>`;
     }
   }

--- a/src/components/wizard/wizard-step-import-partial.ts
+++ b/src/components/wizard/wizard-step-import-partial.ts
@@ -1,10 +1,11 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html } from "lit";
+import { LitElement, type PropertyValues, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { EnterController } from "../../util/enter-controller.js";
 
 /** Terminal result of a bundle import that left some existing files in
  *  place, so a partial import reads as partial rather than a silent
@@ -17,6 +18,21 @@ export class ESPHomeWizardStepImportPartial extends LitElement {
 
   /** Existing files the import kept (did not overwrite). */
   @property({ type: Array }) kept: string[] = [];
+
+  // Set by the parent dialog; the step stays mounted while the dialog is
+  // hidden, so the Enter listener follows this rather than connectedCallback.
+  @property({ type: Boolean }) active = false;
+
+  // Enter mirrors the sole primary "open device" button. Ignore OS key-repeat
+  // so a held Enter from the previous step can't auto-advance through here.
+  private _enter = new EnterController(this, (e) => {
+    if (e.repeat) return;
+    this._open();
+  });
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has("active")) this._enter.set(this.active);
+  }
 
   static styles = [
     espHomeStyles,

--- a/test/components/dialog-enter-submit.test.ts
+++ b/test/components/dialog-enter-submit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Audit for issue #1670: every non-destructive submit dialog/step wired for
+ * Enter fires its primary action on a plain Enter while active, and stays inert
+ * while closed/inactive. Destructive or fleet-wide confirms (overwrite-device,
+ * resolve-conflicts, update-all) intentionally remain click-only and are not
+ * listed here. A new submit dialog should be added to `cases` below; a dialog
+ * that forgets its Enter wiring fails this suite, which is the issue's
+ * "is there a way to identify them in the code?" answer.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import type { LitElement } from "lit";
+import { ESPHomeBulkLabelsDialog } from "../../src/components/labels/bulk-labels-dialog.js";
+import { ESPHomePairBuildServerDialog } from "../../src/components/pair-build-server-dialog.js";
+import { ESPHomeWizardStepImportPartial } from "../../src/components/wizard/wizard-step-import-partial.js";
+import { pressEnter } from "../_press-enter.js";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface EnterCase {
+  name: string;
+  /** Handler property replaced with a spy; what Enter must invoke. */
+  primary: string;
+  mount: () => LitElement;
+  /** Put the host into its submittable + active state. */
+  activate: (host: any) => Promise<void>;
+}
+
+const cases: EnterCase[] = [
+  {
+    name: "bulk-labels apply",
+    primary: "_apply",
+    mount: () => new ESPHomeBulkLabelsDialog(),
+    activate: async (host) => {
+      // Apply is gated on pending changes; force the derived getter true so the
+      // dialog wires confirmOnEnter without staging real per-device edits.
+      Object.defineProperty(host, "_hasPendingChanges", {
+        configurable: true,
+        get: () => true,
+      });
+      host._saving = false;
+      host.open();
+      host.requestUpdate();
+      await host.updateComplete;
+    },
+  },
+  {
+    name: "pair-build-server preview (input step)",
+    primary: "_onPreviewSubmit",
+    mount: () => new ESPHomePairBuildServerDialog(),
+    activate: async (host) => {
+      host.open({ hostname: "server.local" });
+      await host.updateComplete;
+    },
+  },
+  {
+    name: "pair-build-server confirm step",
+    primary: "_onConfirmSubmit",
+    mount: () => new ESPHomePairBuildServerDialog(),
+    activate: async (host) => {
+      host.open({ hostname: "server.local" });
+      host._step = "confirm";
+      host.requestUpdate();
+      await host.updateComplete;
+    },
+  },
+  {
+    name: "wizard-step import-partial open",
+    primary: "_open",
+    mount: () => new ESPHomeWizardStepImportPartial(),
+    activate: async (host) => {
+      host.active = true;
+      await host.updateComplete;
+    },
+  },
+];
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe.each(cases)(
+  "$name Enter-to-submit (issue #1670)",
+  ({ primary, mount, activate }) => {
+    it("invokes the primary action on Enter while active", async () => {
+      const host = mount() as any;
+      const spy = vi.fn();
+      host[primary] = spy;
+      document.body.appendChild(host);
+      await host.updateComplete;
+      await activate(host);
+      pressEnter();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing on Enter while closed/inactive", async () => {
+      const host = mount() as any;
+      const spy = vi.fn();
+      host[primary] = spy;
+      document.body.appendChild(host);
+      await host.updateComplete;
+      pressEnter();
+      expect(spy).not.toHaveBeenCalled();
+    });
+  }
+);
+
+// A held Enter must not carry from the input step into the confirm submit: the
+// dialog stays open across input→confirm, so a missing repeat guard would send
+// the pair request past the unreviewed pin fingerprint.
+it("pair-build-server ignores a held (repeat) Enter on the input step", async () => {
+  const host = new ESPHomePairBuildServerDialog() as any;
+  const preview = vi.fn();
+  host._onPreviewSubmit = preview;
+  document.body.appendChild(host);
+  await host.updateComplete;
+  host.open({ hostname: "server.local" });
+  await host.updateComplete;
+  pressEnter({ repeat: true });
+  expect(preview).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
# What does this implement/fix?

Some dialogs could not be submitted with ENTER. This wires the existing `EnterController` (via `esphome-base-dialog`'s `confirmOnEnter`, or directly on a wizard step) to the dialogs that had a clear single primary action but no ENTER handling:

- Bulk-labels apply (gated on having pending changes)
- Pair build server, both the hostname input step and the confirm step
- The import-partial wizard step ("Open device")

Destructive or fleet-wide confirms intentionally stay click-only: overwrite-device, resolve-conflicts, and update-all (bulk firmware flash) are deliberately excluded so ENTER cannot trigger them by accident.

To answer the issue's "is there a way to identify them in the code?", this adds an enumerating audit test (`test/components/dialog-enter-submit.test.ts`); a new submit dialog that forgets its ENTER wiring fails that suite.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1670

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
