### PR TITLE
Show an inline error when a reference points at an unknown ID

### DIFF
--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -888,8 +888,6 @@ export class ESPHomeConfigEntryForm extends LitElement {
       requestAddComponent: (domain) => this._requestAddComponent(domain),
       resolveInterfaceProviders: (interfaceName) =>
         this._resolveInterfaceProviders(interfaceName),
-      interfaceProvidersPending: (interfaceName) =>
-        this._interfaceProvidersPending.has(interfaceName),
       scopeValues: (path) => this._scopeValues(path),
       filterRenderable: this._filterRenderable,
       getPendingUnit: (path) => this._pendingUnits.get(path.join(".")),
@@ -1022,7 +1020,7 @@ export class ESPHomeConfigEntryForm extends LitElement {
    */
   private _resolveInterfaceProviders(
     interfaceName: string
-  ): readonly ComponentProvider[] {
+  ): readonly ComponentProvider[] | null {
     if (!interfaceName) return [];
     const cached = this._interfaceProviders.get(interfaceName);
     if (cached) return cached;
@@ -1052,7 +1050,10 @@ export class ESPHomeConfigEntryForm extends LitElement {
         )
         .finally(() => this._interfaceProvidersPending.delete(interfaceName));
     }
-    return [];
+    // Unsettled: no api yet, fetch in flight, or the last fetch failed.
+    // Distinct from a cached [] so consumers don't treat an incomplete
+    // candidate list as complete.
+    return null;
   }
 }
 

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -888,6 +888,8 @@ export class ESPHomeConfigEntryForm extends LitElement {
       requestAddComponent: (domain) => this._requestAddComponent(domain),
       resolveInterfaceProviders: (interfaceName) =>
         this._resolveInterfaceProviders(interfaceName),
+      interfaceProvidersPending: (interfaceName) =>
+        this._interfaceProvidersPending.has(interfaceName),
       scopeValues: (path) => this._scopeValues(path),
       filterRenderable: this._filterRenderable,
       getPendingUnit: (path) => this._pendingUnits.get(path.join(".")),

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -14,7 +14,10 @@ import {
 } from "../../util/config-entry-yaml-scan.js";
 import { isValidEspHomeId } from "../../util/esphome-id.js";
 import { renderInlineError } from "../../util/render-error.js";
-import { resolveSubstitutions } from "../../util/substitutions.js";
+import {
+  hasSubstitutionReference,
+  resolveSubstitutions,
+} from "../../util/substitutions.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -79,7 +82,7 @@ export function renderIdReferenceField(
     hasOrphanValue &&
     providers !== null &&
     isValidEspHomeId(value) &&
-    !candidates.some((c) => c.id.includes("${")) &&
+    !candidates.some((c) => hasSubstitutionReference(c.id)) &&
     !yamlHasExternalIdSources(ctx.yaml);
   const invalid = fieldError || unknownId;
   const unknownIdError = unknownId

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -10,7 +10,10 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import {
   findReferenceCandidates,
   resolveSoleCandidate,
+  yamlHasMergedSources,
 } from "../../util/config-entry-yaml-scan.js";
+import { isValidEsphomeId } from "../../util/esphome-id.js";
+import { renderInlineError } from "../../util/render-error.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
 import {
   effectiveDisabled,
@@ -38,7 +41,7 @@ export function renderIdReferenceField(
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
   const value = String(raw ?? "");
-  const invalid = ctx.errorAt(path) !== null;
+  const fieldError = ctx.errorAt(path) !== null;
 
   // Surface ESPHome's auto-resolved target as the default, but only on an
   // empty field — a committed value isn't a "default".
@@ -67,6 +70,24 @@ export function renderIdReferenceField(
   const orphanOption = hasOrphanValue
     ? idOption(value, value, ctx.localize("device.id_reference_unresolved", { domain }))
     : nothing;
+  // A dangling reference we can be sure about gets an inline error without
+  // waiting for the backend lint round trip: plain identifier (substitutions
+  // and !secret indirections can't be checked), no merged sources that could
+  // define the id in another file, and the provider fetch has settled so the
+  // candidate list is complete. Backend validation stays the authority; a
+  // field-level error from it takes precedence below.
+  const unknownId =
+    hasOrphanValue &&
+    isValidEsphomeId(value) &&
+    !ctx.interfaceProvidersPending(domain) &&
+    !yamlHasMergedSources(ctx.yaml);
+  const invalid = fieldError || unknownId;
+  const unknownIdError =
+    unknownId && !fieldError
+      ? renderInlineError(
+          ctx.localize("device.id_reference_unknown_error", { id: value })
+        )
+      : nothing;
   // Solo "Add new" CTA only when there's genuinely nothing to show.
   const empty = candidates.length === 0 && !hasOrphanValue;
 
@@ -113,7 +134,7 @@ export function renderIdReferenceField(
         >
           ${addOption}
         </wa-select>
-        ${renderFieldError(path, ctx)}
+        ${renderFieldError(path, ctx)}${unknownIdError}
       </div>
     `;
   }
@@ -148,7 +169,7 @@ export function renderIdReferenceField(
         })}
         ${addOption}
       </wa-select>
-      ${renderFieldError(path, ctx)}
+      ${renderFieldError(path, ctx)}${unknownIdError}
     </div>
   `;
 }

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -10,9 +10,9 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import {
   findReferenceCandidates,
   resolveSoleCandidate,
-  yamlHasMergedSources,
+  yamlHasExternalIdSources,
 } from "../../util/config-entry-yaml-scan.js";
-import { isValidEsphomeId } from "../../util/esphome-id.js";
+import { isValidEspHomeId } from "../../util/esphome-id.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
 import {
@@ -32,11 +32,8 @@ export function renderIdReferenceField(
   ctx: RenderCtx
 ) {
   const domain = entry.references_component || "";
-  const candidates = findReferenceCandidates(
-    ctx.yaml,
-    domain,
-    ctx.resolveInterfaceProviders(domain)
-  );
+  const providers = ctx.resolveInterfaceProviders(domain);
+  const candidates = findReferenceCandidates(ctx.yaml, domain, providers ?? []);
   const raw = ctx.getAt(path);
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
   if (bail) return bail;
@@ -71,23 +68,23 @@ export function renderIdReferenceField(
     ? idOption(value, value, ctx.localize("device.id_reference_unresolved", { domain }))
     : nothing;
   // A dangling reference we can be sure about gets an inline error without
-  // waiting for the backend lint round trip: plain identifier (substitutions
-  // and !secret indirections can't be checked), no merged sources that could
-  // define the id in another file, and the provider fetch has settled so the
-  // candidate list is complete. Backend validation stays the authority; a
-  // field-level error from it takes precedence below.
+  // waiting for the backend lint round trip: the provider fetch has settled
+  // (candidate list is complete), the value is a plain identifier
+  // (substitutions and !secret indirections can't be checked), no candidate
+  // id needs substitution to compare, and nothing pulls ids in from other
+  // files. Backend validation stays the authority: a field-level error from
+  // it takes precedence.
   const unknownId =
+    !fieldError &&
     hasOrphanValue &&
-    isValidEsphomeId(value) &&
-    !ctx.interfaceProvidersPending(domain) &&
-    !yamlHasMergedSources(ctx.yaml);
+    providers !== null &&
+    isValidEspHomeId(value) &&
+    !candidates.some((c) => c.id.includes("${")) &&
+    !yamlHasExternalIdSources(ctx.yaml);
   const invalid = fieldError || unknownId;
-  const unknownIdError =
-    unknownId && !fieldError
-      ? renderInlineError(
-          ctx.localize("device.id_reference_unknown_error", { id: value })
-        )
-      : nothing;
+  const unknownIdError = unknownId
+    ? renderInlineError(ctx.localize("device.id_reference_unknown_error", { id: value }))
+    : nothing;
   // Solo "Add new" CTA only when there's genuinely nothing to show.
   const empty = candidates.length === 0 && !hasOrphanValue;
 

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -9,15 +9,11 @@ import { html, nothing } from "lit";
 import type { ConfigEntry } from "../../api/types/config-entries.js";
 import {
   findReferenceCandidates,
+  isCertainlyDanglingId,
   resolveSoleCandidate,
-  yamlHasExternalIdSources,
 } from "../../util/config-entry-yaml-scan.js";
-import { isValidEspHomeId } from "../../util/esphome-id.js";
 import { renderInlineError } from "../../util/render-error.js";
-import {
-  hasSubstitutionReference,
-  resolveSubstitutions,
-} from "../../util/substitutions.js";
+import { resolveSubstitutions } from "../../util/substitutions.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
@@ -71,19 +67,14 @@ export function renderIdReferenceField(
     ? idOption(value, value, ctx.localize("device.id_reference_unresolved", { domain }))
     : nothing;
   // A dangling reference we can be sure about gets an inline error without
-  // waiting for the backend lint round trip: the provider fetch has settled
-  // (candidate list is complete), the value is a plain identifier
-  // (substitutions and !secret indirections can't be checked), no candidate
-  // id needs substitution to compare, and nothing pulls ids in from other
-  // files. Backend validation stays the authority: a field-level error from
-  // it takes precedence.
+  // waiting for the backend lint round trip. The renderer gates on its own
+  // state — backend validation stays the authority, and the provider fetch
+  // must have settled (candidate list complete) — the certainty verdict
+  // itself lives beside the candidate scan.
   const unknownId =
     !fieldError &&
-    hasOrphanValue &&
     providers !== null &&
-    isValidEspHomeId(value) &&
-    !candidates.some((c) => hasSubstitutionReference(c.id)) &&
-    !yamlHasExternalIdSources(ctx.yaml);
+    isCertainlyDanglingId(value, candidates, ctx.yaml);
   const invalid = fieldError || unknownId;
   const unknownIdError = unknownId
     ? renderInlineError(ctx.localize("device.id_reference_unknown_error", { id: value }))
@@ -127,14 +118,14 @@ export function renderIdReferenceField(
       <div class="field" data-field-key=${fieldKeyAttr(path)}>
         ${renderLabel(entry, ctx)}
         <wa-select
-          class=${invalid ? "invalid" : ""}
+          class=${fieldError ? "invalid" : ""}
           ?disabled=${effectiveDisabled(entry, ctx)}
           placeholder=${ctx.localize("device.id_reference_empty", { domain })}
           @change=${onChange}
         >
           ${addOption}
         </wa-select>
-        ${renderFieldError(path, ctx)}${unknownIdError}
+        ${renderFieldError(path, ctx)}
       </div>
     `;
   }

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -67,6 +67,9 @@ export interface RenderCtx {
    * re-renders. Empty until loaded, and ``[]`` for a same-domain reference.
    */
   resolveInterfaceProviders: (interfaceName: string) => ReadonlyArray<ComponentProvider>;
+  /** True while the provider fetch for *interfaceName* is in flight —
+   *  candidate lists are incomplete then, so don't flag unknown ids. */
+  interfaceProvidersPending: (interfaceName: string) => boolean;
   scopeValues: (path: string[]) => Record<string, unknown>;
   filterRenderable: (
     entries: ConfigEntry[],

--- a/src/components/device/config-entry-renderers-types.ts
+++ b/src/components/device/config-entry-renderers-types.ts
@@ -64,12 +64,13 @@ export interface RenderCtx {
   /**
    * Providers of a cross-domain interface reference. Returns synchronously
    * from a per-form cache; a miss kicks an async catalog fetch and
-   * re-renders. Empty until loaded, and ``[]`` for a same-domain reference.
+   * re-renders. ``null`` while unsettled (no api yet, fetch in flight, or
+   * the last fetch failed) — the candidate list is incomplete then, not
+   * empty. ``[]`` is a settled same-domain reference.
    */
-  resolveInterfaceProviders: (interfaceName: string) => ReadonlyArray<ComponentProvider>;
-  /** True while the provider fetch for *interfaceName* is in flight —
-   *  candidate lists are incomplete then, so don't flag unknown ids. */
-  interfaceProvidersPending: (interfaceName: string) => boolean;
+  resolveInterfaceProviders: (
+    interfaceName: string
+  ) => ReadonlyArray<ComponentProvider> | null;
   scopeValues: (path: string[]) => Record<string, unknown>;
   filterRenderable: (
     entries: ConfigEntry[],

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -899,6 +899,7 @@
     "id_reference_empty": "No {domain} configured yet",
     "id_reference_add": "Add {domain}",
     "id_reference_unresolved": "{domain} not defined in this file",
+    "id_reference_unknown_error": "ID \"{id}\" is not defined in this configuration.",
     "return_to_after_dep_prefix": "Adding a dependency. We'll bring you back to",
     "return_to_after_dep_suffix": "after.",
     "add_automation_error": "Failed to add automation",

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -472,7 +472,9 @@ export function findReferenceCandidates(
 // can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
 // replaces that key's value, so it deliberately doesn't match.
 const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/m;
-const INCLUDE_VALUE_RE = /:\s*!include\b/;
+// Any `!include` — value position (`sensor: !include x.yaml`) or list item
+// (`- !include x.yaml`) — can define ids the local scan can't see.
+const INCLUDE_RE = /!include\b/;
 
 /**
  * Whether the YAML root-merges components the scan can't enumerate.
@@ -488,13 +490,13 @@ export function yamlHasMergedSources(yaml: string): boolean {
 
 /**
  * Whether the YAML pulls in ids the local scan can't see: merged sources
- * (`packages:` / `<<:`) or any `!include`d value (`sensor: !include x.yaml`
- * defines that domain's ids in another file). When true, a value missing
+ * (`packages:` / `<<:`) or any `!include`d value (a value-position or
+ * list-item `!include` defines ids in another file). When true, a value missing
  * from the candidate scan isn't proof of a dangling reference.
  */
 export function yamlHasExternalIdSources(yaml: string): boolean {
   if (!yaml) return false;
-  return MERGED_SOURCE_RE.test(yaml) || INCLUDE_VALUE_RE.test(yaml);
+  return MERGED_SOURCE_RE.test(yaml) || INCLUDE_RE.test(yaml);
 }
 
 /**

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -474,6 +474,7 @@ export function findReferenceCandidates(
 // can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
 // replaces that key's value, so it deliberately doesn't match.
 const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/m;
+const MERGE_KEY_RE = /^\s*<<\s*:/m;
 
 /**
  * Whether the YAML root-merges components the scan can't enumerate.
@@ -498,8 +499,11 @@ export function yamlHasExternalIdSources(yaml: string): boolean {
   if (hit !== undefined) return hit;
   // Any include-family tag — `!include`, `!include_dir_list`,
   // `!include_dir_merge_list`, … — in value or list-item position can
-  // define ids the local scan can't see.
-  const result = yamlHasMergedSources(yaml) || yaml.includes("!include");
+  // define ids the local scan can't see; so can a merge key at any
+  // indent (`<<: *anchor` inside a component can merge an `id:` in),
+  // unlike yamlHasMergedSources' deliberately top-level scope.
+  const result =
+    yamlHasMergedSources(yaml) || MERGE_KEY_RE.test(yaml) || yaml.includes("!include");
   externalMemo.set(yaml, result);
   return result;
 }

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -472,9 +472,10 @@ export function findReferenceCandidates(
 // can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
 // replaces that key's value, so it deliberately doesn't match.
 const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/m;
-// Any `!include` — value position (`sensor: !include x.yaml`) or list item
-// (`- !include x.yaml`) — can define ids the local scan can't see.
-const INCLUDE_RE = /!include\b/;
+// Any include-family tag — `!include`, `!include_dir_list`,
+// `!include_dir_merge_list`, … — in value or list-item position can
+// define ids the local scan can't see.
+const INCLUDE_RE = /!include/;
 
 /**
  * Whether the YAML root-merges components the scan can't enumerate.

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -471,7 +471,8 @@ export function findReferenceCandidates(
 // constructs that merge whole component sections in from sources the scan
 // can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
 // replaces that key's value, so it deliberately doesn't match.
-const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/;
+const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/m;
+const INCLUDE_VALUE_RE = /:\s*!include\b/;
 
 /**
  * Whether the YAML root-merges components the scan can't enumerate.
@@ -482,7 +483,18 @@ const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/;
  */
 export function yamlHasMergedSources(yaml: string): boolean {
   if (!yaml) return false;
-  return yaml.split("\n").some((line) => MERGED_SOURCE_RE.test(line));
+  return MERGED_SOURCE_RE.test(yaml);
+}
+
+/**
+ * Whether the YAML pulls in ids the local scan can't see: merged sources
+ * (`packages:` / `<<:`) or any `!include`d value (`sensor: !include x.yaml`
+ * defines that domain's ids in another file). When true, a value missing
+ * from the candidate scan isn't proof of a dangling reference.
+ */
+export function yamlHasExternalIdSources(yaml: string): boolean {
+  if (!yaml) return false;
+  return MERGED_SOURCE_RE.test(yaml) || INCLUDE_VALUE_RE.test(yaml);
 }
 
 /**

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -17,7 +17,9 @@
  * type into a field) from O(N) per keystroke to O(1).
  */
 import type { ComponentCatalogEntry } from "../api/types/components.js";
+import { isValidEspHomeId } from "./esphome-id.js";
 import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin-gpio.js";
+import { hasSubstitutionReference } from "./substitutions.js";
 import {
   collectIdsAtPath,
   findFieldLine,
@@ -472,10 +474,6 @@ export function findReferenceCandidates(
 // can't see. A value-position `!include` (`wifi: !include wifi.yaml`) only
 // replaces that key's value, so it deliberately doesn't match.
 const MERGED_SOURCE_RE = /^(?:packages|<<)\s*:/m;
-// Any include-family tag — `!include`, `!include_dir_list`,
-// `!include_dir_merge_list`, … — in value or list-item position can
-// define ids the local scan can't see.
-const INCLUDE_RE = /!include/;
 
 /**
  * Whether the YAML root-merges components the scan can't enumerate.
@@ -496,8 +494,36 @@ export function yamlHasMergedSources(yaml: string): boolean {
  * from the candidate scan isn't proof of a dangling reference.
  */
 export function yamlHasExternalIdSources(yaml: string): boolean {
-  if (!yaml) return false;
-  return MERGED_SOURCE_RE.test(yaml) || INCLUDE_RE.test(yaml);
+  const hit = externalMemo.get(yaml);
+  if (hit !== undefined) return hit;
+  // Any include-family tag — `!include`, `!include_dir_list`,
+  // `!include_dir_merge_list`, … — in value or list-item position can
+  // define ids the local scan can't see.
+  const result = yamlHasMergedSources(yaml) || yaml.includes("!include");
+  externalMemo.set(yaml, result);
+  return result;
+}
+
+const externalMemo = createScanMemo<string, boolean>((a, b) => a === b);
+
+/**
+ * Whether *value* is a reference the local scan is certain dangles: an
+ * identifier-shaped id (substitutions and !secret indirections can't be
+ * checked) absent from a candidate list that's fully comparable (no
+ * candidate id needs substitution to compare) in a buffer that pulls no
+ * ids in from other files. Callers own their own gates (backend-error
+ * precedence, provider settling) — this is the pure verdict.
+ */
+export function isCertainlyDanglingId(
+  value: string,
+  candidates: ReadonlyArray<{ id: string }>,
+  yaml: string
+): boolean {
+  return (
+    isValidEspHomeId(value) &&
+    !candidates.some((c) => c.id === value || hasSubstitutionReference(c.id)) &&
+    !yamlHasExternalIdSources(yaml)
+  );
 }
 
 /**
@@ -523,4 +549,5 @@ export function resolveSoleCandidate(
 export function _clearScanMemos(): void {
   pinMemo.clear();
   providerMemo.clear();
+  externalMemo.clear();
 }

--- a/src/util/esphome-id.ts
+++ b/src/util/esphome-id.ts
@@ -35,7 +35,10 @@ export function normalizeEspHomeId(input: string): string {
   return input.replace(/[^a-zA-Z0-9_]+/g, "_");
 }
 
+/** The Python-identifier shape ESPHome requires of an id. */
+const ESPHOME_ID_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /** Whether *value* is already a well-formed ESPHome id. */
 export function isValidEspHomeId(value: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+  return ESPHOME_ID_RE.test(value);
 }

--- a/src/util/esphome-id.ts
+++ b/src/util/esphome-id.ts
@@ -36,6 +36,6 @@ export function normalizeEspHomeId(input: string): string {
 }
 
 /** Whether *value* is already a well-formed ESPHome id. */
-export function isValidEsphomeId(value: string): boolean {
+export function isValidEspHomeId(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }

--- a/src/util/esphome-id.ts
+++ b/src/util/esphome-id.ts
@@ -34,3 +34,8 @@
 export function normalizeEspHomeId(input: string): string {
   return input.replace(/[^a-zA-Z0-9_]+/g, "_");
 }
+
+/** Whether *value* is already a well-formed ESPHome id. */
+export function isValidEsphomeId(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -109,7 +109,6 @@ export function makeRenderCtx(
     seedNestedOpen: vi.fn(),
     requestAddComponent: vi.fn(),
     resolveInterfaceProviders: () => [],
-    interfaceProvidersPending: () => false,
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,
     renderEntry: vi.fn(),

--- a/test/components/device/_renderer-fixtures.ts
+++ b/test/components/device/_renderer-fixtures.ts
@@ -109,6 +109,7 @@ export function makeRenderCtx(
     seedNestedOpen: vi.fn(),
     requestAddComponent: vi.fn(),
     resolveInterfaceProviders: () => [],
+    interfaceProvidersPending: () => false,
     scopeValues: () => ({}),
     filterRenderable: (entries) => entries,
     renderEntry: vi.fn(),

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -19,10 +19,10 @@ import type { ComponentProvider } from "../../../src/util/config-entry-yaml-scan
 const resolve = (
   form: ESPHomeConfigEntryForm,
   name: string
-): readonly ComponentProvider[] =>
+): readonly ComponentProvider[] | null =>
   (
     form as unknown as {
-      _resolveInterfaceProviders(n: string): readonly ComponentProvider[];
+      _resolveInterfaceProviders(n: string): readonly ComponentProvider[] | null;
     }
   )._resolveInterfaceProviders(name);
 
@@ -54,14 +54,14 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
     document.body.innerHTML = "";
   });
 
-  it("returns [] on the first miss, then the fetched providers, fetching once", async () => {
+  it("returns null on the first miss, then the fetched providers, fetching once", async () => {
     const getComponents = vi
       .fn()
       .mockResolvedValue(response(["sensor.adc", "sensor.ads1115"]));
     const form = withApi(getComponents);
 
-    // First miss: synchronous empty, fetch kicked off.
-    expect(resolve(form, "voltage_sampler")).toEqual([]);
+    // First miss: unsettled (null), fetch kicked off.
+    expect(resolve(form, "voltage_sampler")).toBeNull();
     // A second call while in flight must not fire a duplicate fetch.
     resolve(form, "voltage_sampler");
     await flush();
@@ -95,9 +95,9 @@ describe("config-entry-form _resolveInterfaceProviders", () => {
 
     resolve(form, "voltage_sampler");
     await flush();
-    // Failure left the cache unset — the next call retries rather than
-    // returning a poisoned empty list forever.
-    expect(resolve(form, "voltage_sampler")).toEqual([]);
+    // Failure left the cache unset — the next call retries (still
+    // unsettled) rather than returning a poisoned empty list forever.
+    expect(resolve(form, "voltage_sampler")).toBeNull();
     await flush();
     expect(getComponents).toHaveBeenCalledTimes(2);
     expect(resolve(form, "voltage_sampler")).toEqual([{ domain: "sensor", stem: "adc" }]);

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -207,10 +207,33 @@ describe("renderIdReferenceField — inline error for an unknown id", () => {
     expect(errorTexts(renderOutputRef(merged, "buzzer_output"))).toHaveLength(0);
   });
 
-  it("does not flag while the provider fetch is still pending", () => {
+  it("does not flag while the provider fetch is unsettled", () => {
     const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_output", {
-      interfaceProvidersPending: () => true,
+      resolveInterfaceProviders: () => null,
     });
     expect(errorTexts(tmpl)).toHaveLength(0);
+  });
+
+  it("does not flag when an included value could define the id elsewhere", () => {
+    const withInclude = `binary_sensor: !include sensors.yaml\n\n${APOLLO_YAML}`;
+    expect(errorTexts(renderOutputRef(withInclude, "buzzer_output"))).toHaveLength(0);
+  });
+
+  it("does not flag when a candidate id needs substitution to compare", () => {
+    const subbed = APOLLO_YAML.replace("id: buzzer_outputd", "id: ${name}_buzzer");
+    expect(errorTexts(renderOutputRef(subbed, "buzzer_output"))).toHaveLength(0);
+  });
+
+  it("yields to a backend error on the same field", () => {
+    const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_output", {
+      errorAt: () => ({
+        key: "output",
+        code: "validation.backend",
+        params: { message: "backend says no" },
+      }),
+    });
+    const texts = errorTexts(tmpl);
+    expect(texts).toHaveLength(1);
+    expect(texts[0]).not.toBe("device.id_reference_unknown_error");
   });
 });

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -224,6 +224,11 @@ describe("renderIdReferenceField — inline error for an unknown id", () => {
     expect(errorTexts(renderOutputRef(subbed, "buzzer_output"))).toHaveLength(0);
   });
 
+  it("does not flag when a candidate id uses a bare $name substitution", () => {
+    const subbed = APOLLO_YAML.replace("id: buzzer_outputd", "id: $node_buzzer");
+    expect(errorTexts(renderOutputRef(subbed, "buzzer_output"))).toHaveLength(0);
+  });
+
   it("yields to a backend error on the same field", () => {
     const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_output", {
       errorAt: () => ({

--- a/test/components/device/config-entry-id-reference-renderer.test.ts
+++ b/test/components/device/config-entry-id-reference-renderer.test.ts
@@ -152,3 +152,65 @@ describe("renderIdReferenceField — resolves ${...} in option labels (#1709)", 
     expect(select?.placeholder).toBe("WIFI Switch Relay");
   });
 });
+
+describe("renderIdReferenceField — inline error for an unknown id", () => {
+  const APOLLO_YAML = [
+    "output:",
+    "  - platform: ledc",
+    "    pin: 18",
+    "    id: buzzer_outputd",
+    "",
+    "rtttl:",
+    "  - output: buzzer_output",
+    "    id: rtttl_player",
+    "",
+  ].join("\n");
+
+  function renderOutputRef(
+    yaml: string,
+    value: string,
+    ctxOverrides: Record<string, unknown> = {}
+  ) {
+    const entry = makeEntry(ConfigEntryType.STRING, { references_component: "output" });
+    return renderIdReferenceField(
+      entry,
+      ["output"],
+      makeRenderCtx({ output: value }, { overrides: { yaml, ...ctxOverrides } })
+    );
+  }
+
+  const errorTexts = (tmpl: unknown): unknown[] =>
+    findTemplatesByAnchor(tmpl, "field-error").map((t) => t.values[0]);
+
+  const selectInvalid = (tmpl: unknown): unknown =>
+    findElementBindings(tmpl, "wa-select")[0]?.class;
+
+  it("flags a dangling reference with an inline error and invalid state", () => {
+    const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_output");
+    expect(errorTexts(tmpl)).toContain("device.id_reference_unknown_error");
+    expect(selectInvalid(tmpl)).toBe("invalid");
+  });
+
+  it("does not flag a resolving reference", () => {
+    const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_outputd");
+    expect(errorTexts(tmpl)).toHaveLength(0);
+    expect(selectInvalid(tmpl)).toBe("");
+  });
+
+  it("does not flag a substitution value", () => {
+    const tmpl = renderOutputRef(APOLLO_YAML, "${my_output}");
+    expect(errorTexts(tmpl)).toHaveLength(0);
+  });
+
+  it("does not flag when merged sources could define the id elsewhere", () => {
+    const merged = `packages:\n  base: !include common.yaml\n\n${APOLLO_YAML}`;
+    expect(errorTexts(renderOutputRef(merged, "buzzer_output"))).toHaveLength(0);
+  });
+
+  it("does not flag while the provider fetch is still pending", () => {
+    const tmpl = renderOutputRef(APOLLO_YAML, "buzzer_output", {
+      interfaceProvidersPending: () => true,
+    });
+    expect(errorTexts(tmpl)).toHaveLength(0);
+  });
+});

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -7,6 +7,7 @@ import {
   findComponentsByProviders,
   findReferenceCandidates,
   findUsedPins,
+  yamlHasExternalIdSources,
   yamlHasMergedSources,
 } from "../../src/util/config-entry-yaml-scan.js";
 
@@ -656,5 +657,24 @@ describe("yamlHasMergedSources", () => {
   it("is false for plain YAML and empty input", () => {
     expect(yamlHasMergedSources("ld2410:\n  id: radar\n")).toBe(false);
     expect(yamlHasMergedSources("")).toBe(false);
+  });
+});
+
+describe("yamlHasExternalIdSources", () => {
+  it("is true for merged sources, like yamlHasMergedSources", () => {
+    expect(yamlHasExternalIdSources("packages:\n  base: !include base.yaml\n")).toBe(
+      true
+    );
+    expect(yamlHasExternalIdSources("<<: !include common.yaml\nesphome:\n")).toBe(true);
+  });
+
+  it("is true for a value-position !include, which can define ids elsewhere", () => {
+    expect(yamlHasExternalIdSources("sensor: !include sensors.yaml\n")).toBe(true);
+    expect(yamlHasExternalIdSources("wifi: !include wifi.yaml\n")).toBe(true);
+  });
+
+  it("is false when every id is locally visible", () => {
+    expect(yamlHasExternalIdSources("ld2410:\n  id: radar\n")).toBe(false);
+    expect(yamlHasExternalIdSources("")).toBe(false);
   });
 });

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -677,6 +677,12 @@ describe("yamlHasExternalIdSources", () => {
     expect(yamlHasExternalIdSources("sensor:\n  - !include sensor_a.yaml\n")).toBe(true);
   });
 
+  it("is true for include-family directory tags", () => {
+    expect(yamlHasExternalIdSources("sensor: !include_dir_merge_list sensors/\n")).toBe(
+      true
+    );
+  });
+
   it("is false when every id is locally visible", () => {
     expect(yamlHasExternalIdSources("ld2410:\n  id: radar\n")).toBe(false);
     expect(yamlHasExternalIdSources("")).toBe(false);

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -673,6 +673,10 @@ describe("yamlHasExternalIdSources", () => {
     expect(yamlHasExternalIdSources("wifi: !include wifi.yaml\n")).toBe(true);
   });
 
+  it("is true for a list-item !include, which can define ids elsewhere", () => {
+    expect(yamlHasExternalIdSources("sensor:\n  - !include sensor_a.yaml\n")).toBe(true);
+  });
+
   it("is false when every id is locally visible", () => {
     expect(yamlHasExternalIdSources("ld2410:\n  id: radar\n")).toBe(false);
     expect(yamlHasExternalIdSources("")).toBe(false);

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -710,6 +710,14 @@ describe("yamlHasExternalIdSources", () => {
     );
   });
 
+  it("is true for an indented merge key, which can merge an id in", () => {
+    expect(
+      yamlHasExternalIdSources(
+        "defaults: &d\n  id: buzzer\noutput:\n  - platform: ledc\n    <<: *d\n"
+      )
+    ).toBe(true);
+  });
+
   it("is false when every id is locally visible", () => {
     expect(yamlHasExternalIdSources("ld2410:\n  id: radar\n")).toBe(false);
     expect(yamlHasExternalIdSources("")).toBe(false);

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -7,6 +7,7 @@ import {
   findComponentsByProviders,
   findReferenceCandidates,
   findUsedPins,
+  isCertainlyDanglingId,
   yamlHasExternalIdSources,
   yamlHasMergedSources,
 } from "../../src/util/config-entry-yaml-scan.js";
@@ -657,6 +658,32 @@ describe("yamlHasMergedSources", () => {
   it("is false for plain YAML and empty input", () => {
     expect(yamlHasMergedSources("ld2410:\n  id: radar\n")).toBe(false);
     expect(yamlHasMergedSources("")).toBe(false);
+  });
+});
+
+describe("isCertainlyDanglingId", () => {
+  const CANDIDATES = [{ id: "out_a" }, { id: "out_b" }];
+  const YAML = "output:\n  - platform: ledc\n    id: out_a\n";
+
+  it("is true for an id-shaped value absent from a comparable candidate list", () => {
+    expect(isCertainlyDanglingId("out_c", CANDIDATES, YAML)).toBe(true);
+  });
+
+  it("is false when the value is present, non-identifier, or indirect", () => {
+    expect(isCertainlyDanglingId("out_a", CANDIDATES, YAML)).toBe(false);
+    expect(isCertainlyDanglingId("${sub}", CANDIDATES, YAML)).toBe(false);
+    expect(isCertainlyDanglingId("!secret x", CANDIDATES, YAML)).toBe(false);
+  });
+
+  it("is false when a candidate id needs substitution to compare", () => {
+    expect(isCertainlyDanglingId("out_c", [{ id: "${name}_out" }], YAML)).toBe(false);
+    expect(isCertainlyDanglingId("out_c", [{ id: "$node_out" }], YAML)).toBe(false);
+  });
+
+  it("is false when the buffer pulls ids in from other files", () => {
+    expect(
+      isCertainlyDanglingId("out_c", CANDIDATES, `sensor: !include x.yaml\n${YAML}`)
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
# What does this implement/fix?

A reference field whose value doesn't resolve to any defined ID now shows an inline error and an invalid state immediately, without waiting for the backend lint round trip. The picker already knew the value was an orphan; it only said so in a quiet option label.

The error only fires when the verdict is certain: plain identifier values (substitutions and secret indirections can't be checked), no packages or merge keys that could define the id in another file, and the interface-provider fetch has settled. A backend validation error on the same field takes precedence over the client-side message.

Verified live: with rtttl referencing an ledc output id, breaking the declaration shows the inline error on the rtttl output field within one render; the backend's richer message replaces it when the lint pass lands.

**Related issue or feature (if applicable):**

- None

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
