### PR TITLE
Detect bare-integer pin values in the used-pin scan

### DIFF
--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,7 +17,7 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import type { ComponentCatalogEntry } from "../api/types/components.js";
-import { scanPinGpios } from "./pin-gpio.js";
+import { parsePinGpio, scanPinGpios } from "./pin-gpio.js";
 import { collectIdsAtPath, parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
 /**
@@ -115,6 +115,12 @@ const FREETEXT_PIN_KEYS = new Set(["name", "friendly_name", "comment"]);
 // value under a free-text key can be skipped by indentation.
 const LINE_KEY_RE = /^(\s*)(?:-\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s*:/;
 
+// A pin-field key: ESPHome's `_pin`/`_gpio` suffix convention (see
+// board-pin-defaults.ts) plus the long-form `pin:` / `number:` sub-keys.
+// Used to recognise a bare-integer pin value (`tx_pin: 1`) that the
+// prefix-anchored token scan can't see.
+const PIN_VALUE_KEY_RE = /(?:^|_)(?:pin|gpio)$|^number$/i;
+
 // A `key:` whose value is a block scalar (`|` / `>`, with optional chomping
 // `+`/`-` and explicit-indent digit, plus an optional trailing comment).
 // Its continuation lines are more-indented prose, scanned via indentation.
@@ -211,7 +217,14 @@ export function findUsedPins(
       if (BLOCK_SCALAR_RE.test(line)) blockScalarIndent = keyMatch[1].length;
       continue;
     }
-    for (const num of scanPinGpios(stripInlineComment(line))) {
+    const stripped = stripInlineComment(line);
+    // A bare-integer pin value (`tx_pin: 1`) carries no `GPIO`/`P` prefix, so
+    // the token scan below can't see it; parse it from a pin-field key's value.
+    if (keyMatch && PIN_VALUE_KEY_RE.test(keyMatch[2])) {
+      const gpio = parsePinGpio(stripped.slice(stripped.indexOf(":") + 1).trim());
+      if (gpio !== null && !used.has(gpio)) used.set(gpio, currentDomain);
+    }
+    for (const num of scanPinGpios(stripped)) {
       if (!used.has(num)) used.set(num, currentDomain);
     }
   }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,7 +17,7 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import type { ComponentCatalogEntry } from "../api/types/components.js";
-import { parsePinGpio, scanPinGpios } from "./pin-gpio.js";
+import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin-gpio.js";
 import { collectIdsAtPath, parseYamlTopLevelSections } from "./yaml-sections-core.js";
 
 /**
@@ -114,12 +114,6 @@ const FREETEXT_PIN_KEYS = new Set(["name", "friendly_name", "comment"]);
 // leading indentation (group 1) and the key (group 2) so a block-scalar
 // value under a free-text key can be skipped by indentation.
 const LINE_KEY_RE = /^(\s*)(?:-\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s*:/;
-
-// A pin-field key: ESPHome's `_pin`/`_gpio` suffix convention (see
-// board-pin-defaults.ts) plus the long-form `pin:` / `number:` sub-keys.
-// Used to recognise a bare-integer pin value (`tx_pin: 1`) that the
-// prefix-anchored token scan can't see.
-const PIN_VALUE_KEY_RE = /(?:^|_)(?:pin|gpio)$|^number$/i;
 
 // A `key:` whose value is a block scalar (`|` / `>`, with optional chomping
 // `+`/`-` and explicit-indent digit, plus an optional trailing comment).
@@ -218,10 +212,10 @@ export function findUsedPins(
       continue;
     }
     const stripped = stripInlineComment(line);
-    // A bare-integer pin value (`tx_pin: 1`) carries no `GPIO`/`P` prefix, so
-    // the token scan below can't see it; parse it from a pin-field key's value.
-    if (keyMatch && PIN_VALUE_KEY_RE.test(keyMatch[2])) {
-      const gpio = parsePinGpio(stripped.slice(stripped.indexOf(":") + 1).trim());
+    // A bare-integer pin value (`tx_pin: 1`) carries no prefix for the token
+    // scan to anchor on; parse it from a pin-field key's value instead.
+    if (keyMatch && isPinFieldKey(keyMatch[2])) {
+      const gpio = parsePinGpio(stripped.slice(keyMatch[0].length).trim());
       if (gpio !== null && !used.has(gpio)) used.set(gpio, currentDomain);
     }
     for (const num of scanPinGpios(stripped)) {

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -141,3 +141,16 @@ export function scanPinGpios(line: string): number[] {
   }
   return out;
 }
+
+// ESPHome's `_pin`/`_gpio` suffix convention (mirrors `board-pin-defaults.ts`'s
+// role strip) plus the long-form `pin:` / `number:` sub-keys.
+const PIN_FIELD_KEY_RE = /(?:^|_)(?:pin|gpio)$|^number$/i;
+
+/**
+ * Whether a mapping key names a pin field. Lets the used-pin scan accept a
+ * bare-integer value (`tx_pin: 1`) that {@link scanPinGpios} can't see — the
+ * token forms it matches all carry a distinctive prefix, a bare int doesn't.
+ */
+export function isPinFieldKey(key: string): boolean {
+  return PIN_FIELD_KEY_RE.test(key);
+}

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -198,34 +198,14 @@ describe("findUsedPins", () => {
     expect(findUsedPins("").size).toBe(0);
   });
 
-  it("detects a bare-integer pin value under a pin-field key", () => {
+  it("detects a bare-integer pin value alongside a prefixed sibling", () => {
     // `tx_pin: 1` has no `GPIO`/`P` prefix for the token scan to anchor on;
-    // it must still register as used (the reported ESP32-PoE-ISO bug).
-    const config = [
-      "uart:",
-      "  - baud_rate: 9600",
-      "    tx_pin: 1",
-      "    rx_pin: GPIO14",
-      "",
-    ].join("\n");
+    // it must still register, without disturbing the prefixed `rx_pin`
+    // (the reported ESP32-PoE-ISO bug).
+    const config = ["uart:", "  - tx_pin: 1", "    rx_pin: GPIO14", ""].join("\n");
     const map = findUsedPins(config);
     expect(map.get(1)).toBe("uart");
     expect(map.get(14)).toBe("uart");
-  });
-
-  it("flags a bare-int / GPIOn conflict across sections", () => {
-    // `uart` claims GPIO1 as a bare int, `stepper` as `GPIO1` — both must land
-    // in the map so the cross-section conflict fires; first scanned domain wins.
-    const config = [
-      "uart:",
-      "  - tx_pin: 1",
-      "stepper:",
-      "  - platform: a4988",
-      "    dir_pin: GPIO1",
-      "",
-    ].join("\n");
-    const map = findUsedPins(config);
-    expect(map.get(1)).toBe("uart");
   });
 
   it("detects a bare-integer long-form `number:` pin value", () => {

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -198,6 +198,58 @@ describe("findUsedPins", () => {
     expect(findUsedPins("").size).toBe(0);
   });
 
+  it("detects a bare-integer pin value under a pin-field key", () => {
+    // `tx_pin: 1` has no `GPIO`/`P` prefix for the token scan to anchor on;
+    // it must still register as used (the reported ESP32-PoE-ISO bug).
+    const config = [
+      "uart:",
+      "  - baud_rate: 9600",
+      "    tx_pin: 1",
+      "    rx_pin: GPIO14",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.get(1)).toBe("uart");
+    expect(map.get(14)).toBe("uart");
+  });
+
+  it("flags a bare-int / GPIOn conflict across sections", () => {
+    // `uart` claims GPIO1 as a bare int, `stepper` as `GPIO1` — both must land
+    // in the map so the cross-section conflict fires; first scanned domain wins.
+    const config = [
+      "uart:",
+      "  - tx_pin: 1",
+      "stepper:",
+      "  - platform: a4988",
+      "    dir_pin: GPIO1",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.get(1)).toBe("uart");
+  });
+
+  it("detects a bare-integer long-form `number:` pin value", () => {
+    const config = ["ethernet:", "  power_pin:", "    number: 13", ""].join("\n");
+    expect(findUsedPins(config).get(13)).toBe("ethernet");
+  });
+
+  it("does not treat non-pin numeric keys as pins", () => {
+    // Only pin-field keys parse a bare int; numeric config values that happen
+    // to fall in GPIO range must not register (`phy_addr: 0`, `data_bits: 8`).
+    const config = [
+      "uart:",
+      "  - baud_rate: 9600",
+      "    data_bits: 8",
+      "ethernet:",
+      "  phy_addr: 0",
+      "stepper:",
+      "  - max_speed: 434",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.size).toBe(0);
+  });
+
   it("returns the same Map reference on repeated calls (memoised)", () => {
     // Pin the cache contract: a re-render that hands us the
     // same yaml + exclude pair returns the cached Map without

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -4,7 +4,7 @@
  * pin-selector renderer (current value + suggestions) and the YAML
  * used-pin scanner (cross-section conflict detection).
  *
- * Three exported functions, each with a load-bearing contract:
+ * Four exported functions, each with a load-bearing contract:
  *
  *  - ``parsePinGpio`` — strict, anchored parse of a *single* pin value
  *    (a field value or one suggestion entry). Returns ``null`` for
@@ -17,6 +17,8 @@
  *    raw lines from the used-pin scan), so the tests pin its known
  *    over-match behaviour on free-text P-tokens too — that's the
  *    contract its caller (``findUsedPins``) is written against.
+ *  - ``isPinFieldKey`` — whether a mapping key names a pin field, so the
+ *    used-pin scan can accept a bare-integer value the token scan misses.
  *
  * Platform pin forms covered (see the module header for the full
  * derivation):
@@ -28,7 +30,12 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { formatPinValue, parsePinGpio, scanPinGpios } from "../../src/util/pin-gpio.js";
+import {
+  formatPinValue,
+  isPinFieldKey,
+  parsePinGpio,
+  scanPinGpios,
+} from "../../src/util/pin-gpio.js";
 
 describe("parsePinGpio", () => {
   it("returns finite numbers verbatim", () => {
@@ -189,5 +196,26 @@ describe("scanPinGpios", () => {
     expect(scanPinGpios("Pump P0.5 valve")).toEqual([5]); // P0.5 -> port0 pin5
     expect(scanPinGpios("P3.invalid")).toEqual([3]); // dotted alt fails, bare P3 wins
     expect(scanPinGpios("P0.5V")).toEqual([0]); // dotted \b fails on V, bare P0 wins
+  });
+});
+
+describe("isPinFieldKey", () => {
+  it("matches the _pin / _gpio suffix and the long-form pin / number keys", () => {
+    for (const key of ["pin", "tx_pin", "dir_pin", "led_gpio", "gpio", "number"]) {
+      expect(isPinFieldKey(key)).toBe(true);
+    }
+  });
+
+  it("rejects numeric config keys that aren't pins", () => {
+    for (const key of [
+      "baud_rate",
+      "phy_addr",
+      "data_bits",
+      "max_speed",
+      "id",
+      "pin_x",
+    ]) {
+      expect(isPinFieldKey(key)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

In the GPIO pin picker, a pin used elsewhere in the config as a bare integer (for example `uart: tx_pin: 1`) was not flagged as "Already used by ...", and no cross-section conflict fired; a config with `tx_pin: 1` and `stepper: dir_pin: GPIO1` showed GPIO1 as free in the stepper dropdown.

The used-pin map is built by a line scan that only matched the prefixed pin token forms (`GPIOn`, and the LibreTiny/nRF52 `P...` forms), since those prefixes are distinctive enough to scan unbounded. A bare integer carries no prefix, so it never entered the map. Pins written as `GPIOn` strings (what the builder emits) were already caught; bare ints come from hand-edited YAML. This parses the value of a pin-field key through the existing `parsePinGpio` helper so bare ints register alongside the prefixed forms. Pin-field keys are detected by the `_pin`/`_gpio` suffix convention (the same one in `board-pin-defaults.ts`, mirroring the backend's `_pin_feature_from_name`) plus the long-form `pin:` / `number:` sub-keys, so numeric non-pin values like `baud_rate: 9600`, `phy_addr: 0`, or `data_bits: 8` are not mistaken for pins.

**Related issue or feature (if applicable):**


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
