### PR TITLE
Keep dashboard filters across page switches

### DIFF
--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -586,10 +586,12 @@ export class ESPHomePageDashboard extends LitElement {
     this._persistFilterState(changed);
   }
 
-  /** Persist filter/search/view state on change. Two layers, kept in one
-   *  seam: the URL (authoritative, shareable) and the session store (seeds
-   *  facets when the URL doesn't carry them). The initial paint re-writes the
-   *  values that ``_hydrateFromUrl`` just read, which is a harmless no-op. */
+  /** Persist filter/search/view state on change. Two layers in one seam: the
+   *  URL (authoritative, shareable) and the session store (seeds facets the URL
+   *  doesn't carry). On the initial paint this writes the hydrated state back: a
+   *  no-op when it came from the URL, but when facets were session-seeded it
+   *  promotes them into the address bar via ``replaceState`` so the URL keeps
+   *  mirroring the active filters (back stack stays clean). */
   private _persistFilterState(changed: PropertyValues): void {
     if (
       ESPHomePageDashboard._urlSyncedFields.some((f) => changed.has(f)) ||

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -98,6 +98,10 @@ import {
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { runBulkUpdate } from "../util/bulk-update.js";
+import {
+  loadDashboardFilters,
+  saveDashboardFilters,
+} from "../util/dashboard-filters-session.js";
 import { readDashboardUrl, writeDashboardUrl } from "../util/dashboard-url.js";
 import {
   activeFacetCount,
@@ -428,6 +432,27 @@ export class ESPHomePageDashboard extends LitElement {
     if (urlState.view !== undefined) this._view = urlState.view;
     if (urlState.yaml !== undefined) this._yamlMode = urlState.yaml;
 
+    // Seed any facet the URL didn't carry from the session store, so filters
+    // survive returning to a bare "/" (command palette, fresh-load back), not
+    // just browser-Back. The URL stays authoritative per-field — a deep link or
+    // shared URL that sets a facet wins over the session seed. Labels are stored
+    // as ids here, so no name resolution is needed (unlike the URL path).
+    const saved = loadDashboardFilters();
+    if (saved) {
+      if (urlState.labels === undefined && saved.labels.length > 0)
+        this._selectedLabels = saved.labels;
+      if (urlState.areas === undefined && saved.areas.length > 0)
+        this._selectedAreas = saved.areas;
+      if (urlState.platforms === undefined && saved.platforms.length > 0)
+        this._selectedPlatforms = saved.platforms;
+      if (urlState.states === undefined && saved.states.length > 0)
+        this._selectedStates = saved.states;
+      if (urlState.updates === undefined && saved.updates.length > 0) {
+        const requested = new Set(saved.updates);
+        this._selectedUpdateStatus = UPDATE_FACET_BUCKETS.filter((b) => requested.has(b));
+      }
+    }
+
     this._syncYamlSearch();
   }
 
@@ -462,6 +487,16 @@ export class ESPHomePageDashboard extends LitElement {
     "_selectedUpdateStatus",
     "_view",
     "_yamlMode",
+  ] as const;
+
+  /** Facet fields persisted to the session store (the URL-synced set minus
+   *  ``_search`` / ``_view`` / ``_yamlMode``, which aren't session-seeded). */
+  private static readonly _sessionSyncedFields = [
+    "_selectedLabels",
+    "_selectedAreas",
+    "_selectedPlatforms",
+    "_selectedStates",
+    "_selectedUpdateStatus",
   ] as const;
 
   private _syncUrl(): void {
@@ -572,6 +607,17 @@ export class ESPHomePageDashboard extends LitElement {
       (changed.has("_labelsCatalog") && this._selectedLabels.length > 0)
     ) {
       this._syncUrl();
+    }
+    // Mirror the facet selection to the session store so it survives a return
+    // to a bare "/" (not just browser-Back). Search / view stay out of scope.
+    if (ESPHomePageDashboard._sessionSyncedFields.some((f) => changed.has(f))) {
+      saveDashboardFilters({
+        labels: this._selectedLabels,
+        areas: this._selectedAreas,
+        platforms: this._selectedPlatforms,
+        states: this._selectedStates,
+        updates: this._selectedUpdateStatus,
+      });
     }
   }
 

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -603,8 +603,16 @@ export class ESPHomePageDashboard extends LitElement {
     // The session store carries only the facets (search / view stay out of
     // scope), so it survives a return to a bare "/" not just browser-Back.
     if (ESPHomePageDashboard._sessionSyncedFields.some((f) => changed.has(f))) {
+      // While URL label *names* are still resolving to ids, ``_selectedLabels``
+      // is still ``[]`` — keep the previously saved ids rather than clobbering
+      // them with the empty placeholder (the resolved ids get saved once the
+      // catalog arrives and ``_selectedLabels`` changes).
+      const labels =
+        this._pendingLabelNames !== null
+          ? (loadDashboardFilters()?.labels ?? [])
+          : this._selectedLabels;
       saveDashboardFilters({
-        labels: this._selectedLabels,
+        labels,
         areas: this._selectedAreas,
         platforms: this._selectedPlatforms,
         states: this._selectedStates,

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -112,7 +112,7 @@ import {
 } from "../util/device-filter.js";
 import { matchesDeviceName } from "../util/device-search.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../util/device-sort.js";
-import { UPDATE_FACET_BUCKETS } from "../util/facets.js";
+import { normalizeUpdateBuckets } from "../util/facets.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
@@ -422,13 +422,11 @@ export class ESPHomePageDashboard extends LitElement {
     if (urlState.areas !== undefined) this._selectedAreas = urlState.areas;
     if (urlState.platforms !== undefined) this._selectedPlatforms = urlState.platforms;
     if (urlState.states !== undefined) this._selectedStates = urlState.states;
-    if (urlState.updates !== undefined) {
-      // Normalize the user-editable URL to known buckets in canonical
-      // order, deduped — so unknown or duplicate ids can't inflate the
-      // active-filter count or render duplicate badges.
-      const requested = new Set(urlState.updates);
-      this._selectedUpdateStatus = UPDATE_FACET_BUCKETS.filter((b) => requested.has(b));
-    }
+    // Normalize the user-editable URL to known buckets in canonical order,
+    // deduped, so unknown or duplicate ids can't inflate the active-filter
+    // count or render duplicate badges.
+    if (urlState.updates !== undefined)
+      this._selectedUpdateStatus = normalizeUpdateBuckets(urlState.updates);
     if (urlState.view !== undefined) this._view = urlState.view;
     if (urlState.yaml !== undefined) this._yamlMode = urlState.yaml;
 
@@ -439,18 +437,12 @@ export class ESPHomePageDashboard extends LitElement {
     // as ids here, so no name resolution is needed (unlike the URL path).
     const saved = loadDashboardFilters();
     if (saved) {
-      if (urlState.labels === undefined && saved.labels.length > 0)
-        this._selectedLabels = saved.labels;
-      if (urlState.areas === undefined && saved.areas.length > 0)
-        this._selectedAreas = saved.areas;
-      if (urlState.platforms === undefined && saved.platforms.length > 0)
-        this._selectedPlatforms = saved.platforms;
-      if (urlState.states === undefined && saved.states.length > 0)
-        this._selectedStates = saved.states;
-      if (urlState.updates === undefined && saved.updates.length > 0) {
-        const requested = new Set(saved.updates);
-        this._selectedUpdateStatus = UPDATE_FACET_BUCKETS.filter((b) => requested.has(b));
-      }
+      if (urlState.labels === undefined) this._selectedLabels = saved.labels;
+      if (urlState.areas === undefined) this._selectedAreas = saved.areas;
+      if (urlState.platforms === undefined) this._selectedPlatforms = saved.platforms;
+      if (urlState.states === undefined) this._selectedStates = saved.states;
+      if (urlState.updates === undefined)
+        this._selectedUpdateStatus = normalizeUpdateBuckets(saved.updates);
     }
 
     this._syncYamlSearch();
@@ -489,15 +481,13 @@ export class ESPHomePageDashboard extends LitElement {
     "_yamlMode",
   ] as const;
 
-  /** Facet fields persisted to the session store (the URL-synced set minus
-   *  ``_search`` / ``_view`` / ``_yamlMode``, which aren't session-seeded). */
-  private static readonly _sessionSyncedFields = [
-    "_selectedLabels",
-    "_selectedAreas",
-    "_selectedPlatforms",
-    "_selectedStates",
-    "_selectedUpdateStatus",
-  ] as const;
+  /** Facet fields persisted to the session store: the URL-synced set minus the
+   *  non-facet fields. Derived so adding a facet to ``_urlSyncedFields`` also
+   *  makes it session-seeded without touching a second list. */
+  private static readonly _sessionSyncedFields =
+    ESPHomePageDashboard._urlSyncedFields.filter(
+      (f) => f !== "_search" && f !== "_view" && f !== "_yamlMode"
+    );
 
   private _syncUrl(): void {
     // While name resolution is still pending (catalog hasn't loaded
@@ -593,23 +583,25 @@ export class ESPHomePageDashboard extends LitElement {
       const next = hits.reduce((sum, h) => sum + h.matches.length, 0);
       if (next !== this._yamlPreviewCount) this._yamlPreviewCount = next;
     }
-    // Mirror filter / search / view state to the URL on every
-    // change, but skip the first paint cycle (where every prop is
-    // "changed" because Lit treats initial assignment as a change) —
-    // the initial state already came from the URL via
-    // ``_hydrateFromUrl``, so writing it back is a no-op.
+    this._persistFilterState(changed);
+  }
+
+  /** Persist filter/search/view state on change. Two layers, kept in one
+   *  seam: the URL (authoritative, shareable) and the session store (seeds
+   *  facets when the URL doesn't carry them). The initial paint re-writes the
+   *  values that ``_hydrateFromUrl`` just read, which is a harmless no-op. */
+  private _persistFilterState(changed: PropertyValues): void {
     if (
       ESPHomePageDashboard._urlSyncedFields.some((f) => changed.has(f)) ||
-      // Label ids serialize to the URL by *name* through the catalog,
-      // and a catalog push (create / rename) can land after the
-      // selection change that referenced it — re-sync so the URL
-      // picks up the resolved / renamed names.
+      // Label ids serialize to the URL by *name* through the catalog, and a
+      // catalog push (create / rename) can land after the selection change that
+      // referenced it — re-sync so the URL picks up the resolved / renamed names.
       (changed.has("_labelsCatalog") && this._selectedLabels.length > 0)
     ) {
       this._syncUrl();
     }
-    // Mirror the facet selection to the session store so it survives a return
-    // to a bare "/" (not just browser-Back). Search / view stay out of scope.
+    // The session store carries only the facets (search / view stay out of
+    // scope), so it survives a return to a bare "/" not just browser-Back.
     if (ESPHomePageDashboard._sessionSyncedFields.some((f) => changed.has(f))) {
       saveDashboardFilters({
         labels: this._selectedLabels,

--- a/src/util/dashboard-filters-session.ts
+++ b/src/util/dashboard-filters-session.ts
@@ -1,0 +1,56 @@
+/**
+ * Session-scoped seed for the dashboard's filter facets so they survive
+ * in-app page switches (open a device, come back via the home/command-palette
+ * path) and tab reloads, then reset when the browser/tab closes. The URL query
+ * string stays the authoritative, shareable layer (see dashboard-url.ts); this
+ * only seeds facets the URL doesn't carry. Search text and view mode are out of
+ * scope. Storage access is guarded so a throw (private mode / sandboxed iframe /
+ * quota) falls back to no seed instead of breaking the dashboard.
+ *
+ * Labels are stored as ids (not names like the URL): same-session, ids are
+ * stable, so the seed path skips the name-resolution dance entirely.
+ */
+
+export const STORAGE_KEY = "esphome-dashboard-filters";
+
+export interface DashboardFilterState {
+  labels: string[];
+  areas: string[];
+  platforms: string[];
+  states: string[];
+  updates: string[];
+}
+
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every((x) => typeof x === "string");
+
+/** Read the saved facet selection, or null if absent / unparseable. A
+ *  malformed individual facet falls back to an empty array. */
+export function loadDashboardFilters(): DashboardFilterState | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+      return null;
+    const obj = parsed as Record<string, unknown>;
+    return {
+      labels: isStringArray(obj.labels) ? obj.labels : [],
+      areas: isStringArray(obj.areas) ? obj.areas : [],
+      platforms: isStringArray(obj.platforms) ? obj.platforms : [],
+      states: isStringArray(obj.states) ? obj.states : [],
+      updates: isStringArray(obj.updates) ? obj.updates : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the facet selection; drops the write if storage is unavailable. */
+export function saveDashboardFilters(state: DashboardFilterState): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Drop the write so filtering still completes.
+  }
+}

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -128,6 +128,14 @@ export const UPDATE_FACET_BUCKETS = ["update_available", "modified"] as const;
 
 type UpdateBucket = (typeof UPDATE_FACET_BUCKETS)[number];
 
+/** Normalize arbitrary update-status ids (from the URL or the session store)
+ *  to the known buckets in canonical order, deduped — so an unknown or
+ *  duplicate id can't inflate the active-filter count or render duplicates. */
+export function normalizeUpdateBuckets(ids: readonly string[]): string[] {
+  const requested = new Set(ids);
+  return UPDATE_FACET_BUCKETS.filter((b) => requested.has(b));
+}
+
 /** Each bucket's membership test — the single source of truth shared
  *  by the facet's counts here and the dashboard's row filter, so the
  *  bucket → device-field mapping isn't written twice. */

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/components/filters/labels-filter-section.js", () => ({}));
 import type { ESPHomeAPI } from "../../src/api/index.js";
 import { DeviceState } from "../../src/api/types/devices.js";
 import { ESPHomeUpdateAllDialog } from "../../src/components/update-all-dialog.js";
+import { saveDashboardFilters } from "../../src/util/dashboard-filters-session.js";
 import type { FacetSelection } from "../../src/util/device-filter.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
@@ -87,6 +88,28 @@ describe("update-all-dialog", () => {
     // Only the online + update-available device (a.yaml) matches the defaults.
     expect(summary).toContain("update_all_dialog.count:1");
     expect(primaryButton(el).disabled).toBe(false);
+  });
+
+  it("ignores persisted dashboard filters (its own default selection wins)", async () => {
+    // Persisting dashboard list filters must not leak into Update All, which
+    // always opens on its own Online + update_available default. A saved filter
+    // that would exclude the matching device (a different platform) must not
+    // change what the dialog targets.
+    saveDashboardFilters({
+      labels: [],
+      areas: [],
+      platforms: ["rp2040"],
+      states: [DeviceState.OFFLINE],
+      updates: ["modified"],
+    });
+    try {
+      const { api } = fakeApi();
+      const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);
+      const summary = el.shadowRoot!.querySelector(".summary")!.textContent ?? "";
+      expect(summary).toContain("update_all_dialog.count:1");
+    } finally {
+      sessionStorage.clear();
+    }
   });
 
   it("installs exactly the matched configurations on confirm", async () => {

--- a/test/pages/dashboard-filter-hydration.test.ts
+++ b/test/pages/dashboard-filter-hydration.test.ts
@@ -10,7 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
-import { saveDashboardFilters } from "../../src/util/dashboard-filters-session.js";
+import {
+  loadDashboardFilters,
+  saveDashboardFilters,
+} from "../../src/util/dashboard-filters-session.js";
 
 const FULL = {
   labels: ["lbl-1"],
@@ -69,6 +72,29 @@ describe("dashboard filter session seeding", () => {
     const page = makePage();
     hydrate(page);
     expect(page._selectedUpdateStatus).toEqual(["update_available"]);
+  });
+
+  it("preserves saved label ids while URL label names are still resolving", () => {
+    // URL labels arrive as names that resolve to ids once the catalog loads;
+    // until then _selectedLabels is [], and persisting that must not wipe the
+    // previously saved label selection from the session store.
+    saveDashboardFilters({
+      labels: ["lbl-1"],
+      areas: [],
+      platforms: [],
+      states: [],
+      updates: [],
+    });
+    const page = makePage();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = page as any;
+    internals._pendingLabelNames = ["Office"];
+    internals._selectedLabels = [];
+    internals._selectedPlatforms = ["esp32"];
+    internals._persistFilterState(new Map([["_selectedPlatforms", undefined]]));
+    const saved = loadDashboardFilters();
+    expect(saved?.labels).toEqual(["lbl-1"]); // preserved, not clobbered to []
+    expect(saved?.platforms).toEqual(["esp32"]); // other facets still saved
   });
 
   it("leaves facets at their empty defaults with no URL and no session", () => {

--- a/test/pages/dashboard-filter-hydration.test.ts
+++ b/test/pages/dashboard-filter-hydration.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the session-seed half of ESPHomePageDashboard._hydrateFromUrl: facets
+ * the URL doesn't carry are restored from the session store, but a facet the
+ * URL sets wins over the session seed (discussion #3717).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+import { saveDashboardFilters } from "../../src/util/dashboard-filters-session.js";
+
+const FULL = {
+  labels: ["lbl-1"],
+  areas: ["Kitchen"],
+  platforms: ["esp32"],
+  states: ["online"],
+  updates: ["update_available"],
+};
+
+function makePage(): ESPHomePageDashboard {
+  const page = new ESPHomePageDashboard();
+  // _syncYamlSearch touches the YAML search controller; the hydrate path
+  // doesn't need it, so stub it like the other dashboard unit tests do.
+  vi.spyOn(page, "_syncYamlSearch").mockImplementation(() => {});
+  return page;
+}
+
+const hydrate = (page: ESPHomePageDashboard) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (page as any)._hydrateFromUrl();
+
+describe("dashboard filter session seeding", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("seeds every facet from the session store when the URL carries none", () => {
+    saveDashboardFilters(FULL);
+    const page = makePage();
+    hydrate(page);
+    expect(page._selectedLabels).toEqual(["lbl-1"]);
+    expect(page._selectedAreas).toEqual(["Kitchen"]);
+    expect(page._selectedPlatforms).toEqual(["esp32"]);
+    expect(page._selectedStates).toEqual(["online"]);
+    expect(page._selectedUpdateStatus).toEqual(["update_available"]);
+  });
+
+  it("lets the URL win per-field while still seeding the rest from session", () => {
+    saveDashboardFilters(FULL);
+    history.replaceState(null, "", "/?platforms=esp8266");
+    const page = makePage();
+    hydrate(page);
+    // URL wins for platforms; the other facets still come from the session.
+    expect(page._selectedPlatforms).toEqual(["esp8266"]);
+    expect(page._selectedAreas).toEqual(["Kitchen"]);
+    expect(page._selectedStates).toEqual(["online"]);
+  });
+
+  it("drops unknown update buckets from the session seed", () => {
+    saveDashboardFilters({ ...FULL, updates: ["bogus", "update_available"] });
+    const page = makePage();
+    hydrate(page);
+    expect(page._selectedUpdateStatus).toEqual(["update_available"]);
+  });
+
+  it("leaves facets at their empty defaults with no URL and no session", () => {
+    const page = makePage();
+    hydrate(page);
+    expect(page._selectedPlatforms).toEqual([]);
+    expect(page._selectedStates).toEqual([]);
+    expect(page._selectedLabels).toEqual([]);
+    expect(page._selectedAreas).toEqual([]);
+    expect(page._selectedUpdateStatus).toEqual([]);
+  });
+});

--- a/test/util/dashboard-filters-session.test.ts
+++ b/test/util/dashboard-filters-session.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadDashboardFilters,
+  saveDashboardFilters,
+  STORAGE_KEY,
+} from "../../src/util/dashboard-filters-session.js";
+
+describe("dashboard-filters-session", () => {
+  // The vitest config runs in the ``node`` environment which has no
+  // ``sessionStorage``; a tiny in-memory Map stand-in covers the three
+  // methods the helper uses.
+  let store: Map<string, string>;
+  beforeEach(() => {
+    store = new Map<string, string>();
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(loadDashboardFilters()).toBeNull();
+  });
+
+  it("round-trips the facet selection", () => {
+    saveDashboardFilters({
+      labels: ["lbl-1", "lbl-2"],
+      areas: ["Kitchen"],
+      platforms: ["esp32"],
+      states: ["online"],
+      updates: ["update_available"],
+    });
+    expect(loadDashboardFilters()).toEqual({
+      labels: ["lbl-1", "lbl-2"],
+      areas: ["Kitchen"],
+      platforms: ["esp32"],
+      states: ["online"],
+      updates: ["update_available"],
+    });
+  });
+
+  it("returns null for unparseable JSON", () => {
+    store.set(STORAGE_KEY, "{not json");
+    expect(loadDashboardFilters()).toBeNull();
+  });
+
+  it("returns null for a non-object payload", () => {
+    store.set(STORAGE_KEY, JSON.stringify(["nope"]));
+    expect(loadDashboardFilters()).toBeNull();
+  });
+
+  it("falls back to empty arrays for missing or malformed facets", () => {
+    // A legacy / partial payload must not throw or leak non-string entries
+    // into a facet — each bad facet degrades to an empty selection.
+    store.set(
+      STORAGE_KEY,
+      JSON.stringify({ platforms: ["esp32"], states: "online", labels: [1, 2] })
+    );
+    expect(loadDashboardFilters()).toEqual({
+      labels: [],
+      areas: [],
+      platforms: ["esp32"],
+      states: [],
+      updates: [],
+    });
+  });
+
+  it("does not throw when storage is unavailable", () => {
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    });
+    expect(() =>
+      saveDashboardFilters({
+        labels: [],
+        areas: [],
+        platforms: ["esp32"],
+        states: [],
+        updates: [],
+      })
+    ).not.toThrow();
+    expect(loadDashboardFilters()).toBeNull();
+  });
+});

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
-import { computeUpdateFacet } from "../../src/util/facets.js";
+import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
 
 // computeUpdateFacet only reads update_available / has_pending_changes.
 function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
@@ -17,6 +17,19 @@ function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
 
 // Echo the key so assertions key off the i18n id, not display copy.
 const localize = ((key: string) => key) as unknown as LocalizeFunc;
+
+describe("normalizeUpdateBuckets", () => {
+  it("keeps known buckets in canonical order, deduped, dropping unknowns", () => {
+    expect(normalizeUpdateBuckets(["modified", "update_available"])).toEqual([
+      "update_available",
+      "modified",
+    ]);
+    expect(
+      normalizeUpdateBuckets(["update_available", "bogus", "update_available"])
+    ).toEqual(["update_available"]);
+    expect(normalizeUpdateBuckets([])).toEqual([]);
+  });
+});
 
 describe("computeUpdateFacet", () => {
   it("returns [] for an up-to-date fleet", () => {


### PR DESCRIPTION
# What does this implement/fix?

Device-list filters (Labels / Area / Platform / Status / Updates) reset when moving between the dashboard and a device editor — unless you happen to return via the browser Back button. View-mode and table sort/columns stick (they're stored in `UserPreferences`), so the inconsistency reads as a bug. Reported in esphome discussion #3717 ("make filter stick").

**Root cause:** facet selections live as `@state` on `esphome-page-dashboard` and are persisted **only** in the URL query string (`dashboard-url.ts`, via `history.replaceState`). The router hard-swaps pages, so opening `/device/:id` unmounts the dashboard and destroys that state. It's only recovered when the return path restores the prior query URL (browser Back / back-arrow). Any return to a bare `/` — the command-palette "Dashboard" action, the `_goHome()` fallback when `history.state === null` (editor opened via fresh load / deep link / refresh), serial-setup — has no query string, so filters reset.

**Fix:** seed the five facet selections from `sessionStorage` layered under the existing URL sync:
- The URL stays authoritative **per-field** on hydrate, so deep links, shared URLs, and browser-Back are unchanged.
- `sessionStorage` only fills facets the URL doesn't carry, so returning to a bare `/` restores them.
- Both are written on facet change.
- **Session-scoped:** survives in-app page switches and tab reloads, clears when the browser/tab closes (decision: no cross-session stickiness). This also keeps "Select all" honest — a restored filter is always reflected by the Filters badge, and never lingers from a previous session.

**Scope is deliberately the dashboard list facets only.** The "Update All" dialog is untouched — it still reads the full device list and resets to its own Online + update_available default on every open (covered by a new test). Free-text search and view-mode are not session-seeded.

New `src/util/dashboard-filters-session.ts` (sessionStorage wrapper, modeled on `split-ratio.ts`); wiring in `src/pages/dashboard.ts` (`_hydrateFromUrl` seed + `updated` save).

Verified on the live dashboard: set a platform filter, open a device editor, return to a bare `/` → filter restored; clear the session (simulating browser close) → bare `/` is unfiltered.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#1015
- esphome discussion #3717: https://github.com/orgs/esphome/discussions/3717

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
