### PR TITLE
Seed a multi_value list default element-wise

### DIFF
--- a/src/components/device/add-component-form-seed.ts
+++ b/src/components/device/add-component-form-seed.ts
@@ -136,8 +136,13 @@ export function seedDefaults(
       continue;
     }
     if (entry.default_value != null) {
+      // A multi_value default can already be a list (octal SPI `data_pins`,
+      // `[6, 7, 15, ...]`); spread it element-wise so each value seeds its own
+      // row with its original type. Only wrap a scalar default into a list.
       out[entry.key] = entry.multi_value
-        ? [String(entry.default_value)]
+        ? Array.isArray(entry.default_value)
+          ? [...entry.default_value]
+          : [String(entry.default_value)]
         : entry.default_value;
     } else if (entry.multi_value && entry.required) {
       out[entry.key] = [];

--- a/test/components/device/add-component-form-seed-fns.test.ts
+++ b/test/components/device/add-component-form-seed-fns.test.ts
@@ -230,6 +230,25 @@ describe("seedDefaults", () => {
     expect(seedDefaults(entries, "", localize)).toEqual({ tags: ["a"] });
   });
 
+  it("spreads a multi_value list default element-wise (octal SPI data_pins)", () => {
+    const entries: ConfigEntry[] = [
+      makeConfigEntry({
+        key: "data_pins",
+        type: ConfigEntryType.PIN,
+        required: true,
+        multi_value: true,
+        locked: true,
+        from_preset: true,
+        default_value: [6, 7, 15, 16, 10, 9, 46, 3],
+      }),
+    ];
+    // Each pin seeds its own row, ints preserved — not joined into one
+    // "6,7,15,..." string in a single-element array.
+    expect(seedDefaults(entries, "", localize, true)).toEqual({
+      data_pins: [6, 7, 15, 16, 10, 9, 46, 3],
+    });
+  });
+
   it("emits an empty array for a required multi_value with no default", () => {
     const entries: ConfigEntry[] = [
       makeConfigEntry({


### PR DESCRIPTION
# What does this implement/fix?

A featured component with a locked `multi_value` PIN field whose preset value is already a list (octal SPI `data_pins`, e.g. `[6, 7, 15, 16, 10, 9, 46, 3]`) rendered the whole list as a single comma-joined row ("6,7,15,16,10,9,46,3") instead of eight locked rows, and clicking Add submitted that lone string, which the backend rejected with `internal_error: Command failed: devices/add_component`.

`seedDefaults` (`add-component-form-seed.ts`) seeded a multi_value default as `[String(entry.default_value)]`, which for a list default collapses it to a one-element array of the joined string. This spreads an already-list default element-wise (preserving each value's type, so pin ints stay ints) and only wraps a scalar default into a one-element array. The multi-value field then renders one locked row per pin and Add submits the real 8-int list.

Surfaced by the new backend bus-lift (esphome/device-builder#1734), which is the first to emit list-valued locked pins.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1736

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
