### PR TITLE
Flash Web Serial on one continuous esploader session

### DIFF
--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -220,11 +220,17 @@ export async function startWebSerialInstall(
 
 // Best-effort release of the held serial port on an early return, so a failed
 // compile / download / flash doesn't leak an open port into the next attempt.
+// Falls back to closing the port directly when transport.disconnect throws,
+// mirroring connectToPort — a still-open port breaks the next port.open.
 async function releaseSerial(detected: DetectedChip): Promise<void> {
   try {
     await disconnect(detected.transport);
   } catch {
-    /* ignore */
+    try {
+      await detected.port.close();
+    } catch {
+      /* best-effort */
+    }
   }
 }
 

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -207,7 +207,9 @@ export async function startWebSerialInstall(
   try {
     await resetAndDisconnect(detected.loader, detected.transport, detected.port);
   } catch {
-    /* ignore reset errors */
+    // resetAndDisconnect disconnects in its own finally; if that threw through
+    // and left the port held, release it so it doesn't leak into a retry.
+    await releaseSerial(detected);
   }
 
   host._statusMessage = host._localize("firmware.status_done");

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -130,11 +130,7 @@ export async function startWebSerialInstall(
     detectedVariant !== expectedNorm &&
     !(expectedIsCoarseEsp32 && detectedVariant.startsWith("esp32"))
   ) {
-    try {
-      await disconnect(detected.transport);
-    } catch {
-      /* ignore */
-    }
+    await releaseSerial(detected);
     host._fail(
       host._localize("firmware.chip_mismatch", {
         detected: detected.chipName,

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -10,7 +10,6 @@ import { getErrorMessage } from "../../util/error-message.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
 import {
-  connectToPort,
   detectChip,
   disconnect,
   flashFirmware,
@@ -145,17 +144,21 @@ export async function startWebSerialInstall(
     return;
   }
 
-  // Disconnect during compile — we'll reconnect to flash.
-  try {
-    await disconnect(detected.transport);
-  } catch {
-    /* ignore */
-  }
+  // Keep this esploader session open through the compile and flash on it
+  // directly. Closing the port here and reopening it to flash left the stub
+  // loader running on the chip while the OS handle was torn down; on boards
+  // where DTR/RTS reset doesn't land (ESP32-C3 behind a CH340) the reopened
+  // port then reused that stale stub and FLASH_DEFL_BEGIN was rejected with
+  // "Failed to enter compressed flash mode" (#1833). The external flasher and
+  // the legacy dashboard both flash on one continuous session for this reason.
 
   // 3. Compile
   host._step = "queued";
   host._statusMessage = host._localize("firmware.status_queued");
-  if (!(await compileOrFail(host, device.configuration))) return;
+  if (!(await compileOrFail(host, device.configuration))) {
+    await releaseSerial(detected);
+    return;
+  }
 
   // 4. Download binary
   host._statusMessage = host._localize("firmware.status_downloading");
@@ -165,6 +168,7 @@ export async function startWebSerialInstall(
     const binaries = await host._api.firmwareGetBinaries(device.configuration);
     const target = pickFlashTarget(detected.chipName, binaries);
     if (!target) {
+      await releaseSerial(detected);
       host._fail(host._localize("serial.no_firmware"));
       return;
     }
@@ -173,36 +177,24 @@ export async function startWebSerialInstall(
       await host._api.firmwareDownloadBytes(device.configuration, target.binary.file)
     );
   } catch {
+    await releaseSerial(detected);
     host._fail(host._localize("firmware.download_failed"));
     return;
   }
 
-  // 5. Reconnect (no browser picker) and flash.
+  // 5. Flash on the still-open session.
   host._step = "flashing";
   host._statusMessage = host._localize("firmware.status_flashing");
   host._flashPercent = 0;
-  let flashDetected: DetectedChip;
   try {
-    flashDetected = await connectToPort(detected.port, onLog);
-  } catch (err) {
-    console.error("[Web Serial] Reconnect failed:", err);
-    host._fail(host._localize("firmware.flash_failed"));
-    return;
-  }
-
-  try {
-    await flashFirmware(flashDetected.loader, firmwareBytes, flashAddress, (p) => {
+    await flashFirmware(detected.loader, firmwareBytes, flashAddress, (p) => {
       host._flashPercent = p.percent;
     });
   } catch (err) {
     console.error("[Web Serial] Flash error:", err);
     // 100% reached: treat as success — device may have reset during verification.
     if (host._flashPercent < 100) {
-      try {
-        await disconnect(flashDetected.transport);
-      } catch {
-        /* ignore */
-      }
+      await releaseSerial(detected);
       host._fail(
         err instanceof Error ? err.message : host._localize("firmware.flash_failed")
       );
@@ -213,11 +205,7 @@ export async function startWebSerialInstall(
   // 6. Reset
   host._statusMessage = host._localize("firmware.status_resetting");
   try {
-    await resetAndDisconnect(
-      flashDetected.loader,
-      flashDetected.transport,
-      flashDetected.port
-    );
+    await resetAndDisconnect(detected.loader, detected.transport, detected.port);
   } catch {
     /* ignore reset errors */
   }
@@ -228,7 +216,17 @@ export async function startWebSerialInstall(
   // install can still reach here, so gate the auto-flip on the dialog still
   // being open. Otherwise the logs viewer pops up on a user who walked away.
   if (host._open && host._showLogsAfterInstall) {
-    flipToLogs(host, flashDetected.port);
+    flipToLogs(host, detected.port);
+  }
+}
+
+// Best-effort release of the held serial port on an early return, so a failed
+// compile / download / flash doesn't leak an open port into the next attempt.
+async function releaseSerial(detected: DetectedChip): Promise<void> {
+  try {
+    await disconnect(detected.transport);
+  } catch {
+    /* ignore */
   }
 }
 

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -7,7 +7,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const wsSerial = vi.hoisted(() => ({
-  connectToPort: vi.fn(),
   detectChip: vi.fn(),
   disconnect: vi.fn(),
   flashFirmware: vi.fn(),
@@ -90,7 +89,6 @@ describe("Web Serial install — HTTP byte download", () => {
   it("fetches firmware bytes over HTTP and flashes them", async () => {
     const { host, api } = makeHost();
     wsSerial.detectChip.mockResolvedValue(CHIP);
-    wsSerial.connectToPort.mockResolvedValue(CHIP);
     wsSerial.disconnect.mockResolvedValue(undefined);
     wsSerial.flashFirmware.mockResolvedValue(undefined);
     wsSerial.resetAndDisconnect.mockResolvedValue(undefined);
@@ -111,24 +109,22 @@ describe("Web Serial install — HTTP byte download", () => {
 
   it("streams esptool detect + flash output into the log (#346)", async () => {
     const { host } = makeHost();
+    let captured: ((l: string) => void) | undefined;
     wsSerial.detectChip.mockImplementation(async (onLog?: (l: string) => void) => {
+      captured = onLog;
       onLog?.("Detecting chip type... ESP32");
       return CHIP;
     });
-    wsSerial.connectToPort.mockImplementation(
-      async (_port: unknown, onLog?: (l: string) => void) => {
-        onLog?.("Writing at 0x00010000...");
-        return CHIP;
-      }
-    );
+    // Flash output reaches the log through the terminal wired at detect: the
+    // session stays open across compile and flash, so no reconnect is needed.
+    wsSerial.flashFirmware.mockImplementation(async () => {
+      captured?.("Writing at 0x00010000...");
+    });
     wsSerial.disconnect.mockResolvedValue(undefined);
-    wsSerial.flashFirmware.mockResolvedValue(undefined);
     wsSerial.resetAndDisconnect.mockResolvedValue(undefined);
 
     await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
 
-    // Before the fix detectChip/connectToPort were called with no onLog, so
-    // esptool output never reached the log buffer.
     expect(host._logLines).toContain("Detecting chip type... ESP32");
     expect(host._logLines).toContain("Writing at 0x00010000...");
   });
@@ -183,7 +179,6 @@ describe("Web Serial install — HTTP byte download", () => {
       { title: "Firmware", file: "firmware.bin" },
     ]);
     wsSerial.detectChip.mockResolvedValue({ ...CHIP, chipName: "ESP8285" });
-    wsSerial.connectToPort.mockResolvedValue({ ...CHIP, chipName: "ESP8285" });
     wsSerial.disconnect.mockResolvedValue(undefined);
     wsSerial.flashFirmware.mockResolvedValue(undefined);
     wsSerial.resetAndDisconnect.mockResolvedValue(undefined);

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -181,6 +181,8 @@ describe("Web Serial install — HTTP byte download", () => {
 
     expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
     expect(wsSerial.flashFirmware).not.toHaveBeenCalled();
+    // The held session must be released on the bail-out, not leaked into a retry.
+    expect(wsSerial.disconnect).toHaveBeenCalledTimes(1);
   });
 
   // ESP8285 is an ESP8266 with embedded flash; `board: esp8285` resolves to the

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -144,6 +144,20 @@ describe("Web Serial install — HTTP byte download", () => {
     expect(wsSerial.disconnect).toHaveBeenCalledWith(CHIP.transport);
   });
 
+  it("closes the port directly when disconnect throws on an early return", async () => {
+    const { host, api } = makeHost();
+    const port = { close: vi.fn().mockResolvedValue(undefined) };
+    wsSerial.detectChip.mockResolvedValue({ ...CHIP, port });
+    wsSerial.disconnect.mockRejectedValue(new Error("disconnect boom"));
+    api.firmwareDownloadBytes.mockRejectedValueOnce(new Error("boom"));
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    expect(host._fail).toHaveBeenCalledWith("firmware.download_failed");
+    // disconnect failed, so the OS handle must still be released via port.close.
+    expect(port.close).toHaveBeenCalledTimes(1);
+  });
+
   it("closes silently when the user cancels the port picker", async () => {
     const { host } = makeHost();
     wsSerial.detectChip.mockRejectedValueOnce(

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -129,6 +129,21 @@ describe("Web Serial install — HTTP byte download", () => {
     expect(host._logLines).toContain("Writing at 0x00010000...");
   });
 
+  it("releases the port when the post-flash reset throws", async () => {
+    const { host } = makeHost();
+    wsSerial.detectChip.mockResolvedValue(CHIP);
+    wsSerial.flashFirmware.mockResolvedValue(undefined);
+    wsSerial.disconnect.mockResolvedValue(undefined);
+    wsSerial.resetAndDisconnect.mockRejectedValueOnce(new Error("reset boom"));
+
+    await startWebSerialInstall(host as unknown as ESPHomeFirmwareInstallDialog);
+
+    // Flash succeeded, so the install still completes; the failed reset must not
+    // leak the held port.
+    expect(host._step).toBe("done");
+    expect(wsSerial.disconnect).toHaveBeenCalledWith(CHIP.transport);
+  });
+
   it("closes silently when the user cancels the port picker", async () => {
     const { host } = makeHost();
     wsSerial.detectChip.mockRejectedValueOnce(


### PR DESCRIPTION
# What does this implement/fix?

The browser Web Serial install closed the serial port during compile, then reopened it to flash. The stub loader stays running on the chip while the OS handle is torn down, so the reopened port reuses a stale stub; on boards where the DTR/RTS reset does not land (an ESP32-C3 behind a CH340), that stale stub rejects `FLASH_DEFL_BEGIN` with "Failed to enter compressed flash mode failed with status 1,0", so the flash always fails right after a clean compile.

This keeps the detect session open through the compile and flashes on it directly, matching the external flasher and the legacy dashboard, which both flash on a single continuous `main()` session. The port is released on any early return so a failed compile or download does not leak it.

Needs a hardware check on the reporter's ESP32-C3 + CH340 before undraft; opening as draft for that reason.

**Related issue or feature (if applicable):**

- Addresses esphome/device-builder#1833

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
