### PR TITLE
Skip bundle members already present in the device

### DIFF
--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -606,6 +606,16 @@ export class ESPHomeAddComponentDialog extends LitElement {
           await handOff(i);
           return;
         }
+        // Skip a member already in the device: a bundle re-applied after a
+        // partial prior run (or with members overlapping existing config) must
+        // not append a duplicate block. The preset id identifies the member in
+        // the running YAML; still chain it so a later member's reference field
+        // resolves to it.
+        const memberId = fields["id"];
+        if (typeof memberId === "string" && collectExistingIds(this.yaml).has(memberId)) {
+          lastAdded = this._chainReference(entry, fields);
+          continue;
+        }
         const { yaml } = await this._api.addComponent(
           this.configuration,
           { component_id: fullIds[i], fields },

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -577,6 +577,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
         bundleName: bundle.name,
       };
     };
+    // Snapshot the ids already in the device once, then extend it as members
+    // are added — so the per-member presence check stays O(1) instead of
+    // re-scanning the whole YAML each step on a large config.
+    const existingIds = collectExistingIds(this.yaml);
     try {
       for (let i = 0; i < fullIds.length; i++) {
         const result = await hydrateForSelection(
@@ -610,9 +614,13 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // partial prior run (or with members overlapping existing config) must
         // not append a duplicate block. The preset id identifies the member in
         // the running YAML; still chain it so a later member's reference field
-        // resolves to it.
+        // resolves to it. This guards the fast path only; a present member that
+        // needs form input (``_fastPathFields`` null, handed off above) can
+        // still be re-added — a rarer path, scoped out alongside the
+        // create-wizard ``_applyFullSetup`` follow-up and backstopped by
+        // ESPHome's global id uniqueness.
         const memberId = fields["id"];
-        if (typeof memberId === "string" && collectExistingIds(this.yaml).has(memberId)) {
+        if (typeof memberId === "string" && existingIds.has(memberId)) {
           lastAdded = this._chainReference(entry, fields);
           continue;
         }
@@ -623,6 +631,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         );
         draft = yaml;
         addedAny = true;
+        if (typeof memberId === "string") existingIds.add(memberId);
         // Keep `this.yaml` current so the next member's dep check + reference
         // dropdown see what this batch already added; the host draft is
         // published once at the end rather than churning the editor per member.

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -633,9 +633,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
       this._open = false;
       this._selected = null;
       this._resetDetourState();
-      toast.success(this._localize("device.bundle_added", { name: bundle.name }), {
-        richColors: true,
-      });
+      // Every member already present is a no-op; don't claim we "Added" it.
+      const message = addedAny
+        ? this._localize("device.bundle_added", { name: bundle.name })
+        : this._localize("device.bundle_already_present", { name: bundle.name });
+      toast.success(message, { richColors: true });
     } catch (err) {
       // A member failed mid-batch: publish what merged so far so the host keeps
       // the already-added members (the draft is otherwise only published on the

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -642,6 +642,7 @@
     "featured_bundle_badge": "Bundle",
     "field_locked_by_board": "Set by the board",
     "bundle_added": "Added {name}",
+    "bundle_already_present": "{name} is already set up",
     "bundle_step_progress": "Step {current} of {total} — Adding {name}",
     "adding_prerequisites_for": "prerequisites for {name}",
     "prereq_unresolved": "Can't add {name}: required prerequisites missing from the board catalog: {ids}",

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -90,6 +90,35 @@ describe("add-component-dialog one-shot bundle", () => {
     expect(d._open).toBe(false);
   });
 
+  it("skips a member already present in the device instead of re-adding it", async () => {
+    const { d, addComponent, getComponentBodies, dialog } = makeDialog();
+    // The device already has member "a" (id `present_a`); re-applying the
+    // bundle must not append it again.
+    dialog.yaml = "switch:\n  - platform: gpio\n    id: present_a\n";
+    getComponentBodies.mockResolvedValue({
+      "featured.bd.a": makeComponentEntry("featured.bd.a", {
+        category: ComponentCategory.SWITCH,
+      }),
+      "featured.bd.b": makeComponentEntry("featured.bd.b", {
+        category: ComponentCategory.SWITCH,
+      }),
+    });
+    addComponent.mockResolvedValue({ yaml: "Y_AFTER_B" });
+    d._fastPathFields = vi.fn().mockImplementation((entry: { id: string }) => ({
+      id: entry.id === "featured.bd.a" ? "present_a" : "new_b",
+    }));
+
+    await d._onBundleSelected(bundleEvent(["a", "b"]));
+
+    // Only the absent member "b" is added; "a" is skipped, not duplicated.
+    expect(addComponent).toHaveBeenCalledTimes(1);
+    expect(addComponent.mock.calls[0][1]).toEqual({
+      component_id: "featured.bd.b",
+      fields: { id: "new_b" },
+    });
+    expect(d._open).toBe(false);
+  });
+
   it("hands off to the interactive sequence when a member needs the form", async () => {
     const { d, addComponent, getComponentBodies } = makeDialog();
     getComponentBodies.mockResolvedValue({

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -15,6 +15,8 @@ vi.mock("../../../src/components/device/add-component-form.js", () => ({}));
 vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
+import toast from "sonner-js";
+
 import { ComponentCategory } from "../../../src/api/types/components.js";
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
@@ -117,6 +119,25 @@ describe("add-component-dialog one-shot bundle", () => {
       fields: { id: "new_b" },
     });
     expect(d._open).toBe(false);
+  });
+
+  it("shows 'already set up' instead of 'Added' when every member is present", async () => {
+    const { d, addComponent, getComponentBodies, dialog } = makeDialog();
+    dialog.yaml = "switch:\n  - platform: gpio\n    id: present_a\n";
+    getComponentBodies.mockResolvedValue({
+      "featured.bd.a": makeComponentEntry("featured.bd.a", {
+        category: ComponentCategory.SWITCH,
+      }),
+    });
+    d._fastPathFields = vi.fn().mockReturnValue({ id: "present_a" });
+
+    await d._onBundleSelected(bundleEvent(["a"]));
+
+    // Nothing was added, so the toast must not claim "Added".
+    expect(addComponent).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("device.bundle_already_present", {
+      richColors: true,
+    });
   });
 
   it("hands off to the interactive sequence when a member needs the form", async () => {

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -72,7 +72,10 @@ describe("add-component-dialog one-shot bundle", () => {
     addComponent
       .mockResolvedValueOnce({ yaml: "Y1" })
       .mockResolvedValueOnce({ yaml: "Y2" });
-    d._fastPathFields = vi.fn().mockReturnValue({ id: "x" });
+    // Distinct member ids — two bundle members never share one in practice.
+    d._fastPathFields = vi.fn().mockImplementation((entry: { id: string }) => ({
+      id: entry.id === "featured.bd.a" ? "xa" : "xb",
+    }));
 
     await d._onBundleSelected(bundleEvent(["a", "b"]));
 
@@ -81,12 +84,12 @@ describe("add-component-dialog one-shot bundle", () => {
     // the first — one accumulating chain, not two independent merges.
     expect(addComponent.mock.calls[0]).toEqual([
       "foo.yaml",
-      { component_id: "featured.bd.a", fields: { id: "x" } },
+      { component_id: "featured.bd.a", fields: { id: "xa" } },
       "esphome:\n  name: foo\n",
     ]);
     expect(addComponent.mock.calls[1]).toEqual([
       "foo.yaml",
-      { component_id: "featured.bd.b", fields: { id: "x" } },
+      { component_id: "featured.bd.b", fields: { id: "xb" } },
       "Y1",
     ]);
     expect(d._open).toBe(false);


### PR DESCRIPTION
# What does this implement/fix?

Applying a board's "full setup" bundle fires `devices/add_component` for every member with no presence check, so a bundle re-applied after a partial prior run (or whose members overlap existing config) appends duplicate blocks, e.g. four identical `output: - platform: ledc ... id: lcd_backlight_output`.

`_onBundleSelected` now skips a member whose preset id is already in the running YAML (via `collectExistingIds`), still chaining its reference so a later member that points at it resolves, instead of appending it again. The create-wizard `_applyFullSetup` path (lower duplicate risk, fresh device) is left for a follow-up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1737

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
