### PR TITLE
Spin the Finish setup button while a device is being created

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -288,6 +288,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
               class="back-button"
               title=${this._localize("layout.back")}
               aria-label=${this._localize("layout.back")}
+              ?disabled=${this._submitting}
               @click=${this._onBack}
             >
               <wa-icon library="mdi" name="arrow-left"></wa-icon>
@@ -422,6 +423,10 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   private _onBack() {
+    // A create is in flight (createDevice + the full-setup component adds);
+    // navigating back mid-add would desync the wizard from the device being
+    // written, so ignore every back path while submitting.
+    if (this._submitting) return;
     this._resetCreateErrors();
     switch (this._step) {
       case "board":

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -323,6 +323,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         return html`<esphome-wizard-step-setup
           .board=${this._selectedBoard}
           ?active=${this._open}
+          ?submitting=${this._submitting}
         ></esphome-wizard-step-setup>`;
       case "empty-config":
         return html`<esphome-wizard-step-empty-config

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -393,6 +393,9 @@ export class ESPHomeWizardStepSetup extends LitElement {
   }
 
   private _onBack() {
+    // The disabled attribute blocks the click; guard the handler too so a
+    // create in flight can't be stepped back out from under.
+    if (this.submitting) return;
     if (this._stage === "wifi") {
       this._stage = "name";
       return;

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -71,9 +71,6 @@ export class ESPHomeWizardStepSetup extends LitElement {
   // stages, so the latch idiom the dialogs use doesn't apply).
   private _enter = new EnterController(this, (e) => {
     if (e.repeat) return;
-    // Honor the same in-flight lock the disabled buttons enforce, so the
-    // keyboard path can't re-dispatch finish-setup mid-create.
-    if (this.submitting) return;
     if (this._canAdvance()) this._onNext();
   });
 
@@ -416,6 +413,10 @@ export class ESPHomeWizardStepSetup extends LitElement {
   }
 
   private _onNext() {
+    // Single in-flight lock for every advance/finish path (button click, Enter
+    // key); the disabled buttons block the pointer, this covers the rest so a
+    // create can't be re-dispatched or stepped forward mid-add.
+    if (this.submitting) return;
     if (this._stage === "name") {
       if (this._collectWifi) {
         this._stage = "wifi";

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -243,7 +243,10 @@ export class ESPHomeWizardStepSetup extends LitElement {
         background: var(--esphome-primary-hover);
       }
 
-      .btn-primary:disabled {
+      /* Both variants set an explicit background, which overrides the UA
+         disabled greying, so a disabled button would otherwise look active;
+         dim it here (Back and Finish setup are both disabled mid-create). */
+      .btn:disabled {
         opacity: 0.5;
         cursor: not-allowed;
       }

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -71,6 +71,9 @@ export class ESPHomeWizardStepSetup extends LitElement {
   // stages, so the latch idiom the dialogs use doesn't apply).
   private _enter = new EnterController(this, (e) => {
     if (e.repeat) return;
+    // Honor the same in-flight lock the disabled buttons enforce, so the
+    // keyboard path can't re-dispatch finish-setup mid-create.
+    if (this.submitting) return;
     if (this._canAdvance()) this._onNext();
   });
 

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { LitElement, css, html, type PropertyValues } from "lit";
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
@@ -15,6 +15,7 @@ import { wifiFieldsStyles } from "../onboarding/wifi-fields-styles.js";
 import { isWifiPasswordTooShort, renderWifiFields } from "../onboarding/wifi-fields.js";
 
 import "@home-assistant/webawesome/dist/components/checkbox/checkbox.js";
+import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
 
 @customElement("esphome-wizard-step-setup")
 export class ESPHomeWizardStepSetup extends LitElement {
@@ -31,6 +32,10 @@ export class ESPHomeWizardStepSetup extends LitElement {
   // Set by the parent dialog; the step stays mounted while the dialog is
   // hidden, so the Enter listener follows this rather than connectedCallback.
   @property({ type: Boolean }) active = false;
+
+  // Set by the parent dialog while createDevice is in flight; a big board
+  // (128-relay full setup) takes seconds, so the button must show progress.
+  @property({ type: Boolean }) submitting = false;
 
   @state()
   private _stage: "name" | "wifi" = "name";
@@ -242,6 +247,19 @@ export class ESPHomeWizardStepSetup extends LitElement {
         opacity: 0.5;
         cursor: not-allowed;
       }
+
+      /* Pin the spinner to a 1em square (box-sizing + flex:none) so it can't
+         reflow the button, and tint it to currentColor; same treatment as the
+         editor Save button (device-editor.styles.ts). */
+      .btn wa-spinner {
+        box-sizing: border-box;
+        flex: none;
+        width: 1em;
+        height: 1em;
+        --track-width: 2px;
+        --indicator-color: currentColor;
+        --track-color: color-mix(in srgb, currentColor 30%, transparent);
+      }
     `,
   ];
 
@@ -282,16 +300,23 @@ export class ESPHomeWizardStepSetup extends LitElement {
       ${this._stage === "name" ? this._renderNameSection() : this._renderWifiSection()}
 
       <div class="actions">
-        <button class="btn btn-secondary" type="button" @click=${this._onBack}>
+        <button
+          class="btn btn-secondary"
+          type="button"
+          ?disabled=${this.submitting}
+          @click=${this._onBack}
+        >
           ${this._localize("wizard.back")}
         </button>
         <div class="actions-right">
           <button
             class="btn btn-primary"
             type="button"
-            ?disabled=${!this._canAdvance()}
+            ?disabled=${!this._canAdvance() || this.submitting}
+            aria-busy=${this.submitting}
             @click=${this._onNext}
           >
+            ${this.submitting ? html`<wa-spinner></wa-spinner>` : nothing}
             ${this._stage === "name" && this._collectWifi
               ? this._localize("wizard.next")
               : this._localize("wizard.finish_setup")}

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -71,6 +71,9 @@ export class ESPHomeWizardStepSetup extends LitElement {
   // stages, so the latch idiom the dialogs use doesn't apply).
   private _enter = new EnterController(this, (e) => {
     if (e.repeat) return;
+    // Match the pointer path: the buttons are disabled while submitting, so the
+    // keyboard must honor the same lock (_onNext is the authoritative backstop).
+    if (this.submitting) return;
     if (this._canAdvance()) this._onNext();
   });
 

--- a/src/components/wizard/wizard-step-setup.ts
+++ b/src/components/wizard/wizard-step-setup.ts
@@ -313,7 +313,7 @@ export class ESPHomeWizardStepSetup extends LitElement {
             class="btn btn-primary"
             type="button"
             ?disabled=${!this._canAdvance() || this.submitting}
-            aria-busy=${this.submitting}
+            aria-busy=${this.submitting || nothing}
             @click=${this._onNext}
           >
             ${this.submitting ? html`<wa-spinner></wa-spinner>` : nothing}

--- a/src/styles/dialog-chrome.ts
+++ b/src/styles/dialog-chrome.ts
@@ -113,7 +113,12 @@ export const primaryHeaderDialogStyles = css`
     opacity: 0.85;
   }
 
-  .back-button:hover {
+  .back-button:hover:not(:disabled) {
     opacity: 1;
+  }
+
+  .back-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 `;

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -156,6 +156,21 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect(createDevice).toHaveBeenCalledTimes(2);
   });
 
+  it("clears submitting and surfaces an error after a failed finish-setup", async () => {
+    // The setup step's spinner follows this flag, so it must clear on failure;
+    // the error is what tells the user the create failed and to retry.
+    const createDevice = vi.fn().mockRejectedValueOnce(new Error("boom"));
+    const el = await mount({ createDevice });
+
+    emitFinish(el, "kitchen");
+    await flush();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._submitting).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._createError).toBeTruthy();
+  });
+
   it("forwards the raw display name so the backend keeps it as friendly_name", async () => {
     // The wizard must NOT slugify here; the backend derives the
     // hostname slug and preserves the descriptive name as

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -156,6 +156,27 @@ describe("create-config-dialog create de-dupe + retry", () => {
     expect(createDevice).toHaveBeenCalledTimes(2);
   });
 
+  it("locks the header back arrow while a create is in flight", async () => {
+    // A never-resolving create keeps _submitting true; going back mid-add would
+    // desync the wizard from the device being written.
+    const createDevice = vi.fn(() => deferred<{ configuration: string }>().promise);
+    const el = await mount({ createDevice });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._step = "setup"; // the step whose header shows the back arrow
+    await el.updateComplete;
+
+    emitFinish(el, "kitchen");
+    await el.updateComplete;
+
+    const back = el.shadowRoot!.querySelector<HTMLButtonElement>(".back-button")!;
+    expect(back.disabled).toBe(true);
+    // The handler is guarded too, so no back path escapes the busy gate.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any)._onBack();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._step).toBe("setup");
+  });
+
   it("clears submitting and surfaces an error after a failed finish-setup", async () => {
     // The setup step's spinner follows this flag, so it must clear on failure;
     // the error is what tells the user the create failed and to retry.

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -260,6 +260,7 @@ describe("wizard-step-setup", () => {
     const primary = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
     const back = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-secondary")!;
     expect(primary.disabled).toBe(false);
+    expect(primary.hasAttribute("aria-busy")).toBe(false);
     expect(el.shadowRoot!.querySelector("wa-spinner")).toBeNull();
 
     el.submitting = true;

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -278,6 +278,17 @@ describe("wizard-step-setup", () => {
     expect(el.shadowRoot!.querySelector("wa-spinner")).toBeNull();
   });
 
+  it("ignores Enter while submitting so the keyboard can't re-dispatch finish", async () => {
+    const el = await mount(noWifiBoard());
+    await setName(el, "kitchen");
+    el.submitting = true;
+    await el.updateComplete;
+    const onFinish = vi.fn();
+    el.addEventListener("finish-setup", onFinish as EventListener);
+    pressEnter();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
   it("finishes without the full setup when the option is unchecked", async () => {
     const el = await mount(fullConfigBoard());
     await setName(el, "kitchen");

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -16,6 +16,7 @@ import { pressEnter } from "../../_press-enter.js";
 // (no ElementInternals); the step only needs its checked/change contract, so
 // render it as a plain unknown element.
 vi.mock("@home-assistant/webawesome/dist/components/checkbox/checkbox.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 // connectedCallback reads the shared (session-cached) secret-keys list to
 // decide whether Wi-Fi is already configured; mock it per-test (no cache bleed).
@@ -251,6 +252,29 @@ describe("wizard-step-setup", () => {
     el.addEventListener("finish-setup", onFinish as EventListener);
     pressEnter();
     expect((onFinish.mock.calls[0][0] as CustomEvent).detail.fullSetup).toBe(false);
+  });
+
+  it("spins and disables both buttons while the parent reports submitting", async () => {
+    const el = await mount(noWifiBoard());
+    await setName(el, "kitchen");
+    const primary = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-primary")!;
+    const back = el.shadowRoot!.querySelector<HTMLButtonElement>(".btn-secondary")!;
+    expect(primary.disabled).toBe(false);
+    expect(el.shadowRoot!.querySelector("wa-spinner")).toBeNull();
+
+    el.submitting = true;
+    await el.updateComplete;
+    expect(primary.disabled).toBe(true);
+    expect(primary.getAttribute("aria-busy")).toBe("true");
+    expect(back.disabled).toBe(true);
+    expect(el.shadowRoot!.querySelector("wa-spinner")).not.toBeNull();
+
+    // The parent clears the flag on success or failure; the spinner goes away
+    // and a valid name is submittable again.
+    el.submitting = false;
+    await el.updateComplete;
+    expect(primary.disabled).toBe(false);
+    expect(el.shadowRoot!.querySelector("wa-spinner")).toBeNull();
   });
 
   it("finishes without the full setup when the option is unchecked", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adding a large board like the KinCony KC868-A128 with all recommended components takes several seconds while the backend generates the config; the Finish setup button gave no feedback during that wait, so it looked hung and people clicked it again. The button now shows a spinner and disables itself (Back too) while the create is in flight, matching the editor Save button. The submitting flag already clears in a finally block, so on failure the spinner clears, the error is shown, and the user can retry.

**Related issue or feature (if applicable):**

- reported for the KinCony KC868-A128; no tracking issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
