### PR TITLE
Add a shared async loading/error/content render helper for dialogs

### DIFF
--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -9,6 +9,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { registerMdiIcons } from "../util/register-icons.js";
+import { renderAsyncState } from "../util/render-async-state.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "./base-dialog.js";
@@ -195,15 +196,14 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
       }
 
       .empty,
-      .loading,
-      .error {
+      .message {
         padding: var(--wa-space-2xl) var(--wa-space-l);
         text-align: center;
         color: var(--wa-color-text-quiet);
         font-size: var(--wa-font-size-s);
       }
 
-      .error {
+      .message.error {
         color: var(--wa-color-danger-text-normal);
       }
 
@@ -292,14 +292,15 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
   }
 
   private _renderBody() {
-    if (this._loading && this._devices.length === 0) {
-      return html`<div class="loading">
-        ${this._localize("dashboard.archived_dialog_loading")}
-      </div>`;
-    }
-    if (this._error) {
-      return html`<div class="error">${this._error}</div>`;
-    }
+    return renderAsyncState({
+      loading: this._loading && this._devices.length === 0,
+      loadingMessage: this._localize("dashboard.archived_dialog_loading"),
+      error: this._error ?? "",
+      content: () => this._renderList(),
+    });
+  }
+
+  private _renderList() {
     if (this._devices.length === 0) {
       return html`<div class="empty">
         ${this._localize("dashboard.archived_dialog_empty")}

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -295,7 +295,7 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
     return renderAsyncState({
       loading: this._loading && this._devices.length === 0,
       loadingMessage: this._localize("dashboard.archived_dialog_loading"),
-      error: this._error ?? "",
+      error: this._error,
       content: () => this._renderList(),
     });
   }

--- a/src/components/desktop-update-dialog.ts
+++ b/src/components/desktop-update-dialog.ts
@@ -12,6 +12,7 @@ import {
 } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { renderAsyncState } from "../util/render-async-state.js";
 
 import "./base-dialog.js";
 
@@ -159,19 +160,15 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
   }
 
   private _renderBody() {
-    if (this._updating) {
-      return html`<div class="message" role="status">
-        ${this._localize("desktop_update_dialog.updating")}
-      </div>`;
-    }
-    if (this._loading) {
-      return html`<div class="message" role="status">
-        ${this._localize("desktop_update_dialog.checking")}
-      </div>`;
-    }
-    if (this._error) {
-      return html`
-        <div class="message error" role="alert">${this._error}</div>
+    return renderAsyncState({
+      loading: this._updating || this._loading,
+      loadingMessage: this._localize(
+        this._updating
+          ? "desktop_update_dialog.updating"
+          : "desktop_update_dialog.checking"
+      ),
+      error: this._error,
+      errorActions: () => html`
         <div class="actions">
           <button class="btn btn--cancel" @click=${this.close}>
             ${this._localize("layout.close")}
@@ -180,8 +177,12 @@ export class ESPHomeDesktopUpdateDialog extends LitElement {
             ${this._localize("desktop_update_dialog.retry")}
           </button>
         </div>
-      `;
-    }
+      `,
+      content: () => this._renderCheck(),
+    });
+  }
+
+  private _renderCheck() {
     const check = this._check;
     if (!check) {
       return nothing;

--- a/src/util/render-async-state.ts
+++ b/src/util/render-async-state.ts
@@ -11,16 +11,18 @@ import { html, nothing, type TemplateResult } from "lit";
  * (e.g. a retry row). ``content()`` owns everything past the two leading
  * branches, including a dialog's own empty state.
  */
-export interface AsyncStateOptions {
+export interface RenderAsyncStateOptions {
   loading: boolean;
   loadingMessage: string;
-  error: string;
+  // Any falsy value (``""`` / ``null`` / ``undefined``) means "no error", so a
+  // ``string | null`` field can be passed straight through without coercion.
+  error: string | null | undefined;
   content: () => TemplateResult | typeof nothing;
-  errorActions?: () => TemplateResult;
+  errorActions?: () => TemplateResult | typeof nothing;
 }
 
 export function renderAsyncState(
-  opts: AsyncStateOptions
+  opts: RenderAsyncStateOptions
 ): TemplateResult | typeof nothing {
   if (opts.loading) {
     return html`<div class="message" role="status">${opts.loadingMessage}</div>`;

--- a/src/util/render-async-state.ts
+++ b/src/util/render-async-state.ts
@@ -1,0 +1,33 @@
+import { html, nothing, type TemplateResult } from "lit";
+
+/**
+ * Render the loading / error / content ladder shared by data-fetching
+ * dialogs. Loading and error surface as a ``.message`` block with the
+ * matching ARIA live role (``status`` / ``alert``); once neither is set
+ * the call falls through to ``content()``.
+ *
+ * The consumer keeps its own ``.message`` CSS (padding / colour differ per
+ * dialog) and supplies any post-error affordance through ``errorActions``
+ * (e.g. a retry row). ``content()`` owns everything past the two leading
+ * branches, including a dialog's own empty state.
+ */
+export interface AsyncStateOptions {
+  loading: boolean;
+  loadingMessage: string;
+  error: string;
+  content: () => TemplateResult | typeof nothing;
+  errorActions?: () => TemplateResult;
+}
+
+export function renderAsyncState(
+  opts: AsyncStateOptions
+): TemplateResult | typeof nothing {
+  if (opts.loading) {
+    return html`<div class="message" role="status">${opts.loadingMessage}</div>`;
+  }
+  if (opts.error) {
+    return html`<div class="message error" role="alert">${opts.error}</div>
+      ${opts.errorActions ? opts.errorActions() : nothing}`;
+  }
+  return opts.content();
+}

--- a/test/util/render-async-state.test.ts
+++ b/test/util/render-async-state.test.ts
@@ -1,0 +1,83 @@
+import { html, nothing } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { renderAsyncState } from "../../src/util/render-async-state.js";
+
+/**
+ * Lit's TemplateResult exposes ``strings`` (static segments) and ``values``
+ * (interpolated parts); inspecting those pins the markup shape without a DOM
+ * (vitest runs this in the ``node`` environment).
+ */
+interface TemplateResult {
+  strings: readonly string[];
+  values: readonly unknown[];
+}
+
+function asTemplate(value: unknown): TemplateResult {
+  return value as TemplateResult;
+}
+
+const content = () => html`<div class="content"></div>`;
+
+describe("renderAsyncState", () => {
+  it("renders a status-role message while loading", () => {
+    const t = asTemplate(
+      renderAsyncState({ loading: true, loadingMessage: "checking", error: "", content })
+    );
+    expect(t.strings.join("")).toMatch(/^<div class="message" role="status">.*<\/div>$/);
+    expect(t.values).toEqual(["checking"]);
+  });
+
+  it("prefers the loading branch when both loading and error are set", () => {
+    const t = asTemplate(
+      renderAsyncState({
+        loading: true,
+        loadingMessage: "checking",
+        error: "boom",
+        content,
+      })
+    );
+    expect(t.strings.join("")).toContain('role="status"');
+    expect(t.values).toEqual(["checking"]);
+  });
+
+  it("renders an alert-role message on error", () => {
+    const t = asTemplate(
+      renderAsyncState({ loading: false, loadingMessage: "", error: "boom", content })
+    );
+    expect(t.strings.join("")).toContain('<div class="message error" role="alert">');
+    expect(t.values[0]).toBe("boom");
+  });
+
+  it("appends errorActions after the error message when provided", () => {
+    const actions = html`<div class="actions"></div>`;
+    const t = asTemplate(
+      renderAsyncState({
+        loading: false,
+        loadingMessage: "",
+        error: "boom",
+        errorActions: () => actions,
+        content,
+      })
+    );
+    expect(t.values[1]).toBe(actions);
+  });
+
+  it("omits errorActions (nothing) when not provided", () => {
+    const t = asTemplate(
+      renderAsyncState({ loading: false, loadingMessage: "", error: "boom", content })
+    );
+    expect(t.values[1]).toBe(nothing);
+  });
+
+  it("falls through to content() when neither loading nor error", () => {
+    const marker = html`<div class="content"></div>`;
+    const result = renderAsyncState({
+      loading: false,
+      loadingMessage: "",
+      error: "",
+      content: () => marker,
+    });
+    expect(result).toBe(marker);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Several dialogs hand-roll the same loading / error / content branch ladder. This adds a small `renderAsyncState` helper in `src/util/` (next to `render-error.ts`) that renders the loading and error states as a `.message` block with the matching ARIA live role (`status` / `alert`), then falls through to a `content()` callback. It seeds the helper in the two cleanest ladders: `archived-devices-dialog` and `desktop-update-dialog`.

The dialogs keep their own `.message` CSS (padding and colour differ per dialog) and pass any post-error affordance through `errorActions` (desktop-update's close/retry row); each dialog's empty state stays inside its `content()`. As a side benefit, the archived-devices loading and error text now carry `role=status` / `role=alert` (previously plain divs). firmware-install and remote-build-job use different patterns (a process-terminal wrapper, a step-based flow) and are left for incremental follow-up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1079

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
