### PR TITLE
Skip the C++ overlay for an empty lambda value

### DIFF
--- a/src/util/esphome-yaml-lang.ts
+++ b/src/util/esphome-yaml-lang.ts
@@ -16,7 +16,7 @@ import {
   foldNodeProp,
   indentService,
 } from "@codemirror/language";
-import type { Input, SyntaxNodeRef } from "@lezer/common";
+import type { Input, SyntaxNode, SyntaxNodeRef } from "@lezer/common";
 import { parseMixed } from "@lezer/common";
 import { parser as yamlParser } from "@lezer/yaml";
 import { indentOf, stripComment } from "./yaml-line-walker.js";
@@ -39,6 +39,21 @@ const RE_BLOCK_SCALAR_OPENER = /:\s*[|>][+-]?\s*$/;
 export const ESPHOME_YAML_INDENT = "  ";
 
 /**
+ * Document span of a `!lambda` value's C++ content: the Literal as-is, the
+ * QuotedLiteral's interior (inside the quotes), or the BlockLiteralContent.
+ * Null when the Tagged node carries no recognised value node.
+ */
+function lambdaSpan(node: SyntaxNode): { from: number; to: number } | null {
+  const literal = node.getChild("Literal");
+  if (literal) return { from: literal.from, to: literal.to };
+  const quoted = node.getChild("QuotedLiteral");
+  if (quoted) return { from: quoted.from + 1, to: quoted.to - 1 };
+  const content = node.getChild("BlockLiteral")?.getChild("BlockLiteralContent");
+  if (content) return { from: content.from, to: content.to };
+  return null;
+}
+
+/**
  * Mixed parser wrapper: when we encounter a Tagged node whose Tag is
  * `!lambda`, overlay the C++ parser on the value content.
  */
@@ -52,39 +67,12 @@ function nestLambdas(node: SyntaxNodeRef, input: Input) {
   const tagText = input.read(tagNode.from, tagNode.to);
   if (tagText !== LAMBDA_TAG) return null;
 
-  // Find the value node — could be Literal, QuotedLiteral, or BlockLiteral
-  const literal = node.node.getChild("Literal");
-  const quoted = node.node.getChild("QuotedLiteral");
-  const block = node.node.getChild("BlockLiteral");
-
-  if (literal) {
-    // Inline: `!lambda return x;` → overlay the Literal
-    return {
-      parser: cppLanguage.parser,
-      overlay: [{ from: literal.from, to: literal.to }],
-    };
-  }
-
-  if (quoted) {
-    // Quoted: `!lambda 'return x;'` → overlay content inside quotes
-    return {
-      parser: cppLanguage.parser,
-      overlay: [{ from: quoted.from + 1, to: quoted.to - 1 }],
-    };
-  }
-
-  if (block) {
-    // Block: `!lambda |-\n  code` → overlay the BlockLiteralContent
-    const content = block.getChild("BlockLiteralContent");
-    if (content) {
-      return {
-        parser: cppLanguage.parser,
-        overlay: [{ from: content.from, to: content.to }],
-      };
-    }
-  }
-
-  return null;
+  // A just-toggled `!lambda` with no code yet has an empty (or, for a lone
+  // quote, inverted) value span; parseMixed's checkRanges rejects a
+  // non-positive overlay range and throws. Skip until there's content.
+  const span = lambdaSpan(node.node);
+  if (!span || span.from >= span.to) return null;
+  return { parser: cppLanguage.parser, overlay: [span] };
 }
 
 /**

--- a/test/util/esphome-yaml-lang.test.ts
+++ b/test/util/esphome-yaml-lang.test.ts
@@ -196,3 +196,40 @@ describe("esphome-yaml language extension shape", () => {
     expect(flat.length).toBeGreaterThan(0);
   });
 });
+
+describe("esphome-yaml lambda C++ overlay", () => {
+  // Forcing a full parse runs parseMixed; an empty `!lambda` value (the shape
+  // produced the instant the Value/λ Lambda toggle is flipped, before any code
+  // is typed) used to overlay a zero-length C++ range and crash checkRanges.
+  const parse = (yaml: string): void => {
+    const state = EditorState.create({
+      doc: yaml,
+      extensions: [indentUnit.of(ESPHOME_YAML_INDENT), esphomeYaml()],
+    });
+    ensureSyntaxTree(state, state.doc.length);
+  };
+
+  it("does not crash on an empty block lambda", () => {
+    expect(() =>
+      parse("mdns:\n  services:\n    - txt:\n        new_1: !lambda |-\n")
+    ).not.toThrow();
+  });
+
+  it("does not crash on an empty quoted lambda", () => {
+    expect(() =>
+      parse("sensor:\n  - filters:\n      - lambda: !lambda ''\n")
+    ).not.toThrow();
+  });
+
+  it("does not crash on a bare !lambda with no value node", () => {
+    // The instant the toggle flips, before any code is typed, the tag has
+    // no value child at all — lambdaSpan returns null, no overlay.
+    expect(() => parse("x: !lambda\n")).not.toThrow();
+  });
+
+  it("still parses a non-empty block lambda without throwing", () => {
+    expect(() =>
+      parse("light:\n  - on_turn_on:\n      - lambda: !lambda |-\n          return 1;\n")
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The YAML editor crashed (`Invalid inner parse ranges given: [{from:N,to:N}]`) the moment a value was switched to a lambda via the Value / λ Lambda toggle. Flipping the toggle writes an empty `!lambda` (no code yet); the C++ overlay then tried to highlight a zero-length range, and parseMixed's checkRanges rejects an empty overlay range and throws, taking down the editor.

The mixed parser now computes the lambda's value span once and skips the C++ overlay when that span is empty (a just-toggled `!lambda`, an empty quoted `!lambda ''`, or an empty block `!lambda |-`); once real code is typed the overlay applies as before. Added tests that forcing a full parse over each empty-lambda shape no longer throws.

**Related issue or feature (if applicable):**

- n/a (reported from the mDNS service editor while toggling a txt value to lambda)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
