### PR TITLE
Keep a pin field's current value selectable when it sits on a reserved pin

### DIFF
--- a/src/components/device/config-entry-pin-renderer.ts
+++ b/src/components/device/config-entry-pin-renderer.ts
@@ -42,9 +42,10 @@ interface PinOptionView {
   warn: boolean;
   /** Board-unavailable (occupied / tied to flash) — grouped under "Reserved". */
   reserved: boolean;
-  /** Non-selectable. A reserved pin is disabled *except* when it's locked to the
-   *  component being edited (ethernet RMII pins under ``ethernet:``), where it's
-   *  still grouped under "Reserved" but stays pickable so its value renders. */
+  /** Non-selectable. A reserved pin is disabled *except* when it's locked to
+   *  the component being edited (ethernet RMII pins under ``ethernet:``) or is
+   *  the field's current value, where it's still grouped under "Reserved" but
+   *  stays pickable so its value renders. */
   disabled: boolean;
   /** Positively carries the field's required features and has no direction
    *  conflict — grouped under "Supports …". */
@@ -331,6 +332,13 @@ export function renderPinField(
     sectionEndLine(ctx.yaml, ctx.fromLine)
   );
   const ownLockedGpios = lockedGpiosForSection(ctx);
+  // The field's current value must stay pickable even on a reserved pin the
+  // board didn't lock to this section (a hand-edited YAML, or a manifest
+  // preset missing its lock) — a disabled selected option blanks the
+  // wa-select head, hiding the real config value.
+  if (valueGpio !== null) {
+    ownLockedGpios.add(valueGpio);
+  }
   const fieldDisabled = effectiveDisabled(entry, ctx);
   const isLongForm = isPlainObject(rawValue);
 

--- a/test/components/device/config-entry-pin-renderer-reserved-value.test.ts
+++ b/test/components/device/config-entry-pin-renderer-reserved-value.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * A reserved pin (``available: false``) that is the field's current value
+ * must stay selectable even when the board doesn't lock it to the section
+ * being edited — a disabled selected option blanks the ``wa-select`` head,
+ * hiding the real config value.
+ */
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { renderPinField } from "../../../src/components/device/config-entry-pin-renderer.js";
+import {
+  makeBoardPin,
+  makeEntry,
+  makeRenderCtx,
+  makeTestBoard,
+} from "./_renderer-fixtures.js";
+
+const board = () =>
+  makeTestBoard({
+    pins: [
+      makeBoardPin(2),
+      makeBoardPin(4, { available: false, occupied_by: "Accessory power switch" }),
+      makeBoardPin(6, { available: false, occupied_by: "SPI flash" }),
+    ],
+  });
+
+function renderedOptions(value: unknown): Map<string, Element> {
+  const entry = makeEntry(ConfigEntryType.PIN, { key: "pin", required: true });
+  const container = document.createElement("div");
+  render(
+    renderPinField(entry, ["pin"], makeRenderCtx({ pin: value }, { board: board() })),
+    container
+  );
+  return new Map(
+    [...container.querySelectorAll("wa-option")].map((o) => [
+      o.getAttribute("value") ?? "",
+      o,
+    ])
+  );
+}
+
+describe("renderPinField — reserved pin holding the current value", () => {
+  it("keeps the current value's option selectable, other reserved pins disabled", () => {
+    const options = renderedOptions(4);
+    const current = options.get("GPIO4")!;
+    expect(current.hasAttribute("selected")).toBe(true);
+    expect(current.hasAttribute("disabled")).toBe(false);
+    expect(options.get("GPIO6")!.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("leaves every reserved pin disabled when the value is elsewhere", () => {
+    const options = renderedOptions(2);
+    expect(options.get("GPIO4")!.hasAttribute("disabled")).toBe(true);
+    expect(options.get("GPIO6")!.hasAttribute("disabled")).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

A reserved pin option (available: false) is disabled unless the board's locked_pins rescues it for the section being edited. When a field's current value lands on a reserved pin outside that set, from a hand edited YAML or a board manifest preset missing its lock, the selected option was disabled and the wa-select head rendered blank, hiding the real config value; this is how the Apollo ESK-1 accessory power switch showed an empty Pin field. Add the current value's GPIO to the rescue set so its option stays pickable and the value always renders, while every other reserved pin stays disabled. The manifest side of the ESK-1 case is fixed in esphome/device-builder#1800, which also adds a validator guard; this change covers the hand edited YAML case that no manifest fix can. Verified in the live dashboard with a config pointing at a reserved pin the board locks to a different section.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#1800

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
