### PR TITLE
Share one unquote helper between yaml-hover and yaml-line-walker

### DIFF
--- a/src/util/yaml-hover.ts
+++ b/src/util/yaml-hover.ts
@@ -44,6 +44,7 @@ import {
   RE_PAIR_LINE,
   readPlatformSibling,
   stripComment,
+  unquote,
 } from "./yaml-line-walker.js";
 
 /** Resolved hover content — Markdown docs plus an optional "See also" link. */
@@ -51,16 +52,6 @@ export interface HoverTarget {
   description: string | null;
   docsUrl: string | null;
   docsTitle: string | null;
-}
-
-/** Strip one layer of matched quotes (mirrors the AST / line-walker). */
-function unquote(value: string): string {
-  if (value.length < 2) return value;
-  const q = value[0];
-  if ((q === '"' || q === "'") && value[value.length - 1] === q) {
-    return value.slice(1, -1);
-  }
-  return value;
 }
 
 /**

--- a/src/util/yaml-line-walker.ts
+++ b/src/util/yaml-line-walker.ts
@@ -69,6 +69,22 @@ export function stripComment(line: string): string {
   return line.slice(0, m.index! + m[0].length - 1).trimEnd();
 }
 
+/** Strip a single layer of matched single or double quotes from
+ *  *value*. Mirrors the AST's ``readLiteralText`` so the regex
+ *  walkers (and ``yaml-hover``) and the AST agree on the
+ *  user-facing string. Deliberately NOT ``yaml-scalar``'s
+ *  ``stripQuotes``: importing ``yaml-scalar`` here would close an
+ *  import cycle (``yaml-scalar`` → ``yaml-serialize`` →
+ *  ``esphome-yaml-lang`` → this module). */
+export function unquote(value: string): string {
+  if (value.length < 2) return value;
+  const q = value[0];
+  if ((q === '"' || q === "'") && value[value.length - 1] === q) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
 // ─── Multi-line walkers ──────────────────────────────────────────────
 
 export interface ParentKey {
@@ -270,16 +286,4 @@ export function readPlatformSibling(
     if (m) return unquote(m[1]);
   }
   return null;
-}
-
-/** Strip a single layer of matched single or double quotes from
- *  *value*. Mirrors the AST's ``readLiteralText`` so the regex
- *  walker and the AST agree on the user-facing string. */
-function unquote(value: string): string {
-  if (value.length < 2) return value;
-  const q = value[0];
-  if ((q === '"' || q === "'") && value[value.length - 1] === q) {
-    return value.slice(1, -1);
-  }
-  return value;
 }

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -10,6 +10,7 @@ import {
   keyPathByIndent,
   readPlatformSibling,
   stripComment,
+  unquote,
 } from "../../src/util/yaml-line-walker.js";
 
 /** Build a CodeMirror `Text` doc from an array of lines. */
@@ -45,6 +46,32 @@ describe("stripComment", () => {
 
   it("trims trailing whitespace when there's no comment", () => {
     expect(stripComment("name: foo   ")).toBe("name: foo");
+  });
+});
+
+describe("unquote", () => {
+  it("strips one layer of matched double quotes", () => {
+    expect(unquote('"gpio"')).toBe("gpio");
+  });
+
+  it("strips one layer of matched single quotes", () => {
+    expect(unquote("'gpio'")).toBe("gpio");
+  });
+
+  it("leaves an unquoted value untouched", () => {
+    expect(unquote("gpio")).toBe("gpio");
+  });
+
+  it("leaves mismatched quotes untouched", () => {
+    expect(unquote("\"gpio'")).toBe("\"gpio'");
+  });
+
+  it("leaves a lone quote character untouched", () => {
+    expect(unquote('"')).toBe('"');
+  });
+
+  it("strips only the outer layer of nested quotes", () => {
+    expect(unquote("'\"gpio\"'")).toBe('"gpio"');
   });
 });
 

--- a/test/util/yaml-line-walker.test.ts
+++ b/test/util/yaml-line-walker.test.ts
@@ -73,6 +73,13 @@ describe("unquote", () => {
   it("strips only the outer layer of nested quotes", () => {
     expect(unquote("'\"gpio\"'")).toBe('"gpio"');
   });
+
+  it("does not decode the YAML '' single-quote escape (unlike stripQuotes)", () => {
+    // Pins the invariant that keeps this helper separate from
+    // yaml-scalar's stripQuotes: swapping in scalar-style parsing
+    // would silently change hover/walker behavior.
+    expect(unquote("'it''s'")).toBe("it''s");
+  });
 });
 
 describe("findParentKey", () => {


### PR DESCRIPTION
# What does this implement/fix?

Deletes the two identical private `unquote` helpers in `src/util/yaml-hover.ts` and `src/util/yaml-line-walker.ts`, exporting a single shared copy from `yaml-line-walker.ts` that both modules use, with unit tests for the newly exported helper. Reusing `stripQuotes` from `yaml-scalar.ts` at these call sites would close an import cycle (`yaml-scalar` imports `yaml-serialize`, which imports `esphome-yaml-lang`, which imports `yaml-line-walker`), so the walker keeps its own exported helper and a comment on it records why; `stripQuotes` stays as the richer scalar parsing variant that also decodes the YAML `''` escape.

**Related issue or feature (if applicable):**

- fixes #1091

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
