### PR TITLE
Tighten the new pin-keys comments per CLAUDE.md

### DIFF
--- a/src/util/pin-gpio.ts
+++ b/src/util/pin-gpio.ts
@@ -35,10 +35,8 @@
 // object names an I/O-expander provider (`pcf8574`, `mcp23xxx`, ...): its value
 // is the hub id and its `number` is an expander channel, not a board GPIO. The
 // backend mirrors this set (BOARD_PIN_KEYS) when it generates the catalog.
-// It's the union of esphome's gpio_base_schema keys (id / number / mode /
-// inverted / allow_other_uses) and the esp32 additions; `id` is included
-// because expander pin schemas extend the same base, so a channel that carries
-// an `id` must not have that `id` mistaken for the provider key.
+// 'id' is included because expander pin schemas extend this same base, so a
+// channel that carries an 'id' must not have it taken for the provider key.
 export const LONG_FORM_PIN_KEYS = new Set([
   "id",
   "number",

--- a/test/util/pin-gpio.test.ts
+++ b/test/util/pin-gpio.test.ts
@@ -120,25 +120,20 @@ describe("parsePinGpio", () => {
     expect(parsePinGpio({ pcf8574: "hub" })).toBeNull();
     // Provider present but hub id empty (mid-edit) -> null, NOT board GPIO 0.
     expect(parsePinGpio({ pcf8574: "", number: 0 })).toBeNull();
-    // A pin-level `id` is a board-GPIO key, not a provider: an expander pin that
-    // also carries an id must still resolve to its provider token, not `id`.
+    // A pin-level id is a board-GPIO key: an expander pin carrying one still
+    // resolves to its provider token, not the id.
     expect(parsePinGpio({ pcf8574: "hub", number: 0, id: "relay1" })).toBe(
       "pcf8574:hub:0"
     );
-    // A plain board pin with an id (and the esp32-only validation key) stays a
-    // board GPIO, not a bogus `id`/`ignore_pin_validation_error` provider token.
+    // A board pin with id and the esp32-only validation key stays a board GPIO.
     expect(
       parsePinGpio({ number: 5, id: "btn", ignore_pin_validation_error: true })
     ).toBe(5);
   });
 
   it("treats every long-form board-GPIO key as a board pin, never an expander provider", () => {
-    // Characterizes the provider-detection contract: any key NOT in
-    // LONG_FORM_PIN_KEYS is read as an I/O-expander provider, so each member
-    // must round-trip a plain board GPIO (here 7) to a number, not a token.
-    // This set mirrors the backend BOARD_PIN_KEYS in lockstep; dropping a key
-    // (or letting it drift) would misclassify a board pin as an expander
-    // channel, and this trips a red test instead of shipping silently.
+    // Each member must round-trip a plain board GPIO to a number; guards the set
+    // against drift that would misclassify a board pin as an expander channel.
     for (const key of LONG_FORM_PIN_KEYS) {
       if (key === "number") continue;
       expect(parsePinGpio({ number: 7, [key]: "x" }), key).toBe(7);


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to esphome/device-builder-frontend#1012 (now merged): tighten the comments that PR added on `LONG_FORM_PIN_KEYS` and its tests to match the project's terse-comment convention.

- Cut the rationale that belongs in the PR, not the source (the `gpio_base_schema` key enumeration, the lockstep-with-backend restatement, the "trips a red test" narration).
- Drop backticks from the JS comments (project convention).
- Keep only the non-obvious *why*: `id` is a board-GPIO key, so it must not be taken for the expander provider.

Comment-only; no behaviour change.

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder-frontend#1012

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
