### PR TITLE
Hide already-present single-instance featured components

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -12,6 +12,7 @@ import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
+import { buildFeaturedId } from "../../util/featured-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -431,8 +432,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
     if (this._submitting) return;
     const { bundle, boardId } = e.detail;
     if (!boardId || bundle.component_ids.length === 0) return;
-    const fullIds = bundle.component_ids.map(
-      (localId) => `featured.${boardId}.${localId}`
+    const fullIds = bundle.component_ids.map((localId) =>
+      buildFeaturedId(boardId, localId)
     );
     const [first, ...rest] = fullIds;
     // Same selection guard as `_onComponentSelected`; a quick

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -50,7 +50,8 @@ export function visibleComponents(
   const featuredRefId = new Map<string, string>();
   const board = host.board;
   if (board) {
-    for (const fc of board.featured_components) {
+    // Slim board entries omit featured_components; guard like the catalog's load().
+    for (const fc of board.featured_components ?? []) {
       featuredRefId.set(buildFeaturedId(board.id, fc.id), fc.component_id);
     }
   }

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { platformSupported } from "../../../util/config-validation.js";
+import { buildFeaturedId } from "../../../util/featured-id.js";
 import {
   parseConfiguredPlatforms,
   parseTopLevelComponents,
@@ -23,7 +24,9 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 //  2. Single-instance components already in the YAML get hidden.
 //     - bare top-level (`web_server`, `wifi`) → match presence of `<id>:`
 //     - platform variant (`time.homeassistant`) → match `<domain>.<platform>`
-//     Multi-conf components always stay visible.
+//     Multi-conf components always stay visible. Featured entries carry a
+//     synthetic `featured.<board>.<localId>` id, so match them by their
+//     underlying `component_id` (e.g. an Onboard Ethernet card → `ethernet`).
 //  3. Core-locked: drop platform variants whose dependencies can't be
 //     satisfied from this dialog. A dep counts as satisfied when it's
 //     already in the user's YAML OR one of the platform-compatible IDs in
@@ -43,11 +46,21 @@ export function visibleComponents(
     ? new Set(platformCompatible.map((c) => c.id))
     : null;
 
+  // Map a featured card's synthetic id back to the component it actually adds.
+  const featuredRefId = new Map<string, string>();
+  const board = host.board;
+  if (board) {
+    for (const fc of board.featured_components) {
+      featuredRefId.set(buildFeaturedId(board.id, fc.id), fc.component_id);
+    }
+  }
+
   return platformCompatible.filter((c) => {
+    const refId = featuredRefId.get(c.id) ?? c.id;
     if (!c.multi_conf) {
-      if (c.id.includes(".")) {
-        if (presentPlatforms.has(c.id)) return false;
-      } else if (present.has(c.id)) {
+      if (refId.includes(".")) {
+        if (presentPlatforms.has(refId)) return false;
+      } else if (present.has(refId)) {
         return false;
       }
     }

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,6 +1,11 @@
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
 
+/** Compose the catalog id for a board's featured entry from its board and local ids. */
+export function buildFeaturedId(boardId: string, localId: string): string {
+  return `${FEATURED_ID_PREFIX}${boardId}.${localId}`;
+}
+
 /** True when a catalog id carries the `featured.` prefix; only the prefix is checked, not the full shape. */
 export function isFeaturedId(id: string): boolean {
   return id.startsWith(FEATURED_ID_PREFIX);

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { BoardCatalogEntry } from "../../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../../src/api/types/components.js";
 import type { ESPHomeComponentCatalog } from "../../../../src/components/device/component-catalog.js";
 import { visibleComponents } from "../../../../src/components/device/component-catalog/filters.js";
@@ -6,11 +7,12 @@ import { visibleComponents } from "../../../../src/components/device/component-c
 function entry(
   id: string,
   supported_platforms: string[] = [],
-  dependencies: string[] = []
+  dependencies: string[] = [],
+  multi_conf = true
 ): ComponentCatalogEntry {
   return {
     id,
-    multi_conf: true,
+    multi_conf,
     dependencies,
     supported_platforms,
   } as unknown as ComponentCatalogEntry;
@@ -19,13 +21,22 @@ function entry(
 function host(
   components: ComponentCatalogEntry[],
   platform: string,
-  lockedCategories: string[] = []
+  {
+    lockedCategories = [],
+    yaml = "",
+    board = null,
+  }: {
+    lockedCategories?: string[];
+    yaml?: string;
+    board?: BoardCatalogEntry | null;
+  } = {}
 ): ESPHomeComponentCatalog {
   return {
     _components: components,
     platform,
-    yaml: "",
+    yaml,
     lockedCategories,
+    board,
   } as unknown as ESPHomeComponentCatalog;
 }
 
@@ -58,7 +69,29 @@ describe("visibleComponents platform gate", () => {
       entry("dep.bk72xx", ["bk72xx"]),
       entry("time.foo", [], ["dep.bk72xx"]),
     ];
-    const ids = visibleComponents(host(locked, "esp32", ["core"])).map((c) => c.id);
+    const ids = visibleComponents(
+      host(locked, "esp32", { lockedCategories: ["core"] })
+    ).map((c) => c.id);
     expect(ids).toEqual([]);
+  });
+});
+
+describe("visibleComponents featured present-filter", () => {
+  const board = {
+    id: "esp32-poe-iso",
+    featured_components: [{ id: "onboard_ethernet", component_id: "ethernet" }],
+  } as unknown as BoardCatalogEntry;
+  const featured = entry("featured.esp32-poe-iso.onboard_ethernet", [], [], false);
+
+  it("hides a featured single-instance component already in the YAML", () => {
+    const ids = visibleComponents(
+      host([featured], "esp32", { yaml: "ethernet:\n  type: LAN8720\n", board })
+    ).map((c) => c.id);
+    expect(ids).toEqual([]);
+  });
+
+  it("keeps the featured component when its target is not configured", () => {
+    const ids = visibleComponents(host([featured], "esp32", { board })).map((c) => c.id);
+    expect(ids).toEqual(["featured.esp32-poe-iso.onboard_ethernet"]);
   });
 });

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -94,4 +94,18 @@ describe("visibleComponents featured present-filter", () => {
     const ids = visibleComponents(host([featured], "esp32", { board })).map((c) => c.id);
     expect(ids).toEqual(["featured.esp32-poe-iso.onboard_ethernet"]);
   });
+
+  it("keeps a multi-conf featured component whose target is already present", () => {
+    // multi_conf components can be added repeatedly, so resolving the real id
+    // must not hide them even when a matching block exists.
+    const multiBoard = {
+      id: "demo",
+      featured_components: [{ id: "relay", component_id: "switch.gpio" }],
+    } as unknown as BoardCatalogEntry;
+    const multi = entry("featured.demo.relay", [], [], true);
+    const ids = visibleComponents(
+      host([multi], "esp32", { yaml: "switch:\n  - platform: gpio\n", board: multiBoard })
+    ).map((c) => c.id);
+    expect(ids).toEqual(["featured.demo.relay"]);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

On a board whose YAML already has a single-instance component configured, the picker's Recommended tab still offered the curated featured card for it; for example an Olimex ESP32-PoE-ISO with `ethernet:` already set still showed the "Onboard Ethernet" recommendation with an Add button, and adding it again is invalid.

Featured cards are materialised with a synthetic `featured.<board>.<localId>` id that overwrites the real component id, so the single-instance present-check in `visibleComponents` tested the synthetic id and never matched `ethernet:` in the YAML. The board already carries `featured_components` with `{ id, component_id }`, so this resolves the synthetic id back to its real `component_id` before the present-check; the regular catalog already hid these, now the Recommended tab does too.

Also adds a `buildFeaturedId` helper to the existing featured-id util and routes the bundle-add path through it, so the `featured.<board>.<local>` shape lives in one place instead of being hand-rolled.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
