### PR TITLE
Propagate ID renames to their references

### DIFF
--- a/src/components/device/config-entry-form.styles.ts
+++ b/src/components/device/config-entry-form.styles.ts
@@ -46,6 +46,13 @@ export const configEntryFormStyles = css`
     margin-top: var(--wa-space-2xs);
   }
 
+  /* Informational line under a field (the declaring-id reference count). */
+  .field-note {
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-2xs);
+    margin-top: var(--wa-space-2xs);
+  }
+
   .field-description {
     font-size: var(--wa-font-size-2xs);
     color: var(--wa-color-text-quiet);

--- a/src/components/device/config-entry-form.ts
+++ b/src/components/device/config-entry-form.ts
@@ -86,6 +86,7 @@ import {
   renderExclusiveGroupField,
   renderFloatWithUnitField,
   renderIconField,
+  renderIdDeclarationField,
   renderIdReferenceField,
   renderMapField,
   renderMultiValueField,
@@ -812,6 +813,11 @@ export class ESPHomeConfigEntryForm extends LitElement {
         return renderStringField(entry, "color", path, ctx);
       case ConfigEntryType.MAC_ADDRESS:
         return renderStringField(entry, "text", path, ctx);
+      case ConfigEntryType.ID:
+        // A declaring id (reference-typed entries exited above via
+        // references_component): a plain string field plus a hint when
+        // other parts of the config reference the current value.
+        return renderIdDeclarationField(entry, path, ctx);
       case ConfigEntryType.LAMBDA:
         return renderLambdaField(entry, path, ctx);
       case ConfigEntryType.JSON:

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -15,16 +15,39 @@ import {
 import { isValidEspHomeId } from "../../util/esphome-id.js";
 import { renderInlineError } from "../../util/render-error.js";
 import { resolveSubstitutions } from "../../util/substitutions.js";
+import { countIdReferences } from "../../util/yaml-id-rename.js";
 import {
   effectiveDisabled,
   fieldKeyAttr,
   renderFieldError,
   renderLabel,
+  renderStringField,
   renderYamlOnlyFallbackIfNonPrimitive,
   type RenderCtx,
 } from "./config-entry-renderers-shared.js";
 
 export const ADD_NEW_SENTINEL = "__esphome_add_new__";
+
+/**
+ * Declaring-id field: a plain string input plus a reference-count hint,
+ * so a rename doesn't feel risky — references follow it (the section
+ * editor propagates the rename across the buffer on flush).
+ */
+export function renderIdDeclarationField(
+  entry: ConfigEntry,
+  path: string[],
+  ctx: RenderCtx
+) {
+  const value = String(ctx.getAt(path) ?? "");
+  const count = isValidEspHomeId(value) ? countIdReferences(ctx.yaml, value) : 0;
+  const hint =
+    count > 0
+      ? html`<span class="field-note"
+          >${ctx.localize("device.id_rename_references_hint", { count })}</span
+        >`
+      : nothing;
+  return renderStringField(entry, "text", path, ctx, hint);
+}
 
 export function renderIdReferenceField(
   entry: ConfigEntry,

--- a/src/components/device/config-entry-id-reference-renderer.ts
+++ b/src/components/device/config-entry-id-reference-renderer.ts
@@ -39,7 +39,9 @@ export function renderIdDeclarationField(
   ctx: RenderCtx
 ) {
   const value = String(ctx.getAt(path) ?? "");
-  const count = isValidEspHomeId(value) ? countIdReferences(ctx.yaml, value) : 0;
+  const count = isValidEspHomeId(value)
+    ? countIdReferences(ctx.yaml, value, ctx.board?.esphome.platform)
+    : 0;
   const hint =
     count > 0
       ? html`<span class="field-note"

--- a/src/components/device/config-entry-renderers-shared.ts
+++ b/src/components/device/config-entry-renderers-shared.ts
@@ -333,7 +333,8 @@ export function renderStringField(
   entry: ConfigEntry,
   inputType: string,
   path: string[],
-  ctx: RenderCtx
+  ctx: RenderCtx,
+  extraHint: unknown = nothing
 ) {
   const raw = ctx.getAt(path);
   const bail = renderYamlOnlyFallbackIfNonPrimitive(entry, path, ctx, raw);
@@ -462,7 +463,7 @@ export function renderStringField(
   return html`
     <div class="field" data-field-key=${fieldKeyAttr(path)}>
       ${renderLabel(entry, ctx)} ${withPicker(textInput)} ${secretHint} ${subHint}
-      ${renderFieldError(path, ctx)}
+      ${extraHint} ${renderFieldError(path, ctx)}
     </div>
   `;
 }

--- a/src/components/device/config-entry-renderers.ts
+++ b/src/components/device/config-entry-renderers.ts
@@ -13,6 +13,7 @@ export {
 
 export {
   ADD_NEW_SENTINEL,
+  renderIdDeclarationField,
   renderIdReferenceField,
 } from "./config-entry-id-reference-renderer.js";
 

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -179,6 +179,10 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
 
   _loadId = 0;
   _draftTimer: ReturnType<typeof setTimeout> | null = null;
+  // Declaring-ID fields edited since the last flush, keyed by dotted path,
+  // holding the id the buffer's references still point at. Non-reactive —
+  // consumed by flushDraft to propagate renames across the buffer.
+  _pendingIdRenames = new Map<string, { path: string[]; from: string }>();
   // Parent loops yaml-draft events back through our yaml prop, which would
   // trigger reload() and lose focus mid-edit. reload() short-circuits when
   // the live yaml matches this snapshot.

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,11 +1,21 @@
 import toast from "sonner-js";
+import type { ConfigEntry } from "../../../api/types/config-entries.js";
+import { ConfigEntryType } from "../../../api/types/config-entries.js";
+import { entryAtPath } from "../../../util/config-entry-tree.js";
 import { validateEntries } from "../../../util/config-validation.js";
-import { setIn } from "../../../util/nested-values.js";
+import { isValidEspHomeId } from "../../../util/esphome-id.js";
+import { getIn, setIn } from "../../../util/nested-values.js";
 import {
   KEEP_EMPTY_STRING_SECTIONS,
   resolveSectionEntries,
 } from "../../../util/section-entry-overrides.js";
 import {
+  idDeclaredElsewhere,
+  renameIdInValues,
+  renameIdReferences,
+} from "../../../util/yaml-id-rename.js";
+import {
+  findSectionRange,
   removeSectionFromYaml,
   updateSectionInYaml,
 } from "../../../util/yaml-section-values.js";
@@ -22,6 +32,7 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   if (!host._config) return;
 
   const renderEntries = resolveSectionEntries(host.sectionKey, host._config.entries);
+  const renames = resolvePendingIdRenames(host, renderEntries);
   host._fieldErrors = validateEntries(
     renderEntries,
     host._values,
@@ -35,11 +46,12 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
     // Section was removed from live YAML between keystroke and debounce
     // (paste / external edit). Drop the splice silently — next picker
     // click re-runs loadConfig against the current YAML.
+    host._pendingIdRenames.clear();
     host._setDirty(false);
     return;
   }
 
-  const newYaml = updateSectionInYaml(
+  let newYaml = updateSectionInYaml(
     host.yaml,
     host.sectionKey,
     host._values,
@@ -50,6 +62,18 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
     // empty-string definitions, so dropping placeholders keeps it loadable.
     { keepEmptyStrings: KEEP_EMPTY_STRING_SECTIONS.has(host.sectionKey) }
   );
+
+  // Rewrite references to renamed ids across the rest of the buffer, in
+  // the same draft so the declaration and its references move as one
+  // buffer swap (one undo step in the YAML pane). The edited section's
+  // new range is excluded — it was just spliced from the renamed values.
+  for (const { from, to } of renames) {
+    const range = findSectionRange(newYaml.split("\n"), host.sectionKey, fromLine);
+    newYaml = renameIdReferences(newYaml, from, to, {
+      excludeFromLine: range.start + 1,
+      excludeToLine: range.end + 1,
+    });
+  }
 
   host._setDirty(false);
 
@@ -65,11 +89,53 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   );
 }
 
+/**
+ * Turn the pending id edits into actionable renames and rewrite the
+ * section's own draft values for each. Skip-and-forget renames that
+ * can't or shouldn't propagate; keep a pending entry whose new value is
+ * mid-edit invalid so a later valid flush still renames from the id the
+ * references actually hold.
+ */
+function resolvePendingIdRenames(
+  host: ESPHomeDeviceSectionConfig,
+  renderEntries: ConfigEntry[]
+): { from: string; to: string }[] {
+  if (!host._pendingIdRenames.size) return [];
+  const sectionRange = findSectionRange(
+    host.yaml.split("\n"),
+    host.sectionKey,
+    resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine)
+  );
+  const exclude = {
+    excludeFromLine: sectionRange.start + 1,
+    excludeToLine: sectionRange.end + 1,
+  };
+  const renames: { from: string; to: string }[] = [];
+  for (const [key, pending] of host._pendingIdRenames) {
+    const to = getIn(host._values, pending.path);
+    if (typeof to !== "string" || !isValidEspHomeId(to)) continue; // keep pending
+    host._pendingIdRenames.delete(key);
+    if (to === pending.from || !isValidEspHomeId(pending.from)) continue;
+    // A surviving declaration elsewhere still owns the old id — renaming
+    // the references would break it.
+    if (
+      sectionRange.start >= 0 &&
+      idDeclaredElsewhere(host.yaml, pending.from, exclude)
+    ) {
+      continue;
+    }
+    host._values = renameIdInValues(host._values, renderEntries, pending.from, to);
+    renames.push({ from: pending.from, to });
+  }
+  return renames;
+}
+
 export function onValueChange(
   host: ESPHomeDeviceSectionConfig,
   e: CustomEvent<ConfigEntryValueChange>
 ): void {
   const { path, value } = e.detail;
+  recordPendingIdRename(host, path);
   host._values = setIn(host._values, path, value);
   host._setDirty(true);
   const errKey = path.join(".");
@@ -84,6 +150,25 @@ export function onValueChange(
     host._clearedBackendPaths = new Set(host._clearedBackendPaths).add(errKey);
   }
   host._scheduleDraftFlush();
+}
+
+/**
+ * Remember the id a declaring ID field held before this edit, so the
+ * flush can rename references from it. First old value wins across the
+ * debounce window; after a successful propagation the entry clears and
+ * the next keystroke records the id the references now hold.
+ */
+function recordPendingIdRename(host: ESPHomeDeviceSectionConfig, path: string[]): void {
+  const key = path.join(".");
+  if (host._pendingIdRenames.has(key) || !host._config) return;
+  const old = getIn(host._values, path);
+  if (typeof old !== "string") return;
+  const entry = entryAtPath(
+    resolveSectionEntries(host.sectionKey, host._config.entries),
+    path
+  );
+  if (entry?.type !== ConfigEntryType.ID || entry.references_component) return;
+  host._pendingIdRenames.set(key, { path, from: old });
 }
 
 /** Point the section's field(s) at generated values (from the security notice)

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -70,7 +70,11 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   // computed once.
   if (renames.length) {
     const range = findSectionRange(newYaml.split("\n"), host.sectionKey, fromLine);
-    const exclude = { excludeFromLine: range.start + 1, excludeToLine: range.end + 1 };
+    const exclude = {
+      excludeFromLine: range.start + 1,
+      excludeToLine: range.end + 1,
+      platform: host.board?.esphome.platform,
+    };
     for (const { from, to } of renames) {
       newYaml = renameIdReferences(newYaml, from, to, exclude);
     }

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,7 +1,6 @@
 import toast from "sonner-js";
 import type { ConfigEntry } from "../../../api/types/config-entries.js";
-import { ConfigEntryType } from "../../../api/types/config-entries.js";
-import { entryAtPath } from "../../../util/config-entry-tree.js";
+import { entryAtPath, isDeclaringIdEntry } from "../../../util/config-entry-tree.js";
 import { validateEntries } from "../../../util/config-validation.js";
 import { isValidEspHomeId } from "../../../util/esphome-id.js";
 import { getIn, setIn } from "../../../util/nested-values.js";
@@ -31,16 +30,6 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   host._draftTimer = null;
   if (!host._config) return;
 
-  const renderEntries = resolveSectionEntries(host.sectionKey, host._config.entries);
-  const renames = resolvePendingIdRenames(host, renderEntries);
-  host._fieldErrors = validateEntries(
-    renderEntries,
-    host._values,
-    host._presentComponents,
-    host.board?.esphome.platform ?? null,
-    host.sectionKey
-  );
-
   const fromLine = resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine);
   if (fromLine === undefined) {
     // Section was removed from live YAML between keystroke and debounce
@@ -50,6 +39,16 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
     host._setDirty(false);
     return;
   }
+
+  const renderEntries = resolveSectionEntries(host.sectionKey, host._config.entries);
+  const renames = resolvePendingIdRenames(host, renderEntries, fromLine);
+  host._fieldErrors = validateEntries(
+    renderEntries,
+    host._values,
+    host._presentComponents,
+    host.board?.esphome.platform ?? null,
+    host.sectionKey
+  );
 
   let newYaml = updateSectionInYaml(
     host.yaml,
@@ -67,12 +66,14 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
   // the same draft so the declaration and its references move as one
   // buffer swap (one undo step in the YAML pane). The edited section's
   // new range is excluded — it was just spliced from the renamed values.
-  for (const { from, to } of renames) {
+  // renameIdReferences never changes the line count, so the range is
+  // computed once.
+  if (renames.length) {
     const range = findSectionRange(newYaml.split("\n"), host.sectionKey, fromLine);
-    newYaml = renameIdReferences(newYaml, from, to, {
-      excludeFromLine: range.start + 1,
-      excludeToLine: range.end + 1,
-    });
+    const exclude = { excludeFromLine: range.start + 1, excludeToLine: range.end + 1 };
+    for (const { from, to } of renames) {
+      newYaml = renameIdReferences(newYaml, from, to, exclude);
+    }
   }
 
   host._setDirty(false);
@@ -98,18 +99,12 @@ export function flushDraft(host: ESPHomeDeviceSectionConfig): void {
  */
 function resolvePendingIdRenames(
   host: ESPHomeDeviceSectionConfig,
-  renderEntries: ConfigEntry[]
+  renderEntries: ConfigEntry[],
+  fromLine: number
 ): { from: string; to: string }[] {
   if (!host._pendingIdRenames.size) return [];
-  const sectionRange = findSectionRange(
-    host.yaml.split("\n"),
-    host.sectionKey,
-    resolveCurrentFromLine(host.yaml, host.sectionKey, host.fromLine)
-  );
-  const exclude = {
-    excludeFromLine: sectionRange.start + 1,
-    excludeToLine: sectionRange.end + 1,
-  };
+  const range = findSectionRange(host.yaml.split("\n"), host.sectionKey, fromLine);
+  const exclude = { excludeFromLine: range.start + 1, excludeToLine: range.end + 1 };
   const renames: { from: string; to: string }[] = [];
   for (const [key, pending] of host._pendingIdRenames) {
     const to = getIn(host._values, pending.path);
@@ -118,12 +113,7 @@ function resolvePendingIdRenames(
     if (to === pending.from || !isValidEspHomeId(pending.from)) continue;
     // A surviving declaration elsewhere still owns the old id — renaming
     // the references would break it.
-    if (
-      sectionRange.start >= 0 &&
-      idDeclaredElsewhere(host.yaml, pending.from, exclude)
-    ) {
-      continue;
-    }
+    if (idDeclaredElsewhere(host.yaml, pending.from, exclude)) continue;
     host._values = renameIdInValues(host._values, renderEntries, pending.from, to);
     renames.push({ from: pending.from, to });
   }
@@ -167,7 +157,7 @@ function recordPendingIdRename(host: ESPHomeDeviceSectionConfig, path: string[])
     resolveSectionEntries(host.sectionKey, host._config.entries),
     path
   );
-  if (entry?.type !== ConfigEntryType.ID || entry.references_component) return;
+  if (!isDeclaringIdEntry(entry)) return;
   host._pendingIdRenames.set(key, { path, from: old });
 }
 

--- a/src/components/device/device-section-config/loading.ts
+++ b/src/components/device/device-section-config/loading.ts
@@ -30,6 +30,7 @@ export async function loadConfig(host: ESPHomeDeviceSectionConfig): Promise<void
     host._draftTimer = null;
   }
   host._lastSelfWrittenYaml = null;
+  host._pendingIdRenames.clear();
 
   try {
     const platform = host.board?.esphome.platform;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -900,6 +900,7 @@
     "id_reference_add": "Add {domain}",
     "id_reference_unresolved": "{domain} not defined in this file",
     "id_reference_unknown_error": "ID \"{id}\" is not defined in this configuration.",
+    "id_rename_references_hint": "Referenced in {count} {count, plural, one {place} other {places}}; references update automatically when you rename this ID.",
     "return_to_after_dep_prefix": "Adding a dependency. We'll bring you back to",
     "return_to_after_dep_suffix": "after.",
     "add_automation_error": "Failed to add automation",

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -26,39 +26,44 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
   return false;
 }
 
-/** The entry a value path addresses, skipping list-index segments the
- *  schema doesn't nest; null when the path doesn't resolve. */
-export function entryAtPath(entries: ConfigEntry[], path: string[]): ConfigEntry | null {
+/**
+ * The entries a value path traverses, outermost first. List-index
+ * segments are skipped: the schema nests an item's fields directly
+ * under the list entry, with no index level. Null when the path
+ * doesn't resolve.
+ */
+function entriesAlongPath(entries: ConfigEntry[], path: string[]): ConfigEntry[] | null {
   let level = entries;
-  let found: ConfigEntry | null = null;
+  const chain: ConfigEntry[] = [];
   for (const key of path) {
     if (isIndexSegment(key)) continue;
     const entry = level.find((e) => e.key === key);
     if (!entry) return null;
-    found = entry;
+    chain.push(entry);
     level = entry.config_entries ?? [];
   }
-  return found;
+  return chain;
+}
+
+/** The entry a value path addresses; null when the path doesn't resolve. */
+export function entryAtPath(entries: ConfigEntry[], path: string[]): ConfigEntry | null {
+  const chain = entriesAlongPath(entries, path);
+  return chain?.length ? chain[chain.length - 1] : null;
 }
 
 /**
  * Whether the entry at *path* — or any NESTED ancestor along it — is
  * `advanced`. Used to reveal a section's hidden advanced fields when the
- * caret or a backend error lands on one. List-index segments are skipped:
- * the schema nests an item's fields directly under the list entry, with
- * no index level. Returns false if the path doesn't resolve.
+ * caret or a backend error lands on one. False if the path doesn't
+ * resolve.
  */
 export function pathIsAdvanced(entries: ConfigEntry[], path: string[]): boolean {
-  let level = entries;
-  let advanced = false;
-  for (const key of path) {
-    if (isIndexSegment(key)) continue;
-    const entry = level.find((e) => e.key === key);
-    if (!entry) return false;
-    if (entry.advanced) advanced = true;
-    level = entry.config_entries ?? [];
-  }
-  return advanced;
+  return entriesAlongPath(entries, path)?.some((e) => e.advanced) ?? false;
+}
+
+/** A declaring id field: creates an id rather than referencing one. */
+export function isDeclaringIdEntry(entry: ConfigEntry | null): boolean {
+  return entry?.type === ConfigEntryType.ID && !entry.references_component;
 }
 
 /**

--- a/src/util/config-entry-tree.ts
+++ b/src/util/config-entry-tree.ts
@@ -26,6 +26,21 @@ export function anyAdvancedEntry(entries: ConfigEntry[]): boolean {
   return false;
 }
 
+/** The entry a value path addresses, skipping list-index segments the
+ *  schema doesn't nest; null when the path doesn't resolve. */
+export function entryAtPath(entries: ConfigEntry[], path: string[]): ConfigEntry | null {
+  let level = entries;
+  let found: ConfigEntry | null = null;
+  for (const key of path) {
+    if (isIndexSegment(key)) continue;
+    const entry = level.find((e) => e.key === key);
+    if (!entry) return null;
+    found = entry;
+    level = entry.config_entries ?? [];
+  }
+  return found;
+}
+
 /**
  * Whether the entry at *path* — or any NESTED ancestor along it — is
  * `advanced`. Used to reveal a section's hidden advanced fields when the

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -72,7 +72,7 @@ import {
  * here use object keys; primitive-keyed memos that wanted to
  * cache `undefined` would need a different shape.
  */
-function createScanMemo<K, V>(equals: (a: K, b: K) => boolean) {
+export function createScanMemo<K, V>(equals: (a: K, b: K) => boolean) {
   let key: K | undefined;
   let value: V | undefined;
   return {

--- a/src/util/yaml-id-rename.ts
+++ b/src/util/yaml-id-rename.ts
@@ -1,0 +1,239 @@
+/**
+ * Find and rewrite references to a component id across the YAML buffer.
+ *
+ * Same philosophy as config-entry-yaml-scan: pragmatic line scans over a
+ * possibly mid-edit buffer, not a full YAML parse. A reference is an
+ * identifier-shaped scalar equal to the id in value position (`key: id`,
+ * `- key: id`, a bare `- id` list item) under a key that isn't known
+ * free text, or an `id(...)` call inside a lambda. Declaring `id:` lines
+ * of sections and list items are excluded — an `id:` nested deeper (an
+ * automation action's target) is a reference.
+ */
+import type { ConfigEntry } from "../api/types/config-entries.js";
+import { createScanMemo } from "./config-entry-yaml-scan.js";
+import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
+import { findFieldLine, parseYamlTopLevelSections } from "./yaml-sections-core.js";
+
+export interface IdReferenceSite {
+  /** 1-indexed line of the reference. */
+  line: number;
+  kind: "value" | "lambda";
+}
+
+/** Options shared by the finder and the renamer. */
+export interface IdScanOptions {
+  /** 1-indexed inclusive range to skip — the section being edited. */
+  excludeFromLine?: number;
+  excludeToLine?: number;
+}
+
+/** Keys whose values are prose or enums, never id references. */
+const FREETEXT_KEYS = new Set([
+  "name",
+  "friendly_name",
+  "comment",
+  "ssid",
+  "password",
+  "platform",
+  "device_class",
+  "icon",
+  "unit_of_measurement",
+  "state_class",
+  "entity_category",
+  "restore_mode",
+  "mode",
+]);
+
+/** `key: value` with an optional list dash; captures prefix, key, value. */
+const VALUE_LINE_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*)(:\s*)(\S.*)$/;
+/** A bare `- value` sequence item; captures prefix and value. */
+const BARE_ITEM_RE = /^(\s*-\s+)([^\s:#].*)$/;
+
+interface Site {
+  lineIdx: number;
+  kind: "value" | "lambda";
+  rewrite: (line: string, newId: string) => string;
+}
+
+/** 0-indexed lines that declare an `id:` for a section or list item. */
+function declarationLines(yaml: string): Set<number> {
+  const out = new Set<number>();
+  for (const section of parseYamlTopLevelSections(yaml)) {
+    const line = findFieldLine(yaml, section, ["id"]);
+    if (line !== null) out.add(line - 1);
+  }
+  return out;
+}
+
+function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
+  const sites: Site[] = [];
+  if (!id) return sites;
+  const lines = yaml.split("\n");
+  const declared = declarationLines(yaml);
+  const lambdaRe = new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g");
+  const from = (opts.excludeFromLine ?? 0) - 1;
+  const to = (opts.excludeToLine ?? 0) - 1;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (opts.excludeFromLine !== undefined && i >= from && i <= to) continue;
+    const line = lines[i];
+    const { value: content } = splitInlineComment(line);
+
+    lambdaRe.lastIndex = 0;
+    if (lambdaRe.test(content)) {
+      sites.push({
+        lineIdx: i,
+        kind: "lambda",
+        rewrite: (l, newId) =>
+          l.replace(new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g"), `id(${newId})`),
+      });
+      continue;
+    }
+    if (declared.has(i)) continue;
+
+    const pair = VALUE_LINE_RE.exec(content);
+    if (pair && !FREETEXT_KEYS.has(pair[2]) && stripQuotes(pair[4].trim()) === id) {
+      sites.push({
+        lineIdx: i,
+        kind: "value",
+        rewrite: (l, newId) => replaceScalar(l, pair[1].length + pair[2].length, newId),
+      });
+      continue;
+    }
+    const bare = BARE_ITEM_RE.exec(content);
+    if (bare && stripQuotes(bare[2].trim()) === id) {
+      sites.push({
+        lineIdx: i,
+        kind: "value",
+        rewrite: (l, newId) => replaceScalar(l, bare[1].length, newId),
+      });
+    }
+  }
+  return sites;
+}
+
+/** Swap the scalar token equal to the old id after *afterCol*, keeping
+ *  quoting style, spacing, and any trailing comment. */
+function replaceScalar(line: string, afterCol: number, newId: string): string {
+  const { value: content, comment } = splitInlineComment(line);
+  const head = content.slice(0, afterCol);
+  const tail = content.slice(afterCol);
+  const rewritten = tail.replace(
+    /(:?\s*)(["']?)([^"'#]*?)(["']?)(\s*)$/,
+    (_m, sep, q1, _old, q2, ws) => `${sep}${q1}${newId}${q2}${ws}`
+  );
+  return head + rewritten + comment;
+}
+
+/**
+ * Every reference to *id* in the buffer, excluding its declarations and
+ * the optional excluded line range (the section being edited).
+ */
+export function findIdReferences(
+  yaml: string,
+  id: string,
+  opts: IdScanOptions = {}
+): IdReferenceSite[] {
+  return scanSites(yaml, id, opts).map((s) => ({ line: s.lineIdx + 1, kind: s.kind }));
+}
+
+interface CountKey {
+  yaml: string;
+  id: string;
+}
+const countMemo = createScanMemo<CountKey, number>(
+  (a, b) => a.yaml === b.yaml && a.id === b.id
+);
+
+/** Memoised reference count for the ID field's awareness hint. */
+export function countIdReferences(yaml: string, id: string): number {
+  const key = { yaml, id };
+  const hit = countMemo.get(key);
+  if (hit !== undefined) return hit;
+  const count = findIdReferences(yaml, id).length;
+  countMemo.set(key, count);
+  return count;
+}
+
+/** Rewrite every reference to *oldId* as *newId*; untouched lines stay
+ *  byte-identical. */
+export function renameIdReferences(
+  yaml: string,
+  oldId: string,
+  newId: string,
+  opts: IdScanOptions = {}
+): string {
+  const sites = scanSites(yaml, oldId, opts);
+  if (!sites.length) return yaml;
+  const lines = yaml.split("\n");
+  for (const site of sites) {
+    lines[site.lineIdx] = site.rewrite(lines[site.lineIdx], newId);
+  }
+  return lines.join("\n");
+}
+
+/** Whether *id* is declared as a section or list-item `id:` outside the
+ *  excluded range — renaming references then would break the survivor. */
+export function idDeclaredElsewhere(
+  yaml: string,
+  id: string,
+  opts: IdScanOptions = {}
+): boolean {
+  const lines = yaml.split("\n");
+  const from = (opts.excludeFromLine ?? 0) - 1;
+  const to = (opts.excludeToLine ?? 0) - 1;
+  for (const lineIdx of declarationLines(yaml)) {
+    if (opts.excludeFromLine !== undefined && lineIdx >= from && lineIdx <= to) {
+      continue;
+    }
+    const pair = VALUE_LINE_RE.exec(splitInlineComment(lines[lineIdx]).value);
+    if (pair && stripQuotes(pair[4].trim()) === id) return true;
+  }
+  return false;
+}
+
+/**
+ * Rewrite references to *oldId* inside the edited section's own draft
+ * values: string leaves whose entry has references_component, plus
+ * id(old) calls in any string leaf (lambdas). Schema-precise where the
+ * buffer scan can't be — the section splices from these values, so they
+ * must agree with the cross-section rewrite.
+ */
+export function renameIdInValues(
+  values: Record<string, unknown>,
+  entries: ConfigEntry[],
+  oldId: string,
+  newId: string
+): Record<string, unknown> {
+  const lambdaRe = new RegExp(String.raw`\bid\(\s*${oldId}\s*\)`, "g");
+  const fixString = (s: string, entry: ConfigEntry | undefined): string => {
+    if (entry?.references_component && s === oldId) return newId;
+    return s.replace(lambdaRe, `id(${newId})`);
+  };
+  const walk = (val: unknown, entry: ConfigEntry | undefined): unknown => {
+    if (typeof val === "string") return fixString(val, entry);
+    if (Array.isArray(val)) {
+      return val.map((item) =>
+        typeof item === "string" ? fixString(item, entry) : walk(item, entry)
+      );
+    }
+    if (val && typeof val === "object") {
+      const level = entry ? (entry.config_entries ?? []) : entries;
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(val)) {
+        out[k] = walk(
+          v,
+          level.find((e) => e.key === k)
+        );
+      }
+      return out;
+    }
+    return val;
+  };
+  return walk(values, undefined) as Record<string, unknown>;
+}
+
+/** Test-only: clear the count memo. */
+export function _clearIdRenameMemos(): void {
+  countMemo.clear();
+}

--- a/src/util/yaml-id-rename.ts
+++ b/src/util/yaml-id-rename.ts
@@ -2,21 +2,29 @@
  * Find and rewrite references to a component id across the YAML buffer.
  *
  * Same philosophy as config-entry-yaml-scan: pragmatic line scans over a
- * possibly mid-edit buffer, not a full YAML parse. A reference is an
- * identifier-shaped scalar equal to the id in value position (`key: id`,
- * `- key: id`, a bare `- id` list item, a `[a, b]` flow-sequence
- * element) under a key that isn't known free text, or an `id(...)` call
- * inside a lambda. Declaring `id:` lines of sections and list items are
- * excluded — an `id:` nested deeper (an automation action's target) is a
- * reference.
+ * possibly mid-edit buffer, not a full YAML parse. Which values can hold
+ * an id comes from the schema, not from guessing by key name:
  *
- * Known tradeoff of the textual scan: a value that merely equals the id
- * under a key outside the free-text denylist (an enum value colliding
- * with a short id like `rgb`) reads as a reference. The schema would
- * disambiguate, but it isn't fetched for foreign sections; the denylist
- * covers the common prose/enum keys.
+ * - a non-declaring `id:` value (an automation action's target) and a
+ *   dotted action-shorthand value (`- switch.turn_on: relay1`) are
+ *   references by ESPHome convention, buffer-wide;
+ * - a `key: value` / bare `- value` / `[a, b]` flow-sequence value is a
+ *   reference only when the containing section's cached catalog entry
+ *   marks that key `references_component` (the same schema the reference
+ *   dropdowns and YAML completion resolve against);
+ * - `substitutions:` values are literal splice text, so any of them can
+ *   carry the id;
+ * - `id(...)` calls inside lambdas are references anywhere.
+ *
+ * A section whose schema isn't cached contributes no schema-keyed sites
+ * (the universal rules above still apply inside it) — the navigator
+ * prefetches every present section's schema, so in practice the cache is
+ * warm. Known tradeoff: a dotted action shorthand whose scalar isn't a
+ * target (`logger.log: msg`) reads as a reference when the message
+ * exactly equals the id.
  */
 import type { ConfigEntry } from "../api/types/config-entries.js";
+import { getCachedComponent, subscribeComponentCache } from "./component-name-cache.js";
 import { createScanMemo } from "./config-entry-yaml-scan.js";
 import { isValidEspHomeId } from "./esphome-id.js";
 import { LIST_SECTIONS } from "./section-entry-overrides.js";
@@ -26,6 +34,7 @@ import {
   parseYamlTopLevelSections,
   readInstanceScalar,
 } from "./yaml-sections-core.js";
+import { sectionKeyOf } from "./yaml-sections.js";
 
 export interface IdReferenceSite {
   /** 1-indexed line of the reference. */
@@ -38,29 +47,17 @@ export interface IdScanOptions {
   /** 1-indexed inclusive range to skip — the section being edited. */
   excludeFromLine?: number;
   excludeToLine?: number;
+  /** Device chip platform (`esp32`, …) — the component-cache bucket the
+   *  app fetches section schemas into. */
+  platform?: string;
 }
-
-/** Keys whose values are prose or enums, never id references. */
-const FREETEXT_KEYS = new Set([
-  "name",
-  "friendly_name",
-  "comment",
-  "ssid",
-  "password",
-  "platform",
-  "device_class",
-  "icon",
-  "unit_of_measurement",
-  "state_class",
-  "entity_category",
-  "restore_mode",
-  "mode",
-]);
 
 /** `key: value` with an optional list dash; captures prefix, key, value. */
 const VALUE_LINE_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*)(:\s*)(\S.*)$/;
+/** `key:` opening a block (no inline value); captures prefix and key. */
+const KEY_ONLY_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*):\s*$/;
 /** A bare `- value` sequence item; captures prefix and value. */
-const BARE_ITEM_RE = /^(\s*-\s+)([^\s:#].*)$/;
+const BARE_ITEM_RE = /^(\s*)-\s+([^\s:#].*)$/;
 
 /** `id(<id>)` lambda call. Safe to build from a validated identifier. */
 const idCallRe = (id: string) => new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g");
@@ -70,6 +67,13 @@ const idTokenRe = (id: string) => new RegExp(String.raw`\b${id}\b`, "g");
 type Site =
   | { lineIdx: number; kind: "value"; afterCol: number }
   | { lineIdx: number; kind: "lambda" };
+
+// The section contexts depend on the component cache, which fills as
+// schemas arrive; the generation busts the memos when it does.
+let cacheGen = 0;
+subscribeComponentCache(() => {
+  cacheGen++;
+});
 
 const declMemo = createScanMemo<string, Set<number>>((a, b) => a === b);
 
@@ -95,6 +99,57 @@ function declarationLines(yaml: string): Set<number> {
   return out;
 }
 
+interface SectionScanCtx {
+  fromIdx: number; // 0-indexed inclusive
+  toIdx: number;
+  /** Keys the section's schema marks `references_component`; null when
+   *  the schema isn't cached — schema-keyed matching is skipped then. */
+  refKeys: ReadonlySet<string> | null;
+  /** `substitutions:` — every value is spliced text, any may carry the id. */
+  allValues: boolean;
+}
+
+function collectRefKeys(entries: ConfigEntry[], out: Set<string>): void {
+  for (const e of entries) {
+    if (e.references_component) out.add(e.key);
+    if (e.config_entries) collectRefKeys(e.config_entries, out);
+  }
+}
+
+interface SectionCtxKey {
+  yaml: string;
+  platform: string | undefined;
+  gen: number;
+}
+
+const sectionCtxMemo = createScanMemo<SectionCtxKey, SectionScanCtx[]>(
+  (a, b) => a.yaml === b.yaml && a.platform === b.platform && a.gen === b.gen
+);
+
+function sectionScanCtxs(yaml: string, platform: string | undefined): SectionScanCtx[] {
+  const key = { yaml, platform, gen: cacheGen };
+  const hit = sectionCtxMemo.get(key);
+  if (hit) return hit;
+  const out: SectionScanCtx[] = [];
+  for (const section of parseYamlTopLevelSections(yaml)) {
+    const fromIdx = section.fromLine - 1;
+    const toIdx = section.toLine - 1;
+    if (section.key === "substitutions") {
+      out.push({ fromIdx, toIdx, refKeys: null, allValues: true });
+      continue;
+    }
+    const comp = getCachedComponent(sectionKeyOf(section), platform);
+    let refKeys: Set<string> | null = null;
+    if (comp) {
+      refKeys = new Set();
+      collectRefKeys(comp.config_entries ?? [], refKeys);
+    }
+    out.push({ fromIdx, toIdx, refKeys, allValues: false });
+  }
+  sectionCtxMemo.set(key, out);
+  return out;
+}
+
 /** Whether a value-position scalar or flow sequence carries *id*. */
 function valueCarriesId(rawValue: string, id: string): boolean {
   if (rawValue.startsWith("[")) {
@@ -106,6 +161,13 @@ function valueCarriesId(rawValue: string, id: string): boolean {
   return stripQuotes(rawValue) === id;
 }
 
+/** Whether *key* can hold an id reference in this section context. */
+function keyHoldsReference(key: string, sctx: SectionScanCtx | undefined): boolean {
+  if (key === "id" || key.includes(".")) return true;
+  if (!sctx) return false;
+  return sctx.allValues || (sctx.refKeys?.has(key) ?? false);
+}
+
 function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
   const sites: Site[] = [];
   // Not identifier-shaped ⇒ can't be an ESPHome id ⇒ no sites. This also
@@ -113,37 +175,80 @@ function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
   if (!isValidEspHomeId(id)) return sites;
   const lines = yaml.split("\n");
   const declared = declarationLines(yaml);
+  const sections = sectionScanCtxs(yaml, opts.platform);
   const lambdaRe = idCallRe(id);
   const from = (opts.excludeFromLine ?? 0) - 1;
   const to = (opts.excludeToLine ?? 0) - 1;
 
+  // Nearest enclosing `key:` per indent, for attributing bare `- value`
+  // items to the key whose block they sit in.
+  const keyStack: { indent: number; key: string }[] = [];
+  let sectionIdx = 0;
+
   for (let i = 0; i < lines.length; i++) {
-    if (opts.excludeFromLine !== undefined && i >= from && i <= to) continue;
+    while (sectionIdx < sections.length && sections[sectionIdx].toIdx < i) sectionIdx++;
+    const sctx =
+      sectionIdx < sections.length && sections[sectionIdx].fromIdx <= i
+        ? sections[sectionIdx]
+        : undefined;
+    const excluded = opts.excludeFromLine !== undefined && i >= from && i <= to;
     const { value: content } = splitInlineComment(lines[i]);
 
-    if (content.includes("id(")) {
+    if (!excluded && content.includes("id(")) {
       lambdaRe.lastIndex = 0;
       if (lambdaRe.test(content)) {
         sites.push({ lineIdx: i, kind: "lambda" });
         continue;
       }
     }
-    if (declared.has(i)) continue;
 
     const pair = VALUE_LINE_RE.exec(content);
     if (pair) {
-      if (!FREETEXT_KEYS.has(pair[2]) && valueCarriesId(pair[4].trim(), id)) {
-        sites.push({
-          lineIdx: i,
-          kind: "value",
-          afterCol: pair[1].length + pair[2].length,
-        });
+      const indent = pair[1].length;
+      while (keyStack.length && keyStack[keyStack.length - 1].indent >= indent) {
+        keyStack.pop();
+      }
+      keyStack.push({ indent, key: pair[2] });
+      if (
+        !excluded &&
+        !declared.has(i) &&
+        keyHoldsReference(pair[2], sctx) &&
+        valueCarriesId(pair[4].trim(), id)
+      ) {
+        sites.push({ lineIdx: i, kind: "value", afterCol: indent + pair[2].length });
       }
       continue;
     }
+    const keyOnly = KEY_ONLY_RE.exec(content);
+    if (keyOnly) {
+      const indent = keyOnly[1].length;
+      while (keyStack.length && keyStack[keyStack.length - 1].indent >= indent) {
+        keyStack.pop();
+      }
+      keyStack.push({ indent, key: keyOnly[2] });
+      continue;
+    }
     const bare = BARE_ITEM_RE.exec(content);
-    if (bare && stripQuotes(bare[2].trim()) === id) {
-      sites.push({ lineIdx: i, kind: "value", afterCol: bare[1].length });
+    if (bare) {
+      // A dash at the owning key's own indent is still its item, so only
+      // deeper keys are popped.
+      const indent = bare[1].length;
+      while (keyStack.length && keyStack[keyStack.length - 1].indent > indent) {
+        keyStack.pop();
+      }
+      const parent = keyStack[keyStack.length - 1];
+      if (
+        !excluded &&
+        parent &&
+        keyHoldsReference(parent.key, sctx) &&
+        stripQuotes(bare[2].trim()) === id
+      ) {
+        sites.push({
+          lineIdx: i,
+          kind: "value",
+          afterCol: content.length - bare[2].length,
+        });
+      }
     }
   }
   return sites;
@@ -176,21 +281,30 @@ export function findIdReferences(
   return scanSites(yaml, id, opts).map((s) => ({ line: s.lineIdx + 1, kind: s.kind }));
 }
 
+interface CountKey {
+  yaml: string;
+  platform: string | undefined;
+  gen: number;
+}
+
 // Keyed on the buffer, holding per-id counts: a form renders several
 // declaring ID fields (nested entities), and a single-entry (yaml, id)
 // memo would thrash across them on every render.
-const countMemo = createScanMemo<string, Map<string, number>>((a, b) => a === b);
+const countMemo = createScanMemo<CountKey, Map<string, number>>(
+  (a, b) => a.yaml === b.yaml && a.platform === b.platform && a.gen === b.gen
+);
 
 /** Memoised reference count for the ID field's awareness hint. */
-export function countIdReferences(yaml: string, id: string): number {
-  let counts = countMemo.get(yaml);
+export function countIdReferences(yaml: string, id: string, platform?: string): number {
+  const key = { yaml, platform, gen: cacheGen };
+  let counts = countMemo.get(key);
   if (!counts) {
     counts = new Map();
-    countMemo.set(yaml, counts);
+    countMemo.set(key, counts);
   }
   const hit = counts.get(id);
   if (hit !== undefined) return hit;
-  const count = findIdReferences(yaml, id).length;
+  const count = findIdReferences(yaml, id, { platform }).length;
   counts.set(id, count);
   return count;
 }
@@ -278,4 +392,5 @@ export function renameIdInValues(
 export function _clearIdRenameMemos(): void {
   countMemo.clear();
   declMemo.clear();
+  sectionCtxMemo.clear();
 }

--- a/src/util/yaml-id-rename.ts
+++ b/src/util/yaml-id-rename.ts
@@ -4,15 +4,28 @@
  * Same philosophy as config-entry-yaml-scan: pragmatic line scans over a
  * possibly mid-edit buffer, not a full YAML parse. A reference is an
  * identifier-shaped scalar equal to the id in value position (`key: id`,
- * `- key: id`, a bare `- id` list item) under a key that isn't known
- * free text, or an `id(...)` call inside a lambda. Declaring `id:` lines
- * of sections and list items are excluded — an `id:` nested deeper (an
- * automation action's target) is a reference.
+ * `- key: id`, a bare `- id` list item, a `[a, b]` flow-sequence
+ * element) under a key that isn't known free text, or an `id(...)` call
+ * inside a lambda. Declaring `id:` lines of sections and list items are
+ * excluded — an `id:` nested deeper (an automation action's target) is a
+ * reference.
+ *
+ * Known tradeoff of the textual scan: a value that merely equals the id
+ * under a key outside the free-text denylist (an enum value colliding
+ * with a short id like `rgb`) reads as a reference. The schema would
+ * disambiguate, but it isn't fetched for foreign sections; the denylist
+ * covers the common prose/enum keys.
  */
 import type { ConfigEntry } from "../api/types/config-entries.js";
 import { createScanMemo } from "./config-entry-yaml-scan.js";
+import { isValidEspHomeId } from "./esphome-id.js";
+import { LIST_SECTIONS } from "./section-entry-overrides.js";
 import { splitInlineComment, stripQuotes } from "./yaml-scalar.js";
-import { findFieldLine, parseYamlTopLevelSections } from "./yaml-sections-core.js";
+import {
+  findFieldLine,
+  parseYamlTopLevelSections,
+  readInstanceScalar,
+} from "./yaml-sections-core.js";
 
 export interface IdReferenceSite {
   /** 1-indexed line of the reference. */
@@ -49,80 +62,106 @@ const VALUE_LINE_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*)(:\s*)(\S.*)$/;
 /** A bare `- value` sequence item; captures prefix and value. */
 const BARE_ITEM_RE = /^(\s*-\s+)([^\s:#].*)$/;
 
-interface Site {
-  lineIdx: number;
-  kind: "value" | "lambda";
-  rewrite: (line: string, newId: string) => string;
-}
+/** `id(<id>)` lambda call. Safe to build from a validated identifier. */
+const idCallRe = (id: string) => new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g");
+/** The identifier as a standalone token. */
+const idTokenRe = (id: string) => new RegExp(String.raw`\b${id}\b`, "g");
 
-/** 0-indexed lines that declare an `id:` for a section or list item. */
+type Site =
+  | { lineIdx: number; kind: "value"; afterCol: number }
+  | { lineIdx: number; kind: "lambda" };
+
+const declMemo = createScanMemo<string, Set<number>>((a, b) => a === b);
+
+/** 0-indexed lines that declare an `id:` for a section or list item.
+ *  LIST_SECTIONS blocks (globals) aren't expanded per item, so their
+ *  item-level `id:` lines are collected by direct scan. */
 function declarationLines(yaml: string): Set<number> {
+  const hit = declMemo.get(yaml);
+  if (hit) return hit;
   const out = new Set<number>();
+  const lines = yaml.split("\n");
   for (const section of parseYamlTopLevelSections(yaml)) {
+    if (LIST_SECTIONS.has(section.key)) {
+      for (let i = section.fromLine - 1; i <= section.toLine - 1; i++) {
+        if (readInstanceScalar(lines[i], "id") !== null) out.add(i);
+      }
+      continue;
+    }
     const line = findFieldLine(yaml, section, ["id"]);
     if (line !== null) out.add(line - 1);
   }
+  declMemo.set(yaml, out);
   return out;
+}
+
+/** Whether a value-position scalar or flow sequence carries *id*. */
+function valueCarriesId(rawValue: string, id: string): boolean {
+  if (rawValue.startsWith("[")) {
+    return rawValue
+      .slice(1, rawValue.lastIndexOf("]") < 0 ? undefined : rawValue.lastIndexOf("]"))
+      .split(",")
+      .some((tok) => stripQuotes(tok.trim()) === id);
+  }
+  return stripQuotes(rawValue) === id;
 }
 
 function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
   const sites: Site[] = [];
-  if (!id) return sites;
+  // Not identifier-shaped ⇒ can't be an ESPHome id ⇒ no sites. This also
+  // keeps the RegExp construction below safe for arbitrary input.
+  if (!isValidEspHomeId(id)) return sites;
   const lines = yaml.split("\n");
   const declared = declarationLines(yaml);
-  const lambdaRe = new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g");
+  const lambdaRe = idCallRe(id);
   const from = (opts.excludeFromLine ?? 0) - 1;
   const to = (opts.excludeToLine ?? 0) - 1;
 
   for (let i = 0; i < lines.length; i++) {
     if (opts.excludeFromLine !== undefined && i >= from && i <= to) continue;
-    const line = lines[i];
-    const { value: content } = splitInlineComment(line);
+    const { value: content } = splitInlineComment(lines[i]);
 
-    lambdaRe.lastIndex = 0;
-    if (lambdaRe.test(content)) {
-      sites.push({
-        lineIdx: i,
-        kind: "lambda",
-        rewrite: (l, newId) =>
-          l.replace(new RegExp(String.raw`\bid\(\s*${id}\s*\)`, "g"), `id(${newId})`),
-      });
-      continue;
+    if (content.includes("id(")) {
+      lambdaRe.lastIndex = 0;
+      if (lambdaRe.test(content)) {
+        sites.push({ lineIdx: i, kind: "lambda" });
+        continue;
+      }
     }
     if (declared.has(i)) continue;
 
     const pair = VALUE_LINE_RE.exec(content);
-    if (pair && !FREETEXT_KEYS.has(pair[2]) && stripQuotes(pair[4].trim()) === id) {
-      sites.push({
-        lineIdx: i,
-        kind: "value",
-        rewrite: (l, newId) => replaceScalar(l, pair[1].length + pair[2].length, newId),
-      });
+    if (pair) {
+      if (!FREETEXT_KEYS.has(pair[2]) && valueCarriesId(pair[4].trim(), id)) {
+        sites.push({
+          lineIdx: i,
+          kind: "value",
+          afterCol: pair[1].length + pair[2].length,
+        });
+      }
       continue;
     }
     const bare = BARE_ITEM_RE.exec(content);
     if (bare && stripQuotes(bare[2].trim()) === id) {
-      sites.push({
-        lineIdx: i,
-        kind: "value",
-        rewrite: (l, newId) => replaceScalar(l, bare[1].length, newId),
-      });
+      sites.push({ lineIdx: i, kind: "value", afterCol: bare[1].length });
     }
   }
   return sites;
 }
 
-/** Swap the scalar token equal to the old id after *afterCol*, keeping
- *  quoting style, spacing, and any trailing comment. */
-function replaceScalar(line: string, afterCol: number, newId: string): string {
+/** Swap standalone tokens equal to the old id after *afterCol*, keeping
+ *  quoting style, spacing, and any trailing comment. Identifier `\b`
+ *  boundaries can't match inside a longer id. */
+function rewriteValue(
+  line: string,
+  afterCol: number,
+  tokenRe: RegExp,
+  newId: string
+): string {
   const { value: content, comment } = splitInlineComment(line);
-  const head = content.slice(0, afterCol);
-  const tail = content.slice(afterCol);
-  const rewritten = tail.replace(
-    /(:?\s*)(["']?)([^"'#]*?)(["']?)(\s*)$/,
-    (_m, sep, q1, _old, q2, ws) => `${sep}${q1}${newId}${q2}${ws}`
+  return (
+    content.slice(0, afterCol) + content.slice(afterCol).replace(tokenRe, newId) + comment
   );
-  return head + rewritten + comment;
 }
 
 /**
@@ -137,26 +176,27 @@ export function findIdReferences(
   return scanSites(yaml, id, opts).map((s) => ({ line: s.lineIdx + 1, kind: s.kind }));
 }
 
-interface CountKey {
-  yaml: string;
-  id: string;
-}
-const countMemo = createScanMemo<CountKey, number>(
-  (a, b) => a.yaml === b.yaml && a.id === b.id
-);
+// Keyed on the buffer, holding per-id counts: a form renders several
+// declaring ID fields (nested entities), and a single-entry (yaml, id)
+// memo would thrash across them on every render.
+const countMemo = createScanMemo<string, Map<string, number>>((a, b) => a === b);
 
 /** Memoised reference count for the ID field's awareness hint. */
 export function countIdReferences(yaml: string, id: string): number {
-  const key = { yaml, id };
-  const hit = countMemo.get(key);
+  let counts = countMemo.get(yaml);
+  if (!counts) {
+    counts = new Map();
+    countMemo.set(yaml, counts);
+  }
+  const hit = counts.get(id);
   if (hit !== undefined) return hit;
   const count = findIdReferences(yaml, id).length;
-  countMemo.set(key, count);
+  counts.set(id, count);
   return count;
 }
 
 /** Rewrite every reference to *oldId* as *newId*; untouched lines stay
- *  byte-identical. */
+ *  byte-identical and the line count never changes. */
 export function renameIdReferences(
   yaml: string,
   oldId: string,
@@ -166,8 +206,13 @@ export function renameIdReferences(
   const sites = scanSites(yaml, oldId, opts);
   if (!sites.length) return yaml;
   const lines = yaml.split("\n");
+  const lambdaRe = idCallRe(oldId);
+  const tokenRe = idTokenRe(oldId);
   for (const site of sites) {
-    lines[site.lineIdx] = site.rewrite(lines[site.lineIdx], newId);
+    lines[site.lineIdx] =
+      site.kind === "lambda"
+        ? lines[site.lineIdx].replace(lambdaRe, `id(${newId})`)
+        : rewriteValue(lines[site.lineIdx], site.afterCol, tokenRe, newId);
   }
   return lines.join("\n");
 }
@@ -186,8 +231,7 @@ export function idDeclaredElsewhere(
     if (opts.excludeFromLine !== undefined && lineIdx >= from && lineIdx <= to) {
       continue;
     }
-    const pair = VALUE_LINE_RE.exec(splitInlineComment(lines[lineIdx]).value);
-    if (pair && stripQuotes(pair[4].trim()) === id) return true;
+    if (readInstanceScalar(lines[lineIdx], "id") === id) return true;
   }
   return false;
 }
@@ -205,18 +249,15 @@ export function renameIdInValues(
   oldId: string,
   newId: string
 ): Record<string, unknown> {
-  const lambdaRe = new RegExp(String.raw`\bid\(\s*${oldId}\s*\)`, "g");
+  if (!isValidEspHomeId(oldId)) return values;
+  const lambdaRe = idCallRe(oldId);
   const fixString = (s: string, entry: ConfigEntry | undefined): string => {
     if (entry?.references_component && s === oldId) return newId;
     return s.replace(lambdaRe, `id(${newId})`);
   };
   const walk = (val: unknown, entry: ConfigEntry | undefined): unknown => {
     if (typeof val === "string") return fixString(val, entry);
-    if (Array.isArray(val)) {
-      return val.map((item) =>
-        typeof item === "string" ? fixString(item, entry) : walk(item, entry)
-      );
-    }
+    if (Array.isArray(val)) return val.map((item) => walk(item, entry));
     if (val && typeof val === "object") {
       const level = entry ? (entry.config_entries ?? []) : entries;
       const out: Record<string, unknown> = {};
@@ -233,7 +274,8 @@ export function renameIdInValues(
   return walk(values, undefined) as Record<string, unknown>;
 }
 
-/** Test-only: clear the count memo. */
+/** Test-only: clear the scan memos. */
 export function _clearIdRenameMemos(): void {
   countMemo.clear();
+  declMemo.clear();
 }

--- a/src/util/yaml-id-rename.ts
+++ b/src/util/yaml-id-rename.ts
@@ -52,10 +52,9 @@ export interface IdScanOptions {
   platform?: string;
 }
 
-/** `key: value` with an optional list dash; captures prefix, key, value. */
-const VALUE_LINE_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*)(:\s*)(\S.*)$/;
-/** `key:` opening a block (no inline value); captures prefix and key. */
-const KEY_ONLY_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*):\s*$/;
+/** `key:` with an optional list dash and optional inline value;
+ *  captures prefix, key, value (undefined for a block-opening key). */
+const PAIR_LINE_RE = /^(\s*(?:-\s+)?)([A-Za-z_][\w.]*)(:\s*)(\S.*)?$/;
 /** A bare `- value` sequence item; captures prefix and value. */
 const BARE_ITEM_RE = /^(\s*)-\s+([^\s:#].*)$/;
 
@@ -202,7 +201,7 @@ function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
       }
     }
 
-    const pair = VALUE_LINE_RE.exec(content);
+    const pair = PAIR_LINE_RE.exec(content);
     if (pair) {
       const indent = pair[1].length;
       while (keyStack.length && keyStack[keyStack.length - 1].indent >= indent) {
@@ -211,21 +210,13 @@ function scanSites(yaml: string, id: string, opts: IdScanOptions = {}): Site[] {
       keyStack.push({ indent, key: pair[2] });
       if (
         !excluded &&
+        pair[4] !== undefined &&
         !declared.has(i) &&
         keyHoldsReference(pair[2], sctx) &&
         valueCarriesId(pair[4].trim(), id)
       ) {
         sites.push({ lineIdx: i, kind: "value", afterCol: indent + pair[2].length });
       }
-      continue;
-    }
-    const keyOnly = KEY_ONLY_RE.exec(content);
-    if (keyOnly) {
-      const indent = keyOnly[1].length;
-      while (keyStack.length && keyStack[keyStack.length - 1].indent >= indent) {
-        keyStack.pop();
-      }
-      keyStack.push({ indent, key: keyOnly[2] });
       continue;
     }
     const bare = BARE_ITEM_RE.exec(content);

--- a/test/components/device/section-config-id-rename.test.ts
+++ b/test/components/device/section-config-id-rename.test.ts
@@ -5,20 +5,47 @@
  * id through the form rewrites every reference to the old id in the same
  * yaml-draft, with the guardrails that keep half-renames impossible.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
 
+import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
 import {
   flushDraft,
   onValueChange,
 } from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import {
+  _clearComponentCache,
+  fetchComponent,
+} from "../../../src/util/component-name-cache.js";
+import { _clearIdRenameMemos } from "../../../src/util/yaml-id-rename.js";
 import { _clearYamlSectionsMemo } from "../../../src/util/yaml-sections.js";
 import { makeEntry } from "./_renderer-fixtures.js";
+
+// The scan resolves reference keys from cached schemas; seed the ones
+// the fixtures' foreign sections use.
+const BODIES = {
+  rtttl: {
+    id: "rtttl",
+    name: "rtttl",
+    config_entries: [{ key: "output", type: "id", references_component: "output" }],
+  },
+} as never as Record<string, never>;
+
+const api = {
+  getComponentBodies: async (ids: string[]) =>
+    Object.fromEntries(ids.filter((id) => id in BODIES).map((id) => [id, BODIES[id]])),
+} as unknown as ESPHomeAPI;
+
+beforeEach(async () => {
+  _clearComponentCache();
+  _clearIdRenameMemos();
+  await Promise.all(Object.keys(BODIES).map((id) => fetchComponent(api, id)));
+});
 
 const APOLLO = `output:
   - platform: ledc

--- a/test/components/device/section-config-id-rename.test.ts
+++ b/test/components/device/section-config-id-rename.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the section editor's ID rename propagation: renaming a declaring
+ * id through the form rewrites every reference to the old id in the same
+ * yaml-draft, with the guardrails that keep half-renames impossible.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
+import { ESPHomeDeviceSectionConfig } from "../../../src/components/device/device-section-config.js";
+import {
+  flushDraft,
+  onValueChange,
+} from "../../../src/components/device/device-section-config/draft-and-delete.js";
+import { _clearYamlSectionsMemo } from "../../../src/util/yaml-sections.js";
+import { makeEntry } from "./_renderer-fixtures.js";
+
+const APOLLO = `output:
+  - platform: ledc
+    pin: 18
+    id: buzzer_output
+
+rtttl:
+  - output: buzzer_output
+    id: rtttl_player
+`;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function host(yaml: string, values: Record<string, unknown>) {
+  _clearYamlSectionsMemo();
+  const c = new ESPHomeDeviceSectionConfig();
+  const inner = c as any;
+  inner.yaml = yaml;
+  inner.sectionKey = "output.ledc";
+  inner.fromLine = 2;
+  inner._config = {
+    entries: [
+      makeEntry(ConfigEntryType.STRING, { key: "platform" }),
+      makeEntry(ConfigEntryType.INTEGER, { key: "pin" }),
+      makeEntry(ConfigEntryType.ID, { key: "id" }),
+    ],
+  };
+  inner._presentComponents = new Set<string>();
+  inner._values = values;
+  inner._scheduleDraftFlush = vi.fn();
+  const drafts: string[] = [];
+  c.addEventListener("yaml-draft", (e) =>
+    drafts.push((e as CustomEvent).detail.yaml as string)
+  );
+  return { c, inner, drafts };
+}
+
+const rename = (c: ESPHomeDeviceSectionConfig, value: string) =>
+  onValueChange(c, new CustomEvent("value-change", { detail: { path: ["id"], value } }));
+
+describe("device-section-config — id rename propagation", () => {
+  it("rewrites the declaration and its references in one draft", () => {
+    const { c, inner, drafts } = host(APOLLO, {
+      platform: "ledc",
+      pin: 18,
+      id: "buzzer_output",
+    });
+    rename(c, "buzzer_outputd");
+    flushDraft(inner);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toContain("id: buzzer_outputd");
+    expect(drafts[0]).toContain("- output: buzzer_outputd");
+    expect(drafts[0]).not.toContain("buzzer_output\n");
+    expect(inner._pendingIdRenames.size).toBe(0);
+  });
+
+  it("tracks chained renames across flushes", () => {
+    const { c, inner, drafts } = host(APOLLO, {
+      platform: "ledc",
+      pin: 18,
+      id: "buzzer_output",
+    });
+    rename(c, "buzzer_o");
+    flushDraft(inner);
+    inner.yaml = drafts[0];
+    rename(c, "buzzer_od");
+    flushDraft(inner);
+    expect(drafts[1]).toContain("- output: buzzer_od");
+  });
+
+  it("keeps the pending rename through an invalid intermediate value", () => {
+    const { c, inner, drafts } = host(APOLLO, {
+      platform: "ledc",
+      pin: 18,
+      id: "buzzer_output",
+    });
+    rename(c, "");
+    flushDraft(inner);
+    expect(inner._pendingIdRenames.size).toBe(1);
+    inner.yaml = drafts.length ? drafts[drafts.length - 1] : inner.yaml;
+    rename(c, "buzzer_final");
+    flushDraft(inner);
+    expect(drafts[drafts.length - 1]).toContain("- output: buzzer_final");
+  });
+
+  it("does not propagate when the old id survives in another section", () => {
+    const dup = `output:
+  - platform: ledc
+    pin: 18
+    id: shared
+
+switch:
+  - platform: gpio
+    id: shared
+    pin: 4
+
+rtttl:
+  - output: shared
+    id: rtttl_player
+`;
+    const { c, inner, drafts } = host(dup, {
+      platform: "ledc",
+      pin: 18,
+      id: "shared",
+    });
+    rename(c, "renamed");
+    flushDraft(inner);
+    expect(drafts[0]).toContain("id: renamed");
+    // The switch still declares `shared`; the rtttl reference must keep
+    // pointing at it.
+    expect(drafts[0]).toContain("- output: shared");
+  });
+
+  it("does not propagate a reverted edit", () => {
+    const { c, inner, drafts } = host(APOLLO, {
+      platform: "ledc",
+      pin: 18,
+      id: "buzzer_output",
+    });
+    rename(c, "buzzer_x");
+    rename(c, "buzzer_output");
+    flushDraft(inner);
+    expect(drafts).toHaveLength(0);
+    expect(inner._pendingIdRenames.size).toBe(0);
+  });
+});

--- a/test/util/yaml-id-rename.test.ts
+++ b/test/util/yaml-id-rename.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { ESPHomeAPI } from "../../src/api/index.js";
+import type { ComponentCatalogEntry } from "../../src/api/types/components.js";
+import type { ConfigEntry } from "../../src/api/types/config-entries.js";
+import {
+  _clearComponentCache,
+  fetchComponent,
+} from "../../src/util/component-name-cache.js";
 import {
   _clearIdRenameMemos,
   countIdReferences,
@@ -8,9 +15,42 @@ import {
 } from "../../src/util/yaml-id-rename.js";
 import { _clearYamlSectionsMemo } from "../../src/util/yaml-sections.js";
 
-beforeEach(() => {
+const entry = (key: string, overrides: Partial<ConfigEntry> = {}): ConfigEntry =>
+  ({ key, type: "string", ...overrides }) as never;
+
+const body = (id: string, entries: ConfigEntry[]): ComponentCatalogEntry =>
+  ({ id, name: id, config_entries: entries }) as never;
+
+/** Schemas for the components the fixtures use; which keys hold id
+ *  references comes from these, not from key names. */
+const BODIES: Record<string, ComponentCatalogEntry> = {
+  rtttl: body("rtttl", [entry("output", { references_component: "output" })]),
+  "light.rgb": body("light.rgb", [
+    entry("red", { references_component: "output" }),
+    entry("outputs", { references_component: "output" }),
+    entry("name"),
+  ]),
+  "switch.gpio": body("switch.gpio", [
+    entry("pin"),
+    entry("interlock", { references_component: "switch" }),
+  ]),
+  "text_sensor.template": body("text_sensor.template", [
+    entry("name"),
+    entry("icon"),
+    entry("device_class"),
+  ]),
+};
+
+const api = {
+  getComponentBodies: async (ids: string[]) =>
+    Object.fromEntries(ids.filter((id) => BODIES[id]).map((id) => [id, BODIES[id]])),
+} as unknown as ESPHomeAPI;
+
+beforeEach(async () => {
+  _clearComponentCache();
   _clearIdRenameMemos();
   _clearYamlSectionsMemo();
+  await Promise.all(Object.keys(BODIES).map((id) => fetchComponent(api, id)));
 });
 
 const APOLLO = `esphome:
@@ -58,7 +98,17 @@ button:
     expect(findIdReferences(yaml, "relay1")).toEqual([{ line: 11, kind: "value" }]);
   });
 
-  it("finds bare sequence items and quoted values", () => {
+  it("treats a dotted action shorthand value as a reference", () => {
+    const yaml = `button:
+  - platform: template
+    name: Toggle
+    on_press:
+      - switch.toggle: relay1
+`;
+    expect(findIdReferences(yaml, "relay1")).toEqual([{ line: 5, kind: "value" }]);
+  });
+
+  it("finds bare sequence items and quoted values via the schema's reference keys", () => {
     const yaml = `output:
   - platform: ledc
     id: out_a
@@ -91,7 +141,7 @@ sensor:
     ]);
   });
 
-  it("skips free-text keys whose value matches the id", () => {
+  it("skips keys the schema doesn't mark as references", () => {
     const yaml = `output:
   - platform: ledc
     id: dark
@@ -103,6 +153,18 @@ text_sensor:
     device_class: dark
 `;
     expect(findIdReferences(yaml, "dark")).toEqual([]);
+  });
+
+  it("skips generic keys in a section whose schema isn't cached", () => {
+    const yaml = `my_unknown_component:
+  some_field: out_a
+  on_thing:
+    - switch.toggle: out_a
+    - lambda: 'id(out_a);'
+`;
+    // some_field can't be confirmed as a reference; the dotted action
+    // shorthand and the lambda call still are.
+    expect(findIdReferences(yaml, "out_a").map((s) => s.line)).toEqual([4, 5]);
   });
 
   it("does not match longer identifiers or other ids", () => {
@@ -207,6 +269,18 @@ describe("countIdReferences", () => {
     expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
     expect(countIdReferences(APOLLO, "rtttl_player")).toBe(0);
     expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
+  });
+
+  it("does not count an enum value colliding with a short id", () => {
+    const yaml = `light:
+  - platform: rgb
+    id: rgb
+    name: rgb
+  - platform: rgb
+    red: rgb
+`;
+    // name is not a reference key in the schema; red is.
+    expect(countIdReferences(yaml, "rgb")).toBe(1);
   });
 
   it("does not count a globals declaration as a reference", () => {

--- a/test/util/yaml-id-rename.test.ts
+++ b/test/util/yaml-id-rename.test.ts
@@ -140,6 +140,23 @@ light:
     expect(out).toContain('red: "out_b" # main channel');
   });
 
+  it("rewrites flow-sequence elements", () => {
+    const yaml = `switch:
+  - platform: gpio
+    id: relay1
+    pin: 4
+  - platform: gpio
+    id: relay2
+    pin: 5
+    interlock: [relay1, relay2]
+`;
+    const out = renameIdReferences(yaml, "relay1", "relay_main", {
+      excludeFromLine: 2,
+      excludeToLine: 4,
+    });
+    expect(out).toContain("interlock: [relay_main, relay2]");
+  });
+
   it("rewrites lambda calls without touching similar tokens", () => {
     const yaml = `script:
   - id: beep
@@ -186,10 +203,30 @@ script:
 });
 
 describe("countIdReferences", () => {
-  it("counts and memoizes", () => {
-    expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
+  it("counts references, several ids against one buffer", () => {
     expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
     expect(countIdReferences(APOLLO, "rtttl_player")).toBe(0);
+    expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
+  });
+
+  it("does not count a globals declaration as a reference", () => {
+    const yaml = `globals:
+  - id: counter_a
+    type: int
+  - id: counter_b
+    type: int
+
+sensor:
+  - platform: template
+    lambda: 'return id(counter_b);'
+`;
+    expect(countIdReferences(yaml, "counter_a")).toBe(0);
+    expect(countIdReferences(yaml, "counter_b")).toBe(1);
+  });
+
+  it("returns zero for a non-identifier value instead of throwing", () => {
+    expect(countIdReferences(APOLLO, "${sub}")).toBe(0);
+    expect(countIdReferences(APOLLO, "bad(id")).toBe(0);
   });
 });
 

--- a/test/util/yaml-id-rename.test.ts
+++ b/test/util/yaml-id-rename.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _clearIdRenameMemos,
+  countIdReferences,
+  findIdReferences,
+  idDeclaredElsewhere,
+  renameIdReferences,
+} from "../../src/util/yaml-id-rename.js";
+import { _clearYamlSectionsMemo } from "../../src/util/yaml-sections.js";
+
+beforeEach(() => {
+  _clearIdRenameMemos();
+  _clearYamlSectionsMemo();
+});
+
+const APOLLO = `esphome:
+  name: mystart
+
+output:
+  - platform: ledc
+    pin: 18
+    id: buzzer_output
+
+rtttl:
+  - output: buzzer_output
+    id: rtttl_player
+`;
+
+describe("findIdReferences", () => {
+  it("finds the reference but not the declaration", () => {
+    expect(findIdReferences(APOLLO, "buzzer_output")).toEqual([
+      { line: 10, kind: "value" },
+    ]);
+  });
+
+  it("respects the excluded section range", () => {
+    expect(
+      findIdReferences(APOLLO, "buzzer_output", {
+        excludeFromLine: 9,
+        excludeToLine: 11,
+      })
+    ).toEqual([]);
+  });
+
+  it("treats a nested id key as a reference (automation action target)", () => {
+    const yaml = `switch:
+  - platform: gpio
+    id: relay1
+    pin: 4
+
+button:
+  - platform: template
+    name: Toggle
+    on_press:
+      - switch.toggle:
+          id: relay1
+`;
+    expect(findIdReferences(yaml, "relay1")).toEqual([{ line: 11, kind: "value" }]);
+  });
+
+  it("finds bare sequence items and quoted values", () => {
+    const yaml = `output:
+  - platform: ledc
+    id: out_a
+
+light:
+  - platform: rgb
+    name: RGB
+    red: "out_a"
+    outputs:
+      - out_a
+`;
+    expect(findIdReferences(yaml, "out_a").map((s) => s.line)).toEqual([8, 10]);
+  });
+
+  it("finds id() calls inside lambdas", () => {
+    const yaml = `output:
+  - platform: ledc
+    id: out_a
+
+sensor:
+  - platform: template
+    lambda: |-
+      id(out_a).turn_on();
+      return id(out_a2).state;
+    on_value: !lambda 'id(out_a).update();'
+`;
+    expect(findIdReferences(yaml, "out_a")).toEqual([
+      { line: 8, kind: "lambda" },
+      { line: 10, kind: "lambda" },
+    ]);
+  });
+
+  it("skips free-text keys whose value matches the id", () => {
+    const yaml = `output:
+  - platform: ledc
+    id: dark
+
+text_sensor:
+  - platform: template
+    name: dark
+    icon: dark
+    device_class: dark
+`;
+    expect(findIdReferences(yaml, "dark")).toEqual([]);
+  });
+
+  it("does not match longer identifiers or other ids", () => {
+    const yaml = `rtttl:
+  - output: buzzer_outputd
+    id: rtttl_player
+`;
+    expect(findIdReferences(yaml, "buzzer_output")).toEqual([]);
+  });
+});
+
+describe("renameIdReferences", () => {
+  it("rewrites the reference and leaves the declaration to the caller", () => {
+    const out = renameIdReferences(APOLLO, "buzzer_output", "buzzer_outputd", {
+      excludeFromLine: 4,
+      excludeToLine: 7,
+    });
+    expect(out).toContain("- output: buzzer_outputd");
+    expect(out).toContain("id: buzzer_output\n");
+  });
+
+  it("preserves quoting and trailing comments", () => {
+    const yaml = `output:
+  - platform: ledc
+    id: out_a
+
+light:
+  - platform: rgb
+    red: "out_a" # main channel
+`;
+    const out = renameIdReferences(yaml, "out_a", "out_b", {
+      excludeFromLine: 2,
+      excludeToLine: 3,
+    });
+    expect(out).toContain('red: "out_b" # main channel');
+  });
+
+  it("rewrites lambda calls without touching similar tokens", () => {
+    const yaml = `script:
+  - id: beep
+    then:
+      - lambda: 'id(out_a).play(); some_id(out_a); id(out_a2).stop();'
+`;
+    const out = renameIdReferences(yaml, "out_a", "out_b");
+    expect(out).toContain("id(out_b).play()");
+    expect(out).toContain("some_id(out_a)");
+    expect(out).toContain("id(out_a2).stop()");
+  });
+
+  it("returns the buffer unchanged when nothing references the id", () => {
+    expect(renameIdReferences(APOLLO, "nope", "still_nope")).toBe(APOLLO);
+  });
+
+  it("rewrites a substitution value holding the id, leaving ${...} usages alone", () => {
+    const yaml = `substitutions:
+  buzzer: buzzer_output
+
+output:
+  - platform: ledc
+    id: buzzer_output
+
+rtttl:
+  - output: \${buzzer}
+    id: player
+
+script:
+  - id: beep
+    then:
+      - lambda: 'id(\${buzzer}).play();'
+`;
+    const out = renameIdReferences(yaml, "buzzer_output", "buzzer_out2", {
+      excludeFromLine: 4,
+      excludeToLine: 6,
+    });
+    // The substitution's value follows the rename, so every ${buzzer}
+    // usage keeps resolving; the usages themselves stay untouched.
+    expect(out).toContain("buzzer: buzzer_out2");
+    expect(out).toContain("- output: ${buzzer}");
+    expect(out).toContain("id(${buzzer}).play()");
+  });
+});
+
+describe("countIdReferences", () => {
+  it("counts and memoizes", () => {
+    expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
+    expect(countIdReferences(APOLLO, "buzzer_output")).toBe(1);
+    expect(countIdReferences(APOLLO, "rtttl_player")).toBe(0);
+  });
+});
+
+describe("idDeclaredElsewhere", () => {
+  const DUP = `output:
+  - platform: ledc
+    id: shared
+
+switch:
+  - platform: gpio
+    id: shared
+    pin: 4
+`;
+
+  it("detects a surviving declaration outside the excluded range", () => {
+    expect(
+      idDeclaredElsewhere(DUP, "shared", { excludeFromLine: 2, excludeToLine: 3 })
+    ).toBe(true);
+  });
+
+  it("is false when the only declaration is the excluded one", () => {
+    expect(
+      idDeclaredElsewhere(APOLLO, "buzzer_output", {
+        excludeFromLine: 4,
+        excludeToLine: 7,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Renaming a component's id through the visual editor now updates every reference to it in the same edit: value-position references, automation targets, substitution values holding the id, and id() calls in lambdas. Previously the rename silently broke the references and the user had to hunt them down from the resulting validation errors.

The declaring ID field also shows a hint with how many places reference the current id, so the rename doesn't feel risky. Guardrails keep half-renames impossible: no propagation when the old id survives as another section's declaration, when either side is a substitution, or across mid-edit invalid values; the pending rename waits for a valid one and chained renames stay consistent across flushes. Everything lands in one yaml-draft, so the YAML pane undoes the declaration and its references atomically.

Chained on #1072 (shares the id-reference renderer and the identifier helpers).

Verified live: renaming an ledc output id referenced by rtttl rewrites both in one draft with no validation errors appearing; the hint reads "Referenced in 1 place".

**Related issue or feature (if applicable):**

- None

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
