### PR TITLE
Lead the All category with board recommendations

### DIFF
--- a/src/components/device/component-catalog.ts
+++ b/src/components/device/component-catalog.ts
@@ -19,6 +19,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { loadMoreFooterStyles } from "../../styles/load-more-footer.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { debounce } from "../../util/debounce.js";
+import { isFeaturedId } from "../../util/featured-id.js";
 import { IntersectionController } from "../../util/intersection-controller.js";
 import { PagedListController } from "../../util/paged-list-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -106,6 +107,25 @@ export class ESPHomeComponentCatalog extends LitElement {
 
   private _debouncedSearch = debounce(() => this._fetchComponents(), 300);
 
+  // The board has addable recommendations and we're not locked to a category
+  // set — the state where "Recommended" is the sensible landing/search scope.
+  // Query-independent: availableFeaturedCount ignores the search box.
+  private _prefersFeatured(): boolean {
+    return (
+      this.lockedCategories.length === 0 &&
+      !!this.boardId &&
+      availableFeaturedCount(this, { applyQuery: false }) > 0
+    );
+  }
+
+  // "Recommended" and "All" both surface the board's recommendations (featured
+  // cards + bundles); a specific category (Sensor, …) does not. Drives the
+  // search auto-switch and bundle visibility off the *current* view, so
+  // returning to All always re-shows them.
+  private _recommendationInclusive(): boolean {
+    return this._category === ComponentCategory.FEATURED || this._category === "all";
+  }
+
   // Not in connectedCallback or prop-reactive: the catalog stays mounted
   // (hidden) inside its dialog whose parents mount on page load. Eager
   // fetching there would (a) burn calls per page load even without dialog
@@ -115,11 +135,7 @@ export class ESPHomeComponentCatalog extends LitElement {
     this._provides = "";
     // Auto-select "Featured" when the board has recommendations still addable;
     // reset away from it when every recommendation is already configured.
-    const hasFeatured =
-      this.lockedCategories.length === 0 &&
-      !!this.boardId &&
-      availableFeaturedCount(this) > 0;
-    if (hasFeatured) {
+    if (this._prefersFeatured()) {
       this._category = ComponentCategory.FEATURED;
     } else if (this._category === ComponentCategory.FEATURED) {
       this._category = "all";
@@ -205,10 +221,9 @@ export class ESPHomeComponentCatalog extends LitElement {
     // at different times) they can briefly disagree and strand the view on an
     // empty "Recommended" category. Once a featured fetch has settled, if its
     // grid is empty fall back to "all" so we never sit on "0 of N / No
-    // components found". A search is server-scoped to the board's recommendations
-    // (getComponents(category=featured, query)), so a term that matches a
-    // recommendation stays here and shows it; a term matching none empties the
-    // grid and falls through to the full catalog (device-builder-frontend#1040).
+    // components found". A search never reaches here: _onSearchInput moves to
+    // "all" (where featured lead) the moment a term is typed, so this guards
+    // only the no-search cold-open race and the all-configured board.
     // ``_provides`` stays excluded — that probe path never runs in Featured.
     if (
       !this._list.loading &&
@@ -246,9 +261,10 @@ export class ESPHomeComponentCatalog extends LitElement {
     // options are noise — the relevant categories are already pinned.
     const showSidebar = this.lockedCategories.length === 0;
 
-    // Bundles only surface in the dedicated "Featured" view.
-    const bundles =
-      this._category === ComponentCategory.FEATURED ? filteredBundles(this) : [];
+    // Bundles (a board concept, like featured cards) surface wherever
+    // recommendations belong: "Recommended" and "All". A specific category
+    // (Sensor, …) stays clean.
+    const bundles = this._recommendationInclusive() ? filteredBundles(this) : [];
     const visible = visibleComponents(this);
     const ambiguous = ambiguousNameIds(visible);
 
@@ -315,7 +331,9 @@ export class ESPHomeComponentCatalog extends LitElement {
                           this,
                           c,
                           c.id === this._expandedId,
-                          this._category === ComponentCategory.FEATURED,
+                          // A featured card keeps its badge/preset styling
+                          // wherever it lands (it now leads "All" too).
+                          isFeaturedId(c.id),
                           this._localize,
                           ambiguous.has(c.id)
                         )
@@ -359,10 +377,15 @@ export class ESPHomeComponentCatalog extends LitElement {
   private _onSearchInput = (ev: Event) => {
     this._search = (ev.target as HTMLInputElement).value;
     this._provides = "";
-    // Stay on the current category. A search inside "Featured" is server-scoped
-    // to the board's recommendations, so a matching term surfaces the featured
-    // card; a term matching none empties the grid and the ``updated`` fallback
-    // drops to "all" (device-builder-frontend#1040).
+    // "Recommended" is the no-search curated shortlist; a search moves to "all",
+    // where the board's featured cards are ranked first (server-side), so every
+    // match is visible with the most relevant on top and no term can strand the
+    // grid (device-builder-frontend#1040, device-builder#1793). Clearing the
+    // search returns to "Recommended". Only from these two recommendation views:
+    // a search inside a specific category (Sensor, …) filters within it.
+    if (this._recommendationInclusive() && this._prefersFeatured()) {
+      this._category = this._search.trim() ? "all" : ComponentCategory.FEATURED;
+    }
     this._debouncedSearch();
   };
 

--- a/src/components/device/component-catalog/filters.ts
+++ b/src/components/device/component-catalog/filters.ts
@@ -1,5 +1,9 @@
 import memoizeOne from "memoize-one";
-import type { FeaturedBundle, FeaturedComponent } from "../../../api/types/boards.js";
+import type {
+  BoardCatalogEntry,
+  FeaturedBundle,
+  FeaturedComponent,
+} from "../../../api/types/boards.js";
 import {
   type ComponentCatalogEntry,
   ComponentCategory,
@@ -19,6 +23,7 @@ import {
 } from "../../../util/yaml-serialize.js";
 import { categoryChipLabel } from "../component-card-category-label.js";
 import type { ESPHomeComponentCatalog } from "../component-catalog.js";
+import { navItemMatches } from "../navigator-search-match.js";
 
 // The catalog re-renders on every search keystroke, and visibleComponents +
 // availableFeaturedCount each scan the YAML, so the same string is parsed
@@ -136,38 +141,41 @@ export function ambiguousNameIds(components: ComponentCatalogEntry[]): Set<strin
 // A bundle drops a fixed set of featured peripherals (each with a preset id)
 // into the config at once. It's fully configured when every component's preset
 // id is in the YAML, so hide it then — a second add would duplicate all of them.
-function presentBundleIds(host: ESPHomeComponentCatalog): Set<string> {
-  const board = host.board;
-  const bundles = board?.featured_bundles ?? [];
-  if (!board || bundles.length === 0) return new Set();
-  const presetIdByLocal = new Map<string, string>();
-  for (const fc of board.featured_components ?? []) {
-    const presetId = fc.fields?.["id"]?.value;
-    if (typeof presetId === "string") presetIdByLocal.set(fc.id, presetId);
+// Memoized on (board, yaml): both are stable across a render, and this runs
+// several times per render (buildCategories + filteredBundles).
+const presentBundleIds = memoizeOne(
+  (board: BoardCatalogEntry | null, yaml: string): Set<string> => {
+    const bundles = board?.featured_bundles ?? [];
+    if (!board || bundles.length === 0) return new Set();
+    const presetIdByLocal = new Map<string, string>();
+    for (const fc of board.featured_components ?? []) {
+      const presetId = fc.fields?.["id"]?.value;
+      if (typeof presetId === "string") presetIdByLocal.set(fc.id, presetId);
+    }
+    const existingIds = memoIds(yaml);
+    const out = new Set<string>();
+    for (const bundle of bundles) {
+      const ids = bundle.component_ids
+        .map((cid) => presetIdByLocal.get(cid))
+        .filter((id): id is string => id !== undefined);
+      if (ids.length > 0 && ids.every((id) => existingIds.has(id))) out.add(bundle.id);
+    }
+    return out;
   }
-  const existingIds = memoIds(host.yaml);
-  const out = new Set<string>();
-  for (const bundle of bundles) {
-    const ids = bundle.component_ids
-      .map((cid) => presetIdByLocal.get(cid))
-      .filter((id): id is string => id !== undefined);
-    if (ids.length > 0 && ids.every((id) => existingIds.has(id))) out.add(bundle.id);
-  }
-  return out;
+);
+
+// Bundles not yet fully configured — the addable set, query aside.
+function addableBundles(host: ESPHomeComponentCatalog): FeaturedBundle[] {
+  const present = presentBundleIds(host.board, host.yaml);
+  return (host.board?.featured_bundles ?? []).filter((b) => !present.has(b.id));
 }
 
 // Bundles live on boards/get_board (not components/*) — filter client-side
 // so a search behaves consistently across featured + bundles + components.
 export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[] {
-  const present = presentBundleIds(host);
-  const bundles = (host.board?.featured_bundles ?? []).filter((b) => !present.has(b.id));
-  const q = host._search.trim().toLowerCase();
-  if (!q) return bundles;
-  return bundles.filter(
-    (b) =>
-      b.name.toLowerCase().includes(q) ||
-      b.description.toLowerCase().includes(q) ||
-      b.id.toLowerCase().includes(q)
+  const q = (host._search ?? "").trim();
+  return addableBundles(host).filter((b) =>
+    navItemMatches(q, b.name, b.description, b.id)
   );
 }
 
@@ -179,13 +187,21 @@ export function filteredBundles(host: ESPHomeComponentCatalog): FeaturedBundle[]
 // here (unlike `visibleComponents`): a board only recommends its own
 // platform-compatible components, and `FeaturedComponent` carries no
 // `supported_platforms` to gate on.
-export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
+export function availableFeaturedCount(
+  host: ESPHomeComponentCatalog,
+  opts?: { applyQuery?: boolean }
+): number {
   const board = host.board;
   if (!board) return 0;
   const featured = board.featured_components ?? [];
   const present = memoPresent(host.yaml);
   const presentPlatforms = memoPlatforms(host.yaml);
   const existingIds = featured.length ? memoIds(host.yaml) : new Set<string>();
+  // Track the search box by default so the "Recommended" badge matches the
+  // grid; ``_prefersFeatured`` probes "does this board recommend anything at
+  // all" and passes applyQuery:false to stay query-independent.
+  const applyQuery = opts?.applyQuery ?? true;
+  const q = applyQuery ? (host._search ?? "").trim() : "";
   // `!== false`, not truthy: the backend omits the `true` default, so an
   // absent multi_conf means multi-conf (still addable). A featured peripheral
   // whose preset id or fixed pins are already configured is never addable,
@@ -194,12 +210,12 @@ export function availableFeaturedCount(host: ESPHomeComponentCatalog): number {
     !featuredIdPresent(fc, existingIds) &&
     !featuredPinsTaken(fc, host.yaml) &&
     (fc.multi_conf !== false ||
-      !isComponentPresent(fc.component_id, present, presentPlatforms));
+      !isComponentPresent(fc.component_id, present, presentPlatforms)) &&
+    navItemMatches(q, fc.name ?? undefined, fc.description ?? undefined, fc.id);
   const components = featured.filter(addable).length;
-  const presentBundles = presentBundleIds(host);
-  const bundles = (board.featured_bundles ?? []).filter(
-    (b) => !presentBundles.has(b.id)
-  ).length;
+  // Query-aware badge counts matching bundles; the query-independent probe
+  // counts every addable one.
+  const bundles = (applyQuery ? filteredBundles(host) : addableBundles(host)).length;
   return components + bundles;
 }
 
@@ -221,8 +237,12 @@ export function buildCategories(
   // the sidebar is hidden, so the YAML reparse would be pure overhead.
   const featuredBadge = host.lockedCategories.length ? 0 : availableFeaturedCount(host);
   const sortableCats = visibleCats.filter((c) => c.id !== ComponentCategory.FEATURED);
+  // "All" now leads with the board's recommendations (featured cards + bundles),
+  // so its badge counts them alongside the regular entries. The re-summed
+  // exclude path drops featured (no category row), so fold the count back in;
+  // ``host._total`` already includes the backend featured entries.
   const visibleTotal = excluded.size
-    ? sortableCats.reduce((sum, c) => sum + c.count, 0)
+    ? sortableCats.reduce((sum, c) => sum + c.count, 0) + featuredBadge
     : host._total;
   // Derive category labels deterministically from the id (the same
   // `categoryChipLabel` the card chip uses) rather than a translation table.

--- a/src/components/device/component-catalog/styles.ts
+++ b/src/components/device/component-catalog/styles.ts
@@ -373,10 +373,26 @@ export const componentCatalogStyles = css`
     font-size: var(--wa-font-size-s);
   }
 
-  /* Featured cards get a subtle primary border so they read as the
-     curated set, distinct from the regular catalog. */
+  /* Featured cards read as the curated set via a thicker edge in the same
+     neutral border color — distinguished by weight, not hue, so it stays
+     subtle. Drawn as an inset ring (box-shadow), not a wider border, so the
+     box model — and thus the card size — matches the regular cards beside it. */
   .component-card--featured {
-    border-color: var(--esphome-tint-border);
+    --featured-ring: var(--wa-color-surface-border);
+    box-shadow: inset 0 0 0 var(--wa-border-width-s) var(--featured-ring);
+    /* transition doesn't accumulate across rules, so restate the base card's
+       animated properties alongside the ring. */
+    transition:
+      border-color var(--wa-transition-normal) var(--wa-transition-easing),
+      box-shadow var(--wa-transition-normal) var(--wa-transition-easing),
+      background var(--wa-transition-normal) var(--wa-transition-easing);
+  }
+
+  /* Track the border's primary highlight on hover / focus so the ring doesn't
+     stay a stale neutral while the border lights up. */
+  .component-card--featured:hover,
+  .component-card--featured:focus-within {
+    --featured-ring: var(--esphome-primary);
   }
 
   .bundle-badge {

--- a/test/components/device/component-catalog-featured-fallback.test.ts
+++ b/test/components/device/component-catalog-featured-fallback.test.ts
@@ -1,12 +1,12 @@
 /**
  * @vitest-environment happy-dom
  *
- * The "Recommended" category must never strand the view on an empty grid:
- * when a featured fetch settles with nothing addable (every recommendation is
- * already configured, or a search matches no recommendation), the catalog falls
- * back to "all" instead of rendering "0 of N / No components found". A search
- * that DOES match a recommendation stays on Featured and shows it, rather than
- * discarding the match by switching to All (device-builder-frontend#1040).
+ * "Recommended" is the no-search curated shortlist. A search moves to "all",
+ * where the board's featured cards rank first (server-side), so every match is
+ * visible with the recommendations on top and no term strands the grid
+ * (device-builder-frontend#1040). Clearing the search returns to Recommended;
+ * an explicitly pinned category opts out. Featured cards keep their styling
+ * wherever they render.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -93,25 +93,16 @@ describe("component-catalog featured-empty fallback", () => {
     expect(getComponents).not.toHaveBeenCalled();
   });
 
-  // The scenario reported in #1040: a search whose term matches no
-  // recommendation must not strand the grid on "No components found".
-  it("falls back to all when a search matches no recommendation", async () => {
-    const { el, getComponents } = await mountFeatured({ search: "zzz", components: [] });
+  // #1040: a Recommended fetch that settles empty (all recommendations
+  // configured) must not strand the grid on "No components found".
+  it("falls back to all when the featured grid settles empty", async () => {
+    const { el, getComponents } = await mountFeatured({ components: [] });
     expect(el._category).toBe("all");
     expect(getComponents).toHaveBeenCalled();
   });
-
-  it("stays on featured when a search matches a recommendation", async () => {
-    const { el, getComponents } = await mountFeatured({
-      search: "ethernet",
-      components: [ETHERNET_CARD],
-    });
-    expect(el._category).toBe("featured");
-    expect(getComponents).not.toHaveBeenCalled();
-  });
 });
 
-describe("component-catalog _onSearchInput keeps the category", () => {
+describe("component-catalog search moves to All (featured leads there)", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
@@ -123,13 +114,21 @@ describe("component-catalog _onSearchInput keeps the category", () => {
     } as unknown as Event);
   };
 
-  it("stays on Featured when a search term is typed", async () => {
+  it("switches to All when a search term is typed", async () => {
     const { el } = await mountFeatured();
     expect(el._category).toBe("featured");
     typeSearch(el, "relay");
-    // No eager switch: the search is server-scoped to the recommendations, and
-    // the updated() fallback drops to All only once an empty featured fetch
-    // settles.
+    // The board's featured cards rank first under "all" (server-side), so a
+    // search surfaces every match with the recommendations on top and can
+    // never strand the grid (#1040, device-builder#1793).
+    expect(el._category).toBe("all");
+  });
+
+  it("returns to Recommended when the search is cleared", async () => {
+    const { el } = await mountFeatured();
+    typeSearch(el, "relay");
+    expect(el._category).toBe("all");
+    typeSearch(el, "");
     expect(el._category).toBe("featured");
   });
 
@@ -137,5 +136,31 @@ describe("component-catalog _onSearchInput keeps the category", () => {
     const { el } = await mountFeatured();
     typeSearch(el, "   ");
     expect(el._category).toBe("featured");
+  });
+
+  it("keeps a specific category on search (only Recommended/All auto-switch)", async () => {
+    const { el } = await mountFeatured();
+    el._category = "sensor";
+    typeSearch(el, "relay");
+    expect(el._category).toBe("sensor");
+  });
+});
+
+describe("component-catalog featured styling under All", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a featured.* card with featured styling under All", async () => {
+    const FEATURED_CARD = {
+      id: "featured.esp32-poe-iso.onboard_ethernet",
+      dependencies: [],
+      supported_platforms: [],
+      multi_conf: true,
+    } as unknown as ComponentCatalogEntry;
+    const { el } = await mountFeatured({ components: [FEATURED_CARD] });
+    el._category = "all";
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector(".component-card--featured")).not.toBeNull();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A board's featured cards and bundles only appeared under the Recommended category. Searching there missed the board's most relevant matches, and the just-merged Recommended-scoped search (#1053) stranded the user on All once a non-matching term bounced there and never returned.

This makes All a superset: the backend (companion PR) ranks a board's featured cards first under All, so typing a search moves there and shows every match with the recommendations on top, while Recommended stays the no-search curated shortlist. Featured cards keep their styling wherever they render, the sidebar badges are query aware and fold in featured plus bundles, and the featured edge is an inset ring that tracks the hover highlight without changing the card size.

**Related issue or feature (if applicable):**

- fixes #1040
- companion to esphome/device-builder#1799

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
