### PR TITLE
Resolve substitutions in the id-reference picker labels

### DIFF
--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -11,6 +11,7 @@ import {
   findReferenceCandidates,
   resolveSoleCandidate,
 } from "../../util/config-entry-yaml-scan.js";
+import { resolveSubstitutions } from "../../util/substitutions.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -124,16 +125,20 @@ export function renderIdReferenceField(
         class=${invalid ? "invalid" : ""}
         ?disabled=${effectiveDisabled(entry, ctx)}
         placeholder=${defaultCandidate
-          ? defaultCandidate.name || defaultCandidate.id
+          ? resolveSubstitutions(defaultCandidate.name, ctx.substitutions) ||
+            defaultCandidate.id
           : nothing}
         @change=${onChange}
       >
         ${orphanOption}
         ${candidates.map((c) => {
           const secondary = c.name ? `${c.id} · ${domain}` : domain;
+          // The label is display-only; the stored value stays c.id. Resolve
+          // ${...} so the picker shows the same name the text field previews.
+          const displayName = resolveSubstitutions(c.name, ctx.substitutions);
           return idOption(
             c.id,
-            c.name || c.id,
+            displayName || c.id,
             c === defaultCandidate
               ? `${secondary} · ${ctx.localize("device.default_option_tag")}`
               : secondary

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -114,3 +114,41 @@ describe("renderIdReferenceField — single-candidate auto-resolve default", () 
     expect(placeholderOf(renderRef("ld2410", SINGLE_LD2410, "radar"))).toBe(nothing);
   });
 });
+
+describe("renderIdReferenceField — resolves ${...} in option labels (#1709)", () => {
+  function renderRef(domain: string, yaml: string, value: string) {
+    const entry = makeEntry(ConfigEntryType.STRING, { references_component: domain });
+    return renderIdReferenceField(
+      entry,
+      ["id"],
+      makeRenderCtx({ id: value }, { overrides: { yaml } })
+    );
+  }
+
+  const SUBS = "substitutions:\n  device_friendly_name: WIFI Switch\n";
+  const SWITCH = (name: string) =>
+    `${SUBS}switch:\n  - platform: output\n    id: relay\n    name: "${name}"\n`;
+
+  const labelOf = (tmpl: unknown, value: string): unknown =>
+    findElementBindings(tmpl, "wa-option").find((o) => o.value === value)?.[".label"];
+
+  it("resolves a substitution in the option's display label", () => {
+    expect(
+      labelOf(renderRef("switch", SWITCH("${device_friendly_name} Relay"), ""), "relay")
+    ).toBe("WIFI Switch Relay");
+  });
+
+  it("leaves an unknown substitution literal (graceful degrade)", () => {
+    expect(labelOf(renderRef("switch", SWITCH("${unknown} Relay"), ""), "relay")).toBe(
+      "${unknown} Relay"
+    );
+  });
+
+  it("resolves the substitution in the sole-candidate placeholder", () => {
+    const select = findElementBindings(
+      renderRef("switch", SWITCH("${device_friendly_name} Relay"), ""),
+      "wa-select"
+    )[0];
+    expect(select?.placeholder).toBe("WIFI Switch Relay");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The id-reference / target picker (for example the Target of a `switch.turn_off:` action, or a `switch.output` reference) rendered its option labels straight from the raw YAML `name:` scalar, so a name like `${device_friendly_name} Relay` showed unresolved, even though text fields already resolve and preview substitutions. This resolves `${...}` against the file's `substitutions:` block for the option labels and the sole-candidate placeholder, reusing the existing `resolveSubstitutions` helper and the substitution map already on the render context.

The label is display-only; the stored value stays the component id, so selection and round-trip are unchanged. An unknown substitution (e.g. one defined in a `packages:` include the scan can't see) degrades to the literal text, matching the previous behaviour. Because the option `.label` drives the closed select's display too, the selected value resolves as well, not just the open dropdown.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1709

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
