### PR TITLE
Show the ESPHome Desktop version in the footer

### DIFF
--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -44,6 +44,9 @@ export interface ServerInfoMessage {
    * is reached directly on its exposed port. Drives the slim header. */
   ha_ingress: boolean;
   requires_auth: boolean;
+  /** ESPHome Desktop wrapper version, from ESPHOME_DESKTOP_VERSION on the
+   * backend; absent or "" when not running under the desktop app. */
+  desktop_version?: string;
 }
 
 export type ServerMessage = ResultMessage | ErrorMessage | EventMessage;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -30,6 +30,7 @@ import {
   buildServerPairingWindowStateContext,
   buildServerPeersContext,
   darkModeContext,
+  desktopVersionContext,
   devicesContext,
   devicesLoadedContext,
   experienceLevelContext,
@@ -116,6 +117,7 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: devicesLoadedContext }) @state() _devicesLoaded = false;
   @provide({ context: versionContext }) @state() _version = "";
   @provide({ context: serverVersionContext }) @state() _serverVersion = "";
+  @provide({ context: desktopVersionContext }) @state() _desktopVersion = "";
   @provide({ context: darkModeContext }) @state() _darkMode = false;
   @provide({ context: isHaIngressContext }) @state() _isHaIngress = false;
   @provide({ context: activeJobsContext }) @state() _activeJobs: Map<
@@ -430,6 +432,7 @@ export class ESPHomeApp extends LitElement {
     this._api.onConnected = (info: ServerInfoMessage) => {
       this._version = info.esphome_version;
       this._serverVersion = info.server_version;
+      this._desktopVersion = info.desktop_version ?? "";
       this._isHaIngress = info.ha_ingress;
       this._apiConnected = true;
       void this._api.ready.then(() => this._afterAuthenticated());

--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import {
+  desktopVersionContext,
   isHaIngressContext,
   localizeContext,
   serverVersionContext,
@@ -16,6 +17,7 @@ import { deviceBuilderChannel } from "../util/device-builder-channel.js";
 import { navigate, runLeaveGuard } from "../util/navigation.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import {
+  desktopDocsUrl,
   deviceBuilderReleaseUrl,
   esphomeChangelogUrl,
 } from "../util/release-notes-url.js";
@@ -45,6 +47,10 @@ export class ESPHomeLayout extends LitElement {
   @consume({ context: serverVersionContext, subscribe: true })
   @state()
   private _serverVersion = "";
+
+  @consume({ context: desktopVersionContext, subscribe: true })
+  @state()
+  private _desktopVersion = "";
 
   @state()
   private _path = stripBase(window.location.pathname);
@@ -393,6 +399,16 @@ export class ESPHomeLayout extends LitElement {
       </div>
       <slot></slot>
       <div class="app-footer">
+        ${
+          this._desktopVersion
+            ? html`<span
+                >${this._footerVersion(
+                  `ESPHome Desktop v${this._desktopVersion}`,
+                  desktopDocsUrl()
+                )}</span
+              >`
+            : nothing
+        }
         ${
           this._serverVersion
             ? html`<span

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -45,6 +45,11 @@ export const serverVersionContext = createContext<string>(
   Symbol("esphome-server-version")
 );
 
+/** Context for the ESPHome Desktop wrapper version string. */
+export const desktopVersionContext = createContext<string>(
+  Symbol("esphome-desktop-version")
+);
+
 /** Context for dark mode state. */
 export const darkModeContext = createContext<boolean>(Symbol("esphome-dark-mode"));
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -9,6 +9,7 @@ export {
   buildServerPairingWindowStateContext,
   buildServerPeersContext,
   darkModeContext,
+  desktopVersionContext,
   devicesContext,
   devicesLoadedContext,
   experienceLevelContext,

--- a/src/util/release-notes-url.ts
+++ b/src/util/release-notes-url.ts
@@ -11,6 +11,11 @@ export function deviceBuilderReleaseUrl(version: string): string | null {
   return `https://github.com/esphome/device-builder/releases/tag/${v}`;
 }
 
+/** Docs URL for the ESPHome Desktop app (fixed; not per-version). */
+export function desktopDocsUrl(): string {
+  return "https://desktop.esphome.io/";
+}
+
 /**
  * Docs URL for an ESPHome version, routed by channel. Stable links to the
  * per-minor changelog on esphome.io; patch and pre-release versions normalize

--- a/test/components/esphome-layout-footer.test.ts
+++ b/test/components/esphome-layout-footer.test.ts
@@ -6,16 +6,19 @@ import { ESPHomeLayout } from "../../src/components/esphome-layout.js";
 interface FooterVersions {
   _serverVersion: string;
   _esphomeVersion: string;
+  _desktopVersion: string;
 }
 
 async function renderFooter(
   serverVersion: string,
-  esphomeVersion: string
+  esphomeVersion: string,
+  desktopVersion = ""
 ): Promise<ESPHomeLayout> {
   const el = new ESPHomeLayout();
   const view = el as unknown as FooterVersions;
   view._serverVersion = serverVersion;
   view._esphomeVersion = esphomeVersion;
+  view._desktopVersion = desktopVersion;
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -47,6 +50,21 @@ describe("esphome-layout footer version links", () => {
       expect(link.getAttribute("target")).toBe("_blank");
       expect(link.getAttribute("rel")).toBe("noopener noreferrer");
     }
+  });
+
+  test("shows the desktop version first, linked to the desktop docs", async () => {
+    el = await renderFooter("1.0.3", "2026.5.3", "1.4.2");
+    const links = footerLinks(el);
+    expect(links).toHaveLength(3);
+    expect(links[0].textContent?.trim()).toBe("ESPHome Desktop v1.4.2");
+    expect(links[0].getAttribute("href")).toBe("https://desktop.esphome.io/");
+  });
+
+  test("omits the desktop line when no desktop version is set", async () => {
+    el = await renderFooter("1.0.3", "2026.5.3");
+    const footer = el.shadowRoot!.querySelector(".app-footer")?.textContent;
+    expect(footer).not.toContain("Desktop");
+    expect(footerLinks(el)).toHaveLength(2);
   });
 
   test("dev Device Builder stays plain text; dev ESPHome links to the next docs root", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adds a third footer line, `ESPHome Desktop v<version>`, rendered first and linked to https://desktop.esphome.io/. The value comes from the backend's new `ServerInfoMessage.desktop_version` field, threaded through a Lit context just like the existing Device Builder and ESPHome version lines; it renders only when present, so non-desktop installs are unchanged.

**Related issue or feature (if applicable):**

- Backend companion: esphome/device-builder#1841

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
