### PR TITLE
Add toast wrappers that default richColors

### DIFF
--- a/src/components/api-key-dialog.ts
+++ b/src/components/api-key-dialog.ts
@@ -2,12 +2,12 @@ import { consume } from "@lit/context";
 import { mdiContentCopy, mdiEye, mdiEyeOff } from "@mdi/js";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { copyToClipboard } from "../util/copy-to-clipboard.js";
+import { notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -181,9 +181,7 @@ export class ESPHomeApiKeyDialog extends LitElement {
     // throws (HA-addon direct port, container-on-LAN deploys
     // reaching the dashboard via ``http://192.168.x.x:6052``).
     if (await copyToClipboard(this.apiKey)) {
-      toast.success(this._localize("dashboard.action_api_key_copied"), {
-        richColors: true,
-      });
+      notifySuccess(this._localize("dashboard.action_api_key_copied"));
     }
     // No failure toast here — the api-key dialog already
     // displays the key in plain text inside the dialog body,

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -57,6 +57,7 @@ import {
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { isExpert } from "../util/experience.js";
+import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
 import { onLoginSubmit } from "./app-shell/auth.js";
 import {
@@ -356,12 +357,11 @@ export class ESPHomeApp extends LitElement {
       }
       this._portToastMs.set(port, now);
     }
-    toast.info(this._localize("layout.usb_device_connected"), {
+    notifyInfo(this._localize("layout.usb_device_connected"), {
       // Stable id so multiple connect events collapse onto the same
       // toast instead of stacking — defence in depth on top of the
       // time-window suppression above.
       id: "esphome-usb-device-connected",
-      richColors: true,
       duration: 8000,
       action: {
         label: this._localize("layout.usb_device_setup"),

--- a/src/components/app-shell/settings-actions.ts
+++ b/src/components/app-shell/settings-actions.ts
@@ -1,4 +1,3 @@
-import toast from "sonner-js";
 import type { VersionMatchPolicy } from "../../api/types/event-subscription.js";
 import type { RemoteBuildSubmitTarget } from "../../api/types/firmware-jobs.js";
 import {
@@ -13,6 +12,7 @@ import {
   type SupportedLocale,
   writeStoredLocale,
 } from "../../common/localize.js";
+import { notifyError } from "../../util/notify.js";
 import type { ESPHomeApp } from "../app-shell.js";
 import { patchOffloadPairing } from "./events.js";
 
@@ -44,7 +44,7 @@ async function optimisticSetting<T>(
     set(previous);
     if (warn) console.warn(warn, err);
     if (toastKey) {
-      toast.error(host._localize(toastKey), { richColors: true });
+      notifyError(host._localize(toastKey));
     }
   } finally {
     inFlight?.(false);
@@ -166,9 +166,7 @@ export async function onSetRemoteBuildCleanupTtl(
     requested < CLEANUP_TTL_MIN_SECONDS ||
     requested > CLEANUP_TTL_MAX_SECONDS
   ) {
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
+    notifyError(host._localize("settings.remote_build_save_failed"));
     return;
   }
   const previous = host._remoteBuildCleanupTtl;
@@ -182,9 +180,7 @@ export async function onSetRemoteBuildCleanupTtl(
     });
   } catch {
     host._remoteBuildCleanupTtl = previous;
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
+    notifyError(host._localize("settings.remote_build_save_failed"));
   } finally {
     host._remoteBuildSetInFlight = false;
   }
@@ -245,9 +241,7 @@ export async function onSetOffloaderPairingEnabled(
     if (previous !== undefined) {
       patchOffloadPairing(host, pin_sha256, { enabled: previous });
     }
-    toast.error(host._localize("settings.remote_build_save_failed"), {
-      richColors: true,
-    });
+    notifyError(host._localize("settings.remote_build_save_failed"));
   } finally {
     host._offloaderWritesInFlight -= 1;
   }

--- a/src/components/dashboard/actions-ui.ts
+++ b/src/components/dashboard/actions-ui.ts
@@ -1,4 +1,3 @@
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type {
   AdoptableDevice,
@@ -12,6 +11,7 @@ import { getErrorMessage } from "../../util/error-message.js";
 import { firmwareJobDisplayName } from "../../util/firmware-job-display.js";
 import { clearJustCreated } from "../../util/just-created.js";
 import { resolveLogBaudRate } from "../../util/log-baud-rate.js";
+import { notifyError, notifySuccess } from "../../util/notify.js";
 import {
   attachSerialLogStream,
   reconnectWebSerialLogs,
@@ -30,35 +30,30 @@ export async function executeFriendlyName(
     result = await host._api.editFriendlyName(device.configuration, newFriendlyName);
   } catch (err) {
     const reason = getErrorMessage(err);
-    toast.error(
+    notifyError(
       host._localize("dashboard.action_friendly_name_failed", {
         name: device.name,
         reason,
-      }),
-      { richColors: true }
+      })
     );
     return;
   }
   if (!result.rewritten) {
-    toast.success(host._localize("dashboard.action_friendly_name_unchanged"), {
-      richColors: true,
-    });
+    notifySuccess(host._localize("dashboard.action_friendly_name_unchanged"));
     return;
   }
   if (!install) {
-    toast.success(
+    notifySuccess(
       host._localize("dashboard.action_friendly_name_success", {
         name: newFriendlyName,
-      }),
-      { richColors: true }
+      })
     );
     return;
   }
-  toast.success(
+  notifySuccess(
     host._localize("dashboard.action_friendly_name_success", {
       name: newFriendlyName,
-    }),
-    { richColors: true }
+    })
   );
   host._openInstallMethod(device);
 }
@@ -75,18 +70,15 @@ export async function executeClone(
     await host._api.cloneDevice(device.configuration, newName, friendly);
   } catch (err) {
     const reason = getErrorMessage(err);
-    toast.error(
+    notifyError(
       host._localize("dashboard.action_clone_failed", {
         name: device.name,
         reason,
-      }),
-      { richColors: true }
+      })
     );
     return;
   }
-  toast.success(host._localize("dashboard.action_clone_success", { name: newName }), {
-    richColors: true,
-  });
+  notifySuccess(host._localize("dashboard.action_clone_success", { name: newName }));
 }
 
 export async function executeRename(
@@ -120,12 +112,11 @@ export async function performRename(
     response = await host._api.renameDevice(device.configuration, newName, configOnly);
   } catch (err) {
     const reason = getErrorMessage(err);
-    toast.error(
+    notifyError(
       host._localize("dashboard.action_rename_failed", {
         name: device.name,
         reason,
-      }),
-      { richColors: true }
+      })
     );
     return;
   }
@@ -144,9 +135,7 @@ export async function performRename(
     );
     return;
   }
-  toast.success(host._localize("dashboard.action_rename_success", { name: newName }), {
-    richColors: true,
-  });
+  notifySuccess(host._localize("dashboard.action_rename_success", { name: newName }));
 }
 
 export async function toggleIgnore(
@@ -157,14 +146,13 @@ export async function toggleIgnore(
     await host._api.ignoreDevice(device.name, !device.ignored);
   } catch {
     const name = device.friendly_name || device.name;
-    toast.error(
+    notifyError(
       host._localize(
         device.ignored
           ? "dashboard.action_unignore_failed"
           : "dashboard.action_ignore_failed",
         { name }
-      ),
-      { richColors: true }
+      )
     );
   }
 }
@@ -181,9 +169,7 @@ export async function deleteLabel(
     }
   } catch (err) {
     console.warn("label delete failed", err);
-    toast.error(host._localize("dashboard.labels_delete_failed"), {
-      richColors: true,
-    });
+    notifyError(host._localize("dashboard.labels_delete_failed"));
   }
 }
 
@@ -203,17 +189,13 @@ export async function openLogsWithMethod(
     host._logsDialog.open(port);
   } else if (method === "web-serial") {
     if (!("serial" in navigator)) {
-      toast.error(host._localize("dashboard.logs_web_serial_unsupported"), {
-        richColors: true,
-      });
+      notifyError(host._localize("dashboard.logs_web_serial_unsupported"));
       return;
     }
     const baudRate = resolveLogBaudRate(device.logger_baud_rate);
     if (baudRate === null) {
       // logger: baud_rate: 0 — UART logging is disabled; serial would be silent.
-      toast.error(host._localize("dashboard.logs_serial_disabled"), {
-        richColors: true,
-      });
+      notifyError(host._localize("dashboard.logs_serial_disabled"));
       return;
     }
     let serialPort: SerialPort | null;
@@ -222,9 +204,7 @@ export async function openLogsWithMethod(
     } catch {
       // The user picked a port but it couldn't open (claimed by another tab,
       // driver error); unlike a picker dismissal this needs feedback.
-      toast.error(host._localize("dashboard.logs_web_serial_open_failed"), {
-        richColors: true,
-      });
+      notifyError(host._localize("dashboard.logs_web_serial_open_failed"));
       return;
     }
     if (!serialPort) return; // User dismissed the port picker.
@@ -241,9 +221,7 @@ export async function openLogsWithMethod(
     try {
       await attachSerialLogStream(serialPort, host._logsDialog, host._localize, baudRate);
     } catch {
-      toast.error(host._localize("dashboard.logs_web_serial_open_failed"), {
-        richColors: true,
-      });
+      notifyError(host._localize("dashboard.logs_web_serial_open_failed"));
     }
   }
 }

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -1,4 +1,3 @@
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
@@ -8,6 +7,7 @@ import { withBase } from "../../util/base-path.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { ESPHomeLogParser, isLikelyGarbageLine } from "../../util/esphome-log-parser.js";
+import { notifyError, notifySuccess } from "../../util/notify.js";
 import {
   connectToPort,
   detectChip,
@@ -41,9 +41,7 @@ export async function archiveDevice(
     await api.archiveDevice(device.configuration);
   } catch (err) {
     const error = getErrorMessage(err);
-    toast.error(localize("dashboard.action_archive_failed", { name, error }), {
-      richColors: true,
-    });
+    notifyError(localize("dashboard.action_archive_failed", { name, error }));
     return false;
   }
   /* The toast carries the discoverability hint for unarchive —
@@ -52,9 +50,8 @@ export async function archiveDevice(
      devices entry lives in the header kebab; spelling it out
      in the success toast saves a "where did my device go?"
      support thread. */
-  toast.success(localize("dashboard.action_archive_success", { name }), {
+  notifySuccess(localize("dashboard.action_archive_success", { name }), {
     description: localize("dashboard.action_archive_success_hint"),
-    richColors: true,
     duration: 8000,
   });
   return true;
@@ -71,14 +68,10 @@ export async function clearQueuedUpdate(
     await api.firmwareClearQueuedUpdate(device.configuration);
   } catch (err) {
     const error = getErrorMessage(err);
-    toast.error(localize("dashboard.queued_update_clear_failed", { name, error }), {
-      richColors: true,
-    });
+    notifyError(localize("dashboard.queued_update_clear_failed", { name, error }));
     return;
   }
-  toast.success(localize("dashboard.queued_update_cleared", { name }), {
-    richColors: true,
-  });
+  notifySuccess(localize("dashboard.queued_update_cleared", { name }));
 }
 
 /**
@@ -104,14 +97,10 @@ export async function unarchiveDevice(
     await api.unarchiveDevice(device.configuration);
   } catch (err) {
     const error = getErrorMessage(err);
-    toast.error(localize("dashboard.action_unarchive_failed", { name, error }), {
-      richColors: true,
-    });
+    notifyError(localize("dashboard.action_unarchive_failed", { name, error }));
     return false;
   }
-  toast.success(localize("dashboard.action_unarchive_success", { name }), {
-    richColors: true,
-  });
+  notifySuccess(localize("dashboard.action_unarchive_success", { name }));
   return true;
 }
 
@@ -131,14 +120,10 @@ export async function deleteArchivedDevice(
     await api.deleteArchivedDevice(device.configuration);
   } catch (err) {
     const error = getErrorMessage(err);
-    toast.error(localize("dashboard.action_delete_archived_failed", { name, error }), {
-      richColors: true,
-    });
+    notifyError(localize("dashboard.action_delete_archived_failed", { name, error }));
     return false;
   }
-  toast.success(localize("dashboard.action_delete_archived_success", { name }), {
-    richColors: true,
-  });
+  notifySuccess(localize("dashboard.action_delete_archived_success", { name }));
   return true;
 }
 
@@ -151,10 +136,10 @@ export async function deleteDevice(
   try {
     await api.deleteDevice(device.configuration);
   } catch {
-    toast.error(localize("dashboard.delete_failed", { name }), { richColors: true });
+    notifyError(localize("dashboard.delete_failed", { name }));
     return false;
   }
-  toast.success(localize("dashboard.deleted", { name }), { richColors: true });
+  notifySuccess(localize("dashboard.deleted", { name }));
   return true;
 }
 
@@ -179,14 +164,14 @@ async function runBulkAction(
     catchAllKey: string;
     successKey: string;
     failureKey: string;
-    successOptions?: Parameters<typeof toast.success>[1];
+    successOptions?: Parameters<typeof notifySuccess>[1];
   }
 ) {
   let results: BulkActionResult[];
   try {
     results = await call(configurations);
   } catch {
-    toast.error(localize(copy.catchAllKey), { richColors: true });
+    notifyError(localize(copy.catchAllKey));
     return;
   }
 
@@ -194,10 +179,7 @@ async function runBulkAction(
   const failed = results.filter((r) => !r.success);
 
   if (succeeded > 0) {
-    toast.success(localize(copy.successKey, { count: succeeded }), {
-      richColors: true,
-      ...copy.successOptions,
-    });
+    notifySuccess(localize(copy.successKey, { count: succeeded }), copy.successOptions);
   }
   // Index by configuration up front so failure-toast naming is
   // O(failures) instead of O(failures × devices) on big selections.
@@ -213,9 +195,8 @@ async function runBulkAction(
     // the failure toasts read like ``Failed to archive "kitchen": ``
     // (dangling colon) because ``action_archive_failed`` /
     // ``action_unarchive_failed`` interpolate ``{error}`` directly.
-    toast.error(
-      localize(copy.failureKey, { name, error: result.error || fallbackError }),
-      { richColors: true }
+    notifyError(
+      localize(copy.failureKey, { name, error: result.error || fallbackError })
     );
   }
 }
@@ -285,9 +266,7 @@ export async function downloadYaml(
       : `${device.configuration}.yaml`;
     a.click();
   } catch {
-    toast.error(localize("dashboard.action_download_yaml_failed", { name }), {
-      richColors: true,
-    });
+    notifyError(localize("dashboard.action_download_yaml_failed", { name }));
   } finally {
     if (url) {
       URL.revokeObjectURL(url);
@@ -350,11 +329,10 @@ export async function detectAndOpenWizard(
 
     if (recognized && options.onRecognized) {
       if (options.localize) {
-        toast.success(
+        notifySuccess(
           options.localize("dashboard.serial_recognized", {
             name: recognized.friendly_name || recognized.name,
-          }),
-          { richColors: true }
+          })
         );
       }
       options.onRecognized(recognized);
@@ -365,11 +343,10 @@ export async function detectAndOpenWizard(
       const board = await fetchBoard(api, manifest.board_id);
       if (board) {
         if (options.localize) {
-          toast.success(
+          notifySuccess(
             options.localize("dashboard.serial_starterkit_detected", {
               name: board.name,
-            }),
-            { richColors: true }
+            })
           );
         }
         createDialog.openWithBoard(board);
@@ -387,11 +364,10 @@ export async function detectAndOpenWizard(
     // opens so the user can pick a board by hand, but a real connect
     // failure gets named instead of vanishing (#1414).
     if (!isPortPickerCancel(err) && options.localize) {
-      toast.error(
+      notifyError(
         options.localize("dashboard.serial_connect_failed", {
           error: getErrorMessage(err),
-        }),
-        { richColors: true }
+        })
       );
     }
     createDialog.open("board");

--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -7,7 +7,7 @@ import { withBase } from "../../util/base-path.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { ESPHomeLogParser, isLikelyGarbageLine } from "../../util/esphome-log-parser.js";
-import { notifyError, notifySuccess } from "../../util/notify.js";
+import { notifyError, notifySuccess, type NotifyOptions } from "../../util/notify.js";
 import {
   connectToPort,
   detectChip,
@@ -164,7 +164,7 @@ async function runBulkAction(
     catchAllKey: string;
     successKey: string;
     failureKey: string;
-    successOptions?: Parameters<typeof notifySuccess>[1];
+    successOptions?: NotifyOptions;
   }
 ) {
   let results: BulkActionResult[];

--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -14,7 +14,7 @@ import { consume } from "@lit/context";
 import { mdiClose } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notifyError } from "../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { AutomationLocation, AutomationTree } from "../../api/types/automations.js";
@@ -270,9 +270,8 @@ export class ESPHomeAddApiActionDialog extends LitElement {
           ? err.message
           : this._localize("device.automation_save_error");
       this._error = msg;
-      toast.error(this._localize("device.automation_save_error"), {
+      notifyError(this._localize("device.automation_save_error"), {
         description: msg,
-        richColors: true,
       });
     } finally {
       this._saving = false;

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -20,7 +20,7 @@
 import { consume } from "@lit/context";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notifyError } from "../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../api/index.js";
 import type {
@@ -477,9 +477,8 @@ export class ESPHomeAddAutomationDialog extends LitElement {
           ? err.message
           : this._localize("device.automation_save_error");
       this._error = msg;
-      toast.error(this._localize("device.automation_save_error"), {
+      notifyError(this._localize("device.automation_save_error"), {
         description: msg,
-        richColors: true,
       });
     } finally {
       this._saving = false;

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -2,7 +2,6 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiClose, mdiPackageVariantClosed } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, FeaturedBundle } from "../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../api/types/components.js";
@@ -15,6 +14,7 @@ import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { collectExistingIds } from "../../util/default-component-id.js";
 import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
 import { formatApiError } from "../../util/format-api-error.js";
+import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { findAddedSection } from "../../util/yaml-sections.js";
 import { parseTopLevelComponents } from "../../util/yaml-serialize.js";
@@ -657,7 +657,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       const message = addedAny
         ? this._localize("device.bundle_added", { name: bundle.name })
         : this._localize("device.bundle_already_present", { name: bundle.name });
-      toast.success(message, { richColors: true });
+      notifySuccess(message);
     } catch (err) {
       // A member failed mid-batch: publish what merged so far so the host keeps
       // the already-added members (the draft is otherwise only published on the
@@ -668,7 +668,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         this._localize,
         "device.add_component_error"
       );
-      toast.error(this._submitError, { richColors: true });
+      notifyError(this._submitError);
     } finally {
       this._submitting = false;
     }
@@ -877,9 +877,8 @@ export class ESPHomeAddComponentDialog extends LitElement {
         // Configless add skipped the form, so the close is the only
         // signal the add happened — toast to confirm.
         if (notify) {
-          toast.success(
-            this._localize("device.component_added", { name: componentName }),
-            { richColors: true }
+          notifySuccess(
+            this._localize("device.component_added", { name: componentName })
           );
         }
       }
@@ -893,7 +892,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
       // would land in an otherwise-empty form view where it's easy to
       // miss — toast it too so the failure can't read as a silent no-op.
       if (notify) {
-        toast.error(this._submitError, { richColors: true });
+        notifyError(this._submitError);
       }
     } finally {
       this._submitting = false;

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -18,7 +18,7 @@ import { consume } from "@lit/context";
 import { mdiClose } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notifyError } from "../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../api/index.js";
 import type {
@@ -290,9 +290,8 @@ export class ESPHomeAddScriptDialog extends LitElement {
           ? err.message
           : this._localize("device.automation_save_error");
       this._error = msg;
-      toast.error(this._localize("device.automation_save_error"), {
+      notifyError(this._localize("device.automation_save_error"), {
         description: msg,
-        richColors: true,
       });
     } finally {
       this._saving = false;

--- a/src/components/device/automation-editor/auto-apply-controller.ts
+++ b/src/components/device/automation-editor/auto-apply-controller.ts
@@ -1,5 +1,4 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import toast from "sonner-js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
@@ -7,6 +6,7 @@ import type {
   AutomationTree,
 } from "../../../api/types/automations.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
+import { notifyError } from "../../../util/notify.js";
 import { applyYamlDiff, emptyAutomationTree } from "./serialise.js";
 
 /** Debounce window between a value change and the auto-apply upsert.
@@ -316,9 +316,8 @@ export class AutoApplyController implements ReactiveController {
     const msg =
       err instanceof Error ? err.message : localize("device.automation_save_error");
     this._options.setError(msg);
-    toast.error(localize("device.automation_save_error"), {
+    notifyError(localize("device.automation_save_error"), {
       description: msg,
-      richColors: true,
     });
   }
 

--- a/src/components/device/automation-editor/hydrate-available-bodies.ts
+++ b/src/components/device/automation-editor/hydrate-available-bodies.ts
@@ -1,4 +1,4 @@
-import toast from "sonner-js";
+import { notifyError } from "../../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
@@ -151,9 +151,7 @@ export function resolveLoadedAvailable(
   const { missingBody, missingField, rejected } = outcome.hydration;
   const failures = missingBody + missingField + rejected;
   if (failures > 0) {
-    toast.error(localize("device.automation_partial_hydration", { count: failures }), {
-      richColors: true,
-    });
+    notifyError(localize("device.automation_partial_hydration", { count: failures }));
   }
   return { available: outcome.available };
 }

--- a/src/components/device/device-section-config.ts
+++ b/src/components/device/device-section-config.ts
@@ -10,7 +10,6 @@ import {
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -27,6 +26,7 @@ import { defaultBoardImageUrl, onBoardImageError } from "../../util/board-image.
 import { pathIsAdvanced } from "../../util/config-entry-tree.js";
 import type { ValidationError } from "../../util/config-validation.js";
 import { renderMarkdown } from "../../util/markdown.js";
+import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { resolveSectionEntries } from "../../util/section-entry-overrides.js";
 import { parseYamlAutomations, type YamlSection } from "../../util/yaml-sections.js";
@@ -685,9 +685,8 @@ export class ESPHomeDeviceSectionConfig extends LitElement {
         err instanceof Error
           ? err.message
           : this._localize("device.automation_save_error");
-      toast.error(this._localize("device.automation_save_error"), {
+      notifyError(this._localize("device.automation_save_error"), {
         description: msg,
-        richColors: true,
       });
     } finally {
       this._deletingRow = "";

--- a/src/components/device/device-section-config/draft-and-delete.ts
+++ b/src/components/device/device-section-config/draft-and-delete.ts
@@ -1,6 +1,6 @@
-import toast from "sonner-js";
 import { validateEntries } from "../../../util/config-validation.js";
 import { setIn } from "../../../util/nested-values.js";
+import { notifySuccess } from "../../../util/notify.js";
 import {
   KEEP_EMPTY_STRING_SECTIONS,
   resolveSectionEntries,
@@ -137,9 +137,7 @@ export async function onDeleteConfirmed(host: ESPHomeDeviceSectionConfig): Promi
         composed: true,
       })
     );
-    toast.success(host._localize("device.section_deleted", { name: title }), {
-      richColors: true,
-    });
+    notifySuccess(host._localize("device.section_deleted", { name: title }));
   } catch (e) {
     host._error =
       e instanceof Error ? e.message : host._localize("device.section_delete_error");

--- a/src/components/device/secret-picker.ts
+++ b/src/components/device/secret-picker.ts
@@ -18,13 +18,13 @@ import {
 } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, devicesContext, localizeContext } from "../../context/index.js";
 import { ensureSecretWithToast } from "../../util/ensure-secret-with-toast.js";
 import { navigate } from "../../util/navigation.js";
+import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { secretValueFromYaml, visibleSecretKeys } from "../../util/secret-eligibility.js";
 import {
@@ -452,9 +452,7 @@ export class ESPHomeSecretPicker extends LitElement {
     } catch {
       // Keep the `!secret` reference rather than replacing it with a blank
       // literal a save would persist as an empty credential; surface the error.
-      toast.error(this._localize("device.secret_picker_manual_error"), {
-        richColors: true,
-      });
+      notifyError(this._localize("device.secret_picker_manual_error"));
     }
   }
 

--- a/src/components/device/secret-value.ts
+++ b/src/components/device/secret-value.ts
@@ -10,7 +10,6 @@ import { consume } from "@lit/context";
 import { mdiAlert, mdiContentCopy } from "@mdi/js";
 import { css, html, LitElement, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
@@ -19,6 +18,7 @@ import {
   ensureSecretWithToast,
   setSecretWithToast,
 } from "../../util/ensure-secret-with-toast.js";
+import { notifyError, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { isSharedSecret, secretValueFromYaml } from "../../util/secret-eligibility.js";
 import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
@@ -332,9 +332,7 @@ export class ESPHomeSecretValue extends LitElement {
       value = secretValueFromYaml(yaml, this.secretKey);
     } catch {
       failed = true;
-      toast.error(this._localize("device.secret_picker_reveal_error"), {
-        richColors: true,
-      });
+      notifyError(this._localize("device.secret_picker_reveal_error"));
     }
     // A newer load (or target change) superseded this one — it now owns
     // `_loading`, so don't clear it or apply this stale result.
@@ -358,7 +356,7 @@ export class ESPHomeSecretValue extends LitElement {
 
   private _copy = async (): Promise<void> => {
     if (await copyToClipboard(this._draftValue)) {
-      toast.success(this._localize("device.secret_reveal_copied"), { richColors: true });
+      notifySuccess(this._localize("device.secret_reveal_copied"));
     }
   };
 

--- a/src/components/device/security-notice.ts
+++ b/src/components/device/security-notice.ts
@@ -18,7 +18,6 @@ import { consume } from "@lit/context";
 import { mdiLockAlert } from "@mdi/js";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -26,6 +25,7 @@ import { apiContext, devicesContext, localizeContext } from "../../context/index
 import { espHomeStyles } from "../../styles/shared.js";
 import { generateApiEncryptionKey } from "../../util/api-encryption-key.js";
 import { resolveDeviceName } from "../../util/device-name.js";
+import { notifyError, notifySuccess } from "../../util/notify.js";
 import { generatePassphrase } from "../../util/passphrase.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { recommendedSecretKeys } from "../../util/secret-eligibility.js";
@@ -239,14 +239,12 @@ export class ESPHomeSecurityNotice extends LitElement {
           composed: true,
         })
       );
-      toast.success(this._localize("device.security_applied"), { richColors: true });
+      notifySuccess(this._localize("device.security_applied"));
     } catch (err) {
       // ensureSecretInYaml aborts (throws) on a read failure rather than
       // clobbering secrets.yaml; log the cause and leave the config untouched.
       console.error("Security secret generation failed", err);
-      toast.error(this._localize(`device.${setting.copyPrefix}_error`), {
-        richColors: true,
-      });
+      notifyError(this._localize(`device.${setting.copyPrefix}_error`));
     } finally {
       this._generating = false;
     }

--- a/src/components/labels/bulk-labels-dialog.ts
+++ b/src/components/labels/bulk-labels-dialog.ts
@@ -24,7 +24,6 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import memoizeOne from "memoize-one";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { ConfiguredDevice, Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -38,6 +37,7 @@ import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js"
 import { dialogChromeStyles } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { labelChipStyles, renderLabelChip } from "../../util/label-chip-template.js";
+import { notifyError, notifyInfo, notifySuccess } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import "../base-dialog.js";
 import { labelsListStyles } from "./labels-list-styles.js";
@@ -488,9 +488,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
       // reconcile dropped the last remaining entry). Acknowledge
       // the click with an info toast so the dialog vanishing
       // doesn't read as a failed action, then clear pending state.
-      toast.info(this._localize("dashboard.labels_bulk_no_changes"), {
-        richColors: true,
-      });
+      notifyInfo(this._localize("dashboard.labels_bulk_no_changes"));
       this._pendingChanges = new Map();
       this._failedConfigurations = null;
       this.close();
@@ -513,9 +511,7 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
       if (gen !== this._applyGeneration) return;
       const failures = results.filter((r) => !r.success);
       if (failures.length === 0) {
-        toast.success(this._localize("dashboard.labels_bulk_saved", { count }), {
-          richColors: true,
-        });
+        notifySuccess(this._localize("dashboard.labels_bulk_saved", { count }));
         // Full success clears the retry-narrow filter so a future
         // re-open via the bulk button would target the whole new
         // selection rather than the previous failure subset.
@@ -546,24 +542,20 @@ export class ESPHomeBulkLabelsDialog extends LitElement {
         // the user is seeing.
         const succeeded = count - failures.length;
         if (succeeded > 0) {
-          toast.success(
-            this._localize("dashboard.labels_bulk_saved", { count: succeeded }),
-            { richColors: true }
+          notifySuccess(
+            this._localize("dashboard.labels_bulk_saved", { count: succeeded })
           );
         }
-        toast.error(
+        notifyError(
           this._localize("dashboard.labels_bulk_save_failed", {
             count: failures.length,
-          }),
-          { richColors: true }
+          })
         );
       }
     } catch (err) {
       if (gen !== this._applyGeneration) return;
       console.warn("set_labels_bulk failed", err);
-      toast.error(this._localize("dashboard.labels_bulk_save_failed", { count }), {
-        richColors: true,
-      });
+      notifyError(this._localize("dashboard.labels_bulk_save_failed", { count }));
     } finally {
       // Only clear ``_saving`` if we're still the active session —
       // a generation bump means a new ``open()`` call already reset

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -27,7 +27,6 @@ import { consume } from "@lit/context";
 import { mdiCheck, mdiClose, mdiPencil, mdiTagMultiple } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { ConfiguredDevice, Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -43,6 +42,7 @@ import {
   resolveLabelIds,
 } from "../../util/label-chip-template.js";
 import { labelChipStyleString } from "../../util/label-style.js";
+import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import "./label-form.js";
 import type { ESPHomeLabelForm } from "./label-form.js";
@@ -398,9 +398,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
         await api.setDeviceLabels(config, nextIds);
       } catch (err) {
         console.warn("set_labels failed", err);
-        toast.error(this._localize("dashboard.labels_save_failed"), {
-          richColors: true,
-        });
+        notifyError(this._localize("dashboard.labels_save_failed"));
       }
     });
     this._saveChain = task;

--- a/src/components/labels/label-form.ts
+++ b/src/components/labels/label-form.ts
@@ -24,7 +24,6 @@ import { consume } from "@lit/context";
 import { mdiCheck, mdiPlus } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { Label } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -38,6 +37,7 @@ import {
   labelChipStyleString,
 } from "../../util/label-style.js";
 import { isLabelNameDuplicate } from "../../util/label-usage.js";
+import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { labelFormStyles } from "./label-form.styles.js";
 
@@ -521,11 +521,10 @@ export class ESPHomeLabelForm extends LitElement {
       }
     } catch (err) {
       console.warn(editing ? "label update failed" : "label create failed", err);
-      toast.error(
+      notifyError(
         this._localize(
           editing ? "dashboard.labels_update_failed" : "dashboard.labels_create_failed"
-        ),
-        { richColors: true }
+        )
       );
     } finally {
       this._saving = false;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -13,7 +13,6 @@ import {
 } from "@mdi/js";
 import { LitElement, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
@@ -21,6 +20,7 @@ import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
+import { notifyError } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { logsDialogStyles } from "./logs-dialog.styles.js";
 import {
@@ -483,9 +483,7 @@ export class ESPHomeLogsDialog extends LitElement {
       // don't double-toast.
       if (this._session.kind !== "reconnecting") return;
       this._session = { kind: "dead" };
-      toast.error(this._localize("dashboard.logs_web_serial_open_failed"), {
-        richColors: true,
-      });
+      notifyError(this._localize("dashboard.logs_web_serial_open_failed"));
     });
   }
 
@@ -577,7 +575,7 @@ export class ESPHomeLogsDialog extends LitElement {
     } catch {
       // setSignals fails if the cable was pulled; tell the user the reset didn't
       // land rather than letting them assume the device rebooted.
-      toast.error(this._localize("dashboard.logs_reset_failed"), { richColors: true });
+      notifyError(this._localize("dashboard.logs_reset_failed"));
     }
   };
 

--- a/src/components/onboarding/onboarding-wizard-dialog.ts
+++ b/src/components/onboarding/onboarding-wizard-dialog.ts
@@ -8,7 +8,6 @@ import {
 } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import { ExperienceLevel } from "../../api/types/system.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -18,6 +17,7 @@ import { espHomeStyles } from "../../styles/shared.js";
 import { EnterController } from "../../util/enter-controller.js";
 import { EXPERIENCE_OPTIONS } from "../../util/experience.js";
 import { formatApiError } from "../../util/format-api-error.js";
+import { notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { choiceCardStyles } from "./choice-card-styles.js";
 import { onChoiceGroupKeydown, renderChoiceCard, rovingTabbable } from "./choice-card.js";
@@ -321,7 +321,7 @@ export class ESPHomeOnboardingWizardDialog extends LitElement {
     } catch (err) {
       // Prefs already landed; a failed ack only re-pops the wizard next load.
       console.warn("Failed to mark onboarding acknowledged:", err);
-      toast.warning(this._localize("onboarding.wizard.ack_failed"), { richColors: true });
+      notifyWarning(this._localize("onboarding.wizard.ack_failed"));
     }
     this._exitedExplicitly = true;
     this._emitAcknowledged();

--- a/src/components/secrets/secrets-structured-editor.ts
+++ b/src/components/secrets/secrets-structured-editor.ts
@@ -8,7 +8,6 @@ import { mdiAlertCircleOutline, mdiClose, mdiPlus } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
-import toast from "sonner-js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { devicesContext, localizeContext } from "../../context/index.js";
@@ -17,6 +16,7 @@ import { modalDialogStyles } from "../../styles/modal-dialog.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { navigate } from "../../util/navigation.js";
+import { notifyError } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { secretHostSlug } from "../../util/secret-eligibility.js";
 import {
@@ -387,7 +387,7 @@ export class ESPHomeSecretsStructuredEditor extends LitElement {
   // edit is visible rather than a silent no-op.
   private _emit(value: string | null) {
     if (value === null) {
-      toast.error(this._localize("secrets.edit_out_of_sync"), { richColors: true });
+      notifyError(this._localize("secrets.edit_out_of_sync"));
       this.requestUpdate();
       return;
     }

--- a/src/components/settings-dialog/build-offload-section.ts
+++ b/src/components/settings-dialog/build-offload-section.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { mdiDelete, mdiLanConnect, mdiPencil } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notify, notifyError, notifySuccess } from "../../util/notify.js";
 
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
 import type { VersionMatchPolicy } from "../../api/types/event-subscription.js";
@@ -441,19 +441,17 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     // preview_pair and re-opens the wizard with the new
     // observed pin).
     if (e.detail.outcome === "success") {
-      toast.success(
+      notifySuccess(
         this._localize("settings.reauth_repair_success", {
           label: e.detail.receiver_label,
-        }),
-        { richColors: true }
+        })
       );
       return;
     }
-    toast.error(
+    notifyError(
       this._localize("settings.reauth_repair_pin_changed", {
         label: e.detail.receiver_label,
-      }),
-      { richColors: true }
+      })
     );
   };
 
@@ -534,7 +532,7 @@ export class ESPHomeSettingsBuildOffload extends LitElement {
     key: string,
     values?: Record<string, string | number>
   ) {
-    toast[level](this._localize(key, values), { richColors: true });
+    notify[level](this._localize(key, values));
   }
 }
 

--- a/src/components/settings-dialog/build-server-section.ts
+++ b/src/components/settings-dialog/build-server-section.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { mdiClose } from "@mdi/js";
 import { LitElement, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notify } from "../../util/notify.js";
 
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
@@ -401,7 +401,7 @@ export class ESPHomeSettingsBuildServer extends LitElement {
     key: string,
     values?: Record<string, string | number>
   ) {
-    toast[level](this._localize(key, values), { richColors: true });
+    notify[level](this._localize(key, values));
   }
 
   private _onToggleEnabled() {

--- a/src/components/settings-dialog/pairing-requests-section.ts
+++ b/src/components/settings-dialog/pairing-requests-section.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import { LitElement, html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
+import { notify } from "../../util/notify.js";
 
 import { APIError } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/esphome-api.js";
@@ -286,7 +286,7 @@ export class ESPHomeSettingsPairingRequests extends LitElement {
     key: string,
     values?: Record<string, string | number>
   ) {
-    toast[level](this._localize(key, values), { richColors: true });
+    notify[level](this._localize(key, values));
   }
 }
 

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -2,7 +2,6 @@ import { consume } from "@lit/context";
 import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import { apiErrorDetails } from "../../api/api-error.js";
 import type { ESPHomeAPI } from "../../api/index.js";
 import type { BoardCatalogEntry, SlimBoard } from "../../api/types/boards.js";
@@ -16,6 +15,7 @@ import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
 import { buildFeaturedId } from "../../util/featured-id.js";
 import { featuredComponentName, fullSetupComponentIds } from "../../util/full-setup.js";
 import { markJustCreated } from "../../util/just-created.js";
+import { notifyWarning } from "../../util/notify.js";
 import { markPendingHighlight } from "../../util/pending-highlight.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import {
@@ -599,7 +599,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     // recommended components need finishing, capped so the toast stays short.
     if (skipped.length > 0) {
       const shown = 3;
-      toast.warning(
+      notifyWarning(
         this._localize("wizard.full_setup_partial", {
           // count drives the singular/plural wording; names/extra list the
           // skipped components, capped. Older count-only Lokalise strings
@@ -607,8 +607,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
           count: skipped.length,
           names: skipped.slice(0, shown).join(", "),
           extra: Math.max(0, skipped.length - shown),
-        }),
-        { richColors: true }
+        })
       );
     }
   }

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -15,7 +15,6 @@ import type { SortingState, VisibilityState } from "@tanstack/lit-table";
 import { LitElement, html, type PropertyValues } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { AdoptableDevice, ConfiguredDevice, Label } from "../api/types/devices.js";
 import type { FirmwareJob } from "../api/types/firmware-jobs.js";
@@ -115,6 +114,7 @@ import { DEVICE_SORT_COLLATOR, deviceSortKey } from "../util/device-sort.js";
 import { normalizeUpdateBuckets } from "../util/facets.js";
 import { computeLabelUsage } from "../util/label-usage.js";
 import { navigate } from "../util/navigation.js";
+import { notifyInfo } from "../util/notify.js";
 import { consumePendingHighlight } from "../util/pending-highlight.js";
 import { consumePendingSerialSetup } from "../util/pending-serial-setup.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -938,7 +938,7 @@ export class ESPHomePageDashboard extends LitElement {
 
   _deleteSelected = () => {
     if (this._selectedDevices.size === 0) {
-      toast.info(this._localize("dashboard.delete_all_none"), { richColors: true });
+      notifyInfo(this._localize("dashboard.delete_all_none"));
       return;
     }
     this._openConfirm({ kind: "delete-bulk" });
@@ -946,7 +946,7 @@ export class ESPHomePageDashboard extends LitElement {
 
   _archiveSelected = () => {
     if (this._selectedDevices.size === 0) {
-      toast.info(this._localize("dashboard.archive_all_none"), { richColors: true });
+      notifyInfo(this._localize("dashboard.archive_all_none"));
       return;
     }
     this._openConfirm({ kind: "archive-bulk" });

--- a/src/pages/device.ts
+++ b/src/pages/device.ts
@@ -3,7 +3,6 @@ import { mdiArrowLeft, mdiChevronRight, mdiMenu } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { BoardCatalogEntry } from "../api/types/boards.js";
 import type { ConfiguredDevice } from "../api/types/devices.js";
@@ -12,6 +11,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import type { ESPHomeCommandDialog } from "../components/command-dialog.js";
 import type { NavSectionName } from "../components/device/device-board-info.js";
 import type { DeviceLayoutMode } from "../components/device/device-editor.js";
+import { notifyError, notifySuccess } from "../util/notify.js";
 // `NavSectionName` is consumed by the section-show event handler; the
 // page itself doesn't pass it down anymore now that the step CTAs
 // always render.
@@ -573,7 +573,7 @@ export class ESPHomePageDevice extends LitElement {
     if (!boardId || !device || boardId === device.board_id) return;
     // Reloading YAML after the swap would discard unsaved edits.
     if (this._isDirty) {
-      toast.error(this._localize("device.change_board_unsaved"), { richColors: true });
+      notifyError(this._localize("device.change_board_unsaved"));
       return;
     }
     try {
@@ -582,10 +582,10 @@ export class ESPHomePageDevice extends LitElement {
         board_id: boardId,
       });
       await this._loadYaml();
-      toast.success(this._localize("device.change_board_success"), { richColors: true });
+      notifySuccess(this._localize("device.change_board_success"));
     } catch (err) {
       console.error("Failed to change board:", err);
-      toast.error(this._localize("device.change_board_error"), { richColors: true });
+      notifyError(this._localize("device.change_board_error"));
     }
   };
 
@@ -870,8 +870,8 @@ export class ESPHomePageDevice extends LitElement {
       this._setHighlight(null, false);
     }
     const message = saved ? "device.yaml_saved" : "device.yaml_save_error";
-    const variant = saved ? toast.success : toast.error;
-    variant(this._localize(message), { richColors: true });
+    const variant = saved ? notifySuccess : notifyError;
+    variant(this._localize(message));
     return saved;
   };
 
@@ -940,7 +940,7 @@ export class ESPHomePageDevice extends LitElement {
       // _saveYaml rejects when a section editor's flushPending upsert fails;
       // surface it and abort rather than leak an unhandled rejection.
       console.error("Failed to save before install:", e);
-      toast.error(this._localize("device.yaml_save_error"), { richColors: true });
+      notifyError(this._localize("device.yaml_save_error"));
       return;
     }
     if (saved) run();

--- a/src/pages/secrets.ts
+++ b/src/pages/secrets.ts
@@ -8,7 +8,6 @@ import {
 } from "@mdi/js";
 import { html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import toast from "sonner-js";
 import { apiErrorDetails } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
 import type { LocalizeFunc } from "../common/localize.js";
@@ -23,6 +22,7 @@ import {
   type SecretsLayout,
 } from "../util/editor-layout.js";
 import { setLeaveGuard } from "../util/navigation.js";
+import { notifyError, notifySuccess } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import { SaveShortcutController } from "../util/save-shortcut-controller.js";
 import { parseSecretsEntries } from "../util/secrets-entries.js";
@@ -452,13 +452,11 @@ export class ESPHomePageSecrets extends LitElement {
       );
     }
     if (saved) {
-      toast.success(this._localize("secrets.saved"), { richColors: true });
+      notifySuccess(this._localize("secrets.saved"));
       return true;
     }
     const base = this._localize("secrets.save_error");
-    toast.error(errorDetail ? `${base}: ${errorDetail}` : base, {
-      richColors: true,
-    });
+    notifyError(errorDetail ? `${base}: ${errorDetail}` : base);
     return false;
   }
 }

--- a/src/util/bulk-update.ts
+++ b/src/util/bulk-update.ts
@@ -1,4 +1,4 @@
-import toast from "sonner-js";
+import { notifyError, notifyInfo } from "./notify.js";
 
 import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
@@ -26,13 +26,10 @@ export async function runBulkUpdate(
   ctx: BulkUpdateContext
 ): Promise<void> {
   if (configurations.length === 0) {
-    toast.info(ctx.localize("layout.update_all_none"), { richColors: true });
+    notifyInfo(ctx.localize("layout.update_all_none"));
     return;
   }
-  toast.info(
-    ctx.localize("layout.update_all_started", { count: configurations.length }),
-    { richColors: true }
-  );
+  notifyInfo(ctx.localize("layout.update_all_started", { count: configurations.length }));
   try {
     await ctx.api.firmwareInstallBulk(configurations);
   } catch (err) {
@@ -45,14 +42,13 @@ export async function runBulkUpdate(
       // ``{local}`` placeholder and misattribute the bucket; fall through
       // to the generic toast.
       const reason = classifyNoCompatiblePeerReason(ctx.pairings, ctx.appVersion);
-      toast.error(
+      notifyError(
         ctx.localize(`layout.update_all_no_compatible_peer_${reason}`, {
           local: ctx.appVersion,
-        }),
-        { richColors: true }
+        })
       );
     } else {
-      toast.error(ctx.localize("layout.update_all_error"), { richColors: true });
+      notifyError(ctx.localize("layout.update_all_error"));
     }
   }
 }

--- a/src/util/ensure-secret-with-toast.ts
+++ b/src/util/ensure-secret-with-toast.ts
@@ -1,6 +1,6 @@
-import toast from "sonner-js";
 import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { LocalizeFunc } from "../common/localize.js";
+import { notify, notifyError, notifySuccess } from "./notify.js";
 import { refreshSecretKeys } from "./secrets-cache.js";
 import { ensureSecretInYaml, setSecretInYaml } from "./secrets-write.js";
 
@@ -25,7 +25,7 @@ async function writeWithToast(
     return true;
   } catch (err) {
     console.error(logLabel, err);
-    toast.error(localize(errorKey), { richColors: true });
+    notifyError(localize(errorKey));
     return false;
   }
 }
@@ -41,9 +41,8 @@ export function ensureSecretWithToast(
 ): Promise<boolean> {
   return writeWithToast(api, messages.errorKey, messages.logLabel, localize, async () => {
     const { created } = await ensureSecretInYaml(api, key, value);
-    toast[created ? "success" : "info"](
-      localize(created ? messages.createdKey : "device.secret_picker_linked", { key }),
-      { richColors: true }
+    notify[created ? "success" : "info"](
+      localize(created ? messages.createdKey : "device.secret_picker_linked", { key })
     );
   });
 }
@@ -58,6 +57,6 @@ export function setSecretWithToast(
 ): Promise<boolean> {
   return writeWithToast(api, messages.errorKey, messages.logLabel, localize, async () => {
     await setSecretInYaml(api, key, value);
-    toast.success(localize(messages.savedKey, { key }), { richColors: true });
+    notifySuccess(localize(messages.savedKey, { key }));
   });
 }

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -2,7 +2,9 @@ import toast from "sonner-js";
 
 // sonner-js doesn't export its options type; derive it from the
 // method signature so the wrappers stay in lockstep with the lib.
-type NotifyOptions = NonNullable<Parameters<typeof toast.error>[1]>;
+// Exported so callers can name the passthrough-options type
+// directly instead of reaching through a wrapper's signature.
+export type NotifyOptions = NonNullable<Parameters<typeof toast.error>[1]>;
 
 /**
  * Thin wrappers over sonner's toast helpers that default

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -1,0 +1,35 @@
+import toast from "sonner-js";
+
+// sonner-js doesn't export its options type; derive it from the
+// method signature so the wrappers stay in lockstep with the lib.
+type NotifyOptions = NonNullable<Parameters<typeof toast.error>[1]>;
+
+/**
+ * Thin wrappers over sonner's toast helpers that default
+ * `richColors: true`, the house style for every user-readable
+ * toast. All other sonner options pass through unchanged (an
+ * explicit `richColors` in `options` still wins).
+ */
+export const notifyError = (message: string, options?: NotifyOptions): string | number =>
+  toast.error(message, { richColors: true, ...options });
+
+export const notifyInfo = (message: string, options?: NotifyOptions): string | number =>
+  toast.info(message, { richColors: true, ...options });
+
+export const notifySuccess = (
+  message: string,
+  options?: NotifyOptions
+): string | number => toast.success(message, { richColors: true, ...options });
+
+export const notifyWarning = (
+  message: string,
+  options?: NotifyOptions
+): string | number => toast.warning(message, { richColors: true, ...options });
+
+/** Severity-indexed dispatch for call sites that pick the level at runtime. */
+export const notify = {
+  error: notifyError,
+  info: notifyInfo,
+  success: notifySuccess,
+  warning: notifyWarning,
+} as const;

--- a/src/util/post-install-logs.ts
+++ b/src/util/post-install-logs.ts
@@ -1,9 +1,9 @@
-import toast from "sonner-js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { streamSerialToDialog } from "../components/dashboard/actions.js";
 import type { ESPHomeLogsDialog } from "../components/logs-dialog.js";
 import { OTA_PORT } from "../components/logs-session.js";
 import { resolveLogBaudRate } from "./log-baud-rate.js";
+import { notifyError } from "./notify.js";
 import { isPortPickerCancel, SERIAL_ACTIVITY_WINDOW_MS } from "./web-serial.js";
 
 // Reopen budget for a port closed by the post-install reset: covers the
@@ -68,7 +68,7 @@ export async function reconnectWebSerialLogs(
   } catch {
     const message = localize("dashboard.logs_web_serial_open_failed");
     logsDialog.setSerialOpenFailed(message);
-    toast.error(message, { richColors: true });
+    notifyError(message);
     return;
   }
   if (!port) {
@@ -256,7 +256,7 @@ export async function attachSerialLogStream(
         port: formatSerialPortLabel(port),
       });
       logsDialog.setSerialOpenFailed(message);
-      toast.error(message, { richColors: true });
+      notifyError(message);
       return;
     }
     port = live;
@@ -285,7 +285,7 @@ export async function handlePostInstallShowLogs(
     const baudRate = resolveLogBaudRate(loggerBaudRate);
     if (baudRate === null) {
       // logger: baud_rate: 0 — UART logging disabled; the port would be silent.
-      toast.error(localize("dashboard.logs_serial_disabled"), { richColors: true });
+      notifyError(localize("dashboard.logs_serial_disabled"));
       return;
     }
     logsDialog.openPassive({

--- a/test/util/notify.test.ts
+++ b/test/util/notify.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner-js", () => ({
+  default: {
+    error: vi.fn(() => "error-id"),
+    info: vi.fn(() => "info-id"),
+    success: vi.fn(() => "success-id"),
+    warning: vi.fn(() => "warning-id"),
+  },
+}));
+
+import toast from "sonner-js";
+import {
+  notify,
+  notifyError,
+  notifyInfo,
+  notifySuccess,
+  notifyWarning,
+} from "../../src/util/notify.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("notify wrappers", () => {
+  it.each([
+    ["error", notifyError, toast.error] as const,
+    ["info", notifyInfo, toast.info] as const,
+    ["success", notifySuccess, toast.success] as const,
+    ["warning", notifyWarning, toast.warning] as const,
+  ])("notify %s defaults richColors and forwards the id", (level, wrapper, method) => {
+    const id = wrapper("hello");
+    expect(method).toHaveBeenCalledWith("hello", { richColors: true });
+    expect(id).toBe(`${level}-id`);
+  });
+
+  it("passes through the remaining sonner options", () => {
+    const onClick = () => undefined;
+    notifyError("boom", {
+      description: "details",
+      duration: 8000,
+      id: "stable-id",
+      action: { label: "Retry", onClick },
+    });
+    expect(toast.error).toHaveBeenCalledWith("boom", {
+      richColors: true,
+      description: "details",
+      duration: 8000,
+      id: "stable-id",
+      action: { label: "Retry", onClick },
+    });
+  });
+
+  it("lets an explicit richColors override the default", () => {
+    notifyInfo("plain", { richColors: false });
+    expect(toast.info).toHaveBeenCalledWith("plain", { richColors: false });
+  });
+
+  it("dispatches by level through the notify map", () => {
+    notify.warning("careful");
+    expect(toast.warning).toHaveBeenCalledWith("careful", { richColors: true });
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds `src/util/notify.ts` with `notifyError` / `notifyInfo` / `notifySuccess` / `notifyWarning` wrappers that default `richColors: true`, plus a `notify` map for the call sites that pick the severity at runtime. Migrates all ~95 toast call sites that were passing `richColors: true` by hand, preserving every other option; toast calls that never set `richColors` are left untouched so their behaviour does not change.

**Related issue or feature (if applicable):**

- fixes #1093

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
