### PR TITLE
Shorten footer version labels so they fit on mobile

### DIFF
--- a/src/components/esphome-layout.ts
+++ b/src/components/esphome-layout.ts
@@ -403,7 +403,7 @@ export class ESPHomeLayout extends LitElement {
           this._desktopVersion
             ? html`<span
                 >${this._footerVersion(
-                  `ESPHome Desktop v${this._desktopVersion}`,
+                  `Desktop ${this._desktopVersion}`,
                   desktopDocsUrl()
                 )}</span
               >`
@@ -413,7 +413,7 @@ export class ESPHomeLayout extends LitElement {
           this._serverVersion
             ? html`<span
                 >${this._footerVersion(
-                  `ESPHome Device Builder v${this._serverVersion}`,
+                  `Device Builder ${this._serverVersion}`,
                   deviceBuilderReleaseUrl(this._serverVersion)
                 )}</span
               >`

--- a/test/components/esphome-layout-footer.test.ts
+++ b/test/components/esphome-layout-footer.test.ts
@@ -43,7 +43,7 @@ describe("esphome-layout footer version links", () => {
     expect(links[0].getAttribute("href")).toBe(
       "https://github.com/esphome/device-builder/releases/tag/1.0.3"
     );
-    expect(links[0].textContent?.trim()).toBe("ESPHome Device Builder v1.0.3");
+    expect(links[0].textContent?.trim()).toBe("Device Builder 1.0.3");
     expect(links[1].getAttribute("href")).toBe("https://esphome.io/changelog/2026.5.0/");
     expect(links[1].textContent?.trim()).toBe("ESPHome 2026.5.3");
     for (const link of links) {
@@ -56,7 +56,7 @@ describe("esphome-layout footer version links", () => {
     el = await renderFooter("1.0.3", "2026.5.3", "1.4.2");
     const links = footerLinks(el);
     expect(links).toHaveLength(3);
-    expect(links[0].textContent?.trim()).toBe("ESPHome Desktop v1.4.2");
+    expect(links[0].textContent?.trim()).toBe("Desktop 1.4.2");
     expect(links[0].getAttribute("href")).toBe("https://desktop.esphome.io/");
   });
 
@@ -74,6 +74,6 @@ describe("esphome-layout footer version links", () => {
     expect(links[0].getAttribute("href")).toBe("https://next.esphome.io/");
     expect(links[0].textContent?.trim()).toBe("ESPHome 2026.7.0-dev");
     const footer = el.shadowRoot!.querySelector(".app-footer")?.textContent;
-    expect(footer).toContain("ESPHome Device Builder v0.0.0");
+    expect(footer).toContain("Device Builder 0.0.0");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

On mobile the three footer version lines are too wide; each `ESPHome …` label wraps to two lines and the columns collide with the last device card. The `ESPHome` prefix is redundant on the first two, so this shortens them to `Desktop 0.13.0` and `Device Builder 1.0.30b3`; the ESPHome core line stays `ESPHome 2026.6.4`. Text only, the release-notes links and layout are unchanged.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder-frontend#1074

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
