### PR TITLE
Tighten and balance the device-editor code-pane padding

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -93,8 +93,8 @@ export const deviceEditorStyles = css`
 
   .editor-floating-actions {
     position: absolute;
-    bottom: var(--wa-space-m);
-    right: var(--wa-space-m);
+    bottom: var(--wa-space-xs);
+    right: var(--wa-space-xs);
     z-index: 10;
     display: inline-flex;
     align-items: center;
@@ -349,21 +349,23 @@ export const deviceEditorStyles = css`
     overflow-y: auto;
   }
 
-  /* The floating Install / Validate / Save row overlays the
-     bottom-right of the card body. Reserve room below the
-     content so the last lines sit a header-matching
-     var(--wa-space-m) above the buttons (button bottom inset +
-     button height + the same top-of-pane gap the editor already
-     has via .editor-pane's padding).
-     Applied to:
-     - .editor-pane--right always (the row sits over its bottom-right
-       in both-pane + right-only layouts).
-     - .editor-layout--left .editor-pane--left (board-info-only
-       layout, where the right pane is hidden and the buttons now
-       overlap the full-width left pane). */
+  /* The floating Install / Validate / Save row overlays the bottom-right and
+     must sit BELOW the content, never over it. Reserve room below: button
+     bottom inset (var(--wa-space-xs)) + button height (2.25rem) + a matching
+     gap. Applies to the code editor (right pane) and the board-info-only layout
+     where the row overlaps the full-width left pane. */
   .editor-pane--right,
   .editor-layout--left .editor-pane--left {
-    padding-bottom: calc(var(--wa-space-m) * 2 + 2.25rem);
+    padding-bottom: calc(2.25rem + var(--wa-space-xs) * 2);
+  }
+
+  /* The code editor brings its own line-number gutter, so the full
+     var(--wa-space-m) inset the config form needs reads as wasted padding that
+     shrinks the text area. Trim the editor pane to a tighter, even inset on the
+     top + sides; the bottom keeps the action-row reserve above. */
+  .editor-pane--right {
+    padding-top: var(--wa-space-xs);
+    padding-inline: var(--wa-space-xs);
   }
 
   .editor-pane-title {

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -19,6 +19,7 @@ import {
   EDITOR_BG_LIGHT,
   EDITOR_FONT_FAMILY,
   EDITOR_FONT_SIZE,
+  EDITOR_GUTTER_PADDING_LEFT,
   editorHeightTheme,
   INDENT_GUIDE_COLORS,
   lightHighlight,
@@ -212,6 +213,12 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           fontFamily: EDITOR_FONT_FAMILY,
           fontVariantLigatures: "none",
           fontSize: EDITOR_FONT_SIZE,
+        },
+        // Trim the CodeMirror default left inset so the line numbers hug the
+        // pane edge instead of reading as extra left padding. The sticky-scroll
+        // overlay measures this at runtime and mirrors it.
+        ".cm-lineNumbers .cm-gutterElement": {
+          paddingLeft: EDITOR_GUTTER_PADDING_LEFT,
         },
         ".cm-esphome-highlight": {
           background: this._darkMode

--- a/src/util/codemirror-theme.ts
+++ b/src/util/codemirror-theme.ts
@@ -23,6 +23,13 @@ import { tags as t } from "@lezer/highlight";
 export const EDITOR_FONT_FAMILY = '"JetBrains Mono", "Fira Code", monospace';
 export const EDITOR_FONT_SIZE = "13px";
 
+/** Left inset of the line-number gutter. Zero so the gutter column sits flush
+ *  with the pane's own padding (the numbers don't read as extra left padding
+ *  beyond the matching right inset). Shared so the sticky-scroll overlay's
+ *  first-paint fallback (``yaml-sticky-theme.ts``) matches the editor before
+ *  the runtime measurement kicks in. */
+export const EDITOR_GUTTER_PADDING_LEFT = "0";
+
 /** Editor background per mode — shared so the sticky-scroll overlay
  *  paints the same colour as the editor it floats over. */
 export const EDITOR_BG_DARK = "#1e1e1e";

--- a/src/util/yaml-sticky-theme.ts
+++ b/src/util/yaml-sticky-theme.ts
@@ -1,6 +1,10 @@
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { EDITOR_FONT_FAMILY, EDITOR_FONT_SIZE } from "./codemirror-theme.js";
+import {
+  EDITOR_FONT_FAMILY,
+  EDITOR_FONT_SIZE,
+  EDITOR_GUTTER_PADDING_LEFT,
+} from "./codemirror-theme.js";
 
 export function buildStickyTheme(background: string): Extension {
   return EditorView.theme({
@@ -54,9 +58,9 @@ export function buildStickyTheme(background: string): Extension {
       boxSizing: "border-box",
       textAlign: "right",
       // Both paddings are set per-row inline (yaml-sticky-render) from the
-      // gutter cell's measured inset; this 5px is only the pre-measure
-      // fallback for the first paint.
-      paddingLeft: "5px",
+      // gutter cell's measured inset; this is only the pre-measure fallback for
+      // the first paint, kept in sync with the editor's gutter inset.
+      paddingLeft: EDITOR_GUTTER_PADDING_LEFT,
       opacity: "0.65",
       userSelect: "none",
     },


### PR DESCRIPTION
# What does this implement/fix?

Fixes unintended padding drift in the device editor's YAML code-pane. The pane was left at a 16px (`--wa-space-m`) inset (the value the config form needs), but the code editor brings its own line-number gutter that sits inside the left padding and adds a 5px inner inset — so the left read heavier than the bare-16px right and the text area was cramped. This asymmetry/heaviness was incidental drift, not a deliberate inset choice.

Changes (all spacing tokens, DRY):
- Editor pane top + left + right → `--wa-space-xs` (8px); measured equal on both sides.
- Line-number gutter inner padding → 0, so the column sits flush with the 8px pane padding (numbers no longer read as extra left inset). The gutter inset is a single shared token (`EDITOR_GUTTER_PADDING_LEFT`) reused by the editor theme and the sticky-scroll overlay's first-paint fallback so they can't drift.
- Floating Install/Validate/Save row dropped to an 8px bottom/right inset; the bottom reserve is recomputed (`calc(2.25rem + var(--wa-space-xs) * 2)`) so the buttons still sit **below** the content and never overlap it (a UX users complained about previously).

Measured empirically after the change: left 8px ≈ right 8px, line-number glyph ~9px from the edge, wider text area; the sticky-scroll overlay stays aligned (it measures the gutter inset at runtime).

**Related issue or feature (if applicable):**

- fixes esphome/device-builder-frontend#1018

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
