### PR TITLE
Don't toggle the command palette on editor-handled keys

### DIFF
--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -107,7 +107,12 @@ export class ESPHomeCommandPalette extends LitElement {
      dedicated keydown listener. Esc is wa-dialog's job: its
      dismissible stack closes only the topmost open dialog. */
   private _onGlobalKeyDown = (e: KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+    // A focused editor may already own this keystroke: CodeMirror runs on
+    // contentDOM (deeper than window) and preventDefaults the keys it binds,
+    // so bail when it did rather than firing on top of it. Shift is excluded
+    // too so Cmd/Ctrl+Shift+K stays the editor's deleteLine (#1705).
+    if (e.defaultPrevented) return;
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "k") {
       e.preventDefault();
       this._toggle();
     }

--- a/test/components/command-palette-shortcut.test.ts
+++ b/test/components/command-palette-shortcut.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// Stub the real wa-dialog: happy-dom can't run its form-associated internals.
+vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
+
+import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
+
+/** The Cmd/Ctrl+K open shortcut, and that Shift is excluded (#1705). */
+describe("esphome-command-palette open shortcut", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  async function mount(): Promise<ESPHomeCommandPalette> {
+    const palette = new ESPHomeCommandPalette();
+    document.body.appendChild(palette);
+    await palette.updateComplete;
+    return palette;
+  }
+
+  const isOpen = (palette: ESPHomeCommandPalette): boolean =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (palette as any)._open;
+
+  test("Ctrl+K opens the palette", async () => {
+    const palette = await mount();
+    expect(isOpen(palette)).toBe(false);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }));
+
+    expect(isOpen(palette)).toBe(true);
+  });
+
+  test("Cmd+K opens the palette", async () => {
+    const palette = await mount();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
+
+    expect(isOpen(palette)).toBe(true);
+  });
+
+  test("Ctrl+Shift+K does not open the palette (stays editor deleteLine)", async () => {
+    const palette = await mount();
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true })
+    );
+
+    expect(isOpen(palette)).toBe(false);
+  });
+
+  test("Cmd+Shift+K does not open the palette", async () => {
+    const palette = await mount();
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", metaKey: true, shiftKey: true })
+    );
+
+    expect(isOpen(palette)).toBe(false);
+  });
+
+  test("Cmd+K already handled by a focused editor does not open the palette", async () => {
+    const palette = await mount();
+    // A deeper handler (e.g. CodeMirror) consumed the keystroke first.
+    window.addEventListener("keydown", (e) => e.preventDefault(), {
+      capture: true,
+      once: true,
+    });
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", ctrlKey: true, cancelable: true })
+    );
+
+    expect(isOpen(palette)).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

The command palette's global Cmd/Ctrl+K listener matched Cmd/Ctrl+Shift+K as well, so inside the CodeMirror YAML editor that combo ran the editor's `deleteLine` and opened the palette at the same time. The handler now bails when a focused editor already consumed the keystroke (`defaultPrevented`, set by CodeMirror on contentDOM before the event reaches `window`), and it excludes Shift so the shortcut stays a plain Cmd/Ctrl+K; this mirrors the existing guards in `pages/device.ts` and `device-editor.ts`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1705

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
