### PR TITLE
Reuse the full board body when re-entering the wizard setup step

### DIFF
--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -80,9 +80,11 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   @state()
   private _selectedBoard: BoardCatalogEntry | null = null;
 
-  /** Board id whose full body has already been fetched into `_selectedBoard`,
-   *  so re-entering the setup step doesn't refetch (getBoard is uncached). */
-  private _upgradedBoardId: string | null = null;
+  /** Full board bodies already fetched, keyed by id, so re-entering the setup
+   *  step reuses the full body (getBoard is uncached) rather than the slim
+   *  picker entry — whose `requires_wifi` hydrates to false and would drop the
+   *  Wi-Fi step on a back-then-re-pick of the same board. */
+  private _fullBoardById = new Map<string, BoardCatalogEntry>();
 
   /** Initial platform-filter label for the board step. Set by
    *  ``openAtBoardStep`` when the caller knows the chip family
@@ -164,7 +166,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._selectedBoard = board;
     this._initialBoardFilter = null;
     this._resetTransientState();
-    this._upgradedBoardId = board.id; // already a full body; no upgrade fetch
+    this._fullBoardById.set(board.id, board); // already a full body; no upgrade fetch
   }
 
   /** Open directly at the board-picker step with an optional
@@ -189,7 +191,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._advancedOpen = false;
     this._import.reset();
     this._submitting = false;
-    this._upgradedBoardId = null;
+    this._fullBoardById.clear();
     this._resetCreateErrors();
     this._open = true;
   }
@@ -383,21 +385,25 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
    *  empty fetch we stay on the picker with an error rather than advance on the
    *  slim entry (whose ``requires_wifi`` hydrates to ``false``). */
   private async _enterSetupStep(board: BoardCatalogEntry): Promise<void> {
-    if (this._upgradedBoardId !== board.id) {
-      let full: BoardCatalogEntry | null = null;
-      try {
-        full = await this._api.getBoard(board.id);
-      } catch (err) {
-        console.warn("Failed to load full board body:", err);
-      }
-      if (this._selectedBoard?.id !== board.id) return; // selection moved on
-      if (!full) {
-        this._createError = this._localize("wizard.board_load_failed");
-        return; // keep the user on the picker to retry
-      }
-      this._selectedBoard = full;
-      this._upgradedBoardId = board.id;
+    const cached = this._fullBoardById.get(board.id);
+    if (cached) {
+      this._selectedBoard = cached; // never enter setup on the slim entry
+      this._step = "setup";
+      return;
     }
+    let full: BoardCatalogEntry | null = null;
+    try {
+      full = await this._api.getBoard(board.id);
+    } catch (err) {
+      console.warn("Failed to load full board body:", err);
+    }
+    if (this._selectedBoard?.id !== board.id) return; // selection moved on
+    if (!full) {
+      this._createError = this._localize("wizard.board_load_failed");
+      return; // keep the user on the picker to retry
+    }
+    this._fullBoardById.set(full.id, full);
+    this._selectedBoard = full;
     this._step = "setup";
   }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -397,7 +397,9 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
         this._createError = this._localize("wizard.board_load_failed");
         return; // keep the user on the picker to retry
       }
-      this._fullBoardById.set(full.id, full);
+      // Key on the slim entry's id (what the lookup and openWithBoard use), not
+      // full.id, so an id the backend canonicalizes still hits the cache.
+      this._fullBoardById.set(board.id, full);
     }
     this._selectedBoard = full; // never enter setup on the slim entry
     this._step = "setup";

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -385,25 +385,21 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
    *  empty fetch we stay on the picker with an error rather than advance on the
    *  slim entry (whose ``requires_wifi`` hydrates to ``false``). */
   private async _enterSetupStep(board: BoardCatalogEntry): Promise<void> {
-    const cached = this._fullBoardById.get(board.id);
-    if (cached) {
-      this._selectedBoard = cached; // never enter setup on the slim entry
-      this._step = "setup";
-      return;
-    }
-    let full: BoardCatalogEntry | null = null;
-    try {
-      full = await this._api.getBoard(board.id);
-    } catch (err) {
-      console.warn("Failed to load full board body:", err);
-    }
-    if (this._selectedBoard?.id !== board.id) return; // selection moved on
+    let full = this._fullBoardById.get(board.id) ?? null;
     if (!full) {
-      this._createError = this._localize("wizard.board_load_failed");
-      return; // keep the user on the picker to retry
+      try {
+        full = await this._api.getBoard(board.id);
+      } catch (err) {
+        console.warn("Failed to load full board body:", err);
+      }
+      if (this._selectedBoard?.id !== board.id) return; // selection moved on
+      if (!full) {
+        this._createError = this._localize("wizard.board_load_failed");
+        return; // keep the user on the picker to retry
+      }
+      this._fullBoardById.set(full.id, full);
     }
-    this._fullBoardById.set(full.id, full);
-    this._selectedBoard = full;
+    this._selectedBoard = full; // never enter setup on the slim entry
     this._step = "setup";
   }
 

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -512,6 +512,27 @@ describe("create-config-dialog stale error on navigation", () => {
     expect((el as any)._step).not.toBe("setup");
     expect(errorText(el)).not.toBeNull();
   });
+
+  // #1798: backing out of setup and re-picking the SAME board must re-enter on
+  // the full body, not the slim picker entry (whose requires_wifi is undefined),
+  // or the Wi-Fi step silently disappears the second time through.
+  it("re-enters setup on the full board body after back then re-pick", async () => {
+    const getBoard = vi.fn().mockResolvedValue({ id: "esp32dev", requires_wifi: true });
+    const el = await mount({ getBoard });
+
+    await goToSetup(el, "esp32dev");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._selectedBoard.requires_wifi).toBe(true);
+
+    el.shadowRoot!.querySelector<HTMLButtonElement>(".back-button")!.click();
+    await el.updateComplete;
+
+    await goToSetup(el, "esp32dev");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._selectedBoard.requires_wifi).toBe(true);
+    // The full body is cached from the first visit, so no redundant refetch.
+    expect(getBoard).toHaveBeenCalledTimes(1);
+  });
 });
 
 // The migration onto esphome-base-dialog swapped the imperative

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -514,8 +514,9 @@ describe("create-config-dialog stale error on navigation", () => {
   });
 
   // #1798: backing out of setup and re-picking the SAME board must re-enter on
-  // the full body, not the slim picker entry (whose requires_wifi is undefined),
-  // or the Wi-Fi step silently disappears the second time through.
+  // the full body, not the slim picker entry (whose requires_wifi is falsy —
+  // undefined on this raw fixture, false once hydrated in the app), or the
+  // Wi-Fi step silently disappears the second time through.
   it("re-enters setup on the full board body after back then re-pick", async () => {
     const getBoard = vi.fn().mockResolvedValue({ id: "esp32dev", requires_wifi: true });
     const el = await mount({ getBoard });


### PR DESCRIPTION
# What does this implement/fix?

During first-device creation the setup wizard advances to the Wi-Fi credentials step, but pressing the header back arrow and re-picking the same board dropped that step and dead-ended the flow.

The Wi-Fi step only shows when the setup step reads `board.requires_wifi === true`, which is a full-body field derived only by `boards/get_board`; the picker emits slim `getBoards` entries whose `requires_wifi` hydrates to `false`. On first entry the dialog upgrades the slim entry to the full body, so the step shows. But it tracked that upgrade with a single-id flag, so after backing out to the picker and re-selecting the same board the upgrade was skipped and `_selectedBoard` was left as the slim entry; `requires_wifi` went `false` and the Wi-Fi step silently disappeared.

Cache fetched full bodies by id and reuse them on re-entry, so setup is never entered on a slim entry. A regression test drives back-then-re-pick and asserts the full body (with `requires_wifi`) is used, and that the cached body avoids a redundant refetch.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1798

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
