### PR TITLE
Collect multi_value nested lists so usb_uart channels submit

### DIFF
--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -1,7 +1,7 @@
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { coerceIntFieldValue } from "../../util/int-input.js";
-import { asMappingList } from "../../util/nested-values.js";
+import { asMappingList, asRecord } from "../../util/nested-values.js";
 import { parseYamlBoolean } from "../../util/yaml-serialize.js";
 
 /**
@@ -21,22 +21,18 @@ export function coerceFields(
     const raw = values[entry.key];
 
     if (entry.type === ConfigEntryType.NESTED) {
-      // multi_value NESTED is a repeatable list of mappings (usb_uart
-      // channels, esphome.devices/areas): coerce each item and keep the
-      // array; without this the field is silently dropped from the
-      // payload and the backend rejects the required field.
+      const childEntries = entry.config_entries ?? [];
+      // multi_value NESTED is a repeatable list of mappings; without
+      // coercing each item the required field is dropped from the payload
+      // and the backend rejects it.
       if (entry.multi_value) {
         const items = asMappingList(raw)
-          .map((item) => coerceFields(entry.config_entries ?? [], item))
+          .map((item) => coerceFields(childEntries, item))
           .filter((item) => Object.keys(item).length > 0);
         if (items.length > 0) out[entry.key] = items;
         continue;
       }
-      const childValues =
-        raw !== null && typeof raw === "object" && !Array.isArray(raw)
-          ? (raw as Record<string, unknown>)
-          : {};
-      const sub = coerceFields(entry.config_entries ?? [], childValues);
+      const sub = coerceFields(childEntries, asRecord(raw));
       if (Object.keys(sub).length > 0) out[entry.key] = sub;
       continue;
     }

--- a/src/components/device/add-component-form-coerce.ts
+++ b/src/components/device/add-component-form-coerce.ts
@@ -1,6 +1,7 @@
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import { coerceIntFieldValue } from "../../util/int-input.js";
+import { asMappingList } from "../../util/nested-values.js";
 import { parseYamlBoolean } from "../../util/yaml-serialize.js";
 
 /**
@@ -20,6 +21,17 @@ export function coerceFields(
     const raw = values[entry.key];
 
     if (entry.type === ConfigEntryType.NESTED) {
+      // multi_value NESTED is a repeatable list of mappings (usb_uart
+      // channels, esphome.devices/areas): coerce each item and keep the
+      // array; without this the field is silently dropped from the
+      // payload and the backend rejects the required field.
+      if (entry.multi_value) {
+        const items = asMappingList(raw)
+          .map((item) => coerceFields(entry.config_entries ?? [], item))
+          .filter((item) => Object.keys(item).length > 0);
+        if (items.length > 0) out[entry.key] = items;
+        continue;
+      }
       const childValues =
         raw !== null && typeof raw === "object" && !Array.isArray(raw)
           ? (raw as Record<string, unknown>)

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -81,3 +81,50 @@ describe("coerceFields nested entity readings", () => {
     expect(coerceFields([tvoc], { tvoc: {} })).toEqual({});
   });
 });
+
+describe("coerceFields multi_value nested list (usb_uart channels)", () => {
+  const channels = makeConfigEntry({
+    key: "channels",
+    type: ConfigEntryType.NESTED,
+    multi_value: true,
+    required: true,
+    config_entries: [
+      makeConfigEntry({ key: "id", type: ConfigEntryType.ID, required: true }),
+      makeConfigEntry({
+        key: "baud_rate",
+        type: ConfigEntryType.INTEGER,
+        required: true,
+      }),
+    ],
+  });
+
+  test("a populated channels list survives with its baud_rate coerced to a number", () => {
+    expect(
+      coerceFields([channels], { channels: [{ id: "usb_cdc_0", baud_rate: "4800" }] })
+    ).toEqual({ channels: [{ id: "usb_cdc_0", baud_rate: 4800 }] });
+  });
+
+  test("multiple channels round-trip in order", () => {
+    expect(
+      coerceFields([channels], {
+        channels: [
+          { id: "usb_cdc_0", baud_rate: "4800" },
+          { id: "usb_cdc_1", baud_rate: "9600" },
+        ],
+      })
+    ).toEqual({
+      channels: [
+        { id: "usb_cdc_0", baud_rate: 4800 },
+        { id: "usb_cdc_1", baud_rate: 9600 },
+      ],
+    });
+  });
+
+  test("an empty list drops out of the payload", () => {
+    expect(coerceFields([channels], { channels: [] })).toEqual({});
+  });
+
+  test("a list of only-empty items drops out of the payload", () => {
+    expect(coerceFields([channels], { channels: [{}] })).toEqual({});
+  });
+});

--- a/test/components/device/add-component-form-coerce.test.ts
+++ b/test/components/device/add-component-form-coerce.test.ts
@@ -104,22 +104,6 @@ describe("coerceFields multi_value nested list (usb_uart channels)", () => {
     ).toEqual({ channels: [{ id: "usb_cdc_0", baud_rate: 4800 }] });
   });
 
-  test("multiple channels round-trip in order", () => {
-    expect(
-      coerceFields([channels], {
-        channels: [
-          { id: "usb_cdc_0", baud_rate: "4800" },
-          { id: "usb_cdc_1", baud_rate: "9600" },
-        ],
-      })
-    ).toEqual({
-      channels: [
-        { id: "usb_cdc_0", baud_rate: 4800 },
-        { id: "usb_cdc_1", baud_rate: 9600 },
-      ],
-    });
-  });
-
   test("an empty list drops out of the payload", () => {
     expect(coerceFields([channels], { channels: [] })).toEqual({});
   });


### PR DESCRIPTION
# What does this implement/fix?

Adding the USB Host UART Interface (`usb_uart`) component through the Add component dialog failed with `invalid_args: Missing required field: Channels` even after filling in the Type and a channel row (ID, Baud Rate).

Channels is a repeatable list of mappings, modeled like `esphome.devices` / `esphome.areas` as a `NESTED` entry with `multi_value: true`. The renderer drew the list and validation passed it, but `coerceFields` only coerced the single map NESTED case; an array value fell back to `{}`, produced an empty result, and the field was never added to the WS payload, so the backend rejected the missing required field. This coerces each item of a `multi_value` NESTED entry and keeps the array, reusing the existing `asMappingList` helper so render, validate, and collect all share one list coercion. Empty lists and empty items still prune out, and inner scalars (baud_rate) coerce to numbers.

**Related issue or feature (if applicable):**

- fixes https://community.home-assistant.io/t/setting-up-component-usb-host-uart-interface-for-device-esp32-s2-devkitc-1-does-not-work/1015007

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
