### PR TITLE
Clarify the palette keydown guard and fix a test name

### DIFF
--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -107,10 +107,13 @@ export class ESPHomeCommandPalette extends LitElement {
      dedicated keydown listener. Esc is wa-dialog's job: its
      dismissible stack closes only the topmost open dialog. */
   private _onGlobalKeyDown = (e: KeyboardEvent) => {
-    // A focused editor may already own this keystroke: CodeMirror runs on
-    // contentDOM (deeper than window) and preventDefaults the keys it binds,
-    // so bail when it did rather than firing on top of it. Shift is excluded
-    // too so Cmd/Ctrl+Shift+K stays the editor's deleteLine (#1705).
+    // A focused editor may already own this keystroke. This listener is on
+    // window in the bubble phase (no capture: true), so CodeMirror's
+    // contentDOM handler runs first and preventDefaults the keys it binds
+    // before the event bubbles up to here; bail when it did rather than
+    // firing on top of it. Switching this to capture would see the event
+    // before CodeMirror and break the guard. Shift is excluded too so
+    // Cmd/Ctrl+Shift+K stays the editor's deleteLine (#1705).
     if (e.defaultPrevented) return;
     if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "k") {
       e.preventDefault();

--- a/test/components/command-palette-shortcut.test.ts
+++ b/test/components/command-palette-shortcut.test.ts
@@ -60,7 +60,7 @@ describe("esphome-command-palette open shortcut", () => {
     expect(isOpen(palette)).toBe(false);
   });
 
-  test("Cmd+K already handled by a focused editor does not open the palette", async () => {
+  test("Ctrl+K already handled by a focused editor does not open the palette", async () => {
     const palette = await mount();
     // A deeper handler (e.g. CodeMirror) consumed the keystroke first.
     window.addEventListener("keydown", (e) => e.preventDefault(), {


### PR DESCRIPTION
# What does this implement/fix?

Addresses two Copilot review nits left on #1005 after it merged; no behaviour change. The palette keydown comment now spells out that the `defaultPrevented` guard works because this is a bubble-phase window listener, so CodeMirror's contentDOM handler runs first and preventDefaults before the event reaches here; switching to capture would break it. The "Cmd+K already handled" test is renamed to "Ctrl+K" since it dispatches a `ctrlKey` event.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder/issues/1705

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
