### PR TITLE
Seed only preset fields in the featured add form

### DIFF
--- a/src/api/types/config-entries.ts
+++ b/src/api/types/config-entries.ts
@@ -168,6 +168,14 @@ export interface ConfigEntry {
    * whose pin can land on one of a few GPIOs.
    */
   suggestions: ConfigPrimitive[] | null;
+  /**
+   * Backend-baked, only on materialised featured-component entries. True
+   * when this field carries a board-side preset value (locked, suggestion,
+   * or plain). The add form seeds `required` + `from_preset` fields but
+   * leaves plain optional catalog defaults unseeded, so a featured add
+   * emits the preset fields rather than every catalog default.
+   */
+  from_preset?: boolean;
 
   // === conditional visibility ===
   /** Key of another entry this one depends on. */

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -84,20 +84,22 @@ export function seedReference(yaml: string, domain: string): string | undefined 
  * required, since a non-required group can still contain required
  * descendants we want to seed.
  *
- * When `seedAll` is true, every entry with a non-null `default_value`
- * is seeded — used for featured components so backend-baked presets
- * land in the payload even on optional fields.
+ * When `seedPresets` is true (featured components), optional entries
+ * flagged `from_preset` are seeded too, so backend-baked presets land in
+ * the payload. Plain catalog defaults stay unseeded so a featured add
+ * emits only the preset fields — matching the create-time auto-add and
+ * avoiding phantom-touched optional groups (e.g. `manual_ip`).
  */
 export function seedDefaults(
   entries: ConfigEntry[],
   yaml: string,
   localize: LocalizeFunc,
-  seedAll: boolean = false
+  seedPresets: boolean = false
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const entry of entries) {
     if (entry.type === ConfigEntryType.NESTED) {
-      const sub = seedDefaults(entry.config_entries ?? [], yaml, localize, seedAll);
+      const sub = seedDefaults(entry.config_entries ?? [], yaml, localize, seedPresets);
       // A required entity sub-reading (ags10's tvoc) serializes only
       // once it holds a value; seed its name (the label) so an
       // untouched Add still produces a valid sensor, matching the
@@ -113,7 +115,7 @@ export function seedDefaults(
       if (Object.keys(sub).length > 0) out[entry.key] = sub;
       continue;
     }
-    if (!seedAll && !entry.required) continue;
+    if (!entry.required && !(seedPresets && entry.from_preset)) continue;
     // Resolve an id reference against the live YAML so a stale featured
     // preset (`i2c_bus`) can't outlive the bus it names. Locked refs are
     // deliberate pins — keep their literal.
@@ -161,13 +163,13 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   } = ctx;
 
   // Featured-component entries (ids prefixed with `featured.`) carry
-  // backend-baked presets in `default_value` for arbitrary fields,
-  // not just required ones. Seed every entry with a non-null default
-  // when filling a featured entry so a board-pinned (locked) optional
-  // field actually emits its preset on submit — otherwise the
-  // backend's locked-validation would reject the empty payload.
-  const seedAll = isFeaturedId(component.id);
-  let next = seedDefaults(entries, yaml, localize, seedAll);
+  // backend-baked presets on arbitrary fields, not just required ones.
+  // Seed those `from_preset` fields so a board-pinned (locked) optional
+  // field still emits its preset on submit — otherwise the backend's
+  // locked-validation would reject the empty payload. Plain catalog
+  // defaults stay unseeded so the add matches the create-time auto-add.
+  const seedPresets = isFeaturedId(component.id);
+  let next = seedDefaults(entries, yaml, localize, seedPresets);
 
   const idEntry = entries.find((e) => e.key === "id" && e.type === ConfigEntryType.ID);
   if (idEntry && next["id"] === undefined) {

--- a/src/components/device/config-entry-render-filter.ts
+++ b/src/components/device/config-entry-render-filter.ts
@@ -173,11 +173,14 @@ export function filterRenderable(
           asRecord(values[entry.key]),
           opts
         );
-        // Keep a group whose own value is a scalar shorthand (no child
-        // renders for it, but the user set it) so it stays visible.
-        if (renderableChildren.length === 0 && !hasMaterialValue(entry, values)) {
-          continue;
-        }
+        // Drop a group with nothing to render. A scalar shorthand at the
+        // group key (e.g. ``pin: GPIO5``) still renders the user's value
+        // read-only; an object/null whose children all filtered out (seeded
+        // optional/advanced leaves in required-only mode) leaves an empty box.
+        const own = values[entry.key];
+        const isScalarShorthand =
+          typeof own === "string" || typeof own === "number" || typeof own === "boolean";
+        if (renderableChildren.length === 0 && !isScalarShorthand) continue;
       }
     } else if (
       opts.requiredOnly &&

--- a/src/util/config-entry-defaults.ts
+++ b/src/util/config-entry-defaults.ts
@@ -51,6 +51,7 @@ export function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEnt
     pin_mode: null,
     locked: false,
     suggestions: null,
+    from_preset: false,
     config_entries: null,
     platform_type: null,
     supported_platforms: undefined,

--- a/src/util/default-component-id.ts
+++ b/src/util/default-component-id.ts
@@ -1,3 +1,4 @@
+import { isFeaturedId } from "./featured-id.js";
 import { readInstanceScalar } from "./yaml-sections-core.js";
 
 /**
@@ -29,10 +30,17 @@ export function generateDefaultComponentId(
   multiConf: boolean,
   existing: ReadonlySet<string>
 ): string | null {
-  const isSingleton = !multiConf && !componentId.includes(".");
+  // A featured id (`featured.<board>.<local>`) carries dots but wraps one
+  // underlying component, so judge singleton-ness by `multiConf` alone —
+  // the dotted form would otherwise always read as a platform entry and a
+  // single-instance wrap (ethernet, wifi) would wrongly get an id.
+  const looksPlatform = isFeaturedId(componentId) ? false : componentId.includes(".");
+  const isSingleton = !multiConf && !looksPlatform;
   if (isSingleton) return null;
 
-  const slug = componentId.replace(/\./g, "_").toLowerCase();
+  // Normalise to a valid ESPHome id ([a-zA-Z_][a-zA-Z0-9_]*): a featured
+  // board id carries dashes (`esp32-poe-iso`) which dots-only wouldn't strip.
+  const slug = componentId.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
   let n = 1;
   let candidate = `${slug}_${n}`;
   while (existing.has(candidate)) {

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -332,14 +332,19 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect((dialog as unknown as { _open: boolean })._open).toBe(true);
   });
 
-  it("fast-paths a featured entry but submits its seedAll-locked presets", async () => {
-    // A featured id seeds every default (seedAll), so its locked preset rides
-    // in the coerced payload even when the field is advanced and the form
+  it("fast-paths a featured entry but submits its from_preset values", async () => {
+    // A featured id seeds its `from_preset` fields, so the preset rides in
+    // the coerced payload even when the field is advanced and the form
     // paints nothing — no `{}`-drop, no need to force the form open.
     const entry = makeComponentEntry("featured.bw15.socket", {
       name: "Socket",
       config_entries: [
-        makeConfigEntry({ key: "implementation", advanced: true, default_value: "lwip" }),
+        makeConfigEntry({
+          key: "implementation",
+          advanced: true,
+          default_value: "lwip",
+          from_preset: true,
+        }),
       ],
     });
     const { dialog, addComponent } = makeDialog(entry);

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -121,15 +121,27 @@ describe("seedDefaults", () => {
     expect(seedDefaults(entries, "", localize)).toEqual({ update_interval: "60s" });
   });
 
-  it("seeds optional defaults too when seedAll is set (featured presets)", () => {
+  it("seeds an optional from_preset field when seedPresets is set (featured presets)", () => {
     const entries: ConfigEntry[] = [
       makeConfigEntry({
         key: "accuracy",
         type: ConfigEntryType.STRING,
         default_value: "0.1",
+        from_preset: true,
       }),
     ];
     expect(seedDefaults(entries, "", localize, true)).toEqual({ accuracy: "0.1" });
+  });
+
+  it("leaves a plain optional default unseeded even with seedPresets set", () => {
+    const entries: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "clock_speed",
+        type: ConfigEntryType.STRING,
+        default_value: "26.67MHz",
+      }),
+    ];
+    expect(seedDefaults(entries, "", localize, true)).toEqual({});
   });
 
   it("wraps a multi_value default in an array", () => {

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -79,6 +79,7 @@ describe("add-component-form resolves featured id references to the live config"
           references_component: "i2c",
           default_value: "i2c_bus",
           locked: presetLocked,
+          from_preset: true,
         }),
       ],
     } as unknown as ComponentCatalogEntry;

--- a/test/components/device/config-entry-render-filter.test.ts
+++ b/test/components/device/config-entry-render-filter.test.ts
@@ -212,6 +212,61 @@ describe("filterRenderable", () => {
     expect(out.map((e) => e.key)).toEqual([]);
   });
 
+  it("drops a required-only NESTED group whose only value is on filtered-out children", () => {
+    // manual_ip: seeded optional/advanced dns leaves give the group a
+    // value, but every child filters out in required-only mode; the
+    // group must not render as an empty box.
+    const entries = [
+      makeEntry({
+        key: "manual_ip",
+        type: ConfigEntryType.NESTED,
+        advanced: true,
+        config_entries: [
+          makeEntry({ key: "static_ip", required: true, advanced: true }),
+          makeEntry({ key: "dns1", advanced: true }),
+        ],
+      }),
+    ];
+    const out = filterRenderable(
+      entries,
+      { manual_ip: { dns1: "0.0.0.0" } },
+      { requiredOnly: true, showAdvanced: false }
+    );
+    expect(out.map((e) => e.key)).toEqual([]);
+  });
+
+  it("drops an empty NESTED group whose own value is null (not a scalar shorthand)", () => {
+    const entries = [
+      makeEntry({
+        key: "manual_ip",
+        type: ConfigEntryType.NESTED,
+        config_entries: [makeEntry({ key: "static_ip" })],
+      }),
+    ];
+    const out = filterRenderable(
+      entries,
+      { manual_ip: null },
+      { requiredOnly: true, showAdvanced: false }
+    );
+    expect(out.map((e) => e.key)).toEqual([]);
+  });
+
+  it("keeps a NESTED group whose own value is a scalar shorthand", () => {
+    const entries = [
+      makeEntry({
+        key: "pin",
+        type: ConfigEntryType.NESTED,
+        config_entries: [makeEntry({ key: "number" })],
+      }),
+    ];
+    const out = filterRenderable(
+      entries,
+      { pin: "GPIO5" },
+      { requiredOnly: true, showAdvanced: false }
+    );
+    expect(out.map((e) => e.key)).toEqual(["pin"]);
+  });
+
   it("keeps NESTED groups with at least one renderable child", () => {
     const entries = [
       makeEntry({

--- a/test/util/default-component-id.test.ts
+++ b/test/util/default-component-id.test.ts
@@ -46,6 +46,30 @@ describe("generateDefaultComponentId", () => {
     );
   });
 
+  it("returns null for a single-instance featured wrap (dotted id, multi_conf false)", () => {
+    // `featured.<board>.<local>` has dots but wraps one underlying
+    // component; a single-instance wrap (ethernet, wifi) must not get an id.
+    expect(
+      generateDefaultComponentId(
+        "featured.esp32-poe-iso.onboard_ethernet",
+        false,
+        new Set()
+      )
+    ).toBe(null);
+  });
+
+  it("suffixes a multi-instance featured wrap and normalises board dashes", () => {
+    // Board dashes (`esp32-poe-iso`) must become underscores so the id is
+    // a valid ESPHome identifier ([a-zA-Z_][a-zA-Z0-9_]*).
+    expect(
+      generateDefaultComponentId(
+        "featured.athom-smart-plug-v3.power_monitor",
+        true,
+        new Set()
+      )
+    ).toBe("featured_athom_smart_plug_v3_power_monitor_1");
+  });
+
   it("walks the suffix counter on collision", () => {
     const existing = new Set(["switch_gpio_1", "switch_gpio_2"]);
     expect(generateDefaultComponentId("switch.gpio", true, existing)).toBe(


### PR DESCRIPTION
# What does this implement/fix?

Fixes the featured add-component form, surfaced by the OLIMEX ESP32-PoE-ISO
"Onboard Ethernet" component: clk prefilled but **Add stayed disabled**, and the
YAML preview carried fields the create-time auto-add never emits.

Root cause: the featured add seeded *every* catalog default. That bloated the
preview (`clock_speed`/`domain`/`enable_on_boot`) and auto-opted into the optional
`manual_ip` group (its `dns` defaults), which made the optional group look
"touched" so its required children (`static_ip`/`gateway`/`subnet`) validated as
missing and disabled Add. The create-time path never does this; it fills only the
manifest preset fields.

Changes:
- **Seed only preset fields.** The featured seed now seeds `required` + `from_preset`
  fields (the backend flag from the companion PR), not plain catalog defaults, so
  the add emits exactly the preset fields and Add enables. Value-only presets are
  pervasive, so `locked` alone can't identify them; the `from_preset` flag does.
- **Drop empty NESTED groups** with no renderable children (defense for any
  phantom-material group), keeping a scalar shorthand at the group key.
- **No auto-id for single-instance featured wraps.** `generateDefaultComponentId`
  judged `featured.<board>.<local>` as a platform entry (dots) and seeded an `id`;
  a single-instance wrap (ethernet, wifi) now gets none, matching create-time.

**Related issue or feature (if applicable):**

- Pairs with esphome/device-builder#1706 (adds the `from_preset` flag).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
