### PR TITLE
Keep the board grid columns equal width

### DIFF
--- a/src/components/wizard/wizard-step-board.styles.ts
+++ b/src/components/wizard/wizard-step-board.styles.ts
@@ -141,7 +141,10 @@ export const wizardStepBoardStyles = css`
 
   .boards-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    /* minmax(0, 1fr), not 1fr (= minmax(auto, 1fr)): a card with wide
+       min-content (a long unbreakable token in a name/description) would
+       otherwise blow its column past its fair share and shrink the other. */
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--wa-space-s);
   }
 
@@ -151,6 +154,8 @@ export const wizardStepBoardStyles = css`
     background: var(--wa-color-surface-default);
     padding: var(--wa-space-m);
     box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
     gap: var(--wa-space-s);
@@ -194,6 +199,7 @@ export const wizardStepBoardStyles = css`
     font-weight: var(--wa-font-weight-bold);
     color: var(--wa-color-text-normal);
     line-height: 1.3;
+    overflow-wrap: anywhere;
   }
 
   .expand-button {
@@ -219,6 +225,7 @@ export const wizardStepBoardStyles = css`
     font-size: var(--wa-font-size-xs);
     color: var(--wa-color-text-quiet);
     line-height: 1.5;
+    overflow-wrap: anywhere;
   }
 
   .board-description--clamp {


### PR DESCRIPTION
# What does this implement/fix?

In the "Select your board" wizard step, the 2-column board grid could render the first column wider than the second once boards with wide content scrolled in. The grid used `grid-template-columns: repeat(2, 1fr)`, and `1fr` is `minmax(auto, 1fr)`, so a card whose content has a large min-content width (a long unbreakable token in a name or an imported description) expands its whole column and steals width from the other; grid columns are shared across rows, so the whole column looked wider.

Apply the same defenses the component catalog grid already uses: `repeat(2, minmax(0, 1fr))` so columns ignore content min-width and stay equal, `min-width: 0` plus `overflow: hidden` on the card so it shrinks to its track, and `overflow-wrap: anywhere` on the title and description so long tokens wrap instead of forcing width.

**Related issue or feature (if applicable):**

- Reported via dashboard testing (ESP32-S3 board picker, first column wider than the second); no separate tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
