### PR TITLE
Complete LONG_FORM_PIN_KEYS with id and ignore_pin_validation_error

### DIFF
--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -35,12 +35,18 @@
 // object names an I/O-expander provider (`pcf8574`, `mcp23xxx`, ...): its value
 // is the hub id and its `number` is an expander channel, not a board GPIO. The
 // backend mirrors this set (BOARD_PIN_KEYS) when it generates the catalog.
+// It's the union of esphome's gpio_base_schema keys (id / number / mode /
+// inverted / allow_other_uses) and the esp32 additions; `id` is included
+// because expander pin schemas extend the same base, so a channel that carries
+// an `id` must not have that `id` mistaken for the provider key.
 export const LONG_FORM_PIN_KEYS = new Set([
+  "id",
   "number",
   "mode",
   "inverted",
-  "ignore_strapping_warning",
   "allow_other_uses",
+  "ignore_strapping_warning",
+  "ignore_pin_validation_error",
   "drive_strength",
 ]);
 

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -120,6 +120,16 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio({ pcf8574: "hub" })).toBeNull();
     // Provider present but hub id empty (mid-edit) -> null, NOT board GPIO 0.
     expect(parsePinGpio({ pcf8574: "", number: 0 })).toBeNull();
+    // A pin-level `id` is a board-GPIO key, not a provider: an expander pin that
+    // also carries an id must still resolve to its provider token, not `id`.
+    expect(parsePinGpio({ pcf8574: "hub", number: 0, id: "relay1" })).toBe(
+      "pcf8574:hub:0"
+    );
+    // A plain board pin with an id (and the esp32-only validation key) stays a
+    // board GPIO, not a bogus `id`/`ignore_pin_validation_error` provider token.
+    expect(
+      parsePinGpio({ number: 5, id: "btn", ignore_pin_validation_error: true })
+    ).toBe(5);
   });
 
   it("treats every long-form board-GPIO key as a board pin, never an expander provider", () => {


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to esphome/device-builder-frontend#1009 (now merged).

`LONG_FORM_PIN_KEYS` drives I/O-expander provider detection in `parsePinGpio`: any key in a long-form pin object that is *not* in this set is treated as an expander provider (its value the hub id). Checked against ESPHome's `gpio_base_schema`, the set was missing two board-GPIO keys:

- `id` (from the base schema) — load-bearing: expander pin schemas (`pcf8574`, etc.) extend the same `gpio_base_schema`, so a channel that also carries an `id` would have that `id` picked as the provider instead of `pcf8574`. A plain board pin with an `id` (a string) was becoming a bogus `id:value:channel` token.
- `ignore_pin_validation_error` (esp32) — its boolean value made `parsePinGpio` return `null` (blank field) for a board pin that set it.

Adds both keys and pins the behavior: an expander pin carrying an `id` still resolves to its provider token, and a board pin with `id` / `ignore_pin_validation_error` resolves to its board GPIO number.

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder-frontend#1009
- backend companion (same set as `BOARD_PIN_KEYS`): esphome/device-builder#1721

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
