### PR TITLE
Keep featured matches when searching the Recommended category

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -205,15 +205,15 @@ export class ESPHomeComponentCatalog extends LitElement {
     // at different times) they can briefly disagree and strand the view on an
     // empty "Recommended" category. Once a featured fetch has settled, if its
     // grid is empty fall back to "all" so we never sit on "0 of N / No
-    // components found". Scoped to the unfiltered Featured view: search/provides
-    // are applied server-side, so an active filter that matches no
-    // recommendation empties the grid legitimately and must render "No
-    // components found", not bounce to All.
+    // components found". A search is server-scoped to the board's recommendations
+    // (getComponents(category=featured, query)), so a term that matches a
+    // recommendation stays here and shows it; a term matching none empties the
+    // grid and falls through to the full catalog (device-builder-frontend#1040).
+    // ``_provides`` stays excluded — that probe path never runs in Featured.
     if (
       !this._list.loading &&
       this.lockedCategories.length === 0 &&
       this._category === ComponentCategory.FEATURED &&
-      !this._search.trim() &&
       !this._provides &&
       visibleComponents(this).length + filteredBundles(this).length === 0
     ) {
@@ -359,14 +359,10 @@ export class ESPHomeComponentCatalog extends LitElement {
   private _onSearchInput = (ev: Event) => {
     this._search = (ev.target as HTMLInputElement).value;
     this._provides = "";
-    // A search inside "Featured" is server-scoped to the board's
-    // recommendations, so a term that matches nothing recommended strands the
-    // grid on "No components found" even when the catalog has matches. Drop to
-    // "all" the moment a search is typed so it spans the whole catalog
-    // (device-builder-frontend#1040).
-    if (this._category === ComponentCategory.FEATURED && this._search.trim()) {
-      this._category = "all";
-    }
+    // Stay on the current category. A search inside "Featured" is server-scoped
+    // to the board's recommendations, so a matching term surfaces the featured
+    // card; a term matching none empties the grid and the ``updated`` fallback
+    // drops to "all" (device-builder-frontend#1040).
     this._debouncedSearch();
   };
 

--- a/test/components/device/component-catalog-featured-fallback.test.ts
+++ b/test/components/device/component-catalog-featured-fallback.test.ts
@@ -3,8 +3,10 @@
  *
  * The "Recommended" category must never strand the view on an empty grid:
  * when a featured fetch settles with nothing addable (every recommendation is
- * already configured), the catalog falls back to "all" instead of rendering
- * "0 of N / No components found".
+ * already configured, or a search matches no recommendation), the catalog falls
+ * back to "all" instead of rendering "0 of N / No components found". A search
+ * that DOES match a recommendation stays on Featured and shows it, rather than
+ * discarding the match by switching to All (device-builder-frontend#1040).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -91,14 +93,25 @@ describe("component-catalog featured-empty fallback", () => {
     expect(getComponents).not.toHaveBeenCalled();
   });
 
-  it("stays on featured when the grid is empty only due to an active search", async () => {
+  // The scenario reported in #1040: a search whose term matches no
+  // recommendation must not strand the grid on "No components found".
+  it("falls back to all when a search matches no recommendation", async () => {
     const { el, getComponents } = await mountFeatured({ search: "zzz", components: [] });
+    expect(el._category).toBe("all");
+    expect(getComponents).toHaveBeenCalled();
+  });
+
+  it("stays on featured when a search matches a recommendation", async () => {
+    const { el, getComponents } = await mountFeatured({
+      search: "ethernet",
+      components: [ETHERNET_CARD],
+    });
     expect(el._category).toBe("featured");
     expect(getComponents).not.toHaveBeenCalled();
   });
 });
 
-describe("component-catalog search switches away from featured", () => {
+describe("component-catalog _onSearchInput keeps the category", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
@@ -110,11 +123,14 @@ describe("component-catalog search switches away from featured", () => {
     } as unknown as Event);
   };
 
-  it("drops Featured to All when a search term is typed", async () => {
+  it("stays on Featured when a search term is typed", async () => {
     const { el } = await mountFeatured();
     expect(el._category).toBe("featured");
     typeSearch(el, "relay");
-    expect(el._category).toBe("all");
+    // No eager switch: the search is server-scoped to the recommendations, and
+    // the updated() fallback drops to All only once an empty featured fetch
+    // settles.
+    expect(el._category).toBe("featured");
   });
 
   it("leaves Featured intact when the search is only whitespace", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Searching the "Recommended" (Featured) category in the Add component dialog returned "No components found" for terms that plainly match a featured card; for example, typing "onboard" on a starter kit board hid the "Onboard RGB LED" recommendation instead of showing it. The search input handler switched the category from Featured to All on every keystroke, so the query ran against the general catalog rather than the board's recommendations, which do not carry those names.

This keeps the category on search, so the fetch stays scoped to the board's recommendations (getComponents category=featured, query); the existing empty grid fallback in updated() drops to All only when no recommendation matches. That preserves the #1040 behavior, a term matching nothing recommended still falls through to the full catalog, without discarding recommendations that do match.

**Related issue or feature (if applicable):**

- Follow-up to #1040

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
