### PR TITLE
Use the shared dialogActionButtonStyles in eight components

### DIFF
--- a/src/components/adopt-dialog.ts
+++ b/src/components/adopt-dialog.ts
@@ -5,7 +5,10 @@ import type { ESPHomeAPI } from "../api/esphome-api.js";
 import type { AdoptableDevice } from "../api/types/devices.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
-import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -57,6 +60,7 @@ export class ESPHomeAdoptDialog extends LitElement {
     // spacing wins; only `.field-label` / `.error` (unique here) apply.
     wifiFieldsStyles,
     dialogActionsRowStyles,
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -176,39 +180,16 @@ export class ESPHomeAdoptDialog extends LitElement {
         color: var(--wa-color-text-quiet);
       }
 
-      .btn {
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
-        transition: background 0.12s;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
-      }
-
+      /* Adoption's commit affordance is success-green rather than the
+         standard primary tint (dialogActionButtonStyles); per that
+         module's guidance, divergent colour intents stay local. This
+         block sits after the shared fragment so it wins the cascade. */
       .btn--primary {
         background: var(--esphome-success);
-        color: var(--esphome-on-primary);
       }
 
       .btn--primary:hover:not(:disabled) {
         background: color-mix(in srgb, var(--esphome-success), black 10%);
-      }
-
-      .btn--primary:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
       }
 
       .field-error {

--- a/src/components/archived-devices-dialog.ts
+++ b/src/components/archived-devices-dialog.ts
@@ -6,6 +6,7 @@ import type { ESPHomeAPI } from "../api/index.js";
 import type { ArchivedDevice } from "../api/types/system.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, localizeContext } from "../context/index.js";
+import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getErrorMessage } from "../util/error-message.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -60,6 +61,8 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
 
   static styles = [
     espHomeStyles,
+    // Shared .btn / .btn--cancel chrome for the footer Close button.
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 560px;
@@ -212,26 +215,6 @@ export class ESPHomeArchivedDevicesDialog extends LitElement {
         justify-content: flex-end;
         gap: var(--wa-space-s);
         padding: var(--wa-space-m) var(--wa-space-l) var(--wa-space-l);
-      }
-
-      .btn {
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
       }
     `,
   ];

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -3,7 +3,10 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -56,6 +59,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     dialogChromeStyles,
     quietCloseButtonStyles,
     dialogActionsRowStyles,
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -82,41 +86,6 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
         font-size: var(--wa-font-size-xs);
         color: var(--wa-color-text-quiet);
         margin-top: var(--wa-space-2xs);
-      }
-
-      .btn {
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
-        transition: background 0.12s;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
-      }
-
-      .btn--primary {
-        background: var(--esphome-primary);
-        color: var(--esphome-on-primary);
-      }
-
-      .btn--primary:hover:not(:disabled) {
-        background: var(--esphome-primary-hover);
-      }
-
-      .btn--primary:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
       }
 
       .field-error {

--- a/src/components/device/add-component-form.styles.ts
+++ b/src/components/device/add-component-form.styles.ts
@@ -128,18 +128,16 @@ export const addComponentFormStyles = css`
     padding-top: var(--wa-space-m);
   }
 
+  /* Deltas over the shared .btn chrome (dialogActionButtonStyles,
+     layered before this module in the host's static styles): icon +
+     label sit inline-centred, disabled applies to every variant (this
+     form's variants are .btn-primary / .btn-secondary, not the shared
+     modifier classes), and the opacity change is animated. */
   .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
-    padding: var(--esphome-button-padding);
-    border-radius: var(--wa-border-radius-m);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-    font-family: inherit;
-    cursor: pointer;
-    border: none;
     transition:
       background 0.12s,
       opacity 0.12s;

--- a/src/components/device/add-component-form.ts
+++ b/src/components/device/add-component-form.ts
@@ -10,6 +10,7 @@ import type { ConfigEntry } from "../../api/types/config-entries.js";
 import { ConfigEntryType } from "../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { dialogActionButtonStyles } from "../../styles/dialog-action-buttons.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { ComponentNameResolverController } from "../../util/component-name-resolver-controller.js";
@@ -140,7 +141,14 @@ export class ESPHomeAddComponentForm extends LitElement {
     () => this.board?.esphome.platform || undefined
   );
 
-  static styles = [espHomeStyles, inputStyles, addComponentFormStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    // Shared .btn base chrome; addComponentFormStyles layers this
+    // form's deltas (inline-flex layout, all-variant :disabled) on top.
+    dialogActionButtonStyles,
+    addComponentFormStyles,
+  ];
 
   // Memoized so the shared form's `.entries` identity is render-stable.
   private _overlayRequired = memoizeOne(overlayRequired);

--- a/src/components/device/change-board-dialog.styles.ts
+++ b/src/components/device/change-board-dialog.styles.ts
@@ -77,25 +77,4 @@ export const changeBoardDialogStyles = css`
     font-size: var(--wa-font-size-xs);
     color: var(--wa-color-text-quiet);
   }
-
-  .btn {
-    padding: var(--esphome-button-padding);
-    border-radius: var(--wa-border-radius-m);
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-bold);
-    font-family: inherit;
-    cursor: pointer;
-    border: none;
-    transition: background 0.12s;
-  }
-
-  .btn--cancel {
-    background: var(--wa-color-surface-lowered);
-    color: var(--wa-color-text-normal);
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-  }
-
-  .btn--cancel:hover {
-    background: var(--wa-color-surface-border);
-  }
 `;

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -4,7 +4,10 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { SlimBoard } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
-import { dialogActionsRowStyles } from "../../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../../styles/dialog-action-buttons.js";
 import {
   dialogChromeStyles,
   quietCloseButtonStyles,
@@ -43,6 +46,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
     dialogChromeStyles,
     quietCloseButtonStyles,
     dialogActionsRowStyles,
+    dialogActionButtonStyles,
     changeBoardDialogStyles,
   ];
 

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -3,7 +3,10 @@ import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -60,6 +63,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     // Neutral header + title + footer (shared) — dialog-chrome.ts.
     dialogChromeStyles,
     dialogActionsRowStyles,
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -98,41 +102,6 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
       .install-row .helper {
         margin-top: 0;
         flex: 1;
-      }
-
-      .btn {
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
-        transition: background 0.12s;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
-      }
-
-      .btn--primary {
-        background: var(--esphome-primary);
-        color: var(--esphome-on-primary);
-      }
-
-      .btn--primary:hover:not(:disabled) {
-        background: var(--esphome-primary-hover);
-      }
-
-      .btn--primary:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
       }
 
       .field-error {

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -3,7 +3,10 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
-import { dialogActionsRowStyles } from "../styles/dialog-action-buttons.js";
+import {
+  dialogActionButtonStyles,
+  dialogActionsRowStyles,
+} from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
@@ -35,6 +38,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     dialogChromeStyles,
     quietCloseButtonStyles,
     dialogActionsRowStyles,
+    dialogActionButtonStyles,
     css`
       esphome-base-dialog {
         --width: 420px;
@@ -55,41 +59,6 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
         font-size: var(--wa-font-size-xs);
         font-weight: var(--wa-font-weight-bold);
         color: var(--wa-color-text-quiet);
-      }
-
-      .btn {
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
-        transition: background 0.12s;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
-      }
-
-      .btn--primary {
-        background: var(--esphome-primary);
-        color: var(--esphome-on-primary);
-      }
-
-      .btn--primary:hover:not(:disabled) {
-        background: var(--esphome-primary-hover);
-      }
-
-      .btn--primary:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
       }
 
       .field-error {

--- a/src/components/select-bar.ts
+++ b/src/components/select-bar.ts
@@ -10,6 +10,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
+import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -41,6 +42,9 @@ export class ESPHomeSelectBar extends LitElement {
 
   static styles = [
     espHomeStyles,
+    // Shared .btn / .btn--cancel / .btn--primary chrome; the local
+    // block below layers the bar-specific deltas on top.
+    dialogActionButtonStyles,
     css`
       @keyframes slide-in {
         from {
@@ -114,17 +118,13 @@ export class ESPHomeSelectBar extends LitElement {
         gap: var(--wa-space-s);
       }
 
+      /* Deltas over the shared .btn chrome: icon + label sit inline,
+         and every variant (not just --primary) greys out while a bulk
+         action is in flight, with the opacity change animated. */
       .btn {
         display: inline-flex;
         align-items: center;
         gap: 6px;
-        padding: var(--esphome-button-padding);
-        border-radius: var(--wa-border-radius-m);
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-bold);
-        font-family: inherit;
-        cursor: pointer;
-        border: none;
         transition:
           background 0.12s,
           opacity 0.12s;
@@ -133,25 +133,6 @@ export class ESPHomeSelectBar extends LitElement {
       .btn:disabled {
         opacity: 0.5;
         cursor: not-allowed;
-      }
-
-      .btn--cancel {
-        background: var(--wa-color-surface-lowered);
-        color: var(--wa-color-text-normal);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-      }
-
-      .btn--cancel:hover {
-        background: var(--wa-color-surface-border);
-      }
-
-      .btn--primary {
-        background: var(--esphome-primary);
-        color: var(--esphome-on-primary);
-      }
-
-      .btn--primary:hover:not(:disabled) {
-        background: var(--esphome-primary-hover);
       }
 
       .btn--danger {


### PR DESCRIPTION
# What does this implement/fix?

Replaces the locally duplicated `.btn` / `.btn--cancel` / `.btn--primary` rules in eight components with the shared `dialogActionButtonStyles` fragment from `src/styles/dialog-action-buttons.ts`. Rules that genuinely differ stay local as overrides layered after the shared fragment; the adopt dialog keeps its green primary, and the select bar and add component form keep their inline flex layout, opacity transition, and whole button disabled treatment. Same shape as the `.actions` footer consolidation in #1081.

**Related issue or feature (if applicable):**

- fixes #1085

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
