### PR TITLE
Add a shared KeyedPromiseCache for keyed promise memoization

### DIFF
--- a/src/util/esphome-schema-core.ts
+++ b/src/util/esphome-schema-core.ts
@@ -173,6 +173,11 @@ const cache = new Map<string, Promise<SchemaBundle | null>>();
  *  behaviour). */
 const versionCache = new KeyedPromiseCache<string>();
 
+/** The single entry in ``versionCache`` — one schema version per
+ *  session, so the cache is keyed by a fixed name rather than a
+ *  magic empty string. */
+const VERSION_KEY = "version";
+
 /** Memoise resolved config-var key lists by ``<bundle>|<componentKey>``.
  *  The result is a Promise so concurrent callers dedupe on the same
  *  network round-trip. Cleared by ``_resetSchemaCacheForTests``. No
@@ -211,7 +216,7 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
   // A successful resolution stays cached for the session — the
   // dashboard's ``esphome_version`` doesn't change without a page
   // reload. A failure is evicted so subsequent calls retry.
-  return versionCache.fetch("", async () => {
+  return versionCache.fetch(VERSION_KEY, async () => {
     const { esphome_version } = await api.getVersion();
     if (esphome_version.endsWith("dev")) return "dev";
     // Probe with GET, not HEAD: the schema CDN serves HEAD responses

--- a/src/util/esphome-schema-core.ts
+++ b/src/util/esphome-schema-core.ts
@@ -18,6 +18,7 @@
  * malformed JSON) so callers fall back to whatever they had before.
  */
 import type { ESPHomeAPI } from "../api/esphome-api.js";
+import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 
 const SCHEMA_HOST = "https://schema.esphome.io";
 
@@ -163,18 +164,23 @@ export interface SchemaConfigVarKey {
  *  key which means "haven't tried yet". */
 const cache = new Map<string, Promise<SchemaBundle | null>>();
 
-/** In-flight version-resolution promise. Stored as a promise so
- *  concurrent callers wait on the same answer; cleared on
- *  failure so the next caller retries (Copilot-flagged: marking
- *  versionResolved=true on failure made version negotiation
- *  non-retriable for the page lifetime — inconsistent with the
- *  bundle cache's transient-eviction behaviour). */
-let versionPromise: Promise<string> | null = null;
+/** In-flight version-resolution promise — a single-entry
+ *  ``KeyedPromiseCache`` under one fixed key so concurrent callers
+ *  wait on the same answer; evicted on failure so the next caller
+ *  retries (Copilot-flagged: marking versionResolved=true on failure
+ *  made version negotiation non-retriable for the page lifetime —
+ *  inconsistent with the bundle cache's transient-eviction
+ *  behaviour). */
+const versionCache = new KeyedPromiseCache<string>();
 
 /** Memoise resolved config-var key lists by ``<bundle>|<componentKey>``.
  *  The result is a Promise so concurrent callers dedupe on the same
- *  network round-trip. Cleared by ``_resetSchemaCacheForTests``. */
-const configVarKeysCache = new Map<string, Promise<SchemaConfigVarKey[]>>();
+ *  network round-trip. Cleared by ``_resetSchemaCacheForTests``. No
+ *  eviction: the collector never rejects (``fetchBundle`` resolves
+ *  ``null`` on every failure), so there is nothing to retry. */
+const configVarKeysCache = new KeyedPromiseCache<SchemaConfigVarKey[]>({
+  evictOnReject: false,
+});
 
 /**
  * Clear the lower-layer caches (bundle cache, in-flight version
@@ -185,7 +191,7 @@ const configVarKeysCache = new Map<string, Promise<SchemaConfigVarKey[]>>();
 export function _resetCoreSchemaCachesForTests() {
   cache.clear();
   configVarKeysCache.clear();
-  versionPromise = null;
+  versionCache.clear();
 }
 
 /**
@@ -202,8 +208,10 @@ export function _resetCoreSchemaCachesForTests() {
  * state when conditions change.
  */
 async function resolveVersion(api: ESPHomeAPI): Promise<string> {
-  if (versionPromise) return versionPromise;
-  const promise = (async () => {
+  // A successful resolution stays cached for the session — the
+  // dashboard's ``esphome_version`` doesn't change without a page
+  // reload. A failure is evicted so subsequent calls retry.
+  return versionCache.fetch("", async () => {
     const { esphome_version } = await api.getVersion();
     if (esphome_version.endsWith("dev")) return "dev";
     // Probe with GET, not HEAD: the schema CDN serves HEAD responses
@@ -224,15 +232,7 @@ async function resolveVersion(api: ESPHomeAPI): Promise<string> {
     // lifetime.)
     if (probe.status === 404) return "dev";
     throw new Error(`schema-host probe returned ${probe.status} for ${esphome_version}`);
-  })();
-  versionPromise = promise;
-  // Evict on failure so subsequent calls retry. A successful
-  // resolution stays cached for the session — the dashboard's
-  // ``esphome_version`` doesn't change without a page reload.
-  promise.catch(() => {
-    if (versionPromise === promise) versionPromise = null;
   });
-  return promise;
 }
 
 /**
@@ -462,9 +462,7 @@ export async function getConfigVarKeys(
   componentKey: string
 ): Promise<SchemaConfigVarKey[]> {
   const cacheKey = `${bundleName}|${componentKey}`;
-  const cached = configVarKeysCache.get(cacheKey);
-  if (cached) return cached;
-  const promise = (async () => {
+  return configVarKeysCache.fetch(cacheKey, async () => {
     const out: SchemaConfigVarKey[] = [];
     const seen = new Set<string>();
     await collectConfigVars(
@@ -477,9 +475,7 @@ export async function getConfigVarKeys(
       new Set()
     );
     return out;
-  })();
-  configVarKeysCache.set(cacheKey, promise);
-  return promise;
+  });
 }
 
 /** Recursively collect config-var keys from a schema, descending

--- a/src/util/esphome-schema.ts
+++ b/src/util/esphome-schema.ts
@@ -33,6 +33,7 @@ import {
   type SchemaConfigVarKey,
   type SchemaSchema,
 } from "./esphome-schema-core.js";
+import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 
 export {
   fetchBundle,
@@ -58,8 +59,10 @@ export type {
   SchemaSchema,
 } from "./esphome-schema-core.js";
 
-/** Memoise nested-path docs by ``<bundle>|<component>|<a.b.c>``. */
-const configVarDocsCache = new Map<string, Promise<string | null>>();
+/** Memoise nested-path docs by ``<bundle>|<component>|<a.b.c>``.
+ *  A transient failure is evicted so the next hover retries instead
+ *  of replaying a rejected promise forever. */
+const configVarDocsCache = new KeyedPromiseCache<string | null>();
 
 /**
  * Reset the in-memory cache. Test-only entry point — production
@@ -86,9 +89,7 @@ export async function getConfigVarDocsAtPath(
 ): Promise<string | null> {
   if (path.length === 0) return null;
   const cacheKey = `${bundleName}|${componentKey}|${path.join(".")}`;
-  const cached = configVarDocsCache.get(cacheKey);
-  if (cached) return cached;
-  const promise = (async () => {
+  return configVarDocsCache.fetch(cacheKey, async () => {
     let cv = await loadSchemaCv(
       api,
       bundleName,
@@ -124,14 +125,7 @@ export async function getConfigVarDocsAtPath(
       cv = found;
     }
     return null;
-  })();
-  // Don't memoize a transient failure — evict on rejection so the next
-  // hover retries instead of replaying a rejected promise forever.
-  promise.catch(() => {
-    if (configVarDocsCache.get(cacheKey) === promise) configVarDocsCache.delete(cacheKey);
   });
-  configVarDocsCache.set(cacheKey, promise);
-  return promise;
 }
 
 /** Find the config-var named *key* reachable from *cv* — descending a

--- a/src/util/keyed-promise-cache.ts
+++ b/src/util/keyed-promise-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Keyed promise memoisation: a ``Map<string, Promise<T>>`` where
+ * concurrent callers for the same key share one in-flight promise and,
+ * by default, a rejected promise is evicted so the next call retries
+ * instead of replaying the failure forever. Shared by
+ * ``provides-cache.ts`` and the schema readers
+ * (``esphome-schema.ts`` / ``esphome-schema-core.ts``).
+ *
+ * This is the third shape in the shared-cache family:
+ * :func:`createSessionBlobCache` (`session-blob-cache.ts`) adds
+ * subscriber notification and a sync ``getCached`` read for whole
+ * immutable payloads, and :class:`BatchedCache` (`batched-cache.ts`)
+ * microtask-batches many keys into one fetcher round trip. This class
+ * is the minimal core both idioms start from — per-key dedupe with a
+ * retry-on-failure policy — for callers that only ever await the
+ * promise.
+ *
+ * Not a fit for ``fetchBundle``'s bundle cache, which re-keys entries
+ * mid-flight (bare name → ``<version>/<name>``) and evicts on a
+ * *resolved* transient-``null``, not on rejection.
+ */
+export interface KeyedPromiseCacheOptions {
+  /** Evict a rejected promise so the next call retries. Default
+   *  ``true`` — the point of the idiom. Set ``false`` to memoise
+   *  rejections too (a replayed rejection is then permanent for the
+   *  cache's lifetime). */
+  evictOnReject?: boolean;
+}
+
+export class KeyedPromiseCache<T> {
+  private readonly _cache = new Map<string, Promise<T>>();
+  private readonly _evictOnReject: boolean;
+
+  constructor(opts: KeyedPromiseCacheOptions = {}) {
+    this._evictOnReject = opts.evictOnReject ?? true;
+  }
+
+  /**
+   * Return the memoised promise for *key*, calling *create* only when
+   * no entry exists. *create* runs synchronously on a miss (callers
+   * rely on the underlying request firing right away); a synchronous
+   * throw propagates and caches nothing.
+   */
+  fetch(key: string, create: () => Promise<T>): Promise<T> {
+    const cached = this._cache.get(key);
+    if (cached) return cached;
+    const promise = create();
+    if (this._evictOnReject) {
+      // Side-listener, not a ``.catch`` chain: callers get the original
+      // promise (and its rejection reason) unchanged. The identity guard
+      // keeps a stale rejection from evicting a fresh entry written
+      // after a ``clear()``.
+      promise.catch(() => {
+        if (this._cache.get(key) === promise) this._cache.delete(key);
+      });
+    }
+    this._cache.set(key, promise);
+    return promise;
+  }
+
+  /** Drop every entry, in-flight or settled. */
+  clear(): void {
+    this._cache.clear();
+  }
+}

--- a/src/util/keyed-promise-cache.ts
+++ b/src/util/keyed-promise-cache.ts
@@ -44,15 +44,22 @@ export class KeyedPromiseCache<T> {
   fetch(key: string, create: () => Promise<T>): Promise<T> {
     const cached = this._cache.get(key);
     if (cached) return cached;
-    const promise = create();
+    let promise: Promise<T>;
     if (this._evictOnReject) {
-      // Side-listener, not a ``.catch`` chain: callers get the original
-      // promise (and its rejection reason) unchanged. The identity guard
-      // keeps a stale rejection from evicting a fresh entry written
-      // after a ``clear()``.
-      promise.catch(() => {
+      // Store and return the rethrowing ``.catch`` chain, not the
+      // original promise with a side-listener. A side-listener would
+      // mark the rejection handled and silence ``unhandledRejection``
+      // diagnostics for callers that drop the returned promise; the
+      // chain rethrows, so an ignored rejection still surfaces (the
+      // behaviour of the hand-rolled caches this replaces). The
+      // identity guard keeps a stale rejection from evicting a fresh
+      // entry written after a ``clear()``.
+      promise = create().catch((err: unknown) => {
         if (this._cache.get(key) === promise) this._cache.delete(key);
+        throw err;
       });
+    } else {
+      promise = create();
     }
     this._cache.set(key, promise);
     return promise;

--- a/src/util/provides-cache.ts
+++ b/src/util/provides-cache.ts
@@ -1,10 +1,11 @@
 import type { ESPHomeAPI } from "../api/index.js";
+import { KeyedPromiseCache } from "./keyed-promise-cache.js";
 
 /** Ids of the components that provide an interface, board-scoped and cached
  *  for the process lifetime. The backend catalog is immutable for that
  *  lifetime (see `component-name-cache`), so the same `provides` query never
  *  needs to re-run. A rejected lookup is evicted so a later call retries. */
-const _cache = new Map<string, Promise<ReadonlySet<string>>>();
+const _cache = new KeyedPromiseCache<ReadonlySet<string>>();
 
 /** Ids of components that provide `interfaceName` on this platform/board. */
 export function providerIds(
@@ -14,9 +15,8 @@ export function providerIds(
   boardId?: string
 ): Promise<ReadonlySet<string>> {
   const key = `${interfaceName}|${platform ?? ""}|${boardId ?? ""}`;
-  let pending = _cache.get(key);
-  if (!pending) {
-    pending = api
+  return _cache.fetch(key, () =>
+    api
       .getComponents({
         provides: interfaceName,
         platform: platform ?? undefined,
@@ -26,13 +26,7 @@ export function providerIds(
         limit: 200,
       })
       .then((resp): ReadonlySet<string> => new Set(resp.components.map((c) => c.id)))
-      .catch((err) => {
-        _cache.delete(key);
-        throw err;
-      });
-    _cache.set(key, pending);
-  }
-  return pending;
+  );
 }
 
 export function _clearProvidesCache(): void {

--- a/test/util/keyed-promise-cache.test.ts
+++ b/test/util/keyed-promise-cache.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { KeyedPromiseCache } from "../../src/util/keyed-promise-cache.js";
+
+describe("KeyedPromiseCache", () => {
+  it("dedupes concurrent callers on one in-flight promise per key", async () => {
+    const create = vi.fn(async () => "value");
+    const cache = new KeyedPromiseCache<string>();
+
+    const a = cache.fetch("k", create);
+    const b = cache.fetch("k", create);
+    expect(b).toBe(a);
+    expect(await a).toBe("value");
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("memoises per key — distinct keys each run their own fetch", async () => {
+    const create = vi.fn(async (key: string) => key.toUpperCase());
+    const cache = new KeyedPromiseCache<string>();
+
+    expect(await cache.fetch("x", () => create("x"))).toBe("X");
+    expect(await cache.fetch("y", () => create("y"))).toBe("Y");
+    expect(await cache.fetch("x", () => create("x"))).toBe("X");
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a resolved promise cached — later calls don't refetch", async () => {
+    const create = vi.fn(async () => ["a"]);
+    const cache = new KeyedPromiseCache<string[]>();
+
+    const first = await cache.fetch("k", create);
+    const second = await cache.fetch("k", create);
+    expect(second).toBe(first);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts a rejected promise so the next call retries", async () => {
+    let attempt = 0;
+    const create = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("transient");
+      return "ok";
+    });
+    const cache = new KeyedPromiseCache<string>();
+
+    await expect(cache.fetch("k", create)).rejects.toThrow("transient");
+    expect(await cache.fetch("k", create)).toBe("ok");
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares the in-flight promise with callers that arrive before the rejection", async () => {
+    let reject!: (err: Error) => void;
+    const create = vi.fn(
+      () =>
+        new Promise<string>((_resolve, rej) => {
+          reject = rej;
+        })
+    );
+    const cache = new KeyedPromiseCache<string>();
+
+    const a = cache.fetch("k", create);
+    const b = cache.fetch("k", create);
+    expect(b).toBe(a);
+    reject(new Error("boom"));
+    await expect(a).rejects.toThrow("boom");
+    await expect(b).rejects.toThrow("boom");
+    // Both callers replayed one attempt; the eviction happened after.
+    expect(create).toHaveBeenCalledTimes(1);
+    cache.fetch("k", create);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("with evictOnReject: false, a rejection is memoised and replayed", async () => {
+    const create = vi.fn(async () => {
+      throw new Error("permanent");
+    });
+    const cache = new KeyedPromiseCache<string>({ evictOnReject: false });
+
+    await expect(cache.fetch("k", create)).rejects.toThrow("permanent");
+    await expect(cache.fetch("k", create)).rejects.toThrow("permanent");
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear() drops entries so the next call refetches", async () => {
+    const create = vi.fn(async () => "value");
+    const cache = new KeyedPromiseCache<string>();
+
+    await cache.fetch("k", create);
+    cache.clear();
+    await cache.fetch("k", create);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("a stale rejection doesn't evict a fresh entry cached after clear()", async () => {
+    let reject!: (err: Error) => void;
+    const cache = new KeyedPromiseCache<string>();
+
+    const stale = cache.fetch(
+      "k",
+      () =>
+        new Promise<string>((_resolve, rej) => {
+          reject = rej;
+        })
+    );
+    stale.catch(() => {}); // the caller handles it; this test cares about the cache
+    cache.clear();
+    const freshCreate = vi.fn(async () => "fresh");
+    await cache.fetch("k", freshCreate);
+    reject(new Error("stale"));
+    await Promise.resolve(); // let the eviction listener run
+    // The fresh entry survives — no refetch.
+    expect(await cache.fetch("k", freshCreate)).toBe("fresh");
+    expect(freshCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/util/keyed-promise-cache.test.ts
+++ b/test/util/keyed-promise-cache.test.ts
@@ -66,8 +66,11 @@ describe("KeyedPromiseCache", () => {
     await expect(b).rejects.toThrow("boom");
     // Both callers replayed one attempt; the eviction happened after.
     expect(create).toHaveBeenCalledTimes(1);
-    cache.fetch("k", create);
+    const retry = cache.fetch("k", create);
     expect(create).toHaveBeenCalledTimes(2);
+    // Settle the retry too so no in-flight promise dangles past the test.
+    reject(new Error("boom again"));
+    await expect(retry).rejects.toThrow("boom again");
   });
 
   it("with evictOnReject: false, a rejection is memoised and replayed", async () => {


### PR DESCRIPTION
# What does this implement/fix?

Adds a small `KeyedPromiseCache` util in `src/util/keyed-promise-cache.ts` for the keyed promise memoization idiom: concurrent callers share one promise per key, and a rejected promise is evicted so the next call retries. Routes `provides-cache.ts`, the docs memo in `esphome-schema.ts`, and the version promise plus the config var keys memo in `esphome-schema-core.ts` through it, replacing four hand rolled copies, with unit tests for the new util. The bundle cache inside `fetchBundle` stays as is; it rekeys entries while they are in flight and evicts on a resolved transient `null` rather than on rejection, so it does not fit the abstraction.

**Related issue or feature (if applicable):**

- fixes #1092

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
