### PR TITLE
Fix empty toolbar button after validate completes on mobile

### DIFF
--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -323,7 +323,7 @@ export class ESPHomeLogsDialog extends LitElement {
           ${this._backToInstall
             ? html`<button
                 slot="toolbar-left"
-                class="term-btn term-btn--ghost"
+                class="term-btn term-btn--ghost term-btn--with-icon"
                 @click=${this._onBackToInstall}
                 title=${this._localize("dashboard.logs_back_to_install_tooltip")}
               >

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -321,17 +321,14 @@ export class ESPHomeLogsDialog extends LitElement {
           ?streaming=${streaming}
         >
           ${this._backToInstall
-            ? html`<button
-                slot="toolbar-left"
-                class="term-btn term-btn--ghost term-btn--with-icon"
-                @click=${this._onBackToInstall}
-                title=${this._localize("dashboard.logs_back_to_install_tooltip")}
-              >
-                <wa-icon library="mdi" name="arrow-left"></wa-icon>
-                <span class="term-btn__label"
-                  >${this._localize("dashboard.logs_back_to_install")}</span
-                >
-              </button>`
+            ? html`<div class="toolbar-slot" slot="toolbar-left">
+                ${renderTermButton({
+                  icon: "arrow-left",
+                  label: this._localize("dashboard.logs_back_to_install"),
+                  title: this._localize("dashboard.logs_back_to_install_tooltip"),
+                  onClick: this._onBackToInstall,
+                })}
+              </div>`
             : ""}
           <div class="toolbar-slot" slot="toolbar-right">
             ${passive

--- a/src/components/process-terminal/process-terminal.styles.ts
+++ b/src/components/process-terminal/process-terminal.styles.ts
@@ -109,10 +109,14 @@ export const termButtonStyles = css`
      toolbar stays on one row instead of wrapping (#542 follow-up). The label
      is visually hidden, not removed, so it still names the button for screen
      readers; the title attribute keeps the tooltip. Icon-less buttons (e.g.
-     the command dialog's text-only Close) have no wa-icon, so they keep their
-     label and are never left empty. */
+     the command dialog's text-only Close) lack term-btn--with-icon, so they
+     keep their label and are never left empty. Class-driven, not :has(wa-icon):
+     when Lit recycles a button across a state change (running Stop becoming an
+     icon-less Close), Safari does not re-invalidate :has() on the removed icon,
+     leaving the label clipped on an empty button; the class binding updates
+     reliably. */
   @media (max-width: ${MOBILE_BREAKPOINT}px) {
-    .term-btn:has(wa-icon) .term-btn__label {
+    .term-btn--with-icon .term-btn__label {
       position: absolute;
       width: 1px;
       height: 1px;

--- a/src/components/process-terminal/toolbar-button.ts
+++ b/src/components/process-terminal/toolbar-button.ts
@@ -31,7 +31,9 @@ export function renderTermButton(opts: TermButtonOpts): TemplateResult {
   const title = opts.title ?? opts.label;
   return html`<button
     type="button"
-    class="term-btn term-btn--${variant} ${opts.icon ? "term-btn--with-icon" : ""} ${opts.active ? "is-active" : ""}"
+    class="term-btn term-btn--${variant} ${opts.icon
+      ? "term-btn--with-icon"
+      : ""} ${opts.active ? "is-active" : ""}"
     ?disabled=${opts.disabled ?? false}
     title=${title ?? nothing}
     aria-label=${opts.label ? nothing : (title ?? nothing)}

--- a/src/components/process-terminal/toolbar-button.ts
+++ b/src/components/process-terminal/toolbar-button.ts
@@ -31,7 +31,7 @@ export function renderTermButton(opts: TermButtonOpts): TemplateResult {
   const title = opts.title ?? opts.label;
   return html`<button
     type="button"
-    class="term-btn term-btn--${variant} ${opts.active ? "is-active" : ""}"
+    class="term-btn term-btn--${variant} ${opts.icon ? "term-btn--with-icon" : ""} ${opts.active ? "is-active" : ""}"
     ?disabled=${opts.disabled ?? false}
     title=${title ?? nothing}
     aria-label=${opts.label ? nothing : (title ?? nothing)}

--- a/test/components/process-terminal/toolbar-button.test.ts
+++ b/test/components/process-terminal/toolbar-button.test.ts
@@ -43,6 +43,16 @@ describe("renderTermButton", () => {
     expect(btn.querySelector("wa-icon")?.getAttribute("name")).toBe("restart");
   });
 
+  it("marks icon buttons with term-btn--with-icon so only they collapse on mobile", () => {
+    const withIcon = mount(
+      renderTermButton({ icon: "stop", label: "Stop", onClick: () => {} })
+    );
+    expect(withIcon.className).toContain("term-btn--with-icon");
+    // Icon-less buttons (Close) keep their label and must not be collapsed.
+    const iconless = mount(renderTermButton({ label: "Close", onClick: () => {} }));
+    expect(iconless.className).not.toContain("term-btn--with-icon");
+  });
+
   it("uses title as the accessible name for an icon-only button", () => {
     const btn = mount(
       renderTermButton({ icon: "download", title: "Download", onClick: () => {} })


### PR DESCRIPTION
# What does this implement/fix?

On mobile, the Validate dialog footer showed an empty button frame once validation finished; the running Stop button gets recycled by Lit into the icon-less Close button, and Safari does not re-invalidate `.term-btn:has(wa-icon)` when the icon is removed, so the label stayed clipped on a now icon-less button. The collapse is now driven by a `term-btn--with-icon` class that updates reliably across the recycle, so the Close label reappears.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
