### PR TITLE
Move the advanced-settings toggle into the section header

### DIFF
--- a/src/components/device/advanced-toggle.ts
+++ b/src/components/device/advanced-toggle.ts
@@ -11,15 +11,21 @@ import "@home-assistant/webawesome/dist/components/switch/switch.js";
 export function renderAdvancedToggle(
   show: boolean,
   localize: LocalizeFunc,
-  onChange: (show: boolean) => void
+  onChange: (show: boolean) => void,
+  count = 0
 ) {
+  const label =
+    count > 0
+      ? localize("device.show_advanced_count", { count })
+      : localize("device.show_advanced");
   return html`<div class="advanced-toggle-row">
     <wa-switch
+      size="small"
       .checked=${show}
       @change=${(e: Event) =>
         onChange((e.target as HTMLInputElement & { checked: boolean }).checked)}
     >
-      ${localize("device.show_advanced")}
+      ${label}
     </wa-switch>
   </div>`;
 }

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -391,7 +391,12 @@ export class ESPHomeAutomationActionNode extends LitElement {
       def.config_entries,
       this._showAdvanced
     );
-    return html`<esphome-config-entry-form
+    return html`${showToggle
+        ? renderAdvancedToggle(this._showAdvanced, this._localize, (show) => {
+            this._showAdvanced = show;
+          })
+        : nothing}
+      <esphome-config-entry-form
         .entries=${def.config_entries}
         .values=${this.value.params}
         .board=${this.board}
@@ -399,12 +404,7 @@ export class ESPHomeAutomationActionNode extends LitElement {
         ?disabled=${this.disabled}
         ?show-advanced=${showAdvanced}
         @value-change=${this._onParamChange}
-      ></esphome-config-entry-form>
-      ${showToggle
-        ? renderAdvancedToggle(this._showAdvanced, this._localize, (show) => {
-            this._showAdvanced = show;
-          })
-        : nothing}`;
+      ></esphome-config-entry-form>`;
   }
 
   /** The bespoke value+unit / lambda Delay widget. The renderer and

--- a/src/components/device/automation-editor/automation-action-node.ts
+++ b/src/components/device/automation-editor/automation-action-node.ts
@@ -37,7 +37,10 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { actionAdvancedState } from "../../../util/config-entry-tree.js";
+import {
+  actionAdvancedState,
+  countAdvancedEntries,
+} from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { renderAdvancedToggle } from "../advanced-toggle.js";
@@ -392,9 +395,14 @@ export class ESPHomeAutomationActionNode extends LitElement {
       this._showAdvanced
     );
     return html`${showToggle
-        ? renderAdvancedToggle(this._showAdvanced, this._localize, (show) => {
-            this._showAdvanced = show;
-          })
+        ? renderAdvancedToggle(
+            this._showAdvanced,
+            this._localize,
+            (show) => {
+              this._showAdvanced = show;
+            },
+            countAdvancedEntries(def.config_entries)
+          )
         : nothing}
       <esphome-config-entry-form
         .entries=${def.config_entries}

--- a/src/components/device/automation-editor/automation-editor.styles.ts
+++ b/src/components/device/automation-editor/automation-editor.styles.ts
@@ -33,7 +33,7 @@ const automationEditorFrameStyles = css`
        header and the next row, so the legacy margin-bottom would
        compound. Just keep the border + bottom padding so the
        divider line still reads as a section break. */
-    border-bottom: 1px solid var(--wa-color-neutral-border-quiet, #e1e4e8);
+    border-bottom: 1px solid var(--wa-color-surface-border);
   }
 
   .ae-header-text {
@@ -123,14 +123,18 @@ const automationEditorFrameStyles = css`
     object-fit: contain;
   }
 
-  /* "Show advanced settings" toggle row — mirrors the device
-     section-config layout so the eye reads the two surfaces as
-     the same kind of form. */
+  /* "Show advanced settings" toggle row. The action-node host renders it
+     above its inline params form, so keep the bottom gap; in the script /
+     automation header it sits after the help text, where the .ae-header-text
+     column gap supplies the spacing, so the bottom margin is zeroed below. */
   .advanced-toggle-row {
     display: flex;
     justify-content: flex-start;
-    margin-top: var(--wa-space-s);
+    margin-bottom: var(--wa-space-s);
     font-size: var(--wa-font-size-s);
+  }
+  .ae-header-text .advanced-toggle-row {
+    margin-bottom: 0;
   }
   .advanced-toggle-row wa-switch {
     font-weight: var(--wa-font-weight-semibold);

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -54,7 +54,10 @@ import {
   fetchComponent,
   getCachedComponent,
 } from "../../../util/component-name-cache.js";
-import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
+import {
+  anyAdvancedEntry,
+  countAdvancedEntries,
+} from "../../../util/config-entry-tree.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
@@ -563,7 +566,6 @@ export class ESPHomeAutomationEditor extends LitElement {
   ) {
     const entries = this._paramFormEntries(activeTrigger);
     if (entries.length === 0) return nothing;
-    const hasAdvanced = anyAdvancedEntry(entries);
     // No outer wrapper / no synthetic group label: the form renders
     // each entry with its own catalog-derived label + description,
     // and a section header above that ("Interval" / "Trigger
@@ -580,11 +582,6 @@ export class ESPHomeAutomationEditor extends LitElement {
         ?show-advanced=${this._showAdvanced}
         @value-change=${this._onTriggerParamsValueChange}
       ></esphome-config-entry-form>
-      ${hasAdvanced
-        ? renderAdvancedToggle(this._showAdvanced, this._localize, (show) => {
-            this._showAdvanced = show;
-          })
-        : nothing}
     `;
   }
 
@@ -672,6 +669,8 @@ export class ESPHomeAutomationEditor extends LitElement {
       activeTrigger?.description ??
       this._localize("device.automation_header_description");
     const imageUrl = intervalComp?.image_url ?? "";
+    const entries = this._paramFormEntries(activeTrigger);
+    const hasAdvanced = anyAdvancedEntry(entries);
     return html`<div class="ae-header">
       <div class="ae-header-text">
         <h2 class="ae-header-title">${title}</h2>
@@ -687,6 +686,16 @@ export class ESPHomeAutomationEditor extends LitElement {
             </a>`
           : nothing}
         <p class="ae-header-desc">${renderMarkdown(descText)}</p>
+        ${hasAdvanced
+          ? renderAdvancedToggle(
+              this._showAdvanced,
+              this._localize,
+              (show) => {
+                this._showAdvanced = show;
+              },
+              countAdvancedEntries(entries)
+            )
+          : nothing}
       </div>
       <div class="ae-header-icon">
         ${imageUrl

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -44,7 +44,10 @@ import {
   fetchComponent,
   getCachedComponent,
 } from "../../../util/component-name-cache.js";
-import { anyAdvancedEntry } from "../../../util/config-entry-tree.js";
+import {
+  anyAdvancedEntry,
+  countAdvancedEntries,
+} from "../../../util/config-entry-tree.js";
 import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
 import { renderMarkdown } from "../../../util/markdown.js";
@@ -405,6 +408,7 @@ export class ESPHomeScriptEditor extends LitElement {
           <wa-icon library="mdi" name="open-in-new"></wa-icon>
         </a>
         <p class="ae-header-desc">${renderMarkdown(descText)}</p>
+        ${this._renderAdvancedToggle(this._configFormEntries())}
       </div>
       <div class="ae-header-icon">
         ${imageUrl
@@ -428,11 +432,7 @@ export class ESPHomeScriptEditor extends LitElement {
    * below the form.
    */
   private _renderConfigForm(automation: AutomationTree, disabled: boolean) {
-    const comp = this._scriptComponent;
-    if (!comp) return nothing;
-    const entries = comp.config_entries.filter(
-      (e) => e.key !== "parameters" && e.key !== "then"
-    );
+    const entries = this._configFormEntries();
     if (entries.length === 0) return nothing;
     // The form is its own flex-column with gap, and the toggle and
     // parameters/actions sit as siblings of it at the editor's root.
@@ -450,8 +450,18 @@ export class ESPHomeScriptEditor extends LitElement {
         ?show-advanced=${this._showAdvanced}
         @value-change=${this._onConfigFormValueChange}
       ></esphome-config-entry-form>
-      ${this._renderAdvancedToggle(entries)}
     `;
+  }
+
+  /** Script config_entries fed to the form: ``parameters`` (bespoke
+   *  typed-declaration UI) and ``then`` (the actions block) are
+   *  rendered elsewhere, so they're filtered out here. */
+  private _configFormEntries(): ConfigEntry[] {
+    return (
+      this._scriptComponent?.config_entries.filter(
+        (e) => e.key !== "parameters" && e.key !== "then"
+      ) ?? []
+    );
   }
 
   /** "Show advanced settings" toggle row. Pulled out so the same
@@ -466,9 +476,14 @@ export class ESPHomeScriptEditor extends LitElement {
     // gating the Parameters editor.
     const hasAdvanced = anyAdvancedEntry(entries) || this._hasParametersEntry();
     if (!hasAdvanced) return nothing;
-    return renderAdvancedToggle(this._showAdvanced, this._localize, (show) => {
-      this._showAdvanced = show;
-    });
+    return renderAdvancedToggle(
+      this._showAdvanced,
+      this._localize,
+      (show) => {
+        this._showAdvanced = show;
+      },
+      countAdvancedEntries(entries)
+    );
   }
 
   /** Does the script catalog define a ``parameters`` entry? Used to

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -474,15 +474,18 @@ export class ESPHomeScriptEditor extends LitElement {
     // component schema (it does), even if the entries we're handing
     // the form have no non-required fields — the toggle is now also
     // gating the Parameters editor.
-    const hasAdvanced = anyAdvancedEntry(entries) || this._hasParametersEntry();
-    if (!hasAdvanced) return nothing;
+    const hasParameters = this._hasParametersEntry();
+    if (!anyAdvancedEntry(entries) && !hasParameters) return nothing;
+    // The toggle also gates the bespoke Parameters block, so count it as one
+    // revealed item; otherwise a params-only script would show no "(N)" hint.
+    const count = countAdvancedEntries(entries) + (hasParameters ? 1 : 0);
     return renderAdvancedToggle(
       this._showAdvanced,
       this._localize,
       (show) => {
         this._showAdvanced = show;
       },
-      countAdvancedEntries(entries)
+      count
     );
   }
 

--- a/src/components/device/device-section-config.styles.ts
+++ b/src/components/device/device-section-config.styles.ts
@@ -17,8 +17,12 @@ export const deviceSectionConfigStyles = css`
     width: 100%;
     gap: var(--wa-space-l);
     padding-bottom: var(--wa-space-m);
-    margin-bottom: var(--wa-space-m);
-    border-bottom: 1px solid var(--wa-color-surface-lowered);
+    /* No margin-bottom: the :host gap already supplies the space below the
+       divider, so the extra margin left an awkwardly large gap between the
+       separator line and the first form item. */
+    /* Match the controls/automations divider (surface-border), not the
+       heavier surface-lowered. */
+    border-bottom: 1px solid var(--wa-color-surface-border);
   }
 
   .section-header-info {
@@ -105,12 +109,11 @@ export const deviceSectionConfigStyles = css`
     gap: var(--wa-space-m);
   }
 
-  /* "Show advanced settings" toggle row, shown below the form when
-     the section has any advanced entries (at any depth). */
+  /* "Show advanced settings" toggle, shown in the header after the help
+     text so it stays put when advanced fields are revealed instead of
+     being shoved below the fold. */
   .advanced-toggle-row {
     display: flex;
-    justify-content: flex-start;
-    margin-top: var(--wa-space-s);
     font-size: var(--wa-font-size-s);
   }
 

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -17,7 +17,11 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { actionFieldLabel } from "../../util/action-field-label.js";
 import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.js";
-import { anyAdvancedEntry, pathIsAdvanced } from "../../util/config-entry-tree.js";
+import {
+  anyAdvancedEntry,
+  countAdvancedEntries,
+  pathIsAdvanced,
+} from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -337,6 +341,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
     // actual user-keyed shape (currently just substitutions).
     const renderEntries = resolveSectionEntries(this.sectionKey, this._config.entries);
     const hasAdvanced = anyAdvancedEntry(renderEntries);
+    const advancedCount = countAdvancedEntries(renderEntries);
     // Free-form / structural sections: show "edit via YAML" instead of the
     // form. external_components and packages are always-YAML (discriminated
     // unions don't fit the catalog — see #361 for the packages data-loss
@@ -373,6 +378,14 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
             ? html`<p class="section-desc">
                 ${renderMarkdown(this._config.description)}
               </p>`
+            : nothing}
+          ${hasAdvanced
+            ? renderAdvancedToggle(
+                showAdvanced,
+                this._localize,
+                (show) => this._setShowAdvanced(show),
+                advancedCount
+              )
             : nothing}
         </div>
         ${this._isUnknown
@@ -430,11 +443,6 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
               @value-change=${this._onValueChange}
               @edit-action-field=${this._onEditActionField}
             ></esphome-config-entry-form>
-            ${hasAdvanced
-              ? renderAdvancedToggle(showAdvanced, this._localize, (show) =>
-                  this._setShowAdvanced(show)
-                )
-              : nothing}
             ${this._error ? html`<p class="error">${this._error}</p>` : nothing}
             ${this._renderApiActionsTable()} ${this._renderTriggersTable()}
             ${this._renderActionsRow(canDelete)}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -641,6 +641,7 @@
     "see_also": "See also:",
     "advanced_options": "Advanced options",
     "show_advanced": "Show advanced settings",
+    "show_advanced_count": "Show advanced settings ({count})",
     "enable_entity": "Enable {name}",
     "multi_value_empty": "No items yet — click + to add one.",
     "multi_value_add": "Add",

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -24,6 +24,15 @@ export function actionAdvancedState(
   };
 }
 
+/** Count of top-level advanced entries — the fields revealed at this level
+ *  when the toggle flips on. Used for the toggle's "(N)" hint. Intentionally
+ *  non-recursive (unlike `anyAdvancedEntry`): a nested advanced field isn't
+ *  revealed here, so a gate that's open with a `(0)`/plain label is expected
+ *  when the only advanced entry sits inside a non-advanced NESTED parent. */
+export function countAdvancedEntries(entries: ConfigEntry[]): number {
+  return entries.reduce((n, e) => n + (e.advanced ? 1 : 0), 0);
+}
+
 /** True when `entries` contains any advanced entry, recursively. */
 export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
   for (const entry of entries) {

--- a/test/components/device/advanced-toggle.test.ts
+++ b/test/components/device/advanced-toggle.test.ts
@@ -11,15 +11,23 @@ vi.mock("@home-assistant/webawesome/dist/components/switch/switch.js", () => ({}
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { renderAdvancedToggle } from "../../../src/components/device/advanced-toggle.js";
 
-const localize: LocalizeFunc = (key) =>
-  key === "device.show_advanced" ? "Show advanced settings" : key;
+const localize: LocalizeFunc = (key, params) => {
+  if (key === "device.show_advanced") return "Show advanced settings";
+  if (key === "device.show_advanced_count")
+    return `Show advanced settings (${params?.count})`;
+  return key;
+};
 
 type SwitchEl = HTMLElement & { checked: boolean };
 
-function mount(show: boolean, onChange: (show: boolean) => void): HTMLElement {
+function mount(
+  show: boolean,
+  onChange: (show: boolean) => void,
+  count?: number
+): HTMLElement {
   const container = document.createElement("div");
   document.body.appendChild(container);
-  render(renderAdvancedToggle(show, localize, onChange), container);
+  render(renderAdvancedToggle(show, localize, onChange, count), container);
   return container;
 }
 
@@ -34,6 +42,17 @@ describe("renderAdvancedToggle", () => {
     expect(sw).not.toBeNull();
     expect(sw!.checked).toBe(true);
     expect(container.textContent).toContain("Show advanced settings");
+  });
+
+  it("appends the count to the label when one is given", () => {
+    const container = mount(false, () => {}, 3);
+    expect(container.textContent).toContain("Show advanced settings (3)");
+  });
+
+  it("omits the count for a zero count", () => {
+    const container = mount(false, () => {}, 0);
+    expect(container.textContent).toContain("Show advanced settings");
+    expect(container.textContent).not.toContain("(0)");
   });
 
   it("reports the new checked value through onChange on change", () => {

--- a/test/components/device/section-config-advanced-toggle-position.test.ts
+++ b/test/components/device/section-config-advanced-toggle-position.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the advanced toggle in the section header (after the help text, above
+ * the form) so revealing advanced fields can't push the control below the fold.
+ */
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+
+const entry = (key: string, advanced: boolean): ConfigEntry =>
+  ({ key, type: ConfigEntryType.STRING, label: key, advanced }) as ConfigEntry;
+
+/**
+ * Render the host's template into a detached container. Detached so the
+ * form-associated wa-children never run connectedCallback (noisy under
+ * happy-dom); the DOM order we assert is set at render time regardless.
+ */
+function renderHost(showAdvanced: boolean): HTMLElement {
+  const c = new ESPHomeDeviceSectionConfig();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = c as any;
+  inner.sectionKey = "sensor.dht";
+  inner.configuration = "device.yaml";
+  inner.yaml = "";
+  inner._config = {
+    title: "DHT",
+    entries: [entry("name", false), entry("update_interval", true)],
+  };
+  if (showAdvanced) inner._setShowAdvanced(true);
+  const container = document.createElement("div");
+  render(inner.render(), container);
+  return container;
+}
+
+/** True when `a` appears before `b` in document order. */
+function precedes(a: Element, b: Element): boolean {
+  return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+function assertToggleInHeaderAboveForm(container: HTMLElement) {
+  const toggle = container.querySelector(".advanced-toggle-row");
+  const form = container.querySelector("esphome-config-entry-form");
+  expect(toggle).toBeTruthy();
+  expect(form).toBeTruthy();
+  // In the header info block (above the form) so it stays put when revealed.
+  expect(toggle!.closest(".section-header-info")).toBeTruthy();
+  expect(precedes(toggle!, form!)).toBe(true);
+}
+
+describe("device-section-config — advanced toggle position", () => {
+  it("renders the toggle in the header, above the form", () => {
+    assertToggleInHeaderAboveForm(renderHost(false));
+  });
+
+  it("keeps the toggle above the form after advanced is revealed", () => {
+    assertToggleInHeaderAboveForm(renderHost(true));
+  });
+});


### PR DESCRIPTION
> **Three alternative approaches to the same problem; we'll merge one and close the other two. My recommendation is #1035 (the switch): advanced fields are sometimes inline within an otherwise non-advanced section, so a "Show advanced settings" switch frames it better than a collapsible "Advanced settings" section, which implies grouping.**
>
> - #1020 — move the control into the section/editor header, above the form
> - #1034 — collapsible "Advanced settings (N)" disclosure, advanced fields below it
> - #1035 — keep the "Show advanced settings" switch at the boundary, advanced fields below it (recommended)

# What does this implement/fix?

The "Show advanced settings" toggle used to render below the form. That created a few problems:

- Turning it on revealed the advanced fields *above* the toggle, so the switch (and the "Delete section" button under it) got pushed down the page; with many advanced fields it ended up below the fold.
- A basic user who flipped it on was then left with a long form and no obvious way to collapse it again; the control they needed had moved out of sight.
- The control jumped position every time you toggled it, which is disorienting.
- There was no hint of how many advanced fields were hidden, so flipping it was a leap.
- Some structured configs (e.g. `esp32:`) already have their own advanced section, and the previous full size toggle sitting inline in the config area looked like one of those structured fields; it wasn't obvious it was a UI control rather than part of the config.

This moves the toggle up into the section/editor header, just after the help text and above the divider, so it stays put when advanced fields are revealed; it can no longer be pushed off-screen, and it reads as a view setting rather than a form field. The distinct smaller switch plus the header placement also make it clear it's a UI control, not a structured config field. It also shows the count ("Show advanced settings (15)") so you can see how much is behind the switch before flipping it.

Applies to the component section editor and the automation and script editors (which share the same header); the inline action node has no header, so it keeps the toggle just above its small form. Also tightens the header divider spacing and matches the divider color to the controls/automations divider.

This effectively restores the original above-the-form placement that an earlier commit had moved to the bottom of the panel.

## Screenshots

1. Component section, toggle off (e.g. Restart Button)

<img width="736" height="709" alt="Screenshot 2026-06-28 at 1 42 48 PM" src="https://github.com/user-attachments/assets/32d5e6ba-6a24-40fe-a9ca-5c48375bec59" />


2. Component section, toggle on (advanced revealed, toggle stays put)
<img width="723" height="738" alt="Screenshot 2026-06-28 at 1 42 43 PM" src="https://github.com/user-attachments/assets/c3067b9f-70cb-4bbd-b0a9-f355f428d703" />




**Related issue or feature (if applicable):**

- N/A; reported via dashboard screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).




