### PR TITLE
Disambiguate same-domain catalog cards by platform

### DIFF
--- a/src/components/device/component-card-category-label.ts
+++ b/src/components/device/component-card-category-label.ts
@@ -37,13 +37,38 @@ export function categoryChipLabel(category: string): string {
 }
 
 /**
+ * Upper-case the platform stem of a catalog id (the part after the
+ * domain in ``<domain>.<stem>``) so two entries that share a name
+ * within one category stay distinguishable — ``stepper.a4988`` and
+ * ``stepper.uln2003`` both carry the name "Stepper Component", and the
+ * category chip can't separate them. Every colliding stem is a part
+ * number or bus token (a4988, uln2003, lcd_gpio, bmp581_i2c), so full
+ * upper-case reads right ("ULN2003", "BMP581 I2C") where title-casing
+ * would mangle it ("Uln2003"). Returns "" for an id with no stem.
+ */
+export function platformLabel(id: string): string {
+  const dot = id.indexOf(".");
+  if (dot === -1) return "";
+  return id
+    .slice(dot + 1)
+    .split("_")
+    .filter((word) => word.length > 0)
+    .map((word) => word.toUpperCase())
+    .join(" ");
+}
+
+/**
  * Compose the Add-Component dialog header for a selected entry,
- * appending the platform label (the same string the card chip
- * shows) so same-name entries from different platforms stay
- * distinguishable once the form view drops the chip. The
- * core-config flow keeps the bare name: its components are
- * unique top-level domains with no same-name collisions, where a
- * "Wi-Fi · Wifi" suffix would be pure redundancy.
+ * appending the category label so same-name entries from
+ * different categories stay distinguishable once the form view
+ * drops the card chip. Same-domain collisions (stepper.a4988 /
+ * stepper.uln2003) share a category, so the header stays
+ * identical there — the grid's platformLabel chip disambiguates
+ * those, and the user has already picked the right card by the
+ * time the form opens. The core-config flow keeps the bare name:
+ * its components are unique top-level domains with no same-name
+ * collisions, where a "Wi-Fi · Wifi" suffix would be pure
+ * redundancy.
  */
 export function componentDialogTitle(
   name: string,

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -20,6 +20,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { debounce } from "../../util/debounce.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
+  ambiguousNameIds,
   buildCategories,
   filteredBundles,
   visibleComponents,
@@ -191,6 +192,7 @@ export class ESPHomeComponentCatalog extends LitElement {
     const bundles =
       this._category === ComponentCategory.FEATURED ? filteredBundles(this) : [];
     const visible = visibleComponents(this);
+    const ambiguous = ambiguousNameIds(visible);
 
     return html`
       ${showSidebar
@@ -247,7 +249,8 @@ export class ESPHomeComponentCatalog extends LitElement {
                         c,
                         c.id === this._expandedId,
                         this._category === ComponentCategory.FEATURED,
-                        this._localize
+                        this._localize,
+                        ambiguous.has(c.id)
                       )
                     )}
                   `

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -47,6 +47,26 @@ export function visibleComponents(
   });
 }
 
+// Ids of entries that share a name with another visible entry in the same
+// category — two platforms of one domain (stepper.a4988 / stepper.uln2003)
+// both inherit the domain's docs-page name. Keying on category as well as
+// name leaves cross-category collisions (sensor.debug / text_sensor.debug)
+// out: the category chip already separates those, and their stems match.
+export function ambiguousNameIds(components: ComponentCatalogEntry[]): Set<string> {
+  const byKey = new Map<string, ComponentCatalogEntry[]>();
+  for (const c of components) {
+    const key = JSON.stringify([c.category, c.name]);
+    const group = byKey.get(key);
+    if (group) group.push(c);
+    else byKey.set(key, [c]);
+  }
+  const ids = new Set<string>();
+  for (const group of byKey.values()) {
+    if (group.length > 1) for (const c of group) ids.add(c.id);
+  }
+  return ids;
+}
+
 // Bundles live on boards/get_board (not components/*) — filter client-side
 // so a search behaves consistently across featured + bundles + components.
 export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[] {

--- a/src/components/device/component-catalog/renderers.ts
+++ b/src/components/device/component-catalog/renderers.ts
@@ -5,6 +5,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import {
   categoryChipLabel,
+  platformLabel,
   shouldShowCategoryChip,
 } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
@@ -75,7 +76,8 @@ export function renderCard(
   component: ComponentCatalogEntry,
   expanded: boolean,
   featured: boolean,
-  localize: LocalizeFunc
+  localize: LocalizeFunc,
+  showPlatform = false
 ): TemplateResult {
   const hasImage = !!component.image_url && !host._imageFailed.has(component.id);
   // Skip the chip entirely when the label is empty (defensive against an
@@ -84,6 +86,9 @@ export function renderCard(
   const categoryLabel = shouldShowCategoryChip(host._category)
     ? categoryChipLabel(component.category)
     : "";
+  // Surfaced only when this card shares a name with another in the same
+  // category; the category chip can't tell same-domain platforms apart.
+  const platform = showPlatform ? platformLabel(component.id) : "";
   return html`
     <article
       class="component-card ${expanded ? "component-card--expanded" : ""} ${featured
@@ -111,6 +116,9 @@ export function renderCard(
           <h3 class="component-title">${component.name}</h3>
           ${categoryLabel
             ? html`<span class="component-category-chip">${categoryLabel}</span>`
+            : nothing}
+          ${platform
+            ? html`<span class="component-category-chip">${platform}</span>`
             : nothing}
         </div>
         <button

--- a/test/components/device/component-card-category-label.test.ts
+++ b/test/components/device/component-card-category-label.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   categoryChipLabel,
   componentDialogTitle,
+  platformLabel,
   shouldShowCategoryChip,
 } from "../../../src/components/device/component-card-category-label.js";
 
@@ -53,8 +54,32 @@ describe("categoryChipLabel", () => {
   });
 });
 
+describe("platformLabel", () => {
+  it("upper-cases the platform stem after the domain", () => {
+    // stepper.a4988 and stepper.uln2003 both carry the name
+    // "Stepper Component"; the stem is the only thing that tells
+    // the two cards apart. Colliding stems are part numbers, so
+    // full upper-case reads right where title-case mangles ULN2003.
+    expect(platformLabel("stepper.a4988")).toBe("A4988");
+    expect(platformLabel("stepper.uln2003")).toBe("ULN2003");
+  });
+
+  it("upper-cases each token of an underscored stem", () => {
+    // display.lcd_gpio / display.lcd_pcf8574 and the bmp581_i2c /
+    // bmp581_spi bus split collide within one category too.
+    expect(platformLabel("display.lcd_gpio")).toBe("LCD GPIO");
+    expect(platformLabel("sensor.bmp581_i2c")).toBe("BMP581 I2C");
+  });
+
+  it("returns an empty string for an id with no platform stem", () => {
+    expect(platformLabel("wifi")).toBe("");
+    expect(platformLabel("")).toBe("");
+    expect(platformLabel("stepper.")).toBe("");
+  });
+});
+
 describe("componentDialogTitle", () => {
-  it("appends the platform label so same-name entries stay distinct", () => {
+  it("appends the category label so cross-category entries stay distinct", () => {
     // All four ``*.atm90e32`` platforms ship the name "ATM90E32
     // Power Sensor"; the form view drops the card chip, so the
     // header is the only thing left to tell them apart

--- a/test/components/device/component-catalog/ambiguous-name-ids.test.ts
+++ b/test/components/device/component-catalog/ambiguous-name-ids.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ComponentCatalogEntry,
+  ComponentCategory,
+} from "../../../../src/api/types/components.js";
+import { ambiguousNameIds } from "../../../../src/components/device/component-catalog/filters.js";
+
+function entry(
+  id: string,
+  name: string,
+  category: ComponentCategory
+): ComponentCatalogEntry {
+  return {
+    id,
+    name,
+    description: "",
+    category,
+    docs_url: "",
+    image_url: "",
+    dependencies: [],
+    multi_conf: true,
+    supported_platforms: [],
+    config_entries: [],
+  };
+}
+
+describe("ambiguousNameIds", () => {
+  it("flags same-name entries within one category", () => {
+    const ids = ambiguousNameIds([
+      entry("stepper.a4988", "Stepper Component", ComponentCategory.STEPPER),
+      entry("stepper.uln2003", "Stepper Component", ComponentCategory.STEPPER),
+    ]);
+    expect(ids).toEqual(new Set(["stepper.a4988", "stepper.uln2003"]));
+  });
+
+  it("ignores same-name entries from different categories", () => {
+    // sensor.debug / text_sensor.debug share the name but the
+    // category chip already separates them.
+    const ids = ambiguousNameIds([
+      entry("sensor.debug", "Debug Component", ComponentCategory.SENSOR),
+      entry("text_sensor.debug", "Debug Component", ComponentCategory.TEXT_SENSOR),
+    ]);
+    expect(ids).toEqual(new Set());
+  });
+
+  it("returns an empty set when every name is unique", () => {
+    const ids = ambiguousNameIds([
+      entry("sensor.dht", "DHT", ComponentCategory.SENSOR),
+      entry("sensor.bme280", "BME280", ComponentCategory.SENSOR),
+    ]);
+    expect(ids).toEqual(new Set());
+  });
+});

--- a/test/components/device/component-catalog/render-card-platform-chip.test.ts
+++ b/test/components/device/component-catalog/render-card-platform-chip.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+//
+// The platform chip disambiguates two cards that share a name within one
+// category (stepper.a4988 / stepper.uln2003): it renders only when
+// renderCard is told the entry is ambiguous, and carries the id's stem.
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import {
+  type ComponentCatalogEntry,
+  ComponentCategory,
+} from "../../../../src/api/types/components.js";
+import { renderCard } from "../../../../src/components/device/component-catalog/renderers.js";
+
+function host(category = "stepper"): unknown {
+  return {
+    _imageFailed: new Set<string>(),
+    _category: category,
+    _onAdd: () => {},
+    _onToggleExpand: () => {},
+    _onImageError: () => {},
+  };
+}
+
+function entry(id: string): ComponentCatalogEntry {
+  return {
+    id,
+    name: "Stepper Component",
+    description: "",
+    category: ComponentCategory.STEPPER,
+    docs_url: "",
+    image_url: "",
+    dependencies: [],
+    multi_conf: true,
+    supported_platforms: [],
+    config_entries: [],
+  };
+}
+
+function renderInto(value: unknown): HTMLElement {
+  const container = document.createElement("div");
+  render(value, container);
+  return container;
+}
+
+const localize = (key: string) => key;
+
+describe("renderCard platform chip", () => {
+  it("renders the platform stem when the entry is ambiguous", () => {
+    const el = renderInto(
+      renderCard(host() as never, entry("stepper.a4988"), false, false, localize, true)
+    );
+    const chips = [...el.querySelectorAll(".component-category-chip")].map((c) =>
+      c.textContent?.trim()
+    );
+    expect(chips).toContain("A4988");
+  });
+
+  it("omits the platform chip when the entry is not ambiguous", () => {
+    const el = renderInto(
+      renderCard(host() as never, entry("stepper.a4988"), false, false, localize, false)
+    );
+    // Under a single-category filter the category chip is suppressed too,
+    // so no chip should render at all.
+    expect(el.querySelector(".component-category-chip")).toBeNull();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The Stepper category in "Add component" shows two cards both titled "Stepper Component" with the same description, so it looks like a duplicate. It is actually the two real platforms, stepper.a4988 and stepper.uln2003, which share the domain's docs page and therefore the same name; the category chip can't tell them apart since the category is identical and it is hidden under a single category filter.

When a card shares a name with another visible card in the same category, this surfaces the platform stem from the id as a chip, so the two cards now read "A4988" and "ULN2003". Cross category same name pairs (sensor.debug, text_sensor.debug) are left to the existing category chip.

**Related issue or feature (if applicable):**

- reported in-app (screenshot); no tracking issue

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
