### PR TITLE
Recognize the renamed rp2 platform key in raw-YAML surfaces

### DIFF
--- a/src/components/device/navigator-row-icons.ts
+++ b/src/components/device/navigator-row-icons.ts
@@ -131,6 +131,8 @@ const DOMAIN_ICON: Record<string, readonly [string, string]> = {
   esp32: ["cpu-32-bit", mdiCpu32Bit],
   esp8266: ["cpu-32-bit", mdiCpu32Bit],
   rp2040: ["cpu-32-bit", mdiCpu32Bit],
+  // esphome#17145 renames the rp2040 platform key to rp2
+  rp2: ["cpu-32-bit", mdiCpu32Bit],
   bk72xx: ["cpu-32-bit", mdiCpu32Bit],
   rtl87xx: ["cpu-32-bit", mdiCpu32Bit],
   ln882x: ["cpu-32-bit", mdiCpu32Bit],

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -528,7 +528,6 @@
       "esp8266": "ESP8266",
       "rp2040": "RP2040",
       "rp2350": "RP2350",
-      "rp2": "RP2",
       "bk72xx": "BK72xx",
       "rtl87xx": "RTL87xx",
       "compact": "Compact",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -528,6 +528,7 @@
       "esp8266": "ESP8266",
       "rp2040": "RP2040",
       "rp2350": "RP2350",
+      "rp2": "RP2",
       "bk72xx": "BK72xx",
       "rtl87xx": "RTL87xx",
       "compact": "Compact",

--- a/src/util/yaml-sections.ts
+++ b/src/util/yaml-sections.ts
@@ -52,6 +52,8 @@ export const CORE_KEYS = new Set([
   "esp32",
   "esp8266",
   "rp2040",
+  // esphome#17145 renames the rp2040 platform key to rp2; keep both
+  "rp2",
   "bk72xx",
   "rtl87xx",
   "ln882x",

--- a/test/components/device/navigator-row-icons.test.ts
+++ b/test/components/device/navigator-row-icons.test.ts
@@ -64,6 +64,8 @@ describe("iconForDomain", () => {
       "esp32",
       "esp8266",
       "rp2040",
+      // esphome#17145 renames the rp2040 platform key to rp2
+      "rp2",
       "bk72xx",
       "rtl87xx",
       "ln882x",

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -500,6 +500,13 @@ describe("categorizeSections", () => {
     expect(components.map((s) => s.key)).toEqual(["sensor", "switch"]);
   });
 
+  it("puts the renamed rp2 platform block into core", () => {
+    // esphome#17145 renames the rp2040 platform key to rp2; both
+    // belong under Core, not Components.
+    const { core } = categorizeSections([mk("rp2"), mk("rp2040")]);
+    expect(core.map((s) => s.key)).toEqual(["rp2", "rp2040"]);
+  });
+
   it("splits a mixed list across all three buckets", () => {
     const result = categorizeSections([mk("esphome"), mk("sensor"), mk("script")]);
     expect(result.core.map((s) => s.key)).toEqual(["esphome"]);


### PR DESCRIPTION
# What does this implement/fix?

ESPHome is renaming the `rp2040` target platform to `rp2` (esphome/esphome#17145), and the legacy `rp2040:` key stays as a deprecated alias, so a user's YAML may now use either `rp2:` or `rp2040:`. The backend folds `rp2` onto `rp2040` everywhere it ingests a platform string (esphome/device-builder#1704), so device-list driven UI keeps showing `rp2040`. The remaining gaps are the few surfaces that parse the user's raw `rp2:` YAML block client-side:

- `CORE_KEYS` (yaml-sections): a `rp2:` block now lands under Core in the editor navigator instead of Components.
- The navigator row icon map keeps the 32-bit MCU chip glyph for a `rp2:` section.

The catalog-driven wizard and component-validation paths need no change here: the board and component catalogs stay keyed on `rp2040` until the coordinated esphome bump, so both sides stay consistent.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1695

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

