### PR TITLE
Export downloadBlob and reuse it in dashboard actions

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -5,6 +5,7 @@ import type { ArchivedDevice, BulkActionResult } from "../../api/types/system.js
 import type { LocalizeFunc } from "../../common/localize.js";
 import { withBase } from "../../util/base-path.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
+import { downloadBlob } from "../../util/download-text.js";
 import { getErrorMessage } from "../../util/error-message.js";
 import { ESPHomeLogParser, isLikelyGarbageLine } from "../../util/esphome-log-parser.js";
 import { notifyError, notifySuccess, type NotifyOptions } from "../../util/notify.js";
@@ -254,23 +255,14 @@ export async function downloadYaml(
   localize: LocalizeFunc
 ) {
   const name = device.friendly_name || device.name;
-  let url: string | undefined;
   try {
     const yaml = await api.getConfig(device.configuration);
-    const blob = new Blob([yaml], { type: "text/yaml" });
-    url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = device.configuration.endsWith(".yaml")
+    const filename = device.configuration.endsWith(".yaml")
       ? device.configuration
       : `${device.configuration}.yaml`;
-    a.click();
+    downloadBlob(yaml, filename, "text/yaml");
   } catch {
     notifyError(localize("dashboard.action_download_yaml_failed", { name }));
-  } finally {
-    if (url) {
-      URL.revokeObjectURL(url);
-    }
   }
 }
 

--- a/src/util/download-text.ts
+++ b/src/util/download-text.ts
@@ -21,11 +21,12 @@ import { stripAnsi } from "./strip-ansi.js";
  *   reads. Holding the URL around would leak the underlying
  *   ``Blob`` for the page's lifetime.
  *
- * Private helper — call sites use :func:`downloadAnsiText` rather than
- * touching this directly. (Binary artifacts download natively via
- * :func:`triggerDownload`, which streams from a URL and skips this.)
+ * Terminal-style output goes through :func:`downloadAnsiText`, which
+ * strips ANSI sequences before delegating here. (Binary artifacts
+ * download natively via :func:`triggerDownload`, which streams from a
+ * URL and skips this.)
  */
-function _downloadBlob(bytes: BlobPart, filename: string, mimeType: string): void {
+export function downloadBlob(bytes: BlobPart, filename: string, mimeType: string): void {
   const blob = new Blob([bytes], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
@@ -91,6 +92,6 @@ export function downloadAnsiText(lines: string[], filename: string): string {
      line per file row regardless of which terminator the upstream
      used. */
   const text = lines.map((line) => stripAnsi(line).replace(/[\r\n]+$/, "")).join("\n");
-  _downloadBlob(text, filename, "text/plain");
+  downloadBlob(text, filename, "text/plain");
   return text;
 }

--- a/test/util/download-text.test.ts
+++ b/test/util/download-text.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { downloadAnsiText, triggerDownload } from "../../src/util/download-text.js";
+import {
+  downloadAnsiText,
+  downloadBlob,
+  triggerDownload,
+} from "../../src/util/download-text.js";
 
 /* The runtime test environment is Node, so we stub the bits of the
    browser API the helper touches. The download mechanics (anchor +
@@ -101,6 +105,21 @@ describe("downloadAnsiText", () => {
     const blob = FakeBlob.instances[0];
     expect(blob.options?.type).toBe("text/plain");
     expect(blob.parts).toEqual(["hello\nworld"]);
+  });
+});
+
+describe("downloadBlob", () => {
+  it("wraps the payload in a Blob with the caller's MIME type and clicks an anchor", () => {
+    const { anchor } = withBrowserStubs(() =>
+      downloadBlob("esphome:\n  name: kitchen\n", "kitchen.yaml", "text/yaml")
+    );
+    expect(FakeBlob.instances).toHaveLength(1);
+    const blob = FakeBlob.instances[0];
+    expect(blob.options?.type).toBe("text/yaml");
+    expect(blob.parts).toEqual(["esphome:\n  name: kitchen\n"]);
+    expect(anchor.href).toBe("blob:fake");
+    expect(anchor.download).toBe("kitchen.yaml");
+    expect(anchor.click).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/util/download-text.test.ts
+++ b/test/util/download-text.test.ts
@@ -33,11 +33,22 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function withBrowserStubs<T>(fn: () => T): { result: T; anchor: FakeAnchor } {
+function withBrowserStubs<T>(fn: () => T): {
+  result: T;
+  anchor: FakeAnchor;
+  url: {
+    createObjectURL: ReturnType<typeof vi.fn>;
+    revokeObjectURL: ReturnType<typeof vi.fn>;
+  };
+} {
   const anchor = new FakeAnchor();
+  const url = {
+    createObjectURL: vi.fn(() => "blob:fake"),
+    revokeObjectURL: vi.fn(),
+  };
   const stubs = {
     Blob: FakeBlob,
-    URL: { createObjectURL: vi.fn(() => "blob:fake"), revokeObjectURL: vi.fn() },
+    URL: url,
     document: { createElement: vi.fn(() => anchor) },
   };
   const g = globalThis as Record<string, unknown>;
@@ -50,7 +61,7 @@ function withBrowserStubs<T>(fn: () => T): { result: T; anchor: FakeAnchor } {
     });
   }
   try {
-    return { result: fn(), anchor };
+    return { result: fn(), anchor, url };
   } finally {
     for (const fn of restore) fn();
   }
@@ -99,12 +110,15 @@ describe("downloadAnsiText", () => {
     expect(result).toBe("[INFO] startup\n[1;31m not-an-escape");
   });
 
-  it("creates a text/plain Blob with the joined content", () => {
-    withBrowserStubs(() => downloadAnsiText(["hello", "[32mworld[0m"], "greeting.txt"));
+  it("creates a text/plain Blob with the joined content and revokes its URL", () => {
+    const { url } = withBrowserStubs(() =>
+      downloadAnsiText(["hello", "[32mworld[0m"], "greeting.txt")
+    );
     expect(FakeBlob.instances).toHaveLength(1);
     const blob = FakeBlob.instances[0];
     expect(blob.options?.type).toBe("text/plain");
     expect(blob.parts).toEqual(["hello\nworld"]);
+    expect(url.revokeObjectURL).toHaveBeenCalledWith("blob:fake");
   });
 });
 
@@ -121,17 +135,33 @@ describe("downloadBlob", () => {
     expect(anchor.download).toBe("kitchen.yaml");
     expect(anchor.click).toHaveBeenCalledTimes(1);
   });
+
+  it("revokes the minted object URL after the click so the Blob doesn't leak", () => {
+    const { anchor, url } = withBrowserStubs(() =>
+      downloadBlob("payload", "file.bin", "application/octet-stream")
+    );
+    expect(url.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(url.revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(url.revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+    // The click fires before the URL is revoked — the reverse order
+    // would hand the browser a dead URL to download.
+    expect(anchor.click.mock.invocationCallOrder[0]).toBeLessThan(
+      url.revokeObjectURL.mock.invocationCallOrder[0]
+    );
+  });
 });
 
 describe("triggerDownload", () => {
   it("navigates an anchor to the URL so the browser streams it to disk", () => {
-    const { anchor } = withBrowserStubs(() =>
+    const { anchor, url } = withBrowserStubs(() =>
       triggerDownload("/api/firmware/download?token=tok", "firmware.elf")
     );
     expect(anchor.href).toBe("/api/firmware/download?token=tok");
     expect(anchor.download).toBe("firmware.elf");
     expect(anchor.click).toHaveBeenCalledTimes(1);
-    // No Blob is constructed — the file is never buffered in memory.
+    // No Blob is constructed — the file is never buffered in memory,
+    // so there is no object URL to mint or revoke either.
     expect(FakeBlob.instances).toHaveLength(0);
+    expect(url.createObjectURL).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

Exports the previously private `_downloadBlob` helper in `src/util/download-text.ts` as `downloadBlob(bytes, filename, mimeType)` and calls it from the `downloadYaml` path in `src/components/dashboard/actions.ts`, deleting the hand rolled Blob, object URL, anchor click, revoke sequence there. Adds a unit test for the exported helper following the existing stub pattern in `test/util/download-text.test.ts`.

**Related issue or feature (if applicable):**

- fixes #1094

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
