### PR TITLE
Extract shared form-field styles for the automation add dialogs

### DIFF
--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -21,6 +21,7 @@ import type { AutomationLocation, AutomationTree } from "../../api/types/automat
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
@@ -60,18 +61,13 @@ export class ESPHomeAddApiActionDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    formFieldStyles,
     css`
       esphome-base-dialog {
         --width: 480px;
       }
       esphome-base-dialog::part(body) {
         padding: var(--wa-space-l);
-      }
-      .intro {
-        font-size: var(--wa-font-size-s);
-        color: var(--wa-color-text-quiet);
-        margin: 0 0 var(--wa-space-m) 0;
-        line-height: 1.5;
       }
       .intro code {
         font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -84,14 +80,6 @@ export class ESPHomeAddApiActionDialog extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-2xs);
-      }
-      .field-label {
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-semibold);
-        color: var(--wa-color-text-normal);
-      }
-      .required {
-        color: var(--esphome-error, #d92d20);
       }
       .actions {
         display: flex;
@@ -142,11 +130,6 @@ export class ESPHomeAddApiActionDialog extends LitElement {
         cursor: not-allowed;
         box-shadow: none;
         transform: none;
-      }
-      .error {
-        color: var(--esphome-error, #d92d20);
-        font-size: var(--wa-font-size-2xs);
-        margin-top: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/components/device/add-automation-dialog.styles.ts
+++ b/src/components/device/add-automation-dialog.styles.ts
@@ -4,8 +4,9 @@ import { css } from "lit";
  * Styles for <esphome-add-automation-dialog>. Extracted from the
  * component file to keep it under the repo's file-size cap (see
  * README → "Code structure policies"). The component pulls these
- * in via its ``static styles`` array alongside ``espHomeStyles`` and
- * ``inputStyles``.
+ * in via its ``static styles`` array alongside ``espHomeStyles``,
+ * ``inputStyles`` and ``formFieldStyles`` (which supplies the shared
+ * .intro / .field-label / .required / .error rules).
  */
 export const addAutomationDialogStyles = css`
   esphome-base-dialog {
@@ -19,11 +20,6 @@ export const addAutomationDialogStyles = css`
     flex-direction: column;
     gap: var(--wa-space-2xs);
     margin-bottom: var(--wa-space-m);
-  }
-  .field-label {
-    font-size: var(--wa-font-size-s);
-    font-weight: var(--wa-font-weight-semibold);
-    color: var(--wa-color-text-normal);
   }
   .field-desc {
     font-size: var(--wa-font-size-2xs);
@@ -83,17 +79,6 @@ export const addAutomationDialogStyles = css`
     cursor: not-allowed;
     box-shadow: none;
     transform: none;
-  }
-  .error {
-    color: var(--esphome-error, #d92d20);
-    font-size: var(--wa-font-size-2xs);
-    margin-top: var(--wa-space-2xs);
-  }
-  .intro {
-    font-size: var(--wa-font-size-s);
-    color: var(--wa-color-text-quiet);
-    margin: 0 0 var(--wa-space-m) 0;
-    line-height: 1.5;
   }
   /* Interval-row pairing: matches the editor's inline
      TIME_PERIOD layout so the dialog reads as the same

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -34,6 +34,7 @@ import type {
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { getErrorMessage } from "../../util/error-message.js";
@@ -107,7 +108,12 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   @state() private _saving = false;
   @state() private _error = "";
 
-  static styles = [espHomeStyles, inputStyles, addAutomationDialogStyles];
+  static styles = [
+    espHomeStyles,
+    inputStyles,
+    formFieldStyles,
+    addAutomationDialogStyles,
+  ];
 
   /**
    * Open the dialog. With no argument, behaves as the navigator's

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -29,6 +29,7 @@ import type {
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { apiContext, localizeContext } from "../../context/index.js";
+import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { getErrorMessage } from "../../util/error-message.js";
@@ -69,18 +70,13 @@ export class ESPHomeAddScriptDialog extends LitElement {
   static styles = [
     espHomeStyles,
     inputStyles,
+    formFieldStyles,
     css`
       esphome-base-dialog {
         --width: 480px;
       }
       esphome-base-dialog::part(body) {
         padding: var(--wa-space-l);
-      }
-      .intro {
-        font-size: var(--wa-font-size-s);
-        color: var(--wa-color-text-quiet);
-        margin: 0 0 var(--wa-space-m) 0;
-        line-height: 1.5;
       }
       .intro code {
         font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -93,14 +89,6 @@ export class ESPHomeAddScriptDialog extends LitElement {
         display: flex;
         flex-direction: column;
         gap: var(--wa-space-2xs);
-      }
-      .field-label {
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-semibold);
-        color: var(--wa-color-text-normal);
-      }
-      .required {
-        color: var(--esphome-error, #d92d20);
       }
       .actions {
         display: flex;
@@ -151,11 +139,6 @@ export class ESPHomeAddScriptDialog extends LitElement {
         cursor: not-allowed;
         box-shadow: none;
         transform: none;
-      }
-      .error {
-        color: var(--esphome-error, #d92d20);
-        font-size: var(--wa-font-size-2xs);
-        margin-top: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/styles/form-fields.ts
+++ b/src/styles/form-fields.ts
@@ -1,0 +1,32 @@
+import { css } from "lit";
+
+/**
+ * Shared form-field styles for the automation "add"-family dialogs
+ * (add-automation, add-script, add-api-action): the intro paragraph,
+ * field labels with a required marker, and the inline error line.
+ *
+ * Consumers include this in their ``static styles`` array (or compose
+ * it into a standalone styles module) and layer any component-specific
+ * overrides after it.
+ */
+export const formFieldStyles = css`
+  .intro {
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-text-quiet);
+    margin: 0 0 var(--wa-space-m) 0;
+    line-height: 1.5;
+  }
+  .field-label {
+    font-size: var(--wa-font-size-s);
+    font-weight: var(--wa-font-weight-semibold);
+    color: var(--wa-color-text-normal);
+  }
+  .required {
+    color: var(--esphome-error, #d92d20);
+  }
+  .error {
+    color: var(--esphome-error, #d92d20);
+    font-size: var(--wa-font-size-2xs);
+    margin-top: var(--wa-space-2xs);
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

Adds a shared `formFieldStyles` module (`src/styles/form-fields.ts`) with the `.intro`, `.field-label`, `.required` and `.error` rules that the automation add dialogs duplicated byte for byte, and adopts it in the api action, script and add automation dialogs, deleting their local copies. The partial copies in `config-entry-form.styles.ts`, `automation-editor.styles.ts` and `add-component-form.styles.ts` genuinely differ (flex labels, descendant `.required` selectors, different `.error` sizing), so those files are left untouched.

**Related issue or feature (if applicable):**

- fixes #1090

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
