### PR TITLE
Restore flash target from the chain's upload on followJob reattach

### DIFF
--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -38,6 +38,7 @@ import { registerMdiIcons } from "../util/register-icons.js";
 import {
   deriveFollowCommandType,
   detachStream,
+  findDependentUpload,
   followJob,
   onForceLocalClick,
   resetRunState,
@@ -261,9 +262,12 @@ export class ESPHomeCommandDialog extends LitElement {
     this.configuration = job.configuration;
     this.name = displayName;
     this._commandType = commandType ?? deriveFollowCommandType(this._jobs, job);
-    this._port = job.port || "OTA";
-    // Restore so a "Build locally instead" retry keeps flashing the bootloader.
-    this._bootloader = job.flash_bootloader === true;
+    // Restore off the chain's UPLOAD when following a COMPILE head, so a
+    // "Build locally instead" retry keeps the target address and keeps
+    // flashing the bootloader.
+    const dependent = findDependentUpload(this._jobs, job);
+    this._port = dependent?.port || job.port || "OTA";
+    this._bootloader = (dependent ?? job).flash_bootloader === true;
     resetRunState(this);
     // Fresh attach is a fresh session — reset toggle defaults so a prior
     // opt-out doesn't silently inherit.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -39,9 +39,10 @@ export function findDependentUpload(
   job: FirmwareJob
 ): FirmwareJob | undefined {
   if (job.job_type !== JobType.COMPILE) return undefined;
-  return [...jobs.values()].find(
-    (j) => j.depends_on === job.job_id && j.job_type === JobType.UPLOAD
-  );
+  for (const j of jobs.values()) {
+    if (j.depends_on === job.job_id && j.job_type === JobType.UPLOAD) return j;
+  }
+  return undefined;
 }
 
 // Dashboard mode pins escaped form (\033[…m); raw form (\x1b[…m) is defensive.

--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -30,6 +30,20 @@ export function deriveFollowCommandType(
   return JOB_TYPE_TO_COMMAND[job.job_type] ?? "install";
 }
 
+// An install chain is followed via its COMPILE head, but the flash target
+// lives on the dependent UPLOAD — restoring port/bootloader off the head
+// reads empty/false and a later "Build locally instead" resubmit flashes
+// the app at the default address.
+export function findDependentUpload(
+  jobs: Map<string, FirmwareJob>,
+  job: FirmwareJob
+): FirmwareJob | undefined {
+  if (job.job_type !== JobType.COMPILE) return undefined;
+  return [...jobs.values()].find(
+    (j) => j.depends_on === job.job_id && j.job_type === JobType.UPLOAD
+  );
+}
+
 // Dashboard mode pins escaped form (\033[…m); raw form (\x1b[…m) is defensive.
 const ANSI_SGR = /(?:\\033|\x1b)\[[0-9;]*m/g;
 // Anchored ERROR prefix so a debug line that quotes the phrase can't match.

--- a/test/components/command-dialog-follow-restore.test.ts
+++ b/test/components/command-dialog-follow-restore.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The public followJob attaches to an install chain via its COMPILE head, but
+ * the flash target lives on the dependent UPLOAD — port and bootloader must
+ * restore from the dependent so a "Build locally instead" resubmit keeps the
+ * typed address and keeps flashing the bootloader.
+ */
+import { describe, expect, it } from "vitest";
+import { type FirmwareJob, JobType } from "../../src/api/types/firmware-jobs.js";
+import { ESPHomeCommandDialog } from "../../src/components/command-dialog.js";
+import { makeFirmwareJob } from "../_make-firmware-job.js";
+
+interface Harness {
+  _port: string;
+  _bootloader: boolean;
+  _jobs: Map<string, FirmwareJob>;
+  _streamId: string;
+  _api: { firmwareFollowJob: () => string };
+  followJob: (job: FirmwareJob, displayName: string) => void;
+}
+
+function mount(jobs: FirmwareJob[]): Harness {
+  const el = new ESPHomeCommandDialog() as unknown as Harness;
+  el._jobs = new Map(jobs.map((j) => [j.job_id, j]));
+  el._streamId = "";
+  el._api = { firmwareFollowJob: () => "stream-1" } as never;
+  return el;
+}
+
+const chain = (upload: Partial<FirmwareJob>): FirmwareJob[] => [
+  makeFirmwareJob({ job_id: "c1", job_type: JobType.COMPILE, port: "" }),
+  makeFirmwareJob({
+    job_id: "u1",
+    job_type: JobType.UPLOAD,
+    depends_on: "c1",
+    ...upload,
+  }),
+];
+
+describe("command-dialog followJob restores flash target from the chain", () => {
+  it("restores bootloader off the dependent upload of a compile head", () => {
+    const jobs = chain({ port: "OTA", flash_bootloader: true });
+    const el = mount(jobs);
+    el.followJob(jobs[0], "device");
+    expect(el._bootloader).toBe(true);
+    expect(el._port).toBe("OTA");
+  });
+
+  it("restores an explicit target address off the dependent upload", () => {
+    const jobs = chain({ port: "192.168.1.42" });
+    const el = mount(jobs);
+    el.followJob(jobs[0], "device");
+    expect(el._port).toBe("192.168.1.42");
+    expect(el._bootloader).toBe(false);
+  });
+
+  it("defaults for a plain compile with no dependent", () => {
+    const compile = makeFirmwareJob({
+      job_id: "c1",
+      job_type: JobType.COMPILE,
+      port: "",
+    });
+    const el = mount([compile]);
+    el.followJob(compile, "device");
+    expect(el._port).toBe("OTA");
+    expect(el._bootloader).toBe(false);
+  });
+
+  it("reads a directly-followed upload's own flags", () => {
+    const upload = makeFirmwareJob({
+      job_id: "u1",
+      job_type: JobType.UPLOAD,
+      port: "OTA",
+      flash_bootloader: true,
+    });
+    const el = mount([upload]);
+    el.followJob(upload, "device");
+    expect(el._bootloader).toBe(true);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Selecting a bootloader install and then clicking "Build locally instead" resubmitted a plain firmware install. The public followJob restores port and bootloader from the job it attaches to, but an install chain is followed via its COMPILE head; the flash target lives on the dependent UPLOAD, so any reattach (device card busy badge, firmware tasks row) wiped `_bootloader` to false and the force local resubmit flashed the app.

followJob now resolves the compile head's dependent UPLOAD (same lookup shape as deriveFollowCommandType) and restores `_port` and `_bootloader` from it. This also fixes the same-shape address bug; reattaching to an install targeting an explicit IP no longer resets the resubmit target to "OTA".

**Related issue or feature (if applicable):**

- follow-up fix to #1069

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
