### PR TITLE
Transition background-color in the shared menu item style

### DIFF
--- a/src/styles/dropdown-menu.ts
+++ b/src/styles/dropdown-menu.ts
@@ -63,11 +63,11 @@ export const dropdownMenuStyles = css`
     font-size: var(--wa-font-size-xs);
     color: var(--wa-color-text-normal);
     cursor: pointer;
-    transition: background 0.1s;
+    transition: background-color 0.1s;
     user-select: none;
   }
 
   .menu-item:hover {
-    background: var(--esphome-tint);
+    background-color: var(--esphome-tint);
   }
 `;


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1101; the shared menu item rule now transitions background-color instead of the background shorthand, and the hover rule sets background-color to match, keeping the animation narrowly scoped as suggested in review.

**Related issue or feature (if applicable):**

- follow up to #1101

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
