### PR TITLE
Fill featured reference fields from their preset id among many candidates

### DIFF
--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -54,6 +54,12 @@ export function findReferencePath(
       continue;
     }
     if (entry.references_component === domain) {
+      // Skip a field the featured preset already pinned (`from_preset` + a literal
+      // `default_value`): preset seeding fills it from the live candidates, so a
+      // chained bundle `_prefillReference` (the last sibling added) must not
+      // overwrite an earlier preset-pinned field. A non-preset ref (the dep
+      // detour) still matches, so its just-added dep id lands as before.
+      if (entry.from_preset && entry.default_value != null) continue;
       return [...prefix, entry.key];
     }
   }
@@ -120,7 +126,20 @@ export function seedDefaults(
     // preset (`i2c_bus`) can't outlive the bus it names. Locked refs are
     // deliberate pins — keep their literal.
     if (entry.references_component && !entry.locked) {
-      const ref = seedReference(yaml, entry.references_component);
+      const candidates = findReferenceCandidates(yaml, entry.references_component, []);
+      // A featured preset that names a component actually present in the live
+      // config (a sibling just added in the same bundle, e.g. `output_blue`)
+      // wins — `resolveSoleCandidate` can't pick among several same-domain
+      // candidates, but the per-field preset already says which one. Check
+      // membership so a stale preset that outlived its target still defers.
+      const presetId =
+        seedPresets &&
+        entry.from_preset &&
+        typeof entry.default_value === "string" &&
+        candidates.some((c) => c.id === entry.default_value)
+          ? entry.default_value
+          : undefined;
+      const ref = presetId ?? resolveSoleCandidate(candidates, yaml)?.id;
       if (ref !== undefined) {
         out[entry.key] = entry.multi_value ? [ref] : ref;
       } else if (entry.multi_value && entry.required) {

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -67,22 +67,6 @@ export function findReferencePath(
 }
 
 /**
- * Seed an unlocked id-reference field with the matching component already in
- * the config, so a stale featured preset can't write an id that doesn't
- * exist. Ambiguous cases — none, several, or a `packages:`/`<<:` merge that
- * could hide one — stay unset, deferring to the dep detour or the picker.
- */
-export function seedReference(yaml: string, domain: string): string | undefined {
-  // Resolve against same-domain candidates only (i2c/spi/uart buses); the
-  // picker also folds in async interface providers. A cross-domain ref finds
-  // nothing here and defers to the picker; for a domain that is both a block
-  // and a provided interface, seeding may fill a value the picker would call
-  // ambiguous — harmless, since it's a real id the user can still change.
-  const candidates = findReferenceCandidates(yaml, domain, []);
-  return resolveSoleCandidate(candidates, yaml)?.id;
-}
-
-/**
  * Seed initial form values. By default only required fields' defaults
  * are pre-filled — pre-filling optional fields the user can't see
  * would just bloat the payload with values they never explicitly

--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -14,7 +14,7 @@ import {
 } from "../../util/default-component-id.js";
 import { resolveEntryLabel } from "../../util/entry-label.js";
 import { isFeaturedId } from "../../util/featured-id.js";
-import { setIn } from "../../util/nested-values.js";
+import { getIn, setIn } from "../../util/nested-values.js";
 
 /** Inputs the seeding pipeline reads off the host component. */
 export interface SeedContext {
@@ -34,33 +34,37 @@ export interface SeedContext {
 }
 
 /**
- * Walk the schema recursively to find the path of the first entry
- * with `references_component === domain`. Returns null if the
- * schema doesn't reference the domain — defensive against the
- * dialog passing a prefill that doesn't apply to this form.
+ * Walk the schema recursively for the path of the first
+ * `references_component === domain` entry that `seeded` has not already
+ * filled. Returns null when the schema references no such unfilled field —
+ * defensive against a prefill that doesn't apply, and so a chained prefill
+ * lands on a still-empty reference instead of overwriting a seeded one.
  */
 export function findReferencePath(
   entries: ConfigEntry[],
   domain: string,
-  prefix: string[]
+  prefix: string[],
+  seeded: Record<string, unknown> = {}
 ): string[] | null {
   for (const entry of entries) {
     if (entry.type === ConfigEntryType.NESTED) {
-      const found = findReferencePath(entry.config_entries ?? [], domain, [
-        ...prefix,
-        entry.key,
-      ]);
+      const found = findReferencePath(
+        entry.config_entries ?? [],
+        domain,
+        [...prefix, entry.key],
+        seeded
+      );
       if (found) return found;
       continue;
     }
     if (entry.references_component === domain) {
-      // Skip a field the featured preset already pinned (`from_preset` + a literal
-      // `default_value`): preset seeding fills it from the live candidates, so a
-      // chained bundle `_prefillReference` (the last sibling added) must not
-      // overwrite an earlier preset-pinned field. A non-preset ref (the dep
-      // detour) still matches, so its just-added dep id lands as before.
-      if (entry.from_preset && entry.default_value != null) continue;
-      return [...prefix, entry.key];
+      const path = [...prefix, entry.key];
+      // Skip a field seedDefaults already filled (from its preset or the sole
+      // candidate) so the chained prefill can't overwrite it; a reference
+      // seedDefaults left empty (a stale or ambiguous preset) still takes the
+      // prefill rather than being stranded.
+      if (getIn(seeded, path) !== undefined) continue;
+      return path;
     }
   }
   return null;
@@ -172,7 +176,10 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   // locked-validation would reject the empty payload. Plain catalog
   // defaults stay unseeded so the add matches the create-time auto-add.
   const seedPresets = isFeaturedId(component.id);
-  let next = seedDefaults(entries, yaml, localize, seedPresets);
+  // Snapshot what seeding owns so a later prefill skips exactly those refs
+  // (not every preset-flagged one), without treating a restored value as seeded.
+  const seededDefaults = seedDefaults(entries, yaml, localize, seedPresets);
+  let next = seededDefaults;
 
   const idEntry = entries.find((e) => e.key === "id" && e.type === ConfigEntryType.ID);
   if (idEntry && next["id"] === undefined) {
@@ -201,7 +208,12 @@ export function buildInitialValues(ctx: SeedContext): Record<string, unknown> {
   }
 
   if (prefillReference) {
-    const targetPath = findReferencePath(entries, prefillReference.domain, []);
+    const targetPath = findReferencePath(
+      entries,
+      prefillReference.domain,
+      [],
+      seededDefaults
+    );
     if (targetPath) {
       next = setIn(next, targetPath, prefillReference.id);
     }

--- a/test/components/device/add-component-form-filter.test.ts
+++ b/test/components/device/add-component-form-filter.test.ts
@@ -24,6 +24,18 @@ describe("addFormNeedsUserInput", () => {
     expect(addFormNeedsUserInput(entries, {}, [], null, NONE)).toBe(true);
   });
 
+  it("keeps the form open for an unlocked reference even when pre-seeded", () => {
+    // A featured bundle member whose reference is pre-filled from its preset
+    // still opens (the user reviews/confirms); the gate keys off unlocked +
+    // visible, not whether a value is present.
+    const entries = [
+      makeConfigEntry({ key: "blue", required: true, references_component: "output" }),
+    ];
+    expect(addFormNeedsUserInput(entries, { blue: "output_blue" }, [], null, NONE)).toBe(
+      true
+    );
+  });
+
   it("skips a fully board-locked exclusive group (every choice is read-only)", () => {
     const entries = [
       makeConfigEntry({ key: "i2c", exclusive_group: "bus", locked: true }),

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -101,6 +101,38 @@ describe("findReferencePath", () => {
     ];
     expect(findReferencePath(entries, "spi", [])).toBeNull();
   });
+
+  it("skips a preset-pinned reference but targets a non-pinned one", () => {
+    const entries: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "blue",
+        references_component: "output",
+        from_preset: true,
+        default_value: "output_blue",
+      }),
+      makeConfigEntry({ key: "warm", references_component: "output" }),
+    ];
+    expect(findReferencePath(entries, "output", [])).toEqual(["warm"]);
+  });
+
+  it("returns null when the only match is preset-pinned", () => {
+    const entries: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "blue",
+        references_component: "output",
+        from_preset: true,
+        default_value: "output_blue",
+      }),
+    ];
+    expect(findReferencePath(entries, "output", [])).toBeNull();
+  });
+
+  it("still targets a from_preset reference whose default_value is null", () => {
+    const entries: ConfigEntry[] = [
+      makeConfigEntry({ key: "i2c_id", references_component: "i2c", from_preset: true }),
+    ];
+    expect(findReferencePath(entries, "i2c", [])).toEqual(["i2c_id"]);
+  });
 });
 
 describe("seedDefaults", () => {
@@ -142,6 +174,56 @@ describe("seedDefaults", () => {
       }),
     ];
     expect(seedDefaults(entries, "", localize, true)).toEqual({});
+  });
+
+  const TWO_OUTPUTS =
+    "output:\n  - platform: ledc\n    id: output_red\n" +
+    "  - platform: ledc\n    id: output_blue\n";
+
+  const presetRef = (over: Partial<ConfigEntry> = {}): ConfigEntry =>
+    makeConfigEntry({
+      key: "blue",
+      type: ConfigEntryType.ID,
+      required: true,
+      references_component: "output",
+      from_preset: true,
+      default_value: "output_blue",
+      ...over,
+    });
+
+  it("fills a from_preset reference from its default when that id is among several candidates", () => {
+    expect(seedDefaults([presetRef()], TWO_OUTPUTS, localize, true)).toEqual({
+      blue: "output_blue",
+    });
+  });
+
+  it("falls back to the sole candidate when the preset id is absent", () => {
+    const yaml = "output:\n  - platform: ledc\n    id: output_only\n";
+    expect(
+      seedDefaults([presetRef({ default_value: "output_missing" })], yaml, localize, true)
+    ).toEqual({ blue: "output_only" });
+  });
+
+  it("leaves the reference unset when the preset id is stale and several candidates exist", () => {
+    expect(
+      seedDefaults(
+        [presetRef({ default_value: "output_missing" })],
+        TWO_OUTPUTS,
+        localize,
+        true
+      )
+    ).toEqual({});
+  });
+
+  it("ignores the from_preset default when seedPresets is false", () => {
+    // Without seedPresets the preset path is off; >1 candidate has no sole match.
+    expect(seedDefaults([presetRef()], TWO_OUTPUTS, localize, false)).toEqual({});
+  });
+
+  it("wraps a multi_value preset reference in an array", () => {
+    expect(
+      seedDefaults([presetRef({ multi_value: true })], TWO_OUTPUTS, localize, true)
+    ).toEqual({ blue: ["output_blue"] });
   });
 
   it("wraps a multi_value default in an array", () => {
@@ -344,6 +426,40 @@ describe("buildInitialValues", () => {
     expect(values.cs_pin).toBe("GPIO5");
     // The just-added bus id still wins over the restored (empty) reference.
     expect(values.i2c_id).toBe("bus_a");
+  });
+
+  it("does not let a chained prefillReference overwrite a preset-pinned ref", () => {
+    // The bundle path hands the last-added sibling (output_warm) as a single
+    // prefill; it must land on the unpinned ref, not clobber blue's preset.
+    const component = makeComponent({
+      id: "featured.bd.id_name",
+      config_entries: [
+        makeConfigEntry({
+          key: "blue",
+          type: ConfigEntryType.ID,
+          required: true,
+          references_component: "output",
+          from_preset: true,
+          default_value: "output_blue",
+        }),
+        makeConfigEntry({ key: "warm", references_component: "output" }),
+      ],
+    });
+    const yaml =
+      "output:\n  - platform: ledc\n    id: output_blue\n" +
+      "  - platform: ledc\n    id: output_warm\n";
+    const values = buildInitialValues({
+      entries: component.config_entries,
+      component,
+      board: null,
+      yaml,
+      prefillReference: { domain: "output", id: "output_warm" },
+      prefillFields: null,
+      restoredValues: null,
+      localize,
+    });
+    expect(values.blue).toBe("output_blue");
+    expect(values.warm).toBe("output_warm");
   });
 
   it("seeds pin entries from the board manifest between id-gen and prefill", () => {

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -14,7 +14,6 @@ import {
   buildInitialValues,
   findReferencePath,
   seedDefaults,
-  seedReference,
 } from "../../../src/components/device/add-component-form-seed.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
@@ -488,26 +487,5 @@ describe("buildInitialValues", () => {
     // "SCL"/"SDA" catalog defaults that don't resolve on the C3.
     expect(values.scl).toBe(9);
     expect(values.sda).toBe(8);
-  });
-});
-
-describe("seedReference", () => {
-  it("resolves a sole same-domain candidate to its id", () => {
-    const yaml = "i2c:\n  - id: bus_a\n";
-    expect(seedReference(yaml, "i2c")).toBe("bus_a");
-  });
-
-  it("defers to undefined when several candidates are ambiguous", () => {
-    const yaml = "i2c:\n  - id: bus_a\n  - id: bus_b\n";
-    expect(seedReference(yaml, "i2c")).toBeUndefined();
-  });
-
-  it("returns undefined when no candidate matches the domain", () => {
-    expect(seedReference("i2c:\n  - id: bus_a\n", "spi")).toBeUndefined();
-  });
-
-  it("defers to undefined when a packages: merge could hide a candidate", () => {
-    const yaml = "packages:\n  base: !include base.yaml\ni2c:\n  - id: bus_a\n";
-    expect(seedReference(yaml, "i2c")).toBeUndefined();
   });
 });

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -101,36 +101,28 @@ describe("findReferencePath", () => {
     expect(findReferencePath(entries, "spi", [])).toBeNull();
   });
 
-  it("skips a preset-pinned reference but targets a non-pinned one", () => {
+  it("skips a reference seeding already filled but targets an unfilled one", () => {
     const entries: ConfigEntry[] = [
-      makeConfigEntry({
-        key: "blue",
-        references_component: "output",
-        from_preset: true,
-        default_value: "output_blue",
-      }),
+      makeConfigEntry({ key: "blue", references_component: "output" }),
       makeConfigEntry({ key: "warm", references_component: "output" }),
     ];
-    expect(findReferencePath(entries, "output", [])).toEqual(["warm"]);
+    expect(findReferencePath(entries, "output", [], { blue: "output_blue" })).toEqual([
+      "warm",
+    ]);
   });
 
-  it("returns null when the only match is preset-pinned", () => {
+  it("returns null when seeding already filled the only matching reference", () => {
     const entries: ConfigEntry[] = [
-      makeConfigEntry({
-        key: "blue",
-        references_component: "output",
-        from_preset: true,
-        default_value: "output_blue",
-      }),
+      makeConfigEntry({ key: "blue", references_component: "output" }),
     ];
-    expect(findReferencePath(entries, "output", [])).toBeNull();
+    expect(findReferencePath(entries, "output", [], { blue: "output_blue" })).toBeNull();
   });
 
-  it("still targets a from_preset reference whose default_value is null", () => {
+  it("targets a reference seeding left empty so a chained prefill isn't stranded", () => {
     const entries: ConfigEntry[] = [
-      makeConfigEntry({ key: "i2c_id", references_component: "i2c", from_preset: true }),
+      makeConfigEntry({ key: "blue", references_component: "output" }),
     ];
-    expect(findReferencePath(entries, "i2c", [])).toEqual(["i2c_id"]);
+    expect(findReferencePath(entries, "output", [], {})).toEqual(["blue"]);
   });
 });
 
@@ -459,6 +451,38 @@ describe("buildInitialValues", () => {
     });
     expect(values.blue).toBe("output_blue");
     expect(values.warm).toBe("output_warm");
+  });
+
+  it("applies a chained prefillReference to a from_preset ref that seeding left empty", () => {
+    // Stale preset id among several same-domain candidates: seedDefaults can't
+    // fill blue, so the just-added dep must still land there, not be stranded.
+    const component = makeComponent({
+      id: "featured.bd.thing",
+      config_entries: [
+        makeConfigEntry({
+          key: "blue",
+          type: ConfigEntryType.ID,
+          required: true,
+          references_component: "output",
+          from_preset: true,
+          default_value: "output_stale",
+        }),
+      ],
+    });
+    const yaml =
+      "output:\n  - platform: ledc\n    id: output_a\n" +
+      "  - platform: ledc\n    id: output_b\n";
+    const values = buildInitialValues({
+      entries: component.config_entries,
+      component,
+      board: null,
+      yaml,
+      prefillReference: { domain: "output", id: "output_a" },
+      prefillFields: null,
+      restoredValues: null,
+      localize,
+    });
+    expect(values.blue).toBe("output_a");
   });
 
   it("seeds pin entries from the board manifest between id-gen and prefill", () => {

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -129,6 +129,45 @@ describe("add-component-form resolves featured id references to the live config"
     } as unknown as ComponentCatalogEntry;
     expect(seededValues(component, "").buses).toEqual([]);
   });
+
+  // A bundle adds 5 bp5758d outputs, then the rgbww light whose 5 output
+  // references each name a specific sibling; sole-candidate can't pick among
+  // 5 same-domain outputs, so each field fills from its own preset id.
+  it("fills each featured reference from its own preset id among many same-domain outputs", () => {
+    const ref = (key: string, id: string) =>
+      makeConfigEntry({
+        key,
+        type: ConfigEntryType.ID,
+        required: true,
+        references_component: "output",
+        from_preset: true,
+        default_value: id,
+      });
+    const light = {
+      id: "featured.arlec.id_name",
+      config_entries: [
+        ref("red", "output_red"),
+        ref("green", "output_green"),
+        ref("blue", "output_blue"),
+        ref("cold_white", "output_cold"),
+        ref("warm_white", "output_warm"),
+      ],
+    } as unknown as ComponentCatalogEntry;
+    const yaml =
+      "output:\n" +
+      "  - platform: bp5758d\n    id: output_red\n" +
+      "  - platform: bp5758d\n    id: output_green\n" +
+      "  - platform: bp5758d\n    id: output_blue\n" +
+      "  - platform: bp5758d\n    id: output_cold\n" +
+      "  - platform: bp5758d\n    id: output_warm\n";
+    expect(seededValues(light, yaml)).toMatchObject({
+      red: "output_red",
+      green: "output_green",
+      blue: "output_blue",
+      cold_white: "output_cold",
+      warm_white: "output_warm",
+    });
+  });
 });
 
 describe("add-component-form dep-add bus prefill (#1425)", () => {


### PR DESCRIPTION
# What does this implement/fix?

Adding a featured bundle through the editor's Add Component dialog could leave the last step's id-reference dropdowns empty. Concretely, the Arlec ALD295HA bundle adds 5 `bp5758d` outputs and then an `rgbww` light whose Blue/Green/Red/Cold White/Warm White fields each reference one of those outputs; the form opened with all 5 dropdowns blank, even though the outputs were already in the draft. At device-create time the same bundle fills correctly, so this was specific to the interactive form path.

Two causes, both in `add-component-form-seed.ts`:

1. `seedDefaults` resolved every reference field by sole-candidate, which returns nothing when more than one same-domain component exists (5 outputs share the `output` domain), so it discarded each field's authored preset id (`blue: output_blue`, etc.).
2. `buildInitialValues` then applied the chained bundle `prefillReference`, which carries only the last-added sibling (`output_warm`) and `findReferencePath` writes it into the first matching reference field, clobbering it.

The fix makes a featured preset authoritative for a reference field when the preset id names a component actually present in the live config, keeping sole-candidate as the fallback for a renamed single bus. It also skips a preset-pinned reference in `findReferencePath`, so the chained prefill fills only an unpinned reference (the dep-detour case) instead of overwriting a preset one. The form still opens for the member (the user reviews it) but now every dropdown is pre-filled.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
