### PR TITLE
Add expert-only toggle to disable git version history

### DIFF
--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -105,7 +105,7 @@ export interface UserPreferences {
   /** This install is only a remote build node: onboarding skips the
    *  Wi-Fi step and device-creation entry points are hidden. */
   remote_compute_only: boolean;
-  /** Auto-commit config edits to a git history. Default ``true``; the
+  /** Auto-commit config edits to a Git history. Default ``true``; the
    *  off switch is an expert-only Appearance toggle. */
   version_history_enabled: boolean;
   /** Highest onboarding-flow version the user has acknowledged.

--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -105,6 +105,9 @@ export interface UserPreferences {
   /** This install is only a remote build node: onboarding skips the
    *  Wi-Fi step and device-creation entry points are hidden. */
   remote_compute_only: boolean;
+  /** Auto-commit config edits to a git history. Default ``true``; the
+   *  off switch is an expert-only Appearance toggle. */
+  version_history_enabled: boolean;
   /** Highest onboarding-flow version the user has acknowledged.
    *  ``0`` ⇒ never gone through onboarding. The dashboard surfaces
    *  the wizard whenever this is below the server's

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -51,6 +51,7 @@ import {
   remoteComputeOnlyContext,
   serverVersionContext,
   versionContext,
+  versionHistoryEnabledContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { isExpert } from "../util/experience.js";
@@ -85,6 +86,7 @@ import {
   onSetRemoteBuildEnabled,
   onSetRemoteComputeOnly,
   onSetTheme,
+  onSetVersionHistoryEnabled,
 } from "./app-shell/settings-actions.js";
 
 import "../pages/dashboard.js";
@@ -136,6 +138,11 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: remoteComputeOnlyContext })
   @state()
   _remoteComputeOnly = false;
+  // Default true until the subscribe snapshot delivers preferences, matching
+  // the backend default so the expert toggle paints as on before first load.
+  @provide({ context: versionHistoryEnabledContext })
+  @state()
+  _versionHistoryEnabled = true;
   // False until the subscribe snapshot delivers preferences; the dashboard
   // fails device creation closed while it's false so a remote-compute install
   // can't flash creation UI before its prefs are known.
@@ -576,6 +583,8 @@ export class ESPHomeApp extends LitElement {
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}
         @set-remote-compute-only=${(e: CustomEvent<boolean>) =>
           onSetRemoteComputeOnly(this, e)}
+        @set-version-history-enabled=${(e: CustomEvent<boolean>) =>
+          onSetVersionHistoryEnabled(this, e)}
         @set-remote-build-enabled=${(e: CustomEvent<boolean>) =>
           onSetRemoteBuildEnabled(this, e)}
         @set-remote-build-cleanup-ttl=${(e: CustomEvent<number>) =>

--- a/src/components/app-shell/data-load.ts
+++ b/src/components/app-shell/data-load.ts
@@ -11,6 +11,7 @@ export function applyPreferences(host: ESPHomeApp, prefs: UserPreferences): void
   host.applyTheme(prefs.theme);
   host._experienceLevel = prefs.experience_level;
   host._remoteComputeOnly = prefs.remote_compute_only;
+  host._versionHistoryEnabled = prefs.version_history_enabled;
 }
 
 export async function loadOnboardingState(host: ESPHomeApp): Promise<void> {

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -109,6 +109,26 @@ export function onSetExpertMode(host: ESPHomeApp, e: CustomEvent<boolean>): void
   setExperienceLevel(host, e.detail ? ExperienceLevel.EXPERT : ExperienceLevel.BEGINNER);
 }
 
+// Turning version history off stops the backend's git auto-commit.
+export function onSetVersionHistoryEnabled(
+  host: ESPHomeApp,
+  e: CustomEvent<boolean>
+): void {
+  void optimisticSetting(host, {
+    get: () => host._versionHistoryEnabled,
+    set: (v) => {
+      host._versionHistoryEnabled = v;
+    },
+    write: () => host._api.updatePreferences({ version_history_enabled: e.detail }),
+    value: e.detail,
+    toastKey: "settings.experience_save_failed",
+    warn: "Failed to save version-history-enabled:",
+    inFlight: (active) => {
+      host._prefsWritesInFlight += active ? 1 : -1;
+    },
+  });
+}
+
 // Optimistic flip with revert-on-failure for security-sensitive toggles.
 // _remoteBuildSetInFlight gates loadRemoteBuildSettings so a reconnect
 // racing the write can't clobber the optimistic value.

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { mdiCodeBraces, mdiFileCompare, mdiMagnify } from "@mdi/js";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -8,6 +8,7 @@ import {
   expertModeContext,
   localizeContext,
   remoteComputeOnlyContext,
+  versionHistoryEnabledContext,
 } from "../../context/index.js";
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
@@ -58,6 +59,10 @@ export class ESPHomeSettingsAppearance extends LitElement {
   @consume({ context: remoteComputeOnlyContext, subscribe: true })
   @state()
   private _remoteComputeOnly = false;
+
+  @consume({ context: versionHistoryEnabledContext, subscribe: true })
+  @state()
+  private _versionHistoryEnabled = true;
 
   @state()
   private _theme: string = localStorage.getItem("esphome-theme") ?? "system";
@@ -141,7 +146,20 @@ export class ESPHomeSettingsAppearance extends LitElement {
         </wa-select>
       </div>
       ${this._renderExpertMode()} ${this._renderRemoteCompute()}
+      ${this._expertMode ? this._renderVersionHistory() : nothing}
     `;
+  }
+
+  // Expert-only: a beginner keeps version history on as a safety net, so the
+  // off switch is hidden unless Expert Mode is enabled.
+  private _renderVersionHistory() {
+    return renderToggleRow(this._localize, {
+      titleId: "version-history-title",
+      titleKey: "settings.version_history",
+      descKey: "settings.version_history_desc",
+      checked: this._versionHistoryEnabled,
+      onToggle: this._onToggleVersionHistory,
+    });
   }
 
   private _renderRemoteCompute() {
@@ -225,6 +243,16 @@ export class ESPHomeSettingsAppearance extends LitElement {
     this.dispatchEvent(
       new CustomEvent("set-remote-compute-only", {
         detail: !this._remoteComputeOnly,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _onToggleVersionHistory() {
+    this.dispatchEvent(
+      new CustomEvent("set-version-history-enabled", {
+        detail: !this._versionHistoryEnabled,
         bubbles: true,
         composed: true,
       })

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -114,7 +114,7 @@ export const remoteComputeOnlyContext = createContext<boolean>(
 );
 
 /**
- * Context for whether git version-history auto-commit is enabled.
+ * Context for whether Git version-history auto-commit is enabled.
  *
  * Default ``true``. Set from the ``subscribe_events`` ``initial_state``
  * snapshot and toggled via the expert-only Settings → Appearance switch;

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -114,6 +114,17 @@ export const remoteComputeOnlyContext = createContext<boolean>(
 );
 
 /**
+ * Context for whether git version-history auto-commit is enabled.
+ *
+ * Default ``true``. Set from the ``subscribe_events`` ``initial_state``
+ * snapshot and toggled via the expert-only Settings → Appearance switch;
+ * when ``false`` the backend stops committing config edits.
+ */
+export const versionHistoryEnabledContext = createContext<boolean>(
+  Symbol("esphome-version-history-enabled")
+);
+
+/**
  * Context for whether preferences have arrived at least once this session.
  *
  * ``false`` until the first ``subscribe_events`` ``initial_state`` snapshot sets

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -31,5 +31,6 @@ export {
   serverVersionContext,
   stubRemoteBuildJobState,
   versionContext,
+  versionHistoryEnabledContext,
 } from "./contexts.js";
 export type { RemoteBuildJobState } from "./contexts.js";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1079,7 +1079,7 @@
     "remote_compute_only": "Only use this for remote compute",
     "remote_compute_only_desc": "Hide device creation and use this install purely as a remote build server for other dashboards.",
     "version_history": "Save version history",
-    "version_history_desc": "Keep a local git history of your config changes so you can view and restore earlier versions. Turn this off to stop the automatic commits.",
+    "version_history_desc": "Keep a local Git history of your config changes so you can view and restore earlier versions. Turn this off to stop the automatic commits.",
     "language": "Language",
     "language_desc": "Choose the language used across the interface.",
     "language_system": "System",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1078,6 +1078,8 @@
     "experience_save_failed": "Failed to save your preference",
     "remote_compute_only": "Only use this for remote compute",
     "remote_compute_only_desc": "Hide device creation and use this install purely as a remote build server for other dashboards.",
+    "version_history": "Save version history",
+    "version_history_desc": "Keep a local git history of your config changes so you can view and restore earlier versions. Turn this off to stop the automatic commits.",
     "language": "Language",
     "language_desc": "Choose the language used across the interface.",
     "language_system": "System",

--- a/test/components/app-shell/data-load.test.ts
+++ b/test/components/app-shell/data-load.test.ts
@@ -111,6 +111,7 @@ describe("loadPreferences (post-wizard context refresh)", () => {
     table_sort_direction: null,
     experience_level: ExperienceLevel.EXPERT,
     remote_compute_only: true,
+    version_history_enabled: true,
     onboarding_completed_version: 2,
   };
 

--- a/test/components/app-shell/events-initial-state-prefs.test.ts
+++ b/test/components/app-shell/events-initial-state-prefs.test.ts
@@ -25,6 +25,7 @@ function prefs(over: Partial<UserPreferences> = {}): UserPreferences {
     table_sort_direction: null,
     experience_level: ExperienceLevel.EXPERT,
     remote_compute_only: true,
+    version_history_enabled: true,
     onboarding_completed_version: 2,
     ...over,
   };

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -9,6 +9,7 @@ import {
   onSetRemoteBuildEnabled,
   onSetRemoteComputeOnly,
   onSetTheme,
+  onSetVersionHistoryEnabled,
 } from "../../../src/components/app-shell/settings-actions.js";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
@@ -23,7 +24,11 @@ const flush = () => new Promise((r) => setTimeout(r, 0));
 
 type PrefsHost = Pick<
   ESPHomeApp,
-  "_experienceLevel" | "_remoteComputeOnly" | "_localize" | "_prefsWritesInFlight"
+  | "_experienceLevel"
+  | "_remoteComputeOnly"
+  | "_versionHistoryEnabled"
+  | "_localize"
+  | "_prefsWritesInFlight"
 > & { _api: { updatePreferences: (p: Record<string, unknown>) => Promise<unknown> } };
 
 function makePrefsHost(
@@ -32,6 +37,7 @@ function makePrefsHost(
   return {
     _experienceLevel: null,
     _remoteComputeOnly: false,
+    _versionHistoryEnabled: true,
     _localize: ((key: string) => key) as ESPHomeApp["_localize"],
     _prefsWritesInFlight: 0,
     _api: { updatePreferences },
@@ -229,6 +235,43 @@ describe("onSetRemoteComputeOnly", () => {
     expect(host._remoteComputeOnly).toBe(true);
     await flush();
     expect(host._remoteComputeOnly).toBe(false);
+    expect(toastError).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("onSetVersionHistoryEnabled", () => {
+  beforeEach(() => toastError.mockClear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("optimistically flips and persists the preference on success", async () => {
+    const update = vi.fn(async () => ({}));
+    const host = makePrefsHost(update);
+    onSetVersionHistoryEnabled(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: false })
+    );
+    expect(host._versionHistoryEnabled).toBe(false);
+    await flush();
+    expect(host._versionHistoryEnabled).toBe(false);
+    expect(update).toHaveBeenCalledWith({ version_history_enabled: false });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("reverts, logs, and toasts on backend rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const host = makePrefsHost(
+      vi.fn(async () => {
+        throw new Error("no");
+      })
+    );
+    onSetVersionHistoryEnabled(
+      host as unknown as ESPHomeApp,
+      new CustomEvent("x", { detail: false })
+    );
+    expect(host._versionHistoryEnabled).toBe(false);
+    await flush();
+    expect(host._versionHistoryEnabled).toBe(true);
     expect(toastError).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalled();
   });

--- a/test/components/settings-dialog/appearance-version-history.test.ts
+++ b/test/components/settings-dialog/appearance-version-history.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The expert-only "Save version history" toggle in Settings → Appearance is
+ * rendered only in Expert Mode and, when clicked, fires a bubbling, composed
+ * `set-version-history-enabled` event carrying the *next* value so app-shell
+ * can persist it.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Stub the wa-select/wa-option theme picker and wa-icon (happy-dom can't run
+// their form-associated internals; they're only chrome here).
+vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
+vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
+
+import { ESPHomeSettingsAppearance } from "../../../src/components/settings-dialog/appearance-section.js";
+
+async function mount(
+  expertMode: boolean,
+  versionHistoryEnabled = true
+): Promise<ESPHomeSettingsAppearance> {
+  const el = new ESPHomeSettingsAppearance();
+  // Both flags are read from Lit contexts app-shell provides; mounted bare,
+  // seed the consumed fields directly.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._expertMode = expertMode;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._versionHistoryEnabled = versionHistoryEnabled;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const versionToggle = (el: ESPHomeSettingsAppearance) =>
+  el.shadowRoot!.querySelector<HTMLButtonElement>(
+    'button.toggle[aria-labelledby="version-history-title"]'
+  );
+
+describe("appearance version-history toggle", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("is hidden unless Expert Mode is on", async () => {
+    expect(versionToggle(await mount(false))).toBeNull();
+    expect(versionToggle(await mount(true))).not.toBeNull();
+  });
+
+  it("reflects the current value via aria-checked", async () => {
+    expect(versionToggle(await mount(true, true))!.getAttribute("aria-checked")).toBe(
+      "true"
+    );
+    expect(versionToggle(await mount(true, false))!.getAttribute("aria-checked")).toBe(
+      "false"
+    );
+  });
+
+  it("fires set-version-history-enabled with the toggled value on click", async () => {
+    const el = await mount(true, true);
+    const listener = vi.fn();
+    el.addEventListener("set-version-history-enabled", listener as EventListener);
+
+    versionToggle(el)!.click();
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event = listener.mock.calls[0][0] as CustomEvent<boolean>;
+    expect(event.detail).toBe(false);
+    expect(event.bubbles).toBe(true);
+    expect(event.composed).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds a toggle, shown only to expert users, to turn off git version history; it matches the new backend `version_history_enabled` preference (esphome/device-builder discussion #3725).

The backend gates its automatic git commits on a `version_history_enabled` preference. This surfaces it as a "Save version history" toggle in Settings > Appearance, shown only in Expert Mode; beginners keep version history on as a safety net, experts who run their own git workflow can turn it off. The preference flows through a new `versionHistoryEnabledContext` provided by app-shell, seeded from the `subscribe_events` snapshot, and written with the same optimistic write path (revert on failure) the other preference toggles use.

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3725
- companion backend PR: esphome/device-builder#1785

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
