### PR TITLE
Save the editor buffer before install/update

### DIFF
--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -902,6 +902,17 @@ export class ESPHomePageDevice extends LitElement {
     this._commandDialog.open("validate");
   };
 
+  // Persist the editor buffer before building — install/compile build the
+  // on-disk file, so an unsaved edit would flash the previous version.
+  // ``_saveYaml`` flushes in-flight form edits and re-validates; it returns
+  // false when the save is cancelled or fails, in which case the build is
+  // aborted.
+  private _installAfterSave = async (run: () => void): Promise<void> => {
+    if (await this._saveYaml()) run();
+  };
+  private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
+  private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);
+
   /** Catch ``clean-build`` from the install dialog's post-failure
    *  hint and route it through this page's command-dialog —
    *  mirrors dashboard's page-level handler so the "clean the
@@ -984,8 +995,8 @@ export class ESPHomePageDevice extends LitElement {
           @nav-collapse=${this._onNavCollapse}
           @save-yaml=${this._saveYaml}
           @validate-device=${this._onValidateClick}
-          @install-device=${this._installCtrl.onInstall}
-          @update-device=${this._installCtrl.onUpdate}
+          @install-device=${this._saveThenInstall}
+          @update-device=${this._saveThenUpdate}
         >
           ${this._renderNavigator("desktop-nav")}
           <esphome-device-editor

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -904,11 +904,18 @@ export class ESPHomePageDevice extends LitElement {
 
   // Persist the editor buffer before building — install/compile build the
   // on-disk file, so an unsaved edit would flash the previous version.
-  // ``_saveYaml`` flushes in-flight form edits and re-validates; it returns
-  // false when the save is cancelled or fails, in which case the build is
-  // aborted.
   private _installAfterSave = async (run: () => void): Promise<void> => {
-    if (await this._saveYaml()) run();
+    let saved: boolean;
+    try {
+      saved = await this._saveYaml();
+    } catch (e) {
+      // _saveYaml rejects when a section editor's flushPending upsert fails;
+      // surface it and abort rather than leak an unhandled rejection.
+      console.error("Failed to save before install:", e);
+      toast.error(this._localize("device.yaml_save_error"), { richColors: true });
+      return;
+    }
+    if (saved) run();
   };
   private _saveThenInstall = () => this._installAfterSave(this._installCtrl.onInstall);
   private _saveThenUpdate = () => this._installAfterSave(this._installCtrl.onUpdate);

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -173,3 +173,64 @@ describe("esphome-page-device save re-entrancy", () => {
     expect(doSave).toHaveBeenCalledTimes(1);
   });
 });
+
+interface InstallView {
+  _installCtrl: { onInstall: () => void; onUpdate: () => void };
+  _saveYaml(): Promise<boolean>;
+  _saveThenInstall(): Promise<void>;
+  _saveThenUpdate(): Promise<void>;
+}
+
+function makeInstallView(saveResult: boolean | Promise<boolean>): {
+  page: InstallView;
+  onInstall: ReturnType<typeof vi.fn>;
+  onUpdate: ReturnType<typeof vi.fn>;
+  saveYaml: ReturnType<typeof vi.fn>;
+} {
+  const page = new ESPHomePageDevice() as unknown as InstallView;
+  const onInstall = vi.fn();
+  const onUpdate = vi.fn();
+  const saveYaml = vi.fn(() => Promise.resolve(saveResult));
+  page._installCtrl = { onInstall, onUpdate };
+  page._saveYaml = saveYaml;
+  return { page, onInstall, onUpdate, saveYaml };
+}
+
+describe("esphome-page-device save before install", () => {
+  test("saves the buffer, then installs, when the save succeeds", async () => {
+    const { page, onInstall, saveYaml } = makeInstallView(true);
+    await page._saveThenInstall();
+    expect(saveYaml).toHaveBeenCalledTimes(1);
+    expect(onInstall).toHaveBeenCalledTimes(1);
+  });
+
+  test("saves the buffer, then updates, when the save succeeds", async () => {
+    const { page, onUpdate, saveYaml } = makeInstallView(true);
+    await page._saveThenUpdate();
+    expect(saveYaml).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not install when the save is cancelled or fails", async () => {
+    // The regression pin: a refused save must abort the build so it can't
+    // flash the stale on-disk version.
+    const { page, onInstall, onUpdate } = makeInstallView(false);
+    await page._saveThenInstall();
+    await page._saveThenUpdate();
+    expect(onInstall).not.toHaveBeenCalled();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("waits for the save to resolve before installing", async () => {
+    let resolveSave!: (ok: boolean) => void;
+    const { page, onInstall } = makeInstallView(
+      new Promise<boolean>((r) => (resolveSave = r))
+    );
+    const pending = page._saveThenInstall();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onInstall).not.toHaveBeenCalled(); // save still in flight
+    resolveSave(true);
+    await pending;
+    expect(onInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/pages/device.test.ts
+++ b/test/pages/device.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import type { EditorValidateResponse } from "../../src/api/types/editor.js";
 import type { DeviceLayoutMode } from "../../src/components/device/device-editor.js";
@@ -181,7 +187,7 @@ interface InstallView {
   _saveThenUpdate(): Promise<void>;
 }
 
-function makeInstallView(saveResult: boolean | Promise<boolean>): {
+function makeInstallView(saveResult: boolean): {
   page: InstallView;
   onInstall: ReturnType<typeof vi.fn>;
   onUpdate: ReturnType<typeof vi.fn>;
@@ -221,16 +227,13 @@ describe("esphome-page-device save before install", () => {
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  test("waits for the save to resolve before installing", async () => {
-    let resolveSave!: (ok: boolean) => void;
-    const { page, onInstall } = makeInstallView(
-      new Promise<boolean>((r) => (resolveSave = r))
-    );
-    const pending = page._saveThenInstall();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(onInstall).not.toHaveBeenCalled(); // save still in flight
-    resolveSave(true);
-    await pending;
-    expect(onInstall).toHaveBeenCalledTimes(1);
+  test("aborts the build and toasts when the save rejects, with no unhandled rejection", async () => {
+    // _saveYaml rejects when a section editor's flushPending upsert fails; the
+    // wrapper must catch it, surface an error, and not build.
+    const { page, onInstall } = makeInstallView(true);
+    page._saveYaml = vi.fn(() => Promise.reject(new Error("upsert failed")));
+    await expect(page._saveThenInstall()).resolves.toBeUndefined();
+    expect(onInstall).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Editing an existing device's YAML and then pressing Update or Install flashed the OLD version unless you clicked Save first; there was no autosave and no save-before-install step.

Install and Update build strictly from the on-disk file; the backend resolves the configuration filename to a path and esphome parses that file, so an unsaved editor buffer was never consulted. The editor buffer only reaches disk through Save (`devices/update_config`). This routes Install and Update through a save-first wrapper that reuses the existing `_saveYaml` (it flushes in-flight visual-editor edits, re-validates, and writes), so the build always uses what you see; the build is aborted only when the save is cancelled or fails. Invalid YAML still surfaces the existing validation dialog rather than silently flashing.

**Related issue or feature (if applicable):**

- Reported on the Home Assistant community forum; Install/Update built the last-saved version instead of the current edits.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
