### PR TITLE
Show installed to target version on the Update button hover

### DIFF
--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -17,6 +17,7 @@ import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import { updateButtonTitle } from "../../util/update-tooltip.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./device-drawer-content.js";
@@ -363,6 +364,12 @@ export class ESPHomeDeviceDrawer extends LitElement {
                 class="action action--accent"
                 ?disabled=${this.busy}
                 @click=${() => this._emitAction("update-device")}
+                title=${updateButtonTitle(
+                  this._localize,
+                  device.deployed_version,
+                  device.current_version,
+                  "dashboard.drawer_update"
+                )}
               >
                 <wa-icon library="mdi" name="upload"></wa-icon>
                 ${this._localize("dashboard.drawer_update")}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -105,8 +105,8 @@ export function renderCardGrid(
             .labelIds=${device.labels ?? []}
             ?has-pending-changes=${device.has_pending_changes === true}
             ?has-update-available=${device.update_available}
-            .installedVersion=${device.deployed_version ?? ""}
-            .availableVersion=${device.current_version ?? ""}
+            .installedVersion=${device.deployed_version}
+            .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}
             ?api-encrypted=${device.api_encrypted === true}
             .apiEncryptionActive=${device.api_encryption_active ?? null}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -105,6 +105,8 @@ export function renderCardGrid(
             .labelIds=${device.labels ?? []}
             ?has-pending-changes=${device.has_pending_changes === true}
             ?has-update-available=${device.update_available}
+            .installedVersion=${device.deployed_version ?? ""}
+            .availableVersion=${device.current_version ?? ""}
             ?api-enabled=${device.api_enabled === true}
             ?api-encrypted=${device.api_encrypted === true}
             .apiEncryptionActive=${device.api_encryption_active ?? null}

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -9,6 +9,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
 import { getCompactEncryptionVisual } from "../../util/encryption-state.js";
 import { formatFileSize } from "../../util/format-file-size.js";
 import { renderLabelChips } from "../../util/label-chip-template.js";
+import { updateButtonTitle } from "../../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../../util/visit-web-ui-link.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 
@@ -325,7 +326,12 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
             ? html`<button
                 class="cell-action-btn cell-action-btn--accent cell-action-btn--install"
                 aria-label=${localize("dashboard.table_action_update")}
-                title=${localize("dashboard.table_action_update")}
+                title=${updateButtonTitle(
+                  localize,
+                  device.deployed_version,
+                  device.current_version,
+                  "dashboard.table_action_update"
+                )}
                 ?disabled=${row.busy}
                 @click=${(e: Event) => dispatchRowEvent(e, "update-device", device)}
               >

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -28,6 +28,7 @@ import { labelsContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { labelChipStyles } from "../util/label-chip-template.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { updateButtonTitle } from "../util/update-tooltip.js";
 import { renderVisitWebUiLink } from "../util/visit-web-ui-link.js";
 import { navigateCards, onHostContextMenu } from "./device-card/keyboard-nav.js";
 import {
@@ -79,6 +80,10 @@ export class ESPHomeDeviceCard extends LitElement {
     false;
   @property({ type: Boolean, attribute: "has-update-available" }) hasUpdateAvailable =
     false;
+
+  // Installed (running) and target ESPHome versions, for the Update hover.
+  @property({ attribute: false }) installedVersion = "";
+  @property({ attribute: false }) availableVersion = "";
   @property({ type: Boolean, attribute: "api-enabled" }) apiEnabled = false;
   @property({ type: Boolean, attribute: "api-encrypted" }) apiEncrypted = false;
 
@@ -241,7 +246,12 @@ export class ESPHomeDeviceCard extends LitElement {
         ?disabled=${this.busy}
         @click=${() => this._emit("update-device")}
         aria-label=${this._localize("dashboard.update")}
-        title=${this._localize("dashboard.update")}
+        title=${updateButtonTitle(
+          this._localize,
+          this.installedVersion,
+          this.availableVersion,
+          "dashboard.update"
+        )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -81,7 +81,7 @@ export class ESPHomeDeviceCard extends LitElement {
   @property({ type: Boolean, attribute: "has-update-available" }) hasUpdateAvailable =
     false;
 
-  // Installed (running) and target ESPHome versions, for the Update hover.
+  // Installed + target ESPHome versions for the Update hover.
   @property({ attribute: false }) installedVersion = "";
   @property({ attribute: false }) availableVersion = "";
   @property({ type: Boolean, attribute: "api-enabled" }) apiEnabled = false;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -162,11 +162,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   @property({ type: Boolean })
   hasUpdateAvailable = false;
 
-  /** Installed (running) ESPHome version, for the Update button hover. */
+  // Installed + target ESPHome versions for the Update button hover.
   @property()
   installedVersion = "";
 
-  /** Target version an update would install, for the Update button hover. */
   @property()
   availableVersion = "";
 

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -162,6 +162,14 @@ export class ESPHomeDeviceEditor extends LitElement {
   @property({ type: Boolean })
   hasUpdateAvailable = false;
 
+  /** Installed (running) ESPHome version, for the Update button hover. */
+  @property()
+  installedVersion = "";
+
+  /** Target version an update would install, for the Update button hover. */
+  @property()
+  availableVersion = "";
+
   @property({ type: Boolean })
   busy = false;
 
@@ -410,6 +418,8 @@ export class ESPHomeDeviceEditor extends LitElement {
       hasUpdateAvailable: this.hasUpdateAvailable,
       hasPendingChanges: this.hasPendingChanges,
       busy: this.busy,
+      installedVersion: this.installedVersion,
+      availableVersion: this.availableVersion,
       onUpdate: () => this._onUpdate(),
       onInstall: () => this._onInstall(),
     });

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -7,9 +7,8 @@ export interface InstallActionProps {
   hasUpdateAvailable: boolean;
   hasPendingChanges: boolean;
   busy: boolean;
-  /** Installed (running) ESPHome version, for the Update hover. */
+  // Installed + target ESPHome versions for the Update hover (see updateButtonTitle).
   installedVersion: string;
-  /** Target version an update would install, for the Update hover. */
   availableVersion: string;
   onUpdate: () => void;
   onInstall: () => void;

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -1,11 +1,16 @@
 import { html, type TemplateResult } from "lit";
 import type { LocalizeFunc } from "../../common/localize.js";
+import { updateButtonTitle } from "../../util/update-tooltip.js";
 
 export interface InstallActionProps {
   localize: LocalizeFunc;
   hasUpdateAvailable: boolean;
   hasPendingChanges: boolean;
   busy: boolean;
+  /** Installed (running) ESPHome version, for the Update hover. */
+  installedVersion: string;
+  /** Target version an update would install, for the Update hover. */
+  availableVersion: string;
   onUpdate: () => void;
   onInstall: () => void;
 }
@@ -27,7 +32,12 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
         class="install-fab install-split__main"
         ?disabled=${p.busy}
         @click=${p.onUpdate}
-        title=${p.localize("dashboard.update")}
+        title=${updateButtonTitle(
+          p.localize,
+          p.installedVersion,
+          p.availableVersion,
+          "dashboard.update"
+        )}
       >
         <wa-icon library="mdi" name="upload"></wa-icon>
         ${p.localize("dashboard.update")}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -1026,6 +1026,8 @@ export class ESPHomePageDevice extends LitElement {
             ?saving=${this._saving}
             ?hasPendingChanges=${this._device?.has_pending_changes === true}
             ?hasUpdateAvailable=${this._device?.update_available === true}
+            .installedVersion=${this._device?.deployed_version ?? ""}
+            .availableVersion=${this._device?.current_version ?? ""}
             ?busy=${this._activeJobs.has(this.id)}
           >
             ${showEdgeTab || this._selectedSection

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -30,6 +30,7 @@
     "add_new_device_hint": "Create a new ESPHome configuration",
     "esphome_web": "ESPHome web",
     "update": "Update",
+    "update_available_version": "Update available: {installed} → {target}",
     "edit": "Edit",
     "logs": "Logs",
     "create_device": "Create device",

--- a/src/util/update-tooltip.ts
+++ b/src/util/update-tooltip.ts
@@ -1,0 +1,17 @@
+import type { LocalizeFunc } from "../common/localize.js";
+
+/**
+ * Hover text for an Update button: installed → target ESPHome version, restoring
+ * the legacy dashboard tooltip. Falls back to the button's own label when either
+ * version is unknown (e.g. a device that hasn't reported its version yet).
+ */
+export function updateButtonTitle(
+  localize: LocalizeFunc,
+  installed: string,
+  target: string,
+  fallbackKey: string
+): string {
+  return installed && target
+    ? localize("dashboard.update_available_version", { installed, target })
+    : localize(fallbackKey);
+}

--- a/src/util/update-tooltip.ts
+++ b/src/util/update-tooltip.ts
@@ -2,8 +2,9 @@ import type { LocalizeFunc } from "../common/localize.js";
 
 /**
  * Hover text for an Update button: installed → target ESPHome version, restoring
- * the legacy dashboard tooltip. Falls back to the button's own label when either
- * version is unknown (e.g. a device that hasn't reported its version yet).
+ * the legacy dashboard tooltip. `installed` is the device's `deployed_version`
+ * (running firmware), `target` its `current_version` (what an update installs).
+ * Falls back to the button's own label when either version is unknown.
  */
 export function updateButtonTitle(
   localize: LocalizeFunc,

--- a/test/components/dashboard/device-drawer-update-title.test.ts
+++ b/test/components/dashboard/device-drawer-update-title.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+// The drawer body renders children that pull in <wa-button> (form-associated,
+// noisy under happy-dom); the footer under test uses plain buttons, so stubbing
+// the body keeps the mount light and quiet.
+vi.mock("../../../src/components/dashboard/device-drawer-content.js", () => ({}));
+
+import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
+import { makeConfiguredDevice } from "../../_make-configured-device.js";
+
+async function mount(device: ReturnType<typeof makeConfiguredDevice>) {
+  const el = new ESPHomeDeviceDrawer();
+  el.open = true;
+  el.device = device;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function footerAccentTitle(el: ESPHomeDeviceDrawer): string | null {
+  return el.shadowRoot!.querySelector<HTMLElement>(".footer .action--accent")!.title;
+}
+
+describe("device-drawer footer Update title", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("wires installed + target versions into the Update button title", async () => {
+    // Identity localize keeps the key; the version key proves both versions
+    // threaded through (helper branch logic is unit-tested in update-tooltip).
+    const el = await mount(
+      makeConfiguredDevice({
+        update_available: true,
+        deployed_version: "2024.6.0",
+        current_version: "2024.12.0",
+      })
+    );
+    expect(footerAccentTitle(el)).toBe("dashboard.update_available_version");
+  });
+
+  it("falls back to the plain Update title when a version is missing", async () => {
+    const el = await mount(
+      makeConfiguredDevice({ update_available: true, deployed_version: "2024.6.0" })
+    );
+    expect(footerAccentTitle(el)).toBe("dashboard.drawer_update");
+  });
+});

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -53,10 +53,10 @@ describe("device-editor footer install action", () => {
     expect(install).toHaveBeenCalledTimes(1);
   });
 
-  it("titles the Update button with the version hover when both versions are known", async () => {
-    // The identity localize keeps the key; we assert the version branch is
-    // selected (wired installed + target through to the button) rather than the
-    // plain "dashboard.update" fallback.
+  it("wires the installed + target versions into the Update button title", async () => {
+    // Identity localize keeps the key; asserting the version key proves both
+    // versions threaded through to the title (the helper's branch logic and
+    // fallback are unit-tested in update-tooltip.test.ts).
     const el = await mount({
       hasUpdateAvailable: true,
       installedVersion: "2024.6.0",
@@ -65,11 +65,6 @@ describe("device-editor footer install action", () => {
     expect(q(el, ".install-split__main")!.title).toBe(
       "dashboard.update_available_version"
     );
-  });
-
-  it("falls back to the plain Update title when a version is missing", async () => {
-    const el = await mount({ hasUpdateAvailable: true, installedVersion: "2024.6.0" });
-    expect(q(el, ".install-split__main")!.title).toBe("dashboard.update");
   });
 
   it("renders a highlighted plain Install (-> picker) when there are pending changes", async () => {

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -53,6 +53,25 @@ describe("device-editor footer install action", () => {
     expect(install).toHaveBeenCalledTimes(1);
   });
 
+  it("titles the Update button with the version hover when both versions are known", async () => {
+    // The identity localize keeps the key; we assert the version branch is
+    // selected (wired installed + target through to the button) rather than the
+    // plain "dashboard.update" fallback.
+    const el = await mount({
+      hasUpdateAvailable: true,
+      installedVersion: "2024.6.0",
+      availableVersion: "2024.12.0",
+    });
+    expect(q(el, ".install-split__main")!.title).toBe(
+      "dashboard.update_available_version"
+    );
+  });
+
+  it("falls back to the plain Update title when a version is missing", async () => {
+    const el = await mount({ hasUpdateAvailable: true, installedVersion: "2024.6.0" });
+    expect(q(el, ".install-split__main")!.title).toBe("dashboard.update");
+  });
+
   it("renders a highlighted plain Install (-> picker) when there are pending changes", async () => {
     const el = await mount({ hasPendingChanges: true });
     const install = vi.fn();

--- a/test/util/update-tooltip.test.ts
+++ b/test/util/update-tooltip.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import type { LocalizeFunc } from "../../src/common/localize.js";
+import { updateButtonTitle } from "../../src/util/update-tooltip.js";
+
+// Interpolating stub mirroring the en.json template, so the test pins the
+// installed -> target ordering (the field-swap is the easy mistake) and the
+// fallback path.
+const localize: LocalizeFunc = (key, values) =>
+  key === "dashboard.update_available_version"
+    ? `Update available: ${values?.installed} → ${values?.target}`
+    : key;
+
+describe("updateButtonTitle", () => {
+  it("shows installed -> target when both versions are known", () => {
+    expect(updateButtonTitle(localize, "2024.6.0", "2024.12.0", "dashboard.update")).toBe(
+      "Update available: 2024.6.0 → 2024.12.0"
+    );
+  });
+
+  it("falls back to the button label when the installed version is unknown", () => {
+    expect(updateButtonTitle(localize, "", "2024.12.0", "dashboard.update")).toBe(
+      "dashboard.update"
+    );
+  });
+
+  it("falls back to the button label when the target version is unknown", () => {
+    expect(
+      updateButtonTitle(localize, "2024.6.0", "", "dashboard.table_action_update")
+    ).toBe("dashboard.table_action_update");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Restores a feature from the legacy dashboard: hovering the Update button shows which ESPHome version a device is currently running and what an update would install, so you can decide whether to update without opening the drawer.

A shared `updateButtonTitle` helper builds the localized hover text "Update available: {installed} → {target}" (installed comes from the device's `deployed_version`, target from `current_version`); it falls back to the button's own label when either version is unknown. It is wired into all three Update buttons: the dashboard grid card, the dashboard table row, and the device editor footer. Both versions are already on the wire, so there is no backend change.

**Related issue or feature (if applicable):**

- Requested in https://github.com/orgs/esphome/discussions/3730

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
