### PR TITLE
Collapse trivial dialog request-close handlers into a controller

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -24,7 +24,10 @@ import { EnterController } from "../util/enter-controller.js";
  * imperative ``dialog.open = true`` pattern some legacy
  * dialogs still use is incompatible with this wrapper —
  * those consumers should switch to a state-driven open flag
- * during migration.
+ * during migration. Consumers with no close-veto logic should
+ * use :class:`DialogOpenController` (``util/dialog-open-controller.ts``)
+ * for the flag + the trivial ``@request-close`` handler instead
+ * of hand-rolling both.
  *
  * **Busy gate**. When ``?busy=true``:
  *

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -11,6 +11,7 @@ import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chr
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
@@ -49,8 +50,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
   @state()
   private _friendlyName = "";
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -115,21 +115,13 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     this._name = "";
     this._friendlyName = "";
     this._resolved = false;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // Flip the reactive flag on the initiating close so a re-render can't
-  // re-assert ?open mid-hide; teardown (the EnterController unbind) stays
-  // in after-hide. esphome-base-dialog never mutates its own open in
-  // response to user actions, so the host owns flipping _open here.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   private _onAfterHide = (): void => {
     this._enter.set(false);
@@ -154,11 +146,11 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
 
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.action_clone_title", {
           name: this.sourceName,
         })}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="field">

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -54,8 +55,7 @@ export class ESPHomeConfirmDialog extends LitElement {
   @property()
   icon = "alert-outline";
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -119,20 +119,20 @@ export class ESPHomeConfirmDialog extends LitElement {
 
   open() {
     this._decided = false;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
 
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this.heading}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="body">
@@ -190,15 +190,8 @@ export class ESPHomeConfirmDialog extends LitElement {
     this.dispatchEvent(new CustomEvent("secondary", { bubbles: true }));
   }
 
-  // Flip _open the moment a close is requested (X / Esc / outside-click),
-  // before wa-dialog finishes hiding, so a re-render can't re-assert ?open
-  // and cancel the in-progress hide. Teardown stays in after-hide.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
-
   private _onAfterHide() {
-    this._open = false;
+    this._dialog.open = false;
     this._enter.set(false);
     if (!this._decided) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));

--- a/src/components/device/add-api-action-dialog.ts
+++ b/src/components/device/add-api-action-dialog.ts
@@ -24,6 +24,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
@@ -53,7 +54,7 @@ export class ESPHomeAddApiActionDialog extends LitElement {
   @property({ attribute: false })
   board: BoardCatalogEntry | null = null;
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
   @state() private _name = "";
   @state() private _saving = false;
   @state() private _error = "";
@@ -137,15 +138,8 @@ export class ESPHomeAddApiActionDialog extends LitElement {
   public open() {
     this._name = "";
     this._error = "";
-    this._open = true;
+    this._dialog.open = true;
   }
-
-  // esphome-base-dialog never mutates its own open on a user-driven close
-  // (Escape / X / backdrop); the host owns flipping _open here, else a
-  // re-render re-asserts ?open and the dialog can't dismiss.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   protected render() {
     const title = this.boardName
@@ -154,11 +148,11 @@ export class ESPHomeAddApiActionDialog extends LitElement {
         })
       : this._localize("device.add_api_action");
     return html`<esphome-base-dialog
-      ?open=${this._open}
+      ?open=${this._dialog.open}
       ?busy=${this._saving}
       .label=${title}
       .confirmOnEnter=${this._onContinue}
-      @request-close=${this._onRequestClose}
+      @request-close=${this._dialog.onRequestClose}
     >
       <p class="intro">
         ${renderMarkdown(this._localize("device.api_action_header_description"))}
@@ -246,7 +240,7 @@ export class ESPHomeAddApiActionDialog extends LitElement {
           composed: true,
         })
       );
-      this._open = false;
+      this._dialog.open = false;
     } catch (err) {
       const msg =
         err instanceof Error

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -36,6 +36,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { renderMarkdown } from "../../util/markdown.js";
 import { parseYamlAutomations } from "../../util/yaml-sections.js";
@@ -81,7 +82,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
   @property({ attribute: false })
   board: BoardCatalogEntry | null = null;
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   @state() private _kind: TargetKind = "device_on";
   @state() private _componentId = "";
@@ -142,16 +143,9 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     this._intervalValue = "";
     this._intervalUnit = "s";
     this._error = "";
-    this._open = true;
+    this._dialog.open = true;
     void this._loadAvailable();
   }
-
-  // esphome-base-dialog never flips its own open on a user-driven close
-  // (Escape / X / outside-click); the host owns _open here. The busy gate
-  // (?busy=_saving) blocks dismissal while an upsert is in flight.
-  private _onRequestClose = () => {
-    this._open = false;
-  };
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
@@ -193,11 +187,11 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         })
       : this._localize("device.add_automation");
     return html`<esphome-base-dialog
-      ?open=${this._open}
+      ?open=${this._dialog.open}
       ?busy=${this._saving}
       .label=${title}
       .confirmOnEnter=${this._onContinue}
-      @request-close=${this._onRequestClose}
+      @request-close=${this._dialog.onRequestClose}
     >
       ${
         this._loading && !this._available
@@ -475,7 +469,7 @@ export class ESPHomeAddAutomationDialog extends LitElement {
         this.yaml
       );
       dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
-      this._open = false;
+      this._dialog.open = false;
     } catch (err) {
       const msg =
         err instanceof Error

--- a/src/components/device/add-component-dialog.ts
+++ b/src/components/device/add-component-dialog.ts
@@ -12,6 +12,7 @@ import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { BusPrefill } from "../../util/bus-constraint-prefill.js";
 import { collectExistingIds } from "../../util/default-component-id.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId, isFeaturedId } from "../../util/featured-id.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { notifyError, notifySuccess } from "../../util/notify.js";
@@ -92,8 +93,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
   @property({ attribute: false })
   lockedCategories: string[] = [];
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   @query("esphome-component-catalog")
   private _catalog!: ESPHomeComponentCatalog;
@@ -196,7 +196,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
-    this._open = true;
+    this._dialog.open = true;
     this.updateComplete.then(() => this._catalog?.load());
   }
 
@@ -212,7 +212,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
     this._selected = null;
     this._submitError = "";
     this._submitting = false;
-    this._open = true;
+    this._dialog.open = true;
     this.updateComplete.then(() => this._catalog?.filterByDomain(domain));
   }
 
@@ -268,10 +268,10 @@ export class ESPHomeAddComponentDialog extends LitElement {
     return html`
       <esphome-base-dialog
         class=${isForm ? "form-view" : ""}
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         ?busy=${this._submitting}
         .label=${title}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @add-component=${this._onComponentSelected}
         @add-bundle=${this._onBundleSelected}
         @form-cancel=${this._onBack}
@@ -351,13 +351,6 @@ export class ESPHomeAddComponentDialog extends LitElement {
       </esphome-base-dialog>
     `;
   }
-
-  // esphome-base-dialog never flips its own open on a user-driven close
-  // (Escape / X / outside-click); the host owns _open here. The busy gate
-  // (?busy=_submitting) blocks dismissal while an add is in flight.
-  private _onRequestClose = () => {
-    this._open = false;
-  };
 
   private async _onComponentSelected(
     e: CustomEvent<{ component: ComponentCatalogEntry }>
@@ -650,7 +643,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
         lastAdded = this._chainReference(entry, fields);
       }
       if (addedAny) this._dispatchDraft(this.yaml);
-      this._open = false;
+      this._dialog.open = false;
       this._selected = null;
       this._resetDetourState();
       // Every member already present is a no-op; don't claim we "Added" it.
@@ -871,7 +864,7 @@ export class ESPHomeAddComponentDialog extends LitElement {
             })
           );
         }
-        this._open = false;
+        this._dialog.open = false;
         this._selected = null;
         this._resetDetourState();
         // Configless add skipped the form, so the close is the only

--- a/src/components/device/add-script-dialog.ts
+++ b/src/components/device/add-script-dialog.ts
@@ -32,6 +32,7 @@ import { apiContext, localizeContext } from "../../context/index.js";
 import { formFieldStyles } from "../../styles/form-fields.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { normalizeEspHomeId } from "../../util/esphome-id.js";
 import { renderMarkdown } from "../../util/markdown.js";
@@ -61,7 +62,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
   @property({ attribute: false })
   board: BoardCatalogEntry | null = null;
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
   @state() private _id = "";
   @state() private _available: AvailableAutomations | null = null;
   @state() private _saving = false;
@@ -146,16 +147,9 @@ export class ESPHomeAddScriptDialog extends LitElement {
   public open() {
     this._id = "";
     this._error = "";
-    this._open = true;
+    this._dialog.open = true;
     void this._loadAvailable();
   }
-
-  // esphome-base-dialog never mutates its own open in response to a user
-  // close (Escape / X / outside-click), so the host flips _open here to
-  // keep the next render's ?open binding in sync.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   private async _loadAvailable() {
     if (!this._api || !this.configuration) return;
@@ -176,11 +170,11 @@ export class ESPHomeAddScriptDialog extends LitElement {
         })
       : this._localize("device.add_script");
     return html`<esphome-base-dialog
-      ?open=${this._open}
+      ?open=${this._dialog.open}
       ?busy=${this._saving}
       .label=${title}
       .confirmOnEnter=${this._onContinue}
-      @request-close=${this._onRequestClose}
+      @request-close=${this._dialog.onRequestClose}
     >
       <p class="intro">
         ${renderMarkdown(this._localize("device.script_header_description"))}
@@ -250,7 +244,7 @@ export class ESPHomeAddScriptDialog extends LitElement {
         this.yaml
       );
       dispatchAutomationAdded(this, this.yaml, location, yaml_diff);
-      this._open = false;
+      this._dialog.open = false;
     } catch (err) {
       const msg =
         err instanceof Error

--- a/src/components/device/automation-editor/catalog-picker-dialog.ts
+++ b/src/components/device/automation-editor/catalog-picker-dialog.ts
@@ -47,6 +47,7 @@ import type { LocalizeFunc } from "../../../common/localize.js";
 import { localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
+import { DialogOpenController } from "../../../util/dialog-open-controller.js";
 import { renderMarkdown } from "../../../util/markdown.js";
 import { registerMdiIcons } from "../../../util/register-icons.js";
 import {
@@ -99,7 +100,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   @property({ attribute: false })
   devices: AvailableComponentInstance[] = [];
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
   @state() private _activeTab: Tab = "by-target";
   @state() private _query = "";
 
@@ -111,15 +112,8 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
   public open() {
     this._activeTab = this.kind === "action" ? "by-target" : "by-type";
     this._query = "";
-    this._open = true;
+    this._dialog.open = true;
   }
-
-  // esphome-base-dialog never mutates its own ``open`` on a user
-  // close (Escape / X / outside-click); without this the next
-  // render re-asserts ``?open`` and the dialog can't dismiss.
-  private _onRequestClose = () => {
-    this._open = false;
-  };
 
   static styles = [
     espHomeStyles,
@@ -316,9 +310,9 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         : ["by-type", "building-blocks"];
 
     return html`<esphome-base-dialog
-      ?open=${this._open}
+      ?open=${this._dialog.open}
       .label=${title}
-      @request-close=${this._onRequestClose}
+      @request-close=${this._dialog.onRequestClose}
     >
       <div class="picker-search">
         <div class="picker-search-wrap">
@@ -547,7 +541,7 @@ export class ESPHomeCatalogPickerDialog extends LitElement {
         composed: true,
       })
     );
-    this._open = false;
+    this._dialog.open = false;
   }
 }
 

--- a/src/components/device/change-board-dialog.ts
+++ b/src/components/device/change-board-dialog.ts
@@ -14,6 +14,7 @@ import {
 } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { boardImageUrl, onBoardImageError } from "../../util/board-image.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { changeBoardDialogStyles } from "./change-board-dialog.styles.js";
 
 import "@home-assistant/webawesome/dist/components/badge/badge.js";
@@ -38,8 +39,7 @@ export class ESPHomeChangeBoardDialog extends LitElement {
   @property({ attribute: false })
   boards: SlimBoard[] = [];
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -51,25 +51,19 @@ export class ESPHomeChangeBoardDialog extends LitElement {
   ];
 
   open() {
-    this._open = true;
+    this._dialog.open = true;
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // esphome-base-dialog never mutates its own open in response to user
-  // actions, so the host owns flipping _open on the initiating close.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("device.change_board_title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
       >
         <p class="intro">
           ${this._localize("device.change_board_desc", {

--- a/src/components/feedback-dialog.ts
+++ b/src/components/feedback-dialog.ts
@@ -21,6 +21,7 @@ import {
 } from "../context/index.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
@@ -185,8 +186,7 @@ export class ESPHomeFeedbackDialog extends LitElement {
   @state()
   private _esphomeVersion = "";
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   @state()
   private _screen: Screen = "main";
@@ -358,21 +358,15 @@ export class ESPHomeFeedbackDialog extends LitElement {
   ];
 
   open() {
-    this._open = true;
+    this._dialog.open = true;
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
 
-  // Flip the reactive flag on the initiating close (X / Esc / outside-click)
-  // before the hide animation, then let after-hide settle it.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
-
   private _onAfterHide = (): void => {
-    this._open = false;
+    this._dialog.open = false;
     this._screen = "main";
   };
 
@@ -384,7 +378,7 @@ export class ESPHomeFeedbackDialog extends LitElement {
   // button), so move focus to the new screen's entry control; otherwise keyboard
   // and screen-reader users are dropped back to document.body.
   protected updated(changed: PropertyValues): void {
-    if (!this._open || !changed.has("_screen")) {
+    if (!this._dialog.open || !changed.has("_screen")) {
       return;
     }
     const previous = changed.get("_screen") as Screen | undefined;
@@ -442,9 +436,9 @@ export class ESPHomeFeedbackDialog extends LitElement {
     const drill = this._screen === "main" ? null : DRILL_SCREENS[this._screen];
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize(drill ? drill.titleKey : "feedback.title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         ${

--- a/src/components/firmware-jobs-dialog.ts
+++ b/src/components/firmware-jobs-dialog.ts
@@ -30,6 +30,7 @@ import {
 } from "../context/index.js";
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { firmwareJobDisplayName } from "../util/firmware-job-display.js";
 import { isTerminalJob as isTerminal } from "../util/firmware-job-status.js";
 import { postInstallShowLogsHandler } from "../util/post-install-logs.js";
@@ -77,7 +78,7 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
   @state()
   _devices: ConfiguredDevice[] = [];
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
   @query("esphome-command-dialog") private _commandDialog!: ESPHomeCommandDialog;
   // Logs dialog for the post-install hand-off when reattaching from this
   // surface. Without one, request-show-logs-after-install would no-op. (#139)
@@ -95,12 +96,12 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
   open() {
     this._now = Date.now();
-    this._open = true;
+    this._dialog.open = true;
     this._startTicker();
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
     this._stopTicker();
   }
 
@@ -148,9 +149,9 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
 
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("firmware_jobs.title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="toolbar">
@@ -208,14 +209,8 @@ export class ESPHomeFirmwareJobsDialog extends LitElement {
     }
   };
 
-  // Flip _open on the initiating close so a ticker-driven re-render can't
-  // re-assert ?open mid-hide; the ticker is torn down once hidden.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
-
   private _onAfterHide = (): void => {
-    this._open = false;
+    this._dialog.open = false;
     this._stopTicker();
   };
 

--- a/src/components/labels/device-labels-editor.ts
+++ b/src/components/labels/device-labels-editor.ts
@@ -36,6 +36,7 @@ import {
   quietCloseButtonStyles,
 } from "../../styles/dialog-chrome.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import {
   labelChipStyles,
   renderLabelChip,
@@ -108,8 +109,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
    *  state non-deterministic on overlapping requests. */
   private _saveChain: Promise<unknown> = Promise.resolve();
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   @query("esphome-label-form")
   private _createForm?: ESPHomeLabelForm;
@@ -247,7 +247,7 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     // persist into the next device's editor and a still-pending save chained
     // against the previous device would gate this one's ``_saving`` indicator.
     if (prev !== undefined && prev.configuration !== this.device.configuration) {
-      this._open = false;
+      this._dialog.open = false;
       this._createForm?.collapse();
       this._saving = false;
       this._saveChain = Promise.resolve();
@@ -305,9 +305,9 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
     const assignedSet = new Set(this._currentLabelIds);
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.labels_dialog_title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onDialogClose}
       >
         <div
@@ -369,17 +369,11 @@ export class ESPHomeDeviceLabelsEditor extends LitElement {
 
   private _openDialog = () => {
     this._createForm?.collapse();
-    this._open = true;
-  };
-
-  // esphome-base-dialog never flips its own open on a user-driven close
-  // (Escape / X / outside-click); the host owns _open here.
-  private _onRequestClose = () => {
-    this._open = false;
+    this._dialog.open = true;
   };
 
   private _onDialogClose = () => {
-    this._open = false;
+    this._dialog.open = false;
     this._createForm?.collapse();
   };
 

--- a/src/components/onboarding-wifi-dialog.ts
+++ b/src/components/onboarding-wifi-dialog.ts
@@ -9,6 +9,7 @@ import { apiContext, localizeContext } from "../context/index.js";
 import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { formatApiError } from "../util/format-api-error.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -41,7 +42,8 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   @state() private _password = "";
   @state() private _saving = false;
   @state() private _error: string | null = null;
-  @state() private _open = false;
+
+  private readonly _dialog = new DialogOpenController(this);
 
   @query("#onboarding-ssid")
   private _ssidInput?: HTMLInputElement;
@@ -58,14 +60,14 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this._password = "";
     this._saving = false;
     this._error = null;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
     // autofocus is unreliable for a shadow-DOM input shown after first paint.
     void this.updateComplete.then(() => this._ssidInput?.focus());
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
 
   static styles = [
@@ -111,10 +113,10 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         ?busy=${this._saving}
         .label=${this._localize("onboarding.wifi.title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${() => this._enter.set(false)}
       >
         <div class="body">
@@ -188,16 +190,6 @@ export class ESPHomeOnboardingWifiDialog extends LitElement {
     this.close();
     this._saving = false;
   }
-
-  /**
-   * Flip the reactive flag on the initiating close so a re-render can't
-   * re-assert ?open mid-hide. While saving, esphome-base-dialog's busy gate
-   * absorbs the X / Escape / backdrop click and never emits request-close, so
-   * the dialog can't hide before the user sees an inline save error.
-   */
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 }
 
 declare global {

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -11,6 +11,7 @@ import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chr
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { renderInlineError } from "../util/render-error.js";
 
@@ -28,8 +29,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
   @state()
   private _value = "";
 
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -90,21 +90,13 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     this.deviceName = name;
     this._value = name;
     this._resolved = false;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // Flip the reactive flag on the initiating close so a re-render can't
-  // re-assert ?open mid-hide; teardown (the EnterController unbind) stays
-  // in after-hide. esphome-base-dialog never mutates its own open in
-  // response to user actions, so the host owns flipping _open here.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   private _onAfterHide = (): void => {
     this._enter.set(false);
@@ -123,9 +115,9 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
 
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("dashboard.action_rename_title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="field">

--- a/src/components/unsaved-changes-dialog.ts
+++ b/src/components/unsaved-changes-dialog.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -29,7 +30,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   @property()
   message = "";
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   private _resolved = false;
 
@@ -38,21 +39,13 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
 
   open() {
     this._resolved = false;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // esphome-base-dialog never mutates its own open on a user-driven close
-  // (Escape / outside-click); the host owns flipping _open here, else a
-  // re-render re-asserts ?open and the dialog can't dismiss. Teardown +
-  // cancel-on-dismiss stay in _onAfterHide.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   static styles = [
     espHomeStyles,
@@ -175,8 +168,8 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   protected render() {
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
-        @request-close=${this._onRequestClose}
+        ?open=${this._dialog.open}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="body">
@@ -222,7 +215,7 @@ export class ESPHomeUnsavedChangesDialog extends LitElement {
   }
 
   private _onAfterHide() {
-    this._open = false;
+    this._dialog.open = false;
     this._enter.set(false);
     if (!this._resolved) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));

--- a/src/components/wizard/create-config-dialog.ts
+++ b/src/components/wizard/create-config-dialog.ts
@@ -12,6 +12,7 @@ import { fullscreenMobileDialog } from "../../styles/dialog-mobile.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import { withBase } from "../../util/base-path.js";
 import { fetchBoard, getCachedBoard } from "../../util/board-body-cache.js";
+import { DialogOpenController } from "../../util/dialog-open-controller.js";
 import { buildFeaturedId } from "../../util/featured-id.js";
 import { featuredComponentName, fullSetupComponentIds } from "../../util/full-setup.js";
 import { markJustCreated } from "../../util/just-created.js";
@@ -75,8 +76,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   // Drives the step components' Enter listeners: the steps stay mounted in
   // the wa-dialog while it's merely hidden (light-dismiss / Escape / close),
   // so they must deactivate on hide, not just on unmount.
-  @state()
-  private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   /** Always a full body (only ever assigned in ``_enterSetupStep`` /
    *  ``openWithBoard``), so the setup step reads a real ``requires_wifi``. */
@@ -196,7 +196,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     this._submitting = false;
     this._pickedBoardId = null;
     this._resetCreateErrors();
-    this._open = true;
+    this._dialog.open = true;
   }
 
   /** Clear both error slots so a stale message from a prior
@@ -211,20 +211,13 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
   }
 
   public close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // esphome-base-dialog never flips its own open on a user-driven close
-  // (Escape / X / outside-click); the host owns _open, else a re-render
-  // re-asserts ?open and the dialog can't dismiss.
-  private _onRequestClose = () => {
-    this._open = false;
-  };
 
   // The step components stay mounted while the dialog is merely hidden, so
   // drop their Enter listeners once it has fully hidden.
   private _onHide = () => {
-    this._open = false;
+    this._dialog.open = false;
   };
 
   // ----- ImportFlowHost: the slice the import controller drives -----
@@ -273,10 +266,10 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
     return html`
       <esphome-base-dialog
         class=${this._step === "board" ? "wide" : ""}
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         ?busy=${this._submitting}
         .label=${this._title}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onHide}
         @next-step=${this._onNextStep}
         @toggle-advanced=${this._onToggleAdvanced}
@@ -330,12 +323,12 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       case "setup":
         return html`<esphome-wizard-step-setup
           .board=${this._selectedBoard}
-          ?active=${this._open}
+          ?active=${this._dialog.open}
           ?submitting=${this._submitting}
         ></esphome-wizard-step-setup>`;
       case "empty-config":
         return html`<esphome-wizard-step-empty-config
-          ?active=${this._open}
+          ?active=${this._dialog.open}
         ></esphome-wizard-step-empty-config>`;
       case "resolve-conflicts":
         return html`<esphome-wizard-step-resolve-conflicts
@@ -350,7 +343,7 @@ export class ESPHomeCreateConfigDialog extends LitElement implements ImportFlowH
       case "import-partial":
         return html`<esphome-wizard-step-import-partial
           .kept=${this._import.partial?.kept ?? []}
-          ?active=${this._open}
+          ?active=${this._dialog.open}
         ></esphome-wizard-step-import-partial>`;
     }
   }

--- a/src/components/yaml-validation-dialog.ts
+++ b/src/components/yaml-validation-dialog.ts
@@ -6,6 +6,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { localizeContext } from "../context/index.js";
 import { modalDialogStyles } from "../styles/modal-dialog.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { DialogOpenController } from "../util/dialog-open-controller.js";
 import { EnterController } from "../util/enter-controller.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 
@@ -53,7 +54,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   /** Included file the first error lives in, or "" when it's in the open config. */
   @property() firstErrorFile = "";
 
-  @state() private _open = false;
+  private readonly _dialog = new DialogOpenController(this);
 
   static styles = [
     espHomeStyles,
@@ -120,21 +121,13 @@ export class ESPHomeYamlValidationDialog extends LitElement {
 
   open() {
     this._resolvedExit = null;
-    this._open = true;
+    this._dialog.open = true;
     this._enter.set(true);
   }
 
   close() {
-    this._open = false;
+    this._dialog.open = false;
   }
-
-  // esphome-base-dialog never mutates its own open on a user-driven close
-  // (Escape / X / outside-click); the host owns flipping _open here, else a
-  // re-render re-asserts ?open and the dialog can't dismiss. Teardown +
-  // cancel-on-dismiss stay in _onAfterHide.
-  private _onRequestClose = (): void => {
-    this._open = false;
-  };
 
   protected render() {
     const message = this._localize("device.yaml_invalid_message", {
@@ -148,9 +141,9 @@ export class ESPHomeYamlValidationDialog extends LitElement {
       : "";
     return html`
       <esphome-base-dialog
-        ?open=${this._open}
+        ?open=${this._dialog.open}
         .label=${this._localize("device.yaml_invalid_title")}
-        @request-close=${this._onRequestClose}
+        @request-close=${this._dialog.onRequestClose}
         @after-hide=${this._onAfterHide}
       >
         <div class="body">
@@ -211,7 +204,7 @@ export class ESPHomeYamlValidationDialog extends LitElement {
   }
 
   private _onAfterHide() {
-    this._open = false;
+    this._dialog.open = false;
     this._enter.set(false);
     if (this._resolvedExit === null) {
       this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -1,0 +1,50 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/**
+ * Owns the reactive open flag for an ``esphome-base-dialog`` host with no
+ * close-veto logic.
+ *
+ * Every state-driven consumer of the wrapper used to carry the same three
+ * pieces: an ``@state() _open`` field, a ``?open=${this._open}`` binding, and
+ * a copy-pasted trivial handler
+ * ``private _onRequestClose = () => { this._open = false; }``. This
+ * controller bundles the flag and the handler so the host binds
+ * ``?open=${this._dialog.open}`` /
+ * ``@request-close=${this._dialog.onRequestClose}`` and the boilerplate
+ * disappears.
+ *
+ * ``onRequestClose`` flips ``open`` the moment a close is requested
+ * (Escape / X / outside-click), before wa-dialog finishes hiding, so a host
+ * re-render can't re-assert ``?open`` and cancel the in-progress hide —
+ * ``esphome-base-dialog`` never mutates its own ``open`` on a user-driven
+ * close, the host owns the flag (see the wrapper's class docs). Teardown
+ * stays in the host's ``@after-hide`` handler.
+ *
+ * Dialogs with a real veto (busy guard, unsaved-changes prompt) keep their
+ * own ``@request-close`` handler instead; the trivial flip here never
+ * ``preventDefault()``s.
+ */
+export class DialogOpenController implements ReactiveController {
+  private _open = false;
+
+  constructor(private readonly _host: ReactiveControllerHost) {
+    _host.addController(this);
+  }
+
+  hostConnected(): void {}
+
+  get open(): boolean {
+    return this._open;
+  }
+
+  set open(value: boolean) {
+    if (value === this._open) return;
+    this._open = value;
+    this._host.requestUpdate();
+  }
+
+  /** The trivial ``@request-close`` handler: flip the flag, veto nothing. */
+  readonly onRequestClose = (): void => {
+    this.open = false;
+  };
+}

--- a/src/util/dialog-open-controller.ts
+++ b/src/util/dialog-open-controller.ts
@@ -31,6 +31,10 @@ export class DialogOpenController implements ReactiveController {
     _host.addController(this);
   }
 
+  // Intentionally empty. ``ReactiveController``'s hooks are all optional,
+  // which makes it a weak type: TypeScript rejects a class sharing no
+  // members with it (TS2559 at ``implements``, TS2345 at
+  // ``addController(this)``), so one no-op hook must stay.
   hostConnected(): void {}
 
   get open(): boolean {

--- a/test/components/clone-device-dialog.test.ts
+++ b/test/components/clone-device-dialog.test.ts
@@ -58,9 +58,9 @@ describe("clone-device-dialog ENTER", () => {
     input.dispatchEvent(new Event("input"));
     await el.updateComplete;
     pressEnter(); // confirms and runs close(), but after-hide hasn't fired
-    // close() flips the reactive _open flag; the base-dialog is still hiding
+    // close() flips the reactive open flag; the base-dialog is still hiding
     // (after-hide not yet fired) so the EnterController listener stays bound.
-    expect((el as unknown as { _open: boolean })._open).toBe(false);
+    expect((el as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(false);
     pressEnter(); // listener still bound; stopped only by the latch
     expect(onConfirm).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,28 +84,31 @@ describe("clone-device-dialog ENTER", () => {
  * Regression coverage for the esphome-base-dialog migration (#549).
  *
  * The migration swapped the imperative ``dialog.open`` for a reactive
- * ``_open`` flag, so the open/close contract is the part most likely to
- * silently regress. esphome-base-dialog never mutates its own ``open`` on
- * a user close, so the host must flip ``_open`` itself in ``_onRequestClose``
+ * open flag (now owned by DialogOpenController), so the open/close
+ * contract is the part most likely to silently regress.
+ * esphome-base-dialog never mutates its own ``open`` on a user close, so
+ * the host's controller must flip the flag in ``onRequestClose``
  * (Escape / X / backdrop) — otherwise a re-render would re-assert ``?open``
  * and the dialog could never dismiss.
  */
 describe("clone-device-dialog base-dialog open contract", () => {
-  it("open() / close() drive the reactive _open flag", async () => {
+  it("open() / close() drive the reactive open flag", async () => {
     const el = await mount(new ESPHomeCloneDeviceDialog());
-    const view = el as unknown as { _open: boolean };
+    const view = el as unknown as { _dialog: { open: boolean } };
     el.open("source");
-    expect(view._open).toBe(true);
+    expect(view._dialog.open).toBe(true);
     el.close();
-    expect(view._open).toBe(false);
+    expect(view._dialog.open).toBe(false);
   });
 
-  it("_onRequestClose flips the reactive open flag", async () => {
+  it("the controller's onRequestClose flips the reactive open flag", async () => {
     const el = await mount(new ESPHomeCloneDeviceDialog());
-    const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
+    const view = el as unknown as {
+      _dialog: { open: boolean; onRequestClose: () => void };
+    };
     el.open("source");
-    expect(view._open).toBe(true);
-    view._onRequestClose();
-    expect(view._open).toBe(false);
+    expect(view._dialog.open).toBe(true);
+    view._dialog.onRequestClose();
+    expect(view._dialog.open).toBe(false);
   });
 });

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -88,9 +88,9 @@ describe("confirm-dialog dismiss / request-close", () => {
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(true);
+    expect((el as any)._dialog.open).toBe(true);
     baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(false);
+    expect((el as any)._dialog.open).toBe(false);
   });
 });

--- a/test/components/device/add-api-action-dialog.test.ts
+++ b/test/components/device/add-api-action-dialog.test.ts
@@ -27,10 +27,10 @@ async function mountDialog(): Promise<ESPHomeAddApiActionDialog> {
 }
 
 const isOpen = (d: ESPHomeAddApiActionDialog): boolean =>
-  (d as unknown as { _open: boolean })._open;
+  (d as unknown as { _dialog: { open: boolean } })._dialog.open;
 
 const requestClose = (d: ESPHomeAddApiActionDialog): void =>
-  (d as unknown as { _onRequestClose: () => void })._onRequestClose();
+  (d as unknown as { _dialog: { onRequestClose: () => void } })._dialog.onRequestClose();
 
 describe("esphome-add-api-action-dialog base-dialog open contract", () => {
   it("open() drives the reactive _open flag", async () => {
@@ -40,7 +40,7 @@ describe("esphome-add-api-action-dialog base-dialog open contract", () => {
     expect(isOpen(dialog)).toBe(true);
   });
 
-  it("_onRequestClose flips _open back to false", async () => {
+  it("the controller's onRequestClose flips the open flag back to false", async () => {
     const dialog = await mountDialog();
     dialog.open();
     expect(isOpen(dialog)).toBe(true);

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -440,7 +440,7 @@ describe("add-automation-dialog open/close contract", () => {
   const baseDialog = (d: ESPHomeAddAutomationDialog): HTMLElement =>
     d.shadowRoot!.querySelector("esphome-base-dialog")!;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isOpen = (d: ESPHomeAddAutomationDialog): boolean => (d as any)._open;
+  const isOpen = (d: ESPHomeAddAutomationDialog): boolean => (d as any)._dialog.open;
 
   it("open() flips the reactive flag and binds ?open", async () => {
     const api = {

--- a/test/components/device/add-component-dialog-bundle.test.ts
+++ b/test/components/device/add-component-dialog-bundle.test.ts
@@ -23,7 +23,7 @@ import { _clearComponentCache } from "../../../src/util/component-name-cache.js"
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 interface Internals {
-  _open: boolean;
+  _dialog: { open: boolean };
   _prefillReference: { domain: string; id: string } | null;
   _bundleProgress: { current: number; total: number; bundleName: string } | null;
   _fastPathFields: (entry: unknown) => Record<string, unknown> | null;
@@ -92,7 +92,7 @@ describe("add-component-dialog one-shot bundle", () => {
       { component_id: "featured.bd.b", fields: { id: "xb" } },
       "Y1",
     ]);
-    expect(d._open).toBe(false);
+    expect(d._dialog.open).toBe(false);
   });
 
   it("skips a member already present in the device instead of re-adding it", async () => {
@@ -121,7 +121,7 @@ describe("add-component-dialog one-shot bundle", () => {
       component_id: "featured.bd.b",
       fields: { id: "new_b" },
     });
-    expect(d._open).toBe(false);
+    expect(d._dialog.open).toBe(false);
   });
 
   it("shows 'already set up' instead of 'Added' when every member is present", async () => {

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -31,8 +31,8 @@ function makeDialog(entry: ReturnType<typeof makeComponentEntry>) {
   const dialog = new ESPHomeAddComponentDialog();
   Object.assign(dialog as unknown as Record<string, unknown>, {
     _api: { addComponent, getComponentBodies },
-    _open: true,
   });
+  (dialog as unknown as { _dialog: { open: boolean } })._dialog.open = true;
   dialog.configuration = "foo.yaml";
   dialog.yaml = "esphome:\n  name: foo\n";
   return { dialog, addComponent };
@@ -72,7 +72,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       richColors: true,
     });
     // Form view never opened: dialog closed, selection cleared.
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
   });
 
@@ -89,7 +91,7 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(toast.success).not.toHaveBeenCalled();
     // Form view: the entry is selected, dialog stays open.
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("adds directly when the only fields are optional and non-name", async () => {
@@ -109,7 +111,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       { component_id: "debug", fields: {} },
       "esphome:\n  name: foo\n"
     );
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("opens the form when an always-shown name field survives required-only", async () => {
@@ -125,7 +129,7 @@ describe("add-component-dialog skips the form for configless components", () => 
 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("opens the form for a configless component with a missing dependency", async () => {
@@ -144,7 +148,7 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(addComponent).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("fast-paths a configless component once its dependency is present", async () => {
@@ -163,7 +167,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       { component_id: "captive_portal", fields: {} },
       "wifi:\n  ssid: foo\n"
     );
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("opens the form for an advanced-only exclusive group (always-shown dropdown)", async () => {
@@ -182,7 +188,7 @@ describe("add-component-dialog skips the form for configless components", () => 
     await select(dialog, "chooser");
 
     expect(addComponent).not.toHaveBeenCalled();
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("opens the form for an advanced-only constraint cluster (always-shown box)", async () => {
@@ -200,7 +206,7 @@ describe("add-component-dialog skips the form for configless components", () => 
     await select(dialog, "clustered");
 
     expect(addComponent).not.toHaveBeenCalled();
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("adds an advanced-only component directly (Socket), toasts, and closes", async () => {
@@ -223,7 +229,9 @@ describe("add-component-dialog skips the form for configless components", () => 
     expect(toast.success).toHaveBeenCalledWith("device.component_added", {
       richColors: true,
     });
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
   });
 
@@ -248,7 +256,7 @@ describe("add-component-dialog skips the form for configless components", () => 
 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("fast-paths but submits the seeded id the form would have sent (not {})", async () => {
@@ -274,7 +282,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       },
       "esphome:\n  name: foo\n"
     );
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("fast-paths an advanced-only component whose dep is satisfied by a platform stem", async () => {
@@ -292,7 +302,9 @@ describe("add-component-dialog skips the form for configless components", () => 
     await select(dialog, "socket");
 
     expect(addComponent).toHaveBeenCalled();
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("opens the form for an advanced-only component when a prefill is active", async () => {
@@ -313,7 +325,7 @@ describe("add-component-dialog skips the form for configless components", () => 
 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("opens the form for an advanced-only component with a missing dependency", async () => {
@@ -328,7 +340,7 @@ describe("add-component-dialog skips the form for configless components", () => 
 
     expect(addComponent).not.toHaveBeenCalled();
     expect((dialog as unknown as { _selected: unknown })._selected).toBe(entry);
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 
   it("fast-paths a featured entry but submits its from_preset values", async () => {
@@ -355,7 +367,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       { component_id: "featured.bw15.socket", fields: { implementation: "lwip" } },
       "esphome:\n  name: foo\n"
     );
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("fast-paths a featured entry that has no config entries (no presets to lose)", async () => {
@@ -372,7 +386,9 @@ describe("add-component-dialog skips the form for configless components", () => 
       { component_id: "featured.bw15.async_tcp", fields: {} },
       "esphome:\n  name: foo\n"
     );
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
   });
 
   it("toasts the error and keeps the dialog open when a configless add fails", async () => {
@@ -389,6 +405,6 @@ describe("add-component-dialog skips the form for configless components", () => 
     // and the dialog stays open as a recovery surface.
     expect(toast.error).toHaveBeenCalledWith("boom", { richColors: true });
     expect(toast.success).not.toHaveBeenCalled();
-    expect((dialog as unknown as { _open: boolean })._open).toBe(true);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(true);
   });
 });

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -110,7 +110,9 @@ describe("add-component-dialog preserves the editor draft (#1146)", () => {
     );
     expect(seen).toEqual([{ type: "yaml-draft" }]);
     // Navigate-and-close branch ran: dialog closed, selection cleared.
-    expect((dialog as unknown as { _open: boolean })._open).toBe(false);
+    expect((dialog as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(
+      false
+    );
     expect((dialog as unknown as { _selected: unknown })._selected).toBeNull();
   });
 });

--- a/test/components/device/add-component-dialog-open-close.test.ts
+++ b/test/components/device/add-component-dialog-open-close.test.ts
@@ -33,7 +33,7 @@ const dialog = (el: ESPHomeAddComponentDialog): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isOpen = (el: ESPHomeAddComponentDialog): boolean => (el as any)._open;
+const isOpen = (el: ESPHomeAddComponentDialog): boolean => (el as any)._dialog.open;
 
 describe("add-component-dialog open/close contract", () => {
   it("open() flips the reactive open flag and binds ?open", async () => {

--- a/test/components/device/add-dialogs-enter.test.ts
+++ b/test/components/device/add-dialogs-enter.test.ts
@@ -74,10 +74,13 @@ describe.each([
 
   it("stops firing once the dialog closes", async () => {
     const { dialog, onContinue } = await mount(ctor as new () => LitElement);
-    const view = dialog as unknown as { open: () => void; _onRequestClose: () => void };
+    const view = dialog as unknown as {
+      open: () => void;
+      _dialog: { onRequestClose: () => void };
+    };
     view.open();
     await dialog.updateComplete;
-    view._onRequestClose(); // flips _open false (Escape / X / backdrop path)
+    view._dialog.onRequestClose(); // flips the open flag false (Escape / X / backdrop path)
     await dialog.updateComplete;
     pressEnter();
     expect(onContinue).not.toHaveBeenCalled();

--- a/test/components/device/add-script-dialog.test.ts
+++ b/test/components/device/add-script-dialog.test.ts
@@ -7,7 +7,7 @@
  * ``_open`` flag, so the open/close contract is the part most likely to
  * silently regress. esphome-base-dialog never mutates its own ``open`` on
  * a user close (Escape / X / outside-click), so the host must flip
- * ``_open`` itself in ``_onRequestClose`` — otherwise a re-render would
+ * the open flag itself in the controller's ``onRequestClose`` — otherwise a re-render would
  * re-assert ``?open`` and the dialog could never dismiss.
  */
 import { describe, expect, it, vi } from "vitest";
@@ -19,20 +19,22 @@ import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-scrip
 import { mount } from "../../_dom.js";
 
 describe("add-script-dialog base-dialog open contract", () => {
-  it("open() drives the reactive _open flag", async () => {
+  it("open() drives the reactive open flag", async () => {
     const el = await mount(new ESPHomeAddScriptDialog());
-    const view = el as unknown as { _open: boolean };
-    expect(view._open).toBe(false);
+    const view = el as unknown as { _dialog: { open: boolean } };
+    expect(view._dialog.open).toBe(false);
     el.open();
-    expect(view._open).toBe(true);
+    expect(view._dialog.open).toBe(true);
   });
 
-  it("_onRequestClose flips the reactive open flag", async () => {
+  it("the controller's onRequestClose flips the reactive open flag", async () => {
     const el = await mount(new ESPHomeAddScriptDialog());
-    const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
+    const view = el as unknown as {
+      _dialog: { open: boolean; onRequestClose: () => void };
+    };
     el.open();
-    expect(view._open).toBe(true);
-    view._onRequestClose();
-    expect(view._open).toBe(false);
+    expect(view._dialog.open).toBe(true);
+    view._dialog.onRequestClose();
+    expect(view._dialog.open).toBe(false);
   });
 });

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -30,7 +30,7 @@ async function mountDialog(
 }
 
 const isOpen = (d: ESPHomeCatalogPickerDialog): boolean =>
-  (d as unknown as { _open: boolean })._open;
+  (d as unknown as { _dialog: { open: boolean } })._dialog.open;
 const activeTab = (d: ESPHomeCatalogPickerDialog): string =>
   (d as unknown as { _activeTab: string })._activeTab;
 
@@ -51,11 +51,13 @@ describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
     expect(activeTab(dialog)).toBe("by-type");
   });
 
-  it("_onRequestClose flips _open back to false", async () => {
+  it("the controller's onRequestClose flips the open flag back to false", async () => {
     const dialog = await mountDialog();
     dialog.open();
     expect(isOpen(dialog)).toBe(true);
-    (dialog as unknown as { _onRequestClose: () => void })._onRequestClose();
+    (
+      dialog as unknown as { _dialog: { onRequestClose: () => void } }
+    )._dialog.onRequestClose();
     expect(isOpen(dialog)).toBe(false);
   });
 

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  *
  * Pins the label editor's reactive open/close contract after the migration
- * onto esphome-base-dialog (#549): the dialog tracks _open via ?open, and
+ * onto esphome-base-dialog (#549): the dialog tracks its open flag via ?open, and
  * request-close / after-hide both mirror it back to false so a user-driven
  * close (Escape / X / outside-click) actually dismisses. Saves fire on every
  * label toggle while the dialog stays open, so it deliberately does NOT bind
@@ -39,7 +39,7 @@ const dialog = (el: ESPHomeDeviceLabelsEditor): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isOpen = (el: ESPHomeDeviceLabelsEditor): boolean => (el as any)._open;
+const isOpen = (el: ESPHomeDeviceLabelsEditor): boolean => (el as any)._dialog.open;
 
 describe("device-labels-editor open/close contract", () => {
   it("opens via the Edit-labels trigger", async () => {
@@ -51,19 +51,19 @@ describe("device-labels-editor open/close contract", () => {
     expect(dialog(el).hasAttribute("open")).toBe(true);
   });
 
-  it("flips _open to false on request-close", async () => {
+  it("flips the open flag to false on request-close", async () => {
     const el = await mount();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._open = true;
+    (el as any)._dialog.open = true;
     await el.updateComplete;
     dialog(el).dispatchEvent(new CustomEvent("request-close"));
     expect(isOpen(el)).toBe(false);
   });
 
-  it("flips _open to false on after-hide", async () => {
+  it("flips the open flag to false on after-hide", async () => {
     const el = await mount();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._open = true;
+    (el as any)._dialog.open = true;
     await el.updateComplete;
     dialog(el).dispatchEvent(new CustomEvent("after-hide"));
     expect(isOpen(el)).toBe(false);
@@ -72,7 +72,7 @@ describe("device-labels-editor open/close contract", () => {
   it("closes when the device prop swaps to a different device", async () => {
     const el = await mount();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._open = true;
+    (el as any)._dialog.open = true;
     await el.updateComplete;
     el.device = { configuration: "bedroom", labels: [] } as unknown as ConfiguredDevice;
     await el.updateComplete;
@@ -82,7 +82,7 @@ describe("device-labels-editor open/close contract", () => {
   it("stays open on a same-device update (e.g. DEVICE_UPDATED after a toggle)", async () => {
     const el = await mount();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._open = true;
+    (el as any)._dialog.open = true;
     await el.updateComplete;
     // Same configuration, new labels (and a new object ref, as the dashboard
     // hands down after set_labels) — the dialog must NOT close.

--- a/test/components/onboarding-wifi-dialog.test.ts
+++ b/test/components/onboarding-wifi-dialog.test.ts
@@ -23,7 +23,7 @@ import { ESPHomeOnboardingWifiDialog } from "../../src/components/onboarding-wif
 interface DialogPrivateView extends EventTarget {
   _ssid: string;
   _password: string;
-  _open: boolean;
+  _dialog: { open: boolean; onRequestClose(): void };
   _saving: boolean;
   _error: string | null;
   _api: {
@@ -31,7 +31,6 @@ interface DialogPrivateView extends EventTarget {
   };
   readonly _passwordTooShort: boolean;
   _save(): Promise<void>;
-  _onRequestClose(): void;
 }
 
 function makeDialog(): DialogPrivateView {
@@ -103,25 +102,26 @@ describe("onboarding-wifi-dialog password-length gate", () => {
  *
  * The migration moved the save-in-flight close veto onto base-dialog's
  * ``?busy`` gate and replaced the imperative ``dialog.open`` with a
- * reactive ``_open`` flag, so the close / error paths are the part most
+ * reactive open flag (owned by DialogOpenController), so the close /
+ * error paths are the part most
  * likely to silently regress. These pin the contract the host still
  * owns: a failed save keeps the dialog open with an inline error, a
  * successful save closes it and fires ``secrets-saved``, and the reactive
- * close path flips ``_open``.
+ * close path flips the controller's open flag.
  */
 describe("onboarding-wifi-dialog close / error gating", () => {
   test("a failed save shows the inline error and leaves the dialog open", async () => {
     const dialog = makeDialog();
     const setWifiCredentials = vi.fn().mockRejectedValue(new Error("write failed"));
     dialog._api = { setWifiCredentials };
-    dialog._open = true;
+    dialog._dialog.open = true;
     dialog._ssid = "MyNetwork";
     dialog._password = "12345678";
 
     await dialog._save();
 
     expect(dialog._error).toBeTruthy(); // inline error surfaced
-    expect(dialog._open).toBe(true); // dialog stays open to retry
+    expect(dialog._dialog.open).toBe(true); // dialog stays open to retry
     expect(dialog._saving).toBe(false); // re-enabled for another attempt
   });
 
@@ -129,7 +129,7 @@ describe("onboarding-wifi-dialog close / error gating", () => {
     const dialog = makeDialog();
     const setWifiCredentials = vi.fn().mockResolvedValue(undefined);
     dialog._api = { setWifiCredentials };
-    dialog._open = true;
+    dialog._dialog.open = true;
     dialog._ssid = "MyNetwork";
     dialog._password = "12345678";
 
@@ -142,14 +142,14 @@ describe("onboarding-wifi-dialog close / error gating", () => {
     }
 
     expect(setWifiCredentials).toHaveBeenCalledWith("MyNetwork", "12345678");
-    expect(dialog._open).toBe(false); // closed via the reactive flag
+    expect(dialog._dialog.open).toBe(false); // closed via the reactive flag
     expect(saved).toHaveBeenCalledTimes(1); // pickers + kebab wording refresh
   });
 
-  test("_onRequestClose flips the reactive open flag", () => {
+  test("the controller's onRequestClose flips the reactive open flag", () => {
     const dialog = makeDialog();
-    dialog._open = true;
-    dialog._onRequestClose();
-    expect(dialog._open).toBe(false);
+    dialog._dialog.open = true;
+    dialog._dialog.onRequestClose();
+    expect(dialog._dialog.open).toBe(false);
   });
 });

--- a/test/components/rename-device-dialog.test.ts
+++ b/test/components/rename-device-dialog.test.ts
@@ -66,9 +66,9 @@ describe("rename-device-dialog ENTER", () => {
     el.addEventListener("rename-confirm", onConfirm as EventListener);
     await setValue(el, "kitchen");
     pressEnter(); // confirms and runs close(), but after-hide hasn't fired
-    // close() flips the reactive _open flag; the base-dialog is still hiding
+    // close() flips the reactive open flag; the base-dialog is still hiding
     // (after-hide not yet fired) so the EnterController listener stays bound.
-    expect((el as unknown as { _open: boolean })._open).toBe(false);
+    expect((el as unknown as { _dialog: { open: boolean } })._dialog.open).toBe(false);
     pressEnter(); // listener still bound; stopped only by the latch
     expect(onConfirm).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,28 +94,31 @@ describe("rename-device-dialog ENTER", () => {
  * Regression coverage for the esphome-base-dialog migration (#549).
  *
  * The migration swapped the imperative ``dialog.open`` for a reactive
- * ``_open`` flag, so the open/close contract is the part most likely to
- * silently regress. esphome-base-dialog never mutates its own ``open`` on
- * a user close, so the host must flip ``_open`` itself in ``_onRequestClose``
+ * open flag (now owned by DialogOpenController), so the open/close
+ * contract is the part most likely to silently regress.
+ * esphome-base-dialog never mutates its own ``open`` on a user close, so
+ * the host's controller must flip the flag in ``onRequestClose``
  * (Escape / X / backdrop) — otherwise a re-render would re-assert ``?open``
  * and the dialog could never dismiss.
  */
 describe("rename-device-dialog base-dialog open contract", () => {
-  it("open() / close() drive the reactive _open flag", async () => {
+  it("open() / close() drive the reactive open flag", async () => {
     const el = await mount(new ESPHomeRenameDeviceDialog());
-    const view = el as unknown as { _open: boolean };
+    const view = el as unknown as { _dialog: { open: boolean } };
     el.open("oldname");
-    expect(view._open).toBe(true);
+    expect(view._dialog.open).toBe(true);
     el.close();
-    expect(view._open).toBe(false);
+    expect(view._dialog.open).toBe(false);
   });
 
-  it("_onRequestClose flips the reactive open flag", async () => {
+  it("the controller's onRequestClose flips the reactive open flag", async () => {
     const el = await mount(new ESPHomeRenameDeviceDialog());
-    const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
+    const view = el as unknown as {
+      _dialog: { open: boolean; onRequestClose: () => void };
+    };
     el.open("oldname");
-    expect(view._open).toBe(true);
-    view._onRequestClose();
-    expect(view._open).toBe(false);
+    expect(view._dialog.open).toBe(true);
+    view._dialog.onRequestClose();
+    expect(view._dialog.open).toBe(false);
   });
 });

--- a/test/components/unsaved-changes-dialog.test.ts
+++ b/test/components/unsaved-changes-dialog.test.ts
@@ -84,9 +84,9 @@ describe("unsaved-changes-dialog dismiss / request-close", () => {
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(true);
+    expect((el as any)._dialog.open).toBe(true);
     baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(false);
+    expect((el as any)._dialog.open).toBe(false);
   });
 });

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -541,14 +541,15 @@ describe("create-config-dialog stale error on navigation", () => {
   });
 });
 
-// The migration onto esphome-base-dialog swapped the imperative
-// `_dialog.open = …` for a reactive `_open` flag. _onRequestClose flipping
-// _open back to false is the load-bearing part — without it a user-driven
-// close (Escape / X / outside-click) wouldn't dismiss. Pin the contract.
+// The migration onto esphome-base-dialog swapped the imperative wa-dialog
+// `open = …` for a reactive open flag (owned by DialogOpenController).
+// The controller's onRequestClose flipping the flag back to false is the
+// load-bearing part — without it a user-driven close (Escape / X /
+// outside-click) wouldn't dismiss. Pin the contract.
 describe("create-config-dialog open/close contract", () => {
   const isOpen = (el: ESPHomeCreateConfigDialog): boolean =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (el as any)._open;
+    (el as any)._dialog.open;
 
   it("open() and openAtBoardStep() set the reactive open flag", async () => {
     const el = await mount({});
@@ -560,7 +561,7 @@ describe("create-config-dialog open/close contract", () => {
     expect(isOpen(el)).toBe(true);
   });
 
-  it("flips _open to false on request-close from the wrapper", async () => {
+  it("flips the open flag to false on request-close from the wrapper", async () => {
     const el = await mount({});
     expect(isOpen(el)).toBe(true);
     el.shadowRoot!.querySelector("esphome-base-dialog")!.dispatchEvent(
@@ -569,7 +570,7 @@ describe("create-config-dialog open/close contract", () => {
     expect(isOpen(el)).toBe(false);
   });
 
-  it("close() sets _open to false", async () => {
+  it("close() sets the open flag to false", async () => {
     const el = await mount({});
     el.close();
     expect(isOpen(el)).toBe(false);

--- a/test/components/yaml-validation-dialog.test.ts
+++ b/test/components/yaml-validation-dialog.test.ts
@@ -142,9 +142,9 @@ describe("yaml-validation-dialog dismiss / request-close", () => {
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(true);
+    expect((el as any)._dialog.open).toBe(true);
     baseDialog(el).dispatchEvent(new CustomEvent("request-close"));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any)._open).toBe(false);
+    expect((el as any)._dialog.open).toBe(false);
   });
 });

--- a/test/util/dialog-open-controller.test.ts
+++ b/test/util/dialog-open-controller.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { DialogOpenController } from "../../src/util/dialog-open-controller.js";
+import { FakeHost } from "../_fake-host.js";
+
+describe("DialogOpenController", () => {
+  it("registers itself on the host and starts closed", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    expect(host.controllers).toContain(ctrl);
+    expect(ctrl.open).toBe(false);
+  });
+
+  it("requests a host update when the flag changes", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+
+    ctrl.open = true;
+    expect(ctrl.open).toBe(true);
+    expect(host.updates).toBe(1);
+
+    ctrl.open = false;
+    expect(ctrl.open).toBe(false);
+    expect(host.updates).toBe(2);
+  });
+
+  it("does not request an update on a same-value write", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+
+    ctrl.open = false;
+    expect(host.updates).toBe(0);
+
+    ctrl.open = true;
+    ctrl.open = true;
+    expect(host.updates).toBe(1);
+  });
+
+  // The close-animation race guard the copy-pasted host handlers used to
+  // pin: the flag must flip on the initiating request-close, before
+  // wa-dialog finishes hiding, so a host re-render can't re-assert ?open.
+  it("onRequestClose flips the flag false", () => {
+    const host = new FakeHost();
+    const ctrl = new DialogOpenController(host);
+    ctrl.open = true;
+
+    ctrl.onRequestClose();
+    expect(ctrl.open).toBe(false);
+    expect(host.updates).toBe(2);
+  });
+
+  it("onRequestClose is a stable reference usable as an event listener", () => {
+    const ctrl = new DialogOpenController(new FakeHost());
+    const first = ctrl.onRequestClose;
+    ctrl.open = true;
+    expect(ctrl.onRequestClose).toBe(first);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Adds a small `DialogOpenController` reactive controller (mirroring the existing `EnterController` pattern) that owns a dialog's reactive open flag and provides the trivial `request-close` handler, then migrates the 16 `esphome-base-dialog` consumers that all duplicated the identical `_onRequestClose = () => { this._open = false; }` boilerplate onto it. Dialogs with real busy or unsaved changes veto logic keep their custom handlers; behavior is unchanged, the flag still flips on the initiating close so a rerender cannot reassert `?open` while the dialog is still hiding.

**Related issue or feature (if applicable):**

- fixes #1088

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
