### PR TITLE
Offer full setup when an existing bundle covers every featured component

### DIFF
--- a/src/util/full-setup.ts
+++ b/src/util/full-setup.ts
@@ -17,7 +17,9 @@ function fullSetupBundle(board: BoardCatalogEntry): FeaturedBundle | null {
   );
   if (synthesized) return synthesized;
   const featuredIds = board.featured_components.map((c) => c.id);
-  if (featuredIds.length < 2) return null;
+  // every() is vacuously true on an empty set; without this a board with no
+  // featured components would match an arbitrary bundle.
+  if (featuredIds.length === 0) return null;
   return (
     board.featured_bundles.find((b) => {
       const members = new Set(b.component_ids);

--- a/src/util/full-setup.ts
+++ b/src/util/full-setup.ts
@@ -3,25 +3,43 @@ import type { BoardCatalogEntry, FeaturedBundle } from "../api/types/boards.js";
 /** Local id of the all-recommended bundle the backend synthesizes (see #1726). */
 const ALL_RECOMMENDED_BUNDLE_ID = "all_recommended";
 
-/** The backend-synthesized dependency-ordered full-setup bundle, or null. */
-function allRecommendedBundle(board: BoardCatalogEntry): FeaturedBundle | null {
-  return board.featured_bundles.find((b) => b.id === ALL_RECOMMENDED_BUNDLE_ID) ?? null;
+/**
+ * The board's dependency-ordered full-setup bundle, or null.
+ *
+ * Prefers the synthesized ``all_recommended``; otherwise an importer-derived
+ * bundle that already covers every featured component — the backend skips
+ * synthesizing ``all_recommended`` in that case (sync_boards coverage check),
+ * so the existing covering bundle is the canonical full setup.
+ */
+function fullSetupBundle(board: BoardCatalogEntry): FeaturedBundle | null {
+  const synthesized = board.featured_bundles.find(
+    (b) => b.id === ALL_RECOMMENDED_BUNDLE_ID
+  );
+  if (synthesized) return synthesized;
+  const featuredIds = board.featured_components.map((c) => c.id);
+  if (featuredIds.length < 2) return null;
+  return (
+    board.featured_bundles.find((b) => {
+      const members = new Set(b.component_ids);
+      return featuredIds.every((id) => members.has(id));
+    }) ?? null
+  );
 }
 
 /**
  * Whether the create wizard should offer a "set up with everything" choice.
  *
- * Only when the board is a complete onboard config (``full_config``) AND the
- * backend synthesized an ``all_recommended`` bundle — i.e. there's a single
- * dependency-ordered list to apply. Boards whose recommended set is only
- * reachable through a chained curated bundle aren't offered the one-click setup
- * (it would add components out of order); they use the Add Component dialog.
+ * Only when the board is a complete onboard config (``full_config``) and a
+ * single dependency-ordered bundle covers every featured component. Boards
+ * whose recommended set is split across partial bundles aren't offered the
+ * one-click setup (it would add components out of order); they use the Add
+ * Component dialog.
  */
 export function boardOffersFullSetup(board: BoardCatalogEntry | null): boolean {
-  return !!board?.full_config && allRecommendedBundle(board) !== null;
+  return !!board?.full_config && fullSetupBundle(board) !== null;
 }
 
 /** The featured local ids to add for a board's full setup, dependency-ordered. */
 export function fullSetupComponentIds(board: BoardCatalogEntry): string[] {
-  return allRecommendedBundle(board)?.component_ids ?? [];
+  return fullSetupBundle(board)?.component_ids ?? [];
 }

--- a/test/util/full-setup.test.ts
+++ b/test/util/full-setup.test.ts
@@ -50,6 +50,31 @@ describe("boardOffersFullSetup", () => {
     ).toBe(true);
   });
 
+  it("covers a single featured component (no over-broad >=2 guard)", () => {
+    expect(
+      boardOffersFullSetup(
+        board({
+          full_config: true,
+          featured_components: components(["only"]),
+          featured_bundles: [
+            { id: "setup", name: "x", component_ids: ["only"] },
+          ] as never,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("is false when the featured set is empty (no vacuous bundle match)", () => {
+    expect(
+      boardOffersFullSetup(
+        board({
+          full_config: true,
+          featured_bundles: [{ id: "stray", name: "x", component_ids: ["a"] }] as never,
+        })
+      )
+    ).toBe(false);
+  });
+
   it("is false when no bundle covers the full featured set", () => {
     // A partial bundle that misses a featured component → no blind apply.
     expect(

--- a/test/util/full-setup.test.ts
+++ b/test/util/full-setup.test.ts
@@ -18,25 +18,51 @@ function board(flags: Partial<BoardCatalogEntry>): BoardCatalogEntry {
 const allRecommended = (ids: string[]) =>
   [{ id: "all_recommended", name: "x", component_ids: ids }] as never;
 
+const components = (ids: string[]) => ids.map((id) => ({ id })) as never;
+
 describe("boardOffersFullSetup", () => {
-  it("is true only for a full-config board with an all_recommended bundle", () => {
+  it("is true for a full-config board with an all_recommended bundle", () => {
     expect(
       boardOffersFullSetup(
         board({ full_config: true, featured_bundles: allRecommended(["a", "b"]) })
       )
     ).toBe(true);
-    // Full config but no synthesized bundle (a chained curated bundle covered
-    // it) → not offered as one click.
-    expect(
-      boardOffersFullSetup(
-        board({ full_config: true, featured_components: [{ id: "a" }] as never })
-      )
-    ).toBe(false);
     // Has the bundle but isn't a full config → never offered.
     expect(
       boardOffersFullSetup(board({ featured_bundles: allRecommended(["a", "b"]) }))
     ).toBe(false);
     expect(boardOffersFullSetup(null)).toBe(false);
+  });
+
+  it("is true when an importer-derived bundle already covers every featured component", () => {
+    // The ALD295HA shape: full_config, no all_recommended, one bundle whose
+    // component_ids cover all featured components (backend skipped synthesis).
+    expect(
+      boardOffersFullSetup(
+        board({
+          full_config: true,
+          featured_components: components(["hub", "out", "light"]),
+          featured_bundles: [
+            { id: "light_setup", name: "x", component_ids: ["hub", "out", "light"] },
+          ] as never,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("is false when no bundle covers the full featured set", () => {
+    // A partial bundle that misses a featured component → no blind apply.
+    expect(
+      boardOffersFullSetup(
+        board({
+          full_config: true,
+          featured_components: components(["hub", "out", "light"]),
+          featured_bundles: [
+            { id: "partial", name: "x", component_ids: ["hub", "out"] },
+          ] as never,
+        })
+      )
+    ).toBe(false);
   });
 });
 
@@ -46,9 +72,31 @@ describe("fullSetupComponentIds", () => {
     expect(fullSetupComponentIds(b)).toEqual(["c", "a", "b"]);
   });
 
-  it("returns empty when there is no all_recommended bundle", () => {
+  it("prefers all_recommended over a covering bundle", () => {
     const b = board({
-      featured_bundles: [{ id: "light_setup", name: "x", component_ids: ["a"] }] as never,
+      featured_components: components(["a", "b"]),
+      featured_bundles: [
+        { id: "light_setup", name: "x", component_ids: ["a", "b"] },
+        { id: "all_recommended", name: "x", component_ids: ["b", "a"] },
+      ] as never,
+    });
+    expect(fullSetupComponentIds(b)).toEqual(["b", "a"]);
+  });
+
+  it("returns the covering bundle's dependency order when there is no all_recommended", () => {
+    const b = board({
+      featured_components: components(["light", "hub", "out"]),
+      featured_bundles: [
+        { id: "light_setup", name: "x", component_ids: ["hub", "out", "light"] },
+      ] as never,
+    });
+    expect(fullSetupComponentIds(b)).toEqual(["hub", "out", "light"]);
+  });
+
+  it("returns empty when no bundle covers the featured set", () => {
+    const b = board({
+      featured_components: components(["a", "b"]),
+      featured_bundles: [{ id: "partial", name: "x", component_ids: ["a"] }] as never,
     });
     expect(fullSetupComponentIds(b)).toEqual([]);
   });


### PR DESCRIPTION
# What does this implement/fix?

The create wizard only showed the "Set up with all recommended components" checkbox when a board had a featured bundle whose id was exactly `all_recommended`. The backend deliberately skips synthesizing that bundle when an importer-derived bundle already covers every featured component, so complete onboard boards in that shape offered no one-click setup in the wizard.

Example: the Arlec ALD295HA (`full_config`, no `all_recommended`, one dependency-ordered bundle `id_name_setup` whose `component_ids` are all 7 featured components: the BP5758D hub, its 5 outputs, then the RGB+CCT light) showed the name step with no full-setup checkbox; the user had to add components one by one in the editor's "Choose components" dialog instead.

This widens the bundle finder in `src/util/full-setup.ts` to prefer `all_recommended` and otherwise fall back to any bundle that already covers the full featured set; both `boardOffersFullSetup` and `fullSetupComponentIds` route through it. The covering bundle is the importer's dependency order (hub and outputs before the light), which is exactly what the finish handler applies. No backend change is needed; the catalog data is already correct, and the backend already treats an existing covering bundle as the canonical full setup (its coverage check is why `all_recommended` wasn't synthesized).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
