### PR TITLE
De-duplicate locale helpers into translations-lib.ts

### DIFF
--- a/build-scripts/gen-language-manifest.cjs
+++ b/build-scripts/gen-language-manifest.cjs
@@ -23,97 +23,28 @@
 const fs = require("fs");
 const path = require("path");
 
+// The locale helpers (`toBcp47`, `localeCompleteness`, the base-language
+// constant) live once in translations-lib.ts, under the unit tests in
+// test/build-scripts/translations-lib.test.ts. Node's native TypeScript type
+// stripping together with `require(esm)` — both available on the `engines`
+// floor (>= 22.18) — lets this CommonJS script require that ESM module
+// synchronously, the same mechanism `node build-scripts/translations.ts`
+// already relies on. `BASE_LANGUAGE` names the in-repo source-of-truth
+// English file; completeness is measured against its key set.
+const {
+  BASE_LANGUAGE,
+  localeCompleteness,
+  toBcp47,
+} = require("./translations-lib.ts");
+
 const ROOT_DIR = path.resolve(__dirname, "..");
 const TRANSLATIONS_DIR = path.join(ROOT_DIR, "src", "translations");
 const OUTPUT_DIR = path.join(ROOT_DIR, "src", "generated");
 const OUTPUT_FILE = path.join(OUTPUT_DIR, "language-manifest.json");
 
-// The in-repo source of truth English file; completeness is measured against
-// its key set.
-const BASE_LOCALE = "en";
-
 // Placeholder shown when a locale file lacks a translated `flag` key (the
 // runtime picker uses the same white-flag fallback).
 const FLAG_FALLBACK = "🏳️";
-
-// Canonicalize a filename stem to a BCP 47 tag. Downloaded files already use
-// canonical hyphenated names (the download tool normalizes `zh_CN` → `zh-CN`),
-// so this is defensive: hyphenate then run through Intl for canonical casing,
-// falling back to the raw hyphenated form for anything Intl rejects.
-//
-// Intentionally duplicated from build-scripts/translations-lib.ts (the
-// bodies are byte-identical). It is NOT shared because this is a CommonJS
-// build-time script that can't `require` that `.ts` ESM module without a
-// loader. Keep the two copies in sync if you ever change one. (The runtime
-// localizer no longer needs its own copy: it derives AVAILABLE_LOCALES from
-// this manifest, which is already canonical, and the download tool
-// canonicalizes filenames at the write boundary.)
-const toBcp47 = (stem) => {
-  const hyphenated = stem.replace(/_/g, "-");
-  try {
-    return Intl.getCanonicalLocales(hyphenated)[0] ?? hyphenated;
-  } catch {
-    return hyphenated;
-  }
-};
-
-// Flatten a nested messages object to a map of dot-joined leaf key → string
-// value. Non-string leaves are skipped so they never count as translatable.
-//
-// Intentionally duplicated from build-scripts/translations-lib.ts (see the
-// toBcp47 note above for why this CommonJS script can't import that ESM
-// module). `localeCompleteness` there is the unit-tested reference; keep this
-// copy byte-compatible with it.
-const flattenMessages = (obj, prefix = "", out = new Map()) => {
-  for (const [key, value] of Object.entries(obj)) {
-    if (value !== null && typeof value === "object") {
-      flattenMessages(value, `${prefix}${key}.`, out);
-    } else if (typeof value === "string") {
-      out.set(`${prefix}${key}`, value);
-    }
-  }
-  return out;
-};
-
-// Flatten the English base once per base object and reuse it across locales
-// (every locale in a run is measured against the same base). Mirrors
-// translations-lib.ts; keep byte-compatible.
-const baseLeavesCache = new WeakMap();
-
-const flattenBase = (base) => {
-  let leaves = baseLeavesCache.get(base);
-  if (leaves === undefined) {
-    leaves = flattenMessages(base);
-    baseLeavesCache.set(base, leaves);
-  }
-  return leaves;
-};
-
-// Percentage (integer 0–100) of the English source's leaf keys that carry a
-// non-empty value in `locale`. See translations-lib.ts `localeCompleteness`
-// for the full rationale; this is the synced build-script copy.
-const localeCompleteness = (base, locale) => {
-  const baseLeaves = flattenBase(base);
-  const total = baseLeaves.size;
-  if (total === 0) {
-    return 100;
-  }
-  const localeLeaves = flattenMessages(locale);
-  let translated = 0;
-  for (const key of baseLeaves.keys()) {
-    const value = localeLeaves.get(key);
-    if (value !== undefined && value.length > 0) {
-      translated += 1;
-    }
-  }
-  if (translated >= total) {
-    return 100;
-  }
-  if (translated === 0) {
-    return 0;
-  }
-  return Math.min(99, Math.max(1, Math.round((translated / total) * 100)));
-};
 
 function generate() {
   const entries = fs
@@ -121,7 +52,7 @@ function generate() {
     .filter((name) => name.endsWith(".json"))
     .sort();
 
-  const basePath = path.join(TRANSLATIONS_DIR, `${BASE_LOCALE}.json`);
+  const basePath = path.join(TRANSLATIONS_DIR, `${BASE_LANGUAGE}.json`);
   const baseData = JSON.parse(fs.readFileSync(basePath, "utf-8"));
 
   const manifest = {};

--- a/build-scripts/gen-language-manifest.cjs
+++ b/build-scripts/gen-language-manifest.cjs
@@ -26,10 +26,11 @@ const path = require("path");
 // The locale helpers (`toBcp47`, `localeCompleteness`, the base-language
 // constant) live once in translations-lib.ts, under the unit tests in
 // test/build-scripts/translations-lib.test.ts. Node's native TypeScript type
-// stripping together with `require(esm)` — both available on the `engines`
-// floor (>= 22.18) — lets this CommonJS script require that ESM module
-// synchronously, the same mechanism `node build-scripts/translations.ts`
-// already relies on. `BASE_LANGUAGE` names the in-repo source-of-truth
+// stripping (which `node build-scripts/translations.ts` already relies on)
+// together with `require(esm)` — both available on the `engines` floor
+// (>= 22.18) — lets this CommonJS script require that ESM module
+// synchronously; this is the first script here that leans on `require(esm)`
+// specifically. `BASE_LANGUAGE` names the in-repo source-of-truth
 // English file; completeness is measured against its key set.
 let translationsLib;
 try {

--- a/build-scripts/gen-language-manifest.cjs
+++ b/build-scripts/gen-language-manifest.cjs
@@ -37,8 +37,19 @@ try {
   translationsLib = require("./translations-lib.ts");
 } catch (err) {
   // `engines` is only an install-time warning, so an unsupported Node still
-  // reaches this require and dies with an opaque loader error (unknown `.ts`
-  // extension or an ESM require failure). Name the actual floor instead.
+  // reaches this require and dies with an opaque loader error. Rephrase only
+  // the known loader/version failures: unknown `.ts` extension, require(esm)
+  // unavailable, or the CJS loader parsing unstripped TypeScript syntax as
+  // JavaScript (a bare SyntaxError; translations-lib.ts itself is
+  // syntax-checked by tsc and its unit tests, so a SyntaxError here means
+  // the loader). Anything else is a real bug and rethrows untouched.
+  const isLoaderFailure =
+    (err && err.code === "ERR_UNKNOWN_FILE_EXTENSION") ||
+    (err && err.code === "ERR_REQUIRE_ESM") ||
+    err instanceof SyntaxError;
+  if (!isLoaderFailure) {
+    throw err;
+  }
   throw new Error(
     `Loading build-scripts/translations-lib.ts failed on Node ${process.version}; ` +
       "this script needs Node >= 22.18 (native TypeScript type stripping and require(esm)).",
@@ -49,14 +60,16 @@ const { BASE_LANGUAGE, localeCompleteness, toBcp47 } = translationsLib;
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const TRANSLATIONS_DIR = path.join(ROOT_DIR, "src", "translations");
-const OUTPUT_DIR = path.join(ROOT_DIR, "src", "generated");
-const OUTPUT_FILE = path.join(OUTPUT_DIR, "language-manifest.json");
+const OUTPUT_FILE = path.join(ROOT_DIR, "src", "generated", "language-manifest.json");
 
 // Placeholder shown when a locale file lacks a translated `flag` key (the
 // runtime picker uses the same white-flag fallback).
 const FLAG_FALLBACK = "🏳️";
 
-function generate() {
+// `outputFile` is overridable (CLI arg below) so tests can write to a temp
+// directory instead of the real src/generated file; every repo entry point
+// (build/dev/lint/test setup) uses the default.
+function generate(outputFile = OUTPUT_FILE) {
   const entries = fs
     .readdirSync(TRANSLATIONS_DIR)
     .filter((name) => name.endsWith(".json"))
@@ -78,16 +91,19 @@ function generate() {
     };
   }
 
-  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-  fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
   return manifest;
 }
 
 module.exports = { generate };
 
 if (require.main === module) {
-  const manifest = generate();
+  const outputFile = process.argv[2]
+    ? path.resolve(process.argv[2])
+    : OUTPUT_FILE;
+  const manifest = generate(outputFile);
   console.log(
-    `Wrote ${path.relative(ROOT_DIR, OUTPUT_FILE)} (${Object.keys(manifest).join(", ")})`
+    `Wrote ${path.relative(ROOT_DIR, outputFile)} (${Object.keys(manifest).join(", ")})`
   );
 }

--- a/build-scripts/gen-language-manifest.cjs
+++ b/build-scripts/gen-language-manifest.cjs
@@ -31,11 +31,20 @@ const path = require("path");
 // synchronously, the same mechanism `node build-scripts/translations.ts`
 // already relies on. `BASE_LANGUAGE` names the in-repo source-of-truth
 // English file; completeness is measured against its key set.
-const {
-  BASE_LANGUAGE,
-  localeCompleteness,
-  toBcp47,
-} = require("./translations-lib.ts");
+let translationsLib;
+try {
+  translationsLib = require("./translations-lib.ts");
+} catch (err) {
+  // `engines` is only an install-time warning, so an unsupported Node still
+  // reaches this require and dies with an opaque loader error (unknown `.ts`
+  // extension or an ESM require failure). Name the actual floor instead.
+  throw new Error(
+    `Loading build-scripts/translations-lib.ts failed on Node ${process.version}; ` +
+      "this script needs Node >= 22.18 (native TypeScript type stripping and require(esm)).",
+    { cause: err }
+  );
+}
+const { BASE_LANGUAGE, localeCompleteness, toBcp47 } = translationsLib;
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const TRANSLATIONS_DIR = path.join(ROOT_DIR, "src", "translations");

--- a/build-scripts/translations-lib.ts
+++ b/build-scripts/translations-lib.ts
@@ -92,10 +92,10 @@ function flattenBase(base: Messages): Map<string, string> {
 // least one translated key reads ≥1% so a barely-started language isn't shown
 // as a flat 0%.
 //
-// The language-manifest generator keeps a byte-compatible copy of this logic
-// (build-scripts/gen-language-manifest.cjs); it's a CommonJS build script that
-// can't import this ESM module, so the two must be kept in sync. This copy is
-// the unit-tested reference.
+// The language-manifest generator (build-scripts/gen-language-manifest.cjs)
+// `require`s this module directly — native type stripping plus require(esm)
+// make that work from CommonJS — so this unit-tested implementation is the
+// only copy.
 export function localeCompleteness(base: Messages, locale: Messages): number {
   const baseLeaves = flattenBase(base);
   const total = baseLeaves.size;

--- a/test/build-scripts/gen-language-manifest.test.ts
+++ b/test/build-scripts/gen-language-manifest.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+// The generator is a CommonJS script that requires the ESM module
+// translations-lib.ts through Node's native type stripping. Vitest's
+// transform pipeline would paper over that seam if the script were imported
+// here, so run it in a plain Node child process, exactly like `npm run lint`
+// and test/global-setup.mjs do, and assert on the manifest it writes to the
+// real (gitignored) output path.
+describe("gen-language-manifest.cjs", () => {
+  it("runs under plain Node and writes a well-formed manifest", async () => {
+    // tsconfig restricts `types` to @types/w3c-web-serial, so node
+    // module specifiers don't type-check; vitest resolves them fine.
+    // @ts-ignore — node-only module
+    const { execFileSync } = await import("node:child_process");
+    // @ts-ignore — node-only module
+    const fs = await import("node:fs");
+    // @ts-ignore — node-only module
+    const path = await import("node:path");
+    // @ts-ignore — node-only module
+    const url = await import("node:url");
+
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const root = path.resolve(here, "../..");
+    const script = path.join(root, "build-scripts", "gen-language-manifest.cjs");
+
+    // @ts-ignore — node-only global
+    const nodeBinary: string = process.execPath;
+    const stdout = execFileSync(nodeBinary, [script], { encoding: "utf-8" });
+    expect(stdout).toContain("language-manifest.json");
+
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(root, "src", "generated", "language-manifest.json"),
+        "utf-8"
+      )
+    ) as Record<string, { language: string; flag: string; completeness: number }>;
+
+    // en.json is the committed source-of-truth locale: always present, and
+    // by definition 100% complete against its own key set.
+    expect(manifest.en).toBeDefined();
+    expect(manifest.en.language).toBe("English");
+    expect(manifest.en.flag).toBe("🇬🇧");
+    expect(manifest.en.completeness).toBe(100);
+
+    // Every entry (downloaded locales included, when present) carries the
+    // fields the language picker renders synchronously.
+    for (const [code, entry] of Object.entries(manifest)) {
+      expect(typeof entry.language, `${code}.language`).toBe("string");
+      expect(entry.language.length).toBeGreaterThan(0);
+      expect(typeof entry.flag, `${code}.flag`).toBe("string");
+      expect(entry.completeness).toBeGreaterThanOrEqual(0);
+      expect(entry.completeness).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/test/build-scripts/gen-language-manifest.test.ts
+++ b/test/build-scripts/gen-language-manifest.test.ts
@@ -4,52 +4,62 @@ import { describe, expect, it } from "vitest";
 // translations-lib.ts through Node's native type stripping. Vitest's
 // transform pipeline would paper over that seam if the script were imported
 // here, so run it in a plain Node child process, exactly like `npm run lint`
-// and test/global-setup.mjs do, and assert on the manifest it writes to the
-// real (gitignored) output path.
+// and test/global-setup.mjs do. The script's optional output-path argument
+// points the write at a temp directory so the test never touches (or races
+// other tooling on) the real src/generated file.
 describe("gen-language-manifest.cjs", () => {
   it("runs under plain Node and writes a well-formed manifest", async () => {
     // tsconfig restricts `types` to @types/w3c-web-serial, so node
     // module specifiers don't type-check; vitest resolves them fine.
-    // @ts-ignore — node-only module
+    // @ts-expect-error — node-only module
     const { execFileSync } = await import("node:child_process");
-    // @ts-ignore — node-only module
+    // @ts-expect-error — node-only module
     const fs = await import("node:fs");
-    // @ts-ignore — node-only module
+    // @ts-expect-error — node-only module
+    const os = await import("node:os");
+    // @ts-expect-error — node-only module
     const path = await import("node:path");
-    // @ts-ignore — node-only module
+    // @ts-expect-error — node-only module
     const url = await import("node:url");
 
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const root = path.resolve(here, "../..");
     const script = path.join(root, "build-scripts", "gen-language-manifest.cjs");
 
-    // @ts-ignore — node-only global
-    const nodeBinary: string = process.execPath;
-    const stdout = execFileSync(nodeBinary, [script], { encoding: "utf-8" });
-    expect(stdout).toContain("language-manifest.json");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gen-language-manifest-"));
+    const outFile = path.join(tmpDir, "language-manifest.json");
+    try {
+      // @ts-expect-error — node-only global
+      const nodeBinary: string = process.execPath;
+      // execFileSync throws on a non-zero exit, so returning at all asserts
+      // the script ran to completion under the real Node loader.
+      execFileSync(nodeBinary, [script, outFile], { encoding: "utf-8" });
 
-    const manifest = JSON.parse(
-      fs.readFileSync(
-        path.join(root, "src", "generated", "language-manifest.json"),
-        "utf-8"
-      )
-    ) as Record<string, { language: string; flag: string; completeness: number }>;
+      expect(fs.existsSync(outFile)).toBe(true);
+      const manifest = JSON.parse(fs.readFileSync(outFile, "utf-8")) as Record<
+        string,
+        { language: string; flag: string; completeness: number }
+      >;
 
-    // en.json is the committed source-of-truth locale: always present, and
-    // by definition 100% complete against its own key set.
-    expect(manifest.en).toBeDefined();
-    expect(manifest.en.language).toBe("English");
-    expect(manifest.en.flag).toBe("🇬🇧");
-    expect(manifest.en.completeness).toBe(100);
+      // en.json is the committed source-of-truth locale: always present, and
+      // by definition 100% complete against its own key set. Its autonym and
+      // flag are translation content that can legitimately change, so the
+      // per-entry loop below only checks they are present and non-empty.
+      expect(manifest.en).toBeDefined();
+      expect(manifest.en.completeness).toBe(100);
 
-    // Every entry (downloaded locales included, when present) carries the
-    // fields the language picker renders synchronously.
-    for (const [code, entry] of Object.entries(manifest)) {
-      expect(typeof entry.language, `${code}.language`).toBe("string");
-      expect(entry.language.length).toBeGreaterThan(0);
-      expect(typeof entry.flag, `${code}.flag`).toBe("string");
-      expect(entry.completeness).toBeGreaterThanOrEqual(0);
-      expect(entry.completeness).toBeLessThanOrEqual(100);
+      // Every entry (downloaded locales included, when present) carries the
+      // fields the language picker renders synchronously.
+      for (const [code, entry] of Object.entries(manifest)) {
+        expect(typeof entry.language, `${code}.language`).toBe("string");
+        expect(entry.language.length, `${code}.language`).toBeGreaterThan(0);
+        expect(typeof entry.flag, `${code}.flag`).toBe("string");
+        expect(entry.flag.length, `${code}.flag`).toBeGreaterThan(0);
+        expect(entry.completeness, `${code}.completeness`).toBeGreaterThanOrEqual(0);
+        expect(entry.completeness, `${code}.completeness`).toBeLessThanOrEqual(100);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

The four locale helpers (`toBcp47`, `flattenMessages`, `flattenBase`, `localeCompleteness`) were byte identical copies maintained by hand in `translations-lib.ts` and `gen-language-manifest.cjs`, with only the TypeScript copy under unit tests. The manifest generator now `require`s `translations-lib.ts` directly; Node's native type stripping plus require(esm), both available on the engines floor (>=22.18) and already relied on by `node build-scripts/translations.ts`, make that work from CommonJS, so the hand synced copies are deleted and the unit tested implementation is the only one. No callers change; `gen:languages`, `lint`, `build.cjs`, `dev-server.cjs`, and the vitest global setup all keep invoking the same `.cjs` file.

**Related issue or feature (if applicable):**

- fixes #1096

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
