### PR TITLE
Render a lambda map value inline instead of the edit-in-YAML placeholder

### DIFF
--- a/src/components/device/config-entry-renderers/lists.ts
+++ b/src/components/device/config-entry-renderers/lists.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { isLambdaValue } from "../../../api/types/automations.js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../../api/types/config-entries.js";
 import { asMappingList, isPrimitiveOrNullish } from "../../../util/nested-values.js";
@@ -217,12 +218,16 @@ export function renderMapField(entry: ConfigEntry, path: string[], ctx: RenderCt
   };
 
   // Key input commits on blur — committing on every keystroke would re-key
-  // the row mid-edit and steal focus. Non-primitive values render as a
-  // "edit in YAML" placeholder so substitutions carrying arbitrary YAML
-  // aren't stringified to [object Object] and lost on save.
+  // the row mid-edit and steal focus. Complex (non-primitive, non-lambda)
+  // values render as a "edit in YAML" placeholder so substitutions carrying
+  // arbitrary YAML aren't stringified to [object Object] and lost on save.
   const renderRow = (rowKey: string) => {
     const valuePath = [...path, rowKey];
-    const complex = !isPrimitiveOrNullish(map[rowKey]);
+    // A lambda (``!lambda`` object) isn't a structural complex value — it's a
+    // templatable scalar the value template renders inline (lambda mode), so
+    // route it through the template rather than the edit-in-YAML placeholder.
+    const rawValue = map[rowKey];
+    const complex = !isPrimitiveOrNullish(rawValue) && !isLambdaValue(rawValue);
     return html`
       <div class="map-row" data-field-key=${fieldKeyAttr(valuePath)}>
         <input

--- a/test/components/device/render-map-field.test.ts
+++ b/test/components/device/render-map-field.test.ts
@@ -131,6 +131,20 @@ describe("renderMapField (substitutions / logger.logs / etc.)", () => {
     expect(paths).toEqual([["simple"]]);
   });
 
+  it("renders a lambda value inline via the value template (not the placeholder)", () => {
+    // A ``!lambda`` value is an object, but it isn't a structural complex
+    // value — the templatable value template edits it inline (lambda mode),
+    // so it must reach renderEntry rather than the edit-in-YAML placeholder.
+    const values = {
+      simple: "hello",
+      code: { _lambda: "return 1;", _tag: "!lambda" },
+    };
+    const stub = makeCtx(values);
+    renderMapField(makeMapEntry(), [], stub.ctx);
+    const paths = stub.renderEntry.mock.calls.map((c) => c[1]);
+    expect(paths).toEqual([["simple"], ["code"]]);
+  });
+
   it("treats every primitive shape as editable: string, number, boolean, null", () => {
     // Validates that ``isPrimitiveOrNullish`` covers the YAML
     // scalar set ESPHome substitutions surface as.


### PR DESCRIPTION
# What does this implement/fix?

Switching a map value (for example an mDNS service txt record) to a lambda via the Value / λ Lambda toggle made the row fall back to "Complex value — edit in YAML", so the value could no longer be edited inline and the toggle disappeared (no way back to a literal from the visual form).

The map renderer flagged any non-primitive value as complex, which swept up lambda values; a lambda is not a structural complex value (list / dict), it is a templatable scalar the value template already edits inline in lambda mode. Treat a lambda value as not-complex so the row renders the value template (which shows the inline lambda editor and keeps the toggle) instead of the placeholder; genuine lists / dicts still get the edit-in-YAML placeholder.

**Related issue or feature (if applicable):**

- n/a (reported from the mDNS service editor while toggling a txt value to lambda)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
