### PR TITLE
Extract a shared header-menu render helper for the kebab tests

### DIFF
--- a/test/components/_esphome-header-actions-helpers.ts
+++ b/test/components/_esphome-header-actions-helpers.ts
@@ -9,12 +9,22 @@
 import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
 
 /**
+ * Gating flags the kebab-menu suites toggle before opening the menu — the
+ * public ``dashboardRoute`` prop and the private ``_desktopUpdateCapable``
+ * state. Narrowly typed (rather than ``Record<string, unknown>``) so a typo
+ * in a gate name is a compile error; extend it as new suites need more gates.
+ */
+export interface HeaderMenuOverrides {
+  dashboardRoute?: boolean;
+  _desktopUpdateCapable?: boolean;
+}
+
+/**
  * Construct an open header-actions kebab menu with optional gating-prop
- * overrides applied, appended and settled. Pass public props by name
- * (``dashboardRoute``) or private state directly (``_desktopUpdateCapable``).
+ * overrides applied, appended and settled.
  */
 export async function renderOpenHeaderMenu(
-  overrides: Record<string, unknown> = {}
+  overrides: HeaderMenuOverrides = {}
 ): Promise<ESPHomeHeaderActions> {
   const el = new ESPHomeHeaderActions();
   Object.assign(el, overrides);

--- a/test/components/_esphome-header-actions-helpers.ts
+++ b/test/components/_esphome-header-actions-helpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared mount helper for the ``esphome-header-actions`` kebab-menu tests.
+ *
+ * The archived / search / check-updates suites each open the menu the same
+ * way (construct, force ``_open``, append, settle) and differ only in the
+ * gating prop they set first, so that boilerplate lives here rather than
+ * getting copy-pasted per suite.
+ */
+import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+
+/**
+ * Construct an open header-actions kebab menu with optional gating-prop
+ * overrides applied, appended and settled. Pass public props by name
+ * (``dashboardRoute``) or private state directly (``_desktopUpdateCapable``).
+ */
+export async function renderOpenHeaderMenu(
+  overrides: Record<string, unknown> = {}
+): Promise<ESPHomeHeaderActions> {
+  const el = new ESPHomeHeaderActions();
+  Object.assign(el, overrides);
+  (el as unknown as { _open: boolean })._open = true;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}

--- a/test/components/esphome-header-actions-archived.test.ts
+++ b/test/components/esphome-header-actions-archived.test.ts
@@ -7,17 +7,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
-
-async function renderOpenMenu(dashboardRoute: boolean): Promise<ESPHomeHeaderActions> {
-  const el = new ESPHomeHeaderActions();
-  el.dashboardRoute = dashboardRoute;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._open = true;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 
 describe("header-actions Archived Devices visibility", () => {
   afterEach(() => {
@@ -25,14 +15,14 @@ describe("header-actions Archived Devices visibility", () => {
   });
 
   it("renders the Archived Devices entry on the dashboard route", async () => {
-    const el = await renderOpenMenu(true);
+    const el = await renderOpenHeaderMenu({ dashboardRoute: true });
     expect(
       el.shadowRoot!.querySelector('wa-icon[name="archive-outline"]')
     ).not.toBeNull();
   });
 
   it("hides the Archived Devices entry off the dashboard route", async () => {
-    const el = await renderOpenMenu(false);
+    const el = await renderOpenHeaderMenu({ dashboardRoute: false });
     expect(el.shadowRoot!.querySelector('wa-icon[name="archive-outline"]')).toBeNull();
   });
 });

--- a/test/components/esphome-header-actions-check-updates.test.ts
+++ b/test/components/esphome-header-actions-check-updates.test.ts
@@ -7,20 +7,10 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
+import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 
-async function renderOpenMenu(
-  desktopUpdateCapable: boolean
-): Promise<ESPHomeHeaderActions> {
-  const el = new ESPHomeHeaderActions();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._desktopUpdateCapable = desktopUpdateCapable;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._open = true;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+const renderOpenMenu = (desktopUpdateCapable: boolean) =>
+  renderOpenHeaderMenu({ _desktopUpdateCapable: desktopUpdateCapable });
 
 describe("header-actions Check for updates visibility", () => {
   afterEach(() => {

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -9,15 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { OPEN_COMMAND_PALETTE_EVENT } from "../../src/components/command-palette-actions.js";
 import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
-
-async function renderOpenMenu(): Promise<ESPHomeHeaderActions> {
-  const el = new ESPHomeHeaderActions();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._open = true;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 
 function searchItem(el: ESPHomeHeaderActions): HTMLElement {
   return el.shadowRoot!.querySelector('wa-icon[name="magnify"]')!
@@ -30,13 +22,13 @@ describe("header-actions Search item", () => {
   });
 
   it("renders the Search item with a shortcut hint", async () => {
-    const el = await renderOpenMenu();
+    const el = await renderOpenHeaderMenu();
     expect(el.shadowRoot!.querySelector('wa-icon[name="magnify"]')).not.toBeNull();
     expect(el.shadowRoot!.querySelector(".menu-item-shortcut")).not.toBeNull();
   });
 
   it("fires the open-palette event and closes the menu on click", async () => {
-    const el = await renderOpenMenu();
+    const el = await renderOpenHeaderMenu();
     const listener = vi.fn();
     window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, listener);
 


### PR DESCRIPTION
# What does this implement/fix?

The three `esphome-header-actions` kebab-menu suites each defined a byte-identical mount helper (construct the element, force `_open`, append, await `updateComplete`), differing only in the gating prop they set. This extracts that boilerplate into a shared `renderOpenHeaderMenu(overrides)` helper under `test/components/`, so each suite passes just its own gating prop; the archived suite sets `dashboardRoute`, check-updates sets `_desktopUpdateCapable`, search sets nothing. Test only, no source change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1077

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
