### PR TITLE
Render bold-wrapped Markdown links in editor hover docs

### DIFF
--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -12,12 +12,11 @@
  * templates so user content is escaped safely (no `unsafeHTML`,
  * nothing gets injected into innerHTML).
  *
- * Nesting is intentionally NOT supported — inline formatting won't
- * cascade inside other inline formatting (no `**bold with `code`**`).
- * The descriptions we get are simple enough that one level of
- * formatting per token covers the vocabulary; supporting nesting
- * would need a real Markdown parser. If that becomes a real problem
- * later, swap this util for `marked` or `micromark`.
+ * Bold and italic render one level of nested inline formatting, so a
+ * link or `` `code` `` inside `**...**` still renders — ESPHome
+ * docstrings bold-wrap links (`**[Action](url)**:`). Deeper nesting
+ * isn't supported; the descriptions we get don't need it. If that
+ * changes, swap this util for `marked` or `micromark`.
  */
 import type { TemplateResult } from "lit";
 import { html, nothing } from "lit";
@@ -113,9 +112,9 @@ function renderSegment(seg: Segment): TemplateResult | string {
     case "code":
       return html`<code class="md-code">${seg.text}</code>`;
     case "bold":
-      return html`<strong>${seg.text}</strong>`;
+      return html`<strong>${parseMarkdown(seg.text).map(renderSegment)}</strong>`;
     case "italic":
-      return html`<em>${seg.text}</em>`;
+      return html`<em>${parseMarkdown(seg.text).map(renderSegment)}</em>`;
   }
 }
 

--- a/test/util/markdown-render.test.ts
+++ b/test/util/markdown-render.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Renders renderMarkdown to real DOM. ESPHome docstrings bold-wrap links
+ * (`**[Action](url)**:`); the inline renderer must recurse one level so the
+ * link inside the bold stays clickable instead of leaking as literal text.
+ */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { renderMarkdown } from "../../src/util/markdown.js";
+
+function renderInto(input: string): HTMLDivElement {
+  const host = document.createElement("div");
+  render(renderMarkdown(input), host);
+  return host;
+}
+
+describe("renderMarkdown — bold-wrapped inline formatting", () => {
+  it("renders a link inside bold as a clickable anchor", () => {
+    const host = renderInto("**[Action](https://esphome.io/x)**: do a thing");
+    const strong = host.querySelector("strong")!;
+    const anchor = strong.querySelector("a.md-link")!;
+    expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
+    expect(anchor.textContent).toBe("Action");
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(host.textContent).toBe("Action: do a thing");
+  });
+
+  it("renders code inside bold", () => {
+    const host = renderInto("**`true`**");
+    const code = host.querySelector("strong code.md-code")!;
+    expect(code.textContent).toBe("true");
+  });
+
+  it("keeps plain bold as bold with no anchor", () => {
+    const host = renderInto("**plain bold**");
+    expect(host.querySelector("strong")!.textContent).toBe("plain bold");
+    expect(host.querySelector("a")).toBeNull();
+  });
+
+  it("does not make a bold-wrapped unsafe link clickable", () => {
+    const host = renderInto("**[x](javascript:void)**");
+    expect(host.querySelector("a")).toBeNull();
+    expect(host.querySelector("strong")!.textContent).toBe("x");
+  });
+});
+
+describe("renderMarkdown — unwrapped link still works", () => {
+  it("renders a bare markdown link as an anchor", () => {
+    const host = renderInto("[Action](https://esphome.io/x)");
+    const anchor = host.querySelector("a.md-link")!;
+    expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
+    expect(anchor.textContent).toBe("Action");
+  });
+});

--- a/test/util/markdown-render.test.ts
+++ b/test/util/markdown-render.test.ts
@@ -29,6 +29,13 @@ describe("renderMarkdown — bold-wrapped inline formatting", () => {
     expect(host.textContent).toBe("Action: do a thing");
   });
 
+  it("renders a link inside italic as a clickable anchor", () => {
+    const host = renderInto("_[Action](https://esphome.io/x)_");
+    const anchor = host.querySelector("em a.md-link")!;
+    expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
+    expect(anchor.textContent).toBe("Action");
+  });
+
   it("renders code inside bold", () => {
     const host = renderInto("**`true`**");
     const code = host.querySelector("strong code.md-code")!;


### PR DESCRIPTION
# What does this implement/fix?

Hovering a config key like `lock_action:` in the YAML editor showed the raw Markdown `[Action](https://next.esphome.io/automations/actions#all-actions):` as bold literal text with an unclickable URL, instead of a clickable "Action" link. ESPHome docstrings bold-wrap their links (`**[Action](url)**:`), and the inline Markdown renderer matched the leading `**` first, swallowing the whole `[Action](url)` as the bold token's inner text and emitting it verbatim inside `<strong>`.

`renderSegment` now recurses one level for bold and italic, so a link or `` `code` `` inside `**...**` (or `*...*` / `_..._`) renders properly; the bold-wrapped link becomes a clickable anchor again. Recursion is bounded (bold's inner text can't contain another emphasis marker) and the existing link-safety gate still applies, so a bold-wrapped unsafe scheme stays plain text. This fixes every caller of `renderMarkdown`, the editor hover and the Visual Editor catalog descriptions, not just `lock_action`.

**Related issue or feature (if applicable):**

- Reported against the dashboard hover docs (template lock `lock_action` / `unlock_action`); no tracking issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
