### PR TITLE
Collapse the Recommended category when nothing is available

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -71,6 +71,8 @@ export interface FeaturedComponent {
   name: string | null;
   description: string | null;
   fields: Record<string, FieldPreset>;
+  /** Underlying component's multi_conf; absent means multi-conf (omit_default). */
+  multi_conf?: boolean;
 }
 
 /**

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -21,6 +21,7 @@ import { debounce } from "../../util/debounce.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
   ambiguousNameIds,
+  availableFeaturedCount,
   buildCategories,
   filteredBundles,
   visibleComponents,
@@ -95,13 +96,12 @@ export class ESPHomeComponentCatalog extends LitElement {
   // request would go out with empty platform / board_id.
   public load() {
     this._provides = "";
-    // Auto-select "Featured" when the board has any recommendations; reset
-    // away from it when reopening against a board without any.
-    const featuredCount =
-      (this.board?.featured_components?.length ?? 0) +
-      (this.board?.featured_bundles?.length ?? 0);
+    // Auto-select "Featured" when the board has recommendations still addable;
+    // reset away from it when every recommendation is already configured.
     const hasFeatured =
-      this.lockedCategories.length === 0 && !!this.boardId && featuredCount > 0;
+      this.lockedCategories.length === 0 &&
+      !!this.boardId &&
+      availableFeaturedCount(this) > 0;
     if (hasFeatured) {
       this._category = ComponentCategory.FEATURED;
     } else if (this._category === ComponentCategory.FEATURED) {

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -104,32 +104,23 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
   );
 }
 
-// Recommendations still addable for this board: a featured component counts
-// when it's multi-conf or not yet configured; a bundle counts when at least
-// one of its components is still addable. Drives the Recommended badge and the
-// auto-select so an all-configured board collapses the category instead of
-// showing an empty "0 of N" list.
+// Recommendations shown for this board: a featured component counts when it's
+// multi-conf or not yet configured; bundles are counted as-is, matching the
+// grid (`filteredBundles`) which doesn't present-filter them. Drives the
+// Recommended badge and the auto-select so an all-configured board collapses
+// the category instead of showing an empty "0 of N" list.
 export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   const board = host.board;
   if (!board) return 0;
   const present = parseTopLevelComponents(host.yaml);
   const presentPlatforms = parseConfiguredPlatforms(host.yaml);
-  const components = board.featured_components ?? [];
   // `!== false`, not truthy: the backend omits the `true` default, so an
   // absent multi_conf means multi-conf (still addable).
   const addable = (fc: FeaturedComponent) =>
     fc.multi_conf !== false ||
     !isComponentPresent(fc.component_id, present, presentPlatforms);
-  const byLocalId = new Map(components.map((fc) => [fc.id, fc]));
-  const bundleAvailable = (b: FeaturedBundle) =>
-    b.component_ids.some((localId) => {
-      const fc = byLocalId.get(localId);
-      return !fc || addable(fc);
-    });
-  return (
-    components.filter(addable).length +
-    (board.featured_bundles ?? []).filter(bundleAvailable).length
-  );
+  const components = (board.featured_components ?? []).filter(addable).length;
+  return components + (board.featured_bundles?.length ?? 0);
 }
 
 interface CategoryEntry {
@@ -146,8 +137,9 @@ export function buildCategories(
   const visibleCats = host._categories.filter((c) => !excluded.has(c.id));
   // Badge the post-filter available count so an all-configured board drops the
   // "Featured" row entirely (the if-guard below); the backend category count is
-  // pre-filter and would leave a stale, empty badge.
-  const featuredBadge = availableFeaturedCount(host);
+  // pre-filter and would leave a stale, empty badge. Skipped in locked mode —
+  // the sidebar is hidden, so the YAML reparse would be pure overhead.
+  const featuredBadge = host.lockedCategories.length ? 0 : availableFeaturedCount(host);
   const sortableCats = visibleCats.filter((c) => c.id !== ComponentCategory.FEATURED);
   const visibleTotal = excluded.size
     ? sortableCats.reduce((sum, c) => sum + c.count, 0)

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -1,9 +1,10 @@
-import type { FeaturedBundle } from "../../../api/types/boards.js";
+import type { FeaturedBundle, FeaturedComponent } from "../../../api/types/boards.js";
 import {
   type ComponentCatalogEntry,
   ComponentCategory,
 } from "../../../api/types/components.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { isComponentPresent } from "../../../util/component-presence.js";
 import { platformSupported } from "../../../util/config-validation.js";
 import { buildFeaturedId } from "../../../util/featured-id.js";
 import {
@@ -58,12 +59,8 @@ export function visibleComponents(
 
   return platformCompatible.filter((c) => {
     const refId = featuredRefId.get(c.id) ?? c.id;
-    if (!c.multi_conf) {
-      if (refId.includes(".")) {
-        if (presentPlatforms.has(refId)) return false;
-      } else if (present.has(refId)) {
-        return false;
-      }
+    if (!c.multi_conf && isComponentPresent(refId, present, presentPlatforms)) {
+      return false;
     }
     if (coreCompatible && c.id.includes(".") && c.dependencies.length > 0) {
       const allSatisfied = c.dependencies.every(
@@ -109,6 +106,34 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
   );
 }
 
+// Recommendations still addable for this board: a featured component counts
+// when it's multi-conf or not yet configured; a bundle counts when at least
+// one of its components is still addable. Drives the Recommended badge and the
+// auto-select so an all-configured board collapses the category instead of
+// showing an empty "0 of N" list.
+export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
+  const board = host.board;
+  if (!board) return 0;
+  const present = host.yaml ? parseTopLevelComponents(host.yaml) : new Set<string>();
+  const presentPlatforms = host.yaml
+    ? parseConfiguredPlatforms(host.yaml)
+    : new Set<string>();
+  const components = board.featured_components ?? [];
+  const addable = (fc: FeaturedComponent) =>
+    fc.multi_conf !== false ||
+    !isComponentPresent(fc.component_id, present, presentPlatforms);
+  const byLocalId = new Map(components.map((fc) => [fc.id, fc]));
+  const bundleAvailable = (b: FeaturedBundle) =>
+    b.component_ids.some((localId) => {
+      const fc = byLocalId.get(localId);
+      return !fc || addable(fc);
+    });
+  return (
+    components.filter(addable).length +
+    (board.featured_bundles ?? []).filter(bundleAvailable).length
+  );
+}
+
 interface CategoryEntry {
   id: string;
   label: string;
@@ -121,12 +146,10 @@ export function buildCategories(
 ): CategoryEntry[] {
   const excluded = new Set(host.excludeCategories);
   const visibleCats = host._categories.filter((c) => !excluded.has(c.id));
-  // Pin "Featured" — peel it out so it doesn't appear twice in the alpha list.
-  const featuredCat = visibleCats.find((c) => c.id === ComponentCategory.FEATURED);
-  const bundleCount = host.board?.featured_bundles?.length ?? 0;
-  // Bundles live on the board manifest, not in components categories —
-  // add them to the headline count so the badge matches the rendered grid.
-  const featuredBadge = featuredCat ? featuredCat.count + bundleCount : bundleCount;
+  // Badge the post-filter available count so an all-configured board drops the
+  // "Featured" row entirely (the if-guard below); the backend category count is
+  // pre-filter and would leave a stale, empty badge.
+  const featuredBadge = availableFeaturedCount(host);
   const sortableCats = visibleCats.filter((c) => c.id !== ComponentCategory.FEATURED);
   const visibleTotal = excluded.size
     ? sortableCats.reduce((sum, c) => sum + c.count, 0)

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -108,7 +108,10 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
 // multi-conf or not yet configured; bundles are counted as-is, matching the
 // grid (`filteredBundles`) which doesn't present-filter them. Drives the
 // Recommended badge and the auto-select so an all-configured board collapses
-// the category instead of showing an empty "0 of N" list.
+// the category instead of showing an empty "0 of N" list. No platform gate
+// here (unlike `visibleComponents`): a board only recommends its own
+// platform-compatible components, and `FeaturedComponent` carries no
+// `supported_platforms` to gate on.
 export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   const board = host.board;
   if (!board) return 0;

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -35,10 +35,8 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 export function visibleComponents(
   host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
-  const present = host.yaml ? parseTopLevelComponents(host.yaml) : new Set<string>();
-  const presentPlatforms = host.yaml
-    ? parseConfiguredPlatforms(host.yaml)
-    : new Set<string>();
+  const present = parseTopLevelComponents(host.yaml);
+  const presentPlatforms = parseConfiguredPlatforms(host.yaml);
   const lockedToCore = host.lockedCategories.length > 0;
   const platformCompatible = host._components.filter((c) =>
     platformSupported(c.supported_platforms, host.platform)
@@ -114,11 +112,11 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
 export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   const board = host.board;
   if (!board) return 0;
-  const present = host.yaml ? parseTopLevelComponents(host.yaml) : new Set<string>();
-  const presentPlatforms = host.yaml
-    ? parseConfiguredPlatforms(host.yaml)
-    : new Set<string>();
+  const present = parseTopLevelComponents(host.yaml);
+  const presentPlatforms = parseConfiguredPlatforms(host.yaml);
   const components = board.featured_components ?? [];
+  // `!== false`, not truthy: the backend omits the `true` default, so an
+  // absent multi_conf means multi-conf (still addable).
   const addable = (fc: FeaturedComponent) =>
     fc.multi_conf !== false ||
     !isComponentPresent(fc.component_id, present, presentPlatforms);

--- a/src/util/component-presence.ts
+++ b/src/util/component-presence.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether a component id is already configured in the YAML's present set.
+ *
+ * A platform-variant id (`time.homeassistant`) matches a configured platform;
+ * a bare id (`ethernet`, `wifi`) matches a top-level block.
+ */
+export function isComponentPresent(
+  id: string,
+  present: ReadonlySet<string>,
+  presentPlatforms: ReadonlySet<string>
+): boolean {
+  return id.includes(".") ? presentPlatforms.has(id) : present.has(id);
+}

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { BoardCatalogEntry } from "../../../../src/api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../../src/api/types/components.js";
 import type { ESPHomeComponentCatalog } from "../../../../src/components/device/component-catalog.js";
-import { visibleComponents } from "../../../../src/components/device/component-catalog/filters.js";
+import {
+  availableFeaturedCount,
+  buildCategories,
+  visibleComponents,
+} from "../../../../src/components/device/component-catalog/filters.js";
 
 function entry(
   id: string,
@@ -107,5 +111,87 @@ describe("visibleComponents featured present-filter", () => {
       host([multi], "esp32", { yaml: "switch:\n  - platform: gpio\n", board: multiBoard })
     ).map((c) => c.id);
     expect(ids).toEqual(["featured.demo.relay"]);
+  });
+});
+
+describe("availableFeaturedCount", () => {
+  const board = (
+    featured_components: unknown[],
+    featured_bundles: unknown[] = []
+  ): BoardCatalogEntry =>
+    ({ id: "b", featured_components, featured_bundles }) as unknown as BoardCatalogEntry;
+
+  it("is 0 with no board", () => {
+    expect(availableFeaturedCount(host([], "esp32"))).toBe(0);
+  });
+
+  it("drops a single-instance featured component already configured", () => {
+    const b = board([{ id: "eth", component_id: "ethernet", multi_conf: false }]);
+    expect(availableFeaturedCount(host([], "esp32", { board: b }))).toBe(1);
+    expect(
+      availableFeaturedCount(host([], "esp32", { yaml: "ethernet:\n", board: b }))
+    ).toBe(0);
+  });
+
+  it("keeps a multi-conf featured component even when its domain is present", () => {
+    const b = board([{ id: "relay", component_id: "switch.gpio", multi_conf: true }]);
+    expect(
+      availableFeaturedCount(
+        host([], "esp32", { yaml: "switch:\n  - platform: gpio\n", board: b })
+      )
+    ).toBe(1);
+  });
+
+  it("treats a missing multi_conf as multi-conf (available)", () => {
+    const b = board([{ id: "relay", component_id: "switch.gpio" }]);
+    expect(
+      availableFeaturedCount(
+        host([], "esp32", { yaml: "switch:\n  - platform: gpio\n", board: b })
+      )
+    ).toBe(1);
+  });
+
+  it("counts a bundle while at least one of its components is addable", () => {
+    const b = board(
+      [
+        { id: "eth", component_id: "ethernet", multi_conf: false },
+        { id: "relay", component_id: "switch.gpio", multi_conf: true },
+      ],
+      [{ id: "kit", component_ids: ["eth", "relay"] }]
+    );
+    // ethernet present but relay still addable -> the one bundle counts (+ relay)
+    expect(
+      availableFeaturedCount(host([], "esp32", { yaml: "ethernet:\n", board: b }))
+    ).toBe(2);
+  });
+});
+
+describe("buildCategories Recommended collapse", () => {
+  const localize = (k: string) => k;
+  const hostWith = (board: BoardCatalogEntry | null, yaml: string) =>
+    ({
+      _categories: [{ id: "featured", count: 1 }],
+      _total: 1,
+      excludeCategories: [],
+      board,
+      yaml,
+    }) as unknown as ESPHomeComponentCatalog;
+  const board = {
+    id: "b",
+    featured_components: [{ id: "eth", component_id: "ethernet", multi_conf: false }],
+    featured_bundles: [],
+  } as unknown as BoardCatalogEntry;
+
+  it("omits the Featured row when nothing is available", () => {
+    const ids = buildCategories(hostWith(board, "ethernet:\n"), localize).map(
+      (c) => c.id
+    );
+    expect(ids).not.toContain("featured");
+  });
+
+  it("keeps the Featured row when a recommendation is available", () => {
+    const cats = buildCategories(hostWith(board, ""), localize);
+    const featured = cats.find((c) => c.id === "featured");
+    expect(featured?.count).toBe(1);
   });
 });

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -151,7 +151,7 @@ describe("availableFeaturedCount", () => {
     ).toBe(1);
   });
 
-  it("counts a bundle while at least one of its components is addable", () => {
+  it("counts bundles as-is (matching the grid), plus addable components", () => {
     const b = board(
       [
         { id: "eth", component_id: "ethernet", multi_conf: false },
@@ -159,7 +159,7 @@ describe("availableFeaturedCount", () => {
       ],
       [{ id: "kit", component_ids: ["eth", "relay"] }]
     );
-    // ethernet present but relay still addable -> the one bundle counts (+ relay)
+    // ethernet present (dropped), relay addable (1), bundle always counts (1)
     expect(
       availableFeaturedCount(host([], "esp32", { yaml: "ethernet:\n", board: b }))
     ).toBe(2);
@@ -168,11 +168,16 @@ describe("availableFeaturedCount", () => {
 
 describe("buildCategories Recommended collapse", () => {
   const localize = (k: string) => k;
-  const hostWith = (board: BoardCatalogEntry | null, yaml: string) =>
+  const hostWith = (
+    board: BoardCatalogEntry | null,
+    yaml: string,
+    lockedCategories: string[] = []
+  ) =>
     ({
       _categories: [{ id: "featured", count: 1 }],
       _total: 1,
       excludeCategories: [],
+      lockedCategories,
       board,
       yaml,
     }) as unknown as ESPHomeComponentCatalog;
@@ -193,5 +198,10 @@ describe("buildCategories Recommended collapse", () => {
     const cats = buildCategories(hostWith(board, ""), localize);
     const featured = cats.find((c) => c.id === "featured");
     expect(featured?.count).toBe(1);
+  });
+
+  it("omits the Featured row in locked-category mode", () => {
+    const ids = buildCategories(hostWith(board, "", ["core"]), localize).map((c) => c.id);
+    expect(ids).not.toContain("featured");
   });
 });

--- a/test/util/component-presence.test.ts
+++ b/test/util/component-presence.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isComponentPresent } from "../../src/util/component-presence.js";
+
+describe("isComponentPresent", () => {
+  const present = new Set(["ethernet", "wifi"]);
+  const presentPlatforms = new Set(["time.homeassistant"]);
+
+  it("matches a bare id against top-level blocks", () => {
+    expect(isComponentPresent("ethernet", present, presentPlatforms)).toBe(true);
+    expect(isComponentPresent("api", present, presentPlatforms)).toBe(false);
+  });
+
+  it("matches a platform-variant id against configured platforms", () => {
+    expect(isComponentPresent("time.homeassistant", present, presentPlatforms)).toBe(
+      true
+    );
+    expect(isComponentPresent("time.sntp", present, presentPlatforms)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #992. With single-instance recommendations now hidden, a board whose only recommendation is already configured (an Olimex PoE board with `ethernet:` set) still showed a stale "Recommended ①" badge, auto-opened that tab, and rendered an empty "No components found" list. The Recommended count was pre-filter.

This counts only recommendations that are still addable; a featured component counts when it is multi-conf or not yet configured, and a bundle counts while at least one of its components is addable. The badge then drops the Recommended row when nothing is available, and the dialog opens on All instead of an empty Recommended tab. The multi-conf check uses the new `multi_conf` field on board featured components (companion backend PR esphome/device-builder#1707); a missing value is treated as multi-conf, so this is backward compatible and stays as today's behavior until the field ships.

Also extracts `isComponentPresent` so `visibleComponents` and the availability count share one present-check.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
