### PR TITLE
Preview the underlying component key for featured add forms

### DIFF
--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -14,6 +14,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
 import { validateEntries, type ValidationError } from "../../util/config-validation.js";
+import { resolveFeaturedComponentId } from "../../util/featured-id.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { setIn } from "../../util/nested-values.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -464,7 +465,10 @@ export class ESPHomeAddComponentForm extends LitElement {
   }
 
   private _generateYamlPreview(): string {
-    const lines: string[] = [`${this.component.id}:`];
+    // Featured ids are synthetic (`featured.<board>.<local>`); preview the
+    // underlying component the block resolves to, matching the committed YAML.
+    const key = resolveFeaturedComponentId(this.component.id, this.board);
+    const lines: string[] = [`${key}:`];
     lines.push(...serializeYamlValues(this._values, "  "));
     return lines.join("\n");
   }

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,3 +1,5 @@
+import type { BoardCatalogEntry } from "../api/types/boards.js";
+
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
 
@@ -9,4 +11,16 @@ export function buildFeaturedId(boardId: string, localId: string): string {
 /** True when a catalog id carries the `featured.` prefix; only the prefix is checked, not the full shape. */
 export function isFeaturedId(id: string): boolean {
   return id.startsWith(FEATURED_ID_PREFIX);
+}
+
+/** Resolve a featured catalog id to the component it actually adds; non-featured or unknown ids pass through. */
+export function resolveFeaturedComponentId(
+  id: string,
+  board: BoardCatalogEntry | null
+): string {
+  if (!board || !isFeaturedId(id)) return id;
+  const fc = (board.featured_components ?? []).find(
+    (c) => buildFeaturedId(board.id, c.id) === id
+  );
+  return fc?.component_id ?? id;
 }

--- a/src/util/featured-id.ts
+++ b/src/util/featured-id.ts
@@ -1,7 +1,11 @@
-import type { BoardCatalogEntry } from "../api/types/boards.js";
-
 /** The `featured.<board>.<local>` id prefix marking a board-curated preset entry. */
 export const FEATURED_ID_PREFIX = "featured.";
+
+/** The minimal board shape the resolver needs (any `BoardCatalogEntry` fits). */
+type FeaturedIdBoard = {
+  id: string;
+  featured_components?: ReadonlyArray<{ id: string; component_id: string }>;
+};
 
 /** Compose the catalog id for a board's featured entry from its board and local ids. */
 export function buildFeaturedId(boardId: string, localId: string): string {
@@ -16,7 +20,7 @@ export function isFeaturedId(id: string): boolean {
 /** Resolve a featured catalog id to the component it actually adds; non-featured or unknown ids pass through. */
 export function resolveFeaturedComponentId(
   id: string,
-  board: BoardCatalogEntry | null
+  board: FeaturedIdBoard | null
 ): string {
   if (!board || !isFeaturedId(id)) return id;
   const fc = (board.featured_components ?? []).find(

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import { isFeaturedId, resolveFeaturedComponentId } from "../../src/util/featured-id.js";
 
 describe("isFeaturedId", () => {
@@ -22,7 +21,7 @@ describe("resolveFeaturedComponentId", () => {
   const board = {
     id: "esp32-poe-iso",
     featured_components: [{ id: "onboard_ethernet", component_id: "ethernet" }],
-  } as unknown as BoardCatalogEntry;
+  };
 
   it("resolves a featured id to its underlying component_id", () => {
     expect(

--- a/test/util/featured-id.test.ts
+++ b/test/util/featured-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { isFeaturedId } from "../../src/util/featured-id.js";
+import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
+import { isFeaturedId, resolveFeaturedComponentId } from "../../src/util/featured-id.js";
 
 describe("isFeaturedId", () => {
   it("is true for a featured.<board>.<local> id", () => {
@@ -14,5 +15,29 @@ describe("isFeaturedId", () => {
 
   it("requires the trailing dot, not just the word", () => {
     expect(isFeaturedId("featuredthing")).toBe(false);
+  });
+});
+
+describe("resolveFeaturedComponentId", () => {
+  const board = {
+    id: "esp32-poe-iso",
+    featured_components: [{ id: "onboard_ethernet", component_id: "ethernet" }],
+  } as unknown as BoardCatalogEntry;
+
+  it("resolves a featured id to its underlying component_id", () => {
+    expect(
+      resolveFeaturedComponentId("featured.esp32-poe-iso.onboard_ethernet", board)
+    ).toBe("ethernet");
+  });
+
+  it("passes a non-featured id through", () => {
+    expect(resolveFeaturedComponentId("sensor.dht", board)).toBe("sensor.dht");
+  });
+
+  it("passes an unknown featured id or null board through unchanged", () => {
+    expect(resolveFeaturedComponentId("featured.esp32-poe-iso.unknown", board)).toBe(
+      "featured.esp32-poe-iso.unknown"
+    );
+    expect(resolveFeaturedComponentId("featured.x.y", null)).toBe("featured.x.y");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The add-component "Show YAML" preview keyed the block off the synthetic featured id (`featured.<board>.<local>`) instead of the component it actually adds. On an Olimex PoE board, adding Onboard Ethernet previewed `featured.esp32-poe-iso.onboard_ethernet:` rather than `ethernet:`. The committed YAML was already correct; only the preview label was wrong.

The form already holds the board, whose `featured_components` carry `{ id, component_id }`, so this resolves the featured id to its `component_id` client-side, the same mapping the catalog filter uses; no backend change. The pre-existing platform-component approximation (a regular `sensor.dht` previews as `sensor.dht:` rather than `sensor:` with `platform: dht`) is unchanged and out of scope.

**Related issue or feature (if applicable):**

- fixes #998

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
