### PR TITLE
Consume the auto-closed brace when accepting a substitution completion

### DIFF
--- a/src/util/yaml-completion.ts
+++ b/src/util/yaml-completion.ts
@@ -147,8 +147,14 @@ export function createYamlCompletionSource(
       if (subRefMatch) {
         const subs = collectSubstitutionKeys(state);
         if (subs.length > 0) {
+          // closeBrackets (basicSetup) auto-inserts a matching ``}`` when
+          // the user types ``{``, so the buffer is already ``${<cursor>}``.
+          // Extend the replaced range over that brace so accepting an option
+          // doesn't leave a doubled ``}``.
+          const closeBrace = state.sliceDoc(pos, pos + 1) === "}" ? 1 : 0;
           return {
             from: valueFrom,
+            to: pos + closeBrace,
             options: subs.map((name) => ({
               label: `\${${name}}`,
               apply: `\${${name}}`,

--- a/test/util/yaml-completion-substitution.test.ts
+++ b/test/util/yaml-completion-substitution.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { CompletionContext } from "@codemirror/autocomplete";
+import { forceParsing } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { esphomeYaml } from "../../src/util/esphome-yaml-lang.js";
+import { createYamlCompletionSource } from "../../src/util/yaml-completion.js";
+
+// The substitution branch returns before the catalog loads, so an empty API
+// is enough.
+const fakeApi = {
+  getComponents: async () => ({ components: [] }),
+  getComponentBodies: async () => ({}),
+  getComponent: async () => null,
+} as never;
+
+async function completeAt(doc: string, pos: number) {
+  const view = new EditorView({
+    state: EditorState.create({ doc, extensions: [esphomeYaml()] }),
+  });
+  try {
+    forceParsing(view, doc.length, 60000);
+    const ctx = new CompletionContext(view.state, pos, false);
+    return await createYamlCompletionSource(fakeApi)(ctx);
+  } finally {
+    view.destroy();
+  }
+}
+
+const HEAD = ["substitutions:", "  name: x", "esphome:", "  name: ${name"].join("\n");
+
+describe("substitution ${} completion", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("swallows the closeBrackets-inserted ``}`` so the value isn't doubled", async () => {
+    // closeBrackets auto-inserts ``}`` when ``{`` is typed: the buffer already
+    // reads ``${name}`` with the cursor before the brace.
+    const doc = `${HEAD}}`;
+    const pos = HEAD.length;
+    const result = await completeAt(doc, pos);
+    expect(result).not.toBeNull();
+    expect(result!.to).toBe(pos + 1);
+    const opt = result!.options[0];
+    expect(opt.apply).toBe("${name}");
+    const applied = doc.slice(0, result!.from) + opt.apply + doc.slice(result!.to!);
+    expect(applied.endsWith("name: ${name}")).toBe(true);
+    expect(applied).not.toContain("}}");
+  });
+
+  it("emits a single ``}`` when no brace follows the cursor", async () => {
+    // No auto-close (paste, bracket-matching off): the completion supplies the
+    // closing brace itself.
+    const doc = HEAD;
+    const pos = HEAD.length;
+    const result = await completeAt(doc, pos);
+    expect(result).not.toBeNull();
+    expect(result!.to).toBe(pos);
+    const opt = result!.options[0];
+    const applied = doc.slice(0, result!.from) + opt.apply + doc.slice(result!.to!);
+    expect(applied.endsWith("name: ${name}")).toBe(true);
+    expect(applied).not.toContain("}}");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

In the YAML config editor, typing `${` after declaring `substitutions:` opens a completion list of substitution names. Accepting one produced `${name}}` — a doubled closing brace — instead of `${name}`.

The completion itself was correct (its `apply` is `${name}`, one brace). The doubling came from CodeMirror's `closeBrackets` extension (pulled in via `basicSetup`): the instant the user types `{`, it auto-inserts a matching `}`, so the buffer already reads `${name}` with the cursor before the brace. The substitution `CompletionResult` was returned with `from` but no `to`, so CodeMirror defaulted `to` to the cursor and replaced only `${name`, leaving the auto-closed `}` behind.

Fix: extend the result's replaced range over a `}` sitting at the cursor (`to: pos + (next char is "}" ? 1 : 0)`), so accepting an option replaces `${name}` rather than inserting alongside the stray brace. When no brace follows (paste, or bracket-matching off) the completion still supplies its own single `}`. Scoped to the substitution completion — `closeBrackets` is unchanged for `[]`/`{}`/quotes elsewhere.

Added `test/util/yaml-completion-substitution.test.ts` pinning both paths (auto-closed brace consumed; lone completion still emits one brace).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1761

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
