### PR TITLE
Adopt formatApiError at hand-rolled error message call sites

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -14,6 +14,7 @@ import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { validateDeviceName } from "../util/config-validation.js";
 import { EnterController } from "../util/enter-controller.js";
+import { formatApiError } from "../util/format-api-error.js";
 import { markJustCreated } from "../util/just-created.js";
 import { previewPackageImportUrl } from "../util/package-import-url.js";
 import { renderInlineError } from "../util/render-error.js";
@@ -512,10 +513,7 @@ export class ESPHomeAdoptDialog extends LitElement {
         })
       );
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("dashboard.adopt_error_generic");
+      this._error = formatApiError(err, this._localize, "dashboard.adopt_error_generic");
     } finally {
       /* Always clear the busy state. On success the dialog closes
          and the user never sees this — but if anything downstream

--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -25,6 +25,7 @@ import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
@@ -248,10 +249,7 @@ export class ESPHomeAddApiActionDialog extends LitElement {
       );
       this._open = false;
     } catch (err) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_save_error");
+      const msg = formatApiError(err, this._localize, "device.automation_save_error");
       this._error = msg;
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -37,6 +37,7 @@ import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
 import { addAutomationDialogStyles } from "./add-automation-dialog.styles.js";
@@ -477,10 +478,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
       dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
       this._open = false;
     } catch (err) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_save_error");
+      const msg = formatApiError(err, this._localize, "device.automation_save_error");
       this._error = msg;
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -34,6 +34,7 @@ import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { dispatchAutomationAdded } from "./dispatch-automation-added.js";
@@ -252,10 +253,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
       dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
       this._open = false;
     } catch (err) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_save_error");
+      const msg = formatApiError(err, this._localize, "device.automation_save_error");
       this._error = msg;
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,

--- a/src/components/device/automation-editor/api-action-editor.ts
+++ b/src/components/device/automation-editor/api-action-editor.ts
@@ -40,6 +40,7 @@ import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
 import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
@@ -332,10 +333,7 @@ export class ESPHomeApiActionEditor extends LitElement {
         this.value = m.tree;
       }
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_parse_error");
+      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
     }
   }
 

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -6,6 +6,7 @@ import type {
   AutomationTree,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { notifyError } from "../../../util/notify.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
@@ -313,8 +314,7 @@ export class AutoApplyController implements ReactiveController {
    *  revert-on-failure rule for optimistic updates). */
   private _surfaceSaveError(err: unknown): void {
     const localize = this._options.getLocalize();
-    const msg =
-      err instanceof Error ? err.message : localize("device.automation_save_error");
+    const msg = formatApiError(err, localize, "device.automation_save_error");
     this._options.setError(msg);
     notifyError(localize("device.automation_save_error"), {
       description: msg,

--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -45,6 +45,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
@@ -290,10 +291,7 @@ export class ESPHomeAutomationEditor extends LitElement {
         this.value = m.tree;
       }
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_parse_error");
+      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
     }
   }
 

--- a/src/components/device/automation-editor/script-editor.ts
+++ b/src/components/device/automation-editor/script-editor.ts
@@ -44,6 +44,7 @@ import {
 } from "../../../util/component-name-cache.js";
 import { getErrorMessage } from "../../../util/error-message.js";
 import { normalizeEspHomeId } from "../../../util/esphome-id.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import "../config-entry-form.js";
@@ -254,10 +255,7 @@ export class ESPHomeScriptEditor extends LitElement {
         this.value = m.tree;
       }
     } catch (err) {
-      this._error =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_parse_error");
+      this._error = formatApiError(err, this._localize, "device.automation_parse_error");
     }
   }
 

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -682,11 +682,7 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         })
       );
     } catch (err) {
-      const msg = formatApiError(
-        err,
-        this._localize,
-        "device.automation_save_error"
-      );
+      const msg = formatApiError(err, this._localize, "device.automation_save_error");
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,
       });

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -25,6 +25,7 @@ import {
 import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.js";
 import { pathIsAdvanced } from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -681,10 +682,11 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         })
       );
     } catch (err) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : this._localize("device.automation_save_error");
+      const msg = formatApiError(
+        err,
+        this._localize,
+        "device.automation_save_error"
+      );
       notifyError(this._localize("device.automation_save_error"), {
         description: msg,
       });

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,4 +1,5 @@
 import { validateEntries } from "../../../util/config-validation.js";
+import { formatApiError } from "../../../util/format-api-error.js";
 import { setIn } from "../../../util/nested-values.js";
 import { notifySuccess } from "../../../util/notify.js";
 import {
@@ -139,8 +140,7 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
     );
     notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
-    host._error =
-      e instanceof Error ? e.message : host._localize("device.section_delete_error");
+    host._error = formatApiError(e, host._localize, "device.section_delete_error");
   } finally {
     host._deleting = false;
   }

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -7,6 +7,7 @@ import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
+import { formatApiError } from "../../util/format-api-error.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
 import {
@@ -191,9 +192,7 @@ export async function startWebSerialInstall(
     // 100% reached: treat as success — device may have reset during verification.
     if (host._flashPercent < 100) {
       await releaseSerial(detected);
-      host._fail(
-        err instanceof Error ? err.message : host._localize("firmware.flash_failed")
-      );
+      host._fail(formatApiError(err, host._localize, "firmware.flash_failed"));
       return;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Replaces the hand rolled `err instanceof Error ? err.message : localize(...)` ternaries with the existing `formatApiError` util, keeping each site's original fallback key. As the util intends, an `APIError` now surfaces its structured `details` instead of the wire form message, so internal codes like `INVALID_ARGS:` no longer leak into dialogs and toasts. Rebased onto #1100; the editors' save and delete error sites now live in `auto-apply-controller.ts` and use `formatApiError` there.

**Related issue or feature (if applicable):**

- fixes #1084

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
