### PR TITLE
Parse list items with a nested sub-mapping among scalar siblings

### DIFF
--- a/src/util/yaml-section-block-reader.ts
+++ b/src/util/yaml-section-block-reader.ts
@@ -25,6 +25,7 @@ import {
   isListItemLine,
   KEY_PATTERN,
   LIST_ITEM_BARE_DASH_RE,
+  LIST_ITEM_INLINE_KEY_PREFIX_RE,
   listItemRegexFor,
   parseBlockScalarHeader,
 } from "./yaml-section-lexer.js";
@@ -73,9 +74,18 @@ const parseListBlock = (
     startIdx,
     canonicalDashIndent
   );
-  const childIndent =
-    _detectListItemChildIndent(lines, firstDashIdx + 1, dashIndent) ??
-    `${dashIndent}${ESPHOME_YAML_INDENT}`;
+  // An inline key on the dash line (``- service:`` / ``- txt:``) fixes the
+  // item's child-key column at that key, even when its value is a deeper
+  // nested map — scanning the next line would read the grandchild indent and
+  // drop the siblings (#1389). Mirrors `_detectSectionChildIndent`; bare-dash
+  // placeholders fall through to the next-line scan. Child keys hand-indented
+  // *deeper* than this column route to the safe raw fallback rather than
+  // parsing structurally — the same tradeoff `_detectSectionChildIndent` makes.
+  const inlineKey = (lines[firstDashIdx] ?? "").match(LIST_ITEM_INLINE_KEY_PREFIX_RE);
+  const childIndent = inlineKey
+    ? " ".repeat(inlineKey[1].length)
+    : (_detectListItemChildIndent(lines, firstDashIdx + 1, dashIndent) ??
+      `${dashIndent}${ESPHOME_YAML_INDENT}`);
   const { endIdx, isComplex } = _scanValueBlock(lines, startIdx, parentIndent);
 
   // Complex blocks are anything beyond a flat scalar list (block
@@ -118,12 +128,32 @@ const parseListBlock = (
 };
 
 /**
+ * Parse a nested mapping under an empty-valued ``key:`` line (``txt:`` then a
+ * deeper ``new_1: …``). *keyLineIdx* is the ``key:`` line; the block must
+ * begin on the next non-blank line strictly deeper than *minIndent*. Returns
+ * the parsed values + resume index, ``"bail"`` for a nested *list* (``- …`` —
+ * an automation handler the editor can't round-trip inline), or ``null`` when
+ * no deeper block follows (the key is a plain empty scalar).
+ */
+const _nestedMappingUnderKey = (
+  lines: string[],
+  keyLineIdx: number,
+  minIndent: number
+): { values: Record<string, unknown>; endIdx: number } | "bail" | null => {
+  const peek = _skipBlankAndCommentLines(lines, keyLineIdx + 1);
+  if (peek >= lines.length) return null;
+  const peekLead = _leadingIndent(lines[peek]);
+  if (peekLead.length <= minIndent) return null;
+  if (lines[peek].slice(peekLead.length).startsWith("-")) return "bail";
+  return parseNestedBlock(lines, keyLineIdx + 1, peekLead);
+};
+
+/**
  * Walk follow-up sub-key lines under a list-item dash and merge
  * them into *item*. Stops at the next sibling dash, blank-then-EOF,
  * or a back-out. Returns the line index after the last sub-key,
  * or ``null`` if anything outside the flat-mapping contract turned
- * up (line strictly deeper than ``childIndent`` ⇒ nested mapping;
- * unmatched key shape; dotted key; block scalar; empty raw).
+ * up (unmatched key shape; dotted key; block scalar; nested list).
  * Mutates *item* in place — keeps the caller's outer loop from
  * having to thread two return values.
  */
@@ -147,6 +177,20 @@ const _parseItemSubKeys = (
     if (sub.startsWith(`${childIndent} `)) return null;
     const field = _matchFlatMappingField(sub, childRe);
     if (!field) return null;
+    // An empty ``key:`` may open a nested mapping (an mdns ``txt:`` map);
+    // capture it as the value and resume so siblings on either side survive.
+    if (field.value === null) {
+      const nested = _nestedMappingUnderKey(lines, j, childIndent.length);
+      if (nested === "bail") return null;
+      if (nested) {
+        // Match the polymorphic call site: store the map only when non-empty,
+        // else keep the bare ``key:`` (null) rather than an empty ``{}``.
+        item[field.key] =
+          Object.keys(nested.values).length > 0 ? nested.values : field.value;
+        j = nested.endIdx;
+        continue;
+      }
+    }
     item[field.key] = field.value;
     j++;
   }
@@ -244,29 +288,28 @@ const collectBlockListMappings = (
       // upgrade the value from ``null`` to ``{params}``.
       if (header.value === null) firstEmptyKey = header.key;
     }
-    // Polymorphic branch (#941, light ``effects:``): a dash header
-    // with a single-key empty value can carry its params at strictly
-    // deeper indent than the dash-line key column. The threshold is
-    // ``dashIndent.length + 2`` (the column of the key after ``- ``),
-    // NOT the detected ``childIndent`` — the latter collapses to the
-    // deeper indent when no flat sibling exists, breaking the
-    // discriminator between "nested under empty key" and "flat sibling
-    // sub-keys". Bail on list-shaped nested content (``- then:`` →
-    // ``  - logger.log:``) so automation handlers still round-trip via
-    // YamlRawValue.
+    // Polymorphic branch (#941, light ``effects:``): a dash header with a
+    // single-key empty value can carry its params at strictly deeper indent
+    // than the dash-line key column. The threshold is that inline-key column,
+    // derived from this item's ``-`` + spaces prefix so a non-canonical
+    // ``-   key:`` doesn't misread a flat sibling at the key column as nested.
+    // Bail on list-shaped nested content (``- then:`` → ``  - logger.log:``)
+    // so automation handlers still round-trip via YamlRawValue.
     if (firstEmptyKey !== null) {
-      const dashKeyColumn = dashIndent.length + 2;
-      const peek = _skipBlankAndCommentLines(lines, at + 1);
-      if (peek < lines.length) {
-        const peekLead = _leadingIndent(lines[peek]);
-        if (peekLead.length > dashKeyColumn) {
-          if (lines[peek].slice(peekLead.length).startsWith("-")) return null;
-          const sub = parseNestedBlock(lines, at + 1, peekLead);
-          if (Object.keys(sub.values).length > 0) {
-            item[firstEmptyKey] = sub.values;
-          }
-          return { item, endIdx: sub.endIdx };
+      const keyColumn =
+        lines[at].match(LIST_ITEM_INLINE_KEY_PREFIX_RE)?.[1].length ??
+        dashIndent.length + 2;
+      const nested = _nestedMappingUnderKey(lines, at, keyColumn);
+      if (nested === "bail") return null;
+      if (nested) {
+        if (Object.keys(nested.values).length > 0) {
+          item[firstEmptyKey] = nested.values;
         }
+        // Absorb trailing flat siblings after the leading nested map (an mdns
+        // ``- txt:`` item followed by ``protocol`` / ``service``). With no
+        // siblings (light ``effects:``) the walk stops at the next dash.
+        const after = _parseItemSubKeys(lines, nested.endIdx, childIndent, childRe, item);
+        return after === null ? null : { item, endIdx: after };
       }
     }
     const after = _parseItemSubKeys(lines, at + 1, childIndent, childRe, item);

--- a/test/util/yaml-section-reader-nested-list.test.ts
+++ b/test/util/yaml-section-reader-nested-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { parseYamlSectionValues } from "../../src/util/yaml-section-reader.js";
 import { updateSectionInYaml } from "../../src/util/yaml-section-values.js";
+import { YamlRawValue } from "../../src/util/yaml-serialize.js";
 
 // A multi_conf list item whose FIRST field is a nested mapping (font.file's
 // structured form). The child-indent detection used to read the item's child
@@ -167,5 +168,165 @@ describe("parseYamlSectionValues — inline comment on the dash-line key", () =>
     const v = parseYamlSectionValues(yaml, "font", 2);
     expect(v.file).toBe("gfonts://Roboto");
     expect(v.id).toBe("f");
+  });
+});
+
+// An mdns service item has scalar keys (service/protocol/port) alongside a
+// nested ``txt:`` map. Under the nested-list-under-a-key path this used to
+// drop the scalar siblings (nested map first) or fall back to YamlRawValue
+// (nested map last/middle), and the under-covered span made the YAML grow a
+// duplicate protocol/service pair on every keystroke.
+describe("parseYamlSectionValues — nested-under-a-key list item with a txt map", () => {
+  const expectFull = (yaml: string) => {
+    const v = parseYamlSectionValues(yaml, "mdns", 1) as Record<string, unknown>;
+    expect(v.services).toEqual([
+      {
+        service: "aioesphome._tcp.local.",
+        protocol: "_tcp",
+        port: "0",
+        txt: { new_1: "fdfd" },
+      },
+    ]);
+  };
+
+  it("captures siblings when the txt map is FIRST", () => {
+    expectFull(`mdns:
+  services:
+    - txt:
+        new_1: fdfd
+      service: aioesphome._tcp.local.
+      protocol: _tcp
+      port: 0
+`);
+  });
+
+  it("captures the txt map when it is LAST", () => {
+    expectFull(`mdns:
+  services:
+    - service: aioesphome._tcp.local.
+      protocol: _tcp
+      port: 0
+      txt:
+        new_1: fdfd
+`);
+  });
+
+  it("captures the txt map when it is in the MIDDLE", () => {
+    expectFull(`mdns:
+  services:
+    - service: aioesphome._tcp.local.
+      txt:
+        new_1: fdfd
+      protocol: _tcp
+      port: 0
+`);
+  });
+
+  it("does not misread a flat sibling as nested when the dash has extra spaces", () => {
+    // ``-   txt:`` (3 spaces after the dash) puts the key column past the
+    // canonical ``dashIndent + 2``. With an empty ``txt:`` followed straight by
+    // flat siblings, the nested-vs-sibling threshold must track the real key
+    // column or ``protocol`` / ``service`` get swallowed as txt's nested map.
+    const v = parseYamlSectionValues(
+      `mdns:
+  services:
+    -   txt:
+        protocol: _tcp
+        service: aioesphome._tcp.local.
+`,
+      "mdns",
+      1
+    ) as Record<string, unknown>;
+    expect(v.services).toEqual([
+      { txt: null, protocol: "_tcp", service: "aioesphome._tcp.local." },
+    ]);
+  });
+
+  it("round-trips and does not grow when one field is edited (regression)", () => {
+    const yaml = `mdns:
+  services:
+    - service: aioesphome._tcp.local.
+      protocol: _tcp
+      txt:
+        new_1: fdfd
+`;
+    const v = parseYamlSectionValues(yaml, "mdns", 1) as Record<string, unknown>;
+    // Idempotent: re-emitting the parsed values reproduces the input.
+    expect(updateSectionInYaml(yaml, "mdns", v, 1)).toBe(yaml);
+    // Editing protocol yields exactly one protocol/service line, no growth.
+    (v.services as Record<string, unknown>[])[0].protocol = "_tcpx";
+    const out = updateSectionInYaml(yaml, "mdns", v, 1);
+    expect((out.match(/protocol:/g) ?? []).length).toBe(1);
+    expect((out.match(/service:/g) ?? []).length).toBe(1);
+    expect(out).toContain("protocol: _tcpx");
+  });
+
+  it("heals an already-corrupted item once a field is edited", () => {
+    const corrupt = `mdns:
+  services:
+    - txt:
+        new_1: fdfd
+      protocol: _tcpnewest
+      service: aioesphome._tcp.local.
+      protocol: _tcpolder
+      service: aioesphome._tcp.local.
+`;
+    const v = parseYamlSectionValues(corrupt, "mdns", 1) as Record<string, unknown>;
+    (v.services as Record<string, unknown>[])[0].protocol = "_tcp";
+    const out = updateSectionInYaml(corrupt, "mdns", v, 1);
+    expect(parseYamlSectionValues(out, "mdns", 1).services).toEqual([
+      {
+        txt: { new_1: "fdfd" },
+        protocol: "_tcp",
+        service: "aioesphome._tcp.local.",
+      },
+    ]);
+  });
+
+  it("captures every entry of a multi-key txt map", () => {
+    const yaml = `mdns:
+  services:
+    - service: aioesphome._tcp.local.
+      txt:
+        new_1: fdfd
+        version: "1.0"
+      protocol: _tcp
+`;
+    expect(parseYamlSectionValues(yaml, "mdns", 1).services).toEqual([
+      {
+        service: "aioesphome._tcp.local.",
+        txt: { new_1: "fdfd", version: "1.0" },
+        protocol: "_tcp",
+      },
+    ]);
+  });
+
+  it("parses every item when the first leads with a txt map and a later one does not", () => {
+    // childIndent is derived once from the first dash; a txt-first first item
+    // must not mis-level the sibling columns of a service-first second item.
+    const yaml = `mdns:
+  services:
+    - txt:
+        new_1: fdfd
+      service: a._tcp.local.
+      protocol: _tcp
+    - service: b._tcp.local.
+      protocol: _udp
+`;
+    expect(parseYamlSectionValues(yaml, "mdns", 1).services).toEqual([
+      { txt: { new_1: "fdfd" }, service: "a._tcp.local.", protocol: "_tcp" },
+      { service: "b._tcp.local.", protocol: "_udp" },
+    ]);
+  });
+
+  it("still falls back to YamlRawValue for a nested LIST (automation handler)", () => {
+    const yaml = `mdns:
+  services:
+    - service: aioesphome._tcp.local.
+      on_press:
+        - logger.log: hi
+`;
+    const v = parseYamlSectionValues(yaml, "mdns", 1) as Record<string, unknown>;
+    expect(v.services).toBeInstanceOf(YamlRawValue);
   });
 });

--- a/test/util/yaml-section-values.test.ts
+++ b/test/util/yaml-section-values.test.ts
@@ -1742,11 +1742,10 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
     expect(values.actions).toBeInstanceOf(YamlRawValue);
   });
 
-  it("falls back to YamlRawValue when items have nested mappings under a sub-key", () => {
-    // ``- key:\n      sub_key:`` (sub_key with empty raw, opening
-    // a deeper mapping) carries shape the flat-mapping helper
-    // can't model. The conservative bail-out keeps the block raw
-    // so the deeper content survives a round-trip.
+  it("structures items that have a nested mapping under a sub-key", () => {
+    // ``- key:\n      sub_key:`` (sub_key opening a deeper mapping) is now
+    // captured as a structured item with its nested value, and round-trips
+    // byte-identically, so the field stays editable in the visual form.
     const yaml = `sensor:
   - platform: template
     name: outside_temp
@@ -1756,7 +1755,8 @@ describe("parseYamlSectionValues — list-of-mappings (multi_value=true)", () =>
           delta: 0.5
 `;
     const values = parseYamlSectionValues(yaml, "sensor.template", 2);
-    expect(values.triggers).toBeInstanceOf(YamlRawValue);
+    expect(values.triggers).toEqual([{ id: "my_trigger", filters: { delta: "0.5" } }]);
+    expect(updateSectionInYaml(yaml, "sensor.template", values, 2)).toBe(yaml);
   });
 
   it("parses effects from the #941 reporter's exact YAML shape", () => {


### PR DESCRIPTION
# What does this implement/fix?

Editing a field of an mDNS `services` item that has a `txt:` map duplicated the item's keys on every keystroke; the YAML grew a new `protocol:`/`service:` pair per character, leaving one list item with dozens of repeated keys.

The cause is the nested-list-under-a-key reader. A `services` item with a nested `txt:` map among scalar siblings was mis-parsed three ways; when the `txt:` map came first the parser captured only `txt` and recorded a key span that stopped before `protocol`/`service`, so the splice kept re-emitting the item while the trailing lines survived as residual and accumulated. When the map came last or in the middle the whole block fell back to a read-only raw value.

This fixes the reader so a list item with a nested sub-mapping among scalar keys parses into a complete structured item with the correct span; it anchors the child indent to the dash line's inline key column, parses a nested map under an empty-valued sub-key, and absorbs trailing siblings after a leading nested map. Nested lists (automation handlers) and block scalars still fall back to raw as before. The serializer was already correct, so the block now round-trips byte-identically, the field edits in place, and opening an already-corrupted config and editing one value collapses it back to a single clean item.

**Related issue or feature (if applicable):**

- n/a (reported from the mDNS service editor)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
