### PR TITLE
Filter the component picker by the device's platform

### DIFF
--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -13,18 +13,21 @@ import { categoryChipLabel } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 
 // Three filters applied client-side:
-//  1. Single-instance components already in the YAML get hidden.
-//     - bare top-level (`web_server`, `wifi`) → match presence of `<id>:`
-//     - platform variant (`time.homeassistant`) → match `<domain>.<platform>`
-//     Multi-conf components always stay visible.
-//  2. Core-locked: drop platform variants whose dependencies can't be
-//     satisfied from this dialog. A dep counts as satisfied when it's
-//     already in the user's YAML OR one of the IDs in this response.
-//  3. Platform gate: drop components incompatible with the device's
+//  1. Platform gate: drop components incompatible with the device's
 //     platform (e.g. bk72xx on an esp32 board). The backend filters too
 //     when it receives `platform`, but the fetch fires once on open and
 //     can race the board resolving with an empty platform; this re-applies
-//     the gate on every render once `host.platform` settles.
+//     the gate on every render once `host.platform` settles. Applied first
+//     so the core dependency-satisfaction set below only counts components
+//     that survive the gate.
+//  2. Single-instance components already in the YAML get hidden.
+//     - bare top-level (`web_server`, `wifi`) → match presence of `<id>:`
+//     - platform variant (`time.homeassistant`) → match `<domain>.<platform>`
+//     Multi-conf components always stay visible.
+//  3. Core-locked: drop platform variants whose dependencies can't be
+//     satisfied from this dialog. A dep counts as satisfied when it's
+//     already in the user's YAML OR one of the platform-compatible IDs in
+//     this response.
 export function visibleComponents(
   host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
@@ -33,10 +36,14 @@ export function visibleComponents(
     ? parseConfiguredPlatforms(host.yaml)
     : new Set<string>();
   const lockedToCore = host.lockedCategories.length > 0;
-  const coreCompatible = lockedToCore ? new Set(host._components.map((c) => c.id)) : null;
+  const platformCompatible = host._components.filter((c) =>
+    platformSupported(c.supported_platforms, host.platform)
+  );
+  const coreCompatible = lockedToCore
+    ? new Set(platformCompatible.map((c) => c.id))
+    : null;
 
-  return host._components.filter((c) => {
-    if (!platformSupported(c.supported_platforms, host.platform)) return false;
+  return platformCompatible.filter((c) => {
     if (!c.multi_conf) {
       if (c.id.includes(".")) {
         if (presentPlatforms.has(c.id)) return false;

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -4,6 +4,7 @@ import {
   ComponentCategory,
 } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { platformSupported } from "../../../util/config-validation.js";
 import {
   parseConfiguredPlatforms,
   parseTopLevelComponents,
@@ -11,7 +12,7 @@ import {
 import { categoryChipLabel } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 
-// Two filters applied client-side:
+// Three filters applied client-side:
 //  1. Single-instance components already in the YAML get hidden.
 //     - bare top-level (`web_server`, `wifi`) → match presence of `<id>:`
 //     - platform variant (`time.homeassistant`) → match `<domain>.<platform>`
@@ -19,6 +20,11 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 //  2. Core-locked: drop platform variants whose dependencies can't be
 //     satisfied from this dialog. A dep counts as satisfied when it's
 //     already in the user's YAML OR one of the IDs in this response.
+//  3. Platform gate: drop components incompatible with the device's
+//     platform (e.g. bk72xx on an esp32 board). The backend filters too
+//     when it receives `platform`, but the fetch fires once on open and
+//     can race the board resolving with an empty platform; this re-applies
+//     the gate on every render once `host.platform` settles.
 export function visibleComponents(
   host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
@@ -30,6 +36,7 @@ export function visibleComponents(
   const coreCompatible = lockedToCore ? new Set(host._components.map((c) => c.id)) : null;
 
   return host._components.filter((c) => {
+    if (!platformSupported(c.supported_platforms, host.platform)) return false;
     if (!c.multi_conf) {
       if (c.id.includes(".")) {
         if (presentPlatforms.has(c.id)) return false;

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -19,7 +19,8 @@ import { YamlRawValue } from "./yaml-serialize.js";
 /**
  * Whether an entry restricted to ``supportedPlatforms`` is allowed on the
  * device's ``targetPlatform``. Empty / missing list is "no constraint";
- * an unknown target (``""`` / null) allows everything.
+ * a falsy target (``""`` / null / undefined — platform not yet resolved)
+ * allows everything.
  */
 export function platformSupported(
   supportedPlatforms: string[] | undefined,

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -17,6 +17,20 @@ import { looksLikeSubstitution } from "./substitutions.js";
 import { YamlRawValue } from "./yaml-serialize.js";
 
 /**
+ * Whether an entry restricted to ``supportedPlatforms`` is allowed on the
+ * device's ``targetPlatform``. Empty / missing list is "no constraint";
+ * an unknown target (``""`` / null) allows everything.
+ */
+export function platformSupported(
+  supportedPlatforms: string[] | undefined,
+  targetPlatform?: string | null
+): boolean {
+  if (!targetPlatform) return true;
+  if (!supportedPlatforms || supportedPlatforms.length === 0) return true;
+  return supportedPlatforms.includes(targetPlatform);
+}
+
+/**
  * Determine if a config entry is currently visible.
  *
  * Visibility is the AND of four checks:
@@ -51,14 +65,7 @@ export function isEntryVisible(
   }
 
   // Platform gate: only check when caller provided the target platform.
-  // Empty / missing ``supported_platforms`` is "no constraint" (the
-  // common case) and the field stays visible.
-  if (
-    targetPlatform &&
-    entry.supported_platforms &&
-    entry.supported_platforms.length > 0 &&
-    !entry.supported_platforms.includes(targetPlatform)
-  ) {
+  if (!platformSupported(entry.supported_platforms, targetPlatform)) {
     return false;
   }
 

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -3,24 +3,29 @@ import type { ComponentCatalogEntry } from "../../../../src/api/types/components
 import type { ESPHomeComponentCatalog } from "../../../../src/components/device/component-catalog.js";
 import { visibleComponents } from "../../../../src/components/device/component-catalog/filters.js";
 
-function entry(id: string, supported_platforms: string[] = []): ComponentCatalogEntry {
+function entry(
+  id: string,
+  supported_platforms: string[] = [],
+  dependencies: string[] = []
+): ComponentCatalogEntry {
   return {
     id,
     multi_conf: true,
-    dependencies: [],
+    dependencies,
     supported_platforms,
   } as unknown as ComponentCatalogEntry;
 }
 
 function host(
   components: ComponentCatalogEntry[],
-  platform: string
+  platform: string,
+  lockedCategories: string[] = []
 ): ESPHomeComponentCatalog {
   return {
     _components: components,
     platform,
     yaml: "",
-    lockedCategories: [],
+    lockedCategories,
   } as unknown as ESPHomeComponentCatalog;
 }
 
@@ -44,5 +49,16 @@ describe("visibleComponents platform gate", () => {
   it("keeps a bk72xx component for a bk72xx board", () => {
     const ids = visibleComponents(host(components, "bk72xx")).map((c) => c.id);
     expect(ids).toEqual(["async_tcp", "bk72xx"]);
+  });
+
+  it("does not count a platform-incompatible dep as satisfied when core-locked", () => {
+    // The variant's only dep is hidden by the platform gate, so it can't be
+    // satisfied from this dialog and the variant must drop too.
+    const locked = [
+      entry("dep.bk72xx", ["bk72xx"]),
+      entry("time.foo", [], ["dep.bk72xx"]),
+    ];
+    const ids = visibleComponents(host(locked, "esp32", ["core"])).map((c) => c.id);
+    expect(ids).toEqual([]);
   });
 });

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ComponentCatalogEntry } from "../../../../src/api/types/components.js";
+import type { ESPHomeComponentCatalog } from "../../../../src/components/device/component-catalog.js";
+import { visibleComponents } from "../../../../src/components/device/component-catalog/filters.js";
+
+function entry(id: string, supported_platforms: string[] = []): ComponentCatalogEntry {
+  return {
+    id,
+    multi_conf: true,
+    dependencies: [],
+    supported_platforms,
+  } as unknown as ComponentCatalogEntry;
+}
+
+function host(
+  components: ComponentCatalogEntry[],
+  platform: string
+): ESPHomeComponentCatalog {
+  return {
+    _components: components,
+    platform,
+    yaml: "",
+    lockedCategories: [],
+  } as unknown as ESPHomeComponentCatalog;
+}
+
+describe("visibleComponents platform gate", () => {
+  const components = [
+    entry("async_tcp"), // no constraint
+    entry("esp32", ["esp32"]),
+    entry("bk72xx", ["bk72xx"]),
+  ];
+
+  it("drops components restricted to other platforms", () => {
+    const ids = visibleComponents(host(components, "esp32")).map((c) => c.id);
+    expect(ids).toEqual(["async_tcp", "esp32"]);
+  });
+
+  it("keeps everything when the platform is unknown", () => {
+    const ids = visibleComponents(host(components, "")).map((c) => c.id);
+    expect(ids).toEqual(["async_tcp", "esp32", "bk72xx"]);
+  });
+
+  it("keeps a bk72xx component for a bk72xx board", () => {
+    const ids = visibleComponents(host(components, "bk72xx")).map((c) => c.id);
+    expect(ids).toEqual(["async_tcp", "bk72xx"]);
+  });
+});

--- a/test/util/config-validation.test.ts
+++ b/test/util/config-validation.test.ts
@@ -4,6 +4,7 @@ import { ConfigEntryType } from "../../src/api/types/config-entries.js";
 import {
   getDeviceNameWarning,
   nearCanonicalOption,
+  platformSupported,
   validateDeviceName,
   validateEntries,
   validateEntry,
@@ -670,5 +671,27 @@ describe("validateEntries — api encryption key format", () => {
     expect(
       validateEntries(entries, { encryption: { key: "bad" } }, undefined, null).size
     ).toBe(0);
+  });
+});
+
+describe("platformSupported", () => {
+  it("allows when the entry has no platform constraint", () => {
+    expect(platformSupported([], "esp32")).toBe(true);
+    expect(platformSupported(undefined, "esp32")).toBe(true);
+  });
+
+  it("allows when the target platform is unknown", () => {
+    expect(platformSupported(["bk72xx"], "")).toBe(true);
+    expect(platformSupported(["bk72xx"], null)).toBe(true);
+    expect(platformSupported(["bk72xx"], undefined)).toBe(true);
+  });
+
+  it("drops a component restricted to other platforms", () => {
+    expect(platformSupported(["bk72xx"], "esp32")).toBe(false);
+  });
+
+  it("keeps a component that lists the target platform", () => {
+    expect(platformSupported(["esp32"], "esp32")).toBe(true);
+    expect(platformSupported(["esp32", "esp8266"], "esp8266")).toBe(true);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

On an esp32 device the "Add configuration" picker offered components from other chip families, e.g. BK72xx (bk72xx/LibreTiny). Each catalog entry already carries `supported_platforms` and the backend filters on it, but the catalog fetches once when the dialog opens; if that fetch races the board resolving with an empty platform, the listing comes back unfiltered and is never re-queried.

This gates the displayed list on `supported_platforms` against the device platform the catalog already holds, so it re-applies on every render once the platform settles, no extra round-trip. The existing platform check in `isEntryVisible` is pulled into a shared `platformSupported` helper so the two callers can't drift; entries with no platform constraint, and devices with an unknown platform, are unaffected.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
