### PR TITLE
Show the resolved substitution hint on the automation Target field

### DIFF
--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "lit";
 
+import { substitutionNoteStyles } from "../substitution-note.styles.js";
 import { automationEditorActionStyles } from "./automation-editor-actions.styles.js";
 import { automationEditorRowStyles } from "./automation-editor-rows.styles.js";
 import { automationEditorScriptParamStyles } from "./automation-editor-script-params.styles.js";
@@ -229,4 +230,5 @@ export const automationEditorStyles = [
   automationEditorScriptParamStyles,
   automationEditorRowStyles,
   automationEditorActionStyles,
+  substitutionNoteStyles,
 ];

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -30,6 +30,7 @@ import { consume } from "@lit/context";
 import { mdiArrowDecisionOutline, mdiDelete, mdiOpenInNew } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
@@ -56,9 +57,11 @@ import {
 import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
+import { parseSubstitutions } from "../../../util/substitutions.js";
 import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import { renderAdvancedToggle } from "../advanced-toggle.js";
 import "../config-entry-form.js";
+import { renderSubstitutionHint } from "../config-entry-renderers-shared.js";
 import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -215,6 +218,10 @@ export class ESPHomeAutomationEditor extends LitElement {
   public get inFlightWrite(): boolean {
     return this._deleting || this._applyInFlight;
   }
+
+  /** Parse ``substitutions:`` from the current YAML once per edit so the
+   *  read-only Target field can preview ${...} like the text fields do. */
+  private _parseSubstitutions = memoizeOne(parseSubstitutions);
 
   static styles = [espHomeStyles, inputStyles, automationEditorStyles];
 
@@ -723,6 +730,11 @@ export class ESPHomeAutomationEditor extends LitElement {
     return html`<div class="field">
       <label class="field-label"> ${this._localize("device.automation_target")} </label>
       <input type="text" readonly .value=${targetValue} />
+      ${renderSubstitutionHint(
+        targetValue,
+        this._parseSubstitutions(this.yaml),
+        this._localize
+      )}
     </div>`;
   }
 

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -61,7 +61,6 @@ import { parseSubstitutions } from "../../../util/substitutions.js";
 import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
 import { renderAdvancedToggle } from "../advanced-toggle.js";
 import "../config-entry-form.js";
-import { renderSubstitutionHint } from "../config-entry-renderers-shared.js";
 import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
@@ -70,6 +69,7 @@ import "./automation-trigger-picker.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
 import { componentDomain, instanceName } from "./component-targets.js";
 import { ParseErrorController } from "./parse-error-controller.js";
+import { renderTargetField } from "./render-target-field.js";
 import {
   applyParamChange,
   applyYamlDiff,
@@ -727,15 +727,11 @@ export class ESPHomeAutomationEditor extends LitElement {
     if (!loc) return nothing;
     if (loc.kind !== "component_on" && loc.kind !== "component_action") return nothing;
     const targetValue = this._targetMetadataValue(loc);
-    return html`<div class="field">
-      <label class="field-label"> ${this._localize("device.automation_target")} </label>
-      <input type="text" readonly .value=${targetValue} />
-      ${renderSubstitutionHint(
-        targetValue,
-        this._parseSubstitutions(this.yaml),
-        this._localize
-      )}
-    </div>`;
+    return renderTargetField(
+      targetValue,
+      this._parseSubstitutions(this.yaml),
+      this._localize
+    );
   }
 
   /**

--- a/src/components/device/automation-editor/render-target-field.ts
+++ b/src/components/device/automation-editor/render-target-field.ts
@@ -1,0 +1,22 @@
+/**
+ * The automation editor's read-only Target identity field. Kept as a pure
+ * function (not a method) so it can be unit-tested without mounting the editor,
+ * which pulls in CodeMirror. Renders the raw target value plus the shared
+ * ``${var}`` / ``$var`` resolved-hint chip, matching the text-field UX.
+ */
+import { html } from "lit";
+
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { renderSubstitutionHint } from "../config-entry-renderers-shared.js";
+
+export function renderTargetField(
+  targetValue: string,
+  substitutions: Map<string, string>,
+  localize: LocalizeFunc
+) {
+  return html`<div class="field">
+    <label class="field-label"> ${localize("device.automation_target")} </label>
+    <input type="text" readonly .value=${targetValue} />
+    ${renderSubstitutionHint(targetValue, substitutions, localize)}
+  </div>`;
+}

--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -82,8 +82,10 @@ export const configEntryFormStyles = css`
   /* Hint shown below a string/password input when the value is a
      !secret reference — clarifies that the field points into
      secrets.yaml instead of holding a literal value. */
-  .secret-note,
-  .substitution-note {
+  /* The .substitution-note chip styles live in substitution-note.styles.js
+     (pulled into fieldRendererStyles) so the automation editor can share
+     them; only .secret-note is here. */
+  .secret-note {
     display: inline-flex;
     align-items: center;
     gap: var(--wa-space-2xs);
@@ -92,29 +94,12 @@ export const configEntryFormStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
-  .secret-note wa-icon,
-  .substitution-note wa-icon {
+  .secret-note wa-icon {
     font-size: 14px;
     color: var(--esphome-primary);
   }
 
-  /* The "defined elsewhere" marker is a quiet heads-up, not a positive
-     resolve, so its braces icon and text stay muted. */
-  .substitution-note--external {
-    color: var(--wa-color-text-quiet);
-  }
-
-  .substitution-note--external wa-icon {
-    color: var(--wa-color-text-quiet);
-  }
-
-  /* …except the warning glyph, which signals the unresolved reference. */
-  .substitution-note--external wa-icon.substitution-warn {
-    color: var(--wa-color-warning-fill-loud, #b8860b);
-  }
-
-  .secret-note code,
-  .substitution-note code {
+  .secret-note code {
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     font-size: var(--wa-font-size-2xs);
     padding: 1px 4px;

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -146,8 +146,8 @@ export function renderSecretHint(value: string, ctx: RenderCtx) {
 }
 
 /**
- * Hint beneath a string field referencing a ``${var}``: previews the
- * value when it resolves against this file's ``substitutions:``, else a
+ * Hint beneath a string field referencing a ``${var}`` or bare ``$var``:
+ * previews the value when it resolves against this file's ``substitutions:``, else a
  * marker whose tooltip notes the reference is resolved at build time
  * (from a package/include), not previewed here. ``nothing`` with no ref.
  */

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -55,6 +55,7 @@ import { constraintClusterStyles } from "./config-entry-renderers/constraint-clu
 import { literalLambdaToggleStyles } from "./config-entry-renderers/literal-lambda-toggle.js";
 import { fieldHighlightStyles } from "./field-highlight.styles.js";
 import type { PasswordInputValueChange } from "./password-input.js";
+import { substitutionNoteStyles } from "./substitution-note.styles.js";
 // Type-only — the `<esphome-secret-picker>` element is registered by the
 // form host (`config-entry-form.ts`). Keeping this module free of the
 // element's DOM-dependent side-effect import lets the renderer unit tests
@@ -75,6 +76,7 @@ export const fieldRendererStyles = [
   literalLambdaToggleStyles,
   constraintClusterStyles,
   fieldHighlightStyles,
+  substitutionNoteStyles,
 ];
 
 registerMdiIcons({

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -15,6 +15,7 @@ import {
 import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
+import type { LocalizeFunc } from "../../common/localize.js";
 import { warningBannerStyles } from "../../styles/banners.js";
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
@@ -148,11 +149,15 @@ export function renderSecretHint(value: string, ctx: RenderCtx) {
  * marker whose tooltip notes the reference is resolved at build time
  * (from a package/include), not previewed here. ``nothing`` with no ref.
  */
-export function renderSubstitutionHint(value: string, ctx: RenderCtx) {
+export function renderSubstitutionHint(
+  value: string,
+  substitutions: Map<string, string>,
+  localize: LocalizeFunc
+) {
   if (!hasSubstitutionReference(value)) return nothing;
-  const resolved = resolveSubstitutions(value, ctx.substitutions);
+  const resolved = resolveSubstitutions(value, substitutions);
   if (hasSubstitutionReference(resolved)) {
-    const hint = ctx.localize("device.substitution_unresolved_hint");
+    const hint = localize("device.substitution_unresolved_hint");
     return html`<span
       class="substitution-note substitution-note--external"
       role="note"
@@ -165,10 +170,10 @@ export function renderSubstitutionHint(value: string, ctx: RenderCtx) {
         library="mdi"
         name="alert-circle-outline"
       ></wa-icon>
-      <span>${ctx.localize("device.substitution_unresolved")}</span>
+      <span>${localize("device.substitution_unresolved")}</span>
     </span>`;
   }
-  const label = ctx.localize("device.substitution_resolves_to");
+  const label = localize("device.substitution_resolves_to");
   return html`<span
     class="substitution-note"
     role="note"
@@ -401,7 +406,10 @@ export function renderStringField(
   const secretHint = secretPicker === nothing ? renderSecretHint(value, ctx) : nothing;
   // Never preview the resolved value for concealed fields — a secret kept
   // in `substitutions:` (e.g. a WiFi/API password) must not leak in plaintext.
-  const subHint = inputType === "password" ? nothing : renderSubstitutionHint(value, ctx);
+  const subHint =
+    inputType === "password"
+      ? nothing
+      : renderSubstitutionHint(value, ctx.substitutions, ctx.localize);
   // When the entry carries a closed list of `suggestions`, render a
   // strict <wa-select> regardless of the underlying inputType — used
   // by featured components to pin the field to one of a few values

--- a/src/components/device/substitution-note.styles.ts
+++ b/src/components/device/substitution-note.styles.ts
@@ -2,9 +2,8 @@ import { css } from "lit";
 
 /** The `${...}` resolved-preview chip rendered by ``renderSubstitutionHint``.
  *  Shadow DOM scopes styles per component, so every host that renders the hint
- *  must include this block. ``config-entry-form.styles.ts`` keeps its own copy
- *  (shared selectors with ``.secret-note``); this is the standalone version for
- *  hosts that only need the substitution chip. */
+ *  must include this block: the config-entry form via ``fieldRendererStyles``,
+ *  the automation editor via ``automationEditorStyles``. */
 export const substitutionNoteStyles = css`
   .substitution-note {
     display: inline-flex;

--- a/src/components/device/substitution-note.styles.ts
+++ b/src/components/device/substitution-note.styles.ts
@@ -1,0 +1,46 @@
+import { css } from "lit";
+
+/** The `${...}` resolved-preview chip rendered by ``renderSubstitutionHint``.
+ *  Shadow DOM scopes styles per component, so every host that renders the hint
+ *  must include this block. ``config-entry-form.styles.ts`` keeps its own copy
+ *  (shared selectors with ``.secret-note``); this is the standalone version for
+ *  hosts that only need the substitution chip. */
+export const substitutionNoteStyles = css`
+  .substitution-note {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    margin-top: var(--wa-space-2xs);
+    font-size: var(--wa-font-size-2xs);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .substitution-note wa-icon {
+    font-size: 14px;
+    color: var(--esphome-primary);
+  }
+
+  /* The "defined elsewhere" marker is a quiet heads-up, not a positive
+     resolve, so its braces icon and text stay muted. */
+  .substitution-note--external {
+    color: var(--wa-color-text-quiet);
+  }
+
+  .substitution-note--external wa-icon {
+    color: var(--wa-color-text-quiet);
+  }
+
+  /* …except the warning glyph, which signals the unresolved reference. */
+  .substitution-note--external wa-icon.substitution-warn {
+    color: var(--wa-color-warning-fill-loud, #b8860b);
+  }
+
+  .substitution-note code {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: var(--wa-font-size-2xs);
+    padding: 1px 4px;
+    border-radius: var(--wa-border-radius-s);
+    background: var(--wa-color-surface-lowered);
+    color: var(--wa-color-text-normal);
+  }
+`;

--- a/src/components/device/substitution-note.styles.ts
+++ b/src/components/device/substitution-note.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "lit";
 
-/** The `${...}` resolved-preview chip rendered by ``renderSubstitutionHint``.
+/** The `${var}` / `$var` resolved-preview chip rendered by ``renderSubstitutionHint``.
  *  Shadow DOM scopes styles per component, so every host that renders the hint
  *  must include this block: the config-entry form via ``fieldRendererStyles``,
  *  the automation editor via ``automationEditorStyles``. */

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -107,4 +107,17 @@ describe("automation-editor auto-apply / delete contract", () => {
     expect(body.includes("_deleting")).toBe(true);
     expect(body.includes("_applyInFlight")).toBe(true);
   });
+
+  it("renders the ${...} resolved hint under the read-only Target field (#1711)", async () => {
+    const src = await readSource();
+    // The editor can't mount in vitest (CodeMirror), so pin the wiring:
+    // _renderIdentityFields must feed the target value through
+    // renderSubstitutionHint with the substitutions parsed from this.yaml.
+    const onIdx = src.indexOf("_renderIdentityFields");
+    const after = src.slice(onIdx);
+    const nextSibling = after.search(/\n\s*private\s+_targetMetadataValue/);
+    const slice = nextSibling > 0 ? after.slice(0, nextSibling) : after;
+    expect(slice).toMatch(/renderSubstitutionHint\(/);
+    expect(slice).toMatch(/_parseSubstitutions\(this\.yaml\)/);
+  });
 });

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -111,13 +111,10 @@ describe("automation-editor auto-apply / delete contract", () => {
   it("renders the ${...} resolved hint under the read-only Target field (#1711)", async () => {
     const src = await readSource();
     // The editor can't mount in vitest (CodeMirror), so pin the wiring:
-    // _renderIdentityFields must feed the target value through
-    // renderSubstitutionHint with the substitutions parsed from this.yaml.
-    const onIdx = src.indexOf("_renderIdentityFields");
-    const after = src.slice(onIdx);
-    const nextSibling = after.search(/\n\s*private\s+_targetMetadataValue/);
-    const slice = nextSibling > 0 ? after.slice(0, nextSibling) : after;
-    expect(slice).toMatch(/renderSubstitutionHint\(/);
-    expect(slice).toMatch(/_parseSubstitutions\(this\.yaml\)/);
+    // the target value is fed through renderSubstitutionHint with the
+    // substitutions parsed from this.yaml. The chip's own logic is covered
+    // by substitution-hint.test.ts.
+    expect(src).toContain("renderSubstitutionHint(");
+    expect(src).toContain("_parseSubstitutions(this.yaml)");
   });
 });

--- a/test/components/device/automation-editor/automation-editor.test.ts
+++ b/test/components/device/automation-editor/automation-editor.test.ts
@@ -107,14 +107,4 @@ describe("automation-editor auto-apply / delete contract", () => {
     expect(body.includes("_deleting")).toBe(true);
     expect(body.includes("_applyInFlight")).toBe(true);
   });
-
-  it("renders the ${...} resolved hint under the read-only Target field (#1711)", async () => {
-    const src = await readSource();
-    // The editor can't mount in vitest (CodeMirror), so pin the wiring:
-    // the target value is fed through renderSubstitutionHint with the
-    // substitutions parsed from this.yaml. The chip's own logic is covered
-    // by substitution-hint.test.ts.
-    expect(src).toContain("renderSubstitutionHint(");
-    expect(src).toContain("_parseSubstitutions(this.yaml)");
-  });
 });

--- a/test/components/device/automation-editor/render-target-field.test.ts
+++ b/test/components/device/automation-editor/render-target-field.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for ``renderTargetField`` (#1711) — the automation editor's read-only
+ * Target identity field. Asserts rendered output (the raw value in the input
+ * plus the resolved ${...} hint) rather than the editor's source text, which
+ * the editor itself can't do in vitest because it pulls in CodeMirror.
+ */
+import { describe, expect, it } from "vitest";
+import { renderTargetField } from "../../../../src/components/device/automation-editor/render-target-field.js";
+import { findTemplatesByAnchor } from "../../../_lit-template-walker.js";
+import { findElementBindings } from "../_renderer-fixtures.js";
+
+const localize = (k: string) => k;
+
+const spanValues = (tmpl: unknown): unknown[] =>
+  findTemplatesByAnchor(tmpl, "<span").flatMap((t) => t.values as unknown[]);
+
+describe("renderTargetField", () => {
+  it("keeps the raw value in the input and previews the resolved substitution", () => {
+    const tmpl = renderTargetField(
+      "${device_friendly_name} Switch (binary_sensor.gpio)",
+      new Map([["device_friendly_name", "WIFI Switch"]]),
+      localize
+    );
+    const input = findElementBindings(tmpl, "input")[0];
+    expect(input[".value"]).toBe("${device_friendly_name} Switch (binary_sensor.gpio)");
+    expect(
+      spanValues(tmpl).some(
+        (v) =>
+          typeof v === "string" && v.includes("WIFI Switch Switch (binary_sensor.gpio)")
+      )
+    ).toBe(true);
+  });
+
+  it("renders no hint chip when the target has no substitution", () => {
+    const tmpl = renderTargetField("Relay (switch.gpio)", new Map(), localize);
+    expect(findElementBindings(tmpl, "input")[0][".value"]).toBe("Relay (switch.gpio)");
+    // The hint is the only <span> the field emits; absent means no chip.
+    expect(findTemplatesByAnchor(tmpl, "<span")).toHaveLength(0);
+  });
+});

--- a/test/components/device/substitution-hint.test.ts
+++ b/test/components/device/substitution-hint.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for ``renderSubstitutionHint`` (#1711). The helper takes the
+ * substitution map + localize directly so non-RenderCtx hosts (the automation
+ * editor's read-only Target field) can render the same ${...} preview chip the
+ * text fields show.
+ */
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderSubstitutionHint } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
+
+const localize = (k: string) => k;
+
+const spanValues = (tmpl: unknown): unknown[] =>
+  findTemplatesByAnchor(tmpl, "<span").flatMap((t) => t.values as unknown[]);
+
+describe("renderSubstitutionHint", () => {
+  it("returns nothing when the value has no ${...} reference", () => {
+    expect(renderSubstitutionHint("plain value", new Map(), localize)).toBe(nothing);
+  });
+
+  it("previews the resolved value when the substitution is known", () => {
+    const tmpl = renderSubstitutionHint(
+      "${device_friendly_name} Switch (binary_sensor.gpio)",
+      new Map([["device_friendly_name", "WIFI Switch"]]),
+      localize
+    );
+    expect(
+      spanValues(tmpl).some(
+        (v) =>
+          typeof v === "string" && v.includes("WIFI Switch Switch (binary_sensor.gpio)")
+      )
+    ).toBe(true);
+  });
+
+  it("marks an unresolved reference (defined outside this file) instead of previewing", () => {
+    const tmpl = renderSubstitutionHint("${from_a_package} X", new Map(), localize);
+    expect(spanValues(tmpl)).toContain("device.substitution_unresolved");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1002. The id-reference picker now resolves `${...}`, but the automation editor's read-only **Target** identity field still showed the raw value (e.g. `${device_friendly_name} Switch (binary_sensor.gpio)`) with no preview. This renders the same `{}` resolved-hint chip under the Target field that the text fields already show, so it reads "WIFI Switch Switch (binary_sensor.gpio)".

`renderSubstitutionHint` is generalized to take `(value, substitutions, localize)` instead of the whole `RenderCtx` (it only used those two), so the automation editor (which has the device YAML and a localize, but no render context) can reuse it. The substitution-note chip styles are extracted into a small shared module included in the automation editor's shadow root; the config-entry form keeps its own copy (its selectors are shared with `.secret-note`).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1711

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
