### PR TITLE
Surface the real add-component error instead of a generic message

### DIFF
--- a/src/components/device/add-component-dialog-selection.ts
+++ b/src/components/device/add-component-dialog-selection.ts
@@ -69,10 +69,11 @@ export async function hydrateForSelection(
     );
     if (seq !== host._selectionSeq) return { kind: "stale" };
     if (!entry) {
-      // A null body isn't a thrown error — ``fetchComponent`` swallows a
-      // transient miss (dropped WS, backend restart) and returns null, so
-      // there's no detail to surface. Say what actually went wrong (couldn't
-      // load) rather than the misleading "failed to add".
+      // A null body isn't a thrown error — the fetch resolved but the backend
+      // omitted this id (a stale or wrong backend). ``fetchComponent`` caches
+      // that miss for the session, so a same-session retry won't recover; a
+      // reload re-fetches. Say what went wrong (couldn't load, reload) rather
+      // than the misleading "failed to add".
       return {
         kind: "error",
         message: host._localize("device.add_component_load_failed"),

--- a/src/components/device/add-component-dialog-selection.ts
+++ b/src/components/device/add-component-dialog-selection.ts
@@ -2,6 +2,7 @@ import type { ESPHomeAPI } from "../../api/index.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { fetchComponent } from "../../util/component-name-cache.js";
+import { formatApiError } from "../../util/format-api-error.js";
 
 /**
  * Slice of ``ESPHomeAddComponentDialog`` state ``hydrateForSelection`` reads.
@@ -68,15 +69,21 @@ export async function hydrateForSelection(
     );
     if (seq !== host._selectionSeq) return { kind: "stale" };
     if (!entry) {
-      return { kind: "error", message: host._localize("device.add_component_error") };
+      // A null body isn't a thrown error — ``fetchComponent`` swallows a
+      // transient miss (dropped WS, backend restart) and returns null, so
+      // there's no detail to surface. Say what actually went wrong (couldn't
+      // load) rather than the misleading "failed to add".
+      return {
+        kind: "error",
+        message: host._localize("device.add_component_load_failed"),
+      };
     }
     return { kind: "ok", entry };
   } catch (err) {
     if (seq !== host._selectionSeq) return { kind: "stale" };
     return {
       kind: "error",
-      message:
-        err instanceof Error ? err.message : host._localize("device.add_component_error"),
+      message: formatApiError(err, host._localize, "device.add_component_error"),
     };
   }
 }

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -14,6 +14,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { collectExistingIds } from "../../util/default-component-id.js";
 import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -662,8 +663,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // the already-added members (the draft is otherwise only published on the
       // success or hand-off paths, not on a throw).
       if (addedAny) this._dispatchDraft(this.yaml);
-      this._submitError =
-        err instanceof Error ? err.message : this._localize("device.add_component_error");
+      this._submitError = formatApiError(
+        err,
+        this._localize,
+        "device.add_component_error"
+      );
       toast.error(this._submitError, { richColors: true });
     } finally {
       this._submitting = false;
@@ -880,8 +884,11 @@ export class ESPHomeAddComponentDialog extends LitElement {
         }
       }
     } catch (err) {
-      this._submitError =
-        err instanceof Error ? err.message : this._localize("device.add_component_error");
+      this._submitError = formatApiError(
+        err,
+        this._localize,
+        "device.add_component_error"
+      );
       // The configless path (notify) has no form fields, so `_submitError`
       // would land in an otherwise-empty form view where it's easy to
       // miss — toast it too so the failure can't read as a silent no-op.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -881,6 +881,7 @@
     "save_error": "Failed to save",
     "section_saved_toast": "\"{title}\" saved",
     "add_component_error": "Failed to add component",
+    "add_component_load_failed": "Couldn't load this component. Check your connection and try again.",
     "add_component_hidden_validation_error": "Can't add this component: a hidden field has invalid input. Please report the fields listed below — they should be visible.",
     "missing_dependencies_title": "{name} requires other components",
     "missing_dependencies_body": "Configure these first, then come back to add this one:",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -881,7 +881,7 @@
     "save_error": "Failed to save",
     "section_saved_toast": "\"{title}\" saved",
     "add_component_error": "Failed to add component",
-    "add_component_load_failed": "Couldn't load this component. Check your connection and try again.",
+    "add_component_load_failed": "Couldn't load this component. Try reloading the page.",
     "add_component_hidden_validation_error": "Can't add this component: a hidden field has invalid input. Please report the fields listed below — they should be visible.",
     "missing_dependencies_title": "{name} requires other components",
     "missing_dependencies_body": "Configure these first, then come back to add this one:",

--- a/test/components/device/add-component-dialog-selection.test.ts
+++ b/test/components/device/add-component-dialog-selection.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import type { ESPHomeAPI } from "../../../src/api/index.js";
+import { APIError, type ESPHomeAPI } from "../../../src/api/index.js";
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import {
   hydrateForSelection,
@@ -45,7 +45,10 @@ describe("hydrateForSelection", () => {
     expect(result).toEqual({ kind: "ok", entry: wifi });
   });
 
-  test("returns error when the catalog has no entry for the id", async () => {
+  test("returns a load-failed message when the body fetch yields no entry", async () => {
+    // A null body is a swallowed transient miss (dropped WS / backend restart),
+    // not a thrown error — so the copy names the load failure rather than the
+    // misleading "failed to add".
     const getComponentBodies = vi.fn().mockResolvedValue({});
     const host = makeHost(getComponentBodies);
 
@@ -53,7 +56,7 @@ describe("hydrateForSelection", () => {
 
     expect(result).toEqual({
       kind: "error",
-      message: "device.add_component_error",
+      message: "device.add_component_load_failed",
     });
   });
 
@@ -64,6 +67,19 @@ describe("hydrateForSelection", () => {
     const result = await hydrateForSelection(host, "wifi");
 
     expect(result).toEqual({ kind: "error", message: "network down" });
+  });
+
+  test("surfaces an APIError's structured details, not the wire-form message", async () => {
+    // formatApiError prefers APIError.details over the "<code>: <details>"
+    // Error.message, so the banner shows the human reason, not the internal code.
+    const getComponentBodies = vi
+      .fn()
+      .mockRejectedValue(new APIError("invalid_args", "GPIO 14 is already in use"));
+    const host = makeHost(getComponentBodies);
+
+    const result = await hydrateForSelection(host, "wifi");
+
+    expect(result).toEqual({ kind: "error", message: "GPIO 14 is already in use" });
   });
 
   test("returns stale when the seq bumps before the response lands", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adding a component — especially a board's recommended bundle — that failed showed a
generic **"Failed to add component"** banner that hid the actual cause, so a user
(and triage) had no idea what went wrong.

Two changes:

- The add / bundle failure catches now reuse the existing `formatApiError` helper, so
  an `APIError` surfaces its structured `details` (e.g. "GPIO 14 is already in use")
  instead of the wire-form `"<code>: <details>"` or the generic fallback.
- The body-load path had a second, sneakier source of the generic text:
  `fetchComponent` resolves but the backend omits the id (a stale or wrong backend) and
  returns `null` — not a thrown error — so there's no detail to surface, and the miss is
  cached for the session (a same-session retry won't recover). That case now gets its own
  honest message ("Couldn't load this component. Try reloading the page.") rather than
  the misleading "failed to add".

Surfaced while testing a new board's recommended bundles against a backend that didn't
have that board's components — exactly the backend-omitted-id (cached-null) case.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).

