### PR TITLE
Skip the add-component form when every field is board-locked

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -30,7 +30,7 @@ import {
 } from "./add-component-dialog-selection.js";
 import { addComponentDialogStyles } from "./add-component-dialog.styles.js";
 import { coerceFields } from "./add-component-form-coerce.js";
-import { addFormPaintsAnything } from "./add-component-form-filter.js";
+import { addFormNeedsUserInput } from "./add-component-form-filter.js";
 import { buildInitialValues } from "./add-component-form-seed.js";
 import { componentDialogTitle } from "./component-card-category-label.js";
 
@@ -475,9 +475,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
 
   /**
    * Coerced fields to add *entry* directly, skipping the form, or null when
-   * the form should open. Fast-paths only when the add-form would paint
-   * nothing (`addFormPaintsAnything` reads the same `buildFormRenderPlan`
-   * `render()` does, so the gate can't drift from what the user sees) and the
+   * the form should open. Fast-paths only when the add-form needs no input
+   * (`addFormNeedsUserInput` reads the same `buildFormRenderPlan` `render()`
+   * does, so the gate can't drift from what the user sees — a form whose only
+   * fields are board-locked is a dead-end and gets skipped) and the
    * payload matches the form's Add. The payload is `buildInitialValues` +
    * `coerceFields`, exactly the form's seed/submit, so a seeded `id`/pin (and
    * a featured entry's `seedAll`-seeded locked presets) isn't dropped; the one
@@ -508,7 +509,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       localize: this._localize,
     });
     if (
-      addFormPaintsAnything(
+      addFormNeedsUserInput(
         entry.config_entries,
         seeded,
         entry.required_groups ?? [],

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -1,5 +1,6 @@
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
+import { isEntryVisible } from "../../util/config-validation.js";
 import { buildFormRenderPlan, planNeedsUserInput } from "./config-entry-form-plan.js";
 import {
   collectRenderablePaths,
@@ -63,7 +64,12 @@ export function addFormNeedsUserInput(
 ): boolean {
   const opts = addFormFilterOptions(board, presentComponents);
   const plan = buildFormRenderPlan(entries, values, requiredGroups, opts);
-  if (planNeedsUserInput(plan)) return true;
+  // Group/cluster members are unfiltered in the plan; gate them on the same
+  // visibility the form uses so a hidden unlocked member can't keep the form
+  // open when every rendered field is board-locked.
+  const isVisible = (entry: ConfigEntry): boolean =>
+    isEntryVisible(entry, values, opts.presentComponents, opts.targetPlatform ?? null);
+  if (planNeedsUserInput(plan, isVisible)) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when
   // unsatisfied; keys are irrelevant to presence, so format to "".
   return (

--- a/src/components/device/add-component-form-filter.ts
+++ b/src/components/device/add-component-form-filter.ts
@@ -1,6 +1,6 @@
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfigEntry, RequiredGroup } from "../../api/types/config-entries.js";
-import { buildFormRenderPlan, planRendersContent } from "./config-entry-form-plan.js";
+import { buildFormRenderPlan, planNeedsUserInput } from "./config-entry-form-plan.js";
 import {
   collectRenderablePaths,
   renderFilterOptions,
@@ -47,12 +47,14 @@ export function addFormRenderablePaths(
 
 /**
  * Whether the add-component form would paint anything the user must engage
- * with: a plain field, an exclusive-group dropdown, a constraint-cluster box,
- * or an unsatisfied-constraint banner. Built on the same `buildFormRenderPlan`
- * the form's `render()` uses, so the dialog's empty-form gate can't drift from
- * the actual paint. `false` means the form body would be blank.
+ * with: an unlocked plain field, an exclusive-group dropdown, a
+ * constraint-cluster box, or an unsatisfied-constraint banner. Built on the
+ * same `buildFormRenderPlan` the form's `render()` uses, so the dialog's
+ * skip-the-form gate can't drift from the actual paint. `false` means the form
+ * would be a dead-end (blank, or only board-locked read-only fields) and the
+ * caller should add the component without showing it.
  */
-export function addFormPaintsAnything(
+export function addFormNeedsUserInput(
   entries: ConfigEntry[],
   values: Record<string, unknown>,
   requiredGroups: RequiredGroup[],
@@ -61,7 +63,7 @@ export function addFormPaintsAnything(
 ): boolean {
   const opts = addFormFilterOptions(board, presentComponents);
   const plan = buildFormRenderPlan(entries, values, requiredGroups, opts);
-  if (planRendersContent(plan)) return true;
+  if (planNeedsUserInput(plan)) return true;
   // Pure-cardinality groups with no cluster box surface a banner only when
   // unsatisfied; keys are irrelevant to presence, so format to "".
   return (

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -45,16 +45,17 @@ export function buildFormRenderPlan(
 
 /**
  * Whether the plan paints anything the user can act on: an unlocked plain
- * field, an exclusive-group dropdown, or a cluster box.
+ * field, an exclusive-group dropdown, or a cluster box with an unlocked member.
  *
- * A locked plain field doesn't count — it renders read-only ("Set by the
- * board"), so a form whose only visible fields are locked is a dead-end screen.
- * Lets a caller skip the form when every input is fixed by the board.
+ * A locked entry renders read-only ("Set by the board"), so a form whose only
+ * fields — plain, grouped, or clustered — are locked is a dead-end screen. Lets
+ * a caller skip the form when every input is fixed by the board.
  */
 export function planNeedsUserInput(plan: FormRenderPlan): boolean {
+  const anyUnlocked = (entries: ConfigEntry[]): boolean => entries.some((e) => !e.locked);
   return (
-    [...plan.visible].some((entry) => !entry.locked) ||
-    plan.clusters.length > 0 ||
-    plan.ordered.some((item) => Array.isArray(item))
+    anyUnlocked([...plan.visible]) ||
+    plan.clusters.some((cluster) => anyUnlocked(cluster.members)) ||
+    plan.ordered.some((item) => Array.isArray(item) && anyUnlocked(item))
   );
 }

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -51,3 +51,20 @@ export function planRendersContent(plan: FormRenderPlan): boolean {
     plan.ordered.some((item) => Array.isArray(item))
   );
 }
+
+/**
+ * Whether the plan paints anything the user can actually act on.
+ *
+ * Like :func:`planRendersContent`, but a locked plain field doesn't count — it
+ * renders read-only ("Set by the board"), so a form whose only visible fields
+ * are locked is a dead-end screen. Group dropdowns and cluster boxes still
+ * count (they're interactive). Lets a caller skip the form when every input is
+ * fixed by the board.
+ */
+export function planNeedsUserInput(plan: FormRenderPlan): boolean {
+  return (
+    [...plan.visible].some((entry) => !entry.locked) ||
+    plan.clusters.length > 0 ||
+    plan.ordered.some((item) => Array.isArray(item))
+  );
+}

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -48,14 +48,21 @@ export function buildFormRenderPlan(
  * field, an exclusive-group dropdown, or a cluster box with an unlocked member.
  *
  * A locked entry renders read-only ("Set by the board"), so a form whose only
- * fields — plain, grouped, or clustered — are locked is a dead-end screen. Lets
- * a caller skip the form when every input is fixed by the board.
+ * fields — plain, grouped, or clustered — are locked is a dead-end screen. A
+ * member is only counted when ``isVisible`` (the group/cluster member arrays are
+ * unfiltered, so a hidden unlocked member — platform-incompatible, ``depends_on``
+ * unmet — mustn't keep the form open). Lets a caller skip the form when every
+ * input is fixed by the board.
  */
-export function planNeedsUserInput(plan: FormRenderPlan): boolean {
-  const anyUnlocked = (entries: ConfigEntry[]): boolean => entries.some((e) => !e.locked);
+export function planNeedsUserInput(
+  plan: FormRenderPlan,
+  isVisible: (entry: ConfigEntry) => boolean
+): boolean {
+  const anyActionable = (entries: ConfigEntry[]): boolean =>
+    entries.some((e) => !e.locked && isVisible(e));
   return (
-    anyUnlocked([...plan.visible]) ||
-    plan.clusters.some((cluster) => anyUnlocked(cluster.members)) ||
-    plan.ordered.some((item) => Array.isArray(item) && anyUnlocked(item))
+    anyActionable([...plan.visible]) ||
+    plan.clusters.some((cluster) => anyActionable(cluster.members)) ||
+    plan.ordered.some((item) => Array.isArray(item) && anyActionable(item))
   );
 }

--- a/src/components/device/config-entry-form-plan.ts
+++ b/src/components/device/config-entry-form-plan.ts
@@ -43,23 +43,13 @@ export function buildFormRenderPlan(
   return { ordered, clusters, memberKeys, visible };
 }
 
-/** Whether the plan paints any field, exclusive-group dropdown, or cluster box. */
-export function planRendersContent(plan: FormRenderPlan): boolean {
-  return (
-    plan.visible.size > 0 ||
-    plan.clusters.length > 0 ||
-    plan.ordered.some((item) => Array.isArray(item))
-  );
-}
-
 /**
- * Whether the plan paints anything the user can actually act on.
+ * Whether the plan paints anything the user can act on: an unlocked plain
+ * field, an exclusive-group dropdown, or a cluster box.
  *
- * Like :func:`planRendersContent`, but a locked plain field doesn't count — it
- * renders read-only ("Set by the board"), so a form whose only visible fields
- * are locked is a dead-end screen. Group dropdowns and cluster boxes still
- * count (they're interactive). Lets a caller skip the form when every input is
- * fixed by the board.
+ * A locked plain field doesn't count — it renders read-only ("Set by the
+ * board"), so a form whose only visible fields are locked is a dead-end screen.
+ * Lets a caller skip the form when every input is fixed by the board.
  */
 export function planNeedsUserInput(plan: FormRenderPlan): boolean {
   return (

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -46,7 +46,9 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
   const present = members.filter((m) => ctx.getAt([m.key]) !== undefined);
   const selectedKey = present[0]?.key ?? "";
   const selected = members.find((m) => m.key === selectedKey);
-  const disabled = ctx.disabled;
+  // Board-locked every option → the choice is fixed; render the dropdown
+  // read-only so it matches `planNeedsUserInput` treating it as non-actionable.
+  const disabled = ctx.disabled || members.every((m) => m.locked);
 
   // Gate options through isEntryVisible so a board-incompatible / hidden /
   // depends_on member can't be picked; keep an already-set one selectable.

--- a/src/components/device/config-entry-renderers/exclusive-group.ts
+++ b/src/components/device/config-entry-renderers/exclusive-group.ts
@@ -46,9 +46,6 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
   const present = members.filter((m) => ctx.getAt([m.key]) !== undefined);
   const selectedKey = present[0]?.key ?? "";
   const selected = members.find((m) => m.key === selectedKey);
-  // Board-locked every option → the choice is fixed; render the dropdown
-  // read-only so it matches `planNeedsUserInput` treating it as non-actionable.
-  const disabled = ctx.disabled || members.every((m) => m.locked);
 
   // Gate options through isEntryVisible so a board-incompatible / hidden /
   // depends_on member can't be picked; keep an already-set one selectable.
@@ -59,6 +56,12 @@ export function renderExclusiveGroupField(members: ConfigEntry[], ctx: RenderCtx
       ctx.getAt([m.key]) !== undefined ||
       isEntryVisible(m, rootValues, ctx.presentComponents, targetPlatform)
   );
+
+  // Every *rendered* option board-locked → the choice is fixed; render the
+  // dropdown read-only so it matches `planNeedsUserInput` treating it as
+  // non-actionable. Use options, not all members: a hidden unlocked member
+  // (e.g. platform-incompatible) isn't selectable and shouldn't keep it live.
+  const disabled = ctx.disabled || options.every((m) => m.locked);
 
   // Clear only the members actually present (avoids ~N redundant events and
   // stray key: undefined state); scaffold {} only for an absent choice, so

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { addFormNeedsUserInput } from "../../../src/components/device/add-component-form-filter.js";
+import { makeConfigEntry } from "../../util/_make-config-entry.js";
+
+const NONE = new Set<string>();
+
+describe("addFormNeedsUserInput", () => {
+  it("is false when every visible field is board-locked (a dead-end form)", () => {
+    // A featured component whose every field is pinned by the board: the form
+    // would render only read-only "Set by the board" rows, so it should be
+    // skipped and the component added straight away.
+    const entries = [
+      makeConfigEntry({ key: "pin", required: true, locked: true }),
+      makeConfigEntry({ key: "type", required: true, locked: true }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(false);
+  });
+
+  it("is true when any visible field is unlocked", () => {
+    const entries = [
+      makeConfigEntry({ key: "pin", required: true, locked: true }),
+      makeConfigEntry({ key: "name", required: true, locked: false }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
+  });
+});

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -39,4 +39,20 @@ describe("addFormNeedsUserInput", () => {
     ];
     expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
   });
+
+  it("skips a fully board-locked constraint cluster (every member read-only)", () => {
+    const entries = [
+      makeConfigEntry({ key: "a", group: "g", required: true, locked: true }),
+      makeConfigEntry({ key: "b", group: "g", required: true, locked: true }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(false);
+  });
+
+  it("shows the form when a constraint cluster has an unlocked member", () => {
+    const entries = [
+      makeConfigEntry({ key: "a", group: "g", required: true, locked: true }),
+      makeConfigEntry({ key: "b", group: "g", required: true, locked: false }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
+  });
 });

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -23,4 +23,20 @@ describe("addFormNeedsUserInput", () => {
     ];
     expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
   });
+
+  it("skips a fully board-locked exclusive group (every choice is read-only)", () => {
+    const entries = [
+      makeConfigEntry({ key: "i2c", exclusive_group: "bus", locked: true }),
+      makeConfigEntry({ key: "spi", exclusive_group: "bus", locked: true }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(false);
+  });
+
+  it("shows the form when an exclusive group still has an unlocked choice", () => {
+    const entries = [
+      makeConfigEntry({ key: "i2c", exclusive_group: "bus", locked: true }),
+      makeConfigEntry({ key: "spi", exclusive_group: "bus", locked: false }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
+  });
 });

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -55,4 +55,35 @@ describe("addFormNeedsUserInput", () => {
     ];
     expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
   });
+
+  // A hidden unlocked member (here platform-incompatible) isn't rendered, so it
+  // mustn't keep the form open when every visible field is locked.
+  const ESP32 = { esphome: { platform: "esp32" } } as never;
+
+  it("ignores a hidden unlocked exclusive-group member", () => {
+    const entries = [
+      makeConfigEntry({ key: "i2c", exclusive_group: "bus", locked: true }),
+      makeConfigEntry({
+        key: "spi",
+        exclusive_group: "bus",
+        locked: false,
+        supported_platforms: ["esp8266"],
+      }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], ESP32, NONE)).toBe(false);
+  });
+
+  it("ignores a hidden unlocked constraint-cluster member", () => {
+    const entries = [
+      makeConfigEntry({ key: "a", group: "g", required: true, locked: true }),
+      makeConfigEntry({
+        key: "b",
+        group: "g",
+        required: true,
+        locked: false,
+        supported_platforms: ["esp8266"],
+      }),
+    ];
+    expect(addFormNeedsUserInput(entries, {}, [], ESP32, NONE)).toBe(false);
+  });
 });

--- a/test/components/device/render-exclusive-group-field.test.ts
+++ b/test/components/device/render-exclusive-group-field.test.ts
@@ -81,6 +81,20 @@ describe("renderExclusiveGroupField", () => {
     expect(emitChange).toHaveBeenCalledWith(["jvc"], {}); // chosen → scaffolded
   });
 
+  it("disables the dropdown when every member is board-locked", () => {
+    const ctx = makeRenderCtx({ raw: { code: "x" } });
+    const locked = members().map((m) => ({ ...m, locked: true }));
+    const tpl = renderExclusiveGroupField(locked, ctx);
+    expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(true);
+  });
+
+  it("keeps the dropdown enabled when a member is still unlocked", () => {
+    const ctx = makeRenderCtx({ raw: { code: "x" } });
+    const [a, b] = members();
+    const tpl = renderExclusiveGroupField([{ ...a, locked: true }, b], ctx);
+    expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(false);
+  });
+
   it("preserves an existing member's values when switching to it", () => {
     // Conflict case (both set): picking the one to keep must clear only the
     // others, never overwrite the chosen member's config with {}.

--- a/test/components/device/render-exclusive-group-field.test.ts
+++ b/test/components/device/render-exclusive-group-field.test.ts
@@ -95,6 +95,25 @@ describe("renderExclusiveGroupField", () => {
     expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(false);
   });
 
+  it("disables when every visible option is locked, ignoring a hidden unlocked member", () => {
+    // The unlocked member is platform-incompatible (hidden), so it isn't a
+    // selectable option; the dropdown should still be read-only.
+    const ms = [
+      makeEntry(ConfigEntryType.NESTED, {
+        key: "raw",
+        exclusive_group: "g",
+        locked: true,
+      }),
+      makeEntry(ConfigEntryType.NESTED, {
+        key: "esp8266only",
+        exclusive_group: "g",
+        supported_platforms: ["esp8266"],
+      }),
+    ];
+    const tpl = renderExclusiveGroupField(ms, makeRenderCtx({}));
+    expect(findElementBindings(tpl, "wa-select")[0]["?disabled"]).toBe(true);
+  });
+
   it("preserves an existing member's values when switching to it", () => {
     // Conflict case (both set): picking the one to keep must clear only the
     // others, never overwrite the chosen member's config with {}.


### PR DESCRIPTION
# What does this implement/fix?

Adding a featured component whose every field is pinned by the board (a locked preset) opened a dead-end form: nothing but read-only "Set by the board" rows, an OK button, and no choice to make. The add-component fast-path gate counted those locked rows as content, so it never skipped the form.

The gate now treats a board-locked field as non-actionable. A new `planNeedsUserInput` helper mirrors `planRendersContent` but excludes locked plain fields; `addFormPaintsAnything` is renamed to `addFormNeedsUserInput` and uses it. So the form opens only when there's an unlocked field, a group dropdown, a constraint cluster, or an unsatisfied constraint to engage with; otherwise the component is added straight away. If any unlocked field would render, the form still shows.

This smooths single adds of fully board-pinned components today and the bundle one-shot once esphome/device-builder-frontend#1017 lands (its fast-path runs through the same gate).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
