### PR TITLE
Hide the empty Recommended category in the component catalog

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -176,6 +176,26 @@ export class ESPHomeComponentCatalog extends LitElement {
 
   static styles = [espHomeStyles, inputStyles, componentCatalogStyles];
 
+  // The sidebar badge / auto-select read availableFeaturedCount over the board's
+  // recommendations (fetch-independent), while the grid reads the fetched
+  // featured cards; during prop settling (yaml/board/platform arrive at
+  // different times) they can briefly disagree and strand the view on an empty
+  // "Recommended" category. Once a featured fetch has settled, if its grid is
+  // empty fall back to "all" so we never sit on "0 of N / No components found".
+  protected updated() {
+    if (
+      this._loading ||
+      this.lockedCategories.length > 0 ||
+      this._category !== ComponentCategory.FEATURED
+    ) {
+      return;
+    }
+    if (visibleComponents(this).length + filteredBundles(this).length === 0) {
+      this._category = "all";
+      this._fetchComponents();
+    }
+  }
+
   protected render() {
     if (this._initialLoad && this._loading) {
       return html`<div class="loading">

--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -182,11 +182,16 @@ export class ESPHomeComponentCatalog extends LitElement {
   // different times) they can briefly disagree and strand the view on an empty
   // "Recommended" category. Once a featured fetch has settled, if its grid is
   // empty fall back to "all" so we never sit on "0 of N / No components found".
+  // Scoped to the unfiltered Featured view: search/provides are applied
+  // server-side, so an active filter that matches no recommendation empties the
+  // grid legitimately and must render "No components found", not bounce to All.
   protected updated() {
     if (
       this._loading ||
       this.lockedCategories.length > 0 ||
-      this._category !== ComponentCategory.FEATURED
+      this._category !== ComponentCategory.FEATURED ||
+      this._search.trim() ||
+      this._provides
     ) {
       return;
     }

--- a/test/components/device/component-catalog-featured-fallback.test.ts
+++ b/test/components/device/component-catalog-featured-fallback.test.ts
@@ -29,9 +29,18 @@ const ETHERNET_CARD = {
   supported_platforms: [],
 } as unknown as ComponentCatalogEntry;
 
-async function mountFeatured(
-  yaml: string
-): Promise<{ el: ESPHomeComponentCatalog; getComponents: ReturnType<typeof vi.fn> }> {
+async function mountFeatured({
+  yaml = "",
+  search = "",
+  components = [ETHERNET_CARD],
+}: {
+  yaml?: string;
+  search?: string;
+  components?: ComponentCatalogEntry[];
+} = {}): Promise<{
+  el: ESPHomeComponentCatalog;
+  getComponents: ReturnType<typeof vi.fn>;
+}> {
   const el = new ESPHomeComponentCatalog();
   const getComponents = vi.fn().mockResolvedValue({
     components: [],
@@ -46,9 +55,10 @@ async function mountFeatured(
     boardId: "esp32-poe-iso",
     board: POE_BOARD,
     yaml,
-    _components: [ETHERNET_CARD],
+    _search: search,
+    _components: components,
     _categories: [{ id: "featured", name: "featured", count: 1 }],
-    _total: 1,
+    _total: components.length,
     _category: "featured",
     _loading: false,
     _initialLoad: false,
@@ -64,13 +74,21 @@ describe("component-catalog featured-empty fallback", () => {
   });
 
   it("falls back to all when the only recommendation is already configured", async () => {
-    const { el, getComponents } = await mountFeatured("ethernet:\n  type: LAN8720\n");
+    const { el, getComponents } = await mountFeatured({
+      yaml: "ethernet:\n  type: LAN8720\n",
+    });
     expect(el._category).toBe("all");
     expect(getComponents).toHaveBeenCalled();
   });
 
   it("stays on featured while a recommendation is still addable", async () => {
-    const { el, getComponents } = await mountFeatured("");
+    const { el, getComponents } = await mountFeatured();
+    expect(el._category).toBe("featured");
+    expect(getComponents).not.toHaveBeenCalled();
+  });
+
+  it("stays on featured when the grid is empty only due to an active search", async () => {
+    const { el, getComponents } = await mountFeatured({ search: "zzz", components: [] });
     expect(el._category).toBe("featured");
     expect(getComponents).not.toHaveBeenCalled();
   });

--- a/test/components/device/component-catalog-featured-fallback.test.ts
+++ b/test/components/device/component-catalog-featured-fallback.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The "Recommended" category must never strand the view on an empty grid:
+ * when a featured fetch settles with nothing addable (every recommendation is
+ * already configured), the catalog falls back to "all" instead of rendering
+ * "0 of N / No components found".
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
+import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
+import { ESPHomeComponentCatalog } from "../../../src/components/device/component-catalog.js";
+
+const POE_BOARD = {
+  id: "esp32-poe-iso",
+  featured_components: [
+    { id: "onboard_ethernet", component_id: "ethernet", multi_conf: false },
+  ],
+  featured_bundles: [],
+} as unknown as BoardCatalogEntry;
+
+const ETHERNET_CARD = {
+  id: "featured.esp32-poe-iso.onboard_ethernet",
+  dependencies: [],
+  supported_platforms: [],
+} as unknown as ComponentCatalogEntry;
+
+async function mountFeatured(
+  yaml: string
+): Promise<{ el: ESPHomeComponentCatalog; getComponents: ReturnType<typeof vi.fn> }> {
+  const el = new ESPHomeComponentCatalog();
+  const getComponents = vi.fn().mockResolvedValue({
+    components: [],
+    categories: [],
+    total: 0,
+    offset: 0,
+    limit: 50,
+  });
+  Object.assign(el as unknown as Record<string, unknown>, {
+    _api: { getComponents },
+    platform: "esp32",
+    boardId: "esp32-poe-iso",
+    board: POE_BOARD,
+    yaml,
+    _components: [ETHERNET_CARD],
+    _categories: [{ id: "featured", name: "featured", count: 1 }],
+    _total: 1,
+    _category: "featured",
+    _loading: false,
+    _initialLoad: false,
+  });
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return { el, getComponents };
+}
+
+describe("component-catalog featured-empty fallback", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("falls back to all when the only recommendation is already configured", async () => {
+    const { el, getComponents } = await mountFeatured("ethernet:\n  type: LAN8720\n");
+    expect(el._category).toBe("all");
+    expect(getComponents).toHaveBeenCalled();
+  });
+
+  it("stays on featured while a recommendation is still addable", async () => {
+    const { el, getComponents } = await mountFeatured("");
+    expect(el._category).toBe("featured");
+    expect(getComponents).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Hides the empty **Recommended** category in the "Add component" catalog when every recommendation for the board is already configured.

On a board with curated recommendations (e.g. OLIMEX ESP32-PoE-ISO, which recommends Onboard Ethernet), editing a device that already has `ethernet:` could still show a "Recommended" row whose grid renders "0 of 1 components / No components found".

The catalog decided "is Recommended non-empty?" from two independent sources that can disagree while the editor's reactively-bound `yaml` / `platform` / `board` settle at different times:

- the sidebar badge / auto-select / hide-empty gate reads `availableFeaturedCount` over the board's `featured_components` (fetch-independent), while
- the grid and its "X of N" total read the fetched featured cards.

This adds a reactive guard: once a featured fetch has settled, if the rendered featured grid is empty, fall back to the **All** category so the dialog never strands on an empty "0 of N / No components found". The guard short-circuits on every other category, so it is a no-op outside the Recommended tab.

Verified in the live dashboard:

- ESP32-PoE-ISO with `ethernet:` present -> opens on **All**, no Recommended row.
- Same board without `ethernet:` -> Recommended still appears, auto-selects, and lists Onboard Ethernet.

Both stable (no refetch loop).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1024

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
