### PR TITLE
Consolidate the dialog .actions footer style into a shared sibling

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -5,6 +5,7 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -55,6 +56,7 @@ export class ESPHomeAdoptDialog extends LitElement {
     // Before the local block so this dialog's own `.field` / `label`
     // spacing wins; only `.field-label` / `.error` (unique here) apply.
     wifiFieldsStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -172,13 +174,6 @@ export class ESPHomeAdoptDialog extends LitElement {
       .checkbox-hint {
         font-size: var(--wa-font-size-xs);
         color: var(--wa-color-text-quiet);
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
 
       .btn {

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -54,6 +55,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
     dialogChromeStyles,
     quietCloseButtonStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -80,13 +82,6 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
         font-size: var(--wa-font-size-xs);
         color: var(--wa-color-text-quiet);
         margin-top: var(--wa-space-2xs);
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
 
       .btn {

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -6,7 +6,10 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { DesktopComponentUpdate, DesktopUpdateCheck } from "../api/types/desktop.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
-import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 
@@ -40,6 +43,7 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
     espHomeStyles,
     dialogChromeStyles,
     dialogActionButtonStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 420px;
@@ -69,12 +73,6 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
       }
       .message.error {
         color: var(--wa-color-danger-fill-loud);
-      }
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
     `,
   ];

--- a/src/components/device/change-board-dialog.styles.ts
+++ b/src/components/device/change-board-dialog.styles.ts
@@ -78,13 +78,6 @@ export const changeBoardDialogStyles = css`
     color: var(--wa-color-text-quiet);
   }
 
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--wa-space-s);
-    padding: var(--wa-space-m) 0 var(--wa-space-l);
-  }
-
   .btn {
     padding: var(--esphome-button-padding);
     border-radius: var(--wa-border-radius-m);

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { dialogActionsRowStyles } from "../../styles/dialog-action-buttons.js";
 import {
   dialogChromeStyles,
   quietCloseButtonStyles,
@@ -41,6 +42,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
     espHomeStyles,
     dialogChromeStyles,
     quietCloseButtonStyles,
+    dialogActionsRowStyles,
     changeBoardDialogStyles,
   ];
 

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -58,6 +59,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     inputStyles,
     // Neutral header + title + footer (shared) — dialog-chrome.ts.
     dialogChromeStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -96,13 +98,6 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
       .install-row .helper {
         margin-top: 0;
         flex: 1;
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
 
       .btn {

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -33,6 +34,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     // Neutral header + title + quiet close button (shared) — dialog-chrome.ts.
     dialogChromeStyles,
     quietCloseButtonStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 420px;
@@ -53,13 +55,6 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
         font-size: var(--wa-font-size-xs);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-quiet);
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
 
       .btn {

--- a/src/components/update-all-dialog.ts
+++ b/src/components/update-all-dialog.ts
@@ -13,7 +13,10 @@ import {
   localizeContext,
   versionContext,
 } from "../context/index.js";
-import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { runBulkUpdate } from "../util/bulk-update.js";
@@ -83,6 +86,7 @@ export class ESPHomeUpdateAllDialog extends LitElement {
     espHomeStyles,
     dialogChromeStyles,
     dialogActionButtonStyles,
+    dialogActionsRowStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -104,13 +108,6 @@ export class ESPHomeUpdateAllDialog extends LitElement {
         padding: var(--wa-space-m) 0 0;
         font-size: var(--wa-font-size-s);
         color: var(--wa-color-text-quiet);
-      }
-
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--wa-space-s);
-        padding: var(--wa-space-m) 0 var(--wa-space-l);
       }
     `,
   ];

--- a/src/styles/dialog-action-buttons.ts
+++ b/src/styles/dialog-action-buttons.ts
@@ -66,3 +66,18 @@ export const dialogActionButtonStyles = css`
     cursor: not-allowed;
   }
 `;
+
+/**
+ * Standalone footer action-row wrapper: a right-aligned button row with
+ * the standard dialog-body padding. Sibling to ``dialogActionButtonStyles``
+ * so a dialog can adopt the shared ``.actions`` row without pulling in the
+ * ``.btn`` chrome (dialogs that self-style their buttons keep those local).
+ */
+export const dialogActionsRowStyles = css`
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--wa-space-s);
+    padding: var(--wa-space-m) 0 var(--wa-space-l);
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

Seven dialogs carried a byte-identical `.actions` footer block (right-aligned button row with the standard dialog-body padding). This adds a `dialogActionsRowStyles` sibling export next to `dialogActionButtonStyles` and drops the local copy from all seven; `update-all-dialog` and `desktop-update-dialog` (which already import the button styles) plus `clone-device`, `adopt`, `friendly-name`, `rename-device`, and `change-board`.

It is a deliberate sibling rather than folding `.actions` into `dialogActionButtonStyles`, because the five self-styling dialogs define their own `.btn` chrome; importing the full button styles would drag in a second, slightly divergent `.btn--cancel:hover` rule. The sibling lets them share the `.actions` row while keeping their button styles local. Those `.btn` copies are still duplicated among themselves; folding that in would change the hover rule, so it is left for a separate follow-up. No behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1078

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
