### PR TITLE
Clear a stale pin select when its value is unset

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -516,10 +516,15 @@ export class ESPHomeConfigEntryForm extends LitElement {
       "wa-option[selected]"
     );
     const desired = selectedOption?.value ?? "";
-    if (!desired) return;
     const current = Array.isArray(select.value)
       ? (select.value[0] ?? "")
       : (select.value ?? "");
+    // Sync to the `?selected` option, INCLUDING the empty case: a pin select
+    // whose value is unset must clear, not keep a stale `.value`. The same
+    // pin-select DOM node is reused across a dep detour (atm90e32 -> spi ->
+    // atm90e32), so without this the CS Pin would keep showing the SPI Clk
+    // Pin's GPIO. The unit picker always has a default unit `?selected`, so it
+    // never hits the empty branch.
     if (current !== desired) {
       select.value = desired;
     }

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -523,8 +523,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
     // whose value is unset must clear, not keep a stale `.value`. The same
     // pin-select DOM node is reused across a dep detour (atm90e32 -> spi ->
     // atm90e32), so without this the CS Pin would keep showing the SPI Clk
-    // Pin's GPIO. The unit picker always has a default unit `?selected`, so it
-    // never hits the empty branch.
+    // Pin's GPIO. The other `data-no-value-sync` selects always render a
+    // `?selected` option (the unit pickers keep the in-use unit; exclusive
+    // group selects a non-empty placeholder sentinel), so only the pin select
+    // reaches the empty branch.
     if (current !== desired) {
       select.value = desired;
     }

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -8,8 +8,8 @@ import {
   type RenderCtx,
 } from "../config-entry-renderers-shared.js";
 
-// Non-empty sentinel so _syncSelectedAttr (which no-ops on "") still
-// selects the placeholder on first paint; mapped back to "" in onChange.
+// Non-empty sentinel so the group always has a `?selected` option for
+// _syncSelectedAttr to push on first paint; mapped back to "" in onChange.
 const NO_SELECTION = "__none__";
 
 // Fold each exclusive_group to its member array at its first member's slot;

--- a/test/components/device/config-entry-form-pin-sync.test.ts
+++ b/test/components/device/config-entry-form-pin-sync.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * `_syncSelectedAttr` drives the `data-no-value-sync` selects (pin pickers,
+ * unit pickers) off their `?selected` option. The pin select DOM node is
+ * reused across a "+ Add <dep>" detour, so an unset pin must CLEAR rather
+ * than keep the stale `.value` that bled in from the dep's own form.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
+
+interface FakeSelect {
+  value: string;
+  querySelector: (sel: string) => { value: string } | null;
+}
+
+function syncSelectedAttr(select: FakeSelect): Promise<void> {
+  const form = new ESPHomeConfigEntryForm();
+  return (
+    form as unknown as { _syncSelectedAttr: (s: FakeSelect) => Promise<void> }
+  )._syncSelectedAttr(select);
+}
+
+describe("_syncSelectedAttr", () => {
+  it("clears a stale value when no option is selected", async () => {
+    // No `wa-option[selected]` => the field's value is unset => clear.
+    const select: FakeSelect = { value: "GPIO18", querySelector: () => null };
+    await syncSelectedAttr(select);
+    expect(select.value).toBe("");
+  });
+
+  it("syncs to the selected option's value", async () => {
+    const select: FakeSelect = {
+      value: "",
+      querySelector: () => ({ value: "GPIO5" }),
+    };
+    await syncSelectedAttr(select);
+    expect(select.value).toBe("GPIO5");
+  });
+
+  it("leaves an already-correct value untouched", async () => {
+    let writes = 0;
+    let current = "GPIO5";
+    const select = {
+      get value() {
+        return current;
+      },
+      set value(v: string) {
+        current = v;
+        writes++;
+      },
+      querySelector: () => ({ value: "GPIO5" }),
+    };
+    await syncSelectedAttr(select as unknown as FakeSelect);
+    expect(current).toBe("GPIO5");
+    expect(writes).toBe(0);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adding a bus device (e.g. an `atm90e32` sensor), clicking "+ Add spi" to add the bus, then returning left the required CS Pin select showing a GPIO it never actually held; the Add button stayed greyed out because the value was never in form state. The same pin select DOM node is reused across the detour (sensor to spi to sensor), so the CS Pin kept displaying the SPI Clk Pin's GPIO that bled in from the detour.

The pin select opts out of the generic value sync (`data-no-value-sync`) and runs `_syncSelectedAttr`, which bailed when no option was `selected`; that left the stale `.value` in place. It now syncs to the selected option including the empty case, so a pin whose value is unset clears to empty. The unit picker (the other `data-no-value-sync` user) always has a default unit selected, so it never hits the empty branch.

**Related issue or feature (if applicable):**

- n/a (found in testing the bus-dependency add flow)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
