### PR TITLE
Keep board-reserved pins selectable for their own component

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -40,9 +40,12 @@ interface PinOptionView {
    *  on an output field. A missing capability is NOT warned (a board manifest
    *  that doesn't tag the feature isn't proof the pin lacks it). */
   warn: boolean;
-  /** Board-unavailable (occupied / tied to flash) — disabled + grouped under
-   *  "Reserved". */
+  /** Board-unavailable (occupied / tied to flash) — grouped under "Reserved". */
   reserved: boolean;
+  /** Non-selectable. A reserved pin is disabled *except* when it's locked to the
+   *  component being edited (ethernet RMII pins under ``ethernet:``), where it's
+   *  still grouped under "Reserved" but stays pickable so its value renders. */
+  disabled: boolean;
   /** Positively carries the field's required features and has no direction
    *  conflict — grouped under "Supports …". */
   supported: boolean;
@@ -66,10 +69,28 @@ function gpioFromAlias(rawValue: unknown, pins: BoardPin[]): number | null {
   return match ? match.gpio : null;
 }
 
+/** GPIOs the board reserves for the component currently being edited. A board
+ *  marks its onboard-function pins ``available: false`` (ethernet RMII, SPI
+ *  flash, …); only the ones locked to *this* section's component
+ *  (``featured_components[].locked_pins`` keyed by ``component_id``) should stay
+ *  selectable here — flash/PSRAM pins, and ethernet pins under a sensor field,
+ *  remain disabled. */
+function lockedGpiosForSection(ctx: RenderCtx): Set<number> {
+  const gpios = new Set<number>();
+  for (const fc of ctx.board?.featured_components ?? []) {
+    if (fc.component_id !== ctx.sectionKey) continue;
+    for (const pin of Object.values(fc.locked_pins ?? {})) {
+      if (typeof pin === "number") gpios.add(pin);
+    }
+  }
+  return gpios;
+}
+
 function buildPinOption(
   pin: BoardPin,
   entry: ConfigEntry,
   usedPins: Map<number | string, string>,
+  ownLockedGpios: Set<number>,
   ctx: RenderCtx
 ): PinOptionView {
   const optValue = formatPinValue(pin.gpio, ctx.board?.esphome.platform);
@@ -83,6 +104,10 @@ function buildPinOption(
     pin.features.includes(f)
   );
   const reserved = pin.available === false;
+  // A reserved pin locked to the component being edited stays selectable — the
+  // ethernet RMII pins are reserved precisely *for* ethernet, so the user must
+  // be able to keep/re-pick them while editing ``ethernet:``.
+  const disabled = reserved && !ownLockedGpios.has(pin.gpio);
   const inUse = !!(occupiedBy || usedBy);
 
   const inUseText = occupiedBy
@@ -107,6 +132,7 @@ function buildPinOption(
     titleText: [inUseText, conflictText, baseSupporting].filter(Boolean).join(" — "),
     warn: inUse || inputOnlyConflict,
     reserved,
+    disabled,
     supported: hasAllFeatures && !inputOnlyConflict,
   };
 }
@@ -121,6 +147,7 @@ function renderPinOptions(
   pins: BoardPin[],
   entry: ConfigEntry,
   usedPins: Map<number | string, string>,
+  ownLockedGpios: Set<number>,
   value: string,
   ctx: RenderCtx
 ): TemplateResult {
@@ -128,7 +155,7 @@ function renderPinOptions(
   const other: PinOptionView[] = [];
   const reserved: PinOptionView[] = [];
   for (const pin of pins) {
-    const view = buildPinOption(pin, entry, usedPins, ctx);
+    const view = buildPinOption(pin, entry, usedPins, ownLockedGpios, ctx);
     (view.reserved ? reserved : view.supported ? supported : other).push(view);
   }
   // Only contrast supported-vs-other when both groups are non-empty; otherwise
@@ -165,7 +192,7 @@ function renderPinOption(v: PinOptionView, value: string): TemplateResult {
     value=${v.optValue}
     .label=${v.primary}
     ?selected=${v.optValue === value}
-    ?disabled=${v.reserved}
+    ?disabled=${v.disabled}
     title=${v.titleText}
   >
     <span class="pin-option-stack">
@@ -293,6 +320,7 @@ export function renderPinField(
     ctx.fromLine,
     sectionEndLine(ctx.yaml, ctx.fromLine)
   );
+  const ownLockedGpios = lockedGpiosForSection(ctx);
   const fieldDisabled = effectiveDisabled(entry, ctx);
   const isLongForm = isPlainObject(rawValue);
 
@@ -322,7 +350,7 @@ export function renderPinField(
         ?disabled=${fieldDisabled}
         @change=${onPinChange}
       >
-        ${renderPinOptions(visible, entry, usedPins, value, ctx)}
+        ${renderPinOptions(visible, entry, usedPins, ownLockedGpios, value, ctx)}
       </wa-select>
       ${renderFieldError(path, ctx)}
       ${renderPinAdvanced(entry, path, ctx, rawValue, isLongForm, fieldDisabled)}

--- a/test/components/device/config-entry-pin-renderer.test.ts
+++ b/test/components/device/config-entry-pin-renderer.test.ts
@@ -353,6 +353,78 @@ describe("renderPinField ESP8266 named aliases", () => {
   });
 });
 
+describe("renderPinField reserved pins locked to the edited component", () => {
+  // A board reserves its onboard-function pins with ``available: false``
+  // (ethernet RMII at GPIO0, SPI flash at GPIO6). ``featured_components``
+  // locks the ethernet pins to ``component_id: "ethernet"``; only those
+  // stay selectable while editing ``ethernet:``.
+  const ethBoard = () =>
+    makeTestBoard({
+      pins: [
+        makeBoardPin(0, { available: false, occupied_by: "Ethernet CLK" }),
+        makeBoardPin(6, { available: false, occupied_by: "SPI Flash" }),
+        makeBoardPin(2),
+      ],
+      overrides: {
+        featured_components: [
+          {
+            id: "ethernet",
+            component_id: "ethernet",
+            name: null,
+            description: null,
+            fields: {},
+            locked_pins: { "clk.pin": 0 },
+          },
+        ],
+      } as never,
+    });
+
+  const optionFor = (result: unknown, value: string) =>
+    findElementBindings(result, "wa-option").find((o) => o.value === value);
+
+  it("renders a locked reserved pin selectable and selected for its own component", () => {
+    const ctx = makeRenderCtx(
+      { clk: { pin: "GPIO0" } },
+      { board: ethBoard(), overrides: { sectionKey: "ethernet" } }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin" }),
+      ["clk", "pin"],
+      ctx
+    );
+    const option = optionFor(result, "GPIO0");
+    expect(option?.["?selected"]).toBe(true);
+    expect(option?.["?disabled"]).toBe(false);
+  });
+
+  it("keeps the same pin disabled when editing a different component", () => {
+    const ctx = makeRenderCtx(
+      {},
+      { board: ethBoard(), overrides: { sectionKey: "sensor.template" } }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin" }),
+      ["pin"],
+      ctx
+    );
+    expect(optionFor(result, "GPIO0")?.["?disabled"]).toBe(true);
+  });
+
+  it("keeps a non-locked reserved pin disabled even for its own component", () => {
+    const ctx = makeRenderCtx(
+      {},
+      { board: ethBoard(), overrides: { sectionKey: "ethernet" } }
+    );
+    const result = renderPinField(
+      makeEntry(ConfigEntryType.PIN, { key: "pin" }),
+      ["pin"],
+      ctx
+    );
+    // GPIO6 (flash) isn't in ethernet's locked_pins — stays disabled.
+    expect(optionFor(result, "GPIO6")?.["?disabled"]).toBe(true);
+  });
+});
+
 describe("renderPinField wa-select binding", () => {
   // The form's ``_syncSelectValues`` clears ``wa-select.value`` to
   // ``""`` for any non-primitive value (transient autocompletion


### PR DESCRIPTION
# What does this implement/fix?

Pins a board reserves for an onboard function (ethernet RMII, SPI flash) are
marked `available: false` and rendered `disabled`, so a `wa-select` cannot
display or re-pick them; opening an OLIMEX ESP32-PoE-ISO WROVER ethernet device
blanked the clk Pin field and blocked re-selecting the RMII pins after changing
one. This drops the `disabled` attribute for a reserved pin locked to the
component being edited (`featured_components` `locked_pins` keyed by
`component_id`), keeping it grouped under Reserved with its note; flash/PSRAM,
and ethernet pins under a sensor field, stay disabled. Needs the companion
backend PR that completes `locked_pins` with the nested ethernet `clk.pin`.

**Related issue or feature (if applicable):**

- Companion backend PR: esphome/device-builder#1774

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
