### PR TITLE
Treat ESP8285 as the esp8266 platform when web flashing

### DIFF
--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -3,7 +3,7 @@ import {
   JobStatus,
   type FirmwareBinary,
 } from "../../api/types/firmware-jobs.js";
-import { chipNameToVariant } from "../../util/chip-variant.js";
+import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
@@ -101,7 +101,9 @@ export async function startWebSerialInstall(
   // until the first compile fills in specifics. Resolve the actual variant
   // via the board catalog and only strict-compare when we have authoritative info.
   host._statusMessage = host._localize("firmware.status_verifying");
-  const detectedVariant = chipNameToVariant(detected.chipName);
+  // chipPlatformFamily folds esp8285 into esp8266 — they're one ESPHome
+  // platform, so an ESP8285 chip on a `board: esp8285` (esp8266) config matches.
+  const detectedVariant = chipPlatformFamily(detected.chipName);
   let expected = device.target_platform;
   let hasAuthoritativeVariant = false;
   if (device.board_id) {
@@ -116,7 +118,10 @@ export async function startWebSerialInstall(
       // Network hiccup — fall back to target_platform.
     }
   }
-  const expectedNorm = expected ? expected.toLowerCase().replace(/-/g, "") : "";
+  // Fold the expected side through the same helper so a board catalog stamping
+  // the esp8285 variant still matches a detected ESP8266/ESP8285. Idempotent on
+  // an already-normalized platform token.
+  const expectedNorm = expected ? chipPlatformFamily(expected) : "";
   // Without a resolved variant, "esp32" stands in for any ESP32 family chip.
   const expectedIsCoarseEsp32 = !hasAuthoritativeVariant && expectedNorm === "esp32";
   if (

--- a/src/components/wizard/wizard-step-board-platforms.ts
+++ b/src/components/wizard/wizard-step-board-platforms.ts
@@ -15,7 +15,7 @@
  *   two chip series (RP2040 / RP2350). Absent for other platforms.
  * - ``label`` is the user-facing chip text.
  */
-import { chipNameToVariant } from "../../util/chip-variant.js";
+import { chipPlatformFamily } from "../../util/chip-variant.js";
 
 export interface WizardBoardPlatform {
   readonly platform: string;
@@ -51,16 +51,16 @@ export const WIZARD_BOARD_PLATFORMS: readonly WizardBoardPlatform[] = [
 /**
  * Map an esptool-js chip name (e.g. ``"ESP32-C6 (QFN32) (revision
  * v0.2)"``) to the platform-filter label the board picker uses
- * (e.g. ``"ESP32-C6"``). Normalises through ``chipNameToVariant``
+ * (e.g. ``"ESP32-C6"``). Normalises through ``chipPlatformFamily``
  * (handles package-specific descriptions like ``ESP32-D0WD`` →
- * ``esp32`` and ``ESP8266EX`` → ``esp8266``), then matches an
- * existing filter chip. Returns ``null`` when no chip represents the
+ * ``esp32`` and folds the esp82 family, so ``ESP8266EX`` / ``ESP8285``
+ * → ``esp8266``), then matches an existing filter chip. Returns
+ * ``null`` when no chip represents the
  * variant (e.g. ESP32-S31/C31/H21) so the caller shows the full
  * picker rather than narrowing to the wrong family.
  */
 export function chipNameToFilterLabel(chipName: string): string | null {
-  let family = chipNameToVariant(chipName);
-  if (family.startsWith("esp82")) family = "esp8266"; // esp8266 / esp8285
+  const family = chipPlatformFamily(chipName); // folds esp8285 → esp8266
   const match = WIZARD_BOARD_PLATFORMS.find(
     (p) =>
       (p.variant && p.variant === family) ||

--- a/src/util/chip-variant.ts
+++ b/src/util/chip-variant.ts
@@ -38,3 +38,14 @@ export function chipNameToVariant(name: string): string {
   if (n.startsWith("esp32")) return "esp32";
   return n;
 }
+
+/**
+ * Like ``chipNameToVariant`` but folds the esp82 family (esp8266 / esp8285) to
+ * the one ``esp8266`` platform they share. Other chips keep their variant token
+ * unchanged (e.g. ``ESP32-S3`` → ``esp32s3``); use this for comparisons that
+ * must treat esp8285 and esp8266 as equal.
+ */
+export function chipPlatformFamily(name: string): string {
+  const v = chipNameToVariant(name);
+  return v.startsWith("esp82") ? "esp8266" : v;
+}

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -167,4 +167,42 @@ describe("Web Serial install — HTTP byte download", () => {
     expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
     expect(wsSerial.flashFirmware).not.toHaveBeenCalled();
   });
+
+  // ESP8285 is an ESP8266 with embedded flash; `board: esp8285` resolves to the
+  // esp8266 platform, so a detected ESP8285 must not trip the chip-mismatch guard.
+  it("flashes an ESP8285 chip on an esp8266 config (#1673)", async () => {
+    const { host, api } = makeHost();
+    host._device.target_platform = "esp8266";
+    host._device.board_id = "esp8285";
+    api.getBoard.mockResolvedValue({ esphome: { platform: "esp8266" } });
+    api.firmwareGetBinaries.mockResolvedValue([
+      { title: "Firmware", file: "firmware.bin" },
+    ]);
+    wsSerial.detectChip.mockResolvedValue({ ...CHIP, chipName: "ESP8285" });
+    wsSerial.connectToPort.mockResolvedValue({ ...CHIP, chipName: "ESP8285" });
+    wsSerial.disconnect.mockResolvedValue(undefined);
+    wsSerial.flashFirmware.mockResolvedValue(undefined);
+    wsSerial.resetAndDisconnect.mockResolvedValue(undefined);
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._fail).not.toHaveBeenCalled();
+    expect(wsSerial.flashFirmware).toHaveBeenCalledTimes(1);
+    expect(wsSerial.flashFirmware.mock.calls[0][2]).toBe(0x0); // esp8266 flashes at 0x0
+    expect(host._step).toBe("done");
+  });
+
+  it("still rejects a genuine chip mismatch (#1673)", async () => {
+    const { host, api } = makeHost();
+    host._device.target_platform = "esp8266";
+    host._device.board_id = "esp8285";
+    api.getBoard.mockResolvedValue({ esphome: { platform: "esp8266" } });
+    wsSerial.detectChip.mockResolvedValue({ ...CHIP, chipName: "ESP32" });
+    wsSerial.disconnect.mockResolvedValue(undefined);
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._fail).toHaveBeenCalledWith("firmware.chip_mismatch");
+    expect(wsSerial.flashFirmware).not.toHaveBeenCalled();
+  });
 });

--- a/test/util/chip-variant.test.ts
+++ b/test/util/chip-variant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { chipNameToVariant } from "../../src/util/chip-variant.js";
+import { chipNameToVariant, chipPlatformFamily } from "../../src/util/chip-variant.js";
 
 describe("chipNameToVariant", () => {
   it("maps plain ESP32 to esp32", () => {
@@ -82,5 +82,19 @@ describe("chipNameToVariant", () => {
   it("returns the normalized input for unknown chips", () => {
     expect(chipNameToVariant("RP2040")).toBe("rp2040");
     expect(chipNameToVariant("Unknown-Chip")).toBe("unknownchip");
+  });
+});
+
+describe("chipPlatformFamily", () => {
+  it("folds the esp82 family to the esp8266 platform (#1673)", () => {
+    expect(chipPlatformFamily("ESP8285")).toBe("esp8266");
+    expect(chipPlatformFamily("ESP8266")).toBe("esp8266");
+    expect(chipPlatformFamily("ESP8266EX")).toBe("esp8266");
+  });
+
+  it("passes other variants through unchanged", () => {
+    expect(chipPlatformFamily("ESP32")).toBe("esp32");
+    expect(chipPlatformFamily("ESP32-S3")).toBe("esp32s3");
+    expect(chipPlatformFamily("RP2040")).toBe("rp2040");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Web flashing an ESP8285 module configured as `esp8266: { board: esp8285 }` failed immediately with "Chip mismatch: detected ESP8285 but device expects esp8266". ESP8285 is an ESP8266 with embedded flash; ESPHome treats `board: esp8285` under the `esp8266` platform, so the two are one platform.

The Web Serial chip-mismatch guard strict-compared the detected variant against the expected platform. `chipNameToVariant("ESP8285")` returns `esp8285` by design; its contract is that callers collapse the `esp82` family (the board-picker label path already did). The install guard forgot to, so `esp8285 !== esp8266` tripped the error.

This adds a small `chipPlatformFamily` helper that folds the `esp82` family to `esp8266`, uses it on both sides of the mismatch compare, and reuses it in the board-picker label path that had the collapse inline.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1673

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
