### PR TITLE
Preserve in-progress form values across the dep detour

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -452,6 +452,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._depDomain = null;
     this._prefillReference = null;
     this._depPrefill = null;
+    this._returnValues = null;
     this._bundleQueue = rest;
     this._bundleProgress = {
       current: 1,
@@ -470,7 +471,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // sending them to the catalog and losing context.
     if (this._returnTo) {
       const restore = this._returnTo;
+      // Back out of the detour like a submit-return: keep the snapshot across
+      // the reset so the user's in-progress values survive on the original
+      // form (the binding reads `_returnValues` with `_returnTo` now null).
+      const snapshot = this._returnValues;
       this._resetDetourState();
+      this._returnValues = snapshot;
       this._selected = restore;
       this._submitError = "";
       return;

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -216,12 +216,19 @@ export class ESPHomeAddComponentDialog extends LitElement {
   /** See ``navigateToDep`` for the seq-counter contract. */
   private _depNavSeq = 0;
 
-  private _resetDetourState() {
+  /** Null every in-flight dep-detour field. Shared with `_onBundleSelected`,
+   *  which abandons the detour but must NOT bump the selection seqs (its
+   *  hydrate already validated against the current token). */
+  private _clearDetourFields() {
     this._returnTo = null;
     this._depDomain = null;
     this._prefillReference = null;
     this._depPrefill = null;
     this._returnValues = null;
+  }
+
+  private _resetDetourState() {
+    this._clearDetourFields();
     this._bundleQueue = [];
     this._bundleProgress = null;
     this._depNavSeq++;
@@ -448,11 +455,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // the `_returnTo` branch in `_onFormSubmit`, restoring the unrelated
     // component while the bundle queue + banner stayed live, and the
     // next submit would jump into bundle step 2 from there.
-    this._returnTo = null;
-    this._depDomain = null;
-    this._prefillReference = null;
-    this._depPrefill = null;
-    this._returnValues = null;
+    this._clearDetourFields();
     this._bundleQueue = rest;
     this._bundleProgress = {
       current: 1,
@@ -627,6 +630,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
           ...this._bundleProgress,
           current: this._bundleProgress.current + 1,
         };
+        // The next bundle step is a fresh component; drop the snapshot from a
+        // detour the prior step took so it can't bleed onto this one.
+        this._returnValues = null;
         this._selected = nextComponent;
       } else {
         // Auto-select the just-added component so the navigator

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -36,6 +36,7 @@ import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 import "../base-dialog.js";
 import "./add-component-form.js";
+import type { ESPHomeAddComponentForm } from "./add-component-form.js";
 import "./component-catalog.js";
 import type { ESPHomeComponentCatalog } from "./component-catalog.js";
 
@@ -93,6 +94,15 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   @query("esphome-component-catalog")
   private _catalog!: ESPHomeComponentCatalog;
+
+  @query("esphome-add-component-form")
+  private _form?: ESPHomeAddComponentForm;
+
+  /** Snapshot of the form's in-progress values, captured when a "+ Add <dep>"
+   *  detour starts and restored when the original form re-mounts, so a field
+   *  the user already filled survives the round-trip. */
+  @state()
+  private _returnValues: Record<string, unknown> | null = null;
 
   @state()
   private _selected: ComponentCatalogEntry | null = null;
@@ -203,6 +213,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._depDomain = null;
     this._prefillReference = null;
     this._depPrefill = null;
+    this._returnValues = null;
     this._bundleQueue = [];
     this._bundleProgress = null;
     this._depNavSeq++;
@@ -302,6 +313,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
               .yaml=${this.yaml}
               .prefillReference=${this._prefillReference}
               .prefillFields=${this._depPrefill?.fields ?? null}
+              .restoredValues=${this._returnTo ? null : this._returnValues}
               .extraRequired=${this._depPrefill?.required ?? null}
               .optionOverrides=${this._depPrefill?.optionOverrides ?? null}
               .submitting=${this._submitting}
@@ -374,6 +386,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       yaml: this.yaml,
       prefillReference: null,
       prefillFields: null,
+      restoredValues: null,
       localize: this._localize,
     });
     if (
@@ -467,6 +480,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   private _onNavigateToDep(e: CustomEvent<{ domain: string }>) {
     e.stopPropagation();
+    // Snapshot what the user has filled before `navigateToDep` swaps
+    // `_selected` and unmounts the form, so it's restored on return.
+    this._returnValues = this._form?.currentValues ?? null;
     return navigateToDep(this as unknown as DepNavHost, e.detail.domain);
   }
 

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -104,6 +104,14 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @state()
   private _returnValues: Record<string, unknown> | null = null;
 
+  /** Restored values for the mounted form: only the *original* component on
+   *  return (`_returnTo` cleared) gets them; the dep's own form during the
+   *  detour (`_returnTo` set) must not, or the dep would inherit the original's
+   *  id and collide. */
+  private get _restoredValuesForMount(): Record<string, unknown> | null {
+    return this._returnTo ? null : this._returnValues;
+  }
+
   @state()
   private _selected: ComponentCatalogEntry | null = null;
 
@@ -313,7 +321,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
               .yaml=${this.yaml}
               .prefillReference=${this._prefillReference}
               .prefillFields=${this._depPrefill?.fields ?? null}
-              .restoredValues=${this._returnTo ? null : this._returnValues}
+              .restoredValues=${this._restoredValuesForMount}
               .extraRequired=${this._depPrefill?.required ?? null}
               .optionOverrides=${this._depPrefill?.optionOverrides ?? null}
               .submitting=${this._submitting}

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -25,6 +25,11 @@ export interface SeedContext {
   yaml: string;
   prefillReference: { domain: string; id: string } | null;
   prefillFields: Record<string, unknown> | null;
+  /** Values the user had entered before a "+ Add <dep>" detour, restored on
+   *  return so a field they already filled (e.g. an SPI device's `cs_pin`)
+   *  isn't lost. Overlaid before `prefillReference` so the just-added dep's id
+   *  still wins for the reference field. */
+  restoredValues: Record<string, unknown> | null;
   localize: LocalizeFunc;
 }
 
@@ -142,8 +147,16 @@ export function seedDefaults(
  *  5. Overlay constraint-derived prefill fields last.
  */
 export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
-  const { entries, component, board, yaml, prefillReference, prefillFields, localize } =
-    ctx;
+  const {
+    entries,
+    component,
+    board,
+    yaml,
+    prefillReference,
+    prefillFields,
+    restoredValues,
+    localize,
+  } = ctx;
 
   // Featured-component entries (ids prefixed with `featured.`) carry
   // backend-baked presets in `default_value` for arbitrary fields,
@@ -172,6 +185,13 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   // "Invalid pin number: 22" squiggle because the bus block
   // falls back to ESP32 GPIO22/21.
   next = seedBoardPinDefaults(component.id, entries, board, next);
+
+  // Restore what the user typed before a "+ Add <dep>" detour, over the freshly
+  // seeded defaults, but before `prefillReference` so the just-added dep's id
+  // still wins for the reference field.
+  if (restoredValues) {
+    next = { ...next, ...restoredValues };
+  }
 
   if (prefillReference) {
     const targetPath = findReferencePath(entries, prefillReference.domain, []);

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -142,9 +142,11 @@ export function seedDefaults(
  *  1. Seed required entries' default values (recursively).
  *  2. Auto-generate a unique `id` for the top-level id field.
  *  3. Seed pin entries from the board manifest.
- *  4. If we were just brought back from a "+ Add <domain>" detour,
+ *  4. Restore the values the user typed before a "+ Add <dep>" detour
+ *     (over the seeded defaults, under the prefills below).
+ *  5. If we were just brought back from a "+ Add <domain>" detour,
  *     prefill the field that points at that domain with the new id.
- *  5. Overlay constraint-derived prefill fields last.
+ *  6. Overlay constraint-derived prefill fields last.
  */
 export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   const {

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -79,6 +79,12 @@ export class ESPHomeAddComponentForm extends LitElement {
   @property({ attribute: false })
   extraRequired: string[] | null = null;
 
+  /** Values the user had entered before a "+ Add <dep>" detour; the dialog
+   *  snapshots them at detour start and hands them back on return so a field
+   *  they already filled (an SPI device's `cs_pin`) survives the round-trip. */
+  @property({ attribute: false })
+  restoredValues: Record<string, unknown> | null = null;
+
   /** Per-field dropdown narrowing the requester imposes via a list
    *  `bus_constraints` value (CN105 -> baud_rate [2400, 9600]); the
    *  matching entry's `options` are limited to these, defaulting first. */
@@ -93,6 +99,12 @@ export class ESPHomeAddComponentForm extends LitElement {
 
   @state()
   private _values: Record<string, unknown> = {};
+
+  /** The in-progress form values, so the dialog can snapshot them before a
+   *  "+ Add <dep>" detour unmounts this form. */
+  get currentValues(): Record<string, unknown> {
+    return this._values;
+  }
 
   @state()
   private _errors: Map<string, ValidationError> = new Map();
@@ -233,6 +245,7 @@ export class ESPHomeAddComponentForm extends LitElement {
       yaml: this.yaml,
       prefillReference: this.prefillReference,
       prefillFields: this.prefillFields,
+      restoredValues: this.restoredValues,
       localize: this._localize,
     });
   }

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -101,9 +101,10 @@ export class ESPHomeAddComponentForm extends LitElement {
   private _values: Record<string, unknown> = {};
 
   /** The in-progress form values, so the dialog can snapshot them before a
-   *  "+ Add <dep>" detour unmounts this form. */
+   *  "+ Add <dep>" detour unmounts this form. A shallow copy so the snapshot
+   *  stays stable if the form keeps editing `_values`. */
   get currentValues(): Record<string, unknown> {
-    return this._values;
+    return { ...this._values };
   }
 
   @state()

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The detour-values snapshot is restored only to the ORIGINAL component on
+ * return, never to the dependency's own form mid-detour, or the dependency
+ * would inherit the original's `id` and collide (the SPI bus taking the
+ * sensor's id).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
+vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+
+interface Internals {
+  _returnTo: unknown;
+  _returnValues: Record<string, unknown> | null;
+  readonly _restoredValuesForMount: Record<string, unknown> | null;
+}
+
+const make = () => new ESPHomeAddComponentDialog() as unknown as Internals;
+
+describe("_restoredValuesForMount", () => {
+  it("withholds values while a detour is in flight (dep form mounting)", () => {
+    const d = make();
+    d._returnValues = { cs_pin: "GPIO5" };
+    d._returnTo = { id: "sensor.atm90e32" };
+    expect(d._restoredValuesForMount).toBeNull();
+  });
+
+  it("restores values once the detour finished (original form re-mounts)", () => {
+    const d = make();
+    d._returnValues = { cs_pin: "GPIO5" };
+    d._returnTo = null;
+    expect(d._restoredValuesForMount).toEqual({ cs_pin: "GPIO5" });
+  });
+
+  it("is null on a fresh open with no snapshot", () => {
+    const d = make();
+    d._returnTo = null;
+    d._returnValues = null;
+    expect(d._restoredValuesForMount).toBeNull();
+  });
+});

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -1,10 +1,10 @@
 /**
  * @vitest-environment happy-dom
  *
- * The detour-values snapshot is restored only to the ORIGINAL component on
- * return, never to the dependency's own form mid-detour, or the dependency
- * would inherit the original's `id` and collide (the SPI bus taking the
- * sensor's id).
+ * Full `_returnValues` (detour value snapshot) lifecycle. The snapshot is
+ * captured when a "+ Add <dep>" detour starts, restored ONLY to the original
+ * component on return, and cleared on every other detour exit so it can't
+ * bleed onto an unrelated form (an id collision being the worst case).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -13,7 +13,9 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
+vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
+import { ComponentCategory } from "../../../src/api/types/components.js";
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
@@ -22,63 +24,125 @@ interface Internals {
   _returnTo: unknown;
   _returnValues: Record<string, unknown> | null;
   _selected: unknown;
-  _submitting: boolean;
-  _api: unknown;
+  _depDomain: string | null;
+  _bundleQueue: string[];
+  _bundleProgress: { current: number; total: number; bundleName: string } | null;
   readonly _restoredValuesForMount: Record<string, unknown> | null;
   _onBack: () => void;
+  _onNavigateToDep: (e: CustomEvent) => Promise<void>;
   _onBundleSelected: (e: CustomEvent) => Promise<void>;
+  _submitComponent: (fields: Record<string, unknown>, notify?: boolean) => Promise<void>;
+  _resetDetourState: () => void;
 }
 
-const make = () => new ESPHomeAddComponentDialog() as unknown as Internals;
+/** Dialog wired with a stub API so `_submitComponent`/detour paths run. */
+function makeDialog() {
+  const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });
+  const getComponentBodies = vi.fn().mockResolvedValue({});
+  const dialog = new ESPHomeAddComponentDialog();
+  Object.assign(dialog as unknown as Record<string, unknown>, {
+    _api: { addComponent, getComponentBodies },
+  });
+  dialog.configuration = "foo.yaml";
+  dialog.yaml = "esphome:\n  name: foo\n";
+  return { d: dialog as unknown as Internals, addComponent, getComponentBodies };
+}
+
+/** Override the `@query` `_form` getter for capture tests. */
+function setForm(
+  d: Internals,
+  form: { currentValues: Record<string, unknown> } | undefined
+) {
+  Object.defineProperty(d, "_form", { value: form, configurable: true });
+}
 
 afterEach(() => {
   _clearComponentCache();
   vi.clearAllMocks();
 });
 
-describe("_restoredValuesForMount", () => {
+describe("_restoredValuesForMount gate", () => {
   it("withholds values while a detour is in flight (dep form mounting)", () => {
-    const d = make();
+    const { d } = makeDialog();
     d._returnValues = { cs_pin: "GPIO5" };
     d._returnTo = { id: "sensor.atm90e32" };
     expect(d._restoredValuesForMount).toBeNull();
   });
 
   it("restores values once the detour finished (original form re-mounts)", () => {
-    const d = make();
+    const { d } = makeDialog();
     d._returnValues = { cs_pin: "GPIO5" };
     d._returnTo = null;
     expect(d._restoredValuesForMount).toEqual({ cs_pin: "GPIO5" });
   });
 
   it("is null on a fresh open with no snapshot", () => {
-    const d = make();
+    const { d } = makeDialog();
     d._returnTo = null;
     d._returnValues = null;
     expect(d._restoredValuesForMount).toBeNull();
   });
 });
 
-describe("_returnValues lifecycle across detour exits", () => {
-  it("preserves the snapshot when backing out of the detour", () => {
-    const d = make();
+describe("_returnValues capture (_onNavigateToDep)", () => {
+  it("snapshots the form's in-progress values before the form unmounts", async () => {
+    const { d, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({ spi: makeComponentEntry("spi") });
+    setForm(d, { currentValues: { cs_pin: "GPIO5", line_frequency: "60HZ" } });
+    // Capture is synchronous, before `navigateToDep` swaps `_selected`.
+    const p = d._onNavigateToDep(
+      new CustomEvent("navigate-to-dep", { detail: { domain: "spi" } })
+    );
+    expect(d._returnValues).toEqual({ cs_pin: "GPIO5", line_frequency: "60HZ" });
+    await p;
+  });
+
+  it("snapshots null when no form is mounted", async () => {
+    const { d, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({ spi: makeComponentEntry("spi") });
+    d._returnValues = { stale: 1 };
+    setForm(d, undefined);
+    const p = d._onNavigateToDep(
+      new CustomEvent("navigate-to-dep", { detail: { domain: "spi" } })
+    );
+    expect(d._returnValues).toBeNull();
+    await p;
+  });
+});
+
+describe("_returnValues across detour exits", () => {
+  it("submit-return leaves the snapshot set so the restored form reads it", async () => {
+    const { d } = makeDialog();
+    const original = makeComponentEntry("sensor.atm90e32", { name: "ATM90E32" });
+    const dep = makeComponentEntry("spi", { category: ComponentCategory.BUS });
+    d._selected = dep;
+    d._returnTo = original;
+    d._depDomain = "spi";
+    d._returnValues = { cs_pin: "GPIO5" };
+
+    await d._submitComponent({ id: "spi_1" });
+
+    expect(d._selected).toBe(original);
+    expect(d._returnTo).toBeNull();
+    expect(d._returnValues).toEqual({ cs_pin: "GPIO5" });
+  });
+
+  it("back-out preserves the snapshot and restores the original form", () => {
+    const { d } = makeDialog();
     const original = { id: "sensor.atm90e32" };
     d._returnTo = original;
     d._returnValues = { cs_pin: "GPIO5" };
 
     d._onBack();
 
-    // Back is treated like a submit-return: original re-mounts with its input.
     expect(d._selected).toBe(original);
     expect(d._returnValues).toEqual({ cs_pin: "GPIO5" });
   });
 
-  it("clears the snapshot when a bundle is picked mid-detour", async () => {
+  it("picking a bundle mid-detour clears the snapshot", async () => {
     const first = makeComponentEntry("featured.bw15.x", { name: "X" });
-    const d = make();
-    d._api = {
-      getComponentBodies: vi.fn().mockResolvedValue({ "featured.bw15.x": first }),
-    };
+    const { d, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({ "featured.bw15.x": first });
     d._returnValues = { cs_pin: "GPIO5" };
 
     await d._onBundleSelected(
@@ -87,6 +151,31 @@ describe("_returnValues lifecycle across detour exits", () => {
       })
     );
 
+    expect(d._returnValues).toBeNull();
+  });
+
+  it("bundle-advance clears the snapshot so it can't bleed onto the next step", async () => {
+    const step2 = makeComponentEntry("featured.bw15.b", { name: "B" });
+    const { d, getComponentBodies } = makeDialog();
+    getComponentBodies.mockResolvedValue({ "featured.bw15.b": step2 });
+    d._selected = makeComponentEntry("output.gpio", {
+      category: ComponentCategory.OUTPUT,
+    });
+    d._returnTo = null;
+    d._bundleQueue = ["featured.bw15.b"];
+    d._bundleProgress = { current: 1, total: 2, bundleName: "Bundle" };
+    d._returnValues = { cs_pin: "GPIO5" };
+
+    await d._submitComponent({ id: "gpio_1" });
+
+    expect(d._selected).toBe(step2);
+    expect(d._returnValues).toBeNull();
+  });
+
+  it("_resetDetourState clears the snapshot", () => {
+    const { d } = makeDialog();
+    d._returnValues = { cs_pin: "GPIO5" };
+    d._resetDetourState();
     expect(d._returnValues).toBeNull();
   });
 });

--- a/test/components/device/add-component-dialog-restore-values.test.ts
+++ b/test/components/device/add-component-dialog-restore-values.test.ts
@@ -6,7 +6,7 @@
  * would inherit the original's `id` and collide (the SPI bus taking the
  * sensor's id).
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -15,14 +15,26 @@ vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 interface Internals {
   _returnTo: unknown;
   _returnValues: Record<string, unknown> | null;
+  _selected: unknown;
+  _submitting: boolean;
+  _api: unknown;
   readonly _restoredValuesForMount: Record<string, unknown> | null;
+  _onBack: () => void;
+  _onBundleSelected: (e: CustomEvent) => Promise<void>;
 }
 
 const make = () => new ESPHomeAddComponentDialog() as unknown as Internals;
+
+afterEach(() => {
+  _clearComponentCache();
+  vi.clearAllMocks();
+});
 
 describe("_restoredValuesForMount", () => {
   it("withholds values while a detour is in flight (dep form mounting)", () => {
@@ -44,5 +56,37 @@ describe("_restoredValuesForMount", () => {
     d._returnTo = null;
     d._returnValues = null;
     expect(d._restoredValuesForMount).toBeNull();
+  });
+});
+
+describe("_returnValues lifecycle across detour exits", () => {
+  it("preserves the snapshot when backing out of the detour", () => {
+    const d = make();
+    const original = { id: "sensor.atm90e32" };
+    d._returnTo = original;
+    d._returnValues = { cs_pin: "GPIO5" };
+
+    d._onBack();
+
+    // Back is treated like a submit-return: original re-mounts with its input.
+    expect(d._selected).toBe(original);
+    expect(d._returnValues).toEqual({ cs_pin: "GPIO5" });
+  });
+
+  it("clears the snapshot when a bundle is picked mid-detour", async () => {
+    const first = makeComponentEntry("featured.bw15.x", { name: "X" });
+    const d = make();
+    d._api = {
+      getComponentBodies: vi.fn().mockResolvedValue({ "featured.bw15.x": first }),
+    };
+    d._returnValues = { cs_pin: "GPIO5" };
+
+    await d._onBundleSelected(
+      new CustomEvent("add-bundle", {
+        detail: { bundle: { name: "B", component_ids: ["x"] }, boardId: "bw15" },
+      })
+    );
+
+    expect(d._returnValues).toBeNull();
   });
 });

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -239,6 +239,7 @@ describe("buildInitialValues", () => {
       yaml: "sensor:\n  - platform: bme280\n    id: sensor_bme280_1\n",
       prefillReference: null,
       prefillFields: null,
+      restoredValues: null,
       localize,
     });
     // _1 is taken in the YAML, so the generator skips to _2.
@@ -263,6 +264,7 @@ describe("buildInitialValues", () => {
       yaml: "",
       prefillReference: null,
       prefillFields: null,
+      restoredValues: null,
       localize,
     });
     expect(values.id).toBe("preset_id");
@@ -286,6 +288,7 @@ describe("buildInitialValues", () => {
       yaml: "",
       prefillReference: null,
       prefillFields: { baud_rate: "2400" },
+      restoredValues: null,
       localize,
     });
     expect(values.baud_rate).toBe("2400");
@@ -302,8 +305,32 @@ describe("buildInitialValues", () => {
       yaml: "",
       prefillReference: { domain: "i2c", id: "bus_a" },
       prefillFields: null,
+      restoredValues: null,
       localize,
     });
+    expect(values.i2c_id).toBe("bus_a");
+  });
+
+  it("restores pre-detour values but lets prefillReference win for the ref field", () => {
+    const component = makeComponent({
+      config_entries: [
+        makeConfigEntry({ key: "cs_pin", type: ConfigEntryType.PIN }),
+        makeConfigEntry({ key: "i2c_id", references_component: "i2c" }),
+      ],
+    });
+    const values = buildInitialValues({
+      entries: component.config_entries,
+      component,
+      board: null,
+      yaml: "",
+      prefillReference: { domain: "i2c", id: "bus_a" },
+      prefillFields: null,
+      restoredValues: { cs_pin: "GPIO5", i2c_id: "stale" },
+      localize,
+    });
+    // The pin the user picked before the "+ Add i2c" detour is preserved.
+    expect(values.cs_pin).toBe("GPIO5");
+    // The just-added bus id still wins over the restored (empty) reference.
     expect(values.i2c_id).toBe("bus_a");
   });
 
@@ -326,6 +353,7 @@ describe("buildInitialValues", () => {
       yaml: "",
       prefillReference: null,
       prefillFields: null,
+      restoredValues: null,
       localize,
     });
     // Board's i2c_scl/i2c_sda feature tags win over the symbolic


### PR DESCRIPTION
# What does this implement/fix?

When you fill some fields in the Add-component form (an SPI device's `cs_pin`, line frequency, etc.) and then click "+ Add <bus>" to add a missing dependency, returning to the form wiped everything you had typed; the form re-mounts and re-seeds from scratch, carrying back only the new dependency's id reference.

This snapshots the form's in-progress values when a "+ Add <dep>" detour starts (in the dialog, before the form unmounts) and overlays them on return via a new `restoredValues` step in `buildInitialValues`. The overlay lands after the seeded defaults and before `prefillReference`, so what you typed survives while the just-added dependency's id still wins for the reference field. The snapshot is only applied to the original form on return, not to the dependency's own form during the detour, so the dependency keeps its own auto-generated id (no id collision).

This is the input-preservation half; the separate stale-pin-display issue (a pin select showing a value it never held after a detour) is fixed in esphome/device-builder-frontend#990.

**Related issue or feature (if applicable):**

- n/a (found in testing the bus-dependency add flow)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
