### PR TITLE
Add a shared test DOM helper module and global body cleanup

### DIFF
--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared DOM helpers for the happy-dom test suites.
+ *
+ * Nearly every component/dialog test used to hand-roll the same snippets:
+ * an async mount (append + settle), a render-into-a-container helper for
+ * pure template functions, and an identity localize stub for host fakes.
+ * They live here once instead; ``test/_setup-dom.ts`` owns the matching
+ * ``document.body`` cleanup between tests.
+ */
+import { render } from "lit";
+
+/**
+ * Append ``el`` to ``document.body`` and wait for its first render.
+ *
+ * ``props`` is ``Object.assign``ed onto the element before it is attached,
+ * for suites that seed public props or private state ahead of the initial
+ * update. Constrained to ``HTMLElement`` (not ``LitElement``) so plain
+ * elements mount too; ``updateComplete`` is awaited when the element has
+ * one (every Lit element) and is a no-op await otherwise.
+ */
+export async function mount<T extends HTMLElement>(
+  el: T,
+  props?: Partial<T>
+): Promise<T> {
+  if (props) {
+    Object.assign(el, props);
+  }
+  document.body.appendChild(el);
+  await (el as { updateComplete?: Promise<unknown> }).updateComplete;
+  return el;
+}
+
+/**
+ * Render a template into a fresh ``<div>`` attached to ``document.body``
+ * and return the container.
+ *
+ * Takes ``unknown`` (mirroring lit's own ``render`` signature) so pure
+ * renderers that return ``TemplateResult | typeof nothing`` pass without
+ * a cast. The container is left attached; the global body cleanup in
+ * ``test/_setup-dom.ts`` removes it between tests.
+ */
+export function renderInto(tpl: unknown): HTMLElement {
+  const container = document.createElement("div");
+  render(tpl, container);
+  document.body.appendChild(container);
+  return container;
+}
+
+/** Identity localize stub for host fakes: returns the key unchanged. */
+export const identityLocalize = (key: string): string => key;

--- a/test/_setup-dom.ts
+++ b/test/_setup-dom.ts
@@ -11,6 +11,6 @@ import { afterEach } from "vitest";
 
 afterEach(() => {
   if (typeof document !== "undefined") {
-    document.body.innerHTML = "";
+    document.body?.replaceChildren();
   }
 });

--- a/test/_setup-dom.ts
+++ b/test/_setup-dom.ts
@@ -1,0 +1,16 @@
+/**
+ * Per-file vitest setup (see ``setupFiles`` in vitest.config.ts).
+ *
+ * Registers the one global ``afterEach`` that clears ``document.body``
+ * between tests, replacing the per-file cleanup boilerplate the DOM suites
+ * used to copy around. Guarded because the suite's default environment is
+ * node (no DOM); only files opting into happy-dom via the
+ * ``@vitest-environment`` pragma have a document to clear.
+ */
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  if (typeof document !== "undefined") {
+    document.body.innerHTML = "";
+  }
+});

--- a/test/components/adopt-dialog-checkbox-reset.test.ts
+++ b/test/components/adopt-dialog-checkbox-reset.test.ts
@@ -5,12 +5,13 @@
  * the reused dialog is reopened: a prior user uncheck must not leave the box
  * visually unchecked while `_encryption` is back to true (issue #1535).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 
 import type { AdoptableDevice } from "../../src/api/types/devices.js";
 import { ESPHomeAdoptDialog } from "../../src/components/adopt-dialog.js";
+import { mount } from "../_dom.js";
 
 const DEVICE = {
   name: "foo-1234",
@@ -19,23 +20,12 @@ const DEVICE = {
   package_import_url: "github://acme/widget/widget.yaml@main",
 } as unknown as AdoptableDevice;
 
-async function mount(): Promise<ESPHomeAdoptDialog> {
-  const el = new ESPHomeAdoptDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 const checkbox = (el: ESPHomeAdoptDialog) =>
   el.shadowRoot!.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
 
 describe("adopt-dialog encryption checkbox reset", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("re-checks the box on reopen after a prior uncheck", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAdoptDialog());
 
     el.open(DEVICE);
     await el.updateComplete;

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -13,6 +13,7 @@ import {
   onSetTheme,
   onSetVersionHistoryEnabled,
 } from "../../../src/components/app-shell/settings-actions.js";
+import { identityLocalize } from "../../_dom.js";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 vi.mock("sonner-js", () => ({
@@ -40,7 +41,7 @@ function makePrefsHost(
     _experienceLevel: null,
     _remoteComputeOnly: false,
     _versionHistoryEnabled: true,
-    _localize: ((key: string) => key) as ESPHomeApp["_localize"],
+    _localize: identityLocalize as ESPHomeApp["_localize"],
     _prefsWritesInFlight: 0,
     _api: { updatePreferences },
   };
@@ -65,7 +66,7 @@ function makeHost(api: StubHost["_api"]): StubHost {
     _offloaderRemoteBuildsEnabled: true,
     _offloaderIncludeLocalInPool: false,
     _offloaderWritesInFlight: 0,
-    _localize: ((key: string) => key) as ESPHomeApp["_localize"],
+    _localize: identityLocalize as ESPHomeApp["_localize"],
     _api: api,
   };
 }
@@ -212,7 +213,7 @@ function makePairingHost(
   return {
     _buildOffloadPairings: new Map([[PAIRING_PIN, makePairing(true)]]),
     _offloaderWritesInFlight: 0,
-    _localize: ((key: string) => key) as ESPHomeApp["_localize"],
+    _localize: identityLocalize as ESPHomeApp["_localize"],
     _api: api,
   };
 }
@@ -413,7 +414,7 @@ function makeRemoteBuildHost(
     _remoteBuildEnabled: false,
     _remoteBuildSetInFlight: false,
     _buildServerIdentityRotationCounter: 0,
-    _localize: ((key: string) => key) as ESPHomeApp["_localize"],
+    _localize: identityLocalize as ESPHomeApp["_localize"],
     _api: { setRemoteBuildSettings },
   };
 }

--- a/test/components/base-dialog-header-prefix.test.ts
+++ b/test/components/base-dialog-header-prefix.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 // Stub the real wa-dialog (happy-dom can't run its form-associated close
 // button); these tests only exercise the wrapper's own header markup.
@@ -7,6 +7,7 @@ import { vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
+import { mount } from "../_dom.js";
 
 /**
  * Regression coverage for the ``header-prefix`` slot added so the
@@ -15,22 +16,9 @@ import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
  * no-op when a consumer doesn't fill it, so a future header refactor can't
  * silently drop it or reorder it past the title.
  */
-async function mount(prefix?: string): Promise<ESPHomeBaseDialog> {
-  const el = new ESPHomeBaseDialog();
-  el.label = "Title";
-  if (prefix) el.innerHTML = prefix;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 describe("esphome-base-dialog header-prefix slot", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   test("renders the prefix slot before the title", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeBaseDialog(), { label: "Title" });
     const prefix = el.shadowRoot!.querySelector('slot[name="header-prefix"]')!;
     const title = el.shadowRoot!.querySelector('[part="title-text"]')!;
     expect(prefix).toBeTruthy();
@@ -41,7 +29,7 @@ describe("esphome-base-dialog header-prefix slot", () => {
   });
 
   test("is empty by default (no slotted content)", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeBaseDialog(), { label: "Title" });
     const prefix = el.shadowRoot!.querySelector(
       'slot[name="header-prefix"]'
     ) as HTMLSlotElement;
@@ -49,7 +37,10 @@ describe("esphome-base-dialog header-prefix slot", () => {
   });
 
   test("accepts slotted content (e.g. a wizard back button)", async () => {
-    const el = await mount('<button slot="header-prefix" class="back">x</button>');
+    const el = await mount(new ESPHomeBaseDialog(), {
+      label: "Title",
+      innerHTML: '<button slot="header-prefix" class="back">x</button>',
+    });
     const prefix = el.shadowRoot!.querySelector(
       'slot[name="header-prefix"]'
     ) as HTMLSlotElement;

--- a/test/components/base-dialog.test.ts
+++ b/test/components/base-dialog.test.ts
@@ -3,25 +3,14 @@
 // Pins the wrapper-owned Enter-to-confirm (issue #1269): a plain Enter fires
 // confirmOnEnter only while open and only when a callback is set, inherits
 // EnterController's focus-target skip rules, and detaches when open flips false.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // wa-dialog runs form-validation lifecycle hooks happy-dom doesn't implement;
 // stub the import so the wrapper can render in the test.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { ESPHomeBaseDialog } from "../../src/components/base-dialog.js";
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
-
-async function mount(props: Partial<ESPHomeBaseDialog>): Promise<ESPHomeBaseDialog> {
-  const el = new ESPHomeBaseDialog();
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../_dom.js";
 
 // Dispatch a bubbling+composed Enter from `from`, which becomes
 // composedPath()[0] (the element the controller treats as focused) and reaches
@@ -40,20 +29,20 @@ function pressEnter(from: Element): void {
 describe("esphome-base-dialog confirmOnEnter", () => {
   it("fires the callback on Enter while open", async () => {
     const confirmOnEnter = vi.fn();
-    await mount({ open: true, confirmOnEnter });
+    await mount(new ESPHomeBaseDialog(), { open: true, confirmOnEnter });
     pressEnter(document.body);
     expect(confirmOnEnter).toHaveBeenCalledTimes(1);
   });
 
   it("does not fire while closed", async () => {
     const confirmOnEnter = vi.fn();
-    await mount({ open: false, confirmOnEnter });
+    await mount(new ESPHomeBaseDialog(), { open: false, confirmOnEnter });
     pressEnter(document.body);
     expect(confirmOnEnter).not.toHaveBeenCalled();
   });
 
   it("does not fire when no callback is set", async () => {
-    const el = await mount({ open: true });
+    const el = await mount(new ESPHomeBaseDialog(), { open: true });
     // Nothing to assert beyond "no throw"; a stray listener would also leak
     // EnterController's preventDefault, so confirm the event isn't claimed.
     const ev = new KeyboardEvent("keydown", {
@@ -69,7 +58,7 @@ describe("esphome-base-dialog confirmOnEnter", () => {
 
   it("fires from a focused text input but not a button or select", async () => {
     const confirmOnEnter = vi.fn();
-    await mount({ open: true, confirmOnEnter });
+    await mount(new ESPHomeBaseDialog(), { open: true, confirmOnEnter });
 
     const input = document.createElement("input");
     const button = document.createElement("button");
@@ -86,7 +75,7 @@ describe("esphome-base-dialog confirmOnEnter", () => {
 
   it("detaches the listener when open flips false", async () => {
     const confirmOnEnter = vi.fn();
-    const el = await mount({ open: true, confirmOnEnter });
+    const el = await mount(new ESPHomeBaseDialog(), { open: true, confirmOnEnter });
 
     el.open = false;
     await el.updateComplete;

--- a/test/components/build-offload-section/render-discovered-hosts.test.ts
+++ b/test/components/build-offload-section/render-discovered-hosts.test.ts
@@ -6,10 +6,11 @@
  * needed both for the component import (WebAwesome touches ``CSSStyleSheet`` at
  * load) and to render the empty/loading status-row template back to its key.
  */
-import { render, type TemplateResult } from "lit";
+import { type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
 import type { RemoteBuildPeer } from "../../../src/api/types/remote-build.js";
 import { ESPHomeSettingsBuildOffload } from "../../../src/components/settings-dialog/build-offload-section.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 
 function peer(
   name: string,
@@ -34,7 +35,7 @@ type Row = { row: string };
 
 function makeHost(peers: RemoteBuildPeer[]) {
   return {
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _discoveredHosts: new Map(peers.map((p) => [p.name, p])),
     _hasPairingFor: () => false,
     _renderDiscoveredRow: (p: RemoteBuildPeer): Row => ({ row: p.name }),
@@ -53,8 +54,7 @@ function renderDiscoveredHosts(host: ReturnType<typeof makeHost>): unknown {
 // it and read back the localize key the row shows.
 function statusRowKey(result: unknown): string | null {
   if (Array.isArray(result)) return null;
-  const el = document.createElement("div");
-  render(result as TemplateResult, el);
+  const el = renderInto(result as TemplateResult);
   return el.querySelector(".row-desc")?.textContent?.trim() ?? null;
 }
 
@@ -85,9 +85,8 @@ function rowTitle(peerInfo: RemoteBuildPeer): string | null {
       (p: RemoteBuildPeer) => TemplateResult
     >
   )._renderDiscoveredRow;
-  const result = fn.call({ _localize: (key: string) => key }, peerInfo);
-  const el = document.createElement("div");
-  render(result, el);
+  const result = fn.call({ _localize: identityLocalize }, peerInfo);
+  const el = renderInto(result);
   return el.querySelector(".row-title")?.textContent?.trim() ?? null;
 }
 

--- a/test/components/build-offload-section/render-offloader-alert.test.ts
+++ b/test/components/build-offload-section/render-offloader-alert.test.ts
@@ -9,8 +9,7 @@ import type {
   OffloaderPinMismatchAlert,
 } from "../../../src/api/types/remote-build-events.js";
 import { renderOffloaderAlert } from "../../../src/components/settings-dialog/build-offload-alert.js";
-
-const localize = (key: string) => key;
+import { identityLocalize as localize } from "../../_dom.js";
 
 const pinMismatch: OffloaderPinMismatchAlert = {
   kind: "pin_mismatch",

--- a/test/components/clone-device-dialog.test.ts
+++ b/test/components/clone-device-dialog.test.ts
@@ -4,27 +4,17 @@
  * Pins that the clone dialog confirms a valid new name on Enter via the
  * shared EnterController.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { ESPHomeCloneDeviceDialog } from "../../src/components/clone-device-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
 
-async function mount(): Promise<ESPHomeCloneDeviceDialog> {
-  const el = new ESPHomeCloneDeviceDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 describe("clone-device-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("confirms a valid new name on Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     el.open("source");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -39,7 +29,7 @@ describe("clone-device-dialog ENTER", () => {
   });
 
   it("fires clone-confirm only once on a repeated Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     el.open("source");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -58,7 +48,7 @@ describe("clone-device-dialog ENTER", () => {
     // identically on the repeat); the listener detaches in _onAfterHide, not
     // close(), so the _resolved latch is the only thing stopping a second
     // dispatch while the dialog is still hiding.
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     el.open("source");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -80,7 +70,7 @@ describe("clone-device-dialog ENTER", () => {
   });
 
   it("ignores Enter with an empty name", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     el.open("source");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -101,12 +91,8 @@ describe("clone-device-dialog ENTER", () => {
  * and the dialog could never dismiss.
  */
 describe("clone-device-dialog base-dialog open contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() / close() drive the reactive _open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     const view = el as unknown as { _open: boolean };
     el.open("source");
     expect(view._open).toBe(true);
@@ -115,7 +101,7 @@ describe("clone-device-dialog base-dialog open contract", () => {
   });
 
   it("_onRequestClose flips the reactive open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeCloneDeviceDialog());
     const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
     el.open("source");
     expect(view._open).toBe(true);

--- a/test/components/codemirror-editor-element.test.ts
+++ b/test/components/codemirror-editor-element.test.ts
@@ -8,9 +8,10 @@
 import type { EditorView } from "@codemirror/view";
 import { html } from "lit";
 import { customElement } from "lit/decorators.js";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { CodeMirrorEditorElement } from "../../src/components/codemirror-editor-element.js";
+import { mount } from "../_dom.js";
 
 @customElement("test-cm-editor")
 class TestCmEditor extends CodeMirrorEditorElement {
@@ -39,34 +40,23 @@ class TestCmEditor extends CodeMirrorEditorElement {
   }
 }
 
-async function mount(): Promise<TestCmEditor> {
-  const el = new TestCmEditor();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 describe("CodeMirrorEditorElement", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("mounts a live EditorView into .cm-wrap", async () => {
-    const el = await mount();
+    const el = await mount(new TestCmEditor());
     expect(el.view).not.toBeNull();
     expect(el.view!.state.doc.toString()).toBe("hello\nworld\n");
     expect(el.container.querySelector(".cm-editor")).not.toBeNull();
   });
 
   it("destroys the view and drops the handle on _destroyView", async () => {
-    const el = await mount();
+    const el = await mount(new TestCmEditor());
     el.destroyView();
     expect(el.view).toBeNull();
     expect(el.container.querySelector(".cm-editor")).toBeNull();
   });
 
   it("tears down the prior view when mounted again", async () => {
-    const el = await mount();
+    const el = await mount(new TestCmEditor());
     const first = el.view!;
     el.remount("again");
     expect(el.view).not.toBe(first);
@@ -76,7 +66,7 @@ describe("CodeMirrorEditorElement", () => {
   });
 
   it("tears the view down when disconnected", async () => {
-    const el = await mount();
+    const el = await mount(new TestCmEditor());
     el.remove();
     expect(el.view).toBeNull();
   });

--- a/test/components/command-palette-expert-mode.test.ts
+++ b/test/components/command-palette-expert-mode.test.ts
@@ -1,13 +1,12 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Stub the real wa-dialog: happy-dom can't run its form-associated internals.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { buildCommands } from "../../src/components/command-palette-actions.js";
 import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
-
-const t = (key: string) => key;
+import { identityLocalize as t } from "../_dom.js";
 
 describe("buildCommands Expert Mode entry", () => {
   it("labels the entry by state and wires the toggle", () => {
@@ -35,10 +34,6 @@ describe("buildCommands Expert Mode entry", () => {
 });
 
 describe("command palette YAML search gating", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   async function openWith(expertMode: boolean): Promise<ESPHomeCommandPalette> {
     const palette = new ESPHomeCommandPalette();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/command-palette-open-event.test.ts
+++ b/test/components/command-palette-open-event.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 // Stub the real wa-dialog: happy-dom can't run its form-associated internals.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
@@ -9,10 +9,6 @@ import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
 
 /** A connected palette opens on the window event the kebab Search item fires. */
 describe("esphome-command-palette open-on-event", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   test("the open-palette event opens the palette", async () => {
     const palette = new ESPHomeCommandPalette();
     document.body.appendChild(palette);

--- a/test/components/command-palette-shortcut.test.ts
+++ b/test/components/command-palette-shortcut.test.ts
@@ -1,30 +1,20 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 // Stub the real wa-dialog: happy-dom can't run its form-associated internals.
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { ESPHomeCommandPalette } from "../../src/components/command-palette.js";
+import { mount } from "../_dom.js";
 
 /** The Cmd/Ctrl+K open shortcut, and that Shift is excluded (#1705). */
 describe("esphome-command-palette open shortcut", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
-  async function mount(): Promise<ESPHomeCommandPalette> {
-    const palette = new ESPHomeCommandPalette();
-    document.body.appendChild(palette);
-    await palette.updateComplete;
-    return palette;
-  }
-
   const isOpen = (palette: ESPHomeCommandPalette): boolean =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (palette as any)._open;
 
   test("Ctrl+K opens the palette", async () => {
-    const palette = await mount();
+    const palette = await mount(new ESPHomeCommandPalette());
     expect(isOpen(palette)).toBe(false);
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }));
@@ -33,7 +23,7 @@ describe("esphome-command-palette open shortcut", () => {
   });
 
   test("Cmd+K opens the palette", async () => {
-    const palette = await mount();
+    const palette = await mount(new ESPHomeCommandPalette());
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
 
@@ -41,7 +31,7 @@ describe("esphome-command-palette open shortcut", () => {
   });
 
   test("Ctrl+Shift+K does not open the palette (stays editor deleteLine)", async () => {
-    const palette = await mount();
+    const palette = await mount(new ESPHomeCommandPalette());
 
     window.dispatchEvent(
       new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true })
@@ -51,7 +41,7 @@ describe("esphome-command-palette open shortcut", () => {
   });
 
   test("Cmd+Shift+K does not open the palette", async () => {
-    const palette = await mount();
+    const palette = await mount(new ESPHomeCommandPalette());
 
     window.dispatchEvent(
       new KeyboardEvent("keydown", { key: "k", metaKey: true, shiftKey: true })
@@ -61,7 +51,7 @@ describe("esphome-command-palette open shortcut", () => {
   });
 
   test("Ctrl+K already handled by a focused editor does not open the palette", async () => {
-    const palette = await mount();
+    const palette = await mount(new ESPHomeCommandPalette());
     // A deeper handler (e.g. CodeMirror) consumed the keystroke first.
     window.addEventListener("keydown", (e) => e.preventDefault(), {
       capture: true,

--- a/test/components/confirm-dialog.test.ts
+++ b/test/components/confirm-dialog.test.ts
@@ -3,28 +3,18 @@
  *
  * Pins that Enter confirms a non-destructive confirm-dialog, never a destructive one.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeConfirmDialog } from "../../src/components/confirm-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
 
-async function mount(): Promise<ESPHomeConfirmDialog> {
-  const el = new ESPHomeConfirmDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 describe("confirm-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("confirms a non-destructive dialog on Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     const onConfirm = vi.fn();
     el.addEventListener("confirm", onConfirm);
     el.open();
@@ -33,7 +23,7 @@ describe("confirm-dialog ENTER", () => {
   });
 
   it("does not confirm a destructive dialog on Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     el.destructive = true;
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -44,7 +34,7 @@ describe("confirm-dialog ENTER", () => {
   });
 
   it("fires confirm only once on a repeated Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     const onConfirm = vi.fn();
     el.addEventListener("confirm", onConfirm);
     el.open();
@@ -54,7 +44,7 @@ describe("confirm-dialog ENTER", () => {
   });
 
   it("does not confirm before the dialog is opened", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     const onConfirm = vi.fn();
     el.addEventListener("confirm", onConfirm);
     pressEnter();
@@ -66,15 +56,11 @@ describe("confirm-dialog ENTER", () => {
 // the request-close handler, and the after-hide -> cancel path. Pin them so the
 // dismiss-cancels contract can't silently regress.
 describe("confirm-dialog dismiss / request-close", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const baseDialog = (el: ESPHomeConfirmDialog): HTMLElement =>
     el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
   it("fires a single cancel when dismissed without a decision", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     el.open();
     await el.updateComplete;
     const onCancel = vi.fn();
@@ -84,7 +70,7 @@ describe("confirm-dialog dismiss / request-close", () => {
   });
 
   it("does not fire cancel when the dialog was confirmed", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     el.open();
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -98,7 +84,7 @@ describe("confirm-dialog dismiss / request-close", () => {
   });
 
   it("flips the reactive open flag to false on request-close", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeConfirmDialog());
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/dashboard/actions.test.ts
+++ b/test/components/dashboard/actions.test.ts
@@ -3,6 +3,7 @@ import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { ConfiguredDevice } from "../../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { deleteDevice } from "../../../src/components/dashboard/actions.js";
+import { identityLocalize } from "../../_dom.js";
 
 const { toastSuccess, toastError } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock("sonner-js", () => ({
   },
 }));
 
-const localize = ((key: string) => key) as LocalizeFunc;
+const localize = identityLocalize as LocalizeFunc;
 
 function makeDevice(): ConfiguredDevice {
   return {

--- a/test/components/dashboard/device-drawer-update-title.test.ts
+++ b/test/components/dashboard/device-drawer-update-title.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // The drawer body renders children that pull in <wa-button> (form-associated,
@@ -8,43 +8,36 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("../../../src/components/dashboard/device-drawer-content.js", () => ({}));
 
 import { ESPHomeDeviceDrawer } from "../../../src/components/dashboard/device-drawer.js";
+import { mount } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
-
-async function mount(device: ReturnType<typeof makeConfiguredDevice>) {
-  const el = new ESPHomeDeviceDrawer();
-  el.open = true;
-  el.device = device;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 function footerAccentTitle(el: ESPHomeDeviceDrawer): string | null {
   return el.shadowRoot!.querySelector<HTMLElement>(".footer .action--accent")!.title;
 }
 
 describe("device-drawer footer Update title", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("wires installed + target versions into the Update button title", async () => {
     // Identity localize keeps the key; the version key proves both versions
     // threaded through (helper branch logic is unit-tested in update-tooltip).
-    const el = await mount(
-      makeConfiguredDevice({
+    const el = await mount(new ESPHomeDeviceDrawer(), {
+      open: true,
+      device: makeConfiguredDevice({
         update_available: true,
         deployed_version: "2024.6.0",
         current_version: "2024.12.0",
-      })
-    );
+      }),
+    });
     expect(footerAccentTitle(el)).toBe("dashboard.update_available_version");
   });
 
   it("falls back to the plain Update title when a version is missing", async () => {
-    const el = await mount(
-      makeConfiguredDevice({ update_available: true, deployed_version: "2024.6.0" })
-    );
+    const el = await mount(new ESPHomeDeviceDrawer(), {
+      open: true,
+      device: makeConfiguredDevice({
+        update_available: true,
+        deployed_version: "2024.6.0",
+      }),
+    });
     expect(footerAccentTitle(el)).toBe("dashboard.drawer_update");
   });
 });

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -5,7 +5,7 @@
  * real row-count size (floored at 1), and the mounted table renders
  * every row on one page while a normal size paginates (discussion #3682).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -76,10 +76,6 @@ const pageSizeAttr = (el: ESPHomeDeviceTable) =>
   el.shadowRoot!.querySelector("esphome-table-pagination")?.getAttribute("page-size");
 
 describe("device-table All rendering", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("paginates at a normal page size (25 of 30 rows)", async () => {
     const el = await mount(30, 25);
     expect(rowCount(el)).toBe(25);

--- a/test/components/dashboard/render-address-value.test.ts
+++ b/test/components/dashboard/render-address-value.test.ts
@@ -14,16 +14,15 @@
  */
 import { describe, expect, it } from "vitest";
 import { renderAddressValue } from "../../../src/components/dashboard/device-drawer-render.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
 } from "../../_lit-template-walker.js";
 
-const _identityLocalize: (key: string) => string = (key) => key;
-
 describe("renderAddressValue", () => {
   it("omits the visit link when url is empty", () => {
-    const result = renderAddressValue("192.168.1.42", "", _identityLocalize);
+    const result = renderAddressValue("192.168.1.42", "", identityLocalize);
     expect(findTemplatesByAnchor(result, "<a").length).toBe(0);
     expect(findTemplatesByAnchor(result, "address-visit-link").length).toBe(0);
     // Still emits the IP value cell.
@@ -33,7 +32,7 @@ describe("renderAddressValue", () => {
 
   it("renders the visit-web link when url is set", () => {
     const url = "http://kitchen.local";
-    const result = renderAddressValue("192.168.1.42", url, _identityLocalize);
+    const result = renderAddressValue("192.168.1.42", url, identityLocalize);
     const anchors = findTemplatesByAnchor(result, "<a");
     expect(anchors.length).toBe(1);
     const bindings = extractAttributeBindings(anchors[0]);
@@ -58,14 +57,14 @@ describe("renderAddressValue", () => {
 
   it("renders the em-dash placeholder when ip is empty", () => {
     // No URL: render the bare placeholder cell with the muted class.
-    const noUrl = renderAddressValue("", "", _identityLocalize);
+    const noUrl = renderAddressValue("", "", identityLocalize);
     const noUrlValues = noUrl.values.flat(Infinity);
     expect(noUrlValues).toContain("—");
 
     // With URL: still render the placeholder, plus the visit link
     // alongside it so the affordance isn't blocked on the first
     // mDNS A-record.
-    const withUrl = renderAddressValue("", "http://kitchen.local", _identityLocalize);
+    const withUrl = renderAddressValue("", "http://kitchen.local", identityLocalize);
     const withUrlValues = withUrl.values.flat(Infinity);
     expect(withUrlValues).toContain("—");
     expect(findTemplatesByAnchor(withUrl, "<a").length).toBe(1);
@@ -75,10 +74,10 @@ describe("renderAddressValue", () => {
     // The class string is built via ``class="value mono ${expr}"``,
     // so ``muted`` lives in ``values`` (an empty string when
     // populated; ``"muted"`` when the placeholder is rendering).
-    const placeholder = renderAddressValue("", "", _identityLocalize);
+    const placeholder = renderAddressValue("", "", identityLocalize);
     expect(placeholder.values).toContain("muted");
 
-    const populated = renderAddressValue("192.168.1.42", "", _identityLocalize);
+    const populated = renderAddressValue("192.168.1.42", "", identityLocalize);
     expect(populated.values).not.toContain("muted");
   });
 });

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -6,13 +6,13 @@
  * threshold, the count-label wiring, and the labels section's edit /
  * create requests driving the dashboard's label-dialog state.
  */
-import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { renderFacets } from "../../../src/components/dashboard/render-facets.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 
 // Minimal host-shaped fake. Empty _devices means the Area/Platform
 // facets compute no options and self-suppress, so the popover
@@ -21,7 +21,7 @@ import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
 function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     _devices: [],
-    _localize: (k: string) => k,
+    _localize: identityLocalize,
     _yamlMode: false,
     _selectedLabels: [],
     _selectedAreas: [],
@@ -39,24 +39,14 @@ function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
   } as unknown as ESPHomePageDashboard;
 }
 
-function renderInto(host: ESPHomePageDashboard): HTMLElement {
-  const container = document.createElement("div");
-  render(renderFacets(host), container);
-  return container;
-}
-
 const sectionByName = (root: HTMLElement, name: string) =>
   [...root.querySelectorAll("esphome-filter-section")].find(
     (el) => el.getAttribute("name") === name
   );
 
 describe("renderFacets", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("collapses every dimension into a single Filters popover", () => {
-    const container = renderInto(makeHost({ _activeFacetCount: 2 }));
+    const container = renderInto(renderFacets(makeHost({ _activeFacetCount: 2 })));
     expect(container.querySelector("esphome-filters-popover")).not.toBeNull();
     expect(container.querySelector("esphome-labels-filter-section")).not.toBeNull();
     // No legacy wrapper / inline pill row.
@@ -74,7 +64,7 @@ describe("renderFacets", () => {
       return key;
     };
     const popover = renderInto(
-      makeHost({ _activeFacetCount: count, _localize: localize })
+      renderFacets(makeHost({ _activeFacetCount: count, _localize: localize }))
     ).querySelector("esphome-filters-popover");
     expect(popover?.getAttribute("count-label")).toBe("dashboard.filter_menu_active");
     expect(calls).toContainEqual(["dashboard.filter_menu_active", { count }]);
@@ -89,17 +79,17 @@ describe("renderFacets", () => {
     const host = makeHost({
       _devices: [{ update_available: true, active_source: "mdns" }],
     });
-    expect(updatesSection(renderInto(host))).not.toBeUndefined();
+    expect(updatesSection(renderInto(renderFacets(host)))).not.toBeUndefined();
   });
 
   it("suppresses the Updates section when the fleet is current", () => {
     const host = makeHost({ _devices: [] });
-    expect(updatesSection(renderInto(host))).toBeUndefined();
+    expect(updatesSection(renderInto(renderFacets(host)))).toBeUndefined();
   });
 
   it("keeps the Updates section when a filter is selected but the fleet is current", () => {
     const host = makeHost({ _devices: [], _selectedUpdateStatus: ["update_available"] });
-    expect(updatesSection(renderInto(host))).not.toBeUndefined();
+    expect(updatesSection(renderInto(renderFacets(host)))).not.toBeUndefined();
   });
 
   it("suppresses the Updates section in YAML-search mode", () => {
@@ -107,11 +97,11 @@ describe("renderFacets", () => {
       _devices: [{ has_pending_changes: true, active_source: "mdns" }],
       _yamlMode: true,
     });
-    expect(updatesSection(renderInto(host))).toBeUndefined();
+    expect(updatesSection(renderInto(renderFacets(host)))).toBeUndefined();
   });
 
   it("suppresses the labels section in YAML-search mode", () => {
-    const container = renderInto(makeHost({ _yamlMode: true }));
+    const container = renderInto(renderFacets(makeHost({ _yamlMode: true })));
     expect(container.querySelector("esphome-labels-filter-section")).toBeNull();
   });
 
@@ -119,20 +109,20 @@ describe("renderFacets", () => {
     Array.from({ length: n }, (_, i) => ({ area: `Area ${i}` }));
 
   it("keeps the Area section plain at 8 or fewer options", () => {
-    const container = renderInto(makeHost({ _devices: areaDevices(8) }));
+    const container = renderInto(renderFacets(makeHost({ _devices: areaDevices(8) })));
     const area = sectionByName(container, "dashboard.filter_area");
     expect(area?.hasAttribute("searchable")).toBe(false);
   });
 
   it("makes the Area section searchable past 8 options", () => {
-    const container = renderInto(makeHost({ _devices: areaDevices(9) }));
+    const container = renderInto(renderFacets(makeHost({ _devices: areaDevices(9) })));
     const area = sectionByName(container, "dashboard.filter_area");
     expect(area?.hasAttribute("searchable")).toBe(true);
   });
 
   it("opens the label dialog in edit mode on request-edit-label", () => {
     const host = makeHost();
-    const container = renderInto(host);
+    const container = renderInto(renderFacets(host));
     const labels = container.querySelector("esphome-labels-filter-section")!;
     const label = { id: "l1", name: "kitchen", color: null };
     labels.dispatchEvent(
@@ -148,7 +138,7 @@ describe("renderFacets", () => {
 
   it("opens the label dialog in create mode on request-create-label", () => {
     const host = makeHost({ _labelDialogEditing: { id: "stale" } });
-    const container = renderInto(host);
+    const container = renderInto(renderFacets(host));
     const labels = container.querySelector("esphome-labels-filter-section")!;
     labels.dispatchEvent(
       new CustomEvent("request-create-label", { bubbles: true, composed: true })

--- a/test/components/dashboard/render-ip-address-row.test.ts
+++ b/test/components/dashboard/render-ip-address-row.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 import type { ESPHomeDeviceDrawerContent } from "../../../src/components/dashboard/device-drawer-content.js";
 import { renderIpAddressRow } from "../../../src/components/dashboard/device-drawer-content/render-sections.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
@@ -13,7 +14,7 @@ import {
 import { makeConfiguredDevice as _device } from "../../_make-configured-device.js";
 
 const _host = {
-  _localize: (key: string) => key,
+  _localize: identityLocalize,
   _ipExpanded: false,
 } as unknown as ESPHomeDeviceDrawerContent;
 

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -11,10 +11,11 @@ import {
   renderMacAddressRow,
   renderVersionSection,
 } from "../../../src/components/dashboard/device-drawer-content/render-sections.js";
+import { identityLocalize } from "../../_dom.js";
 import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
 import { makeConfiguredDevice as _device } from "../../_make-configured-device.js";
 
-const _localize = (key: string) => key;
+const _localize = identityLocalize;
 
 // Text bound inside each row's `.value` div.
 const valueTexts = (result: unknown): unknown[] =>

--- a/test/components/dashboard/render-mdns-expiry.test.ts
+++ b/test/components/dashboard/render-mdns-expiry.test.ts
@@ -12,23 +12,22 @@
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { renderMdnsExpiry } from "../../../src/components/dashboard/device-drawer-render.js";
+import { identityLocalize } from "../../_dom.js";
 import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-walker.js";
-
-const _identityLocalize: (key: string) => string = (key) => key;
 
 describe("renderMdnsExpiry", () => {
   it("renders a details fold-down when remaining + lifetime are present", () => {
-    const result = renderMdnsExpiry(4321, 4500, _identityLocalize, "en");
+    const result = renderMdnsExpiry(4321, 4500, identityLocalize, "en");
     expect(isTemplateResult(result)).toBe(true);
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
 
   it("renders nothing when remaining is null (no PTR cached)", () => {
-    expect(renderMdnsExpiry(null, 4500, _identityLocalize, "en")).toBe(nothing);
+    expect(renderMdnsExpiry(null, 4500, identityLocalize, "en")).toBe(nothing);
   });
 
   it("renders nothing when the lifetime is null (no PTR cached)", () => {
-    expect(renderMdnsExpiry(4321, null, _identityLocalize, "en")).toBe(nothing);
+    expect(renderMdnsExpiry(4321, null, identityLocalize, "en")).toBe(nothing);
   });
 
   it("says 'expires soon' instead of a stuck 0s once the countdown hits zero", () => {

--- a/test/components/dashboard/render-mdns-stale-warning.test.ts
+++ b/test/components/dashboard/render-mdns-stale-warning.test.ts
@@ -13,9 +13,8 @@ import { describe, expect, it } from "vitest";
 import { DeviceState } from "../../../src/api/types/devices.js";
 import type { ReachabilityStateEvent } from "../../../src/api/types/reachability.js";
 import { renderMdnsStaleWarning } from "../../../src/components/dashboard/device-drawer-render.js";
+import { identityLocalize } from "../../_dom.js";
 import { findTemplatesByAnchor, isTemplateResult } from "../../_lit-template-walker.js";
-
-const _identityLocalize: (key: string) => string = (key) => key;
 
 function reachability(
   overrides: Partial<ReachabilityStateEvent> = {}
@@ -37,7 +36,7 @@ function reachability(
 
 describe("renderMdnsStaleWarning", () => {
   it("warns when mDNS is dark but Ping is live", () => {
-    const result = renderMdnsStaleWarning(reachability(), _identityLocalize);
+    const result = renderMdnsStaleWarning(reachability(), identityLocalize);
     expect(isTemplateResult(result)).toBe(true);
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
@@ -48,7 +47,7 @@ describe("renderMdnsStaleWarning", () => {
     // strict ONLINE gate hid it until a reload caught a later snapshot).
     const result = renderMdnsStaleWarning(
       reachability({ state: DeviceState.UNKNOWN, active_source: "ping" }),
-      _identityLocalize
+      identityLocalize
     );
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
@@ -61,7 +60,7 @@ describe("renderMdnsStaleWarning", () => {
         mqtt_last_seen_seconds_ago: 9,
         ping_rtt_ms: null,
       }),
-      _identityLocalize
+      identityLocalize
     );
     expect(findTemplatesByAnchor(result, "<details").length).toBe(1);
   });
@@ -69,7 +68,7 @@ describe("renderMdnsStaleWarning", () => {
   it("stays silent once mDNS has been seen", () => {
     const result = renderMdnsStaleWarning(
       reachability({ active_source: "mdns", mdns_last_seen_seconds_ago: 3 }),
-      _identityLocalize
+      identityLocalize
     );
     expect(result).toBe(nothing);
   });
@@ -77,7 +76,7 @@ describe("renderMdnsStaleWarning", () => {
   it("stays silent when no source is live (offline gets the waiting line)", () => {
     const result = renderMdnsStaleWarning(
       reachability({ ping_last_seen_seconds_ago: null, ping_rtt_ms: null }),
-      _identityLocalize
+      identityLocalize
     );
     expect(result).toBe(nothing);
   });
@@ -87,13 +86,13 @@ describe("renderMdnsStaleWarning", () => {
     // device goes offline; the "online over {source}" copy must not show.
     const result = renderMdnsStaleWarning(
       reachability({ state: DeviceState.OFFLINE, ping_last_seen_seconds_ago: 300 }),
-      _identityLocalize
+      identityLocalize
     );
     expect(result).toBe(nothing);
   });
 
   it("renders nothing for a null snapshot", () => {
-    expect(renderMdnsStaleWarning(null, _identityLocalize)).toBe(nothing);
+    expect(renderMdnsStaleWarning(null, identityLocalize)).toBe(nothing);
   });
 
   it("uses the summary and detail localize keys", () => {

--- a/test/components/dashboard/render-mdns-txt-records.test.ts
+++ b/test/components/dashboard/render-mdns-txt-records.test.ts
@@ -25,13 +25,12 @@
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { renderMdnsTxtRecords } from "../../../src/components/dashboard/device-drawer-render.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   findTemplatesByAnchor,
   isTemplateResult,
   visitTemplates,
 } from "../../_lit-template-walker.js";
-
-const _identityLocalize: (key: string) => string = (key) => key;
 
 describe("renderMdnsTxtRecords", () => {
   it("renders a details/dl with one dt+dd per record, alphabetically sorted", () => {
@@ -43,7 +42,7 @@ describe("renderMdnsTxtRecords", () => {
       mac: "aabbccddeeff",
       api_encryption: "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
     };
-    const result = renderMdnsTxtRecords(records, _identityLocalize);
+    const result = renderMdnsTxtRecords(records, identityLocalize);
     expect(isTemplateResult(result)).toBe(true);
 
     // One ``<details>`` wraps the whole thing, with a ``<dl>``
@@ -81,7 +80,7 @@ describe("renderMdnsTxtRecords", () => {
       version: "2025.4.0",
       api_encryption: "",
     };
-    const result = renderMdnsTxtRecords(records, _identityLocalize);
+    const result = renderMdnsTxtRecords(records, identityLocalize);
     const rowTemplates = findTemplatesByAnchor(result, "<dt>");
     expect(rowTemplates.length).toBe(2);
     const pairs = rowTemplates.map((t) => [t.values[0] as string, t.values[1] as string]);
@@ -122,7 +121,7 @@ describe("renderMdnsTxtRecords", () => {
     };
 
     const orderings = [ascending, descending, shuffled].map((records) => {
-      const result = renderMdnsTxtRecords(records, _identityLocalize);
+      const result = renderMdnsTxtRecords(records, identityLocalize);
       return findTemplatesByAnchor(result, "<dt>").map((t) => [
         t.values[0] as string,
         t.values[1] as string,
@@ -148,14 +147,14 @@ describe("renderMdnsTxtRecords", () => {
     // ``undefined`` on the wire — the drawer must render zero
     // markup so the section stays visually identical to the
     // pre-feature drawer.
-    expect(renderMdnsTxtRecords(undefined, _identityLocalize)).toBe(nothing);
+    expect(renderMdnsTxtRecords(undefined, identityLocalize)).toBe(nothing);
     // ``null`` is the explicit "backend computed the snapshot but
     // had no TXT to surface" signal. Same: zero markup.
-    expect(renderMdnsTxtRecords(null, _identityLocalize)).toBe(nothing);
+    expect(renderMdnsTxtRecords(null, identityLocalize)).toBe(nothing);
     // An empty mapping is the legitimate "TXT was decoded but no
     // entries had string values" case — still hide the section,
     // a chevron with zero rows is just visual noise.
-    expect(renderMdnsTxtRecords({}, _identityLocalize)).toBe(nothing);
+    expect(renderMdnsTxtRecords({}, identityLocalize)).toBe(nothing);
   });
 
   it("never splices key or value strings into static template text", () => {
@@ -175,7 +174,7 @@ describe("renderMdnsTxtRecords", () => {
       config_hash: '" onclick="alert(1)',
       "<key>": "innocent",
     };
-    const result = renderMdnsTxtRecords(dangerous, _identityLocalize);
+    const result = renderMdnsTxtRecords(dangerous, identityLocalize);
 
     // Walk every template and confirm:
     // - none of the static ``strings`` contain the dangerous

--- a/test/components/dashboard/render-toolbar.test.ts
+++ b/test/components/dashboard/render-toolbar.test.ts
@@ -6,8 +6,7 @@
  * host's _clearSearch handler (issue #1160). The handler's own behavior
  * is covered in dashboard-clear-search.test.ts.
  */
-import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -17,10 +16,11 @@ import {
   renderViewToggle,
 } from "../../../src/components/dashboard/render-toolbar.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 
 function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    _localize: (k: string) => k,
+    _localize: identityLocalize,
     _yamlMode: false,
     _search: "",
     _syncYamlSearch: vi.fn(),
@@ -30,45 +30,33 @@ function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
   } as unknown as ESPHomePageDashboard;
 }
 
-function renderInto(host: ESPHomePageDashboard): HTMLElement {
-  const container = document.createElement("div");
-  render(renderSearchInput(host), container);
-  return container;
-}
-
 describe("renderSearchInput", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("hides the clear button when the query is empty", () => {
-    const container = renderInto(makeHost({ _search: "" }));
+    const container = renderInto(renderSearchInput(makeHost({ _search: "" })));
     expect(container.querySelector(".search-clear")).toBeNull();
   });
 
   it("hides the clear button for a whitespace-only query", () => {
-    const container = renderInto(makeHost({ _search: "   " }));
+    const container = renderInto(renderSearchInput(makeHost({ _search: " " })));
     expect(container.querySelector(".search-clear")).toBeNull();
   });
 
   it("shows the clear button when a query is present", () => {
-    const container = renderInto(makeHost({ _search: "kitchen" }));
+    const container = renderInto(renderSearchInput(makeHost({ _search: "kitchen" })));
     expect(container.querySelector(".search-clear")).not.toBeNull();
   });
 
   it("wires the clear button to the host's _clearSearch handler", () => {
     const clearSearch = vi.fn();
     const host = makeHost({ _search: "kitchen", _clearSearch: clearSearch });
-    renderInto(host).querySelector<HTMLButtonElement>(".search-clear")?.click();
+    renderInto(renderSearchInput(host))
+      .querySelector<HTMLButtonElement>(".search-clear")
+      ?.click();
     expect(clearSearch).toHaveBeenCalledOnce();
   });
 });
 
 describe("renderViewToggle Expert Mode gating", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   function makeToggleHost(expertMode: boolean): ESPHomePageDashboard {
     return makeHost({
       _view: DashboardView.CARDS,
@@ -79,8 +67,7 @@ describe("renderViewToggle Expert Mode gating", () => {
   }
 
   function renderToggle(host: ESPHomePageDashboard): HTMLElement {
-    const container = document.createElement("div");
-    render(renderViewToggle(host), container);
+    const container = renderInto(renderViewToggle(host));
     return container;
   }
 

--- a/test/components/dashboard/render-toolbar.test.ts
+++ b/test/components/dashboard/render-toolbar.test.ts
@@ -37,7 +37,7 @@ describe("renderSearchInput", () => {
   });
 
   it("hides the clear button for a whitespace-only query", () => {
-    const container = renderInto(renderSearchInput(makeHost({ _search: " " })));
+    const container = renderInto(renderSearchInput(makeHost({ _search: "   " })));
     expect(container.querySelector(".search-clear")).toBeNull();
   });
 

--- a/test/components/dashboard/render-yaml.test.ts
+++ b/test/components/dashboard/render-yaml.test.ts
@@ -5,14 +5,14 @@
  * configuration filename (not the friendly label), so opening the editor
  * from a search hit loads the device instead of an empty editor.
  */
-import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import type { YamlSearchHit } from "../../../src/api/types/devices.js";
 import { renderYamlMode } from "../../../src/components/dashboard/render-yaml.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 
 function makeHit(): YamlSearchHit {
   return {
@@ -32,31 +32,21 @@ function makeHit(): YamlSearchHit {
 
 function makeHost(hits: YamlSearchHit[]): ESPHomePageDashboard {
   return {
-    _localize: (k: string) => k,
+    _localize: identityLocalize,
     _search: "living",
     _yamlSearch: { hits },
   } as unknown as ESPHomePageDashboard;
 }
 
-function renderInto(host: ESPHomePageDashboard): HTMLElement {
-  const container = document.createElement("div");
-  render(renderYamlMode(host), container);
-  return container;
-}
-
 describe("renderYamlMode hit header", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("links the title to the configuration filename, not the friendly label", () => {
-    const container = renderInto(makeHost([makeHit()]));
+    const container = renderInto(renderYamlMode(makeHost([makeHit()])));
     const anchor = container.querySelector<HTMLAnchorElement>(".yaml-hit-group-name");
     expect(anchor?.getAttribute("href")).toBe("/device/living_room.yaml");
   });
 
   it("displays the friendly label as the title text", () => {
-    const container = renderInto(makeHost([makeHit()]));
+    const container = renderInto(renderYamlMode(makeHost([makeHit()])));
     const anchor = container.querySelector<HTMLAnchorElement>(".yaml-hit-group-name");
     expect(anchor?.textContent?.trim()).toBe("Living Room");
   });

--- a/test/components/dashboard/table-columns.test.ts
+++ b/test/components/dashboard/table-columns.test.ts
@@ -7,14 +7,15 @@
  * hyphen-looking glyph. Populated cells keep their own font.
  */
 import type { CellContext } from "@tanstack/lit-table";
-import { render, type TemplateResult } from "lit";
+import { type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
 import {
   createDeviceColumns,
   type DeviceRow,
 } from "../../../src/components/dashboard/table-columns.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 
-const columns = createDeviceColumns((key) => key);
+const columns = createDeviceColumns(identityLocalize);
 
 function columnByKey(key: string) {
   const col = columns.find((c) => "accessorKey" in c && c.accessorKey === key);
@@ -86,8 +87,7 @@ describe("device table empty-cell placeholder (#1038)", () => {
 
 describe("device table actions", () => {
   it("renders the edit pencil with the accent (action) color", () => {
-    const container = document.createElement("div");
-    render(renderActionsCell(), container);
+    const container = renderInto(renderActionsCell());
     const edit = container.querySelector(".cell-action-btn--edit");
     expect(edit).not.toBeNull();
     expect(edit?.classList.contains("cell-action-btn--accent")).toBe(true);
@@ -120,16 +120,14 @@ function renderNameCell(rowOverrides: Partial<DeviceRow> = {}): TemplateResult {
 // table agrees with the drawer's raw-flag badge instead of diverging (#1037).
 describe("name-cell encryption indicator uses the raw pending flag", () => {
   it("shows encryption-pending but hides the modified dot when the gate is off", () => {
-    const container = document.createElement("div");
-    render(
+    const container = renderInto(
       renderNameCell({
         hasPendingChanges: true, // raw: local edit not yet flashed
         showModified: false, // gated off: mDNS dark + hash-driven pending
         api_enabled: true,
         api_encrypted: true,
         api_encryption_active: null,
-      }),
-      container
+      })
     );
     expect(container.querySelector(".cell-encryption")).not.toBeNull();
     expect(container.querySelector(".cell-indicator--modified")).toBeNull();

--- a/test/components/dashboard/table-pagination.test.ts
+++ b/test/components/dashboard/table-pagination.test.ts
@@ -4,7 +4,7 @@
  * The list view's "All" page-size option: it offers value 0, reports 0
  * on change, and hides the page navigation while active (discussion #3682).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -25,10 +25,6 @@ async function mount(
 }
 
 describe("table-pagination All option", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("offers an 'All' option (value 0) in the page-size selector", async () => {
     const el = await mount({ pageSize: 25 });
     const all = [...el.shadowRoot!.querySelectorAll("option")].find(
@@ -67,10 +63,6 @@ describe("table-pagination All option", () => {
 });
 
 describe("table-pagination accessibility", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   // The visible "Rows per page" <span> is hidden on mobile (and was never
   // programmatically tied to the <select>), so the selector carries its own
   // aria-label to keep an accessible name on every viewport. Guard against a

--- a/test/components/dashboard/table-row-menu-clear-queued.test.ts
+++ b/test/components/dashboard/table-row-menu-clear-queued.test.ts
@@ -4,21 +4,13 @@
  * The kebab menu offers "Clear queued update" only for a device whose
  * queued_update flag is set, and the item emits clear-queued-update.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeTableRowMenu } from "../../../src/components/dashboard/table-row-menu.js";
+import { mount } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
-
-async function mount(queuedUpdate: boolean): Promise<ESPHomeTableRowMenu> {
-  const el = new ESPHomeTableRowMenu();
-  el.device = makeConfiguredDevice({ queued_update: queuedUpdate });
-  el.position = { x: 10, y: 10 };
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 function findClearItem(el: ESPHomeTableRowMenu): Element | undefined {
   return [...el.shadowRoot!.querySelectorAll(".menu-item")].find((item) =>
@@ -27,12 +19,11 @@ function findClearItem(el: ESPHomeTableRowMenu): Element | undefined {
 }
 
 describe("table-row-menu clear-queued-update item", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("emits clear-queued-update for a device with a queued update", async () => {
-    const el = await mount(true);
+    const el = await mount(new ESPHomeTableRowMenu(), {
+      device: makeConfiguredDevice({ queued_update: true }),
+      position: { x: 10, y: 10 },
+    });
     const item = findClearItem(el);
     expect(item).toBeDefined();
 
@@ -43,7 +34,10 @@ describe("table-row-menu clear-queued-update item", () => {
   });
 
   it("hides the item when no update is queued", async () => {
-    const el = await mount(false);
+    const el = await mount(new ESPHomeTableRowMenu(), {
+      device: makeConfiguredDevice({ queued_update: false }),
+      position: { x: 10, y: 10 },
+    });
     expect(findClearItem(el)).toBeUndefined();
   });
 });

--- a/test/components/desktop-update-dialog.test.ts
+++ b/test/components/desktop-update-dialog.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { DesktopUpdateCheck } from "../../src/api/types/desktop.js";
 import { ESPHomeDesktopUpdateDialog } from "../../src/components/desktop-update-dialog.js";
+import { identityLocalize } from "../_dom.js";
 
 function makeCheck(anyAvailable: boolean): DesktopUpdateCheck {
   const upToDate = {
@@ -37,7 +38,7 @@ function make(api: unknown): ESPHomeDesktopUpdateDialog {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any)._api = api;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._localize = (key: string) => key;
+  (el as any)._localize = identityLocalize;
   return el;
 }
 

--- a/test/components/device-card-queued-indicator.test.ts
+++ b/test/components/device-card-queued-indicator.test.ts
@@ -5,7 +5,7 @@
  * status badge keeps showing the device state (an offline device with a
  * queued update still reads "offline").
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -24,10 +24,6 @@ async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCa
 }
 
 describe("device-card queued-update indicator", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("shows the clock and keeps the offline status badge", async () => {
     const el = await mount({ queuedUpdate: true, state: DeviceState.OFFLINE });
     expect(el.shadowRoot!.querySelector(".indicator-queued")).not.toBeNull();

--- a/test/components/device-card.test.ts
+++ b/test/components/device-card.test.ts
@@ -6,7 +6,7 @@
  * encrypted device shows the lock-clock and hides the dot, matching the drawer's
  * raw-flag badge instead of diverging (#1037).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -24,10 +24,6 @@ async function mount(props: Partial<ESPHomeDeviceCard>): Promise<ESPHomeDeviceCa
 }
 
 describe("device-card encryption indicator uses the raw pending flag", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("shows encryption-pending but hides the modified dot when the gate is off", async () => {
     const el = await mount({
       hasPendingChanges: true, // raw: local edit not yet flashed

--- a/test/components/device/add-api-action-dialog.test.ts
+++ b/test/components/device/add-api-action-dialog.test.ts
@@ -8,18 +8,19 @@
  * the ``@request-close`` handler must clear it. Guards against a
  * re-render re-asserting ``?open`` and trapping the dialog open.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 
 import { ESPHomeAddApiActionDialog } from "../../../src/components/device/add-api-action-dialog.js";
+import { identityLocalize } from "../../_dom.js";
 
 async function mountDialog(): Promise<ESPHomeAddApiActionDialog> {
   const dialog = new ESPHomeAddApiActionDialog();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (dialog as any)._localize = (key: string) => key; // no context provider in the test tree
+  (dialog as any)._localize = identityLocalize; // no context provider in the test tree
   document.body.appendChild(dialog);
   await dialog.updateComplete;
   return dialog;
@@ -32,10 +33,6 @@ const requestClose = (d: ESPHomeAddApiActionDialog): void =>
   (d as unknown as { _onRequestClose: () => void })._onRequestClose();
 
 describe("esphome-add-api-action-dialog base-dialog open contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() drives the reactive _open flag", async () => {
     const dialog = await mountDialog();
     expect(isOpen(dialog)).toBe(false);

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -9,7 +9,7 @@
  * has landed the form must stay mounted across reopens, so the same
  * ``wa-select`` element survives instead of being recreated.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -21,6 +21,7 @@ vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../src/api/types/automations.js";
 import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
+import { identityLocalize } from "../../_dom.js";
 
 async function flushPending(times = 5): Promise<void> {
   for (let i = 0; i < times; i++) await Promise.resolve();
@@ -47,7 +48,7 @@ async function mountDialog(api: ESPHomeAPI): Promise<ESPHomeAddAutomationDialog>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (dialog as any)._api = api;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (dialog as any)._localize = (key: string) => key; // no context provider in the test tree
+  (dialog as any)._localize = identityLocalize; // no context provider in the test tree
   dialog.configuration = "device.yaml";
   document.body.appendChild(dialog);
   await dialog.updateComplete;
@@ -59,10 +60,6 @@ const kindSelect = (d: ESPHomeAddAutomationDialog) =>
   d.shadowRoot?.querySelector('wa-select[aria-labelledby="kind-label"]') ?? null;
 
 describe("add-automation-dialog render gate (behavioral)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("shows only the spinner before the first load, then the form", async () => {
     const first = deferred<AvailableAutomations>();
     const getAvailableAutomations = vi.fn(() => first.promise);
@@ -171,10 +168,6 @@ const timeAvailable = (): AvailableAutomations =>
   }) as unknown as AvailableAutomations;
 
 describe("add-automation-dialog list-shaped triggers (#1080)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   async function mountForComponent(): Promise<ESPHomeAddAutomationDialog> {
     const api = {
       getAvailableAutomations: vi.fn(() => Promise.resolve(timeAvailable())),
@@ -262,10 +255,6 @@ const deviceAvailable = (): AvailableAutomations =>
   }) as unknown as AvailableAutomations;
 
 describe("add-automation-dialog device-level list triggers (#1283)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   async function mountForDevice(): Promise<ESPHomeAddAutomationDialog> {
     const api = {
       getAvailableAutomations: vi.fn(() => Promise.resolve(deviceAvailable())),
@@ -337,10 +326,6 @@ const ahtAvailable = (): AvailableAutomations =>
   }) as unknown as AvailableAutomations;
 
 describe("add-automation-dialog sub-entity targets (#1263)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   async function mountForComponentStep(): Promise<ESPHomeAddAutomationDialog> {
     const api = {
       getAvailableAutomations: vi.fn(() => Promise.resolve(ahtAvailable())),
@@ -452,10 +437,6 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
 // contract — request-close flipping _open is what makes a user-driven close
 // (Escape / X / outside-click) actually dismiss.
 describe("add-automation-dialog open/close contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const baseDialog = (d: ESPHomeAddAutomationDialog): HTMLElement =>
     d.shadowRoot!.querySelector("esphome-base-dialog")!;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/device/add-component-dialog-configless.test.ts
+++ b/test/components/device/add-component-dialog-configless.test.ts
@@ -52,7 +52,6 @@ describe("add-component-dialog skips the form for configless components", () => 
   afterEach(() => {
     _clearComponentCache();
     vi.clearAllMocks();
-    document.body.innerHTML = "";
   });
 
   it("adds a configless component directly, toasts, and closes", async () => {

--- a/test/components/device/add-component-dialog-draft.test.ts
+++ b/test/components/device/add-component-dialog-draft.test.ts
@@ -5,7 +5,7 @@
  * and surface the result as a draft (so unsaved edits survive and the
  * user saves explicitly), not as a saved update. Regression for #1146.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -16,10 +16,6 @@ vi.mock("../../../src/components/device/component-catalog.js", () => ({}));
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
 
 describe("add-component-dialog preserves the editor draft (#1146)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("merges into this.yaml and dispatches yaml-draft, not yaml-updated", async () => {
     const dialog = new ESPHomeAddComponentDialog();
     const addComponent = vi.fn().mockResolvedValue({ yaml: "MERGED" });

--- a/test/components/device/add-component-dialog-open-close.test.ts
+++ b/test/components/device/add-component-dialog-open-close.test.ts
@@ -8,7 +8,7 @@
  * form-view back button renders in the wrapper's header-prefix slot and
  * returns to the catalog.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -27,13 +27,7 @@ vi.mock("../../../src/components/device/component-catalog.js", () => {
 });
 
 import { ESPHomeAddComponentDialog } from "../../../src/components/device/add-component-dialog.js";
-
-async function mount(): Promise<ESPHomeAddComponentDialog> {
-  const el = new ESPHomeAddComponentDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 const dialog = (el: ESPHomeAddComponentDialog): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
@@ -42,12 +36,8 @@ const dialog = (el: ESPHomeAddComponentDialog): HTMLElement =>
 const isOpen = (el: ESPHomeAddComponentDialog): boolean => (el as any)._open;
 
 describe("add-component-dialog open/close contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() flips the reactive open flag and binds ?open", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddComponentDialog());
     expect(isOpen(el)).toBe(false);
     el.open();
     await el.updateComplete;
@@ -56,14 +46,14 @@ describe("add-component-dialog open/close contract", () => {
   });
 
   it("openWithSearch() also opens", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddComponentDialog());
     el.openWithSearch("output");
     await el.updateComplete;
     expect(isOpen(el)).toBe(true);
   });
 
   it("flips _open to false on request-close", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
     await el.updateComplete;
     dialog(el).dispatchEvent(new CustomEvent("request-close"));
@@ -71,7 +61,7 @@ describe("add-component-dialog open/close contract", () => {
   });
 
   it("renders the back button in header-prefix in form view and returns to the catalog", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddComponentDialog());
     el.open();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._selected = { name: "GPIO Switch" };

--- a/test/components/device/add-component-dialog-selection.test.ts
+++ b/test/components/device/add-component-dialog-selection.test.ts
@@ -7,6 +7,7 @@ import {
   type SelectionHost,
 } from "../../../src/components/device/add-component-dialog-selection.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
+import { identityLocalize } from "../../_dom.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 function makeHost(
@@ -18,7 +19,7 @@ function makeHost(
     platform: "esp32",
     board: { id: "apollo-esk-1" },
     _selectionSeq: 0,
-    _localize: ((key: string) => key) as SelectionHost["_localize"],
+    _localize: identityLocalize as SelectionHost["_localize"],
     ...overrides,
   };
 }

--- a/test/components/device/add-component-form-provides-dep.test.ts
+++ b/test/components/device/add-component-form-provides-dep.test.ts
@@ -70,7 +70,6 @@ function submitButton(el: ESPHomeAddComponentForm): HTMLButtonElement {
 
 describe("add-component-form provides-satisfied dependency", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
     _clearComponentCache();
     _clearProvidesCache();
     // Restore the console.warn spy even if a test throws before its own restore.

--- a/test/components/device/add-component-form-seed.test.ts
+++ b/test/components/device/add-component-form-seed.test.ts
@@ -11,6 +11,7 @@ import type { ComponentCatalogEntry } from "../../../src/api/types/components.js
 import type { ConfigEntry } from "../../../src/api/types/config-entries.js";
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
+import { identityLocalize } from "../../_dom.js";
 import { makeConfigEntry } from "../../util/_make-config-entry.js";
 
 function ags10Component(): ComponentCatalogEntry {
@@ -49,7 +50,7 @@ function seededValues(
   };
   internals.component = component;
   internals.yaml = yaml;
-  internals._localize = (key) => key;
+  internals._localize = identityLocalize;
   internals._initValues();
   return internals._values;
 }
@@ -193,7 +194,7 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
         makeConfigEntry({ key: "sda", type: ConfigEntryType.PIN }),
       ],
     } as unknown as ComponentCatalogEntry;
-    internals._localize = (key) => key;
+    internals._localize = identityLocalize;
     return internals;
   }
 
@@ -235,7 +236,7 @@ describe("add-component-form dep-add bus prefill (#1425)", () => {
         }),
       ],
     } as unknown as ComponentCatalogEntry;
-    internals._localize = (key) => key;
+    internals._localize = identityLocalize;
     return internals;
   }
 

--- a/test/components/device/add-dialogs-enter.test.ts
+++ b/test/components/device/add-dialogs-enter.test.ts
@@ -20,9 +20,9 @@ import { LitElement } from "lit";
 import { ESPHomeAddApiActionDialog } from "../../../src/components/device/add-api-action-dialog.js";
 import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
 import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-script-dialog.js";
+import { identityLocalize } from "../../_dom.js";
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.clearAllMocks();
 });
 
@@ -45,7 +45,7 @@ async function mount<T extends LitElement>(
   const dialog = new ctor();
   const onContinue = vi.fn();
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  (dialog as any)._localize = (key: string) => key; // no context provider here
+  (dialog as any)._localize = identityLocalize; // no context provider here
   (dialog as any)._onContinue = onContinue;
   /* eslint-enable @typescript-eslint/no-explicit-any */
   document.body.appendChild(dialog);

--- a/test/components/device/add-script-dialog.test.ts
+++ b/test/components/device/add-script-dialog.test.ts
@@ -10,27 +10,17 @@
  * ``_open`` itself in ``_onRequestClose`` — otherwise a re-render would
  * re-assert ``?open`` and the dialog could never dismiss.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeAddScriptDialog } from "../../../src/components/device/add-script-dialog.js";
-
-async function mount(): Promise<ESPHomeAddScriptDialog> {
-  const el = new ESPHomeAddScriptDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 describe("add-script-dialog base-dialog open contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() drives the reactive _open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddScriptDialog());
     const view = el as unknown as { _open: boolean };
     expect(view._open).toBe(false);
     el.open();
@@ -38,7 +28,7 @@ describe("add-script-dialog base-dialog open contract", () => {
   });
 
   it("_onRequestClose flips the reactive open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeAddScriptDialog());
     const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
     el.open();
     expect(view._open).toBe(true);

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -6,7 +6,7 @@
  * config_entries hydrated or they render fieldless. Heavy children are
  * no-op mocked so the editor constructs in a happy-dom window.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -65,9 +65,6 @@ describe("api-action-editor action-catalog hydration (#1286)", () => {
   beforeEach(() => {
     _clearAutomationBodyCache();
     vi.mocked(toast.error).mockClear();
-  });
-  afterEach(() => {
-    document.body.innerHTML = "";
   });
 
   it("hydrates action config_entries so the form renders", async () => {

--- a/test/components/device/automation-editor/automation-action-node-controlflow.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-controlflow.test.ts
@@ -4,7 +4,7 @@
  * A control-flow action node renders its params form alongside its
  * nested action list; children must not suppress the params form.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -64,10 +64,6 @@ async function mountNode(): Promise<ESPHomeAutomationActionNode> {
 }
 
 describe("automation-action-node control-flow rendering (#1285)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the params form for a control-flow action that has nested children", async () => {
     const el = await mountNode();
     // Params form must render even though this action has a nested list.

--- a/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-delay-lambda.test.ts
@@ -10,7 +10,7 @@
  * The node imports ``lambda-editor`` (CodeMirror) directly; ``vi.mock``
  * no-ops it and the other heavy children so the node constructs in happy-dom.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -103,10 +103,6 @@ function toggleButtons(el: ESPHomeAutomationActionNode): HTMLButtonElement[] {
 }
 
 describe("automation-action-node delay lambda", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the lambda body in the editor, not a 0/Seconds default", async () => {
     const { el } = await mountDelay({
       id: { _lambda: "return 0;", _tag: "!lambda" },

--- a/test/components/device/automation-editor/automation-action-node-reset.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-reset.test.ts
@@ -17,7 +17,7 @@
  * children, so ``vi.mock`` no-ops those modules; the node itself
  * constructs in a happy-dom window.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -107,10 +107,6 @@ function enableAdvanced(el: ESPHomeAutomationActionNode): void {
 }
 
 describe("automation-action-node view-state reset on rebind", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("defaults to expanded", async () => {
     const el = await mountNode(node("set_variable"));
     expect(collapseButton(el).getAttribute("aria-expanded")).toBe("true");

--- a/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
+++ b/test/components/device/automation-editor/automation-action-node-trigger-labels.test.ts
@@ -5,7 +5,7 @@
  * per trigger key, each labeled by its humanized key so on_response and
  * on_error read distinctly; else keeps its control-flow wording.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -30,6 +30,7 @@ import type {
 } from "../../../../src/api/types/automations.js";
 import type { ConfigEntry } from "../../../../src/api/types/config-entries.js";
 import { ESPHomeAutomationActionNode } from "../../../../src/components/device/automation-editor/automation-action-node.js";
+import { mount } from "../../../_dom.js";
 
 const urlEntry = {
   key: "url",
@@ -52,18 +53,6 @@ const httpGetNode: ActionNode = {
   children: { on_response: [], on_error: [] },
 } as unknown as ActionNode;
 
-async function mount(
-  action: AutomationAction,
-  node: ActionNode
-): Promise<ESPHomeAutomationActionNode> {
-  const el = new ESPHomeAutomationActionNode();
-  el.value = node;
-  el.catalog = [action];
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
 function nestedLabels(el: ESPHomeAutomationActionNode): string[] {
   return [...el.shadowRoot!.querySelectorAll(".ae-nested-label")].map((p) =>
     p.textContent!.trim()
@@ -71,12 +60,11 @@ function nestedLabels(el: ESPHomeAutomationActionNode): string[] {
 }
 
 describe("automation-action-node trigger labels (esphome/device-builder#1390)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("labels each trigger list by its humanized key", async () => {
-    const el = await mount(httpGetAction, httpGetNode);
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: httpGetNode,
+      catalog: [httpGetAction],
+    });
     expect(nestedLabels(el)).toEqual(["On Response", "On Error"]);
   });
 
@@ -93,12 +81,18 @@ describe("automation-action-node trigger labels (esphome/device-builder#1390)", 
       params: {},
       children: { on_multi_click: [] },
     } as unknown as ActionNode;
-    const el = await mount(action, node);
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: node,
+      catalog: [action],
+    });
     expect(nestedLabels(el)).toEqual(["On Multi Click"]);
   });
 
   it("renders one nested action list per trigger key alongside the params form", async () => {
-    const el = await mount(httpGetAction, httpGetNode);
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: httpGetNode,
+      catalog: [httpGetAction],
+    });
     expect(
       el.shadowRoot!.querySelectorAll("esphome-automation-action-list")
     ).toHaveLength(2);
@@ -118,7 +112,10 @@ describe("automation-action-node trigger labels (esphome/device-builder#1390)", 
       params: {},
       children: { then: [], else: [] },
     } as unknown as ActionNode;
-    const el = await mount(ifAction, ifNode);
+    const el = await mount(new ESPHomeAutomationActionNode(), {
+      value: ifNode,
+      catalog: [ifAction],
+    });
     // Default _localize echoes the key; else takes the localize branch,
     // not the humanizer (which would emit "Else").
     const labels = nestedLabels(el);

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -7,7 +7,7 @@
  * trigger-picker children. ``vi.mock`` no-ops them so the editor
  * itself can construct in a happy-dom window.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -63,10 +63,6 @@ async function mountEditor(
 }
 
 describe("automation-editor mount-time load (behavioral)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("editor mounted with configuration preset issues exactly one getAvailableAutomations call", async () => {
     const getAvailableAutomations = vi.fn().mockResolvedValue(slimAvailable());
     const getAutomationBodies = vi.fn().mockResolvedValue({});

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -5,7 +5,7 @@
  * couldn't decompose it), the editor renders read-only and never
  * upserts — its empty tree must not overwrite the real YAML (#1050).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -75,10 +75,6 @@ async function flushPending(times = 8): Promise<void> {
 }
 
 describe("automation-editor uneditable (errored parse)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders read-only and never upserts when the parsed automation has an error", async () => {
     const upsertAutomation = vi.fn();
     const api = {
@@ -139,10 +135,6 @@ describe("automation-editor uneditable (errored parse)", () => {
 });
 
 describe("automation-editor parse-error banner", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("clears a stale parse error once the YAML parses again", async () => {
     const parseDeviceAutomations = vi
       .fn()

--- a/test/components/device/automation-editor/automation-target-picker.test.ts
+++ b/test/components/device/automation-editor/automation-target-picker.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/option/option.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}));
@@ -11,6 +11,7 @@ import type {
   AvailableComponentInstance,
 } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationTargetPicker } from "../../../../src/components/device/automation-editor/automation-target-picker.js";
+import { identityLocalize } from "../../../_dom.js";
 
 async function mount(
   devices: AvailableComponentInstance[],
@@ -18,7 +19,7 @@ async function mount(
 ): Promise<ESPHomeAutomationTargetPicker> {
   const el = new ESPHomeAutomationTargetPicker();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (el as any)._localize = (key: string) => key;
+  (el as any)._localize = identityLocalize;
   el.devices = devices;
   el.value = value;
   document.body.appendChild(el);
@@ -27,10 +28,6 @@ async function mount(
 }
 
 describe("automation-target-picker sub-entity options", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("disambiguates same-named sub-entities by their parent", async () => {
     const devices: AvailableComponentInstance[] = [
       {

--- a/test/components/device/automation-editor/catalog-load-controller.test.ts
+++ b/test/components/device/automation-editor/catalog-load-controller.test.ts
@@ -8,8 +8,9 @@ import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { CatalogLoadController } from "../../../../src/components/device/automation-editor/catalog-load-controller.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+import { identityLocalize } from "../../../_dom.js";
 
-const localize = ((key: string) => key) as never;
+const localize = identityLocalize as never;
 const stubHost = () => ({ addController: vi.fn() }) as unknown as ReactiveControllerHost;
 
 const emptySlim = (): AvailableAutomations =>

--- a/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
+++ b/test/components/device/automation-editor/catalog-picker-dialog-open-contract.test.ts
@@ -9,12 +9,13 @@
  * test in this folder stays node-env; this file opts into happy-dom
  * per-file so the element can mount.)
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeCatalogPickerDialog } from "../../../../src/components/device/automation-editor/catalog-picker-dialog.js";
+import { identityLocalize } from "../../../_dom.js";
 
 async function mountDialog(
   kind: "action" | "condition" = "action"
@@ -22,7 +23,7 @@ async function mountDialog(
   const dialog = new ESPHomeCatalogPickerDialog();
   dialog.kind = kind;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (dialog as any)._localize = (key: string) => key; // no context provider in the test tree
+  (dialog as any)._localize = identityLocalize; // no context provider in the test tree
   document.body.appendChild(dialog);
   await dialog.updateComplete;
   return dialog;
@@ -34,10 +35,6 @@ const activeTab = (d: ESPHomeCatalogPickerDialog): string =>
   (d as unknown as { _activeTab: string })._activeTab;
 
 describe("esphome-catalog-picker-dialog base-dialog open contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() drives the reactive _open flag and resets the search", async () => {
     const dialog = await mountDialog("action");
     expect(isOpen(dialog)).toBe(false);

--- a/test/components/device/automation-editor/component-target-picker.test.ts
+++ b/test/components/device/automation-editor/component-target-picker.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type { AvailableComponentInstance } from "../../../../src/api/types/automations.js";
 import { ESPHomeComponentTargetPicker } from "../../../../src/components/device/automation-editor/component-target-picker.js";
@@ -63,10 +63,6 @@ function pressOn(
 }
 
 describe("component-target-picker", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("lists sub-entities as rows and the container as a group header", async () => {
     const el = await mount(aht());
     expect(choiceNames(el)).toEqual(["Temperature", "Humidity", "Relay"]);

--- a/test/components/device/automation-editor/hydrate-available-bodies.test.ts
+++ b/test/components/device/automation-editor/hydrate-available-bodies.test.ts
@@ -19,6 +19,7 @@ import {
   resolveLoadedAvailable,
   type LoadAndHydrateOutcome,
 } from "../../../../src/components/device/automation-editor/hydrate-available-bodies.js";
+import { identityLocalize } from "../../../_dom.js";
 
 const configEntry = (key: string): ConfigEntry => ({ key }) as ConfigEntry;
 
@@ -287,7 +288,7 @@ describe("loadAndHydrateAvailable", () => {
 });
 
 describe("resolveLoadedAvailable", () => {
-  const localize = ((key: string) => key) as never;
+  const localize = identityLocalize as never;
   const okOutcome = (failures = 0): LoadAndHydrateOutcome => ({
     status: "ok",
     available: slimAvailable(),

--- a/test/components/device/automation-editor/parse-error-controller.test.ts
+++ b/test/components/device/automation-editor/parse-error-controller.test.ts
@@ -9,6 +9,7 @@ import type {
   ParsedAutomation,
 } from "../../../../src/api/types/automations.js";
 import { ParseErrorController } from "../../../../src/components/device/automation-editor/parse-error-controller.js";
+import { identityLocalize } from "../../../_dom.js";
 import { fakeHost } from "../../../_fake-host.js";
 
 const SCRIPT: AutomationLocation = {
@@ -105,7 +106,7 @@ describe("ParseErrorController.resolve", () => {
       )
     ).toBeNull();
     expect(c.active).toBe(true);
-    const localize = vi.fn((k: string) => k);
+    const localize = vi.fn(identityLocalize);
     c.renderPanel(localize as never);
     expect(localize).toHaveBeenCalledWith("device.yaml_only_section");
     expect(localize).not.toHaveBeenCalledWith("device.automation_parse_error");
@@ -114,7 +115,7 @@ describe("ParseErrorController.resolve", () => {
   it("renders the error alert for a genuine parse error", () => {
     const c = new ParseErrorController(fakeHost());
     c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script");
-    const localize = vi.fn((k: string) => k);
+    const localize = vi.fn(identityLocalize);
     c.renderPanel(localize as never);
     expect(localize).toHaveBeenCalledWith("device.automation_parse_error");
     expect(localize).not.toHaveBeenCalledWith("device.yaml_only_section");
@@ -133,7 +134,7 @@ describe("ParseErrorController.resolve", () => {
     c.resolve([parsed({ error: "boom", unsupported: true })], SCRIPT, "script");
     c.resolve([parsed({ error: "Unknown action id: 'x'" })], SCRIPT, "script");
     expect(c.active).toBe(true);
-    const localize = vi.fn((k: string) => k);
+    const localize = vi.fn(identityLocalize);
     c.renderPanel(localize as never);
     expect(localize).toHaveBeenCalledWith("device.automation_parse_error");
     expect(localize).not.toHaveBeenCalledWith("device.yaml_only_section");

--- a/test/components/device/automation-editor/render-target-field.test.ts
+++ b/test/components/device/automation-editor/render-target-field.test.ts
@@ -6,10 +6,9 @@
  */
 import { describe, expect, it } from "vitest";
 import { renderTargetField } from "../../../../src/components/device/automation-editor/render-target-field.js";
+import { identityLocalize as localize } from "../../../_dom.js";
 import { findTemplatesByAnchor } from "../../../_lit-template-walker.js";
 import { findElementBindings } from "../_renderer-fixtures.js";
-
-const localize = (k: string) => k;
 
 const spanValues = (tmpl: unknown): unknown[] =>
   findTemplatesByAnchor(tmpl, "<span").flatMap((t) => t.values as unknown[]);

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -7,7 +7,7 @@
  * CodeMirror, the action list) are no-op mocked so the editor itself
  * can construct in a happy-dom window.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../../src/components/device/config-entry-form.js", () => ({}));
 vi.mock(
@@ -68,9 +68,6 @@ describe("script-editor action-catalog hydration (#1286)", () => {
   beforeEach(() => {
     _clearAutomationBodyCache();
     vi.mocked(toast.error).mockClear();
-  });
-  afterEach(() => {
-    document.body.innerHTML = "";
   });
 
   it("hydrates action config_entries so the form renders", async () => {

--- a/test/components/device/component-catalog-featured-fallback.test.ts
+++ b/test/components/device/component-catalog-featured-fallback.test.ts
@@ -8,7 +8,7 @@
  * an explicitly pinned category opts out. Featured cards keep their styling
  * wherever they render.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -75,10 +75,6 @@ async function mountFeatured({
 }
 
 describe("component-catalog featured-empty fallback", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("falls back to all when the only recommendation is already configured", async () => {
     const { el, getComponents } = await mountFeatured({
       yaml: "ethernet:\n  type: LAN8720\n",
@@ -103,10 +99,6 @@ describe("component-catalog featured-empty fallback", () => {
 });
 
 describe("component-catalog search moves to All (featured leads there)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const typeSearch = (el: ESPHomeComponentCatalog, value: string) => {
     const input = { value } as HTMLInputElement;
     (el as unknown as { _onSearchInput: (ev: Event) => void })._onSearchInput({
@@ -147,10 +139,6 @@ describe("component-catalog search moves to All (featured leads there)", () => {
 });
 
 describe("component-catalog featured styling under All", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders a featured.* card with featured styling under All", async () => {
     const FEATURED_CARD = {
       id: "featured.esp32-poe-iso.onboard_ethernet",

--- a/test/components/device/component-catalog-provides.test.ts
+++ b/test/components/device/component-catalog-provides.test.ts
@@ -6,7 +6,7 @@
  * component picker lists the interface's providers, falling back to a
  * search only when the domain isn't a homeless interface (issue #1275).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/badge/badge.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -29,10 +29,6 @@ function response(ids: string[]) {
 }
 
 describe("component-catalog filterByDomain provides routing", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("probes the provides filter for an interface domain", async () => {
     const el = new ESPHomeComponentCatalog();
     const getComponents = vi

--- a/test/components/device/component-catalog/filters.test.ts
+++ b/test/components/device/component-catalog/filters.test.ts
@@ -8,6 +8,7 @@ import {
   filteredBundles,
   visibleComponents,
 } from "../../../../src/components/device/component-catalog/filters.js";
+import { identityLocalize } from "../../../_dom.js";
 
 function entry(
   id: string,
@@ -378,7 +379,7 @@ describe("filteredBundles present-filter", () => {
 });
 
 describe("buildCategories Recommended collapse", () => {
-  const localize = (k: string) => k;
+  const localize = identityLocalize;
   const hostWith = (
     board: BoardCatalogEntry | null,
     yaml: string,

--- a/test/components/device/component-catalog/render-bundle-card.test.ts
+++ b/test/components/device/component-catalog/render-bundle-card.test.ts
@@ -4,18 +4,18 @@
 // image_url shows the module photo; without one (or once it has failed to
 // load) it falls back to the box-icon placeholder.
 
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import type { FeaturedBundle } from "../../../../src/api/types/boards.js";
 import { renderBundleCard } from "../../../../src/components/device/component-catalog/renderers.js";
+import { identityLocalize, renderInto } from "../../../_dom.js";
 
 function host(failed: string[] = []): unknown {
   return {
     _imageFailed: new Set(failed),
     _onAddBundle: () => {},
     _onImageError: () => {},
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
   };
 }
 
@@ -27,12 +27,6 @@ function bundle(overrides: Partial<FeaturedBundle> = {}): FeaturedBundle {
     component_ids: ["rgb_leds", "buzzer_output"],
     ...overrides,
   };
-}
-
-function renderInto(value: unknown): HTMLElement {
-  const container = document.createElement("div");
-  render(value, container);
-  return container;
 }
 
 describe("renderBundleCard image", () => {
@@ -64,7 +58,7 @@ describe("renderBundleCard image", () => {
       _imageFailed: new Set<string>(),
       _onAddBundle: () => {},
       _onImageError: (id: string) => failedIds.push(id),
-      _localize: (key: string) => key,
+      _localize: identityLocalize,
     };
     const b = bundle({ image_url: "https://example.com/module.jpg" });
     const el = renderInto(renderBundleCard(spyHost as never, b));

--- a/test/components/device/component-catalog/render-card-platform-chip.test.ts
+++ b/test/components/device/component-catalog/render-card-platform-chip.test.ts
@@ -4,7 +4,6 @@
 // category (stepper.a4988 / stepper.uln2003): it renders only when
 // renderCard is told the entry is ambiguous, and carries the id's stem.
 
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,6 +11,7 @@ import {
   ComponentCategory,
 } from "../../../../src/api/types/components.js";
 import { renderCard } from "../../../../src/components/device/component-catalog/renderers.js";
+import { identityLocalize as localize, renderInto } from "../../../_dom.js";
 
 function host(category = "stepper"): unknown {
   return {
@@ -37,14 +37,6 @@ function entry(id: string): ComponentCatalogEntry {
     config_entries: [],
   };
 }
-
-function renderInto(value: unknown): HTMLElement {
-  const container = document.createElement("div");
-  render(value, container);
-  return container;
-}
-
-const localize = (key: string) => key;
 
 describe("renderCard platform chip", () => {
   it("renders the platform stem when the entry is ambiguous", () => {

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -6,7 +6,7 @@
  * deduped while in flight, and — crucially — NOT poisoned with ``[]`` on a
  * failed fetch so a later render can retry.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
@@ -50,10 +50,6 @@ function response(ids: string[]) {
 }
 
 describe("config-entry-form _resolveInterfaceProviders", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("returns null on the first miss, then the fetched providers, fetching once", async () => {
     const getComponents = vi
       .fn()

--- a/test/components/device/config-entry-pin-renderer-a11y.test.ts
+++ b/test/components/device/config-entry-pin-renderer-a11y.test.ts
@@ -6,11 +6,11 @@
  * wa-optgroup to carry real grouping). They must be ``aria-hidden`` so a
  * screen reader doesn't announce them as stray, contextless text mid-list.
  */
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import { ConfigEntryType, PinFeature } from "../../../src/api/types/config-entries.js";
 import { renderPinField } from "../../../src/components/device/config-entry-pin-renderer.js";
+import { renderInto } from "../../_dom.js";
 import {
   makeBoardPin,
   makeEntry,
@@ -36,10 +36,8 @@ describe("renderPinField — group header a11y", () => {
       required: true,
       pin_features: [PinFeature.ADC],
     });
-    const container = document.createElement("div");
-    render(
-      renderPinField(entry, ["pin"], makeRenderCtx({}, { board: board() })),
-      container
+    const container = renderInto(
+      renderPinField(entry, ["pin"], makeRenderCtx({}, { board: board() }))
     );
 
     const labels = [...container.querySelectorAll(".pin-group-label")];

--- a/test/components/device/config-entry-pin-renderer-reserved-value.test.ts
+++ b/test/components/device/config-entry-pin-renderer-reserved-value.test.ts
@@ -6,11 +6,11 @@
  * being edited — a disabled selected option blanks the ``wa-select`` head,
  * hiding the real config value.
  */
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import { ConfigEntryType } from "../../../src/api/types/config-entries.js";
 import { renderPinField } from "../../../src/components/device/config-entry-pin-renderer.js";
+import { renderInto } from "../../_dom.js";
 import {
   makeBoardPin,
   makeEntry,
@@ -29,10 +29,8 @@ const board = () =>
 
 function renderedOptions(value: unknown): Map<string, Element> {
   const entry = makeEntry(ConfigEntryType.PIN, { key: "pin", required: true });
-  const container = document.createElement("div");
-  render(
-    renderPinField(entry, ["pin"], makeRenderCtx({ pin: value }, { board: board() })),
-    container
+  const container = renderInto(
+    renderPinField(entry, ["pin"], makeRenderCtx({ pin: value }, { board: board() }))
   );
   return new Map(
     [...container.querySelectorAll("wa-option")].map((o) => [

--- a/test/components/device/device-editor-footer.test.ts
+++ b/test/components/device/device-editor-footer.test.ts
@@ -6,7 +6,7 @@
  * available, and a plain Install (-> picker) otherwise — including when the
  * config is in sync, which previously rendered no install button at all.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 // Stub the heavy children (they pull in CodeMirror / wa-button); the footer
@@ -31,10 +31,6 @@ function q(el: ESPHomeDeviceEditor, sel: string): HTMLElement | null {
 }
 
 describe("device-editor footer install action", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders a split button (Update + picker caret) when an update is available", async () => {
     const el = await mount({ showUpdate: true });
     const update = vi.fn();

--- a/test/components/device/device-editor-toolbar.test.ts
+++ b/test/components/device/device-editor-toolbar.test.ts
@@ -7,7 +7,7 @@
  * switch. Extracted to device-editor-toolbar.ts but rendered into the
  * device-editor shadow root, so these assertions mount the real element.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -41,10 +41,6 @@ function qa(el: ESPHomeDeviceEditor, sel: string): HTMLElement[] {
 }
 
 describe("device-editor header toolbar", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the three-way layout switch with the active layout pressed", async () => {
     const el = await mount({ layout: "both" });
     const buttons = qa(el, ".layout-toggle button");
@@ -104,10 +100,6 @@ describe("device-editor header toolbar", () => {
 });
 
 describe("device-editor save button", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("enables on unsaved edits and shows the save icon", async () => {
     const el = await mount({ hasUnsavedEdits: true });
     const btn = q(el, ".save-button") as HTMLButtonElement;

--- a/test/components/device/device-navigator-coalesce.test.ts
+++ b/test/components/device/device-navigator-coalesce.test.ts
@@ -47,7 +47,6 @@ const YAML = "wifi:\n  ssid: foo\n";
 
 describe("device-navigator kickoff gating", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
     _clearAutomationCatalogCache();
     _clearComponentCache();
   });

--- a/test/components/device/device-navigator-filter.test.ts
+++ b/test/components/device/device-navigator-filter.test.ts
@@ -7,7 +7,7 @@
  * no-oped so the element constructs in happy-dom; see
  * ``device-navigator-coalesce.test.ts``.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
@@ -62,10 +62,6 @@ const rowSubtitles = (nav: ESPHomeDeviceNavigator) =>
   [...(nav.shadowRoot?.querySelectorAll(".nav-item-subtitle") ?? [])].map((el) =>
     el.textContent?.trim()
   );
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("navItemMatches", () => {
   it("matches any term case-insensitively", () => {

--- a/test/components/device/device-navigator-grouping.test.ts
+++ b/test/components/device/device-navigator-grouping.test.ts
@@ -6,7 +6,7 @@
  * stay flat. Dialog + search children are no-oped so the element
  * constructs in happy-dom; see ``device-navigator-coalesce.test.ts``.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
@@ -63,10 +63,6 @@ async function setQuery(nav: ESPHomeDeviceNavigator, value: string): Promise<voi
   );
   await nav.updateComplete;
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("device-navigator domain grouping", () => {
   it("renders a subgroup header per domain with its count", async () => {

--- a/test/components/device/device-navigator-labels.test.ts
+++ b/test/components/device/device-navigator-labels.test.ts
@@ -48,7 +48,6 @@ describe("device-navigator core subtitle", () => {
   });
 
   afterEach(() => {
-    document.body.innerHTML = "";
     _clearComponentCache();
   });
 

--- a/test/components/device/device-navigator-overview.test.ts
+++ b/test/components/device/device-navigator-overview.test.ts
@@ -7,7 +7,7 @@
  * Dialog children are no-oped so the element constructs in happy-dom;
  * see ``device-navigator-coalesce.test.ts``.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
@@ -25,10 +25,6 @@ async function mountNavigator(): Promise<ESPHomeDeviceNavigator> {
   await nav.updateComplete;
   return nav;
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("device-navigator section header icons", () => {
   it("renders the shared section icons in header order", async () => {

--- a/test/components/device/device-navigator-reveal.test.ts
+++ b/test/components/device/device-navigator-reveal.test.ts
@@ -64,7 +64,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   // Direct prototype assignment isn't a vi.spyOn, so restore it explicitly.
   Element.prototype.scrollIntoView = originalScrollIntoView;
 });

--- a/test/components/device/device-navigator-row-icons.test.ts
+++ b/test/components/device/device-navigator-row-icons.test.ts
@@ -6,7 +6,7 @@
  * Dialog + icon children are no-oped so the element constructs in happy-dom;
  * see ``device-navigator-coalesce.test.ts``.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
@@ -41,10 +41,6 @@ async function mountNavigator(): Promise<ESPHomeDeviceNavigator> {
 
 const iconNames = (nav: ESPHomeDeviceNavigator, sel: string) =>
   [...(nav.shadowRoot?.querySelectorAll(sel) ?? [])].map((el) => el.getAttribute("name"));
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("device-navigator row icons", () => {
   it("gives ungrouped Core rows a leading domain glyph", async () => {

--- a/test/components/device/device-navigator-search-reveal.test.ts
+++ b/test/components/device/device-navigator-search-reveal.test.ts
@@ -8,7 +8,7 @@
  * it disappears entirely with Expert Mode off. Dialog children are no-oped so
  * the element constructs in happy-dom; see ``device-navigator-coalesce.test.ts``.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../src/components/device/add-automation-dialog.js", () => ({}));
 vi.mock("../../../src/components/device/add-component-dialog.js", () => ({}));
@@ -54,10 +54,6 @@ const searchBox = (nav: ESPHomeDeviceNavigator) =>
   nav.shadowRoot!.querySelector("esphome-navigator-search")!;
 const searchBtn = (nav: ESPHomeDeviceNavigator) =>
   nav.shadowRoot!.querySelector<HTMLButtonElement>(".search-btn");
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("navigator search reveal", () => {
   it("offers neither box nor magnifier on a short config", async () => {

--- a/test/components/device/device-section-automation-list.test.ts
+++ b/test/components/device/device-section-automation-list.test.ts
@@ -5,19 +5,12 @@
  * section editor's API-action, trigger, and component-action surfaces.
  */
 import { describe, expect, it } from "vitest";
+import { mount } from "../../_dom.js";
 
 import {
   ESPHomeSectionAutomationList,
   type AutomationListRow,
 } from "../../../src/components/device/device-section-automation-list.js";
-
-async function mount(props: Partial<ESPHomeSectionAutomationList>) {
-  const el = new ESPHomeSectionAutomationList();
-  Object.assign(el, props);
-  document.body.append(el);
-  await el.updateComplete;
-  return el;
-}
 
 const ROWS: AutomationListRow[] = [
   { key: "automation:component_action:gate:open_action", label: "Open action" },
@@ -25,12 +18,16 @@ const ROWS: AutomationListRow[] = [
 
 describe("esphome-section-automation-list", () => {
   it("renders nothing when empty and there's no add button", async () => {
-    const el = await mount({ rows: [], editLabel: "Edit", deleteLabel: "Delete" });
+    const el = await mount(new ESPHomeSectionAutomationList(), {
+      rows: [],
+      editLabel: "Edit",
+      deleteLabel: "Delete",
+    });
     expect(el.shadowRoot?.querySelector(".list")).toBeNull();
   });
 
   it("shows the empty placeholder when empty but addable", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeSectionAutomationList(), {
       rows: [],
       addLabel: "Add",
       emptyText: "Nothing yet",
@@ -42,7 +39,7 @@ describe("esphome-section-automation-list", () => {
   });
 
   it("omits the empty placeholder when addable but emptyText is absent", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeSectionAutomationList(), {
       rows: [],
       addLabel: "Add",
       editLabel: "Edit",
@@ -54,7 +51,11 @@ describe("esphome-section-automation-list", () => {
   });
 
   it("emits edit / delete with the row key", async () => {
-    const el = await mount({ rows: ROWS, editLabel: "Edit", deleteLabel: "Delete" });
+    const el = await mount(new ESPHomeSectionAutomationList(), {
+      rows: ROWS,
+      editLabel: "Edit",
+      deleteLabel: "Delete",
+    });
     const events: Array<[string, string]> = [];
     el.addEventListener("edit", (e) =>
       events.push(["edit", (e as CustomEvent<{ key: string }>).detail.key])
@@ -71,7 +72,7 @@ describe("esphome-section-automation-list", () => {
   });
 
   it("locks every row while busyKey is set", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeSectionAutomationList(), {
       rows: ROWS,
       busyKey: ROWS[0].key,
       editLabel: "Edit",

--- a/test/components/device/lambda-editor.test.ts
+++ b/test/components/device/lambda-editor.test.ts
@@ -8,25 +8,14 @@
  * echo a spurious change, dirty the form, and trigger a lossy
  * re-serialize of the whole section.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ESPHomeLambdaEditor } from "../../../src/components/device/config-entry-renderers/lambda-editor.js";
-
-async function mount(value: string): Promise<ESPHomeLambdaEditor> {
-  const el = new ESPHomeLambdaEditor();
-  el.value = value;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 describe("lambda-editor lambda-change emission", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("does not emit on a programmatic value-prop sync", async () => {
-    const el = await mount("return 1;");
+    const el = await mount(new ESPHomeLambdaEditor(), { value: "return 1;" });
     const onChange = vi.fn();
     el.addEventListener("lambda-change", onChange);
 
@@ -54,7 +43,7 @@ describe("lambda-editor lambda-change emission", () => {
   });
 
   it("stays silent across repeated programmatic syncs (feedback loop)", async () => {
-    const el = await mount("return 1;");
+    const el = await mount(new ESPHomeLambdaEditor(), { value: "return 1;" });
     const onChange = vi.fn();
     el.addEventListener("lambda-change", onChange);
 
@@ -67,7 +56,7 @@ describe("lambda-editor lambda-change emission", () => {
   });
 
   it("emits exactly once on a user edit", async () => {
-    const el = await mount("return 1;");
+    const el = await mount(new ESPHomeLambdaEditor(), { value: "return 1;" });
     const onChange = vi.fn();
     el.addEventListener("lambda-change", onChange);
 
@@ -83,7 +72,7 @@ describe("lambda-editor lambda-change emission", () => {
   });
 
   it("suppresses a programmatic sync that follows a user edit", async () => {
-    const el = await mount("return 1;");
+    const el = await mount(new ESPHomeLambdaEditor(), { value: "return 1;" });
     const onChange = vi.fn();
     el.addEventListener("lambda-change", onChange);
 

--- a/test/components/device/navigator-labels.test.ts
+++ b/test/components/device/navigator-labels.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../src/components/device/navigator-labels.js";
 import { getCachedComponent } from "../../../src/util/component-name-cache.js";
 import type { YamlSection } from "../../../src/util/yaml-sections.js";
+import { identityLocalize } from "../../_dom.js";
 
 const mockGetCached = vi.mocked(getCachedComponent);
 const named = (name: string) =>
@@ -24,7 +25,7 @@ const ctx: LabelContext = {
   } as unknown as LabelContext["triggerCatalog"],
   platform: "",
   deviceName: "",
-  localize: (key) => key,
+  localize: identityLocalize,
 };
 
 const item = (key: string): YamlSection => ({ key }) as unknown as YamlSection;

--- a/test/components/device/navigator-search-component.test.ts
+++ b/test/components/device/navigator-search-component.test.ts
@@ -5,7 +5,7 @@
  * ``navigator-search`` payload shape, Escape-to-clear (gated on a
  * non-empty value), and that clearing zeroes ``value`` before emitting.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -24,10 +24,6 @@ async function mount(value = ""): Promise<void> {
 }
 
 const input = () => el.shadowRoot!.querySelector("input")!;
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("esphome-navigator-search", () => {
   beforeEach(() => mount());

--- a/test/components/device/secret-picker.test.ts
+++ b/test/components/device/secret-picker.test.ts
@@ -66,7 +66,6 @@ const fireSelectItem = (el: ESPHomeSecretPicker, selector: string): void => {
 };
 
 afterEach(() => {
-  document.body.innerHTML = "";
   _resetSecretKeysCache();
   navigate.mockClear();
 });

--- a/test/components/device/secret-value.test.ts
+++ b/test/components/device/secret-value.test.ts
@@ -65,7 +65,6 @@ const typeValue = async (el: ESPHomeSecretValue, value: string): Promise<void> =
 };
 
 afterEach(() => {
-  document.body.innerHTML = "";
   _resetSecretKeysCache();
   vi.mocked(toast.success).mockClear();
   vi.mocked(toast.error).mockClear();

--- a/test/components/device/security-notice.test.ts
+++ b/test/components/device/security-notice.test.ts
@@ -5,7 +5,7 @@
  * missing marker (api `encryption:`, ota `password:`, web_server `auth:`) and
  * the generate flow that writes secrets.yaml + emits `apply-security-secrets`.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner-js", () => ({
   default: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
@@ -42,10 +42,6 @@ async function mount(
   await el.updateComplete;
   return { el, inner };
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("security-notice — detection", () => {
   // [name, sectionKey, yaml, fromLine, markerPresent]

--- a/test/components/device/substitution-hint.test.ts
+++ b/test/components/device/substitution-hint.test.ts
@@ -7,9 +7,8 @@
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 import { renderSubstitutionHint } from "../../../src/components/device/config-entry-renderers-shared.js";
+import { identityLocalize as localize } from "../../_dom.js";
 import { findTemplatesByAnchor } from "../../_lit-template-walker.js";
-
-const localize = (k: string) => k;
 
 const spanValues = (tmpl: unknown): unknown[] =>
   findTemplatesByAnchor(tmpl, "<span").flatMap((t) => t.values as unknown[]);

--- a/test/components/dialog-enter-submit.test.ts
+++ b/test/components/dialog-enter-submit.test.ts
@@ -82,7 +82,6 @@ const cases: EnterCase[] = [
 ];
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.clearAllMocks();
 });
 

--- a/test/components/esphome-header-actions-archived.test.ts
+++ b/test/components/esphome-header-actions-archived.test.ts
@@ -5,15 +5,11 @@
  * page, so the kebab entry must only render on the dashboard route and stay
  * hidden in the editor where it would no-op (#1320).
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 
 describe("header-actions Archived Devices visibility", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the Archived Devices entry on the dashboard route", async () => {
     const el = await renderOpenHeaderMenu({ dashboardRoute: true });
     expect(

--- a/test/components/esphome-header-actions-check-updates.test.ts
+++ b/test/components/esphome-header-actions-check-updates.test.ts
@@ -5,7 +5,7 @@
  * exposes its update api, so the kebab entry must render only when the backend
  * reports desktop_update_capable and stay hidden otherwise.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { renderOpenHeaderMenu } from "./_esphome-header-actions-helpers.js";
 
@@ -13,10 +13,6 @@ const renderOpenMenu = (desktopUpdateCapable: boolean) =>
   renderOpenHeaderMenu({ _desktopUpdateCapable: desktopUpdateCapable });
 
 describe("header-actions Check for updates visibility", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the entry when the desktop app is update-capable", async () => {
     const el = await renderOpenMenu(true);
     expect(el.shadowRoot!.querySelector('wa-icon[name="update"]')).not.toBeNull();

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -5,7 +5,7 @@
  * palette; clicking it must fire the window event the palette listens for and
  * close the menu.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { OPEN_COMMAND_PALETTE_EVENT } from "../../src/components/command-palette-actions.js";
 import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
@@ -17,10 +17,6 @@ function searchItem(el: ESPHomeHeaderActions): HTMLElement {
 }
 
 describe("header-actions Search item", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the Search item with a shortcut hint", async () => {
     const el = await renderOpenHeaderMenu();
     expect(el.shadowRoot!.querySelector('wa-icon[name="magnify"]')).not.toBeNull();

--- a/test/components/filters/facet-sections.test.ts
+++ b/test/components/filters/facet-sections.test.ts
@@ -5,8 +5,7 @@
  * suppression, the managed flag forwarded to labels, and the onChange patch
  * carrying the facet key the emitting section owns.
  */
-import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Inert section elements — we assert the props/attrs the helper binds, not
 // the components' own rendering.
@@ -16,6 +15,7 @@ vi.mock("../../../src/components/filters/labels-filter-section.js", () => ({}));
 import { DeviceState } from "../../../src/api/types/devices.js";
 import { renderFacetSections } from "../../../src/components/filters/facet-sections.js";
 import type { FacetSelection } from "../../../src/util/device-filter.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
 
 const DEVICES = [
@@ -47,20 +47,17 @@ function emptySelection(): FacetSelection {
 
 function mount(overrides: Record<string, unknown> = {}) {
   const onChange = vi.fn();
-  const container = document.createElement("div");
-  document.body.appendChild(container);
-  render(
+  const container = renderInto(
     renderFacetSections({
       devices: DEVICES,
-      localize: (key: string) => key,
+      localize: identityLocalize,
       selection: emptySelection(),
       labelUsage: {},
       yamlMode: false,
       manageLabels: true,
       onChange,
       ...overrides,
-    }),
-    container
+    })
   );
   const sections = [...container.querySelectorAll<HTMLElement>("[data-facet-key]")];
   return { container, sections, onChange };
@@ -69,10 +66,6 @@ function mount(overrides: Record<string, unknown> = {}) {
 const keys = (sections: HTMLElement[]) => sections.map((s) => s.dataset.facetKey);
 
 describe("renderFacetSections", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders labels + area + platform + status + updates when the fleet warrants", () => {
     const { sections } = mount();
     // Two distinct platforms (>1), one named area (>0), both update buckets.

--- a/test/components/filters/filter-section.test.ts
+++ b/test/components/filters/filter-section.test.ts
@@ -5,7 +5,7 @@
  * ``expanded`` (never self-flipped), ``facet-change`` payloads, and
  * search filtering with its empty states and reset-on-collapse.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -38,10 +38,6 @@ const rows = (el: ESPHomeFilterSection) => [
 ];
 
 describe("esphome-filter-section", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders collapsed by default with aria-expanded false", async () => {
     const el = await mount();
     expect(header(el).getAttribute("aria-expanded")).toBe("false");

--- a/test/components/filters/filters-popover.test.ts
+++ b/test/components/filters/filters-popover.test.ts
@@ -5,7 +5,7 @@
  * Escape with focus handback, outside-click, request-popover-close),
  * the header Clear all, and exclusive-open accordion coordination.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -52,10 +52,6 @@ const badge = (el: ESPHomeFiltersPopover) =>
   el.shadowRoot!.querySelector(".filters-badge");
 
 describe("esphome-filters-popover", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("hides the badge when no facets are active", async () => {
     const { el } = await mount(0);
     expect(badge(el)).toBeNull();

--- a/test/components/filters/labels-filter-section.test.ts
+++ b/test/components/filters/labels-filter-section.test.ts
@@ -5,7 +5,7 @@
  * ``labels-filter-change``, the empty-catalog state, and the
  * close-before-action ordering of the management request events.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -43,10 +43,6 @@ function record(el: ESPHomeLabelsFilterSection, types: string[]): string[] {
 }
 
 describe("esphome-labels-filter-section", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders one row per catalog label with usage counts and chip styling", async () => {
     const el = await mount({ usageCounts: { l1: 3 } });
     const [first, second] = rows(el);

--- a/test/components/firmware-install-dialog-artifact-download.test.ts
+++ b/test/components/firmware-install-dialog-artifact-download.test.ts
@@ -28,6 +28,7 @@ import {
   downloadSelectedBinary,
   startArtifactDownload,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
+import { identityLocalize } from "../_dom.js";
 
 const FACTORY: FirmwareBinary = { title: "Factory format", file: "firmware.factory.bin" };
 const OTA: FirmwareBinary = { title: "OTA format", file: "firmware.ota.bin" };
@@ -73,7 +74,7 @@ function makeHost(getBinariesResults: FirmwareBinary[][]) {
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _compileReject: null as null | ((e: unknown) => void),
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _fail: vi.fn(),
   };
   host._fail = vi.fn((msg: string) => {

--- a/test/components/firmware-install-dialog-artifact-labels.test.ts
+++ b/test/components/firmware-install-dialog-artifact-labels.test.ts
@@ -6,12 +6,12 @@
  * translation (unknown type, or a type without a key). Uses the real English
  * localize so the localized path is actually exercised.
  */
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import type { FirmwareBinary } from "../../src/api/types/firmware-jobs.js";
 import { defaultLocalize } from "../../src/common/localize.js";
 import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { renderStatusExtra } from "../../src/components/firmware-install-dialog/renderers.js";
+import { renderInto } from "../_dom.js";
 
 function rowsText(binaries: FirmwareBinary[]): string {
   const host = {
@@ -21,8 +21,9 @@ function rowsText(binaries: FirmwareBinary[]): string {
     _localize: defaultLocalize,
     _onChooseBinary: () => {},
   };
-  const container = document.createElement("div");
-  render(renderStatusExtra(host as unknown as ESPHomeFirmwareInstallDialog), container);
+  const container = renderInto(
+    renderStatusExtra(host as unknown as ESPHomeFirmwareInstallDialog)
+  );
   return container.textContent ?? "";
 }
 

--- a/test/components/firmware-install-dialog-download-binary.test.ts
+++ b/test/components/firmware-install-dialog-download-binary.test.ts
@@ -31,6 +31,7 @@ import {
   downloadSelectedBinary,
   startDownload,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
+import { identityLocalize } from "../_dom.js";
 
 const FACTORY: FirmwareBinary = { title: "Factory format", file: "firmware.factory.bin" };
 const OTA: FirmwareBinary = {
@@ -73,7 +74,7 @@ function makeHost(installer: Installer, binaries: FirmwareBinary[]) {
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _compileReject: null as null | ((e: unknown) => void),
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _fail: vi.fn(),
   };
   host._fail = vi.fn((msg: string) => {

--- a/test/components/firmware-install-dialog-elf-copy.test.ts
+++ b/test/components/firmware-install-dialog-elf-copy.test.ts
@@ -11,6 +11,7 @@ import {
   cardStatusDetail,
   cardStatusMessage,
 } from "../../src/components/firmware-install-dialog/renderers.js";
+import { identityLocalize } from "../_dom.js";
 
 function textFor(filename: string): string {
   const host = {
@@ -18,7 +19,7 @@ function textFor(filename: string): string {
     _installer: "binary-download",
     _downloadedFilename: filename,
     _binaries: [],
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
   } as unknown as ESPHomeFirmwareInstallDialog;
   return `${cardStatusMessage(host)} ${cardStatusDetail(host)}`;
 }

--- a/test/components/firmware-install-dialog-footer.test.ts
+++ b/test/components/firmware-install-dialog-footer.test.ts
@@ -9,13 +9,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { renderFooter } from "../../src/components/firmware-install-dialog/renderers.js";
+import { identityLocalize } from "../_dom.js";
 import { findTemplatesByAnchor } from "../_lit-template-walker.js";
 
 function footerHost(step: string) {
   return {
     _step: step,
     _installer: "binary-download",
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _close: vi.fn(),
     _cancel: vi.fn(),
     _retry: vi.fn(),

--- a/test/components/firmware-install-dialog-usb-flash.test.ts
+++ b/test/components/firmware-install-dialog-usb-flash.test.ts
@@ -9,6 +9,7 @@ import {
   showOtaLogs,
   startUsbFlash,
 } from "../../src/components/firmware-install-dialog/install-flow.js";
+import { identityLocalize } from "../_dom.js";
 
 const bin = (file: string): FirmwareBinary => ({ file, title: file });
 
@@ -36,7 +37,7 @@ function makeHost(opts: { compileOk: boolean; binaries?: FirmwareBinary[] }) {
       name: "x",
       target_platform: "esp32",
     } as ConfiguredDevice,
-    _localize: (k: string) => k,
+    _localize: identityLocalize,
     _step: "queued",
     _statusMessage: "",
     _errorMessage: "",

--- a/test/components/firmware-install-dialog-usb-handoff.test.ts
+++ b/test/components/firmware-install-dialog-usb-handoff.test.ts
@@ -10,6 +10,7 @@ import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware
 import { handOffToFlasher } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { cardStatusDetail } from "../../src/components/firmware-install-dialog/renderers.js";
 import type { FlasherCallbacks } from "../../src/util/usb-flasher.js";
+import { identityLocalize } from "../_dom.js";
 
 function makeHost() {
   const host = {
@@ -21,7 +22,7 @@ function makeHost() {
     _errorMessage: "",
     _flashPercent: 0,
     _usbFlashTeardown: null as (() => void) | null,
-    _localize: (k: string) => k,
+    _localize: identityLocalize,
     _fail(title: string, detail = "") {
       this._step = "error";
       this._statusMessage = title;

--- a/test/components/firmware-install-dialog-web-serial.test.ts
+++ b/test/components/firmware-install-dialog-web-serial.test.ts
@@ -27,6 +27,7 @@ import { JobSource, JobStatus } from "../../src/api/types/firmware-jobs.js";
 import type { ESPHomeFirmwareInstallDialog } from "../../src/components/firmware-install-dialog.js";
 import { startWebSerialInstall } from "../../src/components/firmware-install-dialog/install-flow.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
+import { identityLocalize } from "../_dom.js";
 
 function makeHost() {
   const api = {
@@ -67,7 +68,7 @@ function makeHost() {
     _jobSource: JobSource.LOCAL,
     _jobSourceLabel: "",
     _compileReject: null as null | ((e: unknown) => void),
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _fail: vi.fn(),
     _close: vi.fn(),
   };

--- a/test/components/firmware-install-dialog/flip-to-logs.test.ts
+++ b/test/components/firmware-install-dialog/flip-to-logs.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../src/util/post-install-logs.js", () => ({
 
 import type { ESPHomeFirmwareInstallDialog } from "../../../src/components/firmware-install-dialog.js";
 import { flipToLogs } from "../../../src/components/firmware-install-dialog/install-flow.js";
+import { identityLocalize } from "../../_dom.js";
 
 function makeHost(loggerBaudRate: number | null): ESPHomeFirmwareInstallDialog {
   return {
@@ -26,7 +27,7 @@ function makeHost(loggerBaudRate: number | null): ESPHomeFirmwareInstallDialog {
       friendly_name: "X",
       logger_baud_rate: loggerBaudRate,
     },
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _open: true,
     reopen: vi.fn(),
   } as unknown as ESPHomeFirmwareInstallDialog;

--- a/test/components/firmware-jobs-dialog/renderers.test.ts
+++ b/test/components/firmware-jobs-dialog/renderers.test.ts
@@ -4,23 +4,18 @@
 // dialog. Mounts the Lit TemplateResult into a happy-dom container (repo idiom)
 // and asserts on the produced DOM.
 
-import { nothing, render } from "lit";
+import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
 
 import { JobSource } from "../../../src/api/types/firmware-jobs.js";
 import { renderSourceLine } from "../../../src/components/firmware-jobs-dialog/renderers.js";
+import { identityLocalize, renderInto } from "../../_dom.js";
 import { makeFirmwareJob } from "../../_make-firmware-job.js";
 
 // renderSourceLine only reads host._localize; a key-echoing stub lets us assert
 // which localization key the branch picked.
 function host(): { _localize: (key: string) => string } {
-  return { _localize: (key: string) => key };
-}
-
-function renderInto(value: unknown): HTMLElement {
-  const container = document.createElement("div");
-  render(value, container);
-  return container;
+  return { _localize: identityLocalize };
 }
 
 describe("renderSourceLine", () => {

--- a/test/components/friendly-name-dialog.test.ts
+++ b/test/components/friendly-name-dialog.test.ts
@@ -4,20 +4,14 @@
  * Pins that the friendly-name dialog confirms a changed value on Enter via
  * the shared EnterController, and goes inert once closed.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/components/base-dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/checkbox/checkbox.js", () => ({}));
 
 import { ESPHomeFriendlyNameDialog } from "../../src/components/friendly-name-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
-
-async function mount(): Promise<ESPHomeFriendlyNameDialog> {
-  const el = new ESPHomeFriendlyNameDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 function setValue(el: ESPHomeFriendlyNameDialog, value: string): Promise<unknown> {
   const input = el.shadowRoot!.querySelector<HTMLInputElement>("#friendly-name-input")!;
@@ -27,12 +21,8 @@ function setValue(el: ESPHomeFriendlyNameDialog, value: string): Promise<unknown
 }
 
 describe("friendly-name-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("confirms a changed friendly name on Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeFriendlyNameDialog());
     el.open("kitchen", "Kitchen");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -50,7 +40,7 @@ describe("friendly-name-dialog ENTER", () => {
     // between (keydown -> updateComplete -> keydown). The listener
     // detaches in willUpdate on the first keydown's close(), so the
     // second finds it gone — no latch needed.
-    const el = await mount();
+    const el = await mount(new ESPHomeFriendlyNameDialog());
     el.open("kitchen", "Kitchen");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -63,7 +53,7 @@ describe("friendly-name-dialog ENTER", () => {
   });
 
   it("ignores Enter once closed (inactive)", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeFriendlyNameDialog());
     el.open("kitchen", "Kitchen");
     await setValue(el, "Living Room");
     el.close();

--- a/test/components/install-method-dialog-bootloader.test.ts
+++ b/test/components/install-method-dialog-bootloader.test.ts
@@ -5,7 +5,7 @@
  * device can accept it (canFlashBootloader), only in install mode, and only
  * while the device is online.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -34,10 +34,6 @@ async function mount(
 
 const bootloaderRow = (d: ESPHomeInstallMethodDialog): HTMLElement | null =>
   d.shadowRoot!.querySelector('wa-icon[name="chip"]')?.closest(".option") ?? null;
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("install-method dialog bootloader option", () => {
   it("renders in the advanced section and emits select-method bootloader", async () => {

--- a/test/components/install-method-dialog-ota-submit-label.test.ts
+++ b/test/components/install-method-dialog-ota-submit-label.test.ts
@@ -52,7 +52,6 @@ const submitLabel = (d: ESPHomeInstallMethodDialog): string =>
 
 describe("install-method-dialog OTA submit label", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
     vi.restoreAllMocks();
   });
 

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -38,7 +38,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.useRealTimers();
 });
 

--- a/test/components/install-method-dialog-web-serial-availability.test.ts
+++ b/test/components/install-method-dialog-web-serial-availability.test.ts
@@ -80,7 +80,6 @@ function methodOnClick(d: ESPHomeInstallMethodDialog, el: Element): string | nul
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 afterEach(() => {
-  document.body.innerHTML = "";
   if (origSerial) Object.defineProperty(navigator, "serial", origSerial);
   else if ("serial" in navigator) delete (navigator as any).serial;
   if (origSecure) Object.defineProperty(window, "isSecureContext", origSecure);

--- a/test/components/install-method-dialog-web-serial-platform.test.ts
+++ b/test/components/install-method-dialog-web-serial-platform.test.ts
@@ -57,7 +57,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   if (origSerial) Object.defineProperty(navigator, "serial", origSerial);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   else if ("serial" in navigator) delete (navigator as any).serial;

--- a/test/components/labels/device-labels-editor.test.ts
+++ b/test/components/labels/device-labels-editor.test.ts
@@ -8,7 +8,7 @@
  * label toggle while the dialog stays open, so it deliberately does NOT bind
  * ?busy (that would dim/lock the dialog on each toggle).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -42,10 +42,6 @@ const dialog = (el: ESPHomeDeviceLabelsEditor): HTMLElement =>
 const isOpen = (el: ESPHomeDeviceLabelsEditor): boolean => (el as any)._open;
 
 describe("device-labels-editor open/close contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("opens via the Edit-labels trigger", async () => {
     const el = await mount();
     expect(isOpen(el)).toBe(false);

--- a/test/components/labels/label-dialog.test.ts
+++ b/test/components/labels/label-dialog.test.ts
@@ -6,7 +6,7 @@
  * tracks create vs edit, and a catalog push dropping the edited
  * label requests close.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -33,10 +33,6 @@ const inner = (el: ESPHomeLabelDialog): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 describe("esphome-label-dialog", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("binds open to the inner dialog", async () => {
     const el = await mount();
     expect(inner(el).hasAttribute("open")).toBe(false);

--- a/test/components/labels/label-form.test.ts
+++ b/test/components/labels/label-form.test.ts
@@ -5,24 +5,15 @@
  * form-cancel so the host closes (#1477); the device-drawer inline create
  * form collapses back to its toggle and stays silent.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import type { Label } from "../../../src/api/types/devices.js";
 import { ESPHomeLabelForm } from "../../../src/components/labels/label-form.js";
+import { mount } from "../../_dom.js";
 
 const LABEL: Label = { id: "l1", name: "kitchen", color: "#ff0000" } as Label;
-
-async function mount(
-  overrides: Partial<Record<string, unknown>> = {}
-): Promise<ESPHomeLabelForm> {
-  const el = new ESPHomeLabelForm();
-  Object.assign(el, overrides);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 const cancelButton = (el: ESPHomeLabelForm): HTMLButtonElement =>
   el.shadowRoot!.querySelector(".create-actions .btn")!;
@@ -31,12 +22,8 @@ const toggleButton = (el: ESPHomeLabelForm): HTMLButtonElement | null =>
   el.shadowRoot!.querySelector(".create-toggle");
 
 describe("esphome-label-form cancel", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("fires form-cancel from the default-open create dialog", async () => {
-    const el = await mount({ defaultOpen: true });
+    const el = await mount(new ESPHomeLabelForm(), { defaultOpen: true });
     const onCancel = vi.fn();
     el.addEventListener("form-cancel", onCancel);
     cancelButton(el).click();
@@ -44,7 +31,7 @@ describe("esphome-label-form cancel", () => {
   });
 
   it("fires form-cancel from edit mode", async () => {
-    const el = await mount({ editing: LABEL });
+    const el = await mount(new ESPHomeLabelForm(), { editing: LABEL });
     const onCancel = vi.fn();
     el.addEventListener("form-cancel", onCancel);
     cancelButton(el).click();
@@ -52,7 +39,7 @@ describe("esphome-label-form cancel", () => {
   });
 
   it("collapses the inline create form to its toggle without firing form-cancel", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeLabelForm());
     el.expand();
     await el.updateComplete;
     const onCancel = vi.fn();

--- a/test/components/logs-dialog.test.ts
+++ b/test/components/logs-dialog.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
@@ -131,10 +131,6 @@ describe("logs-dialog header source chip", () => {
     return el.shadowRoot!.querySelector(".source-chip")?.textContent?.trim() ?? "";
   }
 
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("shows OTA for an OTA session", async () => {
     const el = mount();
     el.open("OTA");
@@ -169,10 +165,6 @@ describe("logs-dialog States toggle gate (#539)", () => {
   // The States toggle is the only toolbar control with aria-pressed.
   const hasStatesToggle = (el: ESPHomeLogsDialog): boolean =>
     el.shadowRoot!.querySelector("[aria-pressed]") !== null;
-
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
 
   it("shows the States toggle for an OTA (network) session", async () => {
     const el = mount();

--- a/test/components/options-combobox.test.ts
+++ b/test/components/options-combobox.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 // happy-dom can't host webawesome's custom elements; we assert the
 // component's own shadow-DOM markup (input + option rows).
@@ -49,10 +49,6 @@ async function open(el: ESPHomeOptionsCombobox) {
   input(el).dispatchEvent(new FocusEvent("focus"));
   await el.updateComplete;
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("esphome-options-combobox", () => {
   test("closed field shows the committed value and no list", async () => {

--- a/test/components/pair-build-server-dialog/on-preview-submit.test.ts
+++ b/test/components/pair-build-server-dialog/on-preview-submit.test.ts
@@ -7,12 +7,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
 import { onPreviewSubmit } from "../../../src/components/pair-build-server-dialog/actions.js";
+import { identityLocalize } from "../../_dom.js";
 
 function makeHost(
   preview: () => Promise<{ pin_sha256: string }>
 ): ESPHomePairBuildServerDialog {
   return {
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _api: { previewRemoteBuildPair: preview },
     _busy: false,
     _hostname: "buildbox.local",

--- a/test/components/pair-build-server-dialog/open-orchestration.test.ts
+++ b/test/components/pair-build-server-dialog/open-orchestration.test.ts
@@ -13,6 +13,7 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
 
 import { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
+import { identityLocalize } from "../../_dom.js";
 
 function makeApi() {
   return {
@@ -30,7 +31,7 @@ function makeApi() {
 function makeDialog(api: unknown): ESPHomePairBuildServerDialog {
   const d = new ESPHomePairBuildServerDialog();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (d as any)._localize = (k: string) => k;
+  (d as any)._localize = identityLocalize;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (d as any)._api = api;
   return d;
@@ -38,7 +39,6 @@ function makeDialog(api: unknown): ESPHomePairBuildServerDialog {
 
 describe("pair dialog open() auto-preview orchestration", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
     vi.clearAllMocks();
   });
 

--- a/test/components/pair-build-server-dialog/render-confirm-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-confirm-step.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
 import { renderConfirmStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
+import { identityLocalize } from "../../_dom.js";
 import { findTemplatesByAnchor, visitTemplates } from "../../_lit-template-walker.js";
 
 function makeHost(
@@ -22,7 +23,7 @@ function makeHost(
   } = {}
 ): ESPHomePairBuildServerDialog {
   return {
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _busy: opts.busy ?? false,
     _sending: opts.sending ?? false,
     _previewedPin: opts.pin ?? "",

--- a/test/components/pair-build-server-dialog/render-sent-step.test.ts
+++ b/test/components/pair-build-server-dialog/render-sent-step.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 import type { IdentityView } from "../../../src/api/types/remote-build.js";
 import type { ESPHomePairBuildServerDialog } from "../../../src/components/pair-build-server-dialog.js";
 import { renderSentStep } from "../../../src/components/pair-build-server-dialog/renderers.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
@@ -33,7 +34,7 @@ const IDENTITY: IdentityView = {
 
 function makeHost(identity: IdentityView | null): ESPHomePairBuildServerDialog {
   return {
-    _localize: (key: string) => key,
+    _localize: identityLocalize,
     _hostname: "buildbox.local",
     _port: "6055",
     _offloaderIdentity: identity,

--- a/test/components/process-terminal/toolbar-button.test.ts
+++ b/test/components/process-terminal/toolbar-button.test.ts
@@ -5,16 +5,15 @@
  * and logs dialog toolbars.
  */
 import type { TemplateResult } from "lit";
-import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import {
   renderTermButton,
   renderTermToggle,
 } from "../../../src/components/process-terminal/toolbar-button.js";
+import { renderInto } from "../../_dom.js";
 
 function mount(tpl: TemplateResult): HTMLButtonElement {
-  const container = document.createElement("div");
-  render(tpl, container);
+  const container = renderInto(tpl);
   return container.querySelector("button")!;
 }
 

--- a/test/components/remote-build-job-dialog-buttons.test.ts
+++ b/test/components/remote-build-job-dialog-buttons.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 // happy-dom can't host webawesome's form-associated internals; the dialog's
 // own button markup is what's under test.
@@ -10,11 +10,12 @@ vi.mock("@home-assistant/webawesome/dist/components/select/select.js", () => ({}
 
 import { ESPHomeRemoteBuildJobDialog } from "../../src/components/remote-build-job-dialog.js";
 import { stubRemoteBuildJobState } from "../../src/context/index.js";
+import { identityLocalize } from "../_dom.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mountInputStep() {
   const el = new ESPHomeRemoteBuildJobDialog();
-  (el as any)._localize = (k: string) => k;
+  (el as any)._localize = identityLocalize;
   (el as any)._open = true;
   (el as any)._step = "input";
   (el as any)._pinSha256 = "ab".repeat(32);
@@ -30,7 +31,7 @@ async function mountInputStep() {
 async function mountExpandedListStep() {
   const el = new ESPHomeRemoteBuildJobDialog();
   const job = stubRemoteBuildJobState("job-1", "ab".repeat(32));
-  (el as any)._localize = (k: string) => k;
+  (el as any)._localize = identityLocalize;
   (el as any)._open = true;
   (el as any)._step = "list";
   (el as any)._jobs = new Map([[job.job_id, job]]);
@@ -48,10 +49,6 @@ function hasClasses(el: Element, want: string[]): boolean {
     !["btn-secondary", "btn-primary", "btn-danger"].some((c) => el.classList.contains(c))
   );
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("remote-build-job-dialog action buttons", () => {
   test("input-step buttons use the shared cancel / primary classes", async () => {

--- a/test/components/remote-build-job-dialog-selects.test.ts
+++ b/test/components/remote-build-job-dialog-selects.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 // happy-dom can't host webawesome's form-associated internals; the
 // attributes under test are readable on the unknown elements.
@@ -29,10 +29,6 @@ async function mountInputStep() {
   return el;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("remote-build-job-dialog submit form selects", () => {
   test("configuration and target pickers are labelled wa-selects with values", async () => {

--- a/test/components/rename-device-dialog.test.ts
+++ b/test/components/rename-device-dialog.test.ts
@@ -4,19 +4,13 @@
  * Pins that the rename dialog confirms a valid new name on Enter (via the
  * shared EnterController), and ignores Enter when unchanged or after close.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 
 import { ESPHomeRenameDeviceDialog } from "../../src/components/rename-device-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
-
-async function mount(): Promise<ESPHomeRenameDeviceDialog> {
-  const el = new ESPHomeRenameDeviceDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 function setValue(el: ESPHomeRenameDeviceDialog, value: string): Promise<unknown> {
   const input = el.shadowRoot!.querySelector("input")!;
@@ -26,12 +20,8 @@ function setValue(el: ESPHomeRenameDeviceDialog, value: string): Promise<unknown
 }
 
 describe("rename-device-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("confirms a valid new name on Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     el.open("oldname");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -43,7 +33,7 @@ describe("rename-device-dialog ENTER", () => {
   });
 
   it("ignores Enter when the name is unchanged", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     el.open("kitchen");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -53,7 +43,7 @@ describe("rename-device-dialog ENTER", () => {
   });
 
   it("fires rename-confirm only once on a repeated Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     el.open("oldname");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -69,7 +59,7 @@ describe("rename-device-dialog ENTER", () => {
     // identically on the repeat); the listener detaches in _onAfterHide, not
     // close(), so the _resolved latch is the only thing stopping a second
     // dispatch while the dialog is still hiding.
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     el.open("oldname");
     await el.updateComplete;
     const onConfirm = vi.fn();
@@ -88,7 +78,7 @@ describe("rename-device-dialog ENTER", () => {
   });
 
   it("ignores Enter after the dialog hides", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     el.open("oldname");
     await setValue(el, "kitchen");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -111,12 +101,8 @@ describe("rename-device-dialog ENTER", () => {
  * and the dialog could never dismiss.
  */
 describe("rename-device-dialog base-dialog open contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("open() / close() drive the reactive _open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     const view = el as unknown as { _open: boolean };
     el.open("oldname");
     expect(view._open).toBe(true);
@@ -125,7 +111,7 @@ describe("rename-device-dialog base-dialog open contract", () => {
   });
 
   it("_onRequestClose flips the reactive open flag", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeRenameDeviceDialog());
     const view = el as unknown as { _open: boolean; _onRequestClose: () => void };
     el.open("oldname");
     expect(view._open).toBe(true);

--- a/test/components/secrets/secrets-structured-editor.test.ts
+++ b/test/components/secrets/secrets-structured-editor.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import toast from "sonner-js";
 
@@ -51,10 +51,6 @@ function onChange(el: ESPHomeSecretsStructuredEditor): { value: string | null } 
   });
   return captured;
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("esphome-secrets-structured-editor", () => {
   test("renders one row per top-level scalar entry", async () => {

--- a/test/components/settings-dialog/appearance-expert-mode.test.ts
+++ b/test/components/settings-dialog/appearance-expert-mode.test.ts
@@ -5,7 +5,7 @@
  * Editor section). Flipping it must fire a bubbling, composed `set-expert-mode`
  * event carrying the *next* value so app-shell can persist it.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Stub the wa-select/wa-option theme picker (happy-dom can't run their
 // form-associated internals) and wa-icon (only chrome here).
@@ -30,10 +30,6 @@ const toggle = (el: ESPHomeSettingsAppearance) =>
   el.shadowRoot!.querySelector<HTMLButtonElement>('button.toggle[role="switch"]')!;
 
 describe("appearance Expert Mode toggle", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("hides the feature list until the chevron is opened", async () => {
     const el = await mount(false);
     const disclosure =

--- a/test/components/settings-dialog/appearance-version-history.test.ts
+++ b/test/components/settings-dialog/appearance-version-history.test.ts
@@ -6,7 +6,7 @@
  * `set-version-history-enabled` event carrying the *next* value so app-shell
  * can persist it.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Stub the wa-select/wa-option theme picker and wa-icon (happy-dom can't run
 // their form-associated internals; they're only chrome here).
@@ -38,10 +38,6 @@ const versionToggle = (el: ESPHomeSettingsAppearance) =>
   );
 
 describe("appearance version-history toggle", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("is hidden unless Expert Mode is on", async () => {
     expect(versionToggle(await mount(false))).toBeNull();
     expect(versionToggle(await mount(true))).not.toBeNull();

--- a/test/components/settings-dialog/build-offload-advanced.test.ts
+++ b/test/components/settings-dialog/build-offload-advanced.test.ts
@@ -6,7 +6,7 @@
  * from everyone who'd use it). Flipping it fires a bubbling, composed
  * `set-offloader-include-local` event carrying the next value.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { ESPHomeSettingsBuildOffloadAdvanced } from "../../../src/components/settings-dialog/build-offload-advanced.js";
 
@@ -26,10 +26,6 @@ const toggle = (el: ESPHomeSettingsBuildOffloadAdvanced) =>
   el.shadowRoot!.querySelector<HTMLButtonElement>('button.toggle[role="switch"]');
 
 describe("build-offload include-local toggle", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the toggle inline, with no advanced-options disclosure", async () => {
     const el = await mount(false);
     const btn = toggle(el);

--- a/test/components/settings-dialog/language-section.test.ts
+++ b/test/components/settings-dialog/language-section.test.ts
@@ -4,13 +4,14 @@ import { describe, expect, it } from "vitest";
 
 import type { LanguageOption, LocalizeFunc } from "../../../src/common/localize.js";
 import { ESPHomeSettingsLanguage } from "../../../src/components/settings-dialog/language-section.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
   visitTemplates,
 } from "../../_lit-template-walker.js";
 
-const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
 
 // Flatten the static strings + string values across the template tree.
 // wa-select can't mount under happy-dom (form association), so inspect the

--- a/test/components/settings-dialog/settings-rows.test.ts
+++ b/test/components/settings-dialog/settings-rows.test.ts
@@ -5,31 +5,18 @@
  * `null` loading variant, the `expert-row` class pass-through, and the status /
  * alert role.
  */
-import { render, type TemplateResult } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   renderStatusRow,
   renderToggleRow,
 } from "../../../src/components/settings-dialog/settings-rows.js";
-
-const localize = (key: string) => key;
-
-function mount(result: TemplateResult): HTMLElement {
-  const el = document.createElement("div");
-  render(result, el);
-  document.body.appendChild(el);
-  return el;
-}
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
+import { identityLocalize as localize, renderInto } from "../../_dom.js";
 
 describe("renderToggleRow", () => {
   it("renders the live toggle with a11y wiring and fires onToggle", () => {
     const onToggle = vi.fn();
-    const el = mount(
+    const el = renderInto(
       renderToggleRow(localize, {
         titleId: "my-title",
         titleKey: "settings.my_title",
@@ -53,7 +40,7 @@ describe("renderToggleRow", () => {
   });
 
   it("applies an extra row class", () => {
-    const el = mount(
+    const el = renderInto(
       renderToggleRow(localize, {
         titleId: "x",
         titleKey: "k",
@@ -68,7 +55,7 @@ describe("renderToggleRow", () => {
   });
 
   it("renders the loading variant (no button) when checked is null", () => {
-    const el = mount(
+    const el = renderInto(
       renderToggleRow(localize, {
         titleId: "x",
         titleKey: "settings.loading_title",
@@ -91,7 +78,7 @@ describe("renderToggleRow", () => {
 
 describe("renderStatusRow", () => {
   it("defaults to role=status with the localized key", () => {
-    const el = mount(renderStatusRow(localize, "settings.empty"));
+    const el = renderInto(renderStatusRow(localize, "settings.empty"));
     const row = el.querySelector(".row")!;
     expect(row.getAttribute("role")).toBe("status");
     expect(el.querySelector(".row-desc")?.textContent?.trim()).toBe("settings.empty");
@@ -99,7 +86,7 @@ describe("renderStatusRow", () => {
   });
 
   it("supports role=alert", () => {
-    const el = mount(renderStatusRow(localize, "settings.failed", "alert"));
+    const el = renderInto(renderStatusRow(localize, "settings.failed", "alert"));
     expect(el.querySelector(".row")!.getAttribute("role")).toBe("alert");
   });
 });

--- a/test/components/shared/render-disclosure.test.ts
+++ b/test/components/shared/render-disclosure.test.ts
@@ -10,13 +10,14 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/library.js", () => ({
 
 import type { LocalizeFunc } from "../../../src/common/localize.js";
 import { renderDisclosure } from "../../../src/components/shared/disclosure.js";
+import { identityLocalize } from "../../_dom.js";
 import {
   extractAttributeBindings,
   findTemplatesByAnchor,
   visitTemplates,
 } from "../../_lit-template-walker.js";
 
-const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
 
 const button = (result: unknown) => findTemplatesByAnchor(result, "<button")[0];
 

--- a/test/components/unsaved-changes-dialog.test.ts
+++ b/test/components/unsaved-changes-dialog.test.ts
@@ -7,31 +7,21 @@
  * request-close / after-hide -> cancel contract holds (the page-leave guard
  * depends on a definitive answer for every dismiss path).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeUnsavedChangesDialog } from "../../src/components/unsaved-changes-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
-
-async function mount(): Promise<ESPHomeUnsavedChangesDialog> {
-  const el = new ESPHomeUnsavedChangesDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 const baseDialog = (el: ESPHomeUnsavedChangesDialog): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 describe("unsaved-changes-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("saves and leaves on Enter (never discards)", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     const onSave = vi.fn();
     const onDiscard = vi.fn();
     el.addEventListener("save", onSave);
@@ -43,7 +33,7 @@ describe("unsaved-changes-dialog ENTER", () => {
   });
 
   it("fires save only once on a repeated Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     const onSave = vi.fn();
     el.addEventListener("save", onSave);
     el.open();
@@ -53,7 +43,7 @@ describe("unsaved-changes-dialog ENTER", () => {
   });
 
   it("does not save before the dialog is opened", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     const onSave = vi.fn();
     el.addEventListener("save", onSave);
     pressEnter();
@@ -65,12 +55,8 @@ describe("unsaved-changes-dialog ENTER", () => {
 // the request-close handler, and the after-hide -> cancel path. Pin them so the
 // dismiss-cancels contract can't silently regress.
 describe("unsaved-changes-dialog dismiss / request-close", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("fires a single cancel when dismissed without a decision", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     el.open();
     await el.updateComplete;
     const onCancel = vi.fn();
@@ -80,7 +66,7 @@ describe("unsaved-changes-dialog dismiss / request-close", () => {
   });
 
   it("does not fire cancel after a decision (save)", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     el.open();
     await el.updateComplete;
     const onSave = vi.fn();
@@ -94,7 +80,7 @@ describe("unsaved-changes-dialog dismiss / request-close", () => {
   });
 
   it("flips the reactive open flag to false on request-close", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeUnsavedChangesDialog());
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/components/update-all-dialog.test.ts
+++ b/test/components/update-all-dialog.test.ts
@@ -5,7 +5,7 @@
  * live matched-device count, disables Update at zero, and bulk-installs exactly
  * the matched configurations on confirm.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // The confirm path runs runBulkUpdate, which fires sonner-js toasts; mock it
 // so the suite doesn't need a live toaster container.
@@ -77,10 +77,6 @@ const offlineUpdatable = makeConfiguredDevice({
 });
 
 describe("update-all-dialog", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("counts only online + update-available devices by default", async () => {
     const { api } = fakeApi();
     const el = await mount([onlineUpdatable, onlineCurrent, offlineUpdatable], api);

--- a/test/components/wizard-step-board-list.test.ts
+++ b/test/components/wizard-step-board-list.test.ts
@@ -40,6 +40,7 @@ class MockObserver {
 
 import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import { ESPHomeWizardStepBoardList } from "../../src/components/wizard/wizard-step-board-list.js";
+import { identityLocalize } from "../_dom.js";
 
 const board = (i: number): BoardCatalogEntry =>
   ({
@@ -60,7 +61,7 @@ async function mount(
   const el = new ESPHomeWizardStepBoardList();
   el.boards = boards;
   el.hasMore = hasMore;
-  el.localize = (k) => k;
+  el.localize = identityLocalize;
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -77,7 +78,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.unstubAllGlobals();
 });
 

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -154,10 +154,6 @@ afterEach(() => {
 });
 
 describe("create-config-dialog create de-dupe + retry", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("drops a second create while the first is in flight", async () => {
     const inflight = deferred<{ configuration: string }>();
     const createDevice = vi.fn(() => inflight.promise);
@@ -451,10 +447,6 @@ describe("create-config-dialog create de-dupe + retry", () => {
 // Navigating (Back, or forward into a new step with another board) must clear
 // it so a stale message doesn't follow the user onto the next attempt (#1487).
 describe("create-config-dialog stale error on navigation", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const errorText = (el: ESPHomeCreateConfigDialog): string | null =>
     el.shadowRoot!.querySelector("p.error")?.textContent ?? null;
 
@@ -554,10 +546,6 @@ describe("create-config-dialog stale error on navigation", () => {
 // _open back to false is the load-bearing part — without it a user-driven
 // close (Escape / X / outside-click) wouldn't dismiss. Pin the contract.
 describe("create-config-dialog open/close contract", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const isOpen = (el: ESPHomeCreateConfigDialog): boolean =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._open;
@@ -591,10 +579,6 @@ describe("create-config-dialog open/close contract", () => {
 // A .tar.gz is binary, so the wizard routes it to importBundle (base64)
 // instead of reading it as text and shoving garbage into createDevice.
 describe("create-config-dialog bundle import", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const step = (el: ESPHomeCreateConfigDialog): string =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._step;
@@ -730,10 +714,6 @@ describe("create-config-dialog bundle import", () => {
 // A YAML upload that collides routes to a confirm step; confirming
 // re-sends with overwrite:true (the backend keeps the device's labels).
 describe("create-config-dialog upload overwrite", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const step = (el: ESPHomeCreateConfigDialog): string =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (el as any)._step;
@@ -809,10 +789,6 @@ describe("create-config-dialog upload overwrite", () => {
 // it survives the method element being unmounted and re-created when the user
 // navigates into an advanced option (empty-config / import) and back.
 describe("create-config-dialog advanced disclosure persistence", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const methodEl = (el: ESPHomeCreateConfigDialog): HTMLElement | null =>
     el.shadowRoot!.querySelector("esphome-wizard-step-method");
 

--- a/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
+++ b/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
@@ -44,7 +44,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.useRealTimers();
   vi.restoreAllMocks();
 });

--- a/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
+++ b/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
@@ -4,7 +4,7 @@
  * Ports flagged in ``newPorts`` render highlighted with a "New" badge
  * so a just-plugged-in device is findable mid-wizard (#1381).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => ({}));
@@ -24,10 +24,6 @@ async function mount(
   return el;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("wizard-step-board-port-select new-port badge", () => {
   it("highlights only the ports flagged as new", async () => {

--- a/test/components/wizard/wizard-step-board-webserial-error.test.ts
+++ b/test/components/wizard/wizard-step-board-webserial-error.test.ts
@@ -47,7 +47,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
   vi.restoreAllMocks();
 });
 

--- a/test/components/wizard/wizard-step-empty-config.test.ts
+++ b/test/components/wizard/wizard-step-empty-config.test.ts
@@ -3,7 +3,7 @@
  *
  * Pins that Enter finishes the empty-config wizard step once a name is set.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepEmptyConfig } from "../../../src/components/wizard/wizard-step-empty-config.js";
 import { pressEnter } from "../../_press-enter.js";
 
@@ -16,10 +16,6 @@ async function mount(): Promise<ESPHomeWizardStepEmptyConfig> {
 }
 
 describe("wizard-step-empty-config ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("emits create-empty-config on Enter once a name is set", async () => {
     const el = await mount();
     const onCreate = vi.fn();

--- a/test/components/wizard/wizard-step-import-partial.test.ts
+++ b/test/components/wizard/wizard-step-import-partial.test.ts
@@ -4,24 +4,15 @@
  * Pins the partial-import result step: lists the kept files and emits
  * open-device when the user continues to the editor.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepImportPartial } from "../../../src/components/wizard/wizard-step-import-partial.js";
-
-async function mount(kept: string[]): Promise<ESPHomeWizardStepImportPartial> {
-  const el = new ESPHomeWizardStepImportPartial();
-  el.kept = kept;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 describe("wizard-step-import-partial", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("lists every kept file", async () => {
-    const el = await mount(["device.yaml", "common/wifi.yaml"]);
+    const el = await mount(new ESPHomeWizardStepImportPartial(), {
+      kept: ["device.yaml", "common/wifi.yaml"],
+    });
     const items = [...el.shadowRoot!.querySelectorAll("ul.kept li")].map(
       (li) => li.textContent
     );
@@ -29,7 +20,9 @@ describe("wizard-step-import-partial", () => {
   });
 
   it("emits open-device when the Open button is clicked", async () => {
-    const el = await mount(["device.yaml"]);
+    const el = await mount(new ESPHomeWizardStepImportPartial(), {
+      kept: ["device.yaml"],
+    });
     const onOpen = vi.fn();
     el.addEventListener("open-device", onOpen as EventListener);
     el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--primary")!.click();

--- a/test/components/wizard/wizard-step-method-advanced.test.ts
+++ b/test/components/wizard/wizard-step-method-advanced.test.ts
@@ -6,7 +6,7 @@
  * toggle signals intent via a ``toggle-advanced`` event rather than flipping
  * local state.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -24,10 +24,6 @@ async function mount(advancedOpen = false): Promise<ESPHomeWizardStepMethod> {
   return el;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("wizard-step-method advanced disclosure", () => {
   it("renders advanced options only when advancedOpen is set", async () => {

--- a/test/components/wizard/wizard-step-method-drop.test.ts
+++ b/test/components/wizard/wizard-step-method-drop.test.ts
@@ -5,7 +5,7 @@
  * drop" hint) must import the dropped file through the same
  * ``import-file`` event as the file-input path (#1386).
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
@@ -23,10 +23,6 @@ async function mount(): Promise<ESPHomeWizardStepMethod> {
   return el;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("wizard-step-method drag and drop", () => {
   it("highlights the step while a file drag hovers", async () => {

--- a/test/components/wizard/wizard-step-overwrite-device.test.ts
+++ b/test/components/wizard/wizard-step-overwrite-device.test.ts
@@ -4,31 +4,24 @@
  * Pins the upload-collision confirm step: Overwrite emits overwrite-device,
  * Cancel routes back to the method step.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepOverwriteDevice } from "../../../src/components/wizard/wizard-step-overwrite-device.js";
-
-async function mount(name: string): Promise<ESPHomeWizardStepOverwriteDevice> {
-  const el = new ESPHomeWizardStepOverwriteDevice();
-  el.deviceName = name;
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 describe("wizard-step-overwrite-device", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders a message paragraph and both actions", async () => {
-    const el = await mount("kitchen.yaml");
+    const el = await mount(new ESPHomeWizardStepOverwriteDevice(), {
+      deviceName: "kitchen.yaml",
+    });
     expect(el.shadowRoot!.querySelector("p")).not.toBeNull();
     expect(el.shadowRoot!.querySelector(".btn--primary")).not.toBeNull();
     expect(el.shadowRoot!.querySelector(".btn--cancel")).not.toBeNull();
   });
 
   it("emits overwrite-device when Overwrite is clicked", async () => {
-    const el = await mount("kitchen.yaml");
+    const el = await mount(new ESPHomeWizardStepOverwriteDevice(), {
+      deviceName: "kitchen.yaml",
+    });
     const onOverwrite = vi.fn();
     el.addEventListener("overwrite-device", onOverwrite as EventListener);
     el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--primary")!.click();
@@ -36,7 +29,9 @@ describe("wizard-step-overwrite-device", () => {
   });
 
   it("routes back to the method step when Cancel is clicked", async () => {
-    const el = await mount("kitchen.yaml");
+    const el = await mount(new ESPHomeWizardStepOverwriteDevice(), {
+      deviceName: "kitchen.yaml",
+    });
     const onNext = vi.fn();
     el.addEventListener("next-step", onNext as EventListener);
     el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--cancel")!.click();

--- a/test/components/wizard/wizard-step-resolve-conflicts.test.ts
+++ b/test/components/wizard/wizard-step-resolve-conflicts.test.ts
@@ -4,26 +4,13 @@
  * Pins the bundle conflict resolver: per-file overwrite toggles, the
  * main-config row flag, the secrets note, and the resolve-conflicts emit.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ESPHomeWizardStepResolveConflicts } from "../../../src/components/wizard/wizard-step-resolve-conflicts.js";
-
-async function mount(
-  props: Partial<ESPHomeWizardStepResolveConflicts>
-): Promise<ESPHomeWizardStepResolveConflicts> {
-  const el = new ESPHomeWizardStepResolveConflicts();
-  Object.assign(el, props);
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../../_dom.js";
 
 describe("wizard-step-resolve-conflicts", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("emits the checked paths as the overwrite set", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeWizardStepResolveConflicts(), {
       conflicts: ["device.yaml", "common/wifi.yaml"],
       mainConfig: "device.yaml",
     });
@@ -40,7 +27,10 @@ describe("wizard-step-resolve-conflicts", () => {
   });
 
   it("toggling a row off removes it from the overwrite set", async () => {
-    const el = await mount({ conflicts: ["device.yaml"], mainConfig: "device.yaml" });
+    const el = await mount(new ESPHomeWizardStepResolveConflicts(), {
+      conflicts: ["device.yaml"],
+      mainConfig: "device.yaml",
+    });
     const onResolve = vi.fn();
     el.addEventListener("resolve-conflicts", onResolve as EventListener);
     const box = el.shadowRoot!.querySelector<HTMLInputElement>("#cf-0")!;
@@ -51,7 +41,7 @@ describe("wizard-step-resolve-conflicts", () => {
   });
 
   it("flags the main-config row and shows the secrets note when present", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeWizardStepResolveConflicts(), {
       conflicts: ["device.yaml"],
       mainConfig: "device.yaml",
       hasSecrets: true,
@@ -61,7 +51,7 @@ describe("wizard-step-resolve-conflicts", () => {
   });
 
   it("omits the badge and secrets note when not applicable", async () => {
-    const el = await mount({
+    const el = await mount(new ESPHomeWizardStepResolveConflicts(), {
       conflicts: ["common/wifi.yaml"],
       mainConfig: "device.yaml",
       hasSecrets: false,
@@ -71,7 +61,9 @@ describe("wizard-step-resolve-conflicts", () => {
   });
 
   it("cancel routes back to the method step", async () => {
-    const el = await mount({ conflicts: ["device.yaml"] });
+    const el = await mount(new ESPHomeWizardStepResolveConflicts(), {
+      conflicts: ["device.yaml"],
+    });
     const onNext = vi.fn();
     el.addEventListener("next-step", onNext as EventListener);
     el.shadowRoot!.querySelector<HTMLButtonElement>(".btn--cancel")!.click();

--- a/test/components/wizard/wizard-step-setup.test.ts
+++ b/test/components/wizard/wizard-step-setup.test.ts
@@ -6,7 +6,7 @@
  * the SSID mandatory there; every other board finishes straight from the name
  * stage. Typed credentials pass through for the backend to persist.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BoardCatalogEntry } from "../../../src/api/types/boards.js";
 import { ESPHomeWizardStepSetup } from "../../../src/components/wizard/wizard-step-setup.js";
 import { fetchSecretKeys } from "../../../src/util/secrets-cache.js";
@@ -82,10 +82,6 @@ function setSsid(el: ESPHomeWizardStepSetup, value: string): Promise<unknown> {
 const stage = (el: ESPHomeWizardStepSetup) => (el as any)._stage;
 
 describe("wizard-step-setup", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("advances to the Wi-Fi stage for a Wi-Fi-only board with no secret", async () => {
     const el = await mount(wifiBoard());
     await setName(el, "kitchen");

--- a/test/components/yaml-editor-cursor-line.test.ts
+++ b/test/components/yaml-editor-cursor-line.test.ts
@@ -10,7 +10,7 @@
 import { forceParsing } from "@codemirror/language";
 import { EditorSelection } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
 
@@ -46,10 +46,6 @@ const caretToLineEnd = (view: EditorView, line: number) =>
   view.dispatch({ selection: EditorSelection.single(view.state.doc.line(line).to) });
 
 describe("yaml-editor cursor-line emission (#946)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("re-emits on a same-line top-level-key change (typing a new block)", async () => {
     // Line 3 starts blank; typing `http_request:` into it keeps line 3 but
     // changes the top-level key from none to http_request.

--- a/test/components/yaml-editor-indent-guides.test.ts
+++ b/test/components/yaml-editor-indent-guides.test.ts
@@ -5,27 +5,17 @@
  * indented rows (the legacy editor's "column lines").
  */
 import type { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
-
-async function mount(): Promise<ESPHomeYamlEditor> {
-  const el = new ESPHomeYamlEditor();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../_dom.js";
 
 const viewOf = (el: ESPHomeYamlEditor): EditorView =>
   (el as unknown as { _view: EditorView })._view;
 
 describe("yaml-editor indentation guides (#1231)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("marks indented lines with the indent-guide decoration", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlEditor());
     el.value = "sensor:\n  - platform: dht\n    pin: D1\n";
     await el.updateComplete;
 
@@ -34,7 +24,7 @@ describe("yaml-editor indentation guides (#1231)", () => {
   });
 
   it("does not mark the top-level (unindented) line", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlEditor());
     el.value = "logger:\n  level: DEBUG\n";
     await el.updateComplete;
 

--- a/test/components/yaml-editor-undo.test.ts
+++ b/test/components/yaml-editor-undo.test.ts
@@ -7,27 +7,17 @@
  */
 import { undo, undoDepth } from "@codemirror/commands";
 import type { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ESPHomeYamlEditor } from "../../src/components/yaml-editor.js";
-
-async function mount(): Promise<ESPHomeYamlEditor> {
-  const el = new ESPHomeYamlEditor();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
+import { mount } from "../_dom.js";
 
 const viewOf = (el: ESPHomeYamlEditor): EditorView =>
   (el as unknown as { _view: EditorView })._view;
 
 describe("yaml-editor undo baseline (#1150)", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("does not record the initial async content load in undo history", async () => {
-    const el = await mount(); // mounts with empty doc
+    const el = await mount(new ESPHomeYamlEditor()); // mounts with empty doc
     el.value = "wifi:\n  ssid: x\n"; // YAML arrives later
     await el.updateComplete;
 
@@ -38,7 +28,7 @@ describe("yaml-editor undo baseline (#1150)", () => {
   });
 
   it("keeps an external repopulate undoable after the user clears the doc", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlEditor());
     el.value = "wifi:\n  ssid: x\n"; // initial load (baselined)
     await el.updateComplete;
     const view = viewOf(el);
@@ -63,7 +53,7 @@ describe("yaml-editor undo baseline (#1150)", () => {
   });
 
   it("still scrolls to the highlight when value + highlightRange load in one cycle", async () => {
-    const el = await mount(); // empty
+    const el = await mount(new ESPHomeYamlEditor()); // empty
     const spy = vi.spyOn(
       el as unknown as { _applyHighlight: () => void },
       "_applyHighlight"
@@ -82,7 +72,7 @@ describe("yaml-editor undo baseline (#1150)", () => {
   });
 
   it("drops a highlight whose start line outlives a doc-shrinking value update", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlEditor());
     el.value = "a\nb\nc\nd\ne\nf\ng\n";
     el.highlightRange = { fromLine: 7, toLine: 7 };
     await el.updateComplete;

--- a/test/components/yaml-validation-dialog.test.ts
+++ b/test/components/yaml-validation-dialog.test.ts
@@ -6,31 +6,21 @@
  * force-save), the goto latch fires once, and the reactive ?open /
  * request-close / after-hide -> cancel contract holds.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@home-assistant/webawesome/dist/components/dialog/dialog.js", () => ({}));
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomeYamlValidationDialog } from "../../src/components/yaml-validation-dialog.js";
+import { mount } from "../_dom.js";
 import { pressEnter } from "../_press-enter.js";
-
-async function mount(): Promise<ESPHomeYamlValidationDialog> {
-  const el = new ESPHomeYamlValidationDialog();
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
 
 const baseDialog = (el: ESPHomeYamlValidationDialog): HTMLElement =>
   el.shadowRoot!.querySelector("esphome-base-dialog")!;
 
 describe("yaml-validation-dialog ENTER", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("goes to the first error on Enter when a line is known", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 12;
     el.firstErrorCol = 4;
     await el.updateComplete;
@@ -43,7 +33,7 @@ describe("yaml-validation-dialog ENTER", () => {
   });
 
   it("does nothing on Enter when no error line is known", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 0;
     await el.updateComplete;
     const onGoto = vi.fn();
@@ -57,7 +47,7 @@ describe("yaml-validation-dialog ENTER", () => {
   });
 
   it("fires goto only once on a repeated Enter", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 3;
     await el.updateComplete;
     const onGoto = vi.fn();
@@ -69,7 +59,7 @@ describe("yaml-validation-dialog ENTER", () => {
   });
 
   it("does not go to the error before the dialog is opened", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 3;
     await el.updateComplete;
     const onGoto = vi.fn();
@@ -83,15 +73,11 @@ describe("yaml-validation-dialog ENTER", () => {
 // meaningless against the open buffer, so "Go to error" must disable rather
 // than navigate nowhere, and the dialog names the offending file instead.
 describe("yaml-validation-dialog included-file error", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const gotoButton = (el: ESPHomeYamlValidationDialog): HTMLButtonElement =>
     el.shadowRoot!.querySelector(".btn--goto")!;
 
   it("disables Go to error when the error is in an included file", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 42;
     el.firstErrorFile = "base.yaml";
     await el.updateComplete;
@@ -100,7 +86,7 @@ describe("yaml-validation-dialog included-file error", () => {
   });
 
   it("does not fire goto on Enter when the error is in an included file", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 42;
     el.firstErrorFile = "base.yaml";
     await el.updateComplete;
@@ -112,7 +98,7 @@ describe("yaml-validation-dialog included-file error", () => {
   });
 
   it("keeps Go to error enabled when the error is in the open file", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 42;
     el.firstErrorFile = "";
     await el.updateComplete;
@@ -125,12 +111,8 @@ describe("yaml-validation-dialog included-file error", () => {
 // the request-close handler, and the after-hide -> cancel path. Pin them so the
 // dismiss-cancels contract (the page-leave guard depends on it) can't regress.
 describe("yaml-validation-dialog dismiss / request-close", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("fires a single cancel when dismissed without a decision", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.open();
     await el.updateComplete;
     const onCancel = vi.fn();
@@ -140,7 +122,7 @@ describe("yaml-validation-dialog dismiss / request-close", () => {
   });
 
   it("does not fire cancel after Go to error was chosen", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.firstErrorLine = 7;
     await el.updateComplete;
     const onGoto = vi.fn();
@@ -156,7 +138,7 @@ describe("yaml-validation-dialog dismiss / request-close", () => {
   });
 
   it("flips the reactive open flag to false on request-close", async () => {
-    const el = await mount();
+    const el = await mount(new ESPHomeYamlValidationDialog());
     el.open();
     await el.updateComplete;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/pages/dashboard-pending-serial-setup.test.ts
+++ b/test/pages/dashboard-pending-serial-setup.test.ts
@@ -47,7 +47,6 @@ describe("dashboard pending serial setup", () => {
   });
 
   afterEach(() => {
-    document.body.innerHTML = "";
     window.history.replaceState({}, "", "/");
   });
 

--- a/test/pages/dashboard-yaml-attr.test.ts
+++ b/test/pages/dashboard-yaml-attr.test.ts
@@ -43,7 +43,6 @@ describe("dashboard yaml host attribute", () => {
   });
 
   afterEach(() => {
-    document.body.innerHTML = "";
     window.history.replaceState({}, "", "/");
     vi.restoreAllMocks();
   });

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -106,7 +106,6 @@ function readBoard(page: ESPHomePageDevice): BoardCatalogEntry | null {
 
 describe("device page _platformReady lifecycle", () => {
   afterEach(() => {
-    document.body.innerHTML = "";
     vi.restoreAllMocks();
     // Shared board-body cache is a module singleton; clear it so a
     // board fetched in one case can't satisfy the next case's fetch.

--- a/test/util/editor-search-phrases.test.ts
+++ b/test/util/editor-search-phrases.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { editorSearchPhrases } from "../../src/util/editor-search-phrases.js";
+import { identityLocalize } from "../_dom.js";
 
 /** Echoes the key so each phrase resolves to its own translation key. */
-const echo: LocalizeFunc = (key) => key;
+const echo: LocalizeFunc = identityLocalize;
 
 function phraseState(localize: LocalizeFunc): EditorState {
   return EditorState.create({ extensions: [editorSearchPhrases(localize)] });

--- a/test/util/ensure-secret-with-toast.test.ts
+++ b/test/util/ensure-secret-with-toast.test.ts
@@ -18,8 +18,9 @@ import {
   setSecretWithToast,
 } from "../../src/util/ensure-secret-with-toast.js";
 import { _resetSecretKeysCache } from "../../src/util/secrets-cache.js";
+import { identityLocalize } from "../_dom.js";
 
-const localize = ((key: string) => key) as (key: string, args?: unknown) => string;
+const localize = identityLocalize as (key: string, args?: unknown) => string;
 const messages = {
   createdKey: "device.created",
   errorKey: "device.error",
@@ -36,7 +37,6 @@ function apiWith(created: boolean, keys: string[]) {
 }
 
 afterEach(() => {
-  document.body.innerHTML = "";
   _resetSecretKeysCache();
   vi.mocked(toast.success).mockClear();
   vi.mocked(toast.error).mockClear();

--- a/test/util/enter-controller.test.ts
+++ b/test/util/enter-controller.test.ts
@@ -5,16 +5,12 @@
  * modifiers, IME, already-handled events, and self-handling focus targets.
  */
 import type { ReactiveControllerHost } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { EnterController } from "../../src/util/enter-controller.js";
 
 const stubHost = { addController() {} } as unknown as ReactiveControllerHost;
 
 let target: HTMLElement;
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 function setup(onEnter = vi.fn()) {
   target = document.createElement("div");

--- a/test/util/facets.test.ts
+++ b/test/util/facets.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { computeUpdateFacet, normalizeUpdateBuckets } from "../../src/util/facets.js";
+import { identityLocalize } from "../_dom.js";
 
 // computeUpdateFacet reads update_available / has_pending_changes, gated on
 // active_source via showUpdateAvailable / showPendingChanges.
@@ -19,7 +20,7 @@ function device(over: Partial<ConfiguredDevice>): ConfiguredDevice {
 }
 
 // Echo the key so assertions key off the i18n id, not display copy.
-const localize = ((key: string) => key) as unknown as LocalizeFunc;
+const localize = identityLocalize as unknown as LocalizeFunc;
 
 describe("normalizeUpdateBuckets", () => {
   it("keeps known buckets in canonical order, deduped, dropping unknowns", () => {

--- a/test/util/file-drop-controller.test.ts
+++ b/test/util/file-drop-controller.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { FileDropController } from "../../src/util/file-drop-controller.js";
 import { dragEvent } from "../_drag-event.js";
 import { FakeHost } from "../_fake-host.js";
@@ -16,10 +16,6 @@ function make(opts: { visible?: boolean } = {}) {
   ctrl.hostConnected();
   return { host, target, onFile, ctrl };
 }
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("FileDropController", () => {
   it("accepts a dragged file: prevents default and flags dragging", () => {

--- a/test/util/firmware-job-display.test.ts
+++ b/test/util/firmware-job-display.test.ts
@@ -4,6 +4,7 @@ import type { FirmwareJob } from "../../src/api/types/firmware-jobs.js";
 import { JobStatus, JobType } from "../../src/api/types/firmware-jobs.js";
 import type { LocalizeFunc } from "../../src/common/localize.js";
 import { firmwareJobDisplayName } from "../../src/util/firmware-job-display.js";
+import { identityLocalize } from "../_dom.js";
 import { makeFirmwareJob } from "../_make-firmware-job.js";
 
 /**
@@ -32,7 +33,7 @@ function job(overrides: Partial<FirmwareJob> = {}): FirmwareJob {
  * never falls through to it, so a key-verbatim stub keeps the
  * test focused on the title-resolution logic.
  */
-const localize: LocalizeFunc = ((key: string) => key) as LocalizeFunc;
+const localize: LocalizeFunc = identityLocalize as LocalizeFunc;
 
 const NO_DEVICES: ConfiguredDevice[] = [];
 

--- a/test/util/label-chip-template.test.ts
+++ b/test/util/label-chip-template.test.ts
@@ -23,8 +23,10 @@
  * ``render-facets.test.ts``) and assert on the produced DOM rather
  * than on lit-html internals.
  */
-import { nothing, render } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { nothing } from "lit";
+import { describe, expect, it } from "vitest";
+
+import { renderInto } from "../_dom.js";
 
 import type { Label } from "../../src/api/types/devices.js";
 import {
@@ -35,12 +37,6 @@ import {
 
 function label(id: string, name: string, color: string | null = null): Label {
   return { id, name, color };
-}
-
-function renderInto(value: unknown): HTMLElement {
-  const container = document.createElement("div");
-  render(value, container);
-  return container;
 }
 
 function chipTexts(container: HTMLElement): string[] {
@@ -92,10 +88,6 @@ describe("resolveLabelIds", () => {
 });
 
 describe("renderLabelChip", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   it("renders the label name as the chip text", () => {
     const container = renderInto(renderLabelChip(label("a", "Kitchen")));
     expect(chipTexts(container)).toEqual(["Kitchen"]);
@@ -132,10 +124,6 @@ describe("renderLabelChip", () => {
 });
 
 describe("renderLabelChips", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   const labels = [
     label("a", "Alpha"),
     label("b", "Beta"),

--- a/test/util/markdown-render.test.ts
+++ b/test/util/markdown-render.test.ts
@@ -6,20 +6,16 @@
  * link inside the bold stays clickable instead of leaking as literal text.
  */
 
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import { renderMarkdown } from "../../src/util/markdown.js";
-
-function renderInto(input: string): HTMLDivElement {
-  const host = document.createElement("div");
-  render(renderMarkdown(input), host);
-  return host;
-}
+import { renderInto } from "../_dom.js";
 
 describe("renderMarkdown — bold-wrapped inline formatting", () => {
   it("renders a link inside bold as a clickable anchor", () => {
-    const host = renderInto("**[Action](https://esphome.io/x)**: do a thing");
+    const host = renderInto(
+      renderMarkdown("**[Action](https://esphome.io/x)**: do a thing")
+    );
     const strong = host.querySelector("strong")!;
     const anchor = strong.querySelector("a.md-link")!;
     expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
@@ -30,26 +26,26 @@ describe("renderMarkdown — bold-wrapped inline formatting", () => {
   });
 
   it("renders a link inside italic as a clickable anchor", () => {
-    const host = renderInto("_[Action](https://esphome.io/x)_");
+    const host = renderInto(renderMarkdown("_[Action](https://esphome.io/x)_"));
     const anchor = host.querySelector("em a.md-link")!;
     expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
     expect(anchor.textContent).toBe("Action");
   });
 
   it("renders code inside bold", () => {
-    const host = renderInto("**`true`**");
+    const host = renderInto(renderMarkdown("**`true`**"));
     const code = host.querySelector("strong code.md-code")!;
     expect(code.textContent).toBe("true");
   });
 
   it("keeps plain bold as bold with no anchor", () => {
-    const host = renderInto("**plain bold**");
+    const host = renderInto(renderMarkdown("**plain bold**"));
     expect(host.querySelector("strong")!.textContent).toBe("plain bold");
     expect(host.querySelector("a")).toBeNull();
   });
 
   it("does not make a bold-wrapped unsafe link clickable", () => {
-    const host = renderInto("**[x](javascript:void)**");
+    const host = renderInto(renderMarkdown("**[x](javascript:void)**"));
     expect(host.querySelector("a")).toBeNull();
     expect(host.querySelector("strong")!.textContent).toBe("x");
   });
@@ -57,7 +53,7 @@ describe("renderMarkdown — bold-wrapped inline formatting", () => {
 
 describe("renderMarkdown — unwrapped link still works", () => {
   it("renders a bare markdown link as an anchor", () => {
-    const host = renderInto("[Action](https://esphome.io/x)");
+    const host = renderInto(renderMarkdown("[Action](https://esphome.io/x)"));
     const anchor = host.querySelector("a.md-link")!;
     expect(anchor.getAttribute("href")).toBe("https://esphome.io/x");
     expect(anchor.textContent).toBe("Action");

--- a/test/util/render-text-links.test.ts
+++ b/test/util/render-text-links.test.ts
@@ -7,11 +7,11 @@
  * renderTextLinks feeds the configuration-invalid banner.
  */
 
-import { render } from "lit";
 import { describe, expect, it } from "vitest";
 
 import { renderTextLinks } from "../../src/util/markdown.js";
 import { renderMessageNode } from "../../src/util/yaml-lint-backend.js";
+import { renderInto } from "../_dom.js";
 
 const MSG = "check the list at https://example.com/tz.";
 
@@ -43,8 +43,7 @@ describe("renderMessageNode", () => {
 
 describe("renderTextLinks", () => {
   it("renders a new-tab md-link anchor in a Lit template", () => {
-    const host = document.createElement("div");
-    render(renderTextLinks(MSG), host);
+    const host = renderInto(renderTextLinks(MSG));
     const anchor = host.querySelector("a")!;
     expect(anchor.getAttribute("href")).toBe("https://example.com/tz");
     expect(anchor.target).toBe("_blank");
@@ -53,8 +52,7 @@ describe("renderTextLinks", () => {
   });
 
   it("renders nothing for empty input", () => {
-    const host = document.createElement("div");
-    render(renderTextLinks(""), host);
+    const host = renderInto(renderTextLinks(""));
     expect(host.querySelector("a")).toBeNull();
     expect(host.textContent).toBe("");
   });

--- a/test/util/secrets-write.test.ts
+++ b/test/util/secrets-write.test.ts
@@ -7,15 +7,11 @@
  * announces ``secrets-saved`` when the backend reports a create, set passes
  * ``overwrite=true`` and always announces.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { ensureSecretInYaml, setSecretInYaml } from "../../src/util/secrets-write.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 function apiWith(created: boolean) {
   return {

--- a/test/util/yaml-search-helpers.test.ts
+++ b/test/util/yaml-search-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   yamlHitLabel,
   yamlSnippetBlockHref,
 } from "../../src/util/yaml-search-helpers.js";
+import { identityLocalize } from "../_dom.js";
 
 /**
  * Build a ``YamlSearchMatch`` with sensible defaults.
@@ -224,7 +225,7 @@ describe("yamlEmptyMessageKey", () => {
 describe("yamlEmptyMessage", () => {
   // The localize stub passes the key through as-is so the
   // test assertions don't depend on the specific en.json values.
-  const passthroughLocalize = (k: string) => k;
+  const passthroughLocalize = identityLocalize;
 
   it("resolves the key through the localize function for empty states", () => {
     expect(yamlEmptyMessage(passthroughLocalize, null)).toBe("yaml_search.searching");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     // Generate the language manifest before any test runs — src/common/
     // localize.ts statically imports it (see gen-language-manifest.cjs).
     globalSetup: ["./test/global-setup.mjs"],
+    // Per-file setup: registers the one global afterEach that clears
+    // document.body between tests (see test/_setup-dom.ts).
+    setupFiles: ["./test/_setup-dom.ts"],
     environment: "node",
     globals: false,
     silent: true,


### PR DESCRIPTION
# What does this implement/fix?

Adds a shared `test/_dom.ts` helper module exporting `mount` (append plus settle, with optional props), `renderInto` (render a template into an attached container) and `identityLocalize`, and registers one global `afterEach` body cleanup via a new `setupFiles` entry (`test/_setup-dom.ts`), then migrates the hand rolled copies across the suite. Suites whose mount or cleanup does extra work (private state seeds, extra settle rounds, fake timers, mock resets) keep their local helpers.

**Related issue or feature (if applicable):**

- fixes #1086

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
