### PR TITLE
Skip the empty Add form for advanced-only components

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -356,11 +356,15 @@ export class ESPHomeAddComponentDialog extends LitElement {
     //
     // The probe and the payload both use the values the form would seed
     // (`buildInitialValues`) coerced exactly as the form's Add does
-    // (`coerceFields`), so the fast-path is provably equivalent to opening
-    // the form and clicking Add: a required+advanced or board-pinned entry
-    // only renders once seeding makes it material (so `{}` would wrongly
-    // fast-path and the form would render it), and a seeded `id`/pin the
-    // form would submit unrendered isn't silently dropped.
+    // (`coerceFields`), so the fast-path matches opening the form and
+    // clicking Add: a required+advanced or board-pinned entry only renders
+    // once seeding makes it material (so `{}` would wrongly fast-path and
+    // the form would render it), and a seeded `id`/pin the form would submit
+    // unrendered isn't silently dropped. The one thing it skips is the
+    // form's `validateEntries` bail, so a contradictory schema (a required
+    // field that is also `advanced` with no default — unfillable in the
+    // form anyway) surfaces a backend-error toast here instead of the
+    // form's client-side block.
     const present = parseTopLevelComponents(this.yaml);
     const seeded = buildInitialValues({
       entries: result.entry.config_entries,

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -336,32 +336,38 @@ export class ESPHomeAddComponentDialog extends LitElement {
     }
     this._selected = result.entry;
     this._submitError = "";
-    // Skip the empty form and add directly only when there is no
-    // non-advanced field to show. The add-form has no "show advanced"
-    // toggle, so an advanced-only component like `socket` (one
-    // `advanced: true` entry) would otherwise strand the user behind a
-    // blank dialog, same dead-end as a configless component. We probe
-    // with `requiredOnly: false` so a component with an *optional*
-    // non-advanced field still opens the form (only advanced/hidden/
-    // platform-gated entries are dropped). Carve-outs that keep the form:
-    // a missing top-level dependency (e.g. `captive_portal` needs `wifi`,
-    // surfaced by the deps banner) and featured entries (their locked
-    // presets must be submitted, so `{}` would fail backend validation).
-    // The empty schema makes the fields payload provably `{}`; on the rare
-    // API failure `_submitComponent` toasts the error (no form surface).
+    // Skip the empty form and add directly only when the form would
+    // paint nothing. We probe with the add-form's exact render filter
+    // (`requiredOnly: true`, no advanced toggle — see
+    // `add-component-form.ts:415-417`, and the lockstep probe in
+    // `_anyErrorIsVisible`), so the gate matches what the user would see:
+    // an advanced-only component like `socket` (one `advanced: true`
+    // entry) and a component whose only fields are optional non-`name`
+    // (deferred to the section editor) both render blank, so both
+    // fast-path instead of stranding the user. Carve-outs that keep the
+    // form: a missing top-level dependency (e.g. `captive_portal` needs
+    // `wifi`, surfaced by the deps banner) and featured entries (their
+    // locked presets must be submitted, so `{}` would fail backend
+    // validation). The empty payload is provably `{}`; on the rare API
+    // failure `_submitComponent` toasts the error (no form surface).
     const present = parseTopLevelComponents(this.yaml);
     const renderable = collectRenderablePaths(
       result.entry.config_entries,
       {},
       {
-        requiredOnly: false,
+        requiredOnly: true,
         showAdvanced: false,
         presentComponents: present,
         targetPlatform: this.board?.esphome.platform ?? null,
       }
     );
-    const isFeatured = result.entry.id.startsWith("featured.");
-    if (renderable.size === 0 && !isFeatured) {
+    // Featured entries carry locked presets in their `config_entries`;
+    // keep the form so those submit. A degenerate featured entry with no
+    // entries has no presets to lose, so let it fast-path like any other
+    // configless component.
+    const hasFeaturedPresets =
+      result.entry.id.startsWith("featured.") && result.entry.config_entries.length > 0;
+    if (renderable.size === 0 && !hasFeaturedPresets) {
       const hasMissingDeps = (result.entry.dependencies ?? []).some(
         (d) => !present.has(d)
       );

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -380,7 +380,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
     const hasFeaturedPresets =
       isFeaturedId(result.entry.id) && result.entry.config_entries.length > 0;
     const hasMissingDeps = (result.entry.dependencies ?? []).some((d) => !present.has(d));
-    if (renderable.size === 0 && !hasFeaturedPresets && !hasMissingDeps) {
+    // Detour/restore flows set `_selected` directly and bypass this handler,
+    // so prefill is null here today. Guard anyway: a prefilled selection
+    // carries overlays/values the `{}`-seeded probe can't predict, so show
+    // the form rather than fast-path with stale inputs.
+    const noPrefill = this._prefillReference === null && this._depPrefill === null;
+    if (renderable.size === 0 && !hasFeaturedPresets && !hasMissingDeps && noPrefill) {
       const fields = coerceFields(result.entry.config_entries, seeded);
       await this._submitComponent(fields, /* notify */ true);
     }

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -27,6 +27,7 @@ import {
   type SelectionHost,
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
+import { coerceFields } from "./add-component-form-coerce.js";
 import { addFormRenderablePaths } from "./add-component-form-filter.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
@@ -348,15 +349,18 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // that keep the form: a missing top-level dependency (e.g.
     // `captive_portal` needs `wifi`, surfaced by the deps banner) and
     // featured entries with presets (their locked `config_entries` must be
-    // submitted, so `{}` would fail backend validation; a degenerate
-    // featured entry with no entries has nothing to lose, so it fast-paths
-    // too). The empty payload is provably `{}`; on the rare API failure
-    // `_submitComponent` toasts the error (no form surface).
+    // submitted, so a thin payload would fail backend validation; a
+    // degenerate featured entry with no entries has nothing to lose, so it
+    // fast-paths too). On the rare API failure `_submitComponent` toasts
+    // the error (no form surface).
     //
-    // Probe with the values the form would seed (`buildInitialValues`), not
-    // `{}`: a required+advanced or board-pinned entry only renders once
-    // seeding makes it material, so an empty-values probe would fast-path
-    // and drop a value the form-driven submit would have sent.
+    // The probe and the payload both use the values the form would seed
+    // (`buildInitialValues`) coerced exactly as the form's Add does
+    // (`coerceFields`), so the fast-path is provably equivalent to opening
+    // the form and clicking Add: a required+advanced or board-pinned entry
+    // only renders once seeding makes it material (so `{}` would wrongly
+    // fast-path and the form would render it), and a seeded `id`/pin the
+    // form would submit unrendered isn't silently dropped.
     const present = parseTopLevelComponents(this.yaml);
     const seeded = buildInitialValues({
       entries: result.entry.config_entries,
@@ -377,7 +381,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
       isFeaturedId(result.entry.id) && result.entry.config_entries.length > 0;
     const hasMissingDeps = (result.entry.dependencies ?? []).some((d) => !present.has(d));
     if (renderable.size === 0 && !hasFeaturedPresets && !hasMissingDeps) {
-      await this._submitComponent({}, /* notify */ true);
+      const fields = coerceFields(result.entry.config_entries, seeded);
+      await this._submitComponent(fields, /* notify */ true);
     }
   }
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -28,6 +28,7 @@ import {
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
 import { addFormRenderablePaths } from "./add-component-form-filter.js";
+import { buildInitialValues } from "./add-component-form-seed.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -351,10 +352,24 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // featured entry with no entries has nothing to lose, so it fast-paths
     // too). The empty payload is provably `{}`; on the rare API failure
     // `_submitComponent` toasts the error (no form surface).
+    //
+    // Probe with the values the form would seed (`buildInitialValues`), not
+    // `{}`: a required+advanced or board-pinned entry only renders once
+    // seeding makes it material, so an empty-values probe would fast-path
+    // and drop a value the form-driven submit would have sent.
     const present = parseTopLevelComponents(this.yaml);
+    const seeded = buildInitialValues({
+      entries: result.entry.config_entries,
+      component: result.entry,
+      board: this.board,
+      yaml: this.yaml,
+      prefillReference: null,
+      prefillFields: null,
+      localize: this._localize,
+    });
     const renderable = addFormRenderablePaths(
       result.entry.config_entries,
-      {},
+      seeded,
       this.board,
       present
     );

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -340,69 +340,57 @@ export class ESPHomeAddComponentDialog extends LitElement {
     }
     this._selected = result.entry;
     this._submitError = "";
-    // Skip the empty form and add directly only when the add-form would
-    // paint nothing. `addFormPaintsAnything` reads the same
-    // `buildFormRenderPlan` the form's `render()` uses (fields, exclusive
-    // groups, constraint clusters, unsatisfied-constraint banners) under the
-    // add-form's fixed filter, so the gate can't drift from what the user
-    // sees: an advanced-only component like `socket` and a component whose
-    // only fields are optional non-`name` both paint blank and fast-path
-    // instead of stranding the user. Carve-outs that keep the form: a missing
-    // top-level dependency (e.g. `captive_portal` needs `wifi`, surfaced by
-    // the deps banner) and featured entries with presets (their locked
-    // `config_entries` must be submitted, so a thin payload would fail backend
-    // validation; a degenerate featured entry with no entries has nothing to
-    // lose, so it fast-paths too). On the rare API failure `_submitComponent`
-    // toasts the error (no form surface).
-    //
-    // The probe and the payload both use the values the form would seed
-    // (`buildInitialValues`) coerced exactly as the form's Add does
-    // (`coerceFields`), so the fast-path matches opening the form and
-    // clicking Add: a required+advanced or board-pinned entry only renders
-    // once seeding makes it material (so `{}` would wrongly fast-path and
-    // the form would render it), and a seeded `id`/pin the form would submit
-    // unrendered isn't silently dropped. The one thing it skips is the
-    // form's `validateEntries` bail, so a contradictory schema (a required
-    // field that is also `advanced` with no default — unfillable in the
-    // form anyway) surfaces a backend-error toast here instead of the
-    // form's client-side block.
+    const fields = this._fastPathFields(result.entry);
+    if (fields) await this._submitComponent(fields, /* notify */ true);
+  }
+
+  /**
+   * Coerced fields to add *entry* directly, skipping the form, or null when
+   * the form should open. Fast-paths only when the add-form would paint
+   * nothing (`addFormPaintsAnything` reads the same `buildFormRenderPlan`
+   * `render()` does, so the gate can't drift from what the user sees) and the
+   * payload matches the form's Add. The payload is `buildInitialValues` +
+   * `coerceFields`, exactly the form's seed/submit, so a seeded `id`/pin isn't
+   * dropped; the one thing skipped is the form's `validateEntries` bail, so a
+   * contradictory required+advanced+no-default schema (unfillable in the form
+   * anyway) surfaces a backend-error toast instead of a client-side block.
+   */
+  private _fastPathFields(entry: ComponentCatalogEntry): Record<string, unknown> | null {
+    // A prefilled/detour selection carries overlays the `{}`-seeded probe
+    // can't predict; show the form. (Detour/restore set `_selected` directly
+    // and bypass this handler, so this is null today — a forward guard.)
+    if (this._prefillReference !== null || this._depPrefill !== null) return null;
+    // Featured entries with presets must submit their locked `config_entries`;
+    // a thin payload would fail backend validation. A degenerate featured
+    // entry with no entries has nothing to lose, so it fast-paths.
+    if (isFeaturedId(entry.id) && entry.config_entries.length > 0) return null;
     const present = parseTopLevelComponents(this.yaml);
+    // `findMissingDependencies` (dotted deps, platform stems) over a plain
+    // top-level-block check, so a stem-satisfied dep doesn't keep a blank
+    // form. The form's async `provides` subtraction isn't replicated — this
+    // stays stricter, only keeping the form a touch more often.
+    if (findMissingDependencies(entry.dependencies ?? [], this.yaml, present).length > 0)
+      return null;
     const seeded = buildInitialValues({
-      entries: result.entry.config_entries,
-      component: result.entry,
+      entries: entry.config_entries,
+      component: entry,
       board: this.board,
       yaml: this.yaml,
       prefillReference: null,
       prefillFields: null,
       localize: this._localize,
     });
-    const paintsNothing = !addFormPaintsAnything(
-      result.entry.config_entries,
-      seeded,
-      result.entry.required_groups ?? [],
-      this.board,
-      present
-    );
-    const hasFeaturedPresets =
-      isFeaturedId(result.entry.id) && result.entry.config_entries.length > 0;
-    // Use the form's own `findMissingDependencies` (dotted deps, platform
-    // stems) rather than a plain top-level-block check, so a dep satisfied
-    // by e.g. a `sensor: platform:` stem doesn't keep a blank form. The
-    // form's async `provides` subtraction isn't replicated here — this stays
-    // stricter (never wrongly auto-adds), only keeping the form a touch more
-    // often for a provides-satisfied dep.
-    const hasMissingDeps =
-      findMissingDependencies(result.entry.dependencies ?? [], this.yaml, present)
-        .length > 0;
-    // Detour/restore flows set `_selected` directly and bypass this handler,
-    // so prefill is null here today. Guard anyway: a prefilled selection
-    // carries overlays/values the `{}`-seeded probe can't predict, so show
-    // the form rather than fast-path with stale inputs.
-    const noPrefill = this._prefillReference === null && this._depPrefill === null;
-    if (paintsNothing && !hasFeaturedPresets && !hasMissingDeps && noPrefill) {
-      const fields = coerceFields(result.entry.config_entries, seeded);
-      await this._submitComponent(fields, /* notify */ true);
-    }
+    if (
+      addFormPaintsAnything(
+        entry.config_entries,
+        seeded,
+        entry.required_groups ?? [],
+        this.board,
+        present
+      )
+    )
+      return null;
+    return coerceFields(entry.config_entries, seeded);
   }
 
   /**

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -12,7 +12,6 @@ import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
-import { isFeaturedId } from "../../util/featured-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -350,20 +349,17 @@ export class ESPHomeAddComponentDialog extends LitElement {
    * nothing (`addFormPaintsAnything` reads the same `buildFormRenderPlan`
    * `render()` does, so the gate can't drift from what the user sees) and the
    * payload matches the form's Add. The payload is `buildInitialValues` +
-   * `coerceFields`, exactly the form's seed/submit, so a seeded `id`/pin isn't
-   * dropped; the one thing skipped is the form's `validateEntries` bail, so a
-   * contradictory required+advanced+no-default schema (unfillable in the form
-   * anyway) surfaces a backend-error toast instead of a client-side block.
+   * `coerceFields`, exactly the form's seed/submit, so a seeded `id`/pin (and
+   * a featured entry's `seedAll`-seeded locked presets) isn't dropped; the one
+   * thing skipped is the form's `validateEntries` bail, so a contradictory
+   * required+advanced+no-default schema (unfillable in the form anyway)
+   * surfaces a backend-error toast instead of a client-side block.
    */
   private _fastPathFields(entry: ComponentCatalogEntry): Record<string, unknown> | null {
     // A prefilled/detour selection carries overlays the `{}`-seeded probe
     // can't predict; show the form. (Detour/restore set `_selected` directly
     // and bypass this handler, so this is null today — a forward guard.)
     if (this._prefillReference !== null || this._depPrefill !== null) return null;
-    // Featured entries with presets must submit their locked `config_entries`;
-    // a thin payload would fail backend validation. A degenerate featured
-    // entry with no entries has nothing to lose, so it fast-paths.
-    if (isFeaturedId(entry.id) && entry.config_entries.length > 0) return null;
     const present = parseTopLevelComponents(this.yaml);
     // `findMissingDependencies` (dotted deps, platform stems) over a plain
     // top-level-block check, so a stem-satisfied dep doesn't keep a blank

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -12,6 +12,7 @@ import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
+import { isFeaturedId } from "../../util/featured-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -26,8 +27,8 @@ import {
   type SelectionHost,
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
+import { addFormRenderablePaths } from "./add-component-form-filter.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
-import { collectRenderablePaths } from "./config-entry-render-filter.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -336,44 +337,32 @@ export class ESPHomeAddComponentDialog extends LitElement {
     }
     this._selected = result.entry;
     this._submitError = "";
-    // Skip the empty form and add directly only when the form would
-    // paint nothing. We probe with the add-form's exact render filter
-    // (`requiredOnly: true`, no advanced toggle — see
-    // `add-component-form.ts:415-417`, and the lockstep probe in
-    // `_anyErrorIsVisible`), so the gate matches what the user would see:
-    // an advanced-only component like `socket` (one `advanced: true`
-    // entry) and a component whose only fields are optional non-`name`
-    // (deferred to the section editor) both render blank, so both
-    // fast-path instead of stranding the user. Carve-outs that keep the
-    // form: a missing top-level dependency (e.g. `captive_portal` needs
-    // `wifi`, surfaced by the deps banner) and featured entries (their
-    // locked presets must be submitted, so `{}` would fail backend
-    // validation). The empty payload is provably `{}`; on the rare API
-    // failure `_submitComponent` toasts the error (no form surface).
+    // Skip the empty form and add directly only when the add-form would
+    // paint nothing. `addFormRenderablePaths` is the add-form's own fixed
+    // filter (required-only, no advanced toggle), so the gate matches what
+    // the user would see: an advanced-only component like `socket` (one
+    // `advanced: true` entry) and a component whose only fields are
+    // optional non-`name` (deferred to the section editor) both render
+    // blank, so both fast-path instead of stranding the user. Carve-outs
+    // that keep the form: a missing top-level dependency (e.g.
+    // `captive_portal` needs `wifi`, surfaced by the deps banner) and
+    // featured entries with presets (their locked `config_entries` must be
+    // submitted, so `{}` would fail backend validation; a degenerate
+    // featured entry with no entries has nothing to lose, so it fast-paths
+    // too). The empty payload is provably `{}`; on the rare API failure
+    // `_submitComponent` toasts the error (no form surface).
     const present = parseTopLevelComponents(this.yaml);
-    const renderable = collectRenderablePaths(
+    const renderable = addFormRenderablePaths(
       result.entry.config_entries,
       {},
-      {
-        requiredOnly: true,
-        showAdvanced: false,
-        presentComponents: present,
-        targetPlatform: this.board?.esphome.platform ?? null,
-      }
+      this.board,
+      present
     );
-    // Featured entries carry locked presets in their `config_entries`;
-    // keep the form so those submit. A degenerate featured entry with no
-    // entries has no presets to lose, so let it fast-path like any other
-    // configless component.
     const hasFeaturedPresets =
-      result.entry.id.startsWith("featured.") && result.entry.config_entries.length > 0;
-    if (renderable.size === 0 && !hasFeaturedPresets) {
-      const hasMissingDeps = (result.entry.dependencies ?? []).some(
-        (d) => !present.has(d)
-      );
-      if (!hasMissingDeps) {
-        await this._submitComponent({}, /* notify */ true);
-      }
+      isFeaturedId(result.entry.id) && result.entry.config_entries.length > 0;
+    const hasMissingDeps = (result.entry.dependencies ?? []).some((d) => !present.has(d));
+    if (renderable.size === 0 && !hasFeaturedPresets && !hasMissingDeps) {
+      await this._submitComponent({}, /* notify */ true);
     }
   }
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -29,7 +29,7 @@ import {
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
 import { coerceFields } from "./add-component-form-coerce.js";
-import { addFormRenderablePaths } from "./add-component-form-filter.js";
+import { addFormPaintsAnything } from "./add-component-form-filter.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
 
@@ -341,19 +341,19 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selected = result.entry;
     this._submitError = "";
     // Skip the empty form and add directly only when the add-form would
-    // paint nothing. `addFormRenderablePaths` is the add-form's own fixed
-    // filter (required-only, no advanced toggle), so the gate matches what
-    // the user would see: an advanced-only component like `socket` (one
-    // `advanced: true` entry) and a component whose only fields are
-    // optional non-`name` (deferred to the section editor) both render
-    // blank, so both fast-path instead of stranding the user. Carve-outs
-    // that keep the form: a missing top-level dependency (e.g.
-    // `captive_portal` needs `wifi`, surfaced by the deps banner) and
-    // featured entries with presets (their locked `config_entries` must be
-    // submitted, so a thin payload would fail backend validation; a
-    // degenerate featured entry with no entries has nothing to lose, so it
-    // fast-paths too). On the rare API failure `_submitComponent` toasts
-    // the error (no form surface).
+    // paint nothing. `addFormPaintsAnything` reads the same
+    // `buildFormRenderPlan` the form's `render()` uses (fields, exclusive
+    // groups, constraint clusters, unsatisfied-constraint banners) under the
+    // add-form's fixed filter, so the gate can't drift from what the user
+    // sees: an advanced-only component like `socket` and a component whose
+    // only fields are optional non-`name` both paint blank and fast-path
+    // instead of stranding the user. Carve-outs that keep the form: a missing
+    // top-level dependency (e.g. `captive_portal` needs `wifi`, surfaced by
+    // the deps banner) and featured entries with presets (their locked
+    // `config_entries` must be submitted, so a thin payload would fail backend
+    // validation; a degenerate featured entry with no entries has nothing to
+    // lose, so it fast-paths too). On the rare API failure `_submitComponent`
+    // toasts the error (no form surface).
     //
     // The probe and the payload both use the values the form would seed
     // (`buildInitialValues`) coerced exactly as the form's Add does
@@ -376,9 +376,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
       prefillFields: null,
       localize: this._localize,
     });
-    const renderable = addFormRenderablePaths(
+    const paintsNothing = !addFormPaintsAnything(
       result.entry.config_entries,
       seeded,
+      result.entry.required_groups ?? [],
       this.board,
       present
     );
@@ -398,7 +399,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // carries overlays/values the `{}`-seeded probe can't predict, so show
     // the form rather than fast-path with stale inputs.
     const noPrefill = this._prefillReference === null && this._depPrefill === null;
-    if (renderable.size === 0 && !hasFeaturedPresets && !hasMissingDeps && noPrefill) {
+    if (paintsNothing && !hasFeaturedPresets && !hasMissingDeps && noPrefill) {
       const fields = coerceFields(result.entry.config_entries, seeded);
       await this._submitComponent(fields, /* notify */ true);
     }

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -16,6 +16,7 @@ import { isFeaturedId } from "../../util/featured-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
+import { findMissingDependencies } from "./add-component-deps.js";
 import { chooseExcludeCategories } from "./add-component-dialog-categories.js";
 import {
   matchesDepDomain,
@@ -383,7 +384,15 @@ export class ESPHomeAddComponentDialog extends LitElement {
     );
     const hasFeaturedPresets =
       isFeaturedId(result.entry.id) && result.entry.config_entries.length > 0;
-    const hasMissingDeps = (result.entry.dependencies ?? []).some((d) => !present.has(d));
+    // Use the form's own `findMissingDependencies` (dotted deps, platform
+    // stems) rather than a plain top-level-block check, so a dep satisfied
+    // by e.g. a `sensor: platform:` stem doesn't keep a blank form. The
+    // form's async `provides` subtraction isn't replicated here — this stays
+    // stricter (never wrongly auto-adds), only keeping the form a touch more
+    // often for a provides-satisfied dep.
+    const hasMissingDeps =
+      findMissingDependencies(result.entry.dependencies ?? [], this.yaml, present)
+        .length > 0;
     // Detour/restore flows set `_selected` directly and bypass this handler,
     // so prefill is null here today. Guard anyway: a prefilled selection
     // carries overlays/values the `{}`-seeded probe can't predict, so show

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -27,6 +27,7 @@ import {
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
+import { collectRenderablePaths } from "./config-entry-render-filter.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -335,16 +336,32 @@ export class ESPHomeAddComponentDialog extends LitElement {
     }
     this._selected = result.entry;
     this._submitError = "";
-    // Skip the empty form and add directly only when there is genuinely
-    // nothing to show: no config fields AND no missing top-level
-    // dependencies. A configless component can still require other
-    // components (e.g. `captive_portal` needs `wifi`), in which case the
-    // form's deps banner guides the user, so keep showing it. The empty
-    // schema makes the fields payload provably `{}` (no defaults, id, or
-    // pins to seed); on the rare API failure `_submitComponent` toasts
-    // the error (see its catch) since there's no form surface for it.
-    if (result.entry.config_entries.length === 0) {
-      const present = parseTopLevelComponents(this.yaml);
+    // Skip the empty form and add directly only when there is no
+    // non-advanced field to show. The add-form has no "show advanced"
+    // toggle, so an advanced-only component like `socket` (one
+    // `advanced: true` entry) would otherwise strand the user behind a
+    // blank dialog, same dead-end as a configless component. We probe
+    // with `requiredOnly: false` so a component with an *optional*
+    // non-advanced field still opens the form (only advanced/hidden/
+    // platform-gated entries are dropped). Carve-outs that keep the form:
+    // a missing top-level dependency (e.g. `captive_portal` needs `wifi`,
+    // surfaced by the deps banner) and featured entries (their locked
+    // presets must be submitted, so `{}` would fail backend validation).
+    // The empty schema makes the fields payload provably `{}`; on the rare
+    // API failure `_submitComponent` toasts the error (no form surface).
+    const present = parseTopLevelComponents(this.yaml);
+    const renderable = collectRenderablePaths(
+      result.entry.config_entries,
+      {},
+      {
+        requiredOnly: false,
+        showAdvanced: false,
+        presentComponents: present,
+        targetPlatform: this.board?.esphome.platform ?? null,
+      }
+    );
+    const isFeatured = result.entry.id.startsWith("featured.");
+    if (renderable.size === 0 && !isFeatured) {
       const hasMissingDeps = (result.entry.dependencies ?? []).some(
         (d) => !present.has(d)
       );

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -1,14 +1,33 @@
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
-import type { ConfigEntry } from "../../api/types/config-entries.js";
-import { collectRenderablePaths } from "./config-entry-render-filter.js";
+import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
+import { buildFormRenderPlan, planRendersContent } from "./config-entry-form-plan.js";
+import {
+  collectRenderablePaths,
+  type RenderFilterOptions,
+} from "./config-entry-render-filter.js";
+import { collectUnsatisfiedConstraints } from "./config-entry-renderers/constraint-banners.js";
+
+/**
+ * The add-component form's fixed render filter: required-only, no advanced
+ * toggle (the inner config-entry form is always mounted `required-only` and
+ * the add-form never exposes a show-advanced toggle).
+ */
+function addFormFilterOptions(
+  board: BoardCatalogEntry | null,
+  presentComponents: ReadonlySet<string>
+): RenderFilterOptions {
+  return {
+    requiredOnly: true,
+    showAdvanced: false,
+    presentComponents,
+    targetPlatform: board?.esphome.platform ?? null,
+  };
+}
 
 /**
  * Dotted paths the add-component form would paint for *entries* under its
- * fixed filter: required-only, no advanced toggle (the inner config-entry
- * form is always mounted `required-only` and the add-form never exposes a
- * show-advanced toggle). The single source of truth for "what the add-form
- * shows" — the dialog's fast-path gate and the form's error-visibility
- * check both read it so they can't drift from the actual paint.
+ * fixed filter. The form's error-visibility check reads it so a validation
+ * error on a hidden field doesn't bail the submit silently.
  */
 export function addFormRenderablePaths(
   entries: ConfigEntry[],
@@ -16,10 +35,43 @@ export function addFormRenderablePaths(
   board: BoardCatalogEntry | null,
   presentComponents: ReadonlySet<string>
 ): Set<string> {
-  return collectRenderablePaths(entries, values, {
-    requiredOnly: true,
-    showAdvanced: false,
-    presentComponents,
-    targetPlatform: board?.esphome.platform ?? null,
-  });
+  return collectRenderablePaths(
+    entries,
+    values,
+    addFormFilterOptions(board, presentComponents)
+  );
+}
+
+/**
+ * Whether the add-component form would paint anything the user must engage
+ * with: a plain field, an exclusive-group dropdown, a constraint-cluster box,
+ * or an unsatisfied-constraint banner. Built on the same `buildFormRenderPlan`
+ * the form's `render()` uses, so the dialog's empty-form gate can't drift from
+ * the actual paint. `false` means the form body would be blank.
+ */
+export function addFormPaintsAnything(
+  entries: ConfigEntry[],
+  values: Record<string, unknown>,
+  requiredGroups: RequiredGroup[],
+  board: BoardCatalogEntry | null,
+  presentComponents: ReadonlySet<string>
+): boolean {
+  const opts = addFormFilterOptions(board, presentComponents);
+  const plan = buildFormRenderPlan(entries, values, requiredGroups, opts);
+  if (planRendersContent(plan)) return true;
+  // Pure-cardinality groups with no cluster box surface a banner only when
+  // unsatisfied; keys are irrelevant to presence, so format to "".
+  return (
+    collectUnsatisfiedConstraints(
+      {
+        entries,
+        requiredGroups,
+        values,
+        presentComponents,
+        targetPlatform: opts.targetPlatform ?? null,
+        formatKeys: () => "",
+      },
+      plan.memberKeys
+    ).length > 0
+  );
 }

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -14,7 +14,7 @@ export function addFormRenderablePaths(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   board: BoardCatalogEntry | null,
-  presentComponents: Set<string>
+  presentComponents: ReadonlySet<string>
 ): Set<string> {
   return collectRenderablePaths(entries, values, {
     requiredOnly: true,

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -3,6 +3,7 @@ import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.
 import { buildFormRenderPlan, planRendersContent } from "./config-entry-form-plan.js";
 import {
   collectRenderablePaths,
+  renderFilterOptions,
   type RenderFilterOptions,
 } from "./config-entry-render-filter.js";
 import { collectUnsatisfiedConstraints } from "./config-entry-renderers/constraint-banners.js";
@@ -10,18 +11,20 @@ import { collectUnsatisfiedConstraints } from "./config-entry-renderers/constrai
 /**
  * The add-component form's fixed render filter: required-only, no advanced
  * toggle (the inner config-entry form is always mounted `required-only` and
- * the add-form never exposes a show-advanced toggle).
+ * the add-form never exposes a show-advanced toggle). Routes through
+ * `renderFilterOptions` so the `board`→`targetPlatform` derivation stays in
+ * lockstep with the form's own paint.
  */
 function addFormFilterOptions(
   board: BoardCatalogEntry | null,
   presentComponents: ReadonlySet<string>
 ): RenderFilterOptions {
-  return {
+  return renderFilterOptions({
     requiredOnly: true,
     showAdvanced: false,
     presentComponents,
-    targetPlatform: board?.esphome.platform ?? null,
-  };
+    board,
+  });
 }
 
 /**

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -1,0 +1,25 @@
+import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { ConfigEntry } from "../../api/types/config-entries.js";
+import { collectRenderablePaths } from "./config-entry-render-filter.js";
+
+/**
+ * Dotted paths the add-component form would paint for *entries* under its
+ * fixed filter: required-only, no advanced toggle (the inner config-entry
+ * form is always mounted `required-only` and the add-form never exposes a
+ * show-advanced toggle). The single source of truth for "what the add-form
+ * shows" — the dialog's fast-path gate and the form's error-visibility
+ * check both read it so they can't drift from the actual paint.
+ */
+export function addFormRenderablePaths(
+  entries: ConfigEntry[],
+  values: Record<string, unknown>,
+  board: BoardCatalogEntry | null,
+  presentComponents: Set<string>
+): Set<string> {
+  return collectRenderablePaths(entries, values, {
+    requiredOnly: true,
+    showAdvanced: false,
+    presentComponents,
+    targetPlatform: board?.esphome.platform ?? null,
+  });
+}

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -13,6 +13,7 @@ import {
   generateDefaultComponentId,
 } from "../../util/default-component-id.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
+import { isFeaturedId } from "../../util/featured-id.js";
 import { setIn } from "../../util/nested-values.js";
 
 /** Inputs the seeding pipeline reads off the host component. */
@@ -150,7 +151,7 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   // when filling a featured entry so a board-pinned (locked) optional
   // field actually emits its preset on submit — otherwise the
   // backend's locked-validation would reject the empty payload.
-  const seedAll = component.id.startsWith("featured.");
+  const seedAll = isFeaturedId(component.id);
   let next = seedDefaults(entries, yaml, localize, seedAll);
 
   const idEntry = entries.find((e) => e.key === "id" && e.type === ConfigEntryType.ID);

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -26,12 +26,12 @@ import {
   findMissingDependencies,
 } from "./add-component-deps.js";
 import { coerceFields } from "./add-component-form-coerce.js";
+import { addFormRenderablePaths } from "./add-component-form-filter.js";
 import { overlayOptions, overlayRequired } from "./add-component-form-overlays.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { addComponentFormStyles } from "./add-component-form.styles.js";
 import "./config-entry-form.js";
 import type { ConfigEntryValueChange } from "./config-entry-form.js";
-import { collectRenderablePaths } from "./config-entry-render-filter.js";
 import { resolveEntryLabel } from "./config-entry-renderers-shared.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -408,13 +408,9 @@ export class ESPHomeAddComponentForm extends LitElement {
   /**
    * True when at least one error in the map lands on an entry the
    * shared ``esphome-config-entry-form`` actually renders. Built on
-   * ``collectRenderablePaths`` so the visibility check stays in
-   * lockstep with the form's render filter — without that lockstep
+   * ``addFormRenderablePaths`` so the visibility check stays in
+   * lockstep with the add-form's render filter — without that lockstep
    * an error on a hidden field would bail the submit silently.
-   *
-   * The add-component form passes ``required-only`` and never
-   * exposes a show-advanced toggle, so we always pass
-   * ``showAdvanced: false`` here.
    */
   private _anyErrorIsVisible(
     errors: Map<string, ValidationError>,
@@ -424,12 +420,12 @@ export class ESPHomeAddComponentForm extends LitElement {
     // ``errors.size > 0``, but we keep the guard so the helper is
     // safe to call from anywhere.
     if (errors.size === 0) return false;
-    const renderedPaths = collectRenderablePaths(this._entries, this._values, {
-      requiredOnly: true,
-      showAdvanced: false,
-      presentComponents,
-      targetPlatform: this.board?.esphome.platform ?? null,
-    });
+    const renderedPaths = addFormRenderablePaths(
+      this._entries,
+      this._values,
+      this.board,
+      presentComponents
+    );
     for (const key of errors.keys()) {
       if (renderedPaths.has(key)) return true;
     }

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -1,0 +1,53 @@
+import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
+import {
+  filterRenderable,
+  type RenderFilterOptions,
+} from "./config-entry-render-filter.js";
+import {
+  buildConstraintClusters,
+  type ConstraintCluster,
+} from "./config-entry-renderers/constraint-cluster.js";
+import { orderExclusiveGroups } from "./config-entry-renderers/exclusive-group.js";
+
+/**
+ * The structural decision `ESPHomeConfigEntryForm.render()` makes before
+ * emitting templates: which entries fold into exclusive-group dropdowns or
+ * constraint-cluster boxes, and which plain entries survive the visibility
+ * filter. Extracted so render() and the add-component dialog's empty-form
+ * gate agree on what the form paints (constraint banners are separate — they
+ * render only for *unsatisfied* groups; see ``collectUnsatisfiedConstraints``).
+ */
+export interface FormRenderPlan {
+  /** Entries in paint order; an array element is one exclusive group. */
+  ordered: (ConfigEntry | ConfigEntry[])[];
+  /** Either/or constraint clusters, each rendered as one bordered box. */
+  clusters: ConstraintCluster[];
+  /** Keys folded into a cluster, dropped from the normal flow. */
+  memberKeys: Set<string>;
+  /** Plain (non-exclusive, non-cluster) entries that pass the filter. */
+  visible: Set<ConfigEntry>;
+}
+
+export function buildFormRenderPlan(
+  entries: ConfigEntry[],
+  values: Record<string, unknown>,
+  requiredGroups: RequiredGroup[],
+  opts: RenderFilterOptions
+): FormRenderPlan {
+  const ordered = orderExclusiveGroups(entries);
+  const { clusters, memberKeys } = buildConstraintClusters(entries, requiredGroups);
+  const nonExclusive = entries.filter(
+    (entry) => !entry.exclusive_group && !memberKeys.has(entry.key)
+  );
+  const visible = new Set(filterRenderable(nonExclusive, values, opts));
+  return { ordered, clusters, memberKeys, visible };
+}
+
+/** Whether the plan paints any field, exclusive-group dropdown, or cluster box. */
+export function planRendersContent(plan: FormRenderPlan): boolean {
+  return (
+    plan.visible.size > 0 ||
+    plan.clusters.length > 0 ||
+    plan.ordered.some((item) => Array.isArray(item))
+  );
+}

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -72,13 +72,12 @@ import "@home-assistant/webawesome/dist/components/select/select.js";
 import "@home-assistant/webawesome/dist/components/switch/switch.js";
 import "../mdi-icon-picker.js";
 import "../options-combobox.js";
+import { buildFormRenderPlan } from "./config-entry-form-plan.js";
 import {
-  buildConstraintClusters,
   fieldRendererStyles,
   formatConstraintKeys,
   isRadioCluster,
   labelFor,
-  orderExclusiveGroups,
   renderBooleanField,
   renderConstraintClusterField,
   renderConstraintRadioField,
@@ -299,22 +298,18 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // mandatory fields first. The section editor mirrors the on-disk YAML
     // order, so it's left untouched.
     const entries = this.requiredOnly ? floatRequiredFirst(this.entries) : this.entries;
-    // Each exclusive_group renders as one always-shown dropdown at its
-    // first member's slot; other entries keep the advanced/visibility
-    // filter (the Set preserves order while dropping filtered-out ones).
-    const ordered = orderExclusiveGroups(entries);
-    // Either/or constraints (chipset OR the timing group) fold into one
-    // bordered box at the first member's slot, like exclusive_group; drop the
-    // members from the normal flow so they aren't also rendered loose.
-    const { clusters, memberKeys } = buildConstraintClusters(
+    // Each exclusive_group renders as one always-shown dropdown at its first
+    // member's slot; either/or constraints fold into one bordered box at the
+    // first member's slot; other entries keep the advanced/visibility filter.
+    // `buildFormRenderPlan` is the shared source of truth the dialog's
+    // empty-form gate reads — keep paint decisions there, not inline here.
+    const { ordered, clusters, memberKeys, visible } = buildFormRenderPlan(
       entries,
-      this.requiredGroups
+      this.values,
+      this.requiredGroups,
+      renderFilterOptions(this)
     );
     const clusterByFirstKey = new Map(clusters.map((c) => [c.members[0].key, c]));
-    const nonExclusive = entries.filter(
-      (entry) => !entry.exclusive_group && !memberKeys.has(entry.key)
-    );
-    const visible = new Set(this._filterRenderable(nonExclusive, this.values));
     // An empty key means "this entry IS the whole values dict" —
     // used by top-level user-keyed sections (substitutions:) where
     // the component itself is the map. Pass ``[]`` so the entry's

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -66,7 +66,7 @@ export interface RenderFilterOptions {
    *  clearing them in YAML lets them collapse back. */
   showAdvanced: boolean;
   /** Pass-through to ``isEntryVisible`` for cross-component checks. */
-  presentComponents?: Set<string>;
+  presentComponents?: ReadonlySet<string>;
   /**
    * The device's target platform (``esp32`` / ``esp8266`` /
    * ``rp2040`` / ...). Forwarded to ``isEntryVisible`` which
@@ -90,7 +90,7 @@ export interface RenderFilterOptions {
 export interface RenderFilterSource {
   requiredOnly: boolean;
   showAdvanced: boolean;
-  presentComponents: Set<string>;
+  presentComponents: ReadonlySet<string>;
   board: BoardCatalogEntry | null;
 }
 

--- a/src/components/device/config-entry-renderers/constraint-banners.ts
+++ b/src/components/device/config-entry-renderers/constraint-banners.ts
@@ -10,7 +10,7 @@ export interface ConstraintBannerInputs {
   entries: ConfigEntry[];
   requiredGroups: RequiredGroup[];
   values: Record<string, unknown>;
-  presentComponents: Set<string>;
+  presentComponents: ReadonlySet<string>;
   targetPlatform: string | null;
   formatKeys: (keys: string[]) => string;
 }

--- a/src/util/config-validation.ts
+++ b/src/util/config-validation.ts
@@ -55,7 +55,7 @@ export function platformSupported(
 export function isEntryVisible(
   entry: ConfigEntry,
   values: Record<string, unknown>,
-  presentComponents?: Set<string>,
+  presentComponents?: ReadonlySet<string>,
   targetPlatform?: string | null
 ): boolean {
   if (entry.hidden) return false;
@@ -295,7 +295,7 @@ export function validateEntry(entry: ConfigEntry, raw: unknown): ValidationError
 export function validateEntries(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
-  presentComponents?: Set<string>,
+  presentComponents?: ReadonlySet<string>,
   targetPlatform?: string | null,
   sectionKey?: string
 ): Map<string, ValidationError> {
@@ -321,7 +321,7 @@ export function validateEntries(
 function _validateEntriesRecursive(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
-  presentComponents: Set<string> | undefined,
+  presentComponents: ReadonlySet<string> | undefined,
   targetPlatform: string | null | undefined,
   pathPrefix: string[],
   errors: Map<string, ValidationError>,

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,7 +1,7 @@
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
 
-/** True for a catalog id carrying the `featured.` prefix (the `featured.<board>.<local>` shape). */
+/** True when a catalog id carries the `featured.` prefix; only the prefix is checked, not the full shape. */
 export function isFeaturedId(id: string): boolean {
   return id.startsWith(FEATURED_ID_PREFIX);
 }

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,0 +1,7 @@
+/** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
+export const FEATURED_ID_PREFIX = "featured.";
+
+/** True for catalog ids in the `featured.<board>.<local>` shape. */
+export function isFeaturedId(id: string): boolean {
+  return id.startsWith(FEATURED_ID_PREFIX);
+}

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,7 +1,7 @@
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
 
-/** True for catalog ids in the `featured.<board>.<local>` shape. */
+/** True for a catalog id carrying the `featured.` prefix (the `featured.<board>.<local>` shape). */
 export function isFeaturedId(id: string): boolean {
   return id.startsWith(FEATURED_ID_PREFIX);
 }

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -241,6 +241,24 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
+  it("fast-paths an advanced-only component whose dep is satisfied by a platform stem", async () => {
+    // The form's findMissingDependencies treats `sensor: platform: atm90e32`
+    // as satisfying an `atm90e32` dep; the gate uses the same logic, so a
+    // plain top-level-block check doesn't keep a blank form here.
+    const entry = makeComponentEntry("socket", {
+      name: "Socket",
+      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+      dependencies: ["atm90e32"],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    dialog.yaml = "sensor:\n  - platform: atm90e32\n";
+
+    await select(dialog, "socket");
+
+    expect(addComponent).toHaveBeenCalled();
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+  });
+
   it("opens the form for an advanced-only component when a prefill is active", async () => {
     // A prefilled selection carries overlays/values the `{}`-seeded probe
     // can't predict, so the gate must not fast-path even when the bare

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -130,6 +130,62 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
+  it("adds an advanced-only component directly (Socket), toasts, and closes", async () => {
+    // `socket` has one entry, `implementation`, marked advanced; the
+    // add-form (required-only, no advanced toggle) paints nothing, so it
+    // must fast-path like a configless component instead of an empty form.
+    const entry = makeComponentEntry("socket", {
+      name: "Socket",
+      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "socket");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "socket", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect(toast.success).toHaveBeenCalledWith("device.component_added", {
+      richColors: true,
+    });
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
+  });
+
+  it("opens the form for an advanced-only component with a missing dependency", async () => {
+    const entry = makeComponentEntry("socket", {
+      name: "Socket",
+      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+      dependencies: ["network"],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "socket");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("opens the form for a featured advanced-only entry (locked presets)", async () => {
+    // A featured entry seeds locked presets the backend requires; a `{}`
+    // fast-path would drop them, so it must always show the form even when
+    // every entry is advanced/optional.
+    const entry = makeComponentEntry("featured.bw15.socket", {
+      name: "Socket",
+      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "featured.bw15.socket");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
   it("toasts the error and keeps the dialog open when a configless add fails", async () => {
     const entry = makeComponentEntry("async_tcp", {
       name: "Async TCP",

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -167,6 +167,43 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
+  it("opens the form for an advanced-only exclusive group (always-shown dropdown)", async () => {
+    // An exclusive_group renders as an always-shown dropdown the user must
+    // choose from, outside the required-only field filter; the gate reads the
+    // same render plan, so it must not fast-path past that choice.
+    const entry = makeComponentEntry("chooser", {
+      name: "Chooser",
+      config_entries: [
+        makeConfigEntry({ key: "mode_a", exclusive_group: "mode", advanced: true }),
+        makeConfigEntry({ key: "mode_b", exclusive_group: "mode", advanced: true }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "chooser");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("opens the form for an advanced-only constraint cluster (always-shown box)", async () => {
+    // An inclusive `group` folds into an always-shown constraint-cluster box;
+    // like the exclusive case, the gate must keep the form.
+    const entry = makeComponentEntry("clustered", {
+      name: "Clustered",
+      config_entries: [
+        makeConfigEntry({ key: "a", group: "g", advanced: true }),
+        makeConfigEntry({ key: "b", group: "g", advanced: true }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "clustered");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
   it("adds an advanced-only component directly (Socket), toasts, and closes", async () => {
     // `socket` has one entry, `implementation`, marked advanced; the
     // add-form (required-only, no advanced toggle) paints nothing, so it

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -190,6 +190,30 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
   });
 
+  it("opens the form for a required advanced field with a default (seeded becomes material)", async () => {
+    // The form seeds required defaults, so a required+advanced entry with a
+    // default_value renders once mounted; the gate seeds too, so it must NOT
+    // fast-path and drop that value.
+    const entry = makeComponentEntry("thing", {
+      name: "Thing",
+      config_entries: [
+        makeConfigEntry({
+          key: "mode",
+          required: true,
+          advanced: true,
+          default_value: "AUTO",
+        }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "thing");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
   it("opens the form for an advanced-only component with a missing dependency", async () => {
     const entry = makeComponentEntry("socket", {
       name: "Socket",

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -332,21 +332,26 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(true);
   });
 
-  it("opens the form for a featured advanced-only entry (locked presets)", async () => {
-    // A featured entry seeds locked presets the backend requires; a `{}`
-    // fast-path would drop them, so it must always show the form even when
-    // every entry is advanced/optional.
+  it("fast-paths a featured entry but submits its seedAll-locked presets", async () => {
+    // A featured id seeds every default (seedAll), so its locked preset rides
+    // in the coerced payload even when the field is advanced and the form
+    // paints nothing — no `{}`-drop, no need to force the form open.
     const entry = makeComponentEntry("featured.bw15.socket", {
       name: "Socket",
-      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+      config_entries: [
+        makeConfigEntry({ key: "implementation", advanced: true, default_value: "lwip" }),
+      ],
     });
     const { dialog, addComponent } = makeDialog(entry);
 
     await select(dialog, "featured.bw15.socket");
 
-    expect(addComponent).not.toHaveBeenCalled();
-    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "featured.bw15.socket", fields: { implementation: "lwip" } },
+      "esphome:\n  name: foo\n"
+    );
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
   it("fast-paths a featured entry that has no config entries (no presets to lose)", async () => {

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -241,6 +241,27 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
+  it("opens the form for an advanced-only component when a prefill is active", async () => {
+    // A prefilled selection carries overlays/values the `{}`-seeded probe
+    // can't predict, so the gate must not fast-path even when the bare
+    // schema renders blank.
+    const entry = makeComponentEntry("socket", {
+      name: "Socket",
+      config_entries: [makeConfigEntry({ key: "implementation", advanced: true })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+    (dialog as unknown as { _prefillReference: unknown })._prefillReference = {
+      domain: "i2c",
+      id: "bus_a",
+    };
+
+    await select(dialog, "socket");
+
+    expect(addComponent).not.toHaveBeenCalled();
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
   it("opens the form for an advanced-only component with a missing dependency", async () => {
     const entry = makeComponentEntry("socket", {
       name: "Socket",

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -18,6 +18,7 @@ vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
 import toast from "sonner-js";
 
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
@@ -212,6 +213,32 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
     expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("fast-paths but submits the seeded id the form would have sent (not {})", async () => {
+    // The form seeds and submits an auto id even though required-only hides
+    // it; the fast-path must submit the same coerced values, not `{}`.
+    const entry = makeComponentEntry("widget", {
+      name: "Widget",
+      multi_conf: true,
+      config_entries: [
+        makeConfigEntry({ key: "id", type: ConfigEntryType.ID }),
+        makeConfigEntry({ key: "tweak", advanced: true }),
+      ],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "widget");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      {
+        component_id: "widget",
+        fields: expect.objectContaining({ id: expect.any(String) }),
+      },
+      "esphome:\n  name: foo\n"
+    );
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
   it("opens the form for an advanced-only component with a missing dependency", async () => {

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -76,10 +76,10 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
   });
 
-  it("opens the form (no direct add) when the component has options", async () => {
+  it("opens the form (no direct add) when the component has a required field", async () => {
     const entry = makeComponentEntry("wifi", {
       name: "WiFi",
-      config_entries: [makeConfigEntry({ key: "ssid" })],
+      config_entries: [makeConfigEntry({ key: "ssid", required: true })],
     });
     const { dialog, addComponent } = makeDialog(entry);
 
@@ -88,6 +88,42 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(addComponent).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
     // Form view: the entry is selected, dialog stays open.
+    expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
+    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("adds directly when the only fields are optional and non-name", async () => {
+    // The add form renders required-only, so an optional non-`name` field
+    // is never painted; opening the form would be the same blank dead-end,
+    // so it fast-paths like an advanced-only component.
+    const entry = makeComponentEntry("debug", {
+      name: "Debug",
+      config_entries: [makeConfigEntry({ key: "update_interval" })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "debug");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "debug", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+  });
+
+  it("opens the form when an always-shown name field survives required-only", async () => {
+    // `name` is on the always-shown allowlist, so a component with just a
+    // name still paints a field — keep the form.
+    const entry = makeComponentEntry("sensor.template", {
+      name: "Template Sensor",
+      config_entries: [makeConfigEntry({ key: "name" })],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "sensor.template");
+
+    expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
     expect((dialog as unknown as { _open: boolean })._open).toBe(true);
   });
@@ -184,6 +220,23 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
     expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+  });
+
+  it("fast-paths a featured entry that has no config entries (no presets to lose)", async () => {
+    const entry = makeComponentEntry("featured.bw15.async_tcp", {
+      name: "Async TCP",
+      config_entries: [],
+    });
+    const { dialog, addComponent } = makeDialog(entry);
+
+    await select(dialog, "featured.bw15.async_tcp");
+
+    expect(addComponent).toHaveBeenCalledWith(
+      "foo.yaml",
+      { component_id: "featured.bw15.async_tcp", fields: {} },
+      "esphome:\n  name: foo\n"
+    );
+    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
   });
 
   it("toasts the error and keeps the dialog open when a configless add fails", async () => {

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isFeaturedId } from "../../src/util/featured-id.js";
+
+describe("isFeaturedId", () => {
+  it("is true for a featured.<board>.<local> id", () => {
+    expect(isFeaturedId("featured.bw15.socket")).toBe(true);
+  });
+
+  it("is false for a plain catalog id", () => {
+    expect(isFeaturedId("sensor.dht")).toBe(false);
+    expect(isFeaturedId("socket")).toBe(false);
+  });
+
+  it("requires the trailing dot, not just the word", () => {
+    expect(isFeaturedId("featuredthing")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adding the "Socket" component opened an Add-component dialog with an empty body (just the YAML preview link, Back, Add). Socket's only config entry is `implementation`, marked `advanced: true`, and the add-component form has no "show advanced" toggle, so it painted nothing; the user was stranded on a blank form.

A prior fix (#604) already fast-paths a configless component (zero entries, e.g. Async TCP) by adding it directly with an empty payload and toasting. Socket fell in the gap: it has one entry, but it's advanced-only, so the count gate missed it.

The gate now skips the form whenever it would paint nothing, not just when the component has zero entries. It reads the form's own render decision via `addFormPaintsAnything`, built on the same `buildFormRenderPlan` the form's `render()` consumes (fields, exclusive-group dropdowns, constraint-cluster boxes, unsatisfied-constraint banners) under the add-form's fixed filter, seeded with the same `buildInitialValues` the form uses, so the emptiness check is in lockstep with what the user actually sees; an advanced-only component like `socket` and a component whose only fields are optional non-`name` (deferred to the section editor) both fast-path. The auto-add submits `coerceFields(entries, seeded)`, the same payload the form's Add would, so a seeded `id`/pin isn't dropped. Featured entries fast-path like any other component; because `buildInitialValues` sets `seedAll` for featured ids, their locked presets ride in that coerced payload rather than being dropped. The missing-dependency carve-out is preserved (`captive_portal` still shows its deps banner), and an active prefill/detour keeps the form too.

**Related issue or feature (if applicable):**

- Reported against the dashboard (adding `socket` shows an empty dialog); no tracking issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


