### PR TITLE
Follow the rename chain's compile into its flash-and-swap tail

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -39,6 +39,7 @@ import type {
   DevicesResponse,
   ImportBundleResponse,
   Label,
+  RenameDeviceResponse,
   UpdateDeviceResponse,
   WizardResponse,
   YamlSearchHit,
@@ -816,16 +817,8 @@ export class ESPHomeAPI {
     configuration: string,
     newName: string,
     configOnly = false
-  ): Promise<{
-    configuration: string;
-    job: FirmwareJob | null;
-    tail_job?: FirmwareJob | null;
-  }> {
-    return this.sendCommand<{
-      configuration: string;
-      job: FirmwareJob | null;
-      tail_job?: FirmwareJob | null;
-    }>(
+  ): Promise<RenameDeviceResponse> {
+    return this.sendCommand<RenameDeviceResponse>(
       "devices/rename",
       { configuration, new_name: newName, ...(configOnly ? { config_only: true } : {}) },
       60000

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -802,10 +802,11 @@ export class ESPHomeAPI {
 
   /** Rename a device (renames YAML file + ``esphome.name``).
    *
-   *  Default kicks off a queued firmware ``RENAME`` job that compiles,
-   *  OTA-installs, and swaps the YAML; the returned ``job`` is what the
-   *  caller follows in the command-dialog so the user sees streaming
-   *  output. Only succeeds against a reachable device.
+   *  Default queues a rename chain: ``job`` is the COMPILE of the renamed
+   *  YAML (the follow target) and ``tail_job`` the dependent RENAME that
+   *  flashes the old address and swaps the files. Older backends return a
+   *  fused ``RENAME`` as ``job`` with no ``tail_job``. Only succeeds
+   *  against a reachable device.
    *
    *  ``configOnly`` renames the YAML + ``esphome.name`` with no compile
    *  or flash and returns ``job: null``, used after the user confirms
@@ -815,8 +816,16 @@ export class ESPHomeAPI {
     configuration: string,
     newName: string,
     configOnly = false
-  ): Promise<{ configuration: string; job: FirmwareJob | null }> {
-    return this.sendCommand<{ configuration: string; job: FirmwareJob | null }>(
+  ): Promise<{
+    configuration: string;
+    job: FirmwareJob | null;
+    tail_job?: FirmwareJob | null;
+  }> {
+    return this.sendCommand<{
+      configuration: string;
+      job: FirmwareJob | null;
+      tail_job?: FirmwareJob | null;
+    }>(
       "devices/rename",
       { configuration, new_name: newName, ...(configOnly ? { config_only: true } : {}) },
       60000

--- a/src/api/types/devices.ts
+++ b/src/api/types/devices.ts
@@ -6,6 +6,7 @@
 // Type-only: ``reachability.ts`` imports ``DeviceState`` from here, so a
 // value import would cycle. ``ReachabilitySource`` is a string-literal union,
 // erased at runtime, so the type-only edge is free.
+import type { FirmwareJob } from "./firmware-jobs.js";
 import type { ReachabilitySource } from "./reachability.js";
 
 // ─── Devices ─────────────────────────────────────────────────
@@ -274,6 +275,13 @@ export interface ImportBundleResponse {
   kept: string[];
   has_secrets: boolean;
   esphome_version: string;
+}
+
+/** Response from devices/rename. ``tail_job`` is absent on pre-chain backends. */
+export interface RenameDeviceResponse {
+  configuration: string;
+  job: FirmwareJob | null;
+  tail_job?: FirmwareJob | null;
 }
 
 /** Response from devices/update. */

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -16,7 +16,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
-import { JobSource, JobStatus, JobType } from "../api/types/firmware-jobs.js";
+import { JobSource, JobStatus } from "../api/types/firmware-jobs.js";
 import type { PairingSummary } from "../api/types/remote-build.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import type { RemoteBuildJobState } from "../context/index.js";
@@ -36,6 +36,7 @@ import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
+  deriveFollowCommandType,
   detachStream,
   followJob,
   onForceLocalClick,
@@ -80,15 +81,6 @@ export type CommandType =
   "install" | "compile" | "validate" | "clean" | "reset" | "rename";
 
 export type CommandState = "running" | "success" | "error";
-
-const JOB_TYPE_TO_COMMAND: Record<string, CommandType> = {
-  [JobType.COMPILE]: "compile",
-  [JobType.INSTALL]: "install",
-  [JobType.UPLOAD]: "install",
-  [JobType.CLEAN]: "clean",
-  [JobType.RESET_BUILD_ENV]: "reset",
-  [JobType.RENAME]: "rename",
-};
 
 @customElement("esphome-command-dialog")
 export class ESPHomeCommandDialog extends LitElement {
@@ -248,12 +240,13 @@ export class ESPHomeCommandDialog extends LitElement {
 
   // Attach to a firmware job's stream. Handles any state — terminal jobs
   // replay buffered output and resolve to the final success/error banner.
-  // ``commandType`` overrides the job-type derivation for chain heads whose
-  // type doesn't name the user's command (a rename's COMPILE head).
+  // ``commandType`` overrides the derivation when the caller knows the
+  // command before the jobs context does (a just-queued rename's COMPILE
+  // head); reattach paths omit it and derive from the chain shape.
   public followJob(job: FirmwareJob, displayName: string, commandType?: CommandType) {
     this.configuration = job.configuration;
     this.name = displayName;
-    this._commandType = commandType ?? JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
+    this._commandType = commandType ?? deriveFollowCommandType(this._jobs, job);
     this._port = job.port || "OTA";
     resetRunState(this);
     // Fresh attach is a fresh session — reset toggle defaults so a prior

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -161,9 +161,9 @@ export class ESPHomeCommandDialog extends LitElement {
   // to "open in editor" (YAML help). Reset per open().
   @state() _failedDuringValidate = false;
 
-  // Flips true when an install COMPILE succeeded but its dependent UPLOAD is
+  // Flips true when a chain COMPILE succeeded but its dependent flash is
   // missing — the build itself was fine, so the clean/reset hint is suppressed.
-  @state() _installMissingUpload = false;
+  @state() _compileMissingDependent = false;
 
   // Locally-primed status / source so the queued overlay + remote-builder
   // sub-line paint on the first frame instead of waiting for the next jobs

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -248,10 +248,12 @@ export class ESPHomeCommandDialog extends LitElement {
 
   // Attach to a firmware job's stream. Handles any state — terminal jobs
   // replay buffered output and resolve to the final success/error banner.
-  public followJob(job: FirmwareJob, displayName: string) {
+  // ``commandType`` overrides the job-type derivation for chain heads whose
+  // type doesn't name the user's command (a rename's COMPILE head).
+  public followJob(job: FirmwareJob, displayName: string, commandType?: CommandType) {
     this.configuration = job.configuration;
     this.name = displayName;
-    this._commandType = JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
+    this._commandType = commandType ?? JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
     this._port = job.port || "OTA";
     resetRunState(this);
     // Fresh attach is a fresh session — reset toggle defaults so a prior

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -174,33 +174,35 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
       const result = data as unknown as { status: string; exit_code: number | null };
       const success = result.status === JobStatus.COMPLETED;
 
-      // On a successful install COMPILE, follow its dependent UPLOAD so success
-      // reflects the flash (#1131). Gate on the finished job being the COMPILE
-      // so the upload's own completion falls straight through to success.
+      // On a successful install/rename COMPILE, follow the dependent flash —
+      // the install's UPLOAD or the rename's flash-and-swap tail — so success
+      // reflects the device, not just the build (#1131). Gate on the finished
+      // job being the COMPILE so the flash's own completion falls through.
       const finished = host._jobs.get(jobId);
       if (
         success &&
-        host._commandType === "install" &&
+        (host._commandType === "install" || host._commandType === "rename") &&
         finished?.job_type === JobType.COMPILE
       ) {
-        // The held UPLOAD is created at install time (#1131); its job_queued is
+        // The held dependent is created with the chain; its job_queued is
         // ordered ahead of this compile's job_completed on the shared WS, so it
-        // is normally already in _jobs. A miss is therefore a real backend gap,
-        // not a still-arriving event for a legitimately-running install.
-        const upload = [...host._jobs.values()].find(
-          (j) => j.job_type === JobType.UPLOAD && j.depends_on === jobId
+        // is normally already in _jobs. A miss is therefore a real backend gap.
+        const flash = [...host._jobs.values()].find(
+          (j) =>
+            j.depends_on === jobId &&
+            (j.job_type === JobType.UPLOAD || j.job_type === JobType.RENAME)
         );
-        if (upload) {
-          // primeAndFollow re-primes the source snapshot from the upload (the
-          // local flash) so the remote-builder sub-line doesn't linger on the
-          // compile's receiver while the upload runs.
-          primeAndFollow(host, upload);
+        if (flash) {
+          // primeAndFollow re-primes the source snapshot from the flash (local)
+          // so the remote-builder sub-line doesn't linger on the compile's
+          // receiver.
+          primeAndFollow(host, flash);
           return;
         }
-        // No upload step — the device was never flashed, so don't report success.
-        console.warn("install compile succeeded but no dependent upload for job", jobId);
+        // No flash step — the device was never flashed, so don't report success.
+        console.warn("compile succeeded but no dependent flash for job", jobId);
         host._state = "error";
-        host._statusMessage = host._localize("command.install_failed");
+        host._statusMessage = host._localize(`command.${host._commandType}_failed`);
         // The compile succeeded, so the clean/reset build-failure hint is
         // misleading here — suppress it.
         host._installMissingUpload = true;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -5,7 +5,7 @@ import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
 import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
 
-const JOB_TYPE_TO_COMMAND: Record<string, CommandType> = {
+const JOB_TYPE_TO_COMMAND: Record<JobType, CommandType> = {
   [JobType.COMPILE]: "compile",
   [JobType.INSTALL]: "install",
   [JobType.UPLOAD]: "install",

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -3,7 +3,32 @@ import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-j
 import { ErrorCode } from "../../api/types/protocol.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
-import type { ESPHomeCommandDialog } from "../command-dialog.js";
+import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
+
+const JOB_TYPE_TO_COMMAND: Record<string, CommandType> = {
+  [JobType.COMPILE]: "compile",
+  [JobType.INSTALL]: "install",
+  [JobType.UPLOAD]: "install",
+  [JobType.CLEAN]: "clean",
+  [JobType.RESET_BUILD_ENV]: "reset",
+  [JobType.RENAME]: "rename",
+};
+
+// A live COMPILE with a held dependent is a chain head — attach in the
+// chain's command mode so success reflects the flash, not just the build.
+// Terminal reattach keeps plain compile mode: it's a log-review path and
+// must show the log the user clicked, not chain into the flash log.
+export function deriveFollowCommandType(
+  jobs: Map<string, FirmwareJob>,
+  job: FirmwareJob
+): CommandType {
+  if (job.job_type === JobType.COMPILE && !isTerminalJobStatus(job.status)) {
+    const dependent = [...jobs.values()].find((j) => j.depends_on === job.job_id);
+    if (dependent?.job_type === JobType.RENAME) return "rename";
+    if (dependent?.job_type === JobType.UPLOAD) return "install";
+  }
+  return JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
+}
 
 // Dashboard mode pins escaped form (\033[…m); raw form (\x1b[…m) is defensive.
 const ANSI_SGR = /(?:\\033|\x1b)\[[0-9;]*m/g;

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -46,7 +46,7 @@ export function resetRunState(host: ESPHomeCommandDialog): void {
   host._statusMessage = "";
   host._userStopped = false;
   host._failedDuringValidate = false;
-  host._installMissingUpload = false;
+  host._compileMissingDependent = false;
 }
 
 export async function startCommand(host: ESPHomeCommandDialog): Promise<void> {
@@ -205,7 +205,7 @@ export function followJob(host: ESPHomeCommandDialog, jobId: string): void {
         host._statusMessage = host._localize(`command.${host._commandType}_failed`);
         // The compile succeeded, so the clean/reset build-failure hint is
         // misleading here — suppress it.
-        host._installMissingUpload = true;
+        host._compileMissingDependent = true;
         host._jobId = "";
         return;
       }

--- a/src/components/command-dialog/renderers.ts
+++ b/src/components/command-dialog/renderers.ts
@@ -110,9 +110,9 @@ export function renderResetSuggestion(
 ): TemplateResult | typeof nothing {
   if (host._state !== "error") return nothing;
   if (host._userStopped) return nothing;
-  // A compile that succeeded but found no upload step isn't a build failure —
-  // clean/reset wouldn't help.
-  if (host._installMissingUpload) return nothing;
+  // A compile that succeeded but found no dependent flash isn't a build
+  // failure — clean/reset wouldn't help.
+  if (host._compileMissingDependent) return nothing;
   if (host._commandType === "validate" || host._failedDuringValidate) {
     return renderValidationFailureSuggestion(host);
   }

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -4,6 +4,7 @@ import type {
   AdoptableDevice,
   ConfiguredDevice,
   Label,
+  RenameDeviceResponse,
 } from "../../api/types/devices.js";
 import { DeviceState } from "../../api/types/devices.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
@@ -114,7 +115,7 @@ export async function performRename(
   newName: string,
   configOnly: boolean
 ): Promise<void> {
-  let response: Awaited<ReturnType<ESPHomeAPI["renameDevice"]>>;
+  let response: RenameDeviceResponse;
   try {
     response = await host._api.renameDevice(device.configuration, newName, configOnly);
   } catch (err) {

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -130,9 +130,16 @@ export async function performRename(
   }
   clearJustCreated();
   if (response.job) {
+    // The chain head is a COMPILE of the new YAML; the tail carries the
+    // "old → new" naming. Older backends return the fused RENAME, no tail.
     host._commandDialog.followJob(
       response.job,
-      firmwareJobDisplayName(response.job, host._devices, host._localize)
+      firmwareJobDisplayName(
+        response.tail_job ?? response.job,
+        host._devices,
+        host._localize
+      ),
+      "rename"
     );
     return;
   }

--- a/test/components/_command-dialog-host.ts
+++ b/test/components/_command-dialog-host.ts
@@ -1,0 +1,59 @@
+// Shared fake ESPHomeCommandDialog host for the chain-follow tests
+// (install + rename) so the mirrored follow-path fields live in one place.
+import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
+import { JobStatus } from "../../src/api/types/firmware-jobs.js";
+import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+
+export interface StreamCbs {
+  onOutput: (line: string) => void;
+  onResult: (data: unknown) => void;
+  onError: (error: string) => void;
+}
+
+export function makeCommandDialogHost(
+  jobs: Map<string, FirmwareJob>,
+  apiExtra: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {}
+) {
+  const follows: Record<string, StreamCbs> = {};
+  let flipped = false;
+  let streamSeq = 0;
+  const host = {
+    _api: {
+      firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
+        follows[jobId] = cbs;
+        return `stream-${++streamSeq}`;
+      },
+      ...apiExtra,
+    },
+    _jobs: jobs,
+    _commandType: "install",
+    _jobId: "",
+    _jobStatus: JobStatus.RUNNING,
+    _state: "running",
+    _statusMessage: "",
+    _streamId: "",
+    _switchingToLocal: false,
+    configuration: "kitchen.yaml",
+    name: "kitchen",
+    _port: "OTA",
+    _lines: [] as string[],
+    _showLogsAfterInstall: true,
+    _userStopped: false,
+    _failedDuringValidate: false,
+    _compileMissingDependent: false,
+    _localize: (key: string) => key,
+    _flipToLogs: () => {
+      flipped = true;
+    },
+    _flushPendingLines: () => {},
+    _resetPendingLines: () => {},
+    _enqueueLine: () => {},
+    ...overrides,
+  };
+  return {
+    host: host as unknown as ESPHomeCommandDialog,
+    follows,
+    flipped: () => flipped,
+  };
+}

--- a/test/components/command-dialog-install-chain.test.ts
+++ b/test/components/command-dialog-install-chain.test.ts
@@ -7,64 +7,12 @@ import {
   JobStatus,
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import {
   followJob,
   onForceLocalClick,
 } from "../../src/components/command-dialog/commands.js";
 import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
-
-interface StreamCbs {
-  onOutput: (line: string) => void;
-  onResult: (data: unknown) => void;
-  onError: (error: string) => void;
-}
-
-function makeHost(
-  jobs: Map<string, FirmwareJob>,
-  apiExtra: Record<string, unknown> = {}
-) {
-  const follows: Record<string, StreamCbs> = {};
-  let flipped = false;
-  let streamSeq = 0;
-  const host = {
-    _api: {
-      firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
-        follows[jobId] = cbs;
-        return `stream-${++streamSeq}`;
-      },
-      ...apiExtra,
-    },
-    _jobs: jobs,
-    _commandType: "install",
-    _jobId: "",
-    _jobStatus: JobStatus.RUNNING,
-    _state: "running",
-    _statusMessage: "",
-    _streamId: "",
-    _switchingToLocal: false,
-    configuration: "kitchen.yaml",
-    name: "kitchen",
-    _port: "OTA",
-    _lines: [] as string[],
-    _showLogsAfterInstall: true,
-    _userStopped: false,
-    _failedDuringValidate: false,
-    _installMissingUpload: false,
-    _localize: (key: string) => key,
-    _flipToLogs: () => {
-      flipped = true;
-    },
-    _flushPendingLines: () => {},
-    _resetPendingLines: () => {},
-    _enqueueLine: () => {},
-  };
-  return {
-    host: host as unknown as ESPHomeCommandDialog,
-    follows,
-    flipped: () => flipped,
-  };
-}
+import { makeCommandDialogHost as makeHost } from "./_command-dialog-host.js";
 
 // A host pre-loaded with an install chain: a COMPILE "c1" and its held UPLOAD
 // "u1" (depends_on "c1"). Overrides tweak either job (e.g. a REMOTE compile).
@@ -137,7 +85,7 @@ describe("command-dialog install chain follow", () => {
     expect(host._state).toBe("error");
     expect(host._statusMessage).toBe("command.install_failed");
     // Flagged so the clean/reset build-failure hint is suppressed (compile was fine).
-    expect(host._installMissingUpload).toBe(true);
+    expect(host._compileMissingDependent).toBe(true);
     expect(flipped()).toBe(false);
     warn.mockRestore();
   });
@@ -206,7 +154,7 @@ describe("command-dialog install chain follow", () => {
     // Stale per-session flags from the cancelled remote attempt.
     host._userStopped = true;
     host._failedDuringValidate = true;
-    host._installMissingUpload = true;
+    host._compileMissingDependent = true;
 
     await onForceLocalClick(host);
 
@@ -216,7 +164,7 @@ describe("command-dialog install chain follow", () => {
     // The new local run starts clean — stale flags can't mis-route its hint.
     expect(host._userStopped).toBe(false);
     expect(host._failedDuringValidate).toBe(false);
-    expect(host._installMissingUpload).toBe(false);
+    expect(host._compileMissingDependent).toBe(false);
 
     follows.c2.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
     expect(host._jobId).toBe("u2");

--- a/test/components/command-dialog-reattach-reset.test.ts
+++ b/test/components/command-dialog-reattach-reset.test.ts
@@ -18,9 +18,9 @@ describe("command-dialog public followJob state reset", () => {
       _compileMissingDependent: boolean;
       _streamId: string;
       _api: { firmwareFollowJob: () => string };
-      followJob: (job: FirmwareJob, displayName: string) => void;
+      followJob: (job: FirmwareJob, displayName: string, commandType?: string) => void;
     };
-    // Left over from a prior install whose compile succeeded but found no upload.
+    // Left over from a prior install whose compile succeeded but found no dependent flash.
     el._compileMissingDependent = true;
     el._streamId = "";
     el._api = { firmwareFollowJob: () => "stream-1" } as never;

--- a/test/components/command-dialog-reattach-reset.test.ts
+++ b/test/components/command-dialog-reattach-reset.test.ts
@@ -4,7 +4,7 @@
  * The command dialog is a reused singleton: clicking a job in firmware-tasks
  * reattaches via the public followJob without going through open()/startCommand.
  * That path must clear per-session flags, else a prior install's missing-upload
- * failure leaves _installMissingUpload set and suppresses the clean/reset hint
+ * failure leaves _compileMissingDependent set and suppresses the clean/reset hint
  * on a subsequently-replayed real build failure. Pin the reset here.
  */
 import { describe, expect, it } from "vitest";
@@ -13,20 +13,20 @@ import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
 
 describe("command-dialog public followJob state reset", () => {
-  it("clears a stale _installMissingUpload on reattach", () => {
+  it("clears a stale _compileMissingDependent on reattach", () => {
     const el = new ESPHomeCommandDialog() as unknown as {
-      _installMissingUpload: boolean;
+      _compileMissingDependent: boolean;
       _streamId: string;
       _api: { firmwareFollowJob: () => string };
       followJob: (job: FirmwareJob, displayName: string) => void;
     };
     // Left over from a prior install whose compile succeeded but found no upload.
-    el._installMissingUpload = true;
+    el._compileMissingDependent = true;
     el._streamId = "";
     el._api = { firmwareFollowJob: () => "stream-1" } as never;
 
     el.followJob(makeFirmwareJob({ job_id: "j1", job_type: JobType.COMPILE }), "device");
 
-    expect(el._installMissingUpload).toBe(false);
+    expect(el._compileMissingDependent).toBe(false);
   });
 });

--- a/test/components/command-dialog-rename-chain.test.ts
+++ b/test/components/command-dialog-rename-chain.test.ts
@@ -6,7 +6,10 @@ import {
   JobStatus,
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
-import { followJob } from "../../src/components/command-dialog/commands.js";
+import {
+  deriveFollowCommandType,
+  followJob,
+} from "../../src/components/command-dialog/commands.js";
 import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
 import { makeCommandDialogHost } from "./_command-dialog-host.js";
 
@@ -107,5 +110,61 @@ describe("command-dialog rename chain follow", () => {
 
     expect(host._state).toBe("error");
     expect(host._statusMessage).toBe("command.rename_failed");
+  });
+});
+
+describe("deriveFollowCommandType (reattach)", () => {
+  it("derives the chain mode for a live compile head with a held dependent", () => {
+    const { host } = renameChainHost();
+    const jobs = (host as unknown as { _jobs: Map<string, FirmwareJob> })._jobs;
+
+    expect(deriveFollowCommandType(jobs, jobs.get("c1")!)).toBe("rename");
+
+    const upload = makeJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      status: JobStatus.QUEUED,
+      depends_on: "c2",
+    });
+    const compile = makeJob({ job_id: "c2", job_type: JobType.COMPILE });
+    const installJobs = new Map([
+      ["c2", compile],
+      ["u1", upload],
+    ]);
+    expect(deriveFollowCommandType(installJobs, compile)).toBe("install");
+  });
+
+  it("keeps plain compile mode for terminal reattach and chainless compiles", () => {
+    // Terminal reattach is a log-review path; it must not chain into the flash log.
+    const done = makeJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      status: JobStatus.COMPLETED,
+    });
+    const tail = makeJob({
+      job_id: "r1",
+      job_type: JobType.RENAME,
+      status: JobStatus.COMPLETED,
+      new_name: "livingroom",
+      depends_on: "c1",
+    });
+    const jobs = new Map([
+      ["c1", done],
+      ["r1", tail],
+    ]);
+    expect(deriveFollowCommandType(jobs, done)).toBe("compile");
+
+    const lone = makeJob({ job_id: "c3", job_type: JobType.COMPILE });
+    expect(deriveFollowCommandType(new Map([["c3", lone]]), lone)).toBe("compile");
+  });
+
+  it("maps non-compile jobs by type", () => {
+    const tail = makeJob({
+      job_id: "r1",
+      job_type: JobType.RENAME,
+      new_name: "livingroom",
+      depends_on: "c1",
+    });
+    expect(deriveFollowCommandType(new Map(), tail)).toBe("rename");
   });
 });

--- a/test/components/command-dialog-rename-chain.test.ts
+++ b/test/components/command-dialog-rename-chain.test.ts
@@ -6,55 +6,20 @@ import {
   JobStatus,
   JobType,
 } from "../../src/api/types/firmware-jobs.js";
-import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
 import { followJob } from "../../src/components/command-dialog/commands.js";
 import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
-
-interface StreamCbs {
-  onOutput: (line: string) => void;
-  onResult: (data: unknown) => void;
-  onError: (error: string) => void;
-}
+import { makeCommandDialogHost } from "./_command-dialog-host.js";
 
 function makeHost(jobs: Map<string, FirmwareJob>) {
-  const follows: Record<string, StreamCbs> = {};
-  let flipped = false;
-  let streamSeq = 0;
-  const host = {
-    _api: {
-      firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
-        follows[jobId] = cbs;
-        return `stream-${++streamSeq}`;
-      },
-    },
-    _jobs: jobs,
-    _commandType: "rename",
-    _jobId: "",
-    _jobStatus: JobStatus.RUNNING,
-    _state: "running",
-    _statusMessage: "",
-    _streamId: "",
-    configuration: "livingroom.yaml",
-    name: "kitchen → livingroom",
-    _port: "OTA",
-    _lines: [] as string[],
-    _showLogsAfterInstall: true,
-    _userStopped: false,
-    _failedDuringValidate: false,
-    _installMissingUpload: false,
-    _localize: (key: string) => key,
-    _flipToLogs: () => {
-      flipped = true;
-    },
-    _flushPendingLines: () => {},
-    _resetPendingLines: () => {},
-    _enqueueLine: () => {},
-  };
-  return {
-    host: host as unknown as ESPHomeCommandDialog,
-    follows,
-    flipped: () => flipped,
-  };
+  return makeCommandDialogHost(
+    jobs,
+    {},
+    {
+      _commandType: "rename",
+      configuration: "livingroom.yaml",
+      name: "kitchen → livingroom",
+    }
+  );
 }
 
 // A COMPILE head "c1" of the renamed YAML plus its held RENAME tail "r1".

--- a/test/components/command-dialog-rename-chain.test.ts
+++ b/test/components/command-dialog-rename-chain.test.ts
@@ -1,0 +1,146 @@
+// A rename follows its COMPILE head into the dependent RENAME flash-and-swap
+// tail: success is reported only after the flash, not when the compile ends.
+import { describe, expect, it, vi } from "vitest";
+import {
+  type FirmwareJob,
+  JobStatus,
+  JobType,
+} from "../../src/api/types/firmware-jobs.js";
+import type { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { followJob } from "../../src/components/command-dialog/commands.js";
+import { makeFirmwareJob as makeJob } from "../_make-firmware-job.js";
+
+interface StreamCbs {
+  onOutput: (line: string) => void;
+  onResult: (data: unknown) => void;
+  onError: (error: string) => void;
+}
+
+function makeHost(jobs: Map<string, FirmwareJob>) {
+  const follows: Record<string, StreamCbs> = {};
+  let flipped = false;
+  let streamSeq = 0;
+  const host = {
+    _api: {
+      firmwareFollowJob: (jobId: string, cbs: StreamCbs): string => {
+        follows[jobId] = cbs;
+        return `stream-${++streamSeq}`;
+      },
+    },
+    _jobs: jobs,
+    _commandType: "rename",
+    _jobId: "",
+    _jobStatus: JobStatus.RUNNING,
+    _state: "running",
+    _statusMessage: "",
+    _streamId: "",
+    configuration: "livingroom.yaml",
+    name: "kitchen → livingroom",
+    _port: "OTA",
+    _lines: [] as string[],
+    _showLogsAfterInstall: true,
+    _userStopped: false,
+    _failedDuringValidate: false,
+    _installMissingUpload: false,
+    _localize: (key: string) => key,
+    _flipToLogs: () => {
+      flipped = true;
+    },
+    _flushPendingLines: () => {},
+    _resetPendingLines: () => {},
+    _enqueueLine: () => {},
+  };
+  return {
+    host: host as unknown as ESPHomeCommandDialog,
+    follows,
+    flipped: () => flipped,
+  };
+}
+
+// A COMPILE head "c1" of the renamed YAML plus its held RENAME tail "r1".
+function renameChainHost() {
+  const compile = makeJob({
+    job_id: "c1",
+    job_type: JobType.COMPILE,
+    configuration: "livingroom.yaml",
+  });
+  const tail = makeJob({
+    job_id: "r1",
+    job_type: JobType.RENAME,
+    configuration: "kitchen.yaml",
+    new_name: "livingroom",
+    status: JobStatus.QUEUED,
+    depends_on: "c1",
+  });
+  return {
+    ...makeHost(
+      new Map([
+        ["c1", compile],
+        ["r1", tail],
+      ])
+    ),
+    compile,
+    tail,
+  };
+}
+
+describe("command-dialog rename chain follow", () => {
+  it("follows the compile into the rename tail and only succeeds after it", () => {
+    const { host, follows, flipped } = renameChainHost();
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(host._state).toBe("running");
+    expect(host._jobId).toBe("r1");
+    expect(follows.r1).toBeDefined();
+
+    follows.r1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(host._state).toBe("success");
+    expect(host._statusMessage).toBe("command.rename_success");
+    expect(host._jobId).toBe("");
+    // Post-rename the device announces under a new name — no log flip.
+    expect(flipped()).toBe(false);
+  });
+
+  it("does not follow the tail when the compile fails", () => {
+    const { host, follows } = renameChainHost();
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.rename_failed");
+    expect(follows.r1).toBeUndefined();
+  });
+
+  it("warns and fails when the compile has no dependent tail", () => {
+    const compile = makeJob({ job_id: "c1", job_type: JobType.COMPILE });
+    const { host, follows } = makeHost(new Map([["c1", compile]]));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.rename_failed");
+    warn.mockRestore();
+  });
+
+  it("reports the tail's failure as a rename failure", () => {
+    const { host, follows } = renameChainHost();
+
+    host._jobId = "c1";
+    followJob(host, "c1");
+    follows.c1.onResult({ status: JobStatus.COMPLETED, exit_code: 0 });
+    follows.r1.onResult({ status: JobStatus.FAILED, exit_code: 1 });
+
+    expect(host._state).toBe("error");
+    expect(host._statusMessage).toBe("command.rename_failed");
+  });
+});

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -92,8 +92,8 @@ describe("renderResetSuggestion — local build", () => {
     expectFallbackToLocal(render(host), host);
   });
 
-  it("renders nothing when the install compile succeeded but had no upload", () => {
-    // The compile was fine; clean/reset wouldn't help a missing upload step.
+  it("renders nothing when a compile succeeded but had no dependent flash", () => {
+    // The compile was fine; clean/reset wouldn't help a missing dependent flash.
     const host = baseHost({ _compileMissingDependent: true });
     expectNoSuggestion(render(host));
   });

--- a/test/components/command-dialog-reset-suggestion.test.ts
+++ b/test/components/command-dialog-reset-suggestion.test.ts
@@ -42,7 +42,7 @@ interface Host {
   _userStopped: boolean;
   _commandType: string;
   _failedDuringValidate: boolean;
-  _installMissingUpload: boolean;
+  _compileMissingDependent: boolean;
   _jobId: string;
   _jobs: Map<string, FirmwareJob>;
   _primedSource: {
@@ -62,7 +62,7 @@ function baseHost(overrides: Partial<Host> = {}): Host {
     _userStopped: false,
     _commandType: "install",
     _failedDuringValidate: false,
-    _installMissingUpload: false,
+    _compileMissingDependent: false,
     _jobId: "job-1",
     _jobs: new Map(),
     _primedSource: null,
@@ -94,7 +94,7 @@ describe("renderResetSuggestion — local build", () => {
 
   it("renders nothing when the install compile succeeded but had no upload", () => {
     // The compile was fine; clean/reset wouldn't help a missing upload step.
-    const host = baseHost({ _installMissingUpload: true });
+    const host = baseHost({ _compileMissingDependent: true });
     expectNoSuggestion(render(host));
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1819, which decomposes the rename into a COMPILE of the renamed YAML plus a dependent RENAME flash-and-swap tail so the compile can run on a paired remote build server. The dialog's chain follow now also applies to renames: on a successful COMPILE it follows the dependent flash (the install's UPLOAD or the rename's tail), so the dialog reports success only after the device is flashed, mirroring the install fix in #1131. performRename follows the returned chain head with an explicit rename command type (the head is a COMPILE, which would otherwise derive compile mode and skip the chain) and takes the "old to new" display name from the new tail_job in the devices/rename response. Backward compatible with older backends that return a fused RENAME job with no tail.

**Related issue or feature (if applicable):**

- companion frontend PR for esphome/device-builder#1819 (fixes esphome/device-builder#1812)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
