### PR TITLE
Unify leading-indent measurement on indentOf

### DIFF
--- a/src/components/device/security-notice.ts
+++ b/src/components/device/security-notice.ts
@@ -30,6 +30,7 @@ import { generatePassphrase } from "../../util/passphrase.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { recommendedSecretKeys } from "../../util/secret-eligibility.js";
 import { ensureSecretInYaml } from "../../util/secrets-write.js";
+import { indentOf } from "../../util/yaml-line-walker.js";
 import { TOP_LEVEL_KEY_START_RE } from "../../util/yaml-section-lexer.js";
 import { findSectionStart } from "../../util/yaml-section-reader.js";
 
@@ -202,7 +203,7 @@ export class ESPHomeSecurityNotice extends LitElement {
       const l = lines[i];
       if (l.trim() === "" || l.trimStart().startsWith("#")) continue;
       if (TOP_LEVEL_KEY_START_RE.test(l)) break; // next top-level section
-      const indent = l.length - l.trimStart().length;
+      const indent = indentOf(l);
       if (childIndent === null) childIndent = indent;
       if (indent < childIndent) break; // dedent — left this block (e.g. next list item)
       if (indent !== childIndent) continue; // deeper-nested key, not a direct child

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -173,12 +173,13 @@ function readLongFormPin(
       end = j;
       continue;
     }
-    if (indentOf(line) <= openIndent) break;
+    const indent = indentOf(line);
+    if (indent <= openIndent) break;
     end = j;
     const m = line.match(LINE_KEY_RE);
     if (m === null) continue; // comment / non-key line — don't anchor childIndent on it
-    if (childIndent === -1) childIndent = indentOf(line);
-    if (indentOf(line) !== childIndent) continue; // skip grandchildren (mode flags)
+    if (childIndent === -1) childIndent = indent;
+    if (indent !== childIndent) continue; // skip grandchildren (mode flags)
     // Record the key even when it has no inline scalar (an empty, mid-edit
     // `pcf8574:`), so parsePinGpio sees the provider and returns null rather
     // than letting the bare `number:` alias a board GPIO.

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -20,6 +20,7 @@ import type { ComponentCatalogEntry } from "../api/types/components.js";
 import { isValidEspHomeId } from "./esphome-id.js";
 import { isPinFieldKey, parsePinGpio, scanPinGpios } from "./pin-gpio.js";
 import { hasSubstitutionReference } from "./substitutions.js";
+import { indentOf } from "./yaml-line-walker.js";
 import {
   collectIdsAtPath,
   findFieldLine,
@@ -128,9 +129,6 @@ const LINE_KEY_RE = /^(\s*)(?:-\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s*:/;
 // Its continuation lines are more-indented prose, scanned via indentation.
 const BLOCK_SCALAR_RE = /:\s*[|>][+-]?\d*\s*(?:#.*)?$/;
 
-// Leading-whitespace width of a line (block-scalar indentation threshold).
-const indentWidth = (line: string): number => line.length - line.trimStart().length;
-
 /**
  * Strip a YAML inline comment. A `#` begins a comment only at line start
  * or when preceded by whitespace (so `http://x#y` keeps its `#`). Pin
@@ -165,7 +163,7 @@ function readLongFormPin(
   lines: string[],
   openerIdx: number
 ): { pin: number | string | null; end: number } {
-  const openIndent = indentWidth(lines[openerIdx]);
+  const openIndent = indentOf(lines[openerIdx]);
   let childIndent = -1;
   const block: Record<string, string> = {};
   let end = openerIdx;
@@ -175,12 +173,12 @@ function readLongFormPin(
       end = j;
       continue;
     }
-    if (indentWidth(line) <= openIndent) break;
+    if (indentOf(line) <= openIndent) break;
     end = j;
     const m = line.match(LINE_KEY_RE);
     if (m === null) continue; // comment / non-key line — don't anchor childIndent on it
-    if (childIndent === -1) childIndent = indentWidth(line);
-    if (indentWidth(line) !== childIndent) continue; // skip grandchildren (mode flags)
+    if (childIndent === -1) childIndent = indentOf(line);
+    if (indentOf(line) !== childIndent) continue; // skip grandchildren (mode flags)
     // Record the key even when it has no inline scalar (an empty, mid-edit
     // `pcf8574:`), so parsePinGpio sees the provider and returns null rather
     // than letting the bare `number:` alias a board GPIO.
@@ -249,7 +247,7 @@ export function findUsedPins(
     // indented deeper than the key. A non-blank line at/under the key indent
     // ends the block.
     if (blockScalarIndent >= 0) {
-      if (line.trim() === "" || indentWidth(line) > blockScalarIndent) continue;
+      if (line.trim() === "" || indentOf(line) > blockScalarIndent) continue;
       blockScalarIndent = -1;
     }
     const keyMatch = line.match(LINE_KEY_RE);

--- a/src/util/config-entry-yaml-scan.ts
+++ b/src/util/config-entry-yaml-scan.ts
@@ -253,7 +253,10 @@ export function findUsedPins(
     }
     const keyMatch = line.match(LINE_KEY_RE);
     if (keyMatch && FREETEXT_PIN_KEYS.has(keyMatch[2].toLowerCase())) {
-      if (BLOCK_SCALAR_RE.test(line)) blockScalarIndent = keyMatch[1].length;
+      // Measure the threshold with the same spaces-only ``indentOf`` used in
+      // the skip comparison above, so a tab in malformed indentation cannot
+      // end the block scalar one line early.
+      if (BLOCK_SCALAR_RE.test(line)) blockScalarIndent = indentOf(line);
       continue;
     }
     const stripped = stripInlineComment(line);

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -26,6 +26,7 @@ import type { EditorValidateResponse } from "../api/types/editor.js";
 import { formRelativePath } from "./backend-field-errors.js";
 import { splitTextLinks } from "./markdown.js";
 import { getKeyPathWithListIndices } from "./yaml-ast.js";
+import { indentOf } from "./yaml-line-walker.js";
 import { isOpenConfigFile } from "./yaml-validation-summary.js";
 
 /** A validation error resolved to a key chain in the open document. */
@@ -174,11 +175,6 @@ export function parseYamlErrorPosition(
   return null;
 }
 
-/** Leading-whitespace width of a line. */
-function indentOf(text: string): number {
-  return text.length - text.trimStart().length;
-}
-
 /** Match a `key:` declaration, capturing its indent and the key token. */
 const KEY_LINE_RE = /^(\s*)([^\s:#][^:]*?)\s*:(?:\s|$)/;
 
@@ -298,8 +294,7 @@ function lineToOffsets(
   // No column → underline the whole line content (skip leading whitespace
   // for a tighter visual).
   const text = info.text;
-  const leading = text.length - text.trimStart().length;
-  const from = info.from + leading;
+  const from = info.from + indentOf(text);
   return { from, to: info.to };
 }
 

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -291,8 +291,11 @@ function lineToOffsets(
     const end = Math.min(start + 1, info.to);
     return { from: start, to: end > start ? end : info.to };
   }
-  // No column → underline the whole line content (skip leading whitespace
-  // for a tighter visual).
+  // No column → underline the whole line content, skipping the leading
+  // space indent for a tighter visual. Spaces-only on purpose: a leading
+  // tab is invalid YAML, and yamllint reports it with its own precise
+  // column, so this fallback rarely sees one; when it does, the underline
+  // simply starts at the offending tab instead of after it.
   const text = info.text;
   const from = info.from + indentOf(text);
   return { from, to: info.to };

--- a/src/util/yaml-sensitive-scan.ts
+++ b/src/util/yaml-sensitive-scan.ts
@@ -236,6 +236,12 @@ export function findSensitiveValueRanges(
           next++;
           continue;
         }
+        // Deliberately whitespace-generic, NOT `indentOf` (spaces-only):
+        // `contIndent` doubles as the mask's start column, and the
+        // header indent it's compared against comes from KEY_LINE's
+        // `(\s*)` capture. Mid-edit input may be invalid YAML; a
+        // spaces-only count would end the block at a tab-led line and
+        // leave the credential on it unmasked.
         const contIndent = (cont.match(/^(\s*)/)?.[1] ?? "").length;
         if (contIndent <= headerIndent) break;
         let valEnd = cont.length;

--- a/test/util/config-entry-yaml-scan.test.ts
+++ b/test/util/config-entry-yaml-scan.test.ts
@@ -245,6 +245,26 @@ describe("findUsedPins", () => {
     expect(map.has(2)).toBe(false);
   });
 
+  it("keeps the block-scalar boundary spaces-only when the key line has a tab", () => {
+    // Malformed mid-edit input can put a tab in the block-scalar key line's
+    // indentation. The skip threshold must use the same spaces-only
+    // ``indentOf`` as the per-line comparison; a threshold that counted the
+    // tab (width 3 here vs spaces-only 0) would sit above the prose line's
+    // indent, end the block one line early, and register the prose token
+    // P0.5 as a phantom used pin.
+    const config = [
+      "switch:",
+      "  - platform: gpio",
+      "    pin: GPIO7",
+      "\t  comment: |", // tab inside the key line's indentation
+      "   wired to P0.5 originally", // P0.5 -> would be pin 5
+      "",
+    ].join("\n");
+    const map = findUsedPins(config);
+    expect(map.get(7)).toBe("switch");
+    expect(map.has(5)).toBe(false);
+  });
+
   it("returns an empty map for empty yaml", () => {
     expect(findUsedPins("").size).toBe(0);
   });


### PR DESCRIPTION
# What does this implement/fix?

Replaces the duplicated leading indent calculations in `config-entry-yaml-scan.ts`, `yaml-lint-backend.ts` and `security-notice.ts` with the canonical `indentOf` from `yaml-line-walker.ts`; this deliberately unifies on counting spaces only, which is the right semantics because YAML indentation never uses tabs. The regex variant in `yaml-sensitive-scan.ts` is intentionally left in place with an explanatory comment, since its count doubles as the mask start column and the credential masking scan must tolerate malformed input where a tab sits in the indentation.

**Related issue or feature (if applicable):**

- fixes #1095

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).


