### PR TITLE
Split BoardCatalogEntry into SlimBoard and the full body type

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -24,7 +24,11 @@ import type {
   ParsedAutomation,
   YamlDiff,
 } from "./types/automations.js";
-import type { BoardCatalogEntry, PagedBoardsResponse } from "./types/boards.js";
+import type {
+  BoardCatalogEntry,
+  PagedBoardsResponse,
+  SlimBoard,
+} from "./types/boards.js";
 import type {
   ComponentCatalogEntry,
   PagedComponentsResponse,
@@ -1315,7 +1319,7 @@ export class ESPHomeAPI {
    * Boards interchangeable with this one (same PlatformIO target);
    * includes `boardId` itself.
    */
-  async getCompatibleBoards(boardId: string): Promise<BoardCatalogEntry[]> {
+  async getCompatibleBoards(boardId: string): Promise<SlimBoard[]> {
     const response = await this.sendCommand<PagedBoardsResponse>(
       "boards/get_compatible_boards",
       { board_id: boardId }

--- a/src/api/types/boards.ts
+++ b/src/api/types/boards.ts
@@ -107,7 +107,15 @@ export interface FeaturedBundle {
   image_url?: string;
 }
 
-export interface BoardCatalogEntry {
+/**
+ * Slim board index entry from ``boards/get_boards`` /
+ * ``boards/get_compatible_boards``. The picker, change-board dialog, and
+ * compatible-board lists get this shape; it deliberately omits the body-only
+ * fields on :class:`BoardCatalogEntry` so reading e.g. ``requires_wifi`` off a
+ * slim entry (where it would silently hydrate to ``false``) is a type error —
+ * callers must upgrade via ``boards/get_board`` first.
+ */
+export interface SlimBoard {
   id: string;
   name: string;
   description: string;
@@ -121,6 +129,13 @@ export interface BoardCatalogEntry {
   product_url: string;
   featured: boolean;
   is_generic: boolean;
+}
+
+/**
+ * Full board body from ``boards/get_board`` — the slim index plus the fields
+ * the backend derives or carries only on the full body.
+ */
+export interface BoardCatalogEntry extends SlimBoard {
   /**
    * The featured components are a complete onboard config (a devices.esphome.io
    * import or a hand-curated product opting in), not optional add-ons. Drives
@@ -139,5 +154,5 @@ export interface BoardCatalogEntry {
 }
 
 export interface PagedBoardsResponse extends PagedResponse {
-  boards: BoardCatalogEntry[];
+  boards: SlimBoard[];
 }

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import {
@@ -28,11 +28,11 @@ export class ESPHomeChangeBoardDialog extends LitElement {
 
   /** The device's current board — shown for context, never in the list. */
   @property({ attribute: false })
-  currentBoard: BoardCatalogEntry | null = null;
+  currentBoard: SlimBoard | null = null;
 
   /** Alternate boards to choose from (current board already excluded). */
   @property({ attribute: false })
-  boards: BoardCatalogEntry[] = [];
+  boards: SlimBoard[] = [];
 
   @state()
   private _open = false;
@@ -82,7 +82,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
     `;
   }
 
-  private _renderBoard(board: BoardCatalogEntry) {
+  private _renderBoard(board: SlimBoard) {
     return html`
       <button type="button" class="board-row" @click=${() => this._select(board)}>
         <img
@@ -111,7 +111,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
     `;
   }
 
-  private _select(board: BoardCatalogEntry) {
+  private _select(board: SlimBoard) {
     this.close();
     this.dispatchEvent(
       new CustomEvent<{ boardId: string }>("select-board", {

--- a/src/components/device/device-board-info.ts
+++ b/src/components/device/device-board-info.ts
@@ -9,7 +9,7 @@ import {
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../../api/index.js";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { espHomeStyles } from "../../styles/shared.js";
@@ -67,7 +67,7 @@ export class ESPHomeDeviceBoardInfo extends LitElement {
   /** Interchangeable boards (same PlatformIO target), current board
    *  excluded; empty keeps the "Change board" link hidden. */
   @state()
-  private _alternateBoards: BoardCatalogEntry[] = [];
+  private _alternateBoards: SlimBoard[] = [];
 
   /** Board id `_alternateBoards` was fetched for; guards a stale response. */
   private _alternatesForBoardId: string | null = null;

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -173,7 +173,6 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._selectedBoard = board;
     this._initialBoardFilter = null;
     this._resetTransientState();
-    this._pickedBoardId = board.id;
     this._fullBoardById.set(board.id, board); // already a full body; no upgrade fetch
   }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -5,7 +5,7 @@ import { customElement, state } from "lit/decorators.js";
 import toast from "sonner-js";
 import { apiErrorDetails } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
 import { primaryHeaderDialogStyles } from "../../styles/dialog-chrome.js";
@@ -48,7 +48,7 @@ type WizardStepDetail =
   | WizardStep
   | {
       step: WizardStep;
-      board?: BoardCatalogEntry | null;
+      board?: SlimBoard | null;
       method?: CreationMethod;
       file?: File;
     };
@@ -77,8 +77,15 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   @state()
   private _open = false;
 
+  /** Always a full body (only ever assigned in ``_enterSetupStep`` /
+   *  ``openWithBoard``), so the setup step reads a real ``requires_wifi``. */
   @state()
   private _selectedBoard: BoardCatalogEntry | null = null;
+
+  /** Id of the board whose upgrade is currently in flight — lets the async
+   *  ``getBoard`` in ``_enterSetupStep`` detect that the selection moved on
+   *  without parking a slim entry in ``_selectedBoard``. */
+  private _pickedBoardId: string | null = null;
 
   /** Full board bodies already fetched, keyed by id, so re-entering the setup
    *  step reuses the full body (getBoard is uncached) rather than the slim
@@ -166,6 +173,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._selectedBoard = board;
     this._initialBoardFilter = null;
     this._resetTransientState();
+    this._pickedBoardId = board.id;
     this._fullBoardById.set(board.id, board); // already a full body; no upgrade fetch
   }
 
@@ -191,6 +199,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._advancedOpen = false;
     this._import.reset();
     this._submitting = false;
+    this._pickedBoardId = null;
     this._fullBoardById.clear();
     this._resetCreateErrors();
     this._open = true;
@@ -367,12 +376,8 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       this._creationMethod = detail.method;
     }
 
-    if (detail.board !== undefined) {
-      this._selectedBoard = detail.board;
-    }
-
-    if (detail.step === "setup" && this._selectedBoard) {
-      void this._enterSetupStep(this._selectedBoard);
+    if (detail.step === "setup" && detail.board) {
+      void this._enterSetupStep(detail.board);
       return;
     }
     this._step = detail.step;
@@ -384,7 +389,8 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
    *  stays up during the (uncached) fetch; a cached id skips it. On a failed /
    *  empty fetch we stay on the picker with an error rather than advance on the
    *  slim entry (whose ``requires_wifi`` hydrates to ``false``). */
-  private async _enterSetupStep(board: BoardCatalogEntry): Promise<void> {
+  private async _enterSetupStep(board: SlimBoard): Promise<void> {
+    this._pickedBoardId = board.id;
     let full = this._fullBoardById.get(board.id) ?? null;
     if (!full) {
       try {
@@ -392,7 +398,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       } catch (err) {
         console.warn("Failed to load full board body:", err);
       }
-      if (this._selectedBoard?.id !== board.id) return; // selection moved on
+      if (this._pickedBoardId !== board.id) return; // selection moved on
       if (!full) {
         this._createError = this._localize("wizard.board_load_failed");
         return; // keep the user on the picker to retry

--- a/src/components/wizard/wizard-step-board-list.ts
+++ b/src/components/wizard/wizard-step-board-list.ts
@@ -2,7 +2,7 @@ import { mdiArrowCollapseAll, mdiArrowExpandAll, mdiOpenInNew, mdiPlus } from "@
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { loadMoreFooterStyles } from "../../styles/load-more-footer.js";
 import { espHomeStyles } from "../../styles/shared.js";
@@ -34,7 +34,7 @@ registerMdiIcons({
 @customElement("esphome-wizard-step-board-list")
 export class ESPHomeWizardStepBoardList extends LitElement {
   @property({ attribute: false })
-  boards: BoardCatalogEntry[] = [];
+  boards: SlimBoard[] = [];
 
   @property({ type: Boolean })
   loading = false;
@@ -64,7 +64,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
   // Split the catalog into the single featured tile + the rest. Memoised on
   // the ``boards`` reference so the find + filter pair shares one walk per
   // page append.
-  private _splitBoards = memoizeOne((boards: BoardCatalogEntry[]) => ({
+  private _splitBoards = memoizeOne((boards: SlimBoard[]) => ({
     featured: boards.find((b) => b.featured),
     regular: boards.filter((b) => !b.featured),
   }));
@@ -145,7 +145,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
     this._intersection.observeIfPresent(this._sentinel, null, "200px");
   }
 
-  private _renderFeatured(board: BoardCatalogEntry) {
+  private _renderFeatured(board: SlimBoard) {
     const imageUrl = boardImageUrl(board);
     return html`
       <div class="featured-card">
@@ -184,7 +184,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
     `;
   }
 
-  private _renderBoardCard(board: BoardCatalogEntry, expanded: boolean) {
+  private _renderBoardCard(board: SlimBoard, expanded: boolean) {
     const imageUrl = boardImageUrl(board);
     return html`
       <article class="board-card ${expanded ? "board-card--expanded" : ""}">
@@ -242,7 +242,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
     `;
   }
 
-  private _onToggleExpand(board: BoardCatalogEntry) {
+  private _onToggleExpand(board: SlimBoard) {
     this._expandedBoardId = this._expandedBoardId === board.id ? null : board.id;
   }
 
@@ -258,7 +258,7 @@ export class ESPHomeWizardStepBoardList extends LitElement {
     return translated === key ? tag : translated;
   }
 
-  private _onAdd(board: BoardCatalogEntry) {
+  private _onAdd(board: SlimBoard) {
     this.dispatchEvent(
       new CustomEvent("add-board", {
         detail: { board },

--- a/src/components/wizard/wizard-step-board.ts
+++ b/src/components/wizard/wizard-step-board.ts
@@ -4,7 +4,7 @@ import { LitElement, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
-import type { BoardCatalogEntry } from "../../api/types/boards.js";
+import type { SlimBoard } from "../../api/types/boards.js";
 import { ESPHOME_DOCS_BASE } from "../../common/docs.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
@@ -56,7 +56,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
   @property({ attribute: false })
   presetFilterLabel: string | null = null;
 
-  private _list = new PagedListController<BoardCatalogEntry>(this);
+  private _list = new PagedListController<SlimBoard>(this);
 
   @state()
   private _search = "";
@@ -245,7 +245,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
     this._list.loadMore();
   };
 
-  private _onAddBoard = (e: CustomEvent<{ board: BoardCatalogEntry }>) => {
+  private _onAddBoard = (e: CustomEvent<{ board: SlimBoard }>) => {
     this._onAdd(e.detail.board);
   };
 
@@ -263,7 +263,7 @@ export class ESPHomeWizardStepBoard extends LitElement {
     this._fetchBoards();
   }
 
-  private _onAdd(board: BoardCatalogEntry) {
+  private _onAdd(board: SlimBoard) {
     this.dispatchEvent(
       new CustomEvent("next-step", {
         detail: { step: "setup", board },

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -7,6 +7,7 @@ import type {
   FeaturedComponent,
   FieldPreset,
   PagedBoardsResponse,
+  SlimBoard,
 } from "../api/types/boards.js";
 
 /**
@@ -25,7 +26,8 @@ import type {
  * a forward-compat field added to the wire shape carries through
  * the hydrator instead of being silently dropped.
  */
-export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
+/** Hydrate the slim index fields shared by every board shape. */
+export function hydrateSlimBoard(entry: SlimBoard): SlimBoard {
   return {
     ...entry,
     esphome: _hydrateEsphome(entry.esphome),
@@ -37,6 +39,13 @@ export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
     product_url: entry.product_url ?? "",
     featured: entry.featured ?? false,
     is_generic: entry.is_generic ?? false,
+  };
+}
+
+export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
+  return {
+    ...entry,
+    ...hydrateSlimBoard(entry),
     full_config: entry.full_config ?? false,
     featured_components: (entry.featured_components ?? []).map(_hydrateFeaturedComponent),
     featured_bundles: (entry.featured_bundles ?? []).map(_hydrateFeaturedBundle),
@@ -56,7 +65,7 @@ export function hydratePagedBoardsResponse(
     total: response.total ?? 0,
     offset: response.offset ?? 0,
     limit: response.limit ?? 50,
-    boards: (response.boards ?? []).map(hydrateBoard),
+    boards: (response.boards ?? []).map(hydrateSlimBoard),
   };
 }
 

--- a/src/util/board-hydrate.ts
+++ b/src/util/board-hydrate.ts
@@ -44,7 +44,6 @@ export function hydrateSlimBoard(entry: SlimBoard): SlimBoard {
 
 export function hydrateBoard(entry: BoardCatalogEntry): BoardCatalogEntry {
   return {
-    ...entry,
     ...hydrateSlimBoard(entry),
     full_config: entry.full_config ?? false,
     featured_components: (entry.featured_components ?? []).map(_hydrateFeaturedComponent),

--- a/src/util/board-image.ts
+++ b/src/util/board-image.ts
@@ -1,4 +1,4 @@
-import type { BoardCatalogEntry } from "../api/types/boards.js";
+import type { SlimBoard } from "../api/types/boards.js";
 import { withBase } from "./base-path.js";
 
 const DEFAULT_BOARD_IMAGE = "/assets/board/default.svg";
@@ -13,7 +13,7 @@ export function defaultBoardImageUrl(): string {
  *  paths the backend serves; `withBase` adds the deployment prefix so they
  *  resolve under HA ingress / a reverse-proxy subpath. External `https://`
  *  URLs (curated boards) pass through unchanged. */
-export function boardImageUrl(board: BoardCatalogEntry): string {
+export function boardImageUrl(board: SlimBoard): string {
   if (board.images.length > 0) return withBase(board.images[0]);
   return defaultBoardImageUrl();
 }

--- a/test/util/board-hydrate.test.ts
+++ b/test/util/board-hydrate.test.ts
@@ -223,6 +223,24 @@ describe("hydratePagedBoardsResponse", () => {
     expect(hydrated.limit).toBe(50);
   });
 
+  it("leaves body-only fields off slim index entries", () => {
+    // The slim path must not attach featured_components / requires_wifi etc.
+    // Reading one off a SlimBoard is a type error, and at runtime the field
+    // stays absent rather than hydrating to a misleading default (the #1798
+    // trap that motivated the SlimBoard / BoardCatalogEntry split).
+    const response = {
+      total: 1,
+      offset: 0,
+      limit: 50,
+      boards: [strippedEntry()],
+    } as unknown as PagedBoardsResponse;
+    const [board] = hydratePagedBoardsResponse(response).boards;
+    expect(board).not.toHaveProperty("featured_components");
+    expect(board).not.toHaveProperty("featured_bundles");
+    expect(board).not.toHaveProperty("requires_wifi");
+    expect(board).not.toHaveProperty("full_config");
+  });
+
   it("re-defaults a wholly-stripped wrapper (forward-compat against omit_default on PagedResponse)", () => {
     // If the backend ever applies omit_default to PagedResponse,
     // a zero-result query strips boards/total/offset/limit — the


### PR DESCRIPTION
# What does this implement/fix?

`boards/get_boards` and `boards/get_compatible_boards` return slim index entries that omit the body-only fields (`featured_components`, `featured_bundles`, `full_config`, `requires_wifi`); only `boards/get_board` derives them. The frontend used one `BoardCatalogEntry` type for both shapes, so reading `requires_wifi` off a slim entry compiled fine and silently hydrated to `false` — the latent trap behind the wizard Wi-Fi-step drop (device-builder#1798 / #1057).

This splits the type: `SlimBoard` is the base (the slim index fields), and `BoardCatalogEntry` extends it with the body-only fields. The slim producers and consumers (the board picker, the compatible-board lists, `device-board-info`, the change-board dialog) are typed on `SlimBoard`, so reading a body-only field off a slim entry is now a compile error rather than a silent `false`. `hydratePagedBoardsResponse` uses a new `hydrateSlimBoard` so slim entries no longer get body-field defaults attached; `hydrateBoard` reuses it for the full body. `boardImageUrl` is widened to `SlimBoard` (it only reads `images`).

The create wizard keeps a full-body `_selectedBoard` (only ever assigned in `_enterSetupStep` / `openWithBoard`) and tracks the in-flight pick with `_pickedBoardId`, instead of parking a slim entry in the full-typed slot to drive the stale-selection guard.

No user-visible behaviour change.

**Related issue or feature (if applicable):**

- fixes #1058

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
