### PR TITLE
Align a templatable value inside a map row

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -391,14 +391,35 @@ export const configEntryFormStyles = css`
 
   /* Inside a map row the value's label and description are
      redundant (the map itself has those at the top) — suppress
-     them so each row stays compact. */
+     them so each row stays compact. A templatable value (Value / λ
+     Lambda toggle) nests its field one level deeper under
+     .templatable-field, so match that too or the label re-appears
+     and offsets the input. */
   .map-row .map-value > .field > label,
-  .map-row .map-value > .field > p.field-description {
+  .map-row .map-value > .field > p.field-description,
+  .map-row .map-value > .templatable-field > .field > label,
+  .map-row .map-value > .templatable-field > .field > p.field-description {
     display: none;
   }
 
-  .map-row .map-value > .field {
+  .map-row .map-value > .field,
+  .map-row .map-value > .templatable-field > .field {
     gap: 0;
+  }
+
+  /* A templatable value stacks its Value / λ Lambda toggle above the input
+     (a full-width field column). In a compact map row that drops the input
+     below the toggle and out of line with the key; lay the toggle and input
+     on one row instead so the value aligns with the key input. */
+  .map-row .map-value > .templatable-field {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+  }
+
+  .map-row .map-value > .templatable-field > .field {
+    flex: 1;
+    min-width: 0;
   }
 
   /* "Complex value — edit in YAML" placeholder for map rows whose


### PR DESCRIPTION
# What does this implement/fix?

In a map value editor (for example an mDNS service `txt` record), a value that uses the Value / λ Lambda toggle rendered misaligned; the value input dropped below the toggle and offset to the right, and its redundant "Value" label re-appeared.

The map-row styles only compacted a plain `.field` value (suppress its label and description, collapse its gap). A templatable value nests its field one level deeper under `.templatable-field` (the toggle plus value column), so those rules never reached it. This extends the existing selectors to the templatable case so the value lines up like every other map row.

**Related issue or feature (if applicable):**

- n/a (reported from the mDNS service editor)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
