### PR TITLE
Share the automation-added dispatch helper between add dialogs

### DIFF
--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -29,7 +29,6 @@ import type {
   AutomationTrigger,
   AvailableAutomations,
   AvailableComponentInstance,
-  YamlDiff,
 } from "../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
@@ -45,7 +44,7 @@ import {
   scopeToContainer,
   triggersForComponent,
 } from "./automation-editor/component-targets.js";
-import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
+import { dispatchAutomationAdded } from "./dispatch-automation-added.js";
 
 /** Kinds the wizard can produce. Mirrors a subset of
  *  ``AutomationLocation``'s discriminator. The callable shapes
@@ -469,7 +468,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         location,
         this.yaml
       );
-      this._dispatchAdded(location, yaml_diff);
+      dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
       this._open = false;
     } catch (err) {
       const msg =
@@ -552,30 +551,6 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   private _catalogTriggerId(location: AutomationLocation): string | null {
     if (location.kind === "interval") return null;
     return this._triggerId;
-  }
-
-  private _dispatchAdded(location: AutomationLocation, yamlDiff: YamlDiff) {
-    // Apply the backend-emitted splice to the device's YAML
-    // buffer so the new automation lands in the page's YAML state
-    // (and thus the YAML pane + the global save button see the
-    // change). The page listens to ``yaml-draft`` and advances
-    // ``_yaml`` without touching ``_savedYaml`` — that's the
-    // existing "dirty buffer, click Save to write" path.
-    const newYaml = applyYamlDiff(this.yaml, yamlDiff);
-    this.dispatchEvent(
-      new CustomEvent<{ yaml: string }>("yaml-draft", {
-        detail: { yaml: newYaml },
-        bubbles: true,
-        composed: true,
-      })
-    );
-    this.dispatchEvent(
-      new CustomEvent<{ sectionKey: string }>("automation-added", {
-        detail: { sectionKey: sectionKeyFromLocation(location) },
-        bubbles: true,
-        composed: true,
-      })
-    );
   }
 }
 

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -35,7 +35,7 @@ import { getErrorMessage } from "../../util/error-message.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
-import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
+import { dispatchAutomationAdded } from "./dispatch-automation-added.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "../base-dialog.js";
@@ -266,23 +266,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
         location,
         this.yaml
       );
-      // Apply the diff to the page's YAML so the new script
-      // lands in ``_yaml`` and the global save button activates.
-      const newYaml = applyYamlDiff(this.yaml, yaml_diff);
-      this.dispatchEvent(
-        new CustomEvent<{ yaml: string }>("yaml-draft", {
-          detail: { yaml: newYaml },
-          bubbles: true,
-          composed: true,
-        })
-      );
-      this.dispatchEvent(
-        new CustomEvent<{ sectionKey: string }>("automation-added", {
-          detail: { sectionKey: sectionKeyFromLocation(location) },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
       this._open = false;
     } catch (err) {
       const msg =

--- a/src/components/device/dispatch-automation-added.ts
+++ b/src/components/device/dispatch-automation-added.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared post-upsert dispatch for the "+ Add automation" and
+ * "+ Add script" wizard dialogs.
+ *
+ * Both dialogs finish the same way after a successful
+ * ``automations/upsert``: apply the backend-emitted splice to the
+ * dialog's YAML buffer and notify the page. Kept in one place so
+ * the event names, detail shapes, and bubbling/composed flags
+ * can't drift between the two wizards.
+ */
+import type { AutomationLocation, YamlDiff } from "../../api/types/automations.js";
+import { applyYamlDiff, sectionKeyFromLocation } from "./automation-editor/serialise.js";
+
+/**
+ * Apply ``yamlDiff`` to ``yaml`` and dispatch the two bubbling,
+ * composed events the device page listens for:
+ *
+ * - ``yaml-draft`` (``detail: { yaml }``) — the spliced YAML, so
+ *   the new automation lands in the page's YAML state (and thus
+ *   the YAML pane + the global save button see the change). The
+ *   page advances ``_yaml`` without touching ``_savedYaml`` —
+ *   that's the existing "dirty buffer, click Save to write" path.
+ * - ``automation-added`` (``detail: { sectionKey }``) — so the
+ *   parent navigator can route to the new section's editor.
+ */
+export function dispatchAutomationAdded(
+  host: HTMLElement,
+  yaml: string,
+  location: AutomationLocation,
+  yamlDiff: YamlDiff
+): void {
+  const newYaml = applyYamlDiff(yaml, yamlDiff);
+  host.dispatchEvent(
+    new CustomEvent<{ yaml: string }>("yaml-draft", {
+      detail: { yaml: newYaml },
+      bubbles: true,
+      composed: true,
+    })
+  );
+  host.dispatchEvent(
+    new CustomEvent<{ sectionKey: string }>("automation-added", {
+      detail: { sectionKey: sectionKeyFromLocation(location) },
+      bubbles: true,
+      composed: true,
+    })
+  );
+}

--- a/test/components/device/dispatch-automation-added.test.ts
+++ b/test/components/device/dispatch-automation-added.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Contract test for the shared post-upsert dispatch used by the
+ * add-automation and add-script wizard dialogs. The device page
+ * listens for these events by name and detail shape, so the wire
+ * names, detail keys, bubbling/composed flags, and the
+ * yaml-draft-before-automation-added ordering are all pinned here.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { YamlDiff } from "../../../src/api/types/automations.js";
+import { dispatchAutomationAdded } from "../../../src/components/device/dispatch-automation-added.js";
+
+const YAML = "esphome:\n  name: test";
+
+/** Insert-shaped diff (toLine == fromLine - 1) appending a script block. */
+const DIFF: YamlDiff = {
+  fromLine: 3,
+  toLine: 2,
+  replacement: "script:\n  - id: my_script\n",
+};
+
+function mountHost(): { parent: HTMLElement; host: HTMLElement } {
+  const parent = document.createElement("div");
+  const host = document.createElement("div");
+  parent.appendChild(host);
+  document.body.appendChild(parent);
+  return { parent, host };
+}
+
+describe("dispatchAutomationAdded", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("dispatches yaml-draft with the spliced yaml, then automation-added with the section key", () => {
+    const { parent, host } = mountHost();
+    const seen: { type: string; detail: unknown; composed: boolean }[] = [];
+    for (const type of ["yaml-draft", "automation-added"]) {
+      // Listen on the parent so the assertion also proves bubbling.
+      parent.addEventListener(type, (e) => {
+        seen.push({
+          type,
+          detail: (e as CustomEvent).detail,
+          composed: e.composed,
+        });
+      });
+    }
+
+    dispatchAutomationAdded(host, YAML, { kind: "script", id: "my_script" }, DIFF);
+
+    expect(seen.map((s) => s.type)).toEqual(["yaml-draft", "automation-added"]);
+    expect(seen[0].detail).toEqual({
+      yaml: "esphome:\n  name: test\nscript:\n  - id: my_script",
+    });
+    expect(seen[1].detail).toEqual({ sectionKey: "automation:script:my_script" });
+    // Both events must cross shadow boundaries to reach the page.
+    expect(seen.every((s) => s.composed)).toBe(true);
+  });
+
+  it("builds the section key from the location for non-script kinds", () => {
+    const { parent, host } = mountHost();
+    let sectionKey = "";
+    parent.addEventListener("automation-added", (e) => {
+      sectionKey = (e as CustomEvent<{ sectionKey: string }>).detail.sectionKey;
+    });
+
+    dispatchAutomationAdded(
+      host,
+      YAML,
+      { kind: "component_on", component_id: "my_switch", trigger: "on_turn_on" },
+      DIFF
+    );
+
+    expect(sectionKey).toBe("automation:component_on:my_switch:on_turn_on");
+  });
+});

--- a/test/components/device/dispatch-automation-added.test.ts
+++ b/test/components/device/dispatch-automation-added.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { YamlDiff } from "../../../src/api/types/automations.js";
+import { applyYamlDiff } from "../../../src/components/device/automation-editor/serialise.js";
 import { dispatchAutomationAdded } from "../../../src/components/device/dispatch-automation-added.js";
 
 const YAML = "esphome:\n  name: test";
@@ -41,7 +42,7 @@ describe("dispatchAutomationAdded", () => {
       // Listen on the parent so the assertion also proves bubbling.
       parent.addEventListener(type, (e) => {
         seen.push({
-          type,
+          type: e.type,
           detail: (e as CustomEvent).detail,
           composed: e.composed,
         });
@@ -51,9 +52,15 @@ describe("dispatchAutomationAdded", () => {
     dispatchAutomationAdded(host, YAML, { kind: "script", id: "my_script" }, DIFF);
 
     expect(seen.map((s) => s.type)).toEqual(["yaml-draft", "automation-added"]);
-    expect(seen[0].detail).toEqual({
-      yaml: "esphome:\n  name: test\nscript:\n  - id: my_script",
-    });
+    // The dispatch contract is "the diff-applied YAML", not a
+    // particular splice formatting, so compare against
+    // applyYamlDiff (which has its own unit tests) ...
+    expect(seen[0].detail).toEqual({ yaml: applyYamlDiff(YAML, DIFF) });
+    // ... and pin that the new block actually made it into the
+    // draft, so a wrong-yaml dispatch still fails loudly here.
+    expect((seen[0].detail as { yaml: string }).yaml).toContain(
+      "script:\n  - id: my_script"
+    );
     expect(seen[1].detail).toEqual({ sectionKey: "automation:script:my_script" });
     // Both events must cross shadow boundaries to reach the page.
     expect(seen.every((s) => s.composed)).toBe(true);


### PR DESCRIPTION
# What does this implement/fix?

Extracts the duplicated post upsert block from the add automation and add script dialogs into a shared `dispatchAutomationAdded(host, yaml, location, yamlDiff)` helper in `src/components/device/dispatch-automation-added.ts`; both dialogs now call it after `upsertAutomation`. Event names, detail shapes, ordering, and bubbling/composed flags are unchanged and now pinned by a contract test.

**Related issue or feature (if applicable):**

- fixes #1089

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
