### PR TITLE
Add a Check for updates menu item for the ESPHome Desktop app

### DIFF
--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -56,6 +56,8 @@ import type {
 } from "./types/firmware-jobs.js";
 import type {
   CommandMessage,
+  DesktopUpdateCheck,
+  DesktopUpdateStarted,
   ErrorMessage,
   EventMessage,
   ResultMessage,
@@ -740,6 +742,24 @@ export class ESPHomeAPI {
   /** Trigger device state polling. */
   async getDeviceStates(): Promise<Record<string, never>> {
     return this.sendCommand("devices/get_states");
+  }
+
+  /**
+   * Check whether the desktop app, ESPHome, or the device builder has an
+   * update available. Only valid when running under an update-capable ESPHome
+   * Desktop app (`ServerInfoMessage.desktop_update_capable`).
+   */
+  async desktopCheckUpdate(): Promise<DesktopUpdateCheck> {
+    return this.sendCommand<DesktopUpdateCheck>("desktop/check_update");
+  }
+
+  /**
+   * Trigger the full desktop update (desktop app, ESPHome, device builder).
+   * Fire-and-forget: the desktop app restarts this backend to install, so the
+   * connection drops; re-check after reconnecting.
+   */
+  async desktopInstallUpdate(): Promise<DesktopUpdateStarted> {
+    return this.sendCommand<DesktopUpdateStarted>("desktop/update");
   }
 
   /**

--- a/src/api/esphome-api.ts
+++ b/src/api/esphome-api.ts
@@ -33,6 +33,7 @@ import type {
   ComponentCatalogEntry,
   PagedComponentsResponse,
 } from "./types/components.js";
+import type { DesktopUpdateCheck, DesktopUpdateStarted } from "./types/desktop.js";
 import type {
   AddComponentResponse,
   ConfiguredDevice,
@@ -56,8 +57,6 @@ import type {
 } from "./types/firmware-jobs.js";
 import type {
   CommandMessage,
-  DesktopUpdateCheck,
-  DesktopUpdateStarted,
   ErrorMessage,
   EventMessage,
   ResultMessage,

--- a/src/api/types/desktop.ts
+++ b/src/api/types/desktop.ts
@@ -1,0 +1,27 @@
+/**
+ * Payload types for the ESPHome Desktop update commands (`desktop/check_update`,
+ * `desktop/update`). Available only when the handshake reports
+ * `ServerInfoMessage.desktop_update_capable` (the desktop app 0.14.0+).
+ */
+
+/** One component's update availability, from `desktop/check_update`. */
+export interface DesktopComponentUpdate {
+  available: boolean;
+  installed: string | null;
+  latest: string | null;
+  error: string | null;
+}
+
+/** Result of `desktop/check_update`: per-component update availability. */
+export interface DesktopUpdateCheck {
+  any_available: boolean;
+  /** The desktop app itself (its self-update from GitHub Releases). */
+  app: DesktopComponentUpdate;
+  esphome: DesktopComponentUpdate;
+  device_builder: DesktopComponentUpdate;
+}
+
+/** Result of `desktop/update`: the update was spawned (the app then restarts). */
+export interface DesktopUpdateStarted {
+  started: boolean;
+}

--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -53,28 +53,6 @@ export interface ServerInfoMessage {
   desktop_update_capable?: boolean;
 }
 
-/** One component's update availability, from `desktop/check_update`. */
-export interface DesktopComponentUpdate {
-  available: boolean;
-  installed: string | null;
-  latest: string | null;
-  error: string | null;
-}
-
-/** Result of `desktop/check_update`: per-component update availability. */
-export interface DesktopUpdateCheck {
-  any_available: boolean;
-  /** The desktop app itself (its self-update from GitHub Releases). */
-  app: DesktopComponentUpdate;
-  esphome: DesktopComponentUpdate;
-  device_builder: DesktopComponentUpdate;
-}
-
-/** Result of `desktop/update`: the update was spawned (the app then restarts). */
-export interface DesktopUpdateStarted {
-  started: boolean;
-}
-
 export type ServerMessage = ResultMessage | ErrorMessage | EventMessage;
 
 export enum ErrorCode {

--- a/src/api/types/protocol.ts
+++ b/src/api/types/protocol.ts
@@ -47,6 +47,32 @@ export interface ServerInfoMessage {
   /** ESPHome Desktop wrapper version, from ESPHOME_DESKTOP_VERSION on the
    * backend; absent or "" when not running under the desktop app. */
   desktop_version?: string;
+  /** True when the desktop app (0.14.0+) exposes its update `api` via
+   * ESPHOME_DESKTOP_BIN; gates the "Check for updates" menu item. Older
+   * desktop apps set desktop_version but not this. */
+  desktop_update_capable?: boolean;
+}
+
+/** One component's update availability, from `desktop/check_update`. */
+export interface DesktopComponentUpdate {
+  available: boolean;
+  installed: string | null;
+  latest: string | null;
+  error: string | null;
+}
+
+/** Result of `desktop/check_update`: per-component update availability. */
+export interface DesktopUpdateCheck {
+  any_available: boolean;
+  /** The desktop app itself (its self-update from GitHub Releases). */
+  app: DesktopComponentUpdate;
+  esphome: DesktopComponentUpdate;
+  device_builder: DesktopComponentUpdate;
+}
+
+/** Result of `desktop/update`: the update was spawned (the app then restarts). */
+export interface DesktopUpdateStarted {
+  started: boolean;
 }
 
 export type ServerMessage = ResultMessage | ErrorMessage | EventMessage;

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -30,6 +30,7 @@ import {
   buildServerPairingWindowStateContext,
   buildServerPeersContext,
   darkModeContext,
+  desktopUpdateCapableContext,
   desktopVersionContext,
   devicesContext,
   devicesLoadedContext,
@@ -92,6 +93,8 @@ import {
 
 import "../pages/dashboard.js";
 import "./command-palette.js";
+import "./desktop-update-dialog.js";
+import type { ESPHomeDesktopUpdateDialog } from "./desktop-update-dialog.js";
 import "./esphome-layout.js";
 import "./esphome-login.js";
 import "./feedback-dialog.js";
@@ -118,6 +121,9 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: versionContext }) @state() _version = "";
   @provide({ context: serverVersionContext }) @state() _serverVersion = "";
   @provide({ context: desktopVersionContext }) @state() _desktopVersion = "";
+  @provide({ context: desktopUpdateCapableContext })
+  @state()
+  _desktopUpdateCapable = false;
   @provide({ context: darkModeContext }) @state() _darkMode = false;
   @provide({ context: isHaIngressContext }) @state() _isHaIngress = false;
   @provide({ context: activeJobsContext }) @state() _activeJobs: Map<
@@ -232,6 +238,8 @@ export class ESPHomeApp extends LitElement {
   @query("esphome-feedback-dialog") private _feedbackDialog!: ESPHomeFeedbackDialog;
   @query("esphome-update-all-dialog")
   private _updateAllDialog!: ESPHomeUpdateAllDialog;
+  @query("esphome-desktop-update-dialog")
+  private _desktopUpdateDialog?: ESPHomeDesktopUpdateDialog;
   @query("esphome-onboarding-wifi-dialog")
   private _onboardingDialog?: HTMLElement & { open(): void };
   @query("esphome-onboarding-wizard-dialog")
@@ -433,6 +441,7 @@ export class ESPHomeApp extends LitElement {
       this._version = info.esphome_version;
       this._serverVersion = info.server_version;
       this._desktopVersion = info.desktop_version ?? "";
+      this._desktopUpdateCapable = info.desktop_update_capable ?? false;
       this._isHaIngress = info.ha_ingress;
       this._apiConnected = true;
       void this._api.ready.then(() => this._afterAuthenticated());
@@ -569,6 +578,7 @@ export class ESPHomeApp extends LitElement {
         @open-firmware-jobs=${() => this._firmwareJobsDialog?.open()}
         @open-reset-build-env=${() => this._firmwareJobsDialog?.openResetBuildEnv()}
         @open-feedback=${() => this._feedbackDialog?.open()}
+        @open-check-updates=${() => this._desktopUpdateDialog?.open()}
         @open-onboarding-wifi=${this._onOpenOnboarding}
       >
         ${this._router.outlet()}
@@ -581,6 +591,7 @@ export class ESPHomeApp extends LitElement {
         @open-update-all=${() => this._updateAllDialog?.open()}
       ></esphome-command-palette>
       <esphome-update-all-dialog></esphome-update-all-dialog>
+      <esphome-desktop-update-dialog></esphome-desktop-update-dialog>
       <esphome-settings-dialog
         @set-theme=${(e: CustomEvent<string>) => onSetTheme(this, e)}
         @set-expert-mode=${(e: CustomEvent<boolean>) => onSetExpertMode(this, e)}

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -1,6 +1,7 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type {
   DesktopComponentUpdate,
@@ -103,9 +104,7 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
       this._check = await this._api.desktopCheckUpdate();
     } catch (err) {
       this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("desktop_update_dialog.check_error");
+        apiErrorDetails(err) || this._localize("desktop_update_dialog.check_error");
     } finally {
       this._loading = false;
     }
@@ -115,13 +114,18 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
     this._updating = true;
     this._error = "";
     try {
-      await this._api.desktopInstallUpdate();
+      const { started } = await this._api.desktopInstallUpdate();
+      if (!started) {
+        // The updater couldn't spawn; clear the busy state so the user isn't
+        // stranded on an un-closable "Updating" dialog (the busy gate blocks
+        // every dismiss path).
+        this._updating = false;
+        this._error = this._localize("desktop_update_dialog.update_error");
+      }
     } catch (err) {
       this._updating = false;
       this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("desktop_update_dialog.update_error");
+        apiErrorDetails(err) || this._localize("desktop_update_dialog.update_error");
     }
   };
 

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -1,0 +1,224 @@
+import { consume } from "@lit/context";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import type { ESPHomeAPI } from "../api/index.js";
+import type {
+  DesktopComponentUpdate,
+  DesktopUpdateCheck,
+} from "../api/types/protocol.js";
+import type { LocalizeFunc } from "../common/localize.js";
+import { apiContext, localizeContext } from "../context/index.js";
+import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
+import { dialogChromeStyles } from "../styles/dialog-chrome.js";
+import { espHomeStyles } from "../styles/shared.js";
+
+import "./base-dialog.js";
+
+/**
+ * "Check for updates" dialog, shown only under an ESPHome Desktop app (0.14.0+)
+ * that exposes its update `api` (gated on `desktopUpdateCapableContext`). On
+ * open it queries `desktop/check_update` and lists per-component availability;
+ * "Update now" triggers `desktop/update` (fire-and-forget) and tells the user
+ * the app will restart. The update stops and restarts this backend to install,
+ * so the connection drops; the user reopens the dialog to re-check afterward.
+ */
+@customElement("esphome-desktop-update-dialog")
+export class ESPHomeDesktopUpdateDialog extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  @consume({ context: apiContext })
+  @state()
+  private _api!: ESPHomeAPI;
+
+  @state() private _open = false;
+  @state() private _loading = false;
+  @state() private _check: DesktopUpdateCheck | null = null;
+  @state() private _error = "";
+  @state() private _updating = false;
+
+  static styles = [
+    espHomeStyles,
+    dialogChromeStyles,
+    dialogActionButtonStyles,
+    css`
+      esphome-base-dialog {
+        --width: 420px;
+      }
+      .component {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--wa-space-m);
+        padding: var(--wa-space-s) 0;
+      }
+      .component + .component {
+        border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+      }
+      .component-name {
+        font-weight: var(--wa-font-weight-semibold);
+      }
+      .component-status {
+        color: var(--wa-color-text-quiet);
+        font-size: var(--wa-font-size-s);
+      }
+      .component-status.available {
+        color: var(--wa-color-brand-fill-loud);
+      }
+      .message {
+        padding: var(--wa-space-m) 0;
+        color: var(--wa-color-text-quiet);
+      }
+      .message.error {
+        color: var(--wa-color-danger-fill-loud);
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--wa-space-s);
+        padding: var(--wa-space-m) 0 var(--wa-space-l);
+      }
+    `,
+  ];
+
+  async open() {
+    this._open = true;
+    this._updating = false;
+    await this._runCheck();
+  }
+
+  close() {
+    this._open = false;
+  }
+
+  private _onAfterHide = (): void => {
+    this._open = false;
+  };
+
+  private _runCheck = async (): Promise<void> => {
+    this._loading = true;
+    this._error = "";
+    this._check = null;
+    try {
+      this._check = await this._api.desktopCheckUpdate();
+    } catch (err) {
+      this._error =
+        err instanceof Error
+          ? err.message
+          : this._localize("desktop_update_dialog.check_error");
+    } finally {
+      this._loading = false;
+    }
+  };
+
+  private _confirm = async (): Promise<void> => {
+    this._updating = true;
+    this._error = "";
+    try {
+      await this._api.desktopInstallUpdate();
+    } catch (err) {
+      this._updating = false;
+      this._error =
+        err instanceof Error
+          ? err.message
+          : this._localize("desktop_update_dialog.update_error");
+    }
+  };
+
+  private _componentRow(nameKey: string, component: DesktopComponentUpdate) {
+    let status: string;
+    let available = false;
+    if (component.error) {
+      status = this._localize("desktop_update_dialog.check_failed");
+    } else if (component.installed === null) {
+      status = this._localize("desktop_update_dialog.not_installed");
+    } else if (component.available && component.latest) {
+      status = `${component.installed} → ${component.latest}`;
+      available = true;
+    } else {
+      status = this._localize("desktop_update_dialog.up_to_date");
+    }
+    return html`
+      <div class="component">
+        <span class="component-name">${this._localize(nameKey)}</span>
+        <span class="component-status ${available ? "available" : ""}">${status}</span>
+      </div>
+    `;
+  }
+
+  protected render() {
+    return html`
+      <esphome-base-dialog
+        ?open=${this._open}
+        ?busy=${this._updating}
+        .label=${this._localize("desktop_update_dialog.title")}
+        @after-hide=${this._onAfterHide}
+      >
+        ${this._open ? this._renderBody() : nothing}
+      </esphome-base-dialog>
+    `;
+  }
+
+  private _renderBody() {
+    if (this._updating) {
+      return html`<div class="message" role="status">
+        ${this._localize("desktop_update_dialog.updating")}
+      </div>`;
+    }
+    if (this._loading) {
+      return html`<div class="message" role="status">
+        ${this._localize("desktop_update_dialog.checking")}
+      </div>`;
+    }
+    if (this._error) {
+      return html`
+        <div class="message error" role="alert">${this._error}</div>
+        <div class="actions">
+          <button class="btn btn--cancel" @click=${this.close}>
+            ${this._localize("layout.close")}
+          </button>
+          <button class="btn btn--primary" @click=${this._runCheck}>
+            ${this._localize("desktop_update_dialog.retry")}
+          </button>
+        </div>
+      `;
+    }
+    const check = this._check;
+    if (!check) {
+      return nothing;
+    }
+    return html`
+      ${this._componentRow("desktop_update_dialog.component_app", check.app)}
+      ${this._componentRow("desktop_update_dialog.component_esphome", check.esphome)}
+      ${this._componentRow(
+        "desktop_update_dialog.component_device_builder",
+        check.device_builder
+      )}
+      ${
+        !check.any_available
+          ? html`<div class="message" role="status">
+              ${this._localize("desktop_update_dialog.all_up_to_date")}
+            </div>`
+          : nothing
+      }
+      <div class="actions">
+        <button class="btn btn--cancel" @click=${this.close}>
+          ${this._localize("layout.close")}
+        </button>
+        <button
+          class="btn btn--primary"
+          ?disabled=${!check.any_available}
+          @click=${this._confirm}
+        >
+          ${this._localize("desktop_update_dialog.update_now")}
+        </button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-desktop-update-dialog": ESPHomeDesktopUpdateDialog;
+  }
+}

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -188,6 +188,10 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
     if (!check) {
       return nothing;
     }
+    const anyError =
+      check.app.error !== null ||
+      check.esphome.error !== null ||
+      check.device_builder.error !== null;
     return html`
       ${this._componentRow("desktop_update_dialog.component_app", check.app)}
       ${this._componentRow("desktop_update_dialog.component_esphome", check.esphome)}
@@ -196,7 +200,9 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
         check.device_builder
       )}
       ${
-        !check.any_available
+        // Only claim "everything is up to date" when nothing is available AND
+        // no component's check failed (a failed row must not read as up to date).
+        !check.any_available && !anyError
           ? html`<div class="message" role="status">
               ${this._localize("desktop_update_dialog.all_up_to_date")}
             </div>`

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -3,10 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
-import type {
-  DesktopComponentUpdate,
-  DesktopUpdateCheck,
-} from "../api/types/protocol.js";
+import type { DesktopComponentUpdate, DesktopUpdateCheck } from "../api/types/desktop.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -11,6 +11,7 @@ import {
   mdiKeyVariant,
   mdiMagnify,
   mdiPlaylistCheck,
+  mdiUpdate,
   mdiWifiCog,
 } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
@@ -22,6 +23,7 @@ import type { OffloaderAlertSnapshotEntry } from "../api/types/remote-build-even
 import type { LocalizeFunc } from "../common/localize.js";
 import {
   buildOffloadAlertsContext,
+  desktopUpdateCapableContext,
   firmwareJobsContext,
   importableDevicesContext,
   localizeContext,
@@ -48,6 +50,7 @@ registerMdiIcons({
   "key-variant": mdiKeyVariant,
   magnify: mdiMagnify,
   "playlist-check": mdiPlaylistCheck,
+  update: mdiUpdate,
   "wifi-cog": mdiWifiCog,
 });
 
@@ -117,6 +120,13 @@ export class ESPHomeHeaderActions extends LitElement {
    *  so the menu label flips in real time. */
   @state()
   private _showIgnored = false;
+
+  /** True only under an ESPHome Desktop app (0.14.0+) that exposes its update
+   *  `api`; gates the "Check for updates" entry. Provided by the app shell
+   *  from the server handshake. */
+  @consume({ context: desktopUpdateCapableContext, subscribe: true })
+  @state()
+  private _desktopUpdateCapable = false;
 
   static styles = [espHomeStyles, headerActionsStyles];
 
@@ -288,6 +298,22 @@ export class ESPHomeHeaderActions extends LitElement {
                       : nothing
                   }
                 </div>
+                ${
+                  this._desktopUpdateCapable
+                    ? html`<div
+                        class="menu-item"
+                        role="menuitem"
+                        tabindex="0"
+                        @click=${this._openCheckForUpdates}
+                        @keydown=${this._onMenuItemKeydown}
+                      >
+                        <wa-icon library="mdi" name="update"></wa-icon>
+                        <span class="menu-item-label"
+                          >${this._localize("layout.check_for_updates")}</span
+                        >
+                      </div>`
+                    : nothing
+                }
                 <div
                   class="menu-item"
                   role="menuitem"
@@ -427,6 +453,16 @@ export class ESPHomeHeaderActions extends LitElement {
     this._close();
     this.dispatchEvent(
       new CustomEvent("open-feedback", {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _openCheckForUpdates() {
+    this._close();
+    this.dispatchEvent(
+      new CustomEvent("open-check-updates", {
         bubbles: true,
         composed: true,
       })

--- a/src/context/contexts.ts
+++ b/src/context/contexts.ts
@@ -50,6 +50,11 @@ export const desktopVersionContext = createContext<string>(
   Symbol("esphome-desktop-version")
 );
 
+/** Context for whether the desktop app can self-update (0.14.0+ CLI present). */
+export const desktopUpdateCapableContext = createContext<boolean>(
+  Symbol("esphome-desktop-update-capable")
+);
+
 /** Context for dark mode state. */
 export const darkModeContext = createContext<boolean>(Symbol("esphome-dark-mode"));
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -9,6 +9,7 @@ export {
   buildServerPairingWindowStateContext,
   buildServerPeersContext,
   darkModeContext,
+  desktopUpdateCapableContext,
   desktopVersionContext,
   devicesContext,
   devicesLoadedContext,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -999,6 +999,7 @@
     "show_ignored_discoveries": "Show ignored discoveries ({count})",
     "hide_ignored_discoveries": "Hide ignored discoveries",
     "reset_build_env": "Reset build environment",
+    "check_for_updates": "Check for updates",
     "feedback_menu": "Found a bug? Have an idea?",
     "back": "Back",
     "close": "Close",
@@ -1049,6 +1050,22 @@
     "switch_to_yaml": "Switch to YAML content search",
     "switch_to_commands": "Switch to command search",
     "update_all": "Update All"
+  },
+  "desktop_update_dialog": {
+    "title": "Check for updates",
+    "checking": "Checking for updates…",
+    "updating": "Updating; the app will restart when it finishes.",
+    "all_up_to_date": "Everything is up to date.",
+    "up_to_date": "Up to date",
+    "not_installed": "Not installed",
+    "check_failed": "Check failed",
+    "check_error": "Could not check for updates.",
+    "update_error": "Could not start the update.",
+    "retry": "Try again",
+    "update_now": "Update now",
+    "component_app": "ESPHome Desktop",
+    "component_esphome": "ESPHome",
+    "component_device_builder": "Device builder"
   },
   "update_all_dialog": {
     "title": "Update All",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1065,7 +1065,7 @@
     "update_now": "Update now",
     "component_app": "ESPHome Desktop",
     "component_esphome": "ESPHome",
-    "component_device_builder": "Device builder"
+    "component_device_builder": "Device Builder"
   },
   "update_all_dialog": {
     "title": "Update All",

--- a/test/api/esphome-api.test.ts
+++ b/test/api/esphome-api.test.ts
@@ -703,6 +703,39 @@ describe("ESPHomeAPI — typed command wrappers", () => {
     await expect(pending).resolves.toEqual(payload);
   });
 
+  it("desktopCheckUpdate sends desktop/check_update and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const payload = {
+      any_available: true,
+      app: { available: true, installed: "0.14.0", latest: "0.15.0", error: null },
+      esphome: {
+        available: false,
+        installed: "2026.6.4",
+        latest: "2026.6.4",
+        error: null,
+      },
+      device_builder: { available: false, installed: null, latest: null, error: null },
+    };
+    const pending = api.desktopCheckUpdate();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("desktop/check_update");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: payload });
+    await expect(pending).resolves.toEqual(payload);
+  });
+
+  it("desktopInstallUpdate sends desktop/update and unwraps the result", async () => {
+    const api = new ESPHomeAPI();
+    const ws = await connect(api);
+    const pending = api.desktopInstallUpdate();
+    const sent = ws.sentAs<{ command: string; message_id: string; args?: unknown }>(0);
+    expect(sent.command).toBe("desktop/update");
+    expect(sent.args).toBeUndefined();
+    ws.receive({ message_id: sent.message_id, result: { started: true } });
+    await expect(pending).resolves.toEqual({ started: true });
+  });
+
   it("addComponent merges configuration into args", async () => {
     const api = new ESPHomeAPI();
     const ws = await connect(api);

--- a/test/components/desktop-update-dialog.test.ts
+++ b/test/components/desktop-update-dialog.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import type { DesktopUpdateCheck } from "../../src/api/types/protocol.js";
+import type { DesktopUpdateCheck } from "../../src/api/types/desktop.js";
 import { ESPHomeDesktopUpdateDialog } from "../../src/components/desktop-update-dialog.js";
 
 function makeCheck(anyAvailable: boolean): DesktopUpdateCheck {

--- a/test/components/desktop-update-dialog.test.ts
+++ b/test/components/desktop-update-dialog.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The update trigger is fire-and-forget, but `desktop/update` can still report
+ * `{ started: false }`; the dialog must not leave the user on the busy
+ * "Updating" screen (the base-dialog busy gate blocks every dismiss path) when
+ * the updater never spawned.
+ *
+ * These exercise the dialog's state logic directly; the element is intentionally
+ * not connected to the DOM, so `wa-dialog` never renders (happy-dom can't drive
+ * its form-validation internals).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { DesktopUpdateCheck } from "../../src/api/types/protocol.js";
+import { ESPHomeDesktopUpdateDialog } from "../../src/components/desktop-update-dialog.js";
+
+function makeCheck(anyAvailable: boolean): DesktopUpdateCheck {
+  const upToDate = {
+    available: false,
+    installed: "1.0.0",
+    latest: "1.0.0",
+    error: null,
+  };
+  return {
+    any_available: anyAvailable,
+    app: anyAvailable
+      ? { available: true, installed: "0.14.0", latest: "0.15.0", error: null }
+      : upToDate,
+    esphome: upToDate,
+    device_builder: { available: false, installed: null, latest: null, error: null },
+  };
+}
+
+function make(api: unknown): ESPHomeDesktopUpdateDialog {
+  const el = new ESPHomeDesktopUpdateDialog();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._api = api;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._localize = (key: string) => key;
+  return el;
+}
+
+describe("desktop-update-dialog", () => {
+  it("loads availability from check_update on open", async () => {
+    const api = { desktopCheckUpdate: vi.fn().mockResolvedValue(makeCheck(true)) };
+    const el = make(api);
+    await el.open();
+    expect(api.desktopCheckUpdate).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._check.any_available).toBe(true);
+  });
+
+  it("does not strand the user when the update fails to start", async () => {
+    const api = {
+      desktopCheckUpdate: vi.fn().mockResolvedValue(makeCheck(true)),
+      desktopInstallUpdate: vi.fn().mockResolvedValue({ started: false }),
+    };
+    const el = make(api);
+    await el.open();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any)._confirm();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._updating).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._error).not.toBe("");
+  });
+
+  it("holds the updating state when the update starts", async () => {
+    const api = {
+      desktopCheckUpdate: vi.fn().mockResolvedValue(makeCheck(true)),
+      desktopInstallUpdate: vi.fn().mockResolvedValue({ started: true }),
+    };
+    const el = make(api);
+    await el.open();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any)._confirm();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._updating).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._error).toBe("");
+  });
+});

--- a/test/components/esphome-header-actions-check-updates.test.ts
+++ b/test/components/esphome-header-actions-check-updates.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * "Check for updates" only works under an ESPHome Desktop app (0.14.0+) that
+ * exposes its update api, so the kebab entry must render only when the backend
+ * reports desktop_update_capable and stay hidden otherwise.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+
+async function renderOpenMenu(
+  desktopUpdateCapable: boolean
+): Promise<ESPHomeHeaderActions> {
+  const el = new ESPHomeHeaderActions();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._desktopUpdateCapable = desktopUpdateCapable;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._open = true;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("header-actions Check for updates visibility", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the entry when the desktop app is update-capable", async () => {
+    const el = await renderOpenMenu(true);
+    expect(el.shadowRoot!.querySelector('wa-icon[name="update"]')).not.toBeNull();
+  });
+
+  it("hides the entry when not update-capable", async () => {
+    const el = await renderOpenMenu(false);
+    expect(el.shadowRoot!.querySelector('wa-icon[name="update"]')).toBeNull();
+  });
+});

--- a/test/components/esphome-header-actions-check-updates.test.ts
+++ b/test/components/esphome-header-actions-check-updates.test.ts
@@ -36,4 +36,19 @@ describe("header-actions Check for updates visibility", () => {
     const el = await renderOpenMenu(false);
     expect(el.shadowRoot!.querySelector('wa-icon[name="update"]')).toBeNull();
   });
+
+  it("dispatches open-check-updates and closes the menu on click", async () => {
+    const el = await renderOpenMenu(true);
+    let fired = false;
+    el.addEventListener("open-check-updates", () => {
+      fired = true;
+    });
+    const item = el
+      .shadowRoot!.querySelector('wa-icon[name="update"]')!
+      .closest<HTMLElement>(".menu-item");
+    item!.click();
+    expect(fired).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any)._open).toBe(false);
+  });
 });


### PR DESCRIPTION
# What does this implement/fix?

Adds a "Check for updates" item to the kebab menu when the dashboard runs inside ESPHome Desktop 0.14.0+; the backend reports `desktop_update_capable` on the WS handshake, which gates the item so it stays hidden on older desktop apps and outside the desktop entirely. The item opens a dialog that lists per component availability (ESPHome Desktop, ESPHome, device builder) from the new `desktop/check_update` command, and an "Update now" button triggers `desktop/update`; that update restarts the app, so the dialog shows an "Updating; the app will restart" state and the user re-checks after it comes back. Companion backend PR: esphome/device-builder#1847.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
