### PR TITLE
Show a pending spinner on the Save button while a YAML save is in flight

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -247,14 +247,27 @@ export const deviceEditorStyles = css`
     border-color: color-mix(in srgb, var(--wa-color-text-normal), transparent 70%);
   }
 
+  /* Single size for every glyph; the fixed slot below derives its
+     box from this one font-size, so there's nothing to keep in sync. */
   .save-button wa-icon,
+  .save-button wa-spinner,
   .validate-button wa-icon,
   .install-fab wa-icon {
     font-size: 16px;
   }
 
+  /* Pin both the idle icon and the in-flight spinner to the same 1em
+     square so swapping them can't reflow the button. wa-icon and
+     wa-spinner measure differently on their own, hence both here. */
+  .save-button wa-icon,
   .save-button wa-spinner {
-    font-size: 14px;
+    box-sizing: border-box;
+    flex: none;
+    width: 1em;
+    height: 1em;
+  }
+
+  .save-button wa-spinner {
     --track-width: 2px;
     --indicator-color: currentColor;
     --track-color: color-mix(in srgb, currentColor 30%, transparent);

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -253,6 +253,13 @@ export const deviceEditorStyles = css`
     font-size: 16px;
   }
 
+  .save-button wa-spinner {
+    font-size: 14px;
+    --track-width: 2px;
+    --indicator-color: currentColor;
+    --track-color: color-mix(in srgb, currentColor 30%, transparent);
+  }
+
   /* Tooltip carrier so the "why disabled" hint reaches mouse users
      even when the underlying button has the disabled attribute
      (which suppresses pointer events on the button itself). */

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -36,6 +36,7 @@ import { renderInstallAction } from "./install-action.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../yaml-diff.js";
 import "../yaml-editor.js";
 import "./device-board-info.js";
@@ -149,6 +150,11 @@ export class ESPHomeDeviceEditor extends LitElement {
    *  resulting commit is correct. */
   @property({ type: Boolean })
   hasUnsavedEdits = false;
+
+  /** A save round-trip (validate + write) is in flight; the Save
+   *  button shows a spinner and stays disabled until it settles. */
+  @property({ type: Boolean })
+  saving = false;
 
   @property({ type: Boolean })
   hasPendingChanges = false;
@@ -274,11 +280,13 @@ export class ESPHomeDeviceEditor extends LitElement {
             <button
               type="button"
               class="save-button"
-              ?disabled=${!this.hasUnsavedEdits}
+              ?disabled=${!this.hasUnsavedEdits || this.saving}
               @click=${this._onSave}
               title=${this._localize("device.save_yaml")}
             >
-              <wa-icon library="mdi" name="content-save"></wa-icon>
+              ${this.saving
+                ? html`<wa-spinner></wa-spinner>`
+                : html`<wa-icon library="mdi" name="content-save"></wa-icon>`}
               ${this._localize("device.save")}
             </button>
           </div>

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -281,6 +281,7 @@ export class ESPHomeDeviceEditor extends LitElement {
               type="button"
               class="save-button"
               ?disabled=${!this.hasUnsavedEdits || this.saving}
+              aria-busy=${this.saving}
               @click=${this._onSave}
               title=${this._localize("device.save_yaml")}
             >

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -690,6 +690,12 @@ export class ESPHomePageDevice extends LitElement {
    * the return value.
    */
   private _saveYaml = async (): Promise<boolean> => {
+    // Mark the Save button busy up front so it acknowledges the
+    // click immediately. The slow phases that follow are the
+    // section-editor flushPending (a backend upsert for the
+    // automation/script editors) and the validate round-trip on a
+    // large config; both deserve the spinner.
+    this._saving = true;
     // Promote any in-flight form keystroke (still inside its 200ms
     // debounce window) into ``_yaml`` so the save commits exactly
     // what the user typed — not what was last flushed. The
@@ -706,7 +712,10 @@ export class ESPHomePageDevice extends LitElement {
     // saved buffer (e.g. user typed and undid a character, or the
     // splice normalised to the same serialisation). Bail before
     // toasting / hitting the backend — neither has anything to do.
-    if (!this._isYamlDirty) return true;
+    if (!this._isYamlDirty) {
+      this._saving = false;
+      return true;
+    }
 
     // Re-validate against the backend before committing. The
     // editor's inline linter runs the same call on a 600ms
@@ -723,10 +732,6 @@ export class ESPHomePageDevice extends LitElement {
     // below is the authority on whether the save worked, and a
     // toast at this layer would shout-down its result.
     if (this.id) {
-      // The validate round-trip is the slow phase on a large config
-      // (a full ESPHome validate pass); mark the Save button busy so
-      // it acknowledges the click instead of looking unresponsive.
-      this._saving = true;
       try {
         // Reuse the linter's last result when it matches the
         // current buffer exactly — saves a WS round-trip and an

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -226,6 +226,9 @@ export class ESPHomePageDevice extends LitElement {
   @state()
   private _savedYaml = "";
 
+  @state()
+  private _saving = false;
+
   @query("esphome-unsaved-changes-dialog")
   private _unsavedDialog!: ESPHomeUnsavedChangesDialog;
 
@@ -720,6 +723,10 @@ export class ESPHomePageDevice extends LitElement {
     // below is the authority on whether the save worked, and a
     // toast at this layer would shout-down its result.
     if (this.id) {
+      // The validate round-trip is the slow phase on a large config
+      // (a full ESPHome validate pass); mark the Save button busy so
+      // it acknowledges the click instead of looking unresponsive.
+      this._saving = true;
       try {
         // Reuse the linter's last result when it matches the
         // current buffer exactly — saves a WS round-trip and an
@@ -755,6 +762,12 @@ export class ESPHomePageDevice extends LitElement {
         }
       } catch (e) {
         console.debug("[save-yaml] validate_yaml failed, saving anyway:", e);
+      } finally {
+        // Drop busy here so the spinner stops while the validation
+        // dialog is open (waiting on the user, not the backend); the
+        // pass-through to _doSaveYaml re-arms it for the commit with
+        // no await in between, so the button never flickers enabled.
+        this._saving = false;
       }
     }
 
@@ -784,6 +797,7 @@ export class ESPHomePageDevice extends LitElement {
     // claim "saved" against a buffer the backend rejected.
     const prevSavedYaml = this._savedYaml;
     this._savedYaml = this._yaml;
+    this._saving = true;
     let saved = true;
     try {
       await this._api.updateConfig(this.id, this._yaml);
@@ -800,6 +814,8 @@ export class ESPHomePageDevice extends LitElement {
         this._savedYaml = prevSavedYaml;
         console.error("Failed to save YAML:", e);
       }
+    } finally {
+      this._saving = false;
     }
     // A committed save ends the fix-the-error errand the error-jump
     // highlight was guiding (validation passed, or the user chose
@@ -971,6 +987,7 @@ export class ESPHomePageDevice extends LitElement {
             @just-created-dismiss=${this._dismissJustCreated}
             @change-board=${this._onChangeBoard}
             ?hasUnsavedEdits=${this._isDirty}
+            ?saving=${this._saving}
             ?hasPendingChanges=${this._device?.has_pending_changes === true}
             ?hasUpdateAvailable=${this._device?.update_available === true}
             ?busy=${this._activeJobs.has(this.id)}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -690,14 +690,17 @@ export class ESPHomePageDevice extends LitElement {
    * the return value.
    */
   private _saveYaml = async (): Promise<boolean> => {
-    // Refuse to start a second save while one is in flight. The Save
-    // button's disabled attribute blocks the mouse, but Cmd/Ctrl+S
-    // (SaveShortcutController) only checks dirtiness — and during the
-    // multi-second validate phase ``_savedYaml`` hasn't been written
-    // yet, so the buffer still reads dirty. Without this guard a
-    // keystroke re-enters and double-validates, double-writes, and
-    // churns the validation-prompt resolver.
-    if (this._saving) return false;
+    // Refuse to start a second save while one is already in progress.
+    // The Save button's disabled attribute blocks the mouse, but
+    // Cmd/Ctrl+S (SaveShortcutController, bound on window) only checks
+    // dirtiness — and ``_savedYaml`` stays stale both through the
+    // multi-second validate phase and while the validation-error
+    // dialog awaits the user, so the buffer keeps reading dirty.
+    // ``_pendingValidationResolve`` is non-null exactly while that
+    // dialog is open; guarding on it too stops a keystroke from
+    // double-validating, double-writing, or resolving the open
+    // prompt's pending promise out from under it.
+    if (this._saving || this._pendingValidationResolve !== null) return false;
     // Mark the Save button busy up front so it acknowledges the
     // click immediately. The slow phases that follow are the
     // section-editor flushPending (a backend upsert for the
@@ -761,13 +764,9 @@ export class ESPHomePageDevice extends LitElement {
             errorFile && this.id && !isOpenConfigFile(errorFile, this.id)
               ? basename(errorFile)
               : "";
-          // A previous prompt that's somehow still pending (the
-          // unsaved-guard already prevents overlapping page-leave
-          // dialogs, but a manual Save click reaches this branch
-          // unguarded) gets resolved as "not saved" before we
-          // reset the resolver — without this the prior caller
-          // would dangle forever.
-          this._pendingValidationResolve?.(false);
+          // The re-entrancy guard at the top of _saveYaml bails while a
+          // prompt is already pending, so the resolver is null here and
+          // can be assigned fresh without dangling a prior caller.
           return new Promise<boolean>((resolve) => {
             this._pendingValidationResolve = resolve;
             this._yamlValidationDialog.open();

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -707,83 +707,89 @@ export class ESPHomePageDevice extends LitElement {
     // automation/script editors) and the validate round-trip on a
     // large config; both deserve the spinner.
     this._saving = true;
-    // Promote any in-flight form keystroke (still inside its 200ms
-    // debounce window) into ``_yaml`` so the save commits exactly
-    // what the user typed — not what was last flushed. The
-    // component editor's flushPending is sync (local YAML splice
-    // only); the automation/script editors return a Promise
-    // because their pending change is a backend upsert call.
-    // ``await`` handles both shapes — awaiting ``undefined``
-    // resolves immediately.
-    await this._activeSection?.flushPending();
-    // The Save button activates on ``_isDirty`` (yaml diff OR the
-    // section editor's transient pre-flush dirty flag), so a click
-    // inside the debounce window can land here with the form
-    // marked dirty but the post-flush yaml unchanged from the
-    // saved buffer (e.g. user typed and undid a character, or the
-    // splice normalised to the same serialisation). Bail before
-    // toasting / hitting the backend — neither has anything to do.
-    if (!this._isYamlDirty) {
-      this._saving = false;
-      return true;
-    }
+    // Everything from here runs inside try/finally so any throw — most
+    // notably a flushPending backend upsert that rejects — clears the
+    // busy flag instead of stranding ``_saving=true``, which the guard
+    // above would then read as a permanent in-progress save and brick
+    // every later attempt. The not-dirty bail and the validation-dialog
+    // branch return through this finally too, stopping the spinner while
+    // the prompt waits on the user. The commit path uses ``return
+    // await`` so the finally fires only after _doSaveYaml settles, not
+    // the moment it's called — _doSaveYaml owns ``_saving`` across the
+    // write (and on the standalone "Save anyway" path), so the flag
+    // stays true with no await between, and the button never flickers.
+    try {
+      // Promote any in-flight form keystroke (still inside its 200ms
+      // debounce window) into ``_yaml`` so the save commits exactly
+      // what the user typed — not what was last flushed. The
+      // component editor's flushPending is sync (local YAML splice
+      // only); the automation/script editors return a Promise
+      // because their pending change is a backend upsert call.
+      // ``await`` handles both shapes — awaiting ``undefined``
+      // resolves immediately.
+      await this._activeSection?.flushPending();
+      // The Save button activates on ``_isDirty`` (yaml diff OR the
+      // section editor's transient pre-flush dirty flag), so a click
+      // inside the debounce window can land here with the form
+      // marked dirty but the post-flush yaml unchanged from the
+      // saved buffer (e.g. user typed and undid a character, or the
+      // splice normalised to the same serialisation). Bail before
+      // toasting / hitting the backend — neither has anything to do.
+      if (!this._isYamlDirty) return true;
 
-    // Re-validate against the backend before committing. The
-    // editor's inline linter runs the same call on a 600ms
-    // debounce, but a save click inside that window would
-    // otherwise commit invalid YAML against a stale "no
-    // diagnostics" snapshot. Authoritative re-check here, then
-    // the prompt only opens when the freshly-saved buffer really
-    // is invalid.
-    //
-    // Network / backend failures fall through to the save —
-    // we'd rather risk an unvalidated commit than block the user
-    // on a backend hiccup. The fall-through stays silent (no
-    // ``toast.error`` here): the actual ``updateConfig`` call
-    // below is the authority on whether the save worked, and a
-    // toast at this layer would shout-down its result.
-    if (this.id) {
-      try {
-        // Reuse the linter's last result when it matches the
-        // current buffer exactly — saves a WS round-trip and an
-        // ESPHome validate pass that just ran in the background.
-        const res =
-          getLastValidatedResult(this.id, this._yaml) ??
-          (await this._api.validateYaml(this.id, this._yaml));
-        const summary = summarizeValidation(res);
-        if (summary.count > 0) {
-          this._validationErrorCount = summary.count;
-          this._validationFirstLine = summary.first?.line ?? 0;
-          this._validationFirstCol = summary.first?.col ?? 0;
-          this._validationFirstMessage = summary.first?.message ?? "";
-          // The reported line is meaningless against the open buffer when
-          // the error is inside an `!include`d file; name that file instead
-          // of leaving the editor to navigate nowhere.
-          const errorFile = summary.first?.file ?? null;
-          this._validationFirstFile =
-            errorFile && this.id && !isOpenConfigFile(errorFile, this.id)
-              ? basename(errorFile)
-              : "";
-          // The re-entrancy guard at the top of _saveYaml bails while a
-          // prompt is already pending, so the resolver is null here and
-          // can be assigned fresh without dangling a prior caller.
-          return new Promise<boolean>((resolve) => {
-            this._pendingValidationResolve = resolve;
-            this._yamlValidationDialog.open();
-          });
+      // Re-validate against the backend before committing. The
+      // editor's inline linter runs the same call on a 600ms
+      // debounce, but a save click inside that window would
+      // otherwise commit invalid YAML against a stale "no
+      // diagnostics" snapshot. Authoritative re-check here, then
+      // the prompt only opens when the freshly-saved buffer really
+      // is invalid.
+      //
+      // Network / backend failures fall through to the save —
+      // we'd rather risk an unvalidated commit than block the user
+      // on a backend hiccup. The fall-through stays silent (no
+      // ``toast.error`` here): the actual ``updateConfig`` call
+      // below is the authority on whether the save worked, and a
+      // toast at this layer would shout-down its result.
+      if (this.id) {
+        try {
+          // Reuse the linter's last result when it matches the
+          // current buffer exactly — saves a WS round-trip and an
+          // ESPHome validate pass that just ran in the background.
+          const res =
+            getLastValidatedResult(this.id, this._yaml) ??
+            (await this._api.validateYaml(this.id, this._yaml));
+          const summary = summarizeValidation(res);
+          if (summary.count > 0) {
+            this._validationErrorCount = summary.count;
+            this._validationFirstLine = summary.first?.line ?? 0;
+            this._validationFirstCol = summary.first?.col ?? 0;
+            this._validationFirstMessage = summary.first?.message ?? "";
+            // The reported line is meaningless against the open buffer when
+            // the error is inside an `!include`d file; name that file instead
+            // of leaving the editor to navigate nowhere.
+            const errorFile = summary.first?.file ?? null;
+            this._validationFirstFile =
+              errorFile && this.id && !isOpenConfigFile(errorFile, this.id)
+                ? basename(errorFile)
+                : "";
+            // The re-entrancy guard at the top of _saveYaml bails while a
+            // prompt is already pending, so the resolver is null here and
+            // can be assigned fresh without dangling a prior caller.
+            return new Promise<boolean>((resolve) => {
+              this._pendingValidationResolve = resolve;
+              this._yamlValidationDialog.open();
+            });
+          }
+        } catch (e) {
+          console.debug("[save-yaml] validate_yaml failed, saving anyway:", e);
         }
-      } catch (e) {
-        console.debug("[save-yaml] validate_yaml failed, saving anyway:", e);
-      } finally {
-        // Drop busy here so the spinner stops while the validation
-        // dialog is open (waiting on the user, not the backend); the
-        // pass-through to _doSaveYaml re-arms it for the commit with
-        // no await in between, so the button never flickers enabled.
-        this._saving = false;
       }
-    }
 
-    return this._doSaveYaml();
+      return await this._doSaveYaml();
+    } finally {
+      this._saving = false;
+    }
   };
 
   /** Commit the current ``_yaml`` to the backend.

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -690,6 +690,14 @@ export class ESPHomePageDevice extends LitElement {
    * the return value.
    */
   private _saveYaml = async (): Promise<boolean> => {
+    // Refuse to start a second save while one is in flight. The Save
+    // button's disabled attribute blocks the mouse, but Cmd/Ctrl+S
+    // (SaveShortcutController) only checks dirtiness — and during the
+    // multi-second validate phase ``_savedYaml`` hasn't been written
+    // yet, so the buffer still reads dirty. Without this guard a
+    // keystroke re-enters and double-validates, double-writes, and
+    // churns the validation-prompt resolver.
+    if (this._saving) return false;
     // Mark the Save button busy up front so it acknowledges the
     // click immediately. The slow phases that follow are the
     // section-editor flushPending (a backend upsert for the

--- a/test/components/device/device-editor-toolbar.test.ts
+++ b/test/components/device/device-editor-toolbar.test.ts
@@ -112,14 +112,16 @@ describe("device-editor save button", () => {
     const el = await mount({ hasUnsavedEdits: true });
     const btn = q(el, ".save-button") as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute("aria-busy")).toBe("false");
     expect(btn.querySelector("wa-icon")!.getAttribute("name")).toBe("content-save");
     expect(btn.querySelector("wa-spinner")).toBeNull();
   });
 
-  it("disables and shows a spinner while a save is in flight", async () => {
+  it("disables, announces aria-busy, and shows a spinner while a save is in flight", async () => {
     const el = await mount({ hasUnsavedEdits: true, saving: true });
     const btn = q(el, ".save-button") as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("aria-busy")).toBe("true");
     expect(btn.querySelector("wa-spinner")).not.toBeNull();
     expect(btn.querySelector("wa-icon")).toBeNull();
   });

--- a/test/components/device/device-editor-toolbar.test.ts
+++ b/test/components/device/device-editor-toolbar.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 // Stub the heavy children (they pull in CodeMirror / wa-button); the toolbar
 // under test uses plain buttons, so this keeps the mount light and quiet.
 vi.mock("../../../src/components/device/device-board-info.js", () => ({}));
@@ -99,5 +100,27 @@ describe("device-editor header toolbar", () => {
     await on.updateComplete;
     // Flips into diff view: the button now offers the way back to the editor.
     expect(q(on, '[aria-label="device.diff_view_editor"]')).not.toBeNull();
+  });
+});
+
+describe("device-editor save button", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("enables on unsaved edits and shows the save icon", async () => {
+    const el = await mount({ hasUnsavedEdits: true });
+    const btn = q(el, ".save-button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.querySelector("wa-icon")!.getAttribute("name")).toBe("content-save");
+    expect(btn.querySelector("wa-spinner")).toBeNull();
+  });
+
+  it("disables and shows a spinner while a save is in flight", async () => {
+    const el = await mount({ hasUnsavedEdits: true, saving: true });
+    const btn = q(el, ".save-button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.querySelector("wa-spinner")).not.toBeNull();
+    expect(btn.querySelector("wa-icon")).toBeNull();
   });
 });

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -91,6 +91,7 @@ interface SaveView {
   _savedYaml: string;
   _saving: boolean;
   _pendingValidationResolve: ((saved: boolean) => void) | null;
+  _activeSection: { flushPending(): Promise<void> | void } | null;
   _saveYaml(): Promise<boolean>;
   _doSaveYaml(): Promise<boolean>;
 }
@@ -129,6 +130,23 @@ describe("esphome-page-device save re-entrancy", () => {
     expect(await page._saveYaml()).toBe(false);
     expect(validateYaml).not.toHaveBeenCalled();
     expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("clears the busy flag when flushPending rejects, so later saves aren't bricked", async () => {
+    // flushPending is a backend upsert for the section editors; if it ever
+    // rejects, the busy flag must not strand true and lock out every save.
+    const flushPending = vi.fn(() => Promise.reject(new Error("upsert failed")));
+    const validateYaml = vi.fn();
+    const page = makeSaveView({ validateYaml });
+    page._activeSection = { flushPending };
+
+    await expect(page._saveYaml()).rejects.toThrow("upsert failed");
+    expect(page._saving).toBe(false); // not stranded
+
+    // The guard isn't stuck: a second attempt runs again (and rejects again).
+    await expect(page._saveYaml()).rejects.toThrow("upsert failed");
+    expect(flushPending).toHaveBeenCalledTimes(2);
+    expect(validateYaml).not.toHaveBeenCalled();
   });
 
   test("a keyboard re-entry during validate doesn't launch a second save", async () => {

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -90,6 +90,7 @@ interface SaveView {
   _yaml: string;
   _savedYaml: string;
   _saving: boolean;
+  _pendingValidationResolve: ((saved: boolean) => void) | null;
   _saveYaml(): Promise<boolean>;
   _doSaveYaml(): Promise<boolean>;
 }
@@ -109,6 +110,21 @@ describe("esphome-page-device save re-entrancy", () => {
     const updateConfig = vi.fn();
     const page = makeSaveView({ validateYaml, updateConfig });
     page._saving = true; // a save is mid-validate
+
+    expect(await page._saveYaml()).toBe(false);
+    expect(validateYaml).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("refuses a re-entry while the validation-error dialog is open", async () => {
+    // The validate-phase finally clears _saving so the spinner stops while the
+    // dialog waits on the user, but _pendingValidationResolve stays set — the
+    // guard must still treat that as a save in progress.
+    const validateYaml = vi.fn();
+    const updateConfig = vi.fn();
+    const page = makeSaveView({ validateYaml, updateConfig });
+    page._saving = false;
+    page._pendingValidationResolve = () => {};
 
     expect(await page._saveYaml()).toBe(false);
     expect(validateYaml).not.toHaveBeenCalled();

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { EditorValidateResponse } from "../../src/api/types/editor.js";
 import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 
@@ -80,5 +81,61 @@ describe("esphome-page-device layout persistence", () => {
     expect(page._layout).toBe("both");
     expect(localStorage.getItem("esphome-editor-layout")).toBe("both");
     expect(updatePreferences).not.toHaveBeenCalled();
+  });
+});
+
+interface SaveView {
+  _api: ESPHomeAPI;
+  id: string;
+  _yaml: string;
+  _savedYaml: string;
+  _saving: boolean;
+  _saveYaml(): Promise<boolean>;
+  _doSaveYaml(): Promise<boolean>;
+}
+
+function makeSaveView(api: Partial<ESPHomeAPI>): SaveView {
+  const page = new ESPHomePageDevice() as unknown as SaveView;
+  page._api = api as unknown as ESPHomeAPI;
+  page.id = "editortest";
+  page._yaml = "esphome:\n  name: x\n";
+  page._savedYaml = ""; // _yaml !== _savedYaml, so the buffer reads dirty
+  return page;
+}
+
+describe("esphome-page-device save re-entrancy", () => {
+  test("refuses to start a save while one is already in flight", async () => {
+    const validateYaml = vi.fn();
+    const updateConfig = vi.fn();
+    const page = makeSaveView({ validateYaml, updateConfig });
+    page._saving = true; // a save is mid-validate
+
+    expect(await page._saveYaml()).toBe(false);
+    expect(validateYaml).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("a keyboard re-entry during validate doesn't launch a second save", async () => {
+    // Hold validate in flight so the second (Cmd/Ctrl+S) re-entry lands while
+    // the first save is still awaiting it; resolve at the end so nothing leaks.
+    let resolveValidate!: (res: EditorValidateResponse) => void;
+    const validateYaml = vi.fn(
+      () => new Promise<EditorValidateResponse>((r) => (resolveValidate = r))
+    );
+    const page = makeSaveView({ validateYaml });
+    // Stub the commit so the first run finishes without touching toasts.
+    const doSave = vi.fn(() => Promise.resolve(true));
+    page._doSaveYaml = doSave;
+
+    const first = page._saveYaml(); // enters, sets _saving, awaits validateYaml
+    await new Promise((r) => setTimeout(r, 0)); // flush to the validate await
+    const second = await page._saveYaml(); // re-entry mid-validate
+    expect(second).toBe(false);
+
+    // Valid (no errors) → first run falls through to the stubbed commit.
+    resolveValidate({ yaml_errors: [], validation_errors: [] });
+    expect(await first).toBe(true);
+    expect(validateYaml).toHaveBeenCalledTimes(1);
+    expect(doSave).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Saving a large config used to look like nothing happened; the Save button stayed clickable for several seconds while the validate and write round trip ran, then the file finally saved. Now the button disables the moment you click it and swaps its icon for a spinner until the save settles, so it clearly acknowledges the click. The spinner covers the slow validate phase and the write; it stops while the validation error dialog is open, since at that point we are waiting on you, not the backend.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1684

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
