### PR TITLE
Hide featured cards whose preset id is already configured

### DIFF
--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -6,6 +6,7 @@ import {
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { isComponentPresent } from "../../../util/component-presence.js";
 import { platformSupported } from "../../../util/config-validation.js";
+import { collectExistingIds } from "../../../util/default-component-id.js";
 import { buildFeaturedId } from "../../../util/featured-id.js";
 import {
   parseConfiguredPlatforms,
@@ -32,6 +33,18 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 //     satisfied from this dialog. A dep counts as satisfied when it's
 //     already in the user's YAML OR one of the platform-compatible IDs in
 //     this response.
+// A featured card pins a specific board peripheral via a preset `id`
+// (apollo `rgb_leds`). Once that id is in the YAML the peripheral is
+// configured, so the card is effectively single-instance even when its
+// underlying type is multi_conf (many LED strips exist, but only one of this).
+function featuredIdPresent(
+  fc: FeaturedComponent,
+  existingIds: ReadonlySet<string>
+): boolean {
+  const presetId = fc.fields?.["id"]?.value;
+  return typeof presetId === "string" && existingIds.has(presetId);
+}
+
 export function visibleComponents(
   host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
@@ -45,18 +58,23 @@ export function visibleComponents(
     ? new Set(platformCompatible.map((c) => c.id))
     : null;
 
-  // Map a featured card's synthetic id back to the component it actually adds.
-  const featuredRefId = new Map<string, string>();
+  // Map a featured card's synthetic id back to its FeaturedComponent.
+  const existingIds = collectExistingIds(host.yaml);
+  const featuredById = new Map<string, FeaturedComponent>();
   const board = host.board;
   if (board) {
     // Slim board entries omit featured_components; guard like the catalog's load().
     for (const fc of board.featured_components ?? []) {
-      featuredRefId.set(buildFeaturedId(board.id, fc.id), fc.component_id);
+      featuredById.set(buildFeaturedId(board.id, fc.id), fc);
     }
   }
 
   return platformCompatible.filter((c) => {
-    const refId = featuredRefId.get(c.id) ?? c.id;
+    const fc = featuredById.get(c.id);
+    if (fc && featuredIdPresent(fc, existingIds)) {
+      return false;
+    }
+    const refId = fc?.component_id ?? c.id;
     if (!c.multi_conf && isComponentPresent(refId, present, presentPlatforms)) {
       return false;
     }
@@ -117,11 +135,14 @@ export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   if (!board) return 0;
   const present = parseTopLevelComponents(host.yaml);
   const presentPlatforms = parseConfiguredPlatforms(host.yaml);
+  const existingIds = collectExistingIds(host.yaml);
   // `!== false`, not truthy: the backend omits the `true` default, so an
-  // absent multi_conf means multi-conf (still addable).
+  // absent multi_conf means multi-conf (still addable). A featured peripheral
+  // whose preset id is already configured is never addable, regardless.
   const addable = (fc: FeaturedComponent) =>
-    fc.multi_conf !== false ||
-    !isComponentPresent(fc.component_id, present, presentPlatforms);
+    !featuredIdPresent(fc, existingIds) &&
+    (fc.multi_conf !== false ||
+      !isComponentPresent(fc.component_id, present, presentPlatforms));
   const components = (board.featured_components ?? []).filter(addable).length;
   return components + (board.featured_bundles?.length ?? 0);
 }

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -59,7 +59,6 @@ export function visibleComponents(
     : null;
 
   // Map a featured card's synthetic id back to its FeaturedComponent.
-  const existingIds = collectExistingIds(host.yaml);
   const featuredById = new Map<string, FeaturedComponent>();
   const board = host.board;
   if (board) {
@@ -68,6 +67,10 @@ export function visibleComponents(
       featuredById.set(buildFeaturedId(board.id, fc.id), fc);
     }
   }
+  // Only scan the YAML for ids when there are featured cards to match against.
+  const existingIds = featuredById.size
+    ? collectExistingIds(host.yaml)
+    : new Set<string>();
 
   return platformCompatible.filter((c) => {
     const fc = featuredById.get(c.id);
@@ -133,9 +136,10 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
 export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   const board = host.board;
   if (!board) return 0;
+  const featured = board.featured_components ?? [];
   const present = parseTopLevelComponents(host.yaml);
   const presentPlatforms = parseConfiguredPlatforms(host.yaml);
-  const existingIds = collectExistingIds(host.yaml);
+  const existingIds = featured.length ? collectExistingIds(host.yaml) : new Set<string>();
   // `!== false`, not truthy: the backend omits the `true` default, so an
   // absent multi_conf means multi-conf (still addable). A featured peripheral
   // whose preset id is already configured is never addable, regardless.
@@ -143,7 +147,7 @@ export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
     !featuredIdPresent(fc, existingIds) &&
     (fc.multi_conf !== false ||
       !isComponentPresent(fc.component_id, present, presentPlatforms));
-  const components = (board.featured_components ?? []).filter(addable).length;
+  const components = featured.filter(addable).length;
   return components + (board.featured_bundles?.length ?? 0);
 }
 

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -118,10 +118,34 @@ export function ambiguousNameIds(components: ComponentCatalogEntry[]): Set<strin
   return ids;
 }
 
+// A bundle drops a fixed set of featured peripherals (each with a preset id)
+// into the config at once. It's fully configured when every component's preset
+// id is in the YAML, so hide it then — a second add would duplicate all of them.
+function presentBundleIds(host: ESPHomeComponentCatalog): Set<string> {
+  const board = host.board;
+  const bundles = board?.featured_bundles ?? [];
+  if (!board || bundles.length === 0) return new Set();
+  const presetIdByLocal = new Map<string, string>();
+  for (const fc of board.featured_components ?? []) {
+    const presetId = fc.fields?.["id"]?.value;
+    if (typeof presetId === "string") presetIdByLocal.set(fc.id, presetId);
+  }
+  const existingIds = memoIds(host.yaml);
+  const out = new Set<string>();
+  for (const bundle of bundles) {
+    const ids = bundle.component_ids
+      .map((cid) => presetIdByLocal.get(cid))
+      .filter((id): id is string => id !== undefined);
+    if (ids.length > 0 && ids.every((id) => existingIds.has(id))) out.add(bundle.id);
+  }
+  return out;
+}
+
 // Bundles live on boards/get_board (not components/*) — filter client-side
 // so a search behaves consistently across featured + bundles + components.
 export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[] {
-  const bundles = host.board?.featured_bundles ?? [];
+  const present = presentBundleIds(host);
+  const bundles = (host.board?.featured_bundles ?? []).filter((b) => !present.has(b.id));
   const q = host._search.trim().toLowerCase();
   if (!q) return bundles;
   return bundles.filter(
@@ -133,8 +157,8 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
 }
 
 // Recommendations shown for this board: a featured component counts when it's
-// multi-conf or not yet configured; bundles are counted as-is, matching the
-// grid (`filteredBundles`) which doesn't present-filter them. Drives the
+// multi-conf or not yet configured; a bundle counts until it's fully
+// configured, matching the grid (`filteredBundles`). Drives the
 // Recommended badge and the auto-select so an all-configured board collapses
 // the category instead of showing an empty "0 of N" list. No platform gate
 // here (unlike `visibleComponents`): a board only recommends its own
@@ -155,7 +179,11 @@ export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
     (fc.multi_conf !== false ||
       !isComponentPresent(fc.component_id, present, presentPlatforms));
   const components = featured.filter(addable).length;
-  return components + (board.featured_bundles?.length ?? 0);
+  const presentBundles = presentBundleIds(host);
+  const bundles = (board.featured_bundles ?? []).filter(
+    (b) => !presentBundles.has(b.id)
+  ).length;
+  return components + bundles;
 }
 
 interface CategoryEntry {

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -36,7 +36,7 @@ import type { ESPHomeComponentCatalog } from "../component-catalog.js";
 // A featured card pins a specific board peripheral via a preset `id`
 // (apollo `rgb_leds`). Once that id is in the YAML the peripheral is
 // configured, so the card is effectively single-instance even when its
-// underlying type is multi_conf (many LED strips exist, but only one of this).
+// underlying type is multi_conf (many LED strips exist, but only one exists on the board).
 function featuredIdPresent(
   fc: FeaturedComponent,
   existingIds: ReadonlySet<string>

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -1,3 +1,4 @@
+import memoizeOne from "memoize-one";
 import type { FeaturedBundle, FeaturedComponent } from "../../../api/types/boards.js";
 import {
   type ComponentCatalogEntry,
@@ -14,6 +15,14 @@ import {
 } from "../../../util/yaml-serialize.js";
 import { categoryChipLabel } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
+
+// The catalog re-renders on every search keystroke, and visibleComponents +
+// availableFeaturedCount each scan the YAML, so the same string is parsed
+// several times per render. memoize-one caches the last result per scan; its
+// single slot fits one open catalog at a time (the catalog is a dialog).
+const memoPresent = memoizeOne(parseTopLevelComponents);
+const memoPlatforms = memoizeOne(parseConfiguredPlatforms);
+const memoIds = memoizeOne(collectExistingIds);
 
 // Three filters applied client-side:
 //  1. Platform gate: drop components incompatible with the device's
@@ -48,8 +57,8 @@ function featuredIdPresent(
 export function visibleComponents(
   host: ESPHomeComponentCatalog
 ): ComponentCatalogEntry[] {
-  const present = parseTopLevelComponents(host.yaml);
-  const presentPlatforms = parseConfiguredPlatforms(host.yaml);
+  const present = memoPresent(host.yaml);
+  const presentPlatforms = memoPlatforms(host.yaml);
   const lockedToCore = host.lockedCategories.length > 0;
   const platformCompatible = host._components.filter((c) =>
     platformSupported(c.supported_platforms, host.platform)
@@ -68,9 +77,7 @@ export function visibleComponents(
     }
   }
   // Only scan the YAML for ids when there are featured cards to match against.
-  const existingIds = featuredById.size
-    ? collectExistingIds(host.yaml)
-    : new Set<string>();
+  const existingIds = featuredById.size ? memoIds(host.yaml) : new Set<string>();
 
   return platformCompatible.filter((c) => {
     const fc = featuredById.get(c.id);
@@ -137,9 +144,9 @@ export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
   const board = host.board;
   if (!board) return 0;
   const featured = board.featured_components ?? [];
-  const present = parseTopLevelComponents(host.yaml);
-  const presentPlatforms = parseConfiguredPlatforms(host.yaml);
-  const existingIds = featured.length ? collectExistingIds(host.yaml) : new Set<string>();
+  const present = memoPresent(host.yaml);
+  const presentPlatforms = memoPlatforms(host.yaml);
+  const existingIds = featured.length ? memoIds(host.yaml) : new Set<string>();
   // `!== false`, not truthy: the backend omits the `true` default, so an
   // absent multi_conf means multi-conf (still addable). A featured peripheral
   // whose preset id is already configured is never addable, regardless.

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -5,6 +5,7 @@ import type { ESPHomeComponentCatalog } from "../../../../src/components/device/
 import {
   availableFeaturedCount,
   buildCategories,
+  filteredBundles,
   visibleComponents,
 } from "../../../../src/components/device/component-catalog/filters.js";
 
@@ -37,6 +38,7 @@ function host(
 ): ESPHomeComponentCatalog {
   return {
     _components: components,
+    _search: "",
     platform,
     yaml,
     lockedCategories,
@@ -209,7 +211,7 @@ describe("availableFeaturedCount", () => {
     ).toBe(0);
   });
 
-  it("counts bundles as-is (matching the grid), plus addable components", () => {
+  it("counts a bundle whose components have no preset id (can't detect presence)", () => {
     const b = board(
       [
         { id: "eth", component_id: "ethernet", multi_conf: false },
@@ -217,10 +219,71 @@ describe("availableFeaturedCount", () => {
       ],
       [{ id: "kit", component_ids: ["eth", "relay"] }]
     );
-    // ethernet present (dropped), relay addable (1), bundle always counts (1)
+    // ethernet present (dropped), relay addable (1), bundle counts (1)
     expect(
       availableFeaturedCount(host([], "esp32", { yaml: "ethernet:\n", board: b }))
     ).toBe(2);
+  });
+
+  it("drops a bundle once all its components' preset ids are configured", () => {
+    const b = board(
+      [
+        {
+          id: "rgb",
+          component_id: "light.esp32_rmt_led_strip",
+          fields: { id: { value: "rgb_leds" } },
+        },
+        {
+          id: "buz",
+          component_id: "output.ledc",
+          fields: { id: { value: "buzzer_output" } },
+        },
+      ],
+      [{ id: "kit", component_ids: ["rgb", "buz"] }]
+    );
+    const both = "light:\n  - id: rgb_leds\noutput:\n  - id: buzzer_output\n";
+    // both featured cards drop AND the bundle drops -> 0
+    expect(availableFeaturedCount(host([], "esp32", { yaml: both, board: b }))).toBe(0);
+    // only rgb present: rgb drops, buz addable (1), bundle not fully configured (1) -> 2
+    const partial = "light:\n  - id: rgb_leds\n";
+    expect(availableFeaturedCount(host([], "esp32", { yaml: partial, board: b }))).toBe(
+      2
+    );
+  });
+});
+
+describe("filteredBundles present-filter", () => {
+  const board = {
+    id: "apollo-esk-1",
+    featured_components: [
+      {
+        id: "rgb",
+        component_id: "light.esp32_rmt_led_strip",
+        fields: { id: { value: "rgb_leds" } },
+      },
+      {
+        id: "buz",
+        component_id: "output.ledc",
+        fields: { id: { value: "buzzer_output" } },
+      },
+    ],
+    featured_bundles: [
+      { id: "kit", name: "Kit", description: "", component_ids: ["rgb", "buz"] },
+    ],
+  } as unknown as BoardCatalogEntry;
+
+  it("hides a bundle when all its components' preset ids are present", () => {
+    const yaml = "light:\n  - id: rgb_leds\noutput:\n  - id: buzzer_output\n";
+    expect(filteredBundles(host([], "esp32", { yaml, board })).map((b) => b.id)).toEqual(
+      []
+    );
+  });
+
+  it("keeps a bundle that is only partially configured", () => {
+    const yaml = "light:\n  - id: rgb_leds\n";
+    expect(filteredBundles(host([], "esp32", { yaml, board })).map((b) => b.id)).toEqual([
+      "kit",
+    ]);
   });
 });
 

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -112,6 +112,44 @@ describe("visibleComponents featured present-filter", () => {
     ).map((c) => c.id);
     expect(ids).toEqual(["featured.demo.relay"]);
   });
+
+  // A featured peripheral pins a preset id, so it is single-instance even when
+  // its underlying type is multi_conf (apollo RGB LEDs / esp32_rmt_led_strip).
+  const ledBoard = {
+    id: "apollo-esk-1",
+    featured_components: [
+      {
+        id: "rgb_leds",
+        component_id: "light.esp32_rmt_led_strip",
+        fields: { id: { value: "rgb_leds" } },
+      },
+      {
+        id: "onboard_rgb_led",
+        component_id: "light.esp32_rmt_led_strip",
+        fields: { id: { value: "onboard_rgb_led" } },
+      },
+    ],
+  } as unknown as BoardCatalogEntry;
+  const rgbLeds = entry("featured.apollo-esk-1.rgb_leds", [], [], true);
+  const onboardRgb = entry("featured.apollo-esk-1.onboard_rgb_led", [], [], true);
+
+  it("hides a multi_conf featured component whose preset id is already configured", () => {
+    const ids = visibleComponents(
+      host([rgbLeds, onboardRgb], "esp32", {
+        yaml: "light:\n  - platform: esp32_rmt_led_strip\n    id: rgb_leds\n",
+        board: ledBoard,
+      })
+    ).map((c) => c.id);
+    // rgb_leds hidden (its id is present); the sibling onboard_rgb_led stays.
+    expect(ids).toEqual(["featured.apollo-esk-1.onboard_rgb_led"]);
+  });
+
+  it("keeps a multi_conf featured component whose preset id is not configured", () => {
+    const ids = visibleComponents(host([rgbLeds], "esp32", { board: ledBoard })).map(
+      (c) => c.id
+    );
+    expect(ids).toEqual(["featured.apollo-esk-1.rgb_leds"]);
+  });
 });
 
 describe("availableFeaturedCount", () => {
@@ -149,6 +187,26 @@ describe("availableFeaturedCount", () => {
         host([], "esp32", { yaml: "switch:\n  - platform: gpio\n", board: b })
       )
     ).toBe(1);
+  });
+
+  it("drops a multi_conf featured component whose preset id is configured", () => {
+    const b = board([
+      {
+        id: "rgb_leds",
+        component_id: "light.esp32_rmt_led_strip",
+        multi_conf: true,
+        fields: { id: { value: "rgb_leds" } },
+      },
+    ]);
+    expect(availableFeaturedCount(host([], "esp32", { board: b }))).toBe(1);
+    expect(
+      availableFeaturedCount(
+        host([], "esp32", {
+          yaml: "light:\n  - platform: esp32_rmt_led_strip\n    id: rgb_leds\n",
+          board: b,
+        })
+      )
+    ).toBe(0);
   });
 
   it("counts bundles as-is (matching the grid), plus addable components", () => {


### PR DESCRIPTION
# What does this implement/fix?

A single-instance featured component could be added twice from the component
catalog. On apollo-esk-1, adding "RGB LEDs" (underlying `light.esp32_rmt_led_strip`)
a second time spliced a duplicate `light:` entry with the same name/id/pin, which
ESPHome rejects ("Duplicate light entity with name 'RGB LEDs'").

The #992 present-filter only hid a featured card when its underlying was
single-instance (`!multi_conf`). A featured component pins a specific board
peripheral (a preset `id` / `name` / `pin`), so it is effectively single-instance
even when the underlying type is `multi_conf`.

`visibleComponents` (and the parallel `availableFeaturedCount`) now also hide a
featured card when its preset `id` (`fc.fields["id"].value`) already appears in
the YAML, regardless of `multi_conf`. The sibling "Onboard RGB LED" (different
preset id) stays addable.

Matching is by `id` (covers the default path); a renamed-id-but-same-name
duplicate is a possible follow-up. The backend gains an authoritative
`ALREADY_EXISTS` guard separately (esphome/device-builder).

**Related issue or feature (if applicable):**

- fixes #1001

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
