### PR TITLE
Name the recommended components that couldn't be auto-added

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -579,7 +579,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     configuration: string,
     board: BoardCatalogEntry
   ): Promise<void> {
-    let skipped = 0;
+    const skipped: string[] = [];
     for (const localId of fullSetupComponentIds(board)) {
       try {
         await this._api.addComponent(configuration, {
@@ -587,16 +587,27 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         });
       } catch (err) {
         console.error(`Full setup: failed to add ${localId} to ${configuration}:`, err);
-        skipped += 1;
+        skipped.push(this._featuredName(board, localId));
       }
     }
-    // A partially-applied device would otherwise look complete; tell the user
-    // some recommended components need finishing in the editor.
-    if (skipped > 0) {
-      toast.warning(this._localize("wizard.full_setup_partial", { count: skipped }), {
-        richColors: true,
-      });
+    // A partially-applied device would otherwise look complete; name which
+    // recommended components need finishing, capped so the toast stays short.
+    if (skipped.length > 0) {
+      const shown = 3;
+      toast.warning(
+        this._localize("wizard.full_setup_partial", {
+          names: skipped.slice(0, shown).join(", "),
+          extra: Math.max(0, skipped.length - shown),
+        }),
+        { richColors: true }
+      );
     }
+  }
+
+  /** Display name for a board's featured local id, falling back to the id. */
+  private _featuredName(board: BoardCatalogEntry, localId: string): string {
+    const featured = board.featured_components.find((c) => c.id === localId);
+    return featured?.name || featured?.component_id || localId;
   }
 
   /** Build a create-flow error message. Falls back to a localised generic

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -596,8 +596,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       const shown = 3;
       toast.warning(
         this._localize("wizard.full_setup_partial", {
-          // count is passed for locales still on the older count-only string
-          // downloaded from Lokalise; the current copy uses names/extra.
+          // count drives the singular/plural wording; names/extra list the
+          // skipped components, capped. Older count-only Lokalise strings
+          // still render off count alone until re-translated.
           count: skipped.length,
           names: skipped.slice(0, shown).join(", "),
           extra: Math.max(0, skipped.length - shown),

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -13,7 +13,7 @@ import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { buildFeaturedId } from "../../util/featured-id.js";
-import { fullSetupComponentIds } from "../../util/full-setup.js";
+import { featuredComponentName, fullSetupComponentIds } from "../../util/full-setup.js";
 import { markJustCreated } from "../../util/just-created.js";
 import { markPendingHighlight } from "../../util/pending-highlight.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -587,7 +587,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         });
       } catch (err) {
         console.error(`Full setup: failed to add ${localId} to ${configuration}:`, err);
-        skipped.push(this._featuredName(board, localId));
+        skipped.push(featuredComponentName(board, localId));
       }
     }
     // A partially-applied device would otherwise look complete; name which
@@ -596,18 +596,15 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       const shown = 3;
       toast.warning(
         this._localize("wizard.full_setup_partial", {
+          // count is passed for locales still on the older count-only string
+          // downloaded from Lokalise; the current copy uses names/extra.
+          count: skipped.length,
           names: skipped.slice(0, shown).join(", "),
           extra: Math.max(0, skipped.length - shown),
         }),
         { richColors: true }
       );
     }
-  }
-
-  /** Display name for a board's featured local id, falling back to the id. */
-  private _featuredName(board: BoardCatalogEntry, localId: string): string {
-    const featured = board.featured_components.find((c) => c.id === localId);
-    return featured?.name || featured?.component_id || localId;
   }
 
   /** Build a create-flow error message. Falls back to a localised generic

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -495,7 +495,7 @@
     "section_name_device_desc": "Naming your project will show up in the ESPHome dashboard. Choose a recognisable, descriptive and memorable name. You can use component names or relevant words. You can edit this after you finish this project.",
     "full_setup": "Set up with all recommended components",
     "full_setup_desc": "Adds this device's onboard components (relays, sensors, and more) so it's ready to use. You can change them afterwards in the editor.",
-    "full_setup_partial": "{count, plural, one {# recommended component couldn't be added automatically} other {# recommended components couldn't be added automatically}}; add them in the editor.",
+    "full_setup_partial": "Couldn't auto-add {names}{extra, plural, =0 {} other { and # more}}; finish in the editor.",
     "wifi_configuration": "Wi-Fi Configuration",
     "wifi_required_desc": "This board connects over Wi-Fi. Enter your network so the device can come online.",
     "other_boards": "Other boards",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -495,7 +495,7 @@
     "section_name_device_desc": "Naming your project will show up in the ESPHome dashboard. Choose a recognisable, descriptive and memorable name. You can use component names or relevant words. You can edit this after you finish this project.",
     "full_setup": "Set up with all recommended components",
     "full_setup_desc": "Adds this device's onboard components (relays, sensors, and more) so it's ready to use. You can change them afterwards in the editor.",
-    "full_setup_partial": "Couldn't auto-add {names}{extra, plural, =0 {} other { and # more}}; finish in the editor.",
+    "full_setup_partial": "{count, plural, one {Couldn't add recommended component {names}} other {Couldn't add recommended components {names}{extra, plural, =0 {} other { and # more}}}}; finish in the editor.",
     "wifi_configuration": "Wi-Fi Configuration",
     "wifi_required_desc": "This board connects over Wi-Fi. Enter your network so the device can come online.",
     "other_boards": "Other boards",

--- a/src/util/full-setup.ts
+++ b/src/util/full-setup.ts
@@ -45,3 +45,9 @@ export function boardOffersFullSetup(board: BoardCatalogEntry | null): boolean {
 export function fullSetupComponentIds(board: BoardCatalogEntry): string[] {
   return fullSetupBundle(board)?.component_ids ?? [];
 }
+
+/** Display name for a board's featured local id, falling back to the id. */
+export function featuredComponentName(board: BoardCatalogEntry, localId: string): string {
+  const featured = board.featured_components.find((c) => c.id === localId);
+  return featured?.name || featured?.component_id || localId;
+}

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -21,11 +21,13 @@ vi.mock("sonner-js", () => ({
   default: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
 
+import { IntlMessageFormat } from "intl-messageformat";
 import toast from "sonner-js";
 
 import { APIError } from "../../../src/api/api-error.js";
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { ESPHomeCreateConfigDialog } from "../../../src/components/wizard/create-config-dialog.js";
+import enMessages from "../../../src/translations/en.json";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   let resolve!: (v: T) => void;
@@ -36,6 +38,19 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 const flush = async (): Promise<void> => {
   for (let i = 0; i < 6; i++) await Promise.resolve();
 };
+
+// Render an en.json key with real ICU MessageFormat so the full-setup tests
+// exercise the actual template (the name cap and =0/other plural branches
+// regress silently under the identity localize default).
+function icuLocalize(key: string, values?: Record<string, string | number>): string {
+  const message = key
+    .split(".")
+    .reduce<unknown>(
+      (node, part) => (node as Record<string, unknown> | undefined)?.[part],
+      enMessages
+    );
+  return new IntlMessageFormat(String(message ?? key), "en").format(values) as string;
+}
 
 async function mount(api: Partial<ESPHomeAPI>): Promise<ESPHomeCreateConfigDialog> {
   const el = new ESPHomeCreateConfigDialog();
@@ -294,6 +309,86 @@ describe("create-config-dialog create de-dupe + retry", () => {
 
     expect(addComponent).toHaveBeenCalledTimes(2);
     expect(toast.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the skipped component in the warning", async () => {
+    vi.mocked(toast.warning).mockClear();
+    const createDevice = vi.fn().mockResolvedValue({ configuration: "relays.yaml" });
+    // relay_1 adds; relay_2 fails and is the one named.
+    const addComponent = vi
+      .fn()
+      .mockResolvedValueOnce({ yaml: "merged" })
+      .mockRejectedValueOnce(new Error("boom"));
+    const el = await mount({ createDevice, addComponent });
+    (el as unknown as { _localize: typeof icuLocalize })._localize = icuLocalize;
+    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
+      new CustomEvent("finish-setup", {
+        detail: {
+          board: {
+            id: "esp32_relay_x4",
+            full_config: true,
+            featured_components: [{ id: "relay_1" }, { id: "relay_2", name: "Relay 2" }],
+            featured_bundles: [
+              { id: "all_recommended", name: "x", component_ids: ["relay_1", "relay_2"] },
+            ],
+          },
+          name: "Relays",
+          wifiSsid: "",
+          wifiPassword: "",
+          fullSetup: true,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await flush();
+    await flush();
+
+    const message = vi.mocked(toast.warning).mock.calls[0]?.[0];
+    expect(message).toContain("Relay 2");
+    // extra=0 branch: a single skip has no "and N more" tail.
+    expect(message).not.toContain("more");
+  });
+
+  it("caps the named list at three and appends 'and N more'", async () => {
+    vi.mocked(toast.warning).mockClear();
+    const createDevice = vi.fn().mockResolvedValue({ configuration: "relays.yaml" });
+    const addComponent = vi.fn().mockRejectedValue(new Error("boom"));
+    const el = await mount({ createDevice, addComponent });
+    (el as unknown as { _localize: typeof icuLocalize })._localize = icuLocalize;
+    el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
+      new CustomEvent("finish-setup", {
+        detail: {
+          board: {
+            id: "esp32_relay_x4",
+            full_config: true,
+            featured_components: [
+              { id: "a", name: "Alpha" },
+              { id: "b", name: "Bravo" },
+              { id: "c", name: "Charlie" },
+              { id: "d", name: "Delta" },
+            ],
+            featured_bundles: [
+              { id: "all_recommended", name: "x", component_ids: ["a", "b", "c", "d"] },
+            ],
+          },
+          name: "Relays",
+          wifiSsid: "",
+          wifiPassword: "",
+          fullSetup: true,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    await flush();
+    await flush();
+
+    const message = vi.mocked(toast.warning).mock.calls[0]?.[0];
+    // Only the first three names show, then the remainder is summarised.
+    expect(message).toContain("Alpha, Bravo, Charlie");
+    expect(message).toContain("and 1 more");
+    expect(message).not.toContain("Delta");
   });
 
   it("skips the full setup when the checkbox is off", async () => {

--- a/test/util/full-setup.test.ts
+++ b/test/util/full-setup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import {
   boardOffersFullSetup,
+  featuredComponentName,
   fullSetupComponentIds,
 } from "../../src/util/full-setup.js";
 
@@ -124,5 +125,22 @@ describe("fullSetupComponentIds", () => {
       featured_bundles: [{ id: "partial", name: "x", component_ids: ["a"] }] as never,
     });
     expect(fullSetupComponentIds(b)).toEqual([]);
+  });
+});
+
+describe("featuredComponentName", () => {
+  it("prefers name, then component_id, then the raw local id", () => {
+    const b = board({
+      featured_components: [
+        { id: "eth", name: "Onboard Ethernet", component_id: "ethernet" },
+        { id: "bus", component_id: "i2c" },
+        { id: "bare" },
+      ] as never,
+    });
+    expect(featuredComponentName(b, "eth")).toBe("Onboard Ethernet");
+    expect(featuredComponentName(b, "bus")).toBe("i2c");
+    expect(featuredComponentName(b, "bare")).toBe("bare");
+    // Unknown local id falls back to itself.
+    expect(featuredComponentName(b, "nope")).toBe("nope");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

When "set up with all recommended components" skips a component that couldn't be auto-added, the toast now names it instead of just showing a count, so the user knows what to finish. It stays short by capping the list to the first three names, then "and N more". Before it read "1 recommended component couldn't be added automatically; add them in the editor" with no hint which one, which looked like a mysterious failure.

The backend companion fix stops the common trigger (onboard ethernet re-added on KC868 boards), so most setups now skip nothing; this makes the rare genuine skip actionable.

**Related issue or feature (if applicable):**

- backend companion: esphome/device-builder#1781

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
