### PR TITLE
Extract shared dropdown-menu styles

### DIFF
--- a/src/components/dashboard/table-column-toggle.ts
+++ b/src/components/dashboard/table-column-toggle.ts
@@ -4,6 +4,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 
@@ -31,6 +32,7 @@ export class ESPHomeTableColumnToggle extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dropdownMenuStyles,
     css`
       :host {
         display: block;
@@ -93,23 +95,22 @@ export class ESPHomeTableColumnToggle extends LitElement {
         }
       }
 
+      /* Base popover chrome comes from the shared dropdownMenuStyles
+         fragment; the rules below are this component's deltas and win
+         because this block sits after the shared one in the styles
+         array. This toggle's popover sits below the app dialogs, so
+         its layers use lower z-indexes than the shared 100/101. */
       .backdrop {
-        position: fixed;
-        inset: 0;
         z-index: 40;
       }
 
       .menu {
+        /* Anchored to the toggle button rather than the viewport. */
         position: absolute;
         right: 0;
         top: calc(100% + 4px);
         z-index: 50;
         min-width: 180px;
-        background: var(--wa-color-surface-raised);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        border-radius: var(--wa-border-radius-l);
-        box-shadow: var(--wa-shadow-l);
-        padding: var(--wa-space-xs) 0;
         animation: menu-in 0.15s ease-out;
       }
 
@@ -127,6 +128,10 @@ export class ESPHomeTableColumnToggle extends LitElement {
         }
       }
 
+      /* Redefines the shared menu-in on purpose: this menu slides down
+         from its anchor instead of scaling in. The last @keyframes
+         definition with a given name wins, and this block comes after
+         dropdownMenuStyles in the styles array. */
       @keyframes menu-in {
         from {
           opacity: 0;
@@ -153,20 +158,11 @@ export class ESPHomeTableColumnToggle extends LitElement {
         margin: var(--wa-space-2xs) 0;
       }
 
+      /* Tighter rows than the shared .menu-item: these are compact
+         checkbox rows, not icon-labelled actions. */
       .menu-item {
-        display: flex;
-        align-items: center;
         gap: var(--wa-space-xs);
         padding: 6px var(--wa-space-m);
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-normal);
-        cursor: pointer;
-        transition: background 0.1s;
-        user-select: none;
-      }
-
-      .menu-item:hover {
-        background: var(--esphome-tint);
       }
 
       .checkbox {

--- a/src/components/dashboard/table-row-menu.ts
+++ b/src/components/dashboard/table-row-menu.ts
@@ -22,6 +22,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { ConfiguredDevice } from "../../api/types/devices.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
+import { dropdownMenuStyles } from "../../styles/dropdown-menu.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { EscapeController } from "../../util/escape-controller.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -92,27 +93,17 @@ export class ESPHomeTableRowMenu extends LitElement {
 
   static styles = [
     espHomeStyles,
+    dropdownMenuStyles,
     css`
       :host {
         display: block;
       }
 
-      .backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 100;
-      }
-
+      /* .backdrop / .menu chrome / @keyframes menu-in / .menu-item
+         come from the shared dropdownMenuStyles fragment; only this
+         menu's width and viewport-fit rules are local. */
       .menu {
-        position: fixed;
-        z-index: 101;
         min-width: 170px;
-        background: var(--wa-color-surface-raised);
-        border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        border-radius: var(--wa-border-radius-l);
-        box-shadow: var(--wa-shadow-l);
-        padding: var(--wa-space-xs) 0;
-        animation: menu-in 0.12s ease-out;
         /* This menu has many items; on short / mobile viewports it would
            otherwise run off the bottom of the screen. Cap it to the
            viewport (8px gutter each side, matching the reposition pad)
@@ -121,33 +112,6 @@ export class ESPHomeTableRowMenu extends LitElement {
         max-height: calc(100vh - 16px);
         max-height: calc(100dvh - 16px);
         overflow-y: auto;
-      }
-
-      @keyframes menu-in {
-        from {
-          opacity: 0;
-          transform: scale(0.95);
-        }
-        to {
-          opacity: 1;
-          transform: scale(1);
-        }
-      }
-
-      .menu-item {
-        display: flex;
-        align-items: center;
-        gap: var(--wa-space-s);
-        padding: 8px var(--wa-space-m);
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-normal);
-        cursor: pointer;
-        transition: background 0.1s;
-        user-select: none;
-      }
-
-      .menu-item:hover {
-        background: var(--esphome-tint);
       }
 
       /* The Visit-web-UI item renders as an <a> so the browser

--- a/src/components/esphome-header-actions.styles.ts
+++ b/src/components/esphome-header-actions.styles.ts
@@ -49,49 +49,11 @@ export const headerActionsStyles = css`
     box-shadow: 0 0 0 2px var(--esphome-primary);
   }
 
-  .backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 100;
-  }
-
+  /* .backdrop / .menu chrome / @keyframes menu-in / .menu-item come
+     from the shared dropdownMenuStyles fragment; only the width is
+     local to this menu. */
   .menu {
-    position: fixed;
-    z-index: 101;
     min-width: 220px;
-    background: var(--wa-color-surface-raised);
-    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-    border-radius: var(--wa-border-radius-l);
-    box-shadow: var(--wa-shadow-l);
-    padding: var(--wa-space-xs) 0;
-    animation: menu-in 0.12s ease-out;
-  }
-
-  @keyframes menu-in {
-    from {
-      opacity: 0;
-      transform: scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: scale(1);
-    }
-  }
-
-  .menu-item {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-s);
-    padding: 8px var(--wa-space-m);
-    font-size: var(--wa-font-size-xs);
-    color: var(--wa-color-text-normal);
-    cursor: pointer;
-    transition: background 0.1s;
-    user-select: none;
-  }
-
-  .menu-item:hover {
-    background: var(--esphome-tint);
   }
 
   .menu-item wa-icon {

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -29,6 +29,7 @@ import {
   localizeContext,
   onboardingPendingContext,
 } from "../context/index.js";
+import { dropdownMenuStyles } from "../styles/dropdown-menu.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EscapeController } from "../util/escape-controller.js";
 import { navigate } from "../util/navigation.js";
@@ -128,7 +129,7 @@ export class ESPHomeHeaderActions extends LitElement {
   @state()
   private _desktopUpdateCapable = false;
 
-  static styles = [espHomeStyles, headerActionsStyles];
+  static styles = [espHomeStyles, dropdownMenuStyles, headerActionsStyles];
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/src/styles/dropdown-menu.ts
+++ b/src/styles/dropdown-menu.ts
@@ -1,0 +1,73 @@
+import { css } from "lit";
+
+/**
+ * Shared chrome for the hand-rolled popover menus (header
+ * overflow menu, table row kebab, column toggle).
+ *
+ * Provides:
+ *
+ *   .backdrop           — full-viewport click-away layer under
+ *                         the menu (fixed, inset 0, z-index 100).
+ *   .menu               — the floating panel: raised surface,
+ *                         border, radius, shadow, vertical
+ *                         padding, and the menu-in entrance
+ *                         animation. Positioning (fixed vs
+ *                         absolute) defaults to fixed; width
+ *                         (min-width) is a per-consumer concern
+ *                         and intentionally not set here.
+ *   @keyframes menu-in  — fade + scale entrance.
+ *   .menu-item          — one row: flex, icon gap, padding,
+ *                         hover tint.
+ *
+ * Consumers drop this fragment into their ``static styles``
+ * array BEFORE their local ``css`` block so local rules of equal
+ * specificity (min-width, z-index tweaks, an alternative
+ * ``@keyframes menu-in``) override the shared ones in cascade
+ * order. Item modifiers (--danger, --disabled, --active, icon
+ * colouring) stay in the consumer's local styles.
+ */
+export const dropdownMenuStyles = css`
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+  }
+
+  .menu {
+    position: fixed;
+    z-index: 101;
+    background: var(--wa-color-surface-raised);
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-l);
+    box-shadow: var(--wa-shadow-l);
+    padding: var(--wa-space-xs) 0;
+    animation: menu-in 0.12s ease-out;
+  }
+
+  @keyframes menu-in {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-s);
+    padding: 8px var(--wa-space-m);
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-normal);
+    cursor: pointer;
+    transition: background 0.1s;
+    user-select: none;
+  }
+
+  .menu-item:hover {
+    background: var(--esphome-tint);
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

Extracts the duplicated popover menu CSS (`.backdrop`, `.menu`, `@keyframes menu-in`, `.menu-item`) into a shared `dropdownMenuStyles` fragment in `src/styles/dropdown-menu.ts`, following the pattern of `dialogActionButtonStyles`. The header overflow menu and the table row kebab drop their copies entirely; the column toggle keeps only its true deltas as overrides layered after the shared block, so all three menus look and behave exactly as before.

**Related issue or feature (if applicable):**

- fixes #1087

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
