### PR TITLE
Hide out-of-sync indicators until mDNS is the live source

### DIFF
--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -98,6 +98,12 @@ export interface ConfiguredDevice {
   active_source?: ReachabilitySource;
   /** True until successfully compiled + deployed */
   has_pending_changes: boolean;
+  /** True when ``has_pending_changes`` came from the mDNS-sourced
+   *  config-hash compare (vs the local mtime fallback). The UI gates
+   *  only this case on a live mDNS, so a local YAML edit still cues
+   *  "install" when mDNS is dark. Optional / absent reads as a local
+   *  (non-mDNS-dependent) pending. */
+  pending_changes_via_hash?: boolean;
   /** True if compiled with older ESPHome version */
   update_available: boolean;
   /**

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -3,6 +3,10 @@
  *
  * Part of the src/api/types.ts barrel split.
  */
+// Type-only: ``reachability.ts`` imports ``DeviceState`` from here, so a
+// value import would cycle. ``ReachabilitySource`` is a string-literal union,
+// erased at runtime, so the type-only edge is free.
+import type { ReachabilitySource } from "./reachability.js";
 
 // ─── Devices ─────────────────────────────────────────────────
 
@@ -84,6 +88,14 @@ export interface ConfiguredDevice {
    * mtime-based change detection.
    */
   deployed_config_hash: string;
+  /** Reachability channel currently driving the device's online state
+   *  (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config
+   *  hash come only from the mDNS broadcast, so the out-of-sync /
+   *  update indicators are gated on ``active_source === "mdns"`` (see
+   *  ``src/util/device-sync.ts``): when mDNS is dark those values are
+   *  stale. Optional on the wire — absent / ``"unknown"`` means no
+   *  source has claimed the device yet, which reads as "not mDNS". */
+  active_source?: ReachabilitySource;
   /** True until successfully compiled + deployed */
   has_pending_changes: boolean;
   /** True if compiled with older ESPHome version */

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -44,6 +44,7 @@ import {
   localizeContext,
 } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -158,8 +159,8 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const d = this.device;
     if (!d) return nothing;
 
-    const hasPendingChanges = d.has_pending_changes === true;
-    const hasUpdateAvailable = d.update_available;
+    const hasPendingChanges = devicePendingChanges(d);
+    const hasUpdateAvailable = deviceUpdateAvailable(d);
     // Four-state encryption indicator. "none" = no Native API surface — no badge.
     const encState = getEncryptionState(d);
     const apiEnabled = encState !== "none";

--- a/src/components/dashboard/device-drawer-content.ts
+++ b/src/components/dashboard/device-drawer-content.ts
@@ -44,7 +44,7 @@ import {
   localizeContext,
 } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { getEncryptionState } from "../../util/encryption-state.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -159,23 +159,23 @@ export class ESPHomeDeviceDrawerContent extends LitElement {
     const d = this.device;
     if (!d) return nothing;
 
-    const hasPendingChanges = devicePendingChanges(d);
-    const hasUpdateAvailable = deviceUpdateAvailable(d);
+    const showModified = showPendingChanges(d);
+    const showUpdate = showUpdateAvailable(d);
     // Four-state encryption indicator. "none" = no Native API surface — no badge.
     const encState = getEncryptionState(d);
     const apiEnabled = encState !== "none";
-    const showAnyBadge = hasPendingChanges || hasUpdateAvailable || apiEnabled;
+    const showAnyBadge = showModified || showUpdate || apiEnabled;
 
     return html`
       ${showAnyBadge
         ? html`<div class="status-badges">
-            ${hasPendingChanges
+            ${showModified
               ? html`<span class="status-badge status-badge--modified">
                   <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
                   ${this._localize("dashboard.status_modified")}
                 </span>`
               : nothing}
-            ${hasUpdateAvailable
+            ${showUpdate
               ? html`<span class="status-badge status-badge--update">
                   <wa-icon library="mdi" name="update"></wa-icon>
                   ${this._localize("dashboard.status_update_available")}

--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfiguredDevice } from "../../../api/types/devices.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { mdnsOnline } from "../../../util/device-sync.js";
 import {
   getEncryptionVisual,
   type EncryptionState,
@@ -131,7 +132,10 @@ export function renderVersionSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const local = d.current_version || "";
-  const deployed = d.deployed_version || "";
+  // The deployed version comes only from mDNS; when mDNS is dark it's stale, so
+  // treat it as unknown and let the existing empty-deployed path show
+  // "waiting for mDNS" instead of a false "out of sync".
+  const deployed = mdnsOnline(d) ? d.deployed_version || "" : "";
   if (!local && !deployed) return nothing;
   const matches = !!local && !!deployed && local === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";
@@ -179,7 +183,8 @@ export function renderConfigHashSection(
   localize: LocalizeFunc
 ): TemplateResult | typeof nothing {
   const expected = d.expected_config_hash || "";
-  const deployed = d.deployed_config_hash || "";
+  // mDNS-sourced; treat as unknown when mDNS is dark (see renderVersionSection).
+  const deployed = mdnsOnline(d) ? d.deployed_config_hash || "" : "";
   if (!expected && !deployed) return nothing;
   const matches = !!expected && !!deployed && expected === deployed;
   const statusIcon = matches ? "check-circle-outline" : "sync";

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -15,7 +15,7 @@ import { DeviceState } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { updateButtonTitle } from "../../util/update-tooltip.js";
@@ -360,7 +360,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
             <wa-icon library="mdi" name="pencil"></wa-icon>
             ${this._localize("dashboard.drawer_edit")}
           </button>
-          ${deviceUpdateAvailable(device)
+          ${showUpdateAvailable(device)
             ? html`<button
                 class="action action--accent"
                 ?disabled=${this.busy}
@@ -375,7 +375,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
                 <wa-icon library="mdi" name="upload"></wa-icon>
                 ${this._localize("dashboard.drawer_update")}
               </button>`
-            : devicePendingChanges(device)
+            : showPendingChanges(device)
               ? html`<button
                   class="action action--accent"
                   ?disabled=${this.busy}

--- a/src/components/dashboard/device-drawer.ts
+++ b/src/components/dashboard/device-drawer.ts
@@ -15,6 +15,7 @@ import { DeviceState } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { updateButtonTitle } from "../../util/update-tooltip.js";
@@ -359,7 +360,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
             <wa-icon library="mdi" name="pencil"></wa-icon>
             ${this._localize("dashboard.drawer_edit")}
           </button>
-          ${device.update_available
+          ${deviceUpdateAvailable(device)
             ? html`<button
                 class="action action--accent"
                 ?disabled=${this.busy}
@@ -374,7 +375,7 @@ export class ESPHomeDeviceDrawer extends LitElement {
                 <wa-icon library="mdi" name="upload"></wa-icon>
                 ${this._localize("dashboard.drawer_update")}
               </button>`
-            : device.has_pending_changes === true
+            : devicePendingChanges(device)
               ? html`<button
                   class="action action--accent"
                   ?disabled=${this.busy}

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -38,7 +38,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { matchesDeviceRow } from "../../util/device-search.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderDeviceTableBody, renderDeviceTableHead } from "./device-table-grid.js";
@@ -282,8 +282,9 @@ export class ESPHomeDeviceTable extends LitElement {
         // than opaque ids.
         labels: resolveLabelIds(d.labels, this._labelCatalog),
         config: d.configuration,
-        hasPendingChanges: devicePendingChanges(d),
-        hasUpdateAvailable: deviceUpdateAvailable(d),
+        hasPendingChanges: d.has_pending_changes === true,
+        showModified: showPendingChanges(d),
+        showUpdate: showUpdateAvailable(d),
         api_enabled: d.api_enabled === true,
         api_encrypted: d.api_encrypted === true,
         api_encryption_active: d.api_encryption_active ?? null,

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -38,6 +38,7 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { labelsContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { matchesDeviceRow } from "../../util/device-search.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
 import { labelChipStyles, resolveLabelIds } from "../../util/label-chip-template.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderDeviceTableBody, renderDeviceTableHead } from "./device-table-grid.js";
@@ -281,8 +282,8 @@ export class ESPHomeDeviceTable extends LitElement {
         // than opaque ids.
         labels: resolveLabelIds(d.labels, this._labelCatalog),
         config: d.configuration,
-        hasPendingChanges: d.has_pending_changes === true,
-        hasUpdateAvailable: d.update_available,
+        hasPendingChanges: devicePendingChanges(d),
+        hasUpdateAvailable: deviceUpdateAvailable(d),
         api_enabled: d.api_enabled === true,
         api_encrypted: d.api_encrypted === true,
         api_encryption_active: d.api_encryption_active ?? null,

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -3,6 +3,7 @@ import { html, type TemplateResult } from "lit";
 import type { AdoptableDevice, ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import { downloadYaml, editDevice } from "./actions.js";
 import { renderFacets } from "./render-facets.js";
@@ -103,8 +104,8 @@ export function renderCardGrid(
             .configuration=${device.configuration}
             .state=${device.state}
             .labelIds=${device.labels ?? []}
-            ?has-pending-changes=${device.has_pending_changes === true}
-            ?has-update-available=${device.update_available}
+            ?has-pending-changes=${devicePendingChanges(device)}
+            ?has-update-available=${deviceUpdateAvailable(device)}
             .installedVersion=${device.deployed_version}
             .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}

--- a/src/components/dashboard/render-content.ts
+++ b/src/components/dashboard/render-content.ts
@@ -3,7 +3,7 @@ import { html, type TemplateResult } from "lit";
 import type { AdoptableDevice, ConfiguredDevice } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../../util/device-sort.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "../../util/device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "../../util/device-sync.js";
 import { buildWebUiUrl } from "../../util/web-ui-url.js";
 import { downloadYaml, editDevice } from "./actions.js";
 import { renderFacets } from "./render-facets.js";
@@ -104,8 +104,9 @@ export function renderCardGrid(
             .configuration=${device.configuration}
             .state=${device.state}
             .labelIds=${device.labels ?? []}
-            ?has-pending-changes=${devicePendingChanges(device)}
-            ?has-update-available=${deviceUpdateAvailable(device)}
+            ?has-pending-changes=${device.has_pending_changes === true}
+            ?show-modified=${showPendingChanges(device)}
+            ?show-update=${showUpdateAvailable(device)}
             .installedVersion=${device.deployed_version}
             .availableVersion=${device.current_version}
             ?api-enabled=${device.api_enabled === true}

--- a/src/components/dashboard/table-columns.ts
+++ b/src/components/dashboard/table-columns.ts
@@ -32,8 +32,12 @@ export interface DeviceRow {
   labels: Label[];
   config: string;
   build_size_bytes: number;
+  // Raw has_pending_changes (device truth) — drives the encryption lock only.
   hasPendingChanges: boolean;
-  hasUpdateAvailable: boolean;
+  // mDNS-gated display flags (see util/device-sync.ts): modified dot + install
+  // button, update column + update button.
+  showModified: boolean;
+  showUpdate: boolean;
   api_enabled: boolean;
   api_encrypted: boolean;
   api_encryption_active: string | null;
@@ -153,17 +157,20 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
           api_enabled: row.api_enabled,
           api_encrypted: row.api_encrypted,
           api_encryption_active: row.api_encryption_active,
+          // Raw flag, not the mDNS-gated ``showModified``: the encryption
+          // "pending" state is about a local YAML edit not yet flashed, so it
+          // must match the drawer's raw-flag badge (mDNS freshness is irrelevant).
           has_pending_changes: row.hasPendingChanges,
         });
         return html`<span class="cell-name-wrap">
           <span class="cell-name">${row.friendly_name || row.name}</span>
-          ${row.hasPendingChanges
+          ${row.showModified
             ? html`<span
                 class="cell-indicator cell-indicator--modified"
                 title=${localize("dashboard.status_modified")}
               ></span>`
             : nothing}
-          ${row.hasUpdateAvailable
+          ${row.showUpdate
             ? html`<span
                 class="cell-indicator cell-indicator--update"
                 title=${localize("dashboard.status_update_available")}
@@ -291,8 +298,8 @@ export function createDeviceColumns(localize: LocalizeFunc): ColumnDef<DeviceRow
            available newer ESPHome version is the more pressing nudge,
            and OTA-update will pick up any pending YAML changes as a
            free side-effect. Mirrors the legacy dashboard. */
-        const showUpdate = row.hasUpdateAvailable;
-        const showInstall = !showUpdate && row.hasPendingChanges;
+        const showUpdate = row.showUpdate;
+        const showInstall = !showUpdate && row.showModified;
         const visitUrl = buildWebUiUrl(device);
         const showVisit = visitUrl !== "";
         // Priority order (highest → lowest, last to drop on narrow

--- a/src/components/device-card.ts
+++ b/src/components/device-card.ts
@@ -76,10 +76,15 @@ export class ESPHomeDeviceCard extends LitElement {
   @property({ attribute: false }) name = "";
   @property() configuration = "";
   @property() state: DeviceState = DeviceState.UNKNOWN;
+  // Raw device truth (``has_pending_changes``). Drives the 4-state encryption
+  // lock indicator only — a local YAML edit not yet flashed, independent of
+  // mDNS — so it stays in sync with the drawer's raw-flag badge.
   @property({ type: Boolean, attribute: "has-pending-changes" }) hasPendingChanges =
     false;
-  @property({ type: Boolean, attribute: "has-update-available" }) hasUpdateAvailable =
-    false;
+  // mDNS-gated display flags (see util/device-sync.ts): whether to surface the
+  // modified / update affordances (dot + install / update button).
+  @property({ type: Boolean, attribute: "show-modified" }) showModified = false;
+  @property({ type: Boolean, attribute: "show-update" }) showUpdate = false;
 
   // Installed + target ESPHome versions for the Update hover.
   @property({ attribute: false }) installedVersion = "";
@@ -87,8 +92,8 @@ export class ESPHomeDeviceCard extends LitElement {
   @property({ type: Boolean, attribute: "api-enabled" }) apiEnabled = false;
   @property({ type: Boolean, attribute: "api-encrypted" }) apiEncrypted = false;
 
-  // api_encryption TXT observed via mDNS. Combined with apiEncrypted and
-  // hasPendingChanges to drive the 4-state lock indicator.
+  // api_encryption TXT observed via mDNS. Combined with apiEncrypted and the
+  // raw hasPendingChanges to drive the 4-state lock indicator.
   @property({ attribute: false }) apiEncryptionActive: string | null = null;
 
   @property({ type: Boolean }) busy = false;
@@ -177,13 +182,13 @@ export class ESPHomeDeviceCard extends LitElement {
           <div class="device-card-header-left">
             <div class="device-name-wrap">
               <h3 class="device-name">${this.name}</h3>
-              ${this.hasPendingChanges
+              ${this.showModified
                 ? html`<span
                     class="indicator-dot indicator-dot--modified"
                     title=${this._localize("dashboard.status_modified")}
                   ></span>`
                 : nothing}
-              ${this.hasUpdateAvailable
+              ${this.showUpdate
                 ? html`<span
                     class="indicator-dot indicator-dot--update"
                     title=${this._localize("dashboard.status_update_available")}
@@ -240,7 +245,7 @@ export class ESPHomeDeviceCard extends LitElement {
   // Long-language locales (French / Dutch) overflow a 300px-min card if
   // every action is labelled; upload icon reads clearly without one.
   private _renderAccentAction() {
-    if (this.hasUpdateAvailable) {
+    if (this.showUpdate) {
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
         ?disabled=${this.busy}
@@ -256,7 +261,7 @@ export class ESPHomeDeviceCard extends LitElement {
         <wa-icon library="mdi" name="upload"></wa-icon>
       </button>`;
     }
-    if (this.hasPendingChanges) {
+    if (this.showModified) {
       return html`<button
         class="action-btn action-btn--accent action-btn--tile"
         ?disabled=${this.busy}

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -157,10 +157,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   saving = false;
 
   @property({ type: Boolean })
-  hasPendingChanges = false;
+  showModified = false;
 
   @property({ type: Boolean })
-  hasUpdateAvailable = false;
+  showUpdate = false;
 
   // Installed + target ESPHome versions for the Update button hover.
   @property()
@@ -414,8 +414,8 @@ export class ESPHomeDeviceEditor extends LitElement {
   private _renderPrimaryAction() {
     return renderInstallAction({
       localize: this._localize,
-      hasUpdateAvailable: this.hasUpdateAvailable,
-      hasPendingChanges: this.hasPendingChanges,
+      showUpdate: this.showUpdate,
+      showModified: this.showModified,
       busy: this.busy,
       installedVersion: this.installedVersion,
       availableVersion: this.availableVersion,

--- a/src/components/device/install-action.ts
+++ b/src/components/device/install-action.ts
@@ -4,8 +4,8 @@ import { updateButtonTitle } from "../../util/update-tooltip.js";
 
 export interface InstallActionProps {
   localize: LocalizeFunc;
-  hasUpdateAvailable: boolean;
-  hasPendingChanges: boolean;
+  showUpdate: boolean;
+  showModified: boolean;
   busy: boolean;
   // Installed + target ESPHome versions for the Update hover (see updateButtonTitle).
   installedVersion: string;
@@ -24,7 +24,7 @@ export interface InstallActionProps {
  * device-editor shadow root, so its `.install-fab` styles apply.
  */
 export function renderInstallAction(p: InstallActionProps): TemplateResult {
-  if (p.hasUpdateAvailable) {
+  if (p.showUpdate) {
     return html`<div class="install-split">
       <button
         type="button"
@@ -55,7 +55,7 @@ export function renderInstallAction(p: InstallActionProps): TemplateResult {
   }
   return html`<button
     type="button"
-    class="install-fab ${p.hasPendingChanges ? "" : "install-fab--muted"}"
+    class="install-fab ${p.showModified ? "" : "install-fab--muted"}"
     ?disabled=${p.busy}
     @click=${p.onInstall}
     title=${p.localize("dashboard.install")}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -30,7 +30,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "../util/device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "../util/device-sync.js";
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
@@ -1025,12 +1025,8 @@ export class ESPHomePageDevice extends LitElement {
             @change-board=${this._onChangeBoard}
             ?hasUnsavedEdits=${this._isDirty}
             ?saving=${this._saving}
-            ?hasPendingChanges=${this._device
-              ? devicePendingChanges(this._device)
-              : false}
-            ?hasUpdateAvailable=${this._device
-              ? deviceUpdateAvailable(this._device)
-              : false}
+            ?showModified=${this._device ? showPendingChanges(this._device) : false}
+            ?showUpdate=${this._device ? showUpdateAvailable(this._device) : false}
             .installedVersion=${this._device?.deployed_version ?? ""}
             .availableVersion=${this._device?.current_version ?? ""}
             ?busy=${this._activeJobs.has(this.id)}

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -30,6 +30,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { withBase } from "../util/base-path.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "../util/device-sync.js";
 import { deviceLayoutToPref, prefToDeviceLayout } from "../util/editor-layout.js";
 import { consumeJustCreated } from "../util/just-created.js";
 import { navigate, setLeaveGuard } from "../util/navigation.js";
@@ -1024,8 +1025,12 @@ export class ESPHomePageDevice extends LitElement {
             @change-board=${this._onChangeBoard}
             ?hasUnsavedEdits=${this._isDirty}
             ?saving=${this._saving}
-            ?hasPendingChanges=${this._device?.has_pending_changes === true}
-            ?hasUpdateAvailable=${this._device?.update_available === true}
+            ?hasPendingChanges=${this._device
+              ? devicePendingChanges(this._device)
+              : false}
+            ?hasUpdateAvailable=${this._device
+              ? deviceUpdateAvailable(this._device)
+              : false}
             .installedVersion=${this._device?.deployed_version ?? ""}
             .availableVersion=${this._device?.current_version ?? ""}
             ?busy=${this._activeJobs.has(this.id)}

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -8,10 +8,17 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 // as out-of-sync once mDNS hears from it again.
 export const mdnsOnline = (d: ConfiguredDevice): boolean => d.active_source === "mdns";
 
-// The "modified" (out-of-sync) and "update available" signals, gated on a live
-// mDNS. Every indicator site derives from these so the rule lives in one place.
+// The "modified" (needs-install) and "update available" signals, gated so a
+// stale mDNS-dark value can't flag a false "out of sync". Every indicator site
+// derives from these so the rule lives in one place.
+//
+// ``update_available`` (device version vs server) is purely mDNS-sourced, so it
+// always needs a live mDNS. ``has_pending_changes`` is only mDNS-dependent when
+// it came from the config-hash compare (``pending_changes_via_hash``); a local
+// mtime-driven edit is trustworthy without mDNS, so it still cues "install".
 export const devicePendingChanges = (d: ConfiguredDevice): boolean =>
-  d.has_pending_changes === true && mdnsOnline(d);
+  d.has_pending_changes === true &&
+  (mdnsOnline(d) || d.pending_changes_via_hash !== true);
 
 export const deviceUpdateAvailable = (d: ConfiguredDevice): boolean =>
   d.update_available === true && mdnsOnline(d);

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -8,17 +8,19 @@ import type { ConfiguredDevice } from "../api/types/devices.js";
 // as out-of-sync once mDNS hears from it again.
 export const mdnsOnline = (d: ConfiguredDevice): boolean => d.active_source === "mdns";
 
-// The "modified" (needs-install) and "update available" signals, gated so a
-// stale mDNS-dark value can't flag a false "out of sync". Every indicator site
+// Whether to SHOW the "modified" (needs-install) and "update available"
+// indicators, gated so a stale mDNS-dark value can't flag a false "out of
+// sync". The raw truth stays on the device fields (``has_pending_changes`` /
+// ``update_available``); these say whether to surface it. Every indicator site
 // derives from these so the rule lives in one place.
 //
 // ``update_available`` (device version vs server) is purely mDNS-sourced, so it
 // always needs a live mDNS. ``has_pending_changes`` is only mDNS-dependent when
 // it came from the config-hash compare (``pending_changes_via_hash``); a local
 // mtime-driven edit is trustworthy without mDNS, so it still cues "install".
-export const devicePendingChanges = (d: ConfiguredDevice): boolean =>
+export const showPendingChanges = (d: ConfiguredDevice): boolean =>
   d.has_pending_changes === true &&
   (mdnsOnline(d) || d.pending_changes_via_hash !== true);
 
-export const deviceUpdateAvailable = (d: ConfiguredDevice): boolean =>
+export const showUpdateAvailable = (d: ConfiguredDevice): boolean =>
   d.update_available === true && mdnsOnline(d);

--- a/src/util/device-sync.ts
+++ b/src/util/device-sync.ts
@@ -1,0 +1,17 @@
+import type { ConfiguredDevice } from "../api/types/devices.js";
+
+// The deployed version / config hash come only from the device's mDNS
+// broadcast, so they are trustworthy only while mDNS is the live source. When
+// mDNS is dark (a ping/MQTT-only "odd setup", e.g. a Docker-bridge dashboard),
+// those values go stale, so we gate the out-of-sync / update indicators on a
+// live mDNS rather than flagging a false "out of sync". The device reappears
+// as out-of-sync once mDNS hears from it again.
+export const mdnsOnline = (d: ConfiguredDevice): boolean => d.active_source === "mdns";
+
+// The "modified" (out-of-sync) and "update available" signals, gated on a live
+// mDNS. Every indicator site derives from these so the rule lives in one place.
+export const devicePendingChanges = (d: ConfiguredDevice): boolean =>
+  d.has_pending_changes === true && mdnsOnline(d);
+
+export const deviceUpdateAvailable = (d: ConfiguredDevice): boolean =>
+  d.update_available === true && mdnsOnline(d);

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -19,6 +19,7 @@
  */
 import { type ConfiguredDevice, DeviceState } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import { devicePendingChanges, deviceUpdateAvailable } from "./device-sync.js";
 
 /** One selectable value inside a facet. */
 export interface FacetOption {
@@ -143,8 +144,8 @@ export const UPDATE_FACET_PREDICATES: Record<
   UpdateBucket,
   (device: ConfiguredDevice) => boolean
 > = {
-  update_available: (d) => d.update_available,
-  modified: (d) => d.has_pending_changes,
+  update_available: (d) => deviceUpdateAvailable(d),
+  modified: (d) => devicePendingChanges(d),
 };
 
 const UPDATE_BUCKET_LABEL_KEY: Record<UpdateBucket, string> = {

--- a/src/util/facets.ts
+++ b/src/util/facets.ts
@@ -19,7 +19,7 @@
  */
 import { type ConfiguredDevice, DeviceState } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
-import { devicePendingChanges, deviceUpdateAvailable } from "./device-sync.js";
+import { showPendingChanges, showUpdateAvailable } from "./device-sync.js";
 
 /** One selectable value inside a facet. */
 export interface FacetOption {
@@ -144,8 +144,8 @@ export const UPDATE_FACET_PREDICATES: Record<
   UpdateBucket,
   (device: ConfiguredDevice) => boolean
 > = {
-  update_available: (d) => deviceUpdateAvailable(d),
-  modified: (d) => devicePendingChanges(d),
+  update_available: (d) => showUpdateAvailable(d),
+  modified: (d) => showPendingChanges(d),
 };
 
 const UPDATE_BUCKET_LABEL_KEY: Record<UpdateBucket, string> = {

--- a/test/_make-configured-device.ts
+++ b/test/_make-configured-device.ts
@@ -39,6 +39,10 @@ const _BASE = {
   deployed_version: "",
   loaded_integrations: [],
   state: DeviceState.UNKNOWN,
+  // Default to a live mDNS source so the happy-path fixture shows its
+  // out-of-sync / update indicators as before; tests covering the mDNS-dark
+  // "hide indicators" behaviour override this to "ping" / "unknown".
+  active_source: "mdns",
   expected_config_hash: "",
   deployed_config_hash: "",
   has_pending_changes: false,

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -86,7 +86,9 @@ describe("renderFacets", () => {
     sectionByName(root, "dashboard.filter_update_status");
 
   it("renders the Updates section when a device needs an update", () => {
-    const host = makeHost({ _devices: [{ update_available: true }] });
+    const host = makeHost({
+      _devices: [{ update_available: true, active_source: "mdns" }],
+    });
     expect(updatesSection(renderInto(host))).not.toBeUndefined();
   });
 
@@ -102,7 +104,7 @@ describe("renderFacets", () => {
 
   it("suppresses the Updates section in YAML-search mode", () => {
     const host = makeHost({
-      _devices: [{ has_pending_changes: true }],
+      _devices: [{ has_pending_changes: true, active_source: "mdns" }],
       _yamlMode: true,
     });
     expect(updatesSection(renderInto(host))).toBeUndefined();

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -48,8 +48,8 @@ function renderActionsCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResul
   }
   const row = {
     busy: false,
-    hasUpdateAvailable: false,
-    hasPendingChanges: false,
+    showUpdate: false,
+    showModified: false,
     _device: { web_port: null },
     ...rowOverrides,
   } as unknown as DeviceRow;
@@ -91,5 +91,47 @@ describe("device table actions", () => {
     const edit = container.querySelector(".cell-action-btn--edit");
     expect(edit).not.toBeNull();
     expect(edit?.classList.contains("cell-action-btn--accent")).toBe(true);
+  });
+});
+
+function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
+  const col = columns.find((c) => "accessorKey" in c && c.accessorKey === "name");
+  if (!col?.cell || typeof col.cell !== "function") {
+    throw new Error("no cell renderer for name column");
+  }
+  const row = {
+    name: "kitchen",
+    friendly_name: "Kitchen",
+    showModified: false,
+    showUpdate: false,
+    hasPendingChanges: false,
+    api_enabled: false,
+    api_encrypted: false,
+    api_encryption_active: null,
+    _device: { web_port: null },
+    ...rowOverrides,
+  } as unknown as DeviceRow;
+  const info = { row: { original: row } } as unknown as CellContext<DeviceRow, unknown>;
+  return col.cell(info) as TemplateResult;
+}
+
+// The encryption lock reads the raw has_pending_changes, the modified dot reads
+// the mDNS-gated flag — so for an mDNS-dark, hash-pending, encrypted device the
+// table agrees with the drawer's raw-flag badge instead of diverging (#1037).
+describe("name-cell encryption indicator uses the raw pending flag", () => {
+  it("shows encryption-pending but hides the modified dot when the gate is off", () => {
+    const container = document.createElement("div");
+    render(
+      renderNameCell({
+        hasPendingChanges: true, // raw: local edit not yet flashed
+        showModified: false, // gated off: mDNS dark + hash-driven pending
+        api_enabled: true,
+        api_encrypted: true,
+        api_encryption_active: null,
+      }),
+      container
+    );
+    expect(container.querySelector(".cell-encryption")).not.toBeNull();
+    expect(container.querySelector(".cell-indicator--modified")).toBeNull();
   });
 });

--- a/test/components/device-card.test.ts
+++ b/test/components/device-card.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The card's encryption lock reads the RAW has_pending_changes, while the
+ * modified dot reads the mDNS-gated showModified — so an mDNS-dark, hash-pending,
+ * encrypted device shows the lock-clock and hides the dot, matching the drawer's
+ * raw-flag badge instead of diverging (#1037).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
+
+import { ESPHomeDeviceCard } from "../../src/components/device-card.js";
+
+async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCard> {
+  const el = new ESPHomeDeviceCard();
+  el.name = "kitchen";
+  el.configuration = "kitchen.yaml";
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("device-card encryption indicator uses the raw pending flag", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows encryption-pending but hides the modified dot when the gate is off", async () => {
+    const el = await mount({
+      hasPendingChanges: true, // raw: local edit not yet flashed
+      showModified: false, // gated off: mDNS dark + hash-driven pending
+      apiEnabled: true,
+      apiEncrypted: true,
+      apiEncryptionActive: null,
+    });
+    expect(el.shadowRoot!.querySelector(".encryption-icon.pending")).not.toBeNull();
+    expect(el.shadowRoot!.querySelector(".indicator-dot--modified")).toBeNull();
+  });
+});

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -36,7 +36,7 @@ describe("device-editor footer install action", () => {
   });
 
   it("renders a split button (Update + picker caret) when an update is available", async () => {
-    const el = await mount({ hasUpdateAvailable: true });
+    const el = await mount({ showUpdate: true });
     const update = vi.fn();
     const install = vi.fn();
     el.addEventListener("update-device", update);
@@ -58,7 +58,7 @@ describe("device-editor footer install action", () => {
     // versions threaded through to the title (the helper's branch logic and
     // fallback are unit-tested in update-tooltip.test.ts).
     const el = await mount({
-      hasUpdateAvailable: true,
+      showUpdate: true,
       installedVersion: "2024.6.0",
       availableVersion: "2024.12.0",
     });
@@ -68,7 +68,7 @@ describe("device-editor footer install action", () => {
   });
 
   it("renders a highlighted plain Install (-> picker) when there are pending changes", async () => {
-    const el = await mount({ hasPendingChanges: true });
+    const el = await mount({ showModified: true });
     const install = vi.fn();
     el.addEventListener("install-device", install);
     expect(q(el, ".install-split")).toBeNull();
@@ -79,7 +79,7 @@ describe("device-editor footer install action", () => {
   });
 
   it("shows a muted-but-usable Install when the config is in sync", async () => {
-    const el = await mount({ hasUpdateAvailable: false, hasPendingChanges: false });
+    const el = await mount({ showUpdate: false, showModified: false });
     const install = vi.fn();
     el.addEventListener("install-device", install);
     const btn = q(el, ".install-fab");

--- a/test/util/device-filter.test.ts
+++ b/test/util/device-filter.test.ts
@@ -28,6 +28,9 @@ function device(over: Partial<ConfiguredDevice> = {}): ConfiguredDevice {
     mac_address: "",
     labels: [],
     area: "",
+    // Live mDNS by default so update/modified filters match; mDNS-dark cases
+    // override active_source.
+    active_source: "mdns",
     update_available: false,
     has_pending_changes: false,
     ...over,

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  devicePendingChanges,
+  deviceUpdateAvailable,
+  mdnsOnline,
+} from "../../src/util/device-sync.js";
+import { makeConfiguredDevice } from "../_make-configured-device.js";
+
+describe("device-sync mDNS gating", () => {
+  it("is mDNS-online only when the live source is mDNS", () => {
+    expect(mdnsOnline(makeConfiguredDevice({ active_source: "mdns" }))).toBe(true);
+    for (const s of ["ping", "mqtt", "unknown"] as const) {
+      expect(mdnsOnline(makeConfiguredDevice({ active_source: s }))).toBe(false);
+    }
+    // Absent on the wire (older / unclaimed) reads as not mDNS.
+    expect(mdnsOnline(makeConfiguredDevice({ active_source: undefined }))).toBe(false);
+  });
+
+  it("hides the modified / update signals while mDNS is dark", () => {
+    const dark = makeConfiguredDevice({
+      active_source: "ping",
+      has_pending_changes: true,
+      update_available: true,
+    });
+    expect(devicePendingChanges(dark)).toBe(false);
+    expect(deviceUpdateAvailable(dark)).toBe(false);
+  });
+
+  it("shows the modified / update signals once mDNS is the live source", () => {
+    const live = makeConfiguredDevice({
+      active_source: "mdns",
+      has_pending_changes: true,
+      update_available: true,
+    });
+    expect(devicePendingChanges(live)).toBe(true);
+    expect(deviceUpdateAvailable(live)).toBe(true);
+  });
+});

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  devicePendingChanges,
-  deviceUpdateAvailable,
   mdnsOnline,
+  showPendingChanges,
+  showUpdateAvailable,
 } from "../../src/util/device-sync.js";
 import { makeConfiguredDevice } from "../_make-configured-device.js";
 
@@ -24,8 +24,8 @@ describe("device-sync mDNS gating", () => {
       pending_changes_via_hash: true,
       update_available: true,
     });
-    expect(devicePendingChanges(dark)).toBe(false);
-    expect(deviceUpdateAvailable(dark)).toBe(false);
+    expect(showPendingChanges(dark)).toBe(false);
+    expect(showUpdateAvailable(dark)).toBe(false);
   });
 
   it("keeps a local mtime-driven modified cue while mDNS is dark", () => {
@@ -37,8 +37,8 @@ describe("device-sync mDNS gating", () => {
       has_pending_changes: true,
       update_available: true,
     });
-    expect(devicePendingChanges(dark)).toBe(true);
-    expect(deviceUpdateAvailable(dark)).toBe(false);
+    expect(showPendingChanges(dark)).toBe(true);
+    expect(showUpdateAvailable(dark)).toBe(false);
   });
 
   it("shows the modified / update signals once mDNS is the live source", () => {
@@ -47,7 +47,7 @@ describe("device-sync mDNS gating", () => {
       has_pending_changes: true,
       update_available: true,
     });
-    expect(devicePendingChanges(live)).toBe(true);
-    expect(deviceUpdateAvailable(live)).toBe(true);
+    expect(showPendingChanges(live)).toBe(true);
+    expect(showUpdateAvailable(live)).toBe(true);
   });
 });

--- a/test/util/device-sync.test.ts
+++ b/test/util/device-sync.test.ts
@@ -17,13 +17,27 @@ describe("device-sync mDNS gating", () => {
     expect(mdnsOnline(makeConfiguredDevice({ active_source: undefined }))).toBe(false);
   });
 
-  it("hides the modified / update signals while mDNS is dark", () => {
+  it("hides the hash-driven modified / update signals while mDNS is dark", () => {
+    const dark = makeConfiguredDevice({
+      active_source: "ping",
+      has_pending_changes: true,
+      pending_changes_via_hash: true,
+      update_available: true,
+    });
+    expect(devicePendingChanges(dark)).toBe(false);
+    expect(deviceUpdateAvailable(dark)).toBe(false);
+  });
+
+  it("keeps a local mtime-driven modified cue while mDNS is dark", () => {
+    // pending_changes_via_hash absent / false ⇒ a local YAML edit, trustworthy
+    // without mDNS, so the needs-install cue stays. update_available is still
+    // mDNS-sourced, so it stays hidden.
     const dark = makeConfiguredDevice({
       active_source: "ping",
       has_pending_changes: true,
       update_available: true,
     });
-    expect(devicePendingChanges(dark)).toBe(false);
+    expect(devicePendingChanges(dark)).toBe(true);
     expect(deviceUpdateAvailable(dark)).toBe(false);
   });
 

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -11,7 +11,7 @@ import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated on
-// active_source via deviceUpdateAvailable / devicePendingChanges.
+// active_source via showUpdateAvailable / showPendingChanges.
 function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
   // Default to a live mDNS source so update/modified buckets surface; the
   // mDNS-dark cases pass active_source explicitly.

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -10,7 +10,8 @@ import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
 
-// computeUpdateFacet only reads update_available / has_pending_changes.
+// computeUpdateFacet reads update_available / has_pending_changes, gated on
+// active_source via deviceUpdateAvailable / devicePendingChanges.
 function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
   // Default to a live mDNS source so update/modified buckets surface; the
   // mDNS-dark cases pass active_source explicitly.

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -12,7 +12,9 @@ import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facet
 
 // computeUpdateFacet only reads update_available / has_pending_changes.
 function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
-  return over as ConfiguredDevice;
+  // Default to a live mDNS source so update/modified buckets surface; the
+  // mDNS-dark cases pass active_source explicitly.
+  return { active_source: "mdns", ...over } as ConfiguredDevice;
 }
 
 // Echo the key so assertions key off the i18n id, not display copy.


### PR DESCRIPTION
# What does this implement/fix?

Hides the out-of-sync / update indicators until mDNS is the device's live source, so an mDNS-dark setup stops showing a false "Out of sync".

The deployed version and config hash come only from the device's mDNS broadcast. When mDNS is dark (a ping or MQTT only setup, e.g. a standalone Docker-bridge dashboard), those values go stale, so the dashboard flags a device as out of sync even though it is running the right firmware; an out-of-band CLI OTA is the reported trigger. We gracefully degrade instead of probing live devices.

Adds a single `mdnsOnline` helper (`src/util/device-sync.ts`) keyed on the new backend `active_source` field, and routes every modified / update indicator through it: the table dots and buttons, the card dots and buttons, the drawer badges, the drawer version and config-hash sections (which fall back to the existing "waiting for mDNS" empty state), the update-status facets and the update-all dialog, and the device editor install button.

The gate is precise, not blanket. `update_available` (device version vs server) is purely mDNS-sourced, so it always needs a live mDNS. `has_pending_changes` is gated only when it came from the config-hash compare (the backend's `pending_changes_via_hash`); a local mtime-driven YAML edit is trustworthy without mDNS, so it still cues install when mDNS is dark. A normal mDNS deployment is unchanged; an mDNS-dark or offline device hides only the stale mDNS-sourced indicators, and they reappear once mDNS hears from it again.

Needs the companion backend PR that adds `active_source` and `pending_changes_via_hash` to the device snapshot.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1758
- Companion backend PR: esphome/device-builder#1764 (adds `active_source`)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
