### PR TITLE
Collect Wi-Fi in the adopt dialog when no shared secret exists

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -13,6 +13,9 @@ import { EnterController } from "../util/enter-controller.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { renderInlineError } from "../util/render-error.js";
+import { fetchSecretKeys, hasSharedWifiSecret } from "../util/secrets-cache.js";
+import { wifiFieldsStyles } from "./onboarding/wifi-fields-styles.js";
+import { isWifiPasswordTooShort, renderWifiFields } from "./onboarding/wifi-fields.js";
 
 import "./base-dialog.js";
 
@@ -38,12 +41,20 @@ export class ESPHomeAdoptDialog extends LitElement {
   @state() private _busy = false;
   @state() private _error: string | null = null;
   @state() private _open = false;
+  @state() private _ssid = "";
+  @state() private _password = "";
+  // undefined until config/get_secrets resolves; only fetched for a
+  // network=wifi device, so a non-wifi adopt never blocks on it.
+  @state() private _hasWifiSecrets: boolean | undefined = undefined;
 
   static styles = [
     espHomeStyles,
     inputStyles,
     // Neutral header + title + footer (shared) — dialog-chrome.ts.
     dialogChromeStyles,
+    // Before the local block so this dialog's own `.field` / `label`
+    // spacing wins; only `.field-label` / `.error` (unique here) apply.
+    wifiFieldsStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -239,7 +250,30 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._encryption = true;
     this._busy = false;
     this._error = null;
+    this._ssid = "";
+    this._password = "";
+    this._hasWifiSecrets = undefined;
     this._open = true;
+    // A Wi-Fi device whose install has no shared wifi_ssid/wifi_password
+    // would import a config referencing an undefined !secret and fail to
+    // validate (esphome/device-builder#1742). Probe the shared secrets so
+    // the Wi-Fi step can prompt + store them before importing.
+    if (device.network === "wifi" && this._api) {
+      fetchSecretKeys(this._api).then((keys) => {
+        this._hasWifiSecrets = hasSharedWifiSecret(keys);
+      });
+    }
+  }
+
+  private get _needsWifi(): boolean {
+    return this._device?.network === "wifi";
+  }
+
+  // Show the Wi-Fi step only for a Wi-Fi device with no shared secret yet;
+  // a device with its own network or an install that already has the secret
+  // skips it, mirroring the create wizard and the legacy adopt dialog.
+  private get _collectWifi(): boolean {
+    return this._needsWifi && this._hasWifiSecrets === false;
   }
 
   close = () => {
@@ -271,7 +305,16 @@ export class ESPHomeAdoptDialog extends LitElement {
     const device = this._device;
     const nameTrimmed = this._name.trim();
     const nameErr = nameTrimmed ? validateDeviceName(nameTrimmed) : null;
-    const canSubmit = !!device && !!nameTrimmed && !nameErr && !this._busy;
+    // Block submit while a wifi device's secrets are still loading
+    // (_hasWifiSecrets undefined) so a fast click can't skip the store, and
+    // once the Wi-Fi step shows require an SSID + a valid-length password.
+    const wifiBlocking = this._needsWifi
+      ? this._hasWifiSecrets === undefined ||
+        (this._collectWifi &&
+          (!this._ssid.trim() || isWifiPasswordTooShort(this._password)))
+      : false;
+    const canSubmit =
+      !!device && !!nameTrimmed && !nameErr && !this._busy && !wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
@@ -324,6 +367,24 @@ export class ESPHomeAdoptDialog extends LitElement {
                   }}
                 />
               </div>
+
+              ${this._collectWifi
+                ? html`
+                    <p class="description">${this._localize("onboarding.wifi.intro")}</p>
+                    ${renderWifiFields({
+                      localize: this._localize,
+                      ssid: this._ssid,
+                      password: this._password,
+                      disabled: this._busy,
+                      onSsidInput: (value) => {
+                        this._ssid = value;
+                      },
+                      onPasswordInput: (value) => {
+                        this._password = value;
+                      },
+                    })}
+                  `
+                : nothing}
 
               <label class="checkbox-row">
                 <input
@@ -410,6 +471,14 @@ export class ESPHomeAdoptDialog extends LitElement {
     this._busy = true;
     this._error = null;
     try {
+      // Persist the shared Wi-Fi secret first so the imported config's
+      // ``!secret wifi_ssid`` resolves; a failure here surfaces in the same
+      // catch and leaves the dialog open. ``secrets-saved`` refreshes the
+      // editor's secret pickers and the kebab wording.
+      if (this._collectWifi) {
+        await this._api.setWifiCredentials(this._ssid.trim(), this._password);
+        window.dispatchEvent(new CustomEvent("secrets-saved"));
+      }
       // ``encryption`` is sent only when the user opted in. Backend
       // signature is ``encryption: str | None = None``; omitting it
       // when False keeps the call site clean and avoids relying on

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -486,10 +486,13 @@ export class ESPHomeAdoptDialog extends LitElement {
       // Persist the shared Wi-Fi secret first so the imported config's
       // ``!secret wifi_ssid`` resolves; a failure here surfaces in the same
       // catch and leaves the dialog open. ``secrets-saved`` refreshes the
-      // editor's secret pickers and the kebab wording.
+      // editor's secret pickers and the kebab wording. Store the raw SSID
+      // (whitespace is significant); the trim is only the non-empty gate.
       if (this._collectWifi) {
-        await this._api.setWifiCredentials(this._ssid.trim(), this._password);
-        window.dispatchEvent(new CustomEvent("secrets-saved"));
+        await this._api.setWifiCredentials(this._ssid, this._password);
+        window.dispatchEvent(
+          new CustomEvent("secrets-saved", { detail: { source: this } })
+        );
       }
       // ``encryption`` is sent only when the user opted in. Backend
       // signature is ``encryption: str | None = None``; omitting it

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -45,7 +45,7 @@ export class ESPHomeAdoptDialog extends LitElement {
   @state() private _password = "";
   // undefined until config/get_secrets resolves; only fetched for a
   // network=wifi device, so a non-wifi adopt never blocks on it.
-  @state() private _hasWifiSecrets: boolean | undefined = undefined;
+  @state() private _hasWifiSecrets?: boolean;
 
   static styles = [
     espHomeStyles,
@@ -258,13 +258,17 @@ export class ESPHomeAdoptDialog extends LitElement {
     // would import a config referencing an undefined !secret and fail to
     // validate (esphome/device-builder#1742). Probe the shared secrets so
     // the Wi-Fi step can prompt + store them before importing.
-    if (device.network === "wifi" && this._api) {
+    if (this._needsWifi && this._api) {
       fetchSecretKeys(this._api).then((keys) => {
         this._hasWifiSecrets = hasSharedWifiSecret(keys);
       });
     }
   }
 
+  // Strictly "wifi" to match the legacy dashboard's adopt gate. A device
+  // that advertised no network (older firmware, network === "") isn't
+  // prompted; closing that hole belongs in the backend import generator,
+  // not a frontend heuristic that would wrongly prompt Ethernet devices.
   private get _needsWifi(): boolean {
     return this._device?.network === "wifi";
   }
@@ -308,11 +312,10 @@ export class ESPHomeAdoptDialog extends LitElement {
     // Block submit while a wifi device's secrets are still loading
     // (_hasWifiSecrets undefined) so a fast click can't skip the store, and
     // once the Wi-Fi step shows require an SSID + a valid-length password.
-    const wifiBlocking = this._needsWifi
-      ? this._hasWifiSecrets === undefined ||
-        (this._collectWifi &&
-          (!this._ssid.trim() || isWifiPasswordTooShort(this._password)))
-      : false;
+    const wifiBlocking =
+      (this._needsWifi && this._hasWifiSecrets === undefined) ||
+      (this._collectWifi &&
+        (!this._ssid.trim() || isWifiPasswordTooShort(this._password)));
     const canSubmit =
       !!device && !!nameTrimmed && !nameErr && !this._busy && !wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";

--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -280,6 +280,19 @@ export class ESPHomeAdoptDialog extends LitElement {
     return this._needsWifi && this._hasWifiSecrets === false;
   }
 
+  // Block submit while a wifi device's secrets are still loading
+  // (_hasWifiSecrets undefined) so a fast Enter can't skip the store, and
+  // once the Wi-Fi step shows require an SSID + a valid-length password.
+  // Read by both canSubmit and _submit so the Enter path (which bypasses
+  // the disabled button) is guarded too.
+  private get _wifiBlocking(): boolean {
+    return (
+      (this._needsWifi && this._hasWifiSecrets === undefined) ||
+      (this._collectWifi &&
+        (!this._ssid.trim() || isWifiPasswordTooShort(this._password)))
+    );
+  }
+
   close = () => {
     /* Arrow function so ``@click=${this.close}`` from the cancel
        button keeps ``this`` bound to the dialog. With a plain method,
@@ -309,15 +322,8 @@ export class ESPHomeAdoptDialog extends LitElement {
     const device = this._device;
     const nameTrimmed = this._name.trim();
     const nameErr = nameTrimmed ? validateDeviceName(nameTrimmed) : null;
-    // Block submit while a wifi device's secrets are still loading
-    // (_hasWifiSecrets undefined) so a fast click can't skip the store, and
-    // once the Wi-Fi step shows require an SSID + a valid-length password.
-    const wifiBlocking =
-      (this._needsWifi && this._hasWifiSecrets === undefined) ||
-      (this._collectWifi &&
-        (!this._ssid.trim() || isWifiPasswordTooShort(this._password)));
     const canSubmit =
-      !!device && !!nameTrimmed && !nameErr && !this._busy && !wifiBlocking;
+      !!device && !!nameTrimmed && !nameErr && !this._busy && !this._wifiBlocking;
     const displayName = device ? device.friendly_name || device.name : "";
 
     return html`
@@ -470,6 +476,9 @@ export class ESPHomeAdoptDialog extends LitElement {
     const name = this._name.trim();
     const friendlyName = this._friendlyName.trim();
     if (!name || validateDeviceName(name)) return;
+    // Enter bypasses the disabled button; re-check the Wi-Fi gate so a
+    // held Enter can't import before the secret store (or with bad creds).
+    if (this._wifiBlocking) return;
 
     this._busy = true;
     this._error = null;

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -91,12 +91,13 @@ describe("adopt-dialog wifi step (#1742)", () => {
     window.addEventListener("secrets-saved", savedListener);
     priv.open(wifiDevice());
     await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
-    priv._ssid = "  MyHomeWifi  ";
+    // Whitespace in an SSID is significant; the raw value is stored verbatim.
+    priv._ssid = " My Home Wifi ";
     priv._password = "hunter2hunter";
 
     await priv._submit();
 
-    expect(setWifiCredentials).toHaveBeenCalledWith("MyHomeWifi", "hunter2hunter");
+    expect(setWifiCredentials).toHaveBeenCalledWith(" My Home Wifi ", "hunter2hunter");
     expect(setWifiCredentials.mock.invocationCallOrder[0]).toBeLessThan(
       importDevice.mock.invocationCallOrder[0]
     );

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -131,4 +131,82 @@ describe("adopt-dialog wifi step (#1742)", () => {
     expect(setWifiCredentials).not.toHaveBeenCalled();
     expect(importDevice).toHaveBeenCalledTimes(1);
   });
+
+  it("blocks submit while the secret probe is still in flight", async () => {
+    // The probe never resolves, so _hasWifiSecrets stays undefined.
+    let release: (keys: string[]) => void = () => {};
+    const getSecretKeys = vi.fn(
+      () => new Promise<string[]>((resolve) => (release = resolve))
+    );
+    const setWifiCredentials = vi.fn(async () => {});
+    const importDevice = vi.fn(async () => ({ configuration: "foo-1234.yaml" }));
+    const priv = new ESPHomeAdoptDialog() as Priv;
+    priv._api = { getSecretKeys, setWifiCredentials, importDevice };
+    priv.open(wifiDevice());
+
+    // A fast Enter (calls _submit directly) before the probe resolves must
+    // neither store a half-known secret nor import an unresolved !secret.
+    expect(priv._wifiBlocking).toBe(true);
+    await priv._submit();
+    expect(setWifiCredentials).not.toHaveBeenCalled();
+    expect(importDevice).not.toHaveBeenCalled();
+    release([]); // let the dangling promise settle
+  });
+
+  it("blocks submit when the password is too short", async () => {
+    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
+    priv._ssid = "My Home Wifi";
+    priv._password = "short"; // 1–7 chars trips isWifiPasswordTooShort
+
+    expect(priv._wifiBlocking).toBe(true);
+    await priv._submit();
+
+    expect(setWifiCredentials).not.toHaveBeenCalled();
+    expect(importDevice).not.toHaveBeenCalled();
+  });
+
+  it("allows an open network (empty password) and stores it verbatim", async () => {
+    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
+    priv._ssid = "OpenNet";
+    priv._password = ""; // empty is not "too short" — open network
+
+    expect(priv._wifiBlocking).toBe(false);
+    await priv._submit();
+
+    expect(setWifiCredentials).toHaveBeenCalledWith("OpenNet", "");
+    expect(importDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open and skips import when storing the secret fails", async () => {
+    const { priv, importDevice } = makeDialog([]);
+    priv._api.setWifiCredentials = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
+    priv._ssid = "My Home Wifi";
+    priv._password = "hunter2hunter";
+
+    await priv._submit();
+
+    // The store threw, so import never ran and the dialog stays open with
+    // the error surfaced and the button live again.
+    expect(importDevice).not.toHaveBeenCalled();
+    expect(priv._error).toBe("disk full");
+    expect(priv._busy).toBe(false);
+    expect(priv._open).toBe(true);
+  });
+
+  it("does not collect wifi when the device advertised no network", async () => {
+    const { priv, getSecretKeys } = makeDialog([]);
+    priv.open({ ...DEVICE, network: "" } as unknown as AdoptableDevice);
+
+    expect(getSecretKeys).not.toHaveBeenCalled();
+    expect(priv._collectWifi).toBe(false);
+    expect(priv._wifiBlocking).toBe(false);
+  });
 });

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -6,10 +6,11 @@
  * double-import on a held Enter. The Enter->action wiring itself mirrors
  * friendly-name-dialog and is covered there.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AdoptableDevice } from "../../src/api/types/devices.js";
 import { ESPHomeAdoptDialog } from "../../src/components/adopt-dialog.js";
+import { _resetSecretKeysCache } from "../../src/util/secrets-cache.js";
 
 const DEVICE = {
   name: "foo-1234",
@@ -18,12 +19,34 @@ const DEVICE = {
   package_import_url: "github://acme/widget/widget.yaml@main",
 } as unknown as AdoptableDevice;
 
+const wifiDevice = (): AdoptableDevice =>
+  ({ ...DEVICE, network: "wifi" }) as unknown as AdoptableDevice;
+const ethernetDevice = (): AdoptableDevice =>
+  ({ ...DEVICE, network: "ethernet" }) as unknown as AdoptableDevice;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Priv = any;
+
+function makeDialog(secretKeys: string[]): {
+  priv: Priv;
+  getSecretKeys: ReturnType<typeof vi.fn>;
+  setWifiCredentials: ReturnType<typeof vi.fn>;
+  importDevice: ReturnType<typeof vi.fn>;
+} {
+  const getSecretKeys = vi.fn(async () => secretKeys);
+  const setWifiCredentials = vi.fn(async () => {});
+  const importDevice = vi.fn(async () => ({ configuration: "foo-1234.yaml" }));
+  const el = new ESPHomeAdoptDialog();
+  const priv = el as Priv;
+  priv._api = { getSecretKeys, setWifiCredentials, importDevice };
+  return { priv, getSecretKeys, setWifiCredentials, importDevice };
+}
+
 describe("adopt-dialog re-entry guard", () => {
   it("_submit ignores re-entry while an import is in flight", async () => {
     const importDevice = vi.fn(() => new Promise<void>(() => {})); // stays in flight
     const el = new ESPHomeAdoptDialog();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const priv = el as any;
+    const priv = el as Priv;
     priv._api = { importDevice };
     priv._device = DEVICE;
     priv._name = "foo-1234";
@@ -31,6 +54,67 @@ describe("adopt-dialog re-entry guard", () => {
     void priv._submit();
     await priv._submit();
 
+    expect(importDevice).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("adopt-dialog wifi step (#1742)", () => {
+  beforeEach(() => {
+    _resetSecretKeysCache();
+  });
+
+  it("collects wifi for a wifi device with no shared secret", async () => {
+    const { priv, getSecretKeys } = makeDialog([]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(false));
+    expect(getSecretKeys).toHaveBeenCalledTimes(1);
+    expect(priv._collectWifi).toBe(true);
+  });
+
+  it("skips the wifi step when the shared secret already exists", async () => {
+    const { priv } = makeDialog(["wifi_ssid", "wifi_password"]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(true));
+    expect(priv._collectWifi).toBe(false);
+  });
+
+  it("never probes secrets or collects wifi for an ethernet device", async () => {
+    const { priv, getSecretKeys } = makeDialog([]);
+    priv.open(ethernetDevice());
+    expect(getSecretKeys).not.toHaveBeenCalled();
+    expect(priv._collectWifi).toBe(false);
+  });
+
+  it("stores the typed credentials before importing and fires secrets-saved", async () => {
+    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
+    const savedListener = vi.fn();
+    window.addEventListener("secrets-saved", savedListener);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
+    priv._ssid = "  MyHomeWifi  ";
+    priv._password = "hunter2hunter";
+
+    await priv._submit();
+
+    expect(setWifiCredentials).toHaveBeenCalledWith("MyHomeWifi", "hunter2hunter");
+    expect(setWifiCredentials.mock.invocationCallOrder[0]).toBeLessThan(
+      importDevice.mock.invocationCallOrder[0]
+    );
+    expect(savedListener).toHaveBeenCalled();
+    window.removeEventListener("secrets-saved", savedListener);
+  });
+
+  it("does not store credentials when the shared secret already exists", async () => {
+    const { priv, setWifiCredentials, importDevice } = makeDialog([
+      "wifi_ssid",
+      "wifi_password",
+    ]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._hasWifiSecrets).toBe(true));
+
+    await priv._submit();
+
+    expect(setWifiCredentials).not.toHaveBeenCalled();
     expect(importDevice).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/components/adopt-dialog.test.ts
+++ b/test/components/adopt-dialog.test.ts
@@ -104,6 +104,19 @@ describe("adopt-dialog wifi step (#1742)", () => {
     window.removeEventListener("secrets-saved", savedListener);
   });
 
+  it("_submit re-checks the wifi gate so Enter can't skip the store", async () => {
+    const { priv, setWifiCredentials, importDevice } = makeDialog([]);
+    priv.open(wifiDevice());
+    await vi.waitFor(() => expect(priv._collectWifi).toBe(true));
+    // SSID still empty: the Enter path (calls _submit directly, bypassing
+    // the disabled button) must refuse rather than import an unresolved
+    // !secret or store an empty SSID.
+    await priv._submit();
+
+    expect(setWifiCredentials).not.toHaveBeenCalled();
+    expect(importDevice).not.toHaveBeenCalled();
+  });
+
   it("does not store credentials when the shared secret already exists", async () => {
     const { priv, setWifiCredentials, importDevice } = makeDialog([
       "wifi_ssid",


### PR DESCRIPTION
# What does this implement/fix?

Take Control adoption failed with `Secret 'wifi_ssid' not defined` for users who have no shared `wifi_ssid` / `wifi_password` in `secrets.yaml` (for example, someone running `wifi.networks` with custom secret names). The adopted config references `!secret wifi_ssid`, which resolves to nothing.

This is a regression from #908, which moved Wi-Fi collection out of first-run onboarding into the create wizard but never added an equivalent step to the adopt dialog; the adopt path lost the shared secret it used to rely on. This restores it: when the discovered device is on Wi-Fi (`network === "wifi"`) and no shared secret exists yet, the adopt dialog shows the shared `wifi-fields`, stores the entered credentials via `config/set_wifi_credentials`, and fires `secrets-saved` before importing. It mirrors the create wizard and the legacy dashboard's adopt dialog. A device with its own network, or an install that already has the shared secret, is unaffected and skips the step.

No backend change; it reuses the existing `config/set_wifi_credentials` command.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1742

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
