### PR TITLE
Auto-add expander hubs and namespace expander pin overlap

### DIFF
--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -74,12 +74,20 @@ export interface FeaturedComponent {
   /** Underlying component's multi_conf; absent means multi-conf (omit_default). */
   multi_conf?: boolean;
   /**
-   * Backend-computed canonical GPIO per locked pin field (e.g. `{scl: 0, sda: 1}`),
-   * derived from the underlying component's PIN schema. The catalog hides this
-   * card when an existing same-domain instance already occupies these exact
-   * pins. Absent for components with no locked pins (omit_default).
+   * Backend-computed canonical occupied-pin identity per locked pin field. A
+   * board GPIO is a number (`{scl: 0, sda: 1}`); a pin on an I/O expander is a
+   * `provider:hub_id:channel` token (`{pin: 'pcf8574:hub_in_1:0'}`) so it never
+   * aliases a board GPIO of the same number. The catalog hides this card when an
+   * existing same-domain instance already occupies these exact pins. Absent for
+   * components with no locked pins (omit_default).
    */
-  locked_pins?: Record<string, number>;
+  locked_pins?: Record<string, number | string>;
+  /**
+   * Local ids of other featured_components on this board that must be added
+   * first, in order (e.g. an i2c bus then the pcf8574 hub a pin sits on). The
+   * add flow adds any missing prerequisite before this component.
+   */
+  requires?: string[];
 }
 
 /**

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -371,10 +371,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // ahead of it through the same sequential queue bundles use.
     const prereqs = this._missingRequiredPrereqs(result.entry);
     if (prereqs && prereqs.missing.length > 0) {
+      // The intermediate steps are the prerequisites (bus, hub), not the picked
+      // component, so frame the banner as "Adding prerequisites for <name>".
       await this._startFeaturedSequence(
         [...prereqs.missing, result.entry.id],
         prereqs.boardId,
-        result.entry.name
+        this._localize("device.adding_prerequisites_for", { name: result.entry.name })
       );
       return;
     }
@@ -389,6 +391,12 @@ export class ESPHomeAddComponentDialog extends LitElement {
    * its `requires` local ids (bus then hub), resolved to full featured ids,
    * keeping only those whose locked id isn't already in the YAML. Returns null
    * for a non-featured entry or one with no requires.
+   *
+   * Invariant: `requires` must be the fully-flattened, ordered prerequisite set
+   * — only the selected component's direct `requires` is resolved here, and the
+   * queued items (added via `_startFeaturedSequence`) do NOT re-resolve their
+   * own `requires`. The backend (esphome/device-builder#1717) emits the complete
+   * chain (e.g. a gpio lists `[bus, hub]`, not just the hub).
    */
   private _missingRequiredPrereqs(
     entry: ComponentCatalogEntry

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -12,7 +12,8 @@ import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
 import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
-import { buildFeaturedId } from "../../util/featured-id.js";
+import { collectExistingIds } from "../../util/default-component-id.js";
+import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -365,10 +366,82 @@ export class ESPHomeAddComponentDialog extends LitElement {
       this._submitError = result.message;
       return;
     }
+    // A featured component can require hub(s)/a bus to exist first (a gpio pin
+    // on a pcf8574 needs the pcf8574 + i2c). Add the missing prerequisites
+    // ahead of it through the same sequential queue bundles use.
+    const prereqs = this._missingRequiredPrereqs(result.entry);
+    if (prereqs && prereqs.missing.length > 0) {
+      await this._startFeaturedSequence(
+        [...prereqs.missing, result.entry.id],
+        prereqs.boardId,
+        result.entry.name
+      );
+      return;
+    }
     this._selected = result.entry;
     this._submitError = "";
     const fields = this._fastPathFields(result.entry);
     if (fields) await this._submitComponent(fields, /* notify */ true);
+  }
+
+  /**
+   * The featured prerequisites a just-selected featured component still needs:
+   * its `requires` local ids (bus then hub), resolved to full featured ids,
+   * keeping only those whose locked id isn't already in the YAML. Returns null
+   * for a non-featured entry or one with no requires.
+   */
+  private _missingRequiredPrereqs(
+    entry: ComponentCatalogEntry
+  ): { boardId: string; missing: string[] } | null {
+    const board = this.board;
+    if (!board || !isFeaturedId(entry.id)) return null;
+    const featured = board.featured_components ?? [];
+    const fc = featured.find((c) => buildFeaturedId(board.id, c.id) === entry.id);
+    if (!fc?.requires?.length) return null;
+    const existingIds = collectExistingIds(this.yaml);
+    const byLocal = new Map(featured.map((c) => [c.id, c]));
+    const missing: string[] = [];
+    for (const reqLocal of fc.requires) {
+      const prereq = byLocal.get(reqLocal);
+      if (!prereq) continue;
+      const presetId = prereq.fields.id?.value;
+      if (typeof presetId === "string" && existingIds.has(presetId)) continue;
+      missing.push(buildFeaturedId(board.id, reqLocal));
+    }
+    return { boardId: board.id, missing };
+  }
+
+  /**
+   * Open the form on the first of *fullIds* and queue the rest, so the
+   * dashboard adds a sequence of featured components one by one. Shared by the
+   * bundle picker and the `requires` prerequisite flow.
+   */
+  private async _startFeaturedSequence(
+    fullIds: string[],
+    boardId: string,
+    progressName: string
+  ) {
+    const [first, ...rest] = fullIds;
+    const result = await hydrateForSelection(
+      this as unknown as SelectionHost,
+      first,
+      boardId
+    );
+    if (result.kind === "stale") return;
+    if (result.kind === "error") {
+      this._submitError = result.message;
+      return;
+    }
+    // Fresh sequence — abandon any in-flight dep-detour state.
+    this._clearDetourFields();
+    this._bundleQueue = rest;
+    this._bundleProgress = {
+      current: 1,
+      total: fullIds.length,
+      bundleName: progressName,
+    };
+    this._selected = result.entry;
+    this._submitError = "";
   }
 
   /**
@@ -435,36 +508,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     const fullIds = bundle.component_ids.map((localId) =>
       buildFeaturedId(boardId, localId)
     );
-    const [first, ...rest] = fullIds;
-    // Same selection guard as `_onComponentSelected`; a quick
-    // re-pick or a card click landing between this bundle's flush
-    // and response must not let the bundle resurrect itself.
-    const result = await hydrateForSelection(
-      this as unknown as SelectionHost,
-      first,
-      boardId
-    );
-    if (result.kind === "stale") return;
-    if (result.kind === "error") {
-      this._submitError = result.message;
-      return;
-    }
-    const component = result.entry;
-    // Picking a bundle is a fresh sequence — abandon any in-flight
-    // dep-detour state from the previous component the user was filling.
-    // Without this clear, the bundle's first submit would route through
-    // the `_returnTo` branch in `_onFormSubmit`, restoring the unrelated
-    // component while the bundle queue + banner stayed live, and the
-    // next submit would jump into bundle step 2 from there.
-    this._clearDetourFields();
-    this._bundleQueue = rest;
-    this._bundleProgress = {
-      current: 1,
-      total: fullIds.length,
-      bundleName: bundle.name,
-    };
-    this._selected = component;
-    this._submitError = "";
+    await this._startFeaturedSequence(fullIds, boardId, bundle.name);
   }
 
   private _onBack() {

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -410,7 +410,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
     const missing: string[] = [];
     for (const reqLocal of fc.requires) {
       const prereq = featured.find((c) => c.id === reqLocal);
-      if (!prereq) continue;
+      if (!prereq) {
+        // A requires id with no matching featured component is a catalog bug in
+        // this same (lockstep) release, not version drift: adding the component
+        // without its prereq ships the broken hub-referencing config this flow
+        // exists to prevent. Surface it to a developer rather than silently.
+        console.warn(
+          `Featured component '${entry.id}' requires '${reqLocal}', which is not in the board catalog; skipping it.`
+        );
+        continue;
+      }
       const presetId = prereq.fields.id?.value;
       if (typeof presetId === "string" && existingIds.has(presetId)) continue;
       missing.push(buildFeaturedId(board.id, reqLocal));

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -370,6 +370,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
     // on a pcf8574 needs the pcf8574 + i2c). Add the missing prerequisites
     // ahead of it through the same sequential queue bundles use.
     const prereqs = this._missingRequiredPrereqs(result.entry);
+    if (prereqs && prereqs.unresolved.length > 0) {
+      // A declared prerequisite isn't in the catalog (a same-release catalog
+      // bug). Refuse rather than add the component without its hub/bus and ship
+      // the broken config this flow exists to prevent.
+      this._submitError = this._localize("device.prereq_unresolved", {
+        name: result.entry.name,
+        ids: prereqs.unresolved.join(", "),
+      });
+      return;
+    }
     if (prereqs && prereqs.missing.length > 0) {
       // The intermediate steps are the prerequisites (bus, hub), not the picked
       // component, so frame the banner as "Adding prerequisites for <name>".
@@ -400,7 +410,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
    */
   private _missingRequiredPrereqs(
     entry: ComponentCatalogEntry
-  ): { boardId: string; missing: string[] } | null {
+  ): { boardId: string; missing: string[]; unresolved: string[] } | null {
     const board = this.board;
     if (!board || !isFeaturedId(entry.id)) return null;
     const featured = board.featured_components ?? [];
@@ -408,23 +418,26 @@ export class ESPHomeAddComponentDialog extends LitElement {
     if (!fc?.requires?.length) return null;
     const existingIds = collectExistingIds(this.yaml);
     const missing: string[] = [];
+    const unresolved: string[] = [];
     for (const reqLocal of fc.requires) {
       const prereq = featured.find((c) => c.id === reqLocal);
       if (!prereq) {
         // A requires id with no matching featured component is a catalog bug in
         // this same (lockstep) release, not version drift: adding the component
         // without its prereq ships the broken hub-referencing config this flow
-        // exists to prevent. Surface it to a developer rather than silently.
+        // exists to prevent. Record it so the caller refuses the add (and warn
+        // with the precise id for a developer).
         console.warn(
-          `Featured component '${entry.id}' requires '${reqLocal}', which is not in the board catalog; skipping it.`
+          `Featured component '${entry.id}' requires '${reqLocal}', which is not in the board catalog.`
         );
+        unresolved.push(reqLocal);
         continue;
       }
       const presetId = prereq.fields.id?.value;
       if (typeof presetId === "string" && existingIds.has(presetId)) continue;
       missing.push(buildFeaturedId(board.id, reqLocal));
     }
-    return { boardId: board.id, missing };
+    return { boardId: board.id, missing, unresolved };
   }
 
   /**

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -399,10 +399,9 @@ export class ESPHomeAddComponentDialog extends LitElement {
     const fc = featured.find((c) => buildFeaturedId(board.id, c.id) === entry.id);
     if (!fc?.requires?.length) return null;
     const existingIds = collectExistingIds(this.yaml);
-    const byLocal = new Map(featured.map((c) => [c.id, c]));
     const missing: string[] = [];
     for (const reqLocal of fc.requires) {
-      const prereq = byLocal.get(reqLocal);
+      const prereq = featured.find((c) => c.id === reqLocal);
       if (!prereq) continue;
       const presetId = prereq.fields.id?.value;
       if (typeof presetId === "string" && existingIds.has(presetId)) continue;

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -206,9 +206,10 @@ export function renderPinField(
     // A locked pin on an I/O expander (a featured preset) is a
     // `provider:hub:channel` channel, not a board GPIO — the board-GPIO picker
     // can't represent it, so show it read-only. Expander pins only ever arrive
-    // via board-locked featured presets, so the editable case is unreachable
-    // today; an editable expander pin would need its own provider-scoped picker
-    // (none exists below) rather than the board-GPIO select.
+    // via board-locked featured presets, so this disabled branch is the only one
+    // reached in practice. An editable expander pin (tests only) falls through to
+    // the board-GPIO select (blank — it can't show the channel) plus the
+    // provider-scoped mode-flag picker in Advanced below.
     return renderExpanderPin(entry, path, ctx, identity);
   }
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -201,10 +201,20 @@ export function renderPinField(
   // for nRF52), so normalise before comparing or the disabled select renders
   // blank.
   const rawValue = ctx.getAt(path);
+  const identity = parsePinGpio(rawValue);
+  if (typeof identity === "string" && effectiveDisabled(entry, ctx)) {
+    // A locked pin on an I/O expander (a featured preset) is a
+    // `provider:hub:channel` channel, not a board GPIO — the board-GPIO picker
+    // can't represent it, so show it read-only. An editable expander pin falls
+    // through and keeps the mode-flag picker (scoped to the provider below).
+    return renderExpanderPin(entry, path, ctx, identity);
+  }
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a
   // `GPIOn` form; this drives both the selected option and the re-add of a
-  // filtered-out active pin below.
-  const valueGpio = parseBoardGpio(rawValue) ?? gpioFromAlias(rawValue, ctx.board.pins);
+  // filtered-out active pin below. An expander token isn't a board GPIO.
+  const valueGpio =
+    (typeof identity === "number" ? identity : null) ??
+    gpioFromAlias(rawValue, ctx.board.pins);
   const platform = ctx.board.esphome.platform;
   // Fallback to ``String(rawValue)`` only when the value is a
   // primitive — js-yaml emits null-prototype maps for partial /
@@ -313,6 +323,28 @@ export function renderPinField(
       </wa-select>
       ${renderFieldError(path, ctx)}
       ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm, fieldDisabled)}
+    </div>
+  `;
+}
+
+/**
+ * Render a pin that sits on an I/O expander read-only. Its `identity` is the
+ * `provider:hub:channel` token; an expander channel isn't a board GPIO, so the
+ * board-pin picker would render blank. Show the hub + channel instead — these
+ * presets are always board-locked, so there's nothing for the user to pick.
+ */
+function renderExpanderPin(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx,
+  identity: string
+): TemplateResult {
+  const [provider, hub, channel] = identity.split(":");
+  return html`
+    <div class="field" data-field-key=${fieldKeyAttr(path)}>
+      ${renderLabel(entry, ctx)}
+      <input type="text" readonly .value=${`${provider} ${hub} · channel ${channel}`} />
+      ${renderFieldError(path, ctx)}
     </div>
   `;
 }

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -205,8 +205,10 @@ export function renderPinField(
   if (typeof identity === "string" && effectiveDisabled(entry, ctx)) {
     // A locked pin on an I/O expander (a featured preset) is a
     // `provider:hub:channel` channel, not a board GPIO — the board-GPIO picker
-    // can't represent it, so show it read-only. An editable expander pin falls
-    // through and keeps the mode-flag picker (scoped to the provider below).
+    // can't represent it, so show it read-only. Expander pins only ever arrive
+    // via board-locked featured presets, so the editable case is unreachable
+    // today; an editable expander pin would need its own provider-scoped picker
+    // (none exists below) rather than the board-GPIO select.
     return renderExpanderPin(entry, path, ctx, identity);
   }
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -202,15 +202,15 @@ export function renderPinField(
   // blank.
   const rawValue = ctx.getAt(path);
   const identity = parsePinGpio(rawValue);
-  if (typeof identity === "string" && effectiveDisabled(entry, ctx)) {
-    // A locked pin on an I/O expander (a featured preset) is a
-    // `provider:hub:channel` channel, not a board GPIO — the board-GPIO picker
-    // can't represent it, so show it read-only. Expander pins only ever arrive
-    // via board-locked featured presets, so this disabled branch is the only one
-    // reached in practice. An editable expander pin (tests only) falls through to
-    // the board-GPIO select (blank — it can't show the channel) plus the
-    // provider-scoped mode-flag picker in Advanced below.
-    return renderExpanderPin(entry, path, ctx, identity);
+  if (typeof identity === "string") {
+    // An I/O-expander pin is a `provider:hub:channel` channel, never a board
+    // GPIO, so the board-GPIO picker can't represent it regardless of disabled
+    // state — show the channel read-only. Gating this on disabled would let an
+    // editable expander pin fall through to the board picker, where a selection
+    // writes a board GPIO into `pin.number` and clobbers the channel. The
+    // Advanced mode-flag disclosure still renders below (the channel's mode is
+    // editable, scoped to the provider), just not the board-GPIO selector.
+    return renderExpanderPin(entry, path, ctx, identity, rawValue);
   }
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a
   // `GPIOn` form; this drives both the selected option and the re-add of a
@@ -331,16 +331,17 @@ export function renderPinField(
 }
 
 /**
- * Render a pin that sits on an I/O expander read-only. Its `identity` is the
- * `provider:hub:channel` token; an expander channel isn't a board GPIO, so the
- * board-pin picker would render blank. Show the hub + channel instead — these
- * presets are always board-locked, so there's nothing for the user to pick.
+ * Render an I/O-expander pin: the `provider:hub:channel` channel shown read-only
+ * (an expander channel isn't a board GPIO, so the board-pin picker can't
+ * represent it) plus the Advanced mode-flag disclosure — the channel's mode is
+ * still editable, scoped to the provider.
  */
 function renderExpanderPin(
   entry: ConfigEntry,
   path: string[],
   ctx: RenderCtx,
-  identity: string
+  identity: string,
+  rawValue: unknown
 ): TemplateResult {
   const [provider, hub, channel] = identity.split(":");
   return html`
@@ -352,6 +353,14 @@ function renderExpanderPin(
         .value=${ctx.localize("device.pin_on_expander", { provider, hub, channel })}
       />
       ${renderFieldError(path, ctx)}
+      ${renderPinAdvanced(
+        entry,
+        path,
+        ctx,
+        rawValue,
+        isPlainObject(rawValue),
+        effectiveDisabled(entry, ctx)
+      )}
     </div>
   `;
 }

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -11,7 +11,7 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType, PinFeature, PinMode } from "../../api/types/config-entries.js";
 import { findUsedPins, sectionEndLine } from "../../util/config-entry-yaml-scan.js";
 import { isPlainObject, isPrimitiveOrNullish } from "../../util/nested-values.js";
-import { formatPinValue, parsePinGpio } from "../../util/pin-gpio.js";
+import { formatPinValue, parseBoardGpio, parsePinGpio } from "../../util/pin-gpio.js";
 import { expandPinModeShorthand } from "../../util/pin-mode.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import {
@@ -69,7 +69,7 @@ function gpioFromAlias(rawValue: unknown, pins: BoardPin[]): number | null {
 function buildPinOption(
   pin: BoardPin,
   entry: ConfigEntry,
-  usedPins: Map<number, string>,
+  usedPins: Map<number | string, string>,
   ctx: RenderCtx
 ): PinOptionView {
   const optValue = formatPinValue(pin.gpio, ctx.board?.esphome.platform);
@@ -120,7 +120,7 @@ function buildPinOption(
 function renderPinOptions(
   pins: BoardPin[],
   entry: ConfigEntry,
-  usedPins: Map<number, string>,
+  usedPins: Map<number | string, string>,
   value: string,
   ctx: RenderCtx
 ): TemplateResult {
@@ -204,7 +204,7 @@ export function renderPinField(
   // Fall back to alias resolution (`RX` → GPIO3) when the value isn't a
   // `GPIOn` form; this drives both the selected option and the re-add of a
   // filtered-out active pin below.
-  const valueGpio = parsePinGpio(rawValue) ?? gpioFromAlias(rawValue, ctx.board.pins);
+  const valueGpio = parseBoardGpio(rawValue) ?? gpioFromAlias(rawValue, ctx.board.pins);
   const platform = ctx.board.esphome.platform;
   // Fallback to ``String(rawValue)`` only when the value is a
   // primitive — js-yaml emits null-prototype maps for partial /
@@ -225,7 +225,7 @@ export function renderPinField(
   // to its GPIO so the box shows the real pin label rather than the raw name.
   const defaultGpio =
     entry.default_value != null
-      ? (parsePinGpio(entry.default_value) ??
+      ? (parseBoardGpio(entry.default_value) ??
         gpioFromAlias(entry.default_value, ctx.board.pins))
       : null;
   const defaultPlaceholder =
@@ -247,7 +247,7 @@ export function renderPinField(
   // pin set instead, with a visible error for the field).
   if (entry.suggestions && entry.suggestions.length > 0) {
     const allowed = new Set(
-      entry.suggestions.map(parsePinGpio).filter((g): g is number => g !== null)
+      entry.suggestions.map(parseBoardGpio).filter((g): g is number => g !== null)
     );
     if (allowed.size > 0) {
       const narrowed = visible.filter((p) => allowed.has(p.gpio));

--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -343,7 +343,11 @@ function renderExpanderPin(
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)}
-      <input type="text" readonly .value=${`${provider} ${hub} · channel ${channel}`} />
+      <input
+        type="text"
+        readonly
+        .value=${ctx.localize("device.pin_on_expander", { provider, hub, channel })}
+      />
       ${renderFieldError(path, ctx)}
     </div>
   `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -634,6 +634,7 @@
     "featured_bundle_badge": "Bundle",
     "field_locked_by_board": "Set by the board",
     "bundle_step_progress": "Step {current} of {total} — Adding {name}",
+    "adding_prerequisites_for": "prerequisites for {name}",
     "docs": "Docs",
     "see_also": "See also:",
     "advanced_options": "Advanced options",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -635,6 +635,7 @@
     "field_locked_by_board": "Set by the board",
     "bundle_step_progress": "Step {current} of {total} — Adding {name}",
     "adding_prerequisites_for": "prerequisites for {name}",
+    "prereq_unresolved": "Can't add {name}: required prerequisites missing from the board catalog: {ids}",
     "docs": "Docs",
     "see_also": "See also:",
     "advanced_options": "Advanced options",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -708,6 +708,7 @@
     "pin_occupied_by": "Reserved for {name}",
     "pin_used_by": "Already used by {name}",
     "pin_input_only": "Input only — can't be used as output",
+    "pin_on_expander": "{provider} {hub} · channel {channel}",
     "pin_group_supports": "Supports {features}",
     "pin_group_other": "Other pins",
     "pin_group_reserved": "Reserved",

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -21,6 +21,7 @@ import {
   isPinFieldKey,
   LONG_FORM_PIN_KEYS,
   parsePinGpio,
+  pinIdentityToken,
   scanPinGpios,
 } from "./pin-gpio.js";
 import {
@@ -197,7 +198,7 @@ function readLongFormPin(
     }
   }
   if (provider !== null && hub !== null && channel !== null) {
-    return { pin: `${provider}:${hub}:${channel}`, end };
+    return { pin: pinIdentityToken(provider, hub, channel), end };
   }
   return { pin: channel, end };
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -179,8 +179,10 @@ function readLongFormPin(
     if (indentWidth(line) !== childIndent) continue; // skip grandchildren (mode flags)
     const m = line.match(LINE_KEY_RE);
     if (m === null) continue;
-    const value = readInstanceScalar(stripInlineComment(line), m[2]);
-    if (value !== null) block[m[2]] = value;
+    // Record the key even when it has no inline scalar (an empty, mid-edit
+    // `pcf8574:`), so parsePinGpio sees the provider and returns null rather
+    // than letting the bare `number:` alias a board GPIO.
+    block[m[2]] = readInstanceScalar(stripInlineComment(line), m[2]) ?? "";
   }
   return { pin: parsePinGpio(block), end };
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,7 +17,12 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import type { ComponentCatalogEntry } from "../api/types/components.js";
-import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin-gpio.js";
+import {
+  isPinFieldKey,
+  LONG_FORM_PIN_KEYS,
+  parsePinGpio,
+  scanPinGpios,
+} from "./pin-gpio.js";
 import {
   collectIdsAtPath,
   findFieldLine,
@@ -106,7 +111,7 @@ const pinKeyEquals = (a: PinKey, b: PinKey) =>
   a.yaml === b.yaml &&
   a.excludeFromLine === b.excludeFromLine &&
   a.excludeToLine === b.excludeToLine;
-const pinMemo = createScanMemo<PinKey, Map<number, string>>(pinKeyEquals);
+const pinMemo = createScanMemo<PinKey, Map<number | string, string>>(pinKeyEquals);
 
 // Keys whose values are free-form human text. `scanPinGpios` is
 // deliberately value-context-agnostic (it's shared with the pin picker,
@@ -150,6 +155,54 @@ function stripInlineComment(line: string): string {
 }
 
 /**
+ * Read a long-form pin block opened at `openerIdx` (a `pin:` / `*_pin:` key
+ * with no inline value) into its canonical identity: a board GPIO `number`, or
+ * the `provider:hub_id:channel` token when the block sits on an I/O expander.
+ * Only the block's direct children are inspected so a nested `mode:` map's
+ * flags aren't mistaken for a provider key. Returns the identity plus the
+ * 0-indexed last line the block spans so the caller can skip past it.
+ */
+function readLongFormPin(
+  lines: string[],
+  openerIdx: number
+): { pin: number | string | null; end: number } {
+  const openIndent = indentWidth(lines[openerIdx]);
+  let childIndent = -1;
+  let channel: number | null = null;
+  let provider: string | null = null;
+  let hub: string | null = null;
+  let end = openerIdx;
+  for (let j = openerIdx + 1; j < lines.length; j++) {
+    const line = lines[j];
+    if (line.trim() === "") {
+      end = j;
+      continue;
+    }
+    if (indentWidth(line) <= openIndent) break;
+    end = j;
+    if (childIndent === -1) childIndent = indentWidth(line);
+    if (indentWidth(line) !== childIndent) continue; // skip grandchildren (mode flags)
+    const m = line.match(LINE_KEY_RE);
+    if (m === null) continue;
+    const key = m[2];
+    if (key === "number") {
+      const gpio = parsePinGpio(readInstanceScalar(stripInlineComment(line), "number"));
+      if (typeof gpio === "number") channel = gpio;
+    } else if (!LONG_FORM_PIN_KEYS.has(key)) {
+      const value = readInstanceScalar(stripInlineComment(line), key);
+      if (value) {
+        provider = key;
+        hub = value;
+      }
+    }
+  }
+  if (provider !== null && hub !== null && channel !== null) {
+    return { pin: `${provider}:${hub}:${channel}`, end };
+  }
+  return { pin: channel, end };
+}
+
+/**
  * Map every pin reference in the YAML to the top-level domain that
  * owns it (e.g. `{ 4: "switch", 5: "binary_sensor" }`). Pin tokens are
  * matched across every platform form (`GPIOn`, bk72xx `P{n}`, rtl87xx
@@ -169,11 +222,11 @@ export function findUsedPins(
   yaml: string,
   excludeFromLine?: number,
   excludeToLine?: number
-): Map<number, string> {
+): Map<number | string, string> {
   const probe: PinKey = { yaml, excludeFromLine, excludeToLine };
   const cached = pinMemo.get(probe);
   if (cached) return cached;
-  const used = new Map<number, string>();
+  const used = new Map<number | string, string>();
   if (!yaml) {
     // Don't cache the empty-yaml early return: a future
     // regression that needs to do exclude-range work even on
@@ -221,7 +274,17 @@ export function findUsedPins(
     // A bare-integer pin value (`tx_pin: 1`) carries no prefix for the token
     // scan to anchor on; parse it from a pin-field key's value instead.
     if (keyMatch && isPinFieldKey(keyMatch[2])) {
-      const gpio = parsePinGpio(stripped.slice(keyMatch[0].length).trim());
+      const inline = stripped.slice(keyMatch[0].length).trim();
+      if (inline === "") {
+        // Long-form pin block: read it as a unit so an expander channel is
+        // namespaced (never aliasing a board GPIO) and a nested `mode:` map
+        // isn't mis-scanned, then skip the lines it spans.
+        const { pin, end } = readLongFormPin(lines, i);
+        if (pin !== null && !used.has(pin)) used.set(pin, currentDomain);
+        i = end;
+        continue;
+      }
+      const gpio = parsePinGpio(inline);
       if (gpio !== null && !used.has(gpio)) used.set(gpio, currentDomain);
     }
     for (const num of scanPinGpios(stripped)) {
@@ -365,16 +428,14 @@ function readInstancePinGpio(
   lines: string[],
   section: YamlSection,
   key: string
-): number | null {
+): number | string | null {
   const lineNo = findFieldLine(yaml, section, [key]);
   if (lineNo === null) return null;
   const scalar = parsePinGpio(readInstanceScalar(lines[lineNo - 1], key));
   if (scalar !== null) return scalar;
-  // Expanded form: descend into the `number:` sub-key.
-  const numLine = findFieldLine(yaml, section, [key, "number"]);
-  return numLine === null
-    ? null
-    : parsePinGpio(readInstanceScalar(lines[numLine - 1], "number"));
+  // Expanded form: read the long-form block (board GPIO, or the
+  // `provider:hub_id:channel` token when the pin sits on an I/O expander).
+  return readLongFormPin(lines, lineNo - 1).pin;
 }
 
 /**
@@ -389,7 +450,7 @@ function readInstancePinGpio(
 export function domainOccupiesPins(
   yaml: string,
   domain: string,
-  lockedPins: Readonly<Record<string, number>>
+  lockedPins: Readonly<Record<string, number | string>>
 ): boolean {
   const keys = Object.keys(lockedPins);
   if (keys.length === 0) return false;

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,13 +17,7 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import type { ComponentCatalogEntry } from "../api/types/components.js";
-import {
-  isPinFieldKey,
-  LONG_FORM_PIN_KEYS,
-  parsePinGpio,
-  pinIdentityToken,
-  scanPinGpios,
-} from "./pin-gpio.js";
+import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin-gpio.js";
 import {
   collectIdsAtPath,
   findFieldLine,
@@ -157,11 +151,13 @@ function stripInlineComment(line: string): string {
 
 /**
  * Read a long-form pin block opened at `openerIdx` (a `pin:` / `*_pin:` key
- * with no inline value) into its canonical identity: a board GPIO `number`, or
- * the `provider:hub_id:channel` token when the block sits on an I/O expander.
- * Only the block's direct children are inspected so a nested `mode:` map's
- * flags aren't mistaken for a provider key. Returns the identity plus the
- * 0-indexed last line the block spans so the caller can skip past it.
+ * with no inline value) into its canonical identity via {@link parsePinGpio} — a
+ * board GPIO `number`, or the `provider:hub_id:channel` token when the block
+ * sits on an I/O expander. Reconstructs the block's direct-child scalars into a
+ * mapping and defers the identity decision to `parsePinGpio`; only the direct
+ * children are collected so a nested `mode:` map's flags can't masquerade as a
+ * provider key. Returns the identity plus the 0-indexed last line the block
+ * spans so the caller can skip past it.
  */
 function readLongFormPin(
   lines: string[],
@@ -169,9 +165,7 @@ function readLongFormPin(
 ): { pin: number | string | null; end: number } {
   const openIndent = indentWidth(lines[openerIdx]);
   let childIndent = -1;
-  let channel: number | null = null;
-  let provider: string | null = null;
-  let hub: string | null = null;
+  const block: Record<string, string> = {};
   let end = openerIdx;
   for (let j = openerIdx + 1; j < lines.length; j++) {
     const line = lines[j];
@@ -185,22 +179,10 @@ function readLongFormPin(
     if (indentWidth(line) !== childIndent) continue; // skip grandchildren (mode flags)
     const m = line.match(LINE_KEY_RE);
     if (m === null) continue;
-    const key = m[2];
-    if (key === "number") {
-      const gpio = parsePinGpio(readInstanceScalar(stripInlineComment(line), "number"));
-      if (typeof gpio === "number") channel = gpio;
-    } else if (!LONG_FORM_PIN_KEYS.has(key)) {
-      const value = readInstanceScalar(stripInlineComment(line), key);
-      if (value) {
-        provider = key;
-        hub = value;
-      }
-    }
+    const value = readInstanceScalar(stripInlineComment(line), m[2]);
+    if (value !== null) block[m[2]] = value;
   }
-  if (provider !== null && hub !== null && channel !== null) {
-    return { pin: pinIdentityToken(provider, hub, channel), end };
-  }
-  return { pin: channel, end };
+  return { pin: parsePinGpio(block), end };
 }
 
 /**

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -175,10 +175,10 @@ function readLongFormPin(
     }
     if (indentWidth(line) <= openIndent) break;
     end = j;
+    const m = line.match(LINE_KEY_RE);
+    if (m === null) continue; // comment / non-key line — don't anchor childIndent on it
     if (childIndent === -1) childIndent = indentWidth(line);
     if (indentWidth(line) !== childIndent) continue; // skip grandchildren (mode flags)
-    const m = line.match(LINE_KEY_RE);
-    if (m === null) continue;
     // Record the key even when it has no inline scalar (an empty, mid-edit
     // `pcf8574:`), so parsePinGpio sees the provider and returns null rather
     // than letting the bare `number:` alias a board GPIO.

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -103,17 +103,17 @@ export function parsePinGpio(s: unknown): number | string | null {
   if (s !== null && typeof s === "object" && !Array.isArray(s)) {
     const obj = s as Record<string, unknown>;
     const provider = Object.keys(obj).find((k) => !LONG_FORM_PIN_KEYS.has(k));
+    // The ``number`` is parsed the same way whichever branch we take, so an
+    // expander channel written ``GPIO0`` resolves like a bare ``0``.
+    const channel = parsePinGpio(obj.number);
     if (provider !== undefined) {
       // I/O-expander channel: namespace it so it never aliases a board GPIO.
       const hub = obj[provider];
-      const channel = obj.number;
-      return typeof hub === "string" &&
-        typeof channel === "number" &&
-        Number.isFinite(channel)
+      return typeof hub === "string" && typeof channel === "number"
         ? pinIdentityToken(provider, hub, channel)
         : null;
     }
-    return parsePinGpio(obj.number);
+    return channel;
   }
   return null;
 }

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -62,8 +62,9 @@ const PORT_A_PIN_RE = /^\s*PA(\d+)\s*$/i;
 const PORT_B_PIN_RE = /^\s*PB(\d+)\s*$/i;
 
 /**
- * Parse a pin reference into a GPIO number. Used both for the field's
- * current value and for individual `suggestions` entries. Featured
+ * Parse a pin reference into a board GPIO number, or an I/O-expander
+ * channel's namespaced `provider:hub_id:channel` token. Used both for the
+ * field's current value and for individual `suggestions` entries. Featured
  * manifests write pins as bare ints (`12`), string forms (`"GPIO12"`,
  * `"gpio12"`), nRF52 port.pin notation (`"P0.27"`, `"P1.1"`), LibreTiny
  * forms (`"P23"` bk72xx, `"PA02"` rtl87xx), or — for fields whose locked

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -110,12 +110,21 @@ export function parsePinGpio(s: unknown): number | string | null {
       return typeof hub === "string" &&
         typeof channel === "number" &&
         Number.isFinite(channel)
-        ? `${provider}:${hub}:${channel}`
+        ? pinIdentityToken(provider, hub, channel)
         : null;
     }
     return parsePinGpio(obj.number);
   }
   return null;
+}
+
+/**
+ * The namespaced identity for a pin on an I/O expander
+ * (`pcf8574:hub_id:0`). Single source of the token shape so the YAML scanner
+ * and the value parser can't drift on what "the same expander channel" means.
+ */
+export function pinIdentityToken(provider: string, hub: string, channel: number): string {
+  return `${provider}:${hub}:${channel}`;
 }
 
 /**

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -33,8 +33,8 @@
 
 // Long-form pin sub-keys that describe a board GPIO. Any other key in a pin
 // object names an I/O-expander provider (`pcf8574`, `mcp23xxx`, ...): its value
-// is the hub id and its `number` is an expander channel, not a board GPIO. Kept
-// in sync with the backend's `_BOARD_PIN_KEYS` (script/sync_boards.py).
+// is the hub id and its `number` is an expander channel, not a board GPIO. The
+// backend mirrors this set (BOARD_PIN_KEYS) when it generates the catalog.
 export const LONG_FORM_PIN_KEYS = new Set([
   "number",
   "mode",

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -108,8 +108,10 @@ export function parsePinGpio(s: unknown): number | string | null {
     const channel = parsePinGpio(obj.number);
     if (provider !== undefined) {
       // I/O-expander channel: namespace it so it never aliases a board GPIO.
+      // A provider key with no resolved hub id (mid-edit) is null, NOT the bare
+      // channel — falling back would alias the channel to a board GPIO.
       const hub = obj[provider];
-      return typeof hub === "string" && typeof channel === "number"
+      return typeof hub === "string" && hub !== "" && typeof channel === "number"
         ? pinIdentityToken(provider, hub, channel)
         : null;
     }

--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -31,6 +31,19 @@
  * is invalid) doesn't need to be threaded in here.
  */
 
+// Long-form pin sub-keys that describe a board GPIO. Any other key in a pin
+// object names an I/O-expander provider (`pcf8574`, `mcp23xxx`, ...): its value
+// is the hub id and its `number` is an expander channel, not a board GPIO. Kept
+// in sync with the backend's `_BOARD_PIN_KEYS` (script/sync_boards.py).
+export const LONG_FORM_PIN_KEYS = new Set([
+  "number",
+  "mode",
+  "inverted",
+  "ignore_strapping_warning",
+  "allow_other_uses",
+  "drive_strength",
+]);
+
 // ln882x splits its GPIOs into two ports of 16: port A is GPIO 0-15, port B is
 // GPIO 16-31, so "PB{n}" resolves to 16 + n (verified constant across every
 // ln882x board's pin map; no other platform uses a "PB" form).
@@ -58,10 +71,13 @@ const PORT_B_PIN_RE = /^\s*PB(\d+)\s*$/i;
  * `{ number: 0, mode: { input: true, pullup: true }, inverted: true }`
  * (Sonoff Basic's front-panel button is the canonical example: the pin
  * is occupied + inverted + needs the internal pull-up, all baked into
- * the preset). Returns `null` for anything we can't parse — the caller
- * drops those entries rather than letting a typo blank the dropdown.
+ * the preset). A pin on an I/O expander
+ * (`{ pcf8574: 'hub_id', number: 0, ... }`) returns the namespaced token
+ * `'pcf8574:hub_id:0'` so its channel never aliases board GPIO 0. Returns
+ * `null` for anything we can't parse — the caller drops those entries rather
+ * than letting a typo blank the dropdown.
  */
-export function parsePinGpio(s: unknown): number | null {
+export function parsePinGpio(s: unknown): number | string | null {
   if (typeof s === "number" && Number.isFinite(s)) return s;
   if (typeof s === "string") {
     const m = s.match(GPIO_PIN_RE);
@@ -85,9 +101,31 @@ export function parsePinGpio(s: unknown): number | null {
     if (bk) return Number(bk[1]);
   }
   if (s !== null && typeof s === "object" && !Array.isArray(s)) {
-    return parsePinGpio((s as Record<string, unknown>).number);
+    const obj = s as Record<string, unknown>;
+    const provider = Object.keys(obj).find((k) => !LONG_FORM_PIN_KEYS.has(k));
+    if (provider !== undefined) {
+      // I/O-expander channel: namespace it so it never aliases a board GPIO.
+      const hub = obj[provider];
+      const channel = obj.number;
+      return typeof hub === "string" &&
+        typeof channel === "number" &&
+        Number.isFinite(channel)
+        ? `${provider}:${hub}:${channel}`
+        : null;
+    }
+    return parsePinGpio(obj.number);
   }
   return null;
+}
+
+/**
+ * Like {@link parsePinGpio} but for callers that only deal in board GPIOs (the
+ * pin picker, alias resolution): an I/O-expander token resolves to `null` since
+ * an expander channel is not a board pin.
+ */
+export function parseBoardGpio(s: unknown): number | null {
+  const parsed = parsePinGpio(s);
+  return typeof parsed === "number" ? parsed : null;
 }
 
 /**

--- a/test/components/device/add-component-dialog-requires.test.ts
+++ b/test/components/device/add-component-dialog-requires.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A featured component can declare `requires` (an i2c bus, then the pcf8574 hub
+ * a gpio pin sits on). Selecting it must surface the prerequisites that aren't
+ * already in the YAML — by their locked id — so the add flow can land them
+ * first. Covers `_missingRequiredPrereqs`, the decision behind the auto-add.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  BoardCatalogEntry,
+  FeaturedComponent,
+} from "../../../src/api/types/boards.js";
+import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
+import { buildFeaturedId } from "../../../src/util/featured-id.js";
+
+const BOARD_ID = "kincony_kc868_a16v3";
+
+function fc(
+  id: string,
+  componentId: string,
+  lockedId: string,
+  requires?: string[]
+): FeaturedComponent {
+  return {
+    id,
+    component_id: componentId,
+    name: id,
+    description: null,
+    fields: { id: { value: lockedId, locked: true, suggestions: null } },
+    ...(requires ? { requires } : {}),
+  };
+}
+
+function makeDialog(yaml: string) {
+  const dialog = new ESPHomeAddComponentDialog();
+  const board = {
+    id: BOARD_ID,
+    featured_components: [
+      fc("bus_a", "i2c", "bus_a"),
+      fc("pcf8574_hub_in_1", "pcf8574", "pcf8574_hub_in_1", ["bus_a"]),
+      fc("input_1", "binary_sensor.gpio", "binary_sensor_gpio_1", [
+        "bus_a",
+        "pcf8574_hub_in_1",
+      ]),
+    ],
+  } as unknown as BoardCatalogEntry;
+  Object.assign(dialog as unknown as Record<string, unknown>, { board });
+  dialog.yaml = yaml;
+  return dialog as unknown as {
+    _missingRequiredPrereqs: (entry: { id: string }) => {
+      boardId: string;
+      missing: string[];
+    } | null;
+  };
+}
+
+const ENTITY_ID = buildFeaturedId(BOARD_ID, "input_1");
+
+describe("_missingRequiredPrereqs", () => {
+  it("lists the bus then the hub, in order, when neither is present", () => {
+    const dialog = makeDialog("esphome:\n  name: foo\n");
+    expect(dialog._missingRequiredPrereqs({ id: ENTITY_ID })).toEqual({
+      boardId: BOARD_ID,
+      missing: [
+        buildFeaturedId(BOARD_ID, "bus_a"),
+        buildFeaturedId(BOARD_ID, "pcf8574_hub_in_1"),
+      ],
+    });
+  });
+
+  it("skips a prerequisite whose locked id is already in the YAML", () => {
+    const dialog = makeDialog("i2c:\n  - id: bus_a\n    sda: 9\n    scl: 10\n");
+    expect(dialog._missingRequiredPrereqs({ id: ENTITY_ID })?.missing).toEqual([
+      buildFeaturedId(BOARD_ID, "pcf8574_hub_in_1"),
+    ]);
+  });
+
+  it("returns null for a non-featured catalog entry", () => {
+    const dialog = makeDialog("esphome:\n  name: foo\n");
+    expect(dialog._missingRequiredPrereqs({ id: "binary_sensor.gpio" })).toBeNull();
+  });
+});

--- a/test/components/device/add-component-dialog-requires.test.ts
+++ b/test/components/device/add-component-dialog-requires.test.ts
@@ -52,6 +52,7 @@ function makeDialog(yaml: string) {
     _missingRequiredPrereqs: (entry: { id: string }) => {
       boardId: string;
       missing: string[];
+      unresolved: string[];
     } | null;
   };
 }
@@ -67,6 +68,7 @@ describe("_missingRequiredPrereqs", () => {
         buildFeaturedId(BOARD_ID, "bus_a"),
         buildFeaturedId(BOARD_ID, "pcf8574_hub_in_1"),
       ],
+      unresolved: [],
     });
   });
 
@@ -82,7 +84,7 @@ describe("_missingRequiredPrereqs", () => {
     expect(dialog._missingRequiredPrereqs({ id: "binary_sensor.gpio" })).toBeNull();
   });
 
-  it("warns and skips a requires id with no matching featured component", () => {
+  it("reports (and warns about) a requires id with no matching featured component", () => {
     const dialog = new ESPHomeAddComponentDialog();
     const board = {
       id: BOARD_ID,
@@ -95,10 +97,15 @@ describe("_missingRequiredPrereqs", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = (
       dialog as unknown as {
-        _missingRequiredPrereqs: (e: { id: string }) => { missing: string[] } | null;
+        _missingRequiredPrereqs: (e: {
+          id: string;
+        }) => { missing: string[]; unresolved: string[] } | null;
       }
     )._missingRequiredPrereqs({ id: ENTITY_ID });
+    // Recorded as unresolved (so the caller refuses the add), not stamped as a
+    // resolvable prerequisite to auto-add.
     expect(result?.missing).toEqual([]);
+    expect(result?.unresolved).toEqual(["ghost_hub"]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("ghost_hub"));
     warn.mockRestore();
   });

--- a/test/components/device/add-component-dialog-requires.test.ts
+++ b/test/components/device/add-component-dialog-requires.test.ts
@@ -6,7 +6,7 @@
  * already in the YAML — by their locked id — so the add flow can land them
  * first. Covers `_missingRequiredPrereqs`, the decision behind the auto-add.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   BoardCatalogEntry,
@@ -80,5 +80,26 @@ describe("_missingRequiredPrereqs", () => {
   it("returns null for a non-featured catalog entry", () => {
     const dialog = makeDialog("esphome:\n  name: foo\n");
     expect(dialog._missingRequiredPrereqs({ id: "binary_sensor.gpio" })).toBeNull();
+  });
+
+  it("warns and skips a requires id with no matching featured component", () => {
+    const dialog = new ESPHomeAddComponentDialog();
+    const board = {
+      id: BOARD_ID,
+      featured_components: [
+        fc("input_1", "binary_sensor.gpio", "binary_sensor_gpio_1", ["ghost_hub"]),
+      ],
+    } as unknown as BoardCatalogEntry;
+    Object.assign(dialog as unknown as Record<string, unknown>, { board });
+    dialog.yaml = "esphome:\n  name: foo\n";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = (
+      dialog as unknown as {
+        _missingRequiredPrereqs: (e: { id: string }) => { missing: string[] } | null;
+      }
+    )._missingRequiredPrereqs({ id: ENTITY_ID });
+    expect(result?.missing).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("ghost_hub"));
+    warn.mockRestore();
   });
 });

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -723,3 +723,26 @@ describe("renderPinField long-form Advanced disclosure", () => {
     expect(findTemplatesByAnchor(result, "<button").length).toBe(0);
   });
 });
+
+describe("renderPinField on an I/O-expander pin", () => {
+  it("shows the locked channel read-only instead of an empty board-GPIO picker", () => {
+    const ctx = makeRenderCtx({
+      pin: { pcf8574: "pcf8574_hub_in_1", number: 9, mode: "INPUT" },
+    });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, {
+        key: "pin",
+        required: true,
+        locked: true,
+        pin_features: [],
+      }),
+      ["pin"],
+      ctx
+    );
+    // An expander channel isn't a board GPIO, so no picker is rendered.
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(0);
+    // The channel is surfaced read-only so the field isn't blank.
+    const input = findElementBindings(result, "input")[0];
+    expect(input[".value"]).toBe("pcf8574 pcf8574_hub_in_1 · channel 9");
+  });
+});

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -753,4 +753,19 @@ describe("renderPinField on an I/O-expander pin", () => {
     const input = findElementBindings(result, "input")[0];
     expect(input[".value"]).toBe("pcf8574 pcf8574_hub_in_1 · channel 9");
   });
+
+  it("renders no board-GPIO picker for an editable expander pin (no channel clobber)", () => {
+    // Not locked: without the unconditional expander guard this would fall
+    // through to the board <wa-select>, where picking a GPIO writes pin.number
+    // and clobbers the channel. The read-only channel display prevents that.
+    const ctx = makeRenderCtx({
+      pin: { pcf8574: "pcf8574_hub_in_1", number: 9, mode: "INPUT" },
+    });
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin", pin_features: [] }),
+      ["pin"],
+      ctx
+    );
+    expect(findTemplatesByAnchor(result, "<wa-select").length).toBe(0);
+  });
 });

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -726,9 +726,17 @@ describe("renderPinField long-form Advanced disclosure", () => {
 
 describe("renderPinField on an I/O-expander pin", () => {
   it("shows the locked channel read-only instead of an empty board-GPIO picker", () => {
-    const ctx = makeRenderCtx({
-      pin: { pcf8574: "pcf8574_hub_in_1", number: 9, mode: "INPUT" },
-    });
+    const ctx = makeRenderCtx(
+      { pin: { pcf8574: "pcf8574_hub_in_1", number: 9, mode: "INPUT" } },
+      {
+        overrides: {
+          localize: (k, params) =>
+            k === "device.pin_on_expander"
+              ? `${params?.provider} ${params?.hub} · channel ${params?.channel}`
+              : k,
+        },
+      }
+    );
     const result = renderPinField(
       makeEntry(ConfigEntryType.PIN, {
         key: "pin",

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -76,6 +76,25 @@ describe("findUsedPins", () => {
     expect(map.get(5)).toBe("binary_sensor");
   });
 
+  it("namespaces an I/O-expander pin so its channel doesn't alias a board GPIO", () => {
+    const config = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    pin:",
+      "      pcf8574: hub_in_1",
+      "      number: 0",
+      "      mode: INPUT",
+      "switch:",
+      "  - platform: gpio",
+      "    pin: GPIO0",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    // Board GPIO 0 (the switch) and the pcf8574 channel 0 are distinct keys.
+    expect(map.get(0)).toBe("switch");
+    expect(map.get("pcf8574:hub_in_1:0")).toBe("binary_sensor");
+  });
+
   it("excludes lines in the inclusive range", () => {
     // Skip lines 4-6 (the binary_sensor block) — pin 5 should
     // not appear.
@@ -288,6 +307,23 @@ describe("domainOccupiesPins", () => {
   it("matches the expanded pin-block (number: sub-key) form", () => {
     const yaml = "i2c:\n  - scl:\n      number: GPIO0\n    sda: 1\n    id: i2c_1\n";
     expect(domainOccupiesPins(yaml, "i2c", { scl: 0, sda: 1 })).toBe(true);
+  });
+
+  it("matches an expander channel by its namespaced token, not a board GPIO", () => {
+    const yaml = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    pin:",
+      "      pcf8574: hub_in_1",
+      "      number: 0",
+      "      mode: INPUT",
+      "",
+    ].join("\n");
+    expect(domainOccupiesPins(yaml, "binary_sensor", { pin: "pcf8574:hub_in_1:0" })).toBe(
+      true
+    );
+    // A board-GPIO-0 lock must NOT match the expander channel 0.
+    expect(domainOccupiesPins(yaml, "binary_sensor", { pin: 0 })).toBe(false);
   });
 
   it("is false when the pins are split across two instances", () => {

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -95,6 +95,19 @@ describe("findUsedPins", () => {
     expect(map.get("pcf8574:hub_in_1:0")).toBe("binary_sensor");
   });
 
+  it("does not alias a mid-edit expander pin (empty hub id) to a board GPIO", () => {
+    const config = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    pin:",
+      "      pcf8574:", // hub id not filled in yet
+      "      number: 0",
+      "",
+    ].join("\n");
+    // The incomplete expander block must not register board GPIO 0 as used.
+    expect(findUsedPins(config).has(0)).toBe(false);
+  });
+
   it("excludes lines in the inclusive range", () => {
     // Skip lines 4-6 (the binary_sensor block) — pin 5 should
     // not appear.

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -95,6 +95,22 @@ describe("findUsedPins", () => {
     expect(map.get("pcf8574:hub_in_1:0")).toBe("binary_sensor");
   });
 
+  it("reads expander pin keys even when a comment leads the long-form block", () => {
+    const config = [
+      "binary_sensor:",
+      "  - platform: gpio",
+      "    pin:",
+      "        # wired to hub input channel 0", // deeper-indented comment first
+      "      pcf8574: hub_in_1",
+      "      number: 0",
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    // The leading comment must not anchor the child indent and hide the keys.
+    expect(map.get("pcf8574:hub_in_1:0")).toBe("binary_sensor");
+    expect(map.has(0)).toBe(false);
+  });
+
   it("does not alias a mid-edit expander pin (empty hub id) to a board GPIO", () => {
     const config = [
       "binary_sensor:",

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -33,6 +33,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatPinValue,
   isPinFieldKey,
+  parseBoardGpio,
   parsePinGpio,
   scanPinGpios,
 } from "../../src/util/pin-gpio.js";
@@ -106,6 +107,16 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio({ mode: { input: true } })).toBeNull();
   });
 
+  it("namespaces an I/O-expander pin so its channel never aliases a board GPIO", () => {
+    // The pcf8574 hub channel 0 must not collide with board GPIO 0.
+    expect(parsePinGpio({ pcf8574: "pcf8574_hub_in_1", number: 0, mode: "INPUT" })).toBe(
+      "pcf8574:pcf8574_hub_in_1:0"
+    );
+    expect(parsePinGpio({ mcp23017: "hub", number: 7 })).toBe("mcp23017:hub:7");
+    // Expander key present but no resolvable channel -> null, not a board pin.
+    expect(parsePinGpio({ pcf8574: "hub" })).toBeNull();
+  });
+
   it("returns null for unparseable or non-pin inputs", () => {
     expect(parsePinGpio("abc")).toBeNull();
     expect(parsePinGpio("")).toBeNull();
@@ -113,6 +124,15 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio(undefined)).toBeNull();
     expect(parsePinGpio([1])).toBeNull(); // arrays are not pin-block objects
     expect(parsePinGpio(true)).toBeNull();
+  });
+});
+
+describe("parseBoardGpio", () => {
+  it("returns the board GPIO and drops expander tokens", () => {
+    expect(parseBoardGpio(12)).toBe(12);
+    expect(parseBoardGpio({ number: 5, mode: { input: true } })).toBe(5);
+    // An expander channel is not a board pin.
+    expect(parseBoardGpio({ pcf8574: "hub", number: 0 })).toBeNull();
   });
 });
 

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -33,6 +33,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatPinValue,
   isPinFieldKey,
+  LONG_FORM_PIN_KEYS,
   parseBoardGpio,
   parsePinGpio,
   scanPinGpios,
@@ -119,6 +120,19 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio({ pcf8574: "hub" })).toBeNull();
     // Provider present but hub id empty (mid-edit) -> null, NOT board GPIO 0.
     expect(parsePinGpio({ pcf8574: "", number: 0 })).toBeNull();
+  });
+
+  it("treats every long-form board-GPIO key as a board pin, never an expander provider", () => {
+    // Characterizes the provider-detection contract: any key NOT in
+    // LONG_FORM_PIN_KEYS is read as an I/O-expander provider, so each member
+    // must round-trip a plain board GPIO (here 7) to a number, not a token.
+    // This set mirrors the backend BOARD_PIN_KEYS in lockstep; dropping a key
+    // (or letting it drift) would misclassify a board pin as an expander
+    // channel, and this trips a red test instead of shipping silently.
+    for (const key of LONG_FORM_PIN_KEYS) {
+      if (key === "number") continue;
+      expect(parsePinGpio({ number: 7, [key]: "x" }), key).toBe(7);
+    }
   });
 
   it("returns null for unparseable or non-pin inputs", () => {

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -113,8 +113,12 @@ describe("parsePinGpio", () => {
       "pcf8574:pcf8574_hub_in_1:0"
     );
     expect(parsePinGpio({ mcp23017: "hub", number: 7 })).toBe("mcp23017:hub:7");
+    // The channel is parsed like any pin value, so a string `number` works.
+    expect(parsePinGpio({ pcf8574: "hub", number: "0" })).toBe("pcf8574:hub:0");
     // Expander key present but no resolvable channel -> null, not a board pin.
     expect(parsePinGpio({ pcf8574: "hub" })).toBeNull();
+    // Provider present but hub id empty (mid-edit) -> null, NOT board GPIO 0.
+    expect(parsePinGpio({ pcf8574: "", number: 0 })).toBeNull();
   });
 
   it("returns null for unparseable or non-pin inputs", () => {


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1717. Recommended components on boards that drive I/O through a `pcf8574` (or other) expander hub now carry a `requires` list (the i2c bus, then the hub a gpio pin sits on). Selecting such a component routes the missing prerequisites through the existing sequential add queue (the one bundles use), so the hub + bus are added first and the resulting config compiles instead of referencing a hub that doesn't exist. Prerequisites already present in the YAML (matched by their locked id) are skipped, and the banner reads "Adding prerequisites for &lt;name&gt;" during those steps.

It also teaches every pin-overlap path the expander namespace. An I/O-expander channel is modeled as a `provider:hub_id:channel` identity (e.g. `pcf8574:pcf8574_hub_in_1:0`) instead of a bare board GPIO:

- `parsePinGpio` returns the token for an expander pin (parsing the channel scalar, requiring a non-empty hub); `parseBoardGpio` (new) stays number-only for the pin picker and alias resolution. `pinIdentityToken` is the single source of the token shape.
- The used-pin scan (`findUsedPins`) and `domainOccupiesPins` read the long-form pin block as a unit (via `readLongFormPin`, which defers the identity decision to `parsePinGpio`), so an expander channel no longer aliases a board GPIO of the same number, and a mid-edit pin with an unfilled hub id doesn't false-collide on GPIO 0.
- `FeaturedComponent.locked_pins` widens to `Record<string, number | string>`.
- A featured gpio whose **locked** pin sits on an expander renders the hub + channel **read-only** (the board-pin picker can't represent it); an editable expander pin still gets the mode-flag picker scoped to the provider.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1716
- backend companion (emits `requires` + the namespaced `locked_pins`, materializes the hubs/bus): esphome/device-builder#1717

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
