### PR TITLE
Split automation-editor below the file size cap

### DIFF
--- a/src/components/device/automation-editor/automation-editor.ts
+++ b/src/components/device/automation-editor/automation-editor.ts
@@ -27,7 +27,6 @@
  * is outstanding.
  */
 import { consume } from "@lit/context";
-import { mdiArrowDecisionOutline, mdiDelete, mdiOpenInNew } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
@@ -36,52 +35,39 @@ import type { ESPHomeAPI } from "../../../api/index.js";
 import type {
   AutomationLocation,
   AutomationTree,
-  AutomationTrigger,
   AvailableAutomations,
   AvailableComponentInstance,
   AvailableScript,
 } from "../../../api/types/automations.js";
 import type { BoardCatalogEntry } from "../../../api/types/boards.js";
 import type { ComponentCatalogEntry } from "../../../api/types/components.js";
-import type { ConfigEntry } from "../../../api/types/config-entries.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { apiContext, localizeContext } from "../../../context/index.js";
 import { inputStyles } from "../../../styles/inputs.js";
 import { espHomeStyles } from "../../../styles/shared.js";
-import { automationHeaderTitle } from "../../../util/automation-header-title.js";
-import {
-  fetchComponent,
-  getCachedComponent,
-} from "../../../util/component-name-cache.js";
-import { renderMarkdown } from "../../../util/markdown.js";
-import { registerMdiIcons } from "../../../util/register-icons.js";
 import { parseSubstitutions } from "../../../util/substitutions.js";
-import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
-import "../config-entry-form.js";
 import { AutoApplyController } from "./auto-apply-controller.js";
-import "./automation-action-list.js";
 import type { ESPHomeAutomationActionList } from "./automation-action-list.js";
 import { automationEditorStyles } from "./automation-editor.styles.js";
-import "./automation-target-picker.js";
-import "./automation-trigger-picker.js";
 import { CatalogLoadController } from "./catalog-load-controller.js";
-import { componentDomain, instanceName } from "./component-targets.js";
+import { loadIntervalComponent } from "./load-interval-component.js";
 import { ParseErrorController } from "./parse-error-controller.js";
-import { renderTargetField } from "./render-target-field.js";
+import { renderAutomationHeader } from "./render-automation-header.js";
+import {
+  renderActionsSection,
+  renderAddModePickers,
+  renderDeleteRow,
+  renderIdentityFields,
+  renderTriggerParamsForm,
+} from "./render-automation-sections.js";
 import {
   applyParamChange,
   emptyAutomationTree,
   sectionKeyFromLocation,
 } from "./serialise.js";
+import { bareTriggerKey, effectiveTriggerIdFor } from "./trigger-identity.js";
 
-import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
-
-registerMdiIcons({
-  "arrow-decision-outline": mdiArrowDecisionOutline,
-  delete: mdiDelete,
-  "open-in-new": mdiOpenInNew,
-});
 
 @customElement("esphome-automation-editor")
 export class ESPHomeAutomationEditor extends LitElement {
@@ -261,26 +247,16 @@ export class ESPHomeAutomationEditor extends LitElement {
     }
   }
 
-  /** Lazy fetch of the ``interval`` component catalog entry.
-   *  Reuses the shared component-name cache so the navigator's
-   *  pre-fetch (for the label) doubles as the editor's source. */
+  /** Lazy fetch of the ``interval`` component catalog entry —
+   *  cache-first + error-swallowing, see the helper module. */
   private async _loadIntervalComponent() {
     if (!this._api) return;
-    const platform = this.platform || undefined;
-    const boardId = this.board?.id;
-    const cached = getCachedComponent(`interval`, platform, boardId);
-    if (cached) {
-      this._intervalComponent = cached;
-      return;
-    }
-    try {
-      const entry = await fetchComponent(this._api, `interval`, platform, boardId);
-      if (entry) this._intervalComponent = entry;
-    } catch {
-      /* swallow — the editor falls back to the static label when no
-         catalog entry is available; transient backend hiccups
-         shouldn't surface as an error here. */
-    }
+    const entry = await loadIntervalComponent(
+      this._api,
+      this.platform || undefined,
+      this.board?.id
+    );
+    if (entry) this._intervalComponent = entry;
   }
 
   /**
@@ -401,187 +377,76 @@ export class ESPHomeAutomationEditor extends LitElement {
     const actions = this._available?.actions ?? [];
     const conditions = this._available?.conditions ?? [];
     const disabled = this._engine.deleting;
-    // For ``device_on`` and ``component_on`` the trigger lives in the
-    // location alongside the YAML splice destination. Mirror it into
-    // the editor's effective trigger id so the picker shows the right
-    // selection on first paint without a manual sync step.
-    //
-    // ``trigger_id`` is the catalog-qualified id
-    // (``"switch.on_turn_on"``). ``location.trigger`` is the bare
-    // YAML key (``"on_turn_on"``) the writer splices under the
-    // component. For ``device_on`` the two coincide because
-    // device-level catalog ids carry no domain prefix.
-    const effectiveTriggerId =
-      automation.trigger_id ??
-      (target?.kind === "device_on"
-        ? target.trigger || null
-        : target?.kind === "component_on"
-          ? this._catalogIdFor(target) || null
-          : null);
+    const effectiveTriggerId = effectiveTriggerIdFor(automation, target, devices);
     const activeTrigger = effectiveTriggerId
       ? (triggers.find((t) => t.id === effectiveTriggerId) ?? null)
       : null;
     return html`
-      ${this._renderHeader(activeTrigger)}
+      ${renderAutomationHeader(
+        this.location,
+        this._intervalComponent,
+        activeTrigger,
+        this._localize
+      )}
       ${
         this.addMode
-          ? this._renderAddModePickers(
+          ? renderAddModePickers({
               target,
               triggers,
               devices,
               scripts,
               effectiveTriggerId,
               automation,
-              disabled
-            )
-          : html`${this._renderIdentityFields(
-              activeTrigger
-            )}${this._renderTriggerParamsForm(activeTrigger, automation, disabled)}`
+              board: this.board,
+              yaml: this.yaml,
+              disabled,
+              onTargetChange: this._onTargetChange,
+              onTriggerChange: this._onTriggerChange,
+              onTriggerParamsChange: this._onTriggerParamsChange,
+            })
+          : html`${renderIdentityFields(
+              this.location,
+              devices,
+              this._parseSubstitutions(this.yaml),
+              this._localize
+            )}${renderTriggerParamsForm({
+              location: this.location,
+              intervalComponent: this._intervalComponent,
+              activeTrigger,
+              automation,
+              board: this.board,
+              yaml: this.yaml,
+              disabled,
+              showAdvanced: this._showAdvanced,
+              onValueChange: this._onTriggerParamsValueChange,
+              onAdvancedToggle: this._onAdvancedToggle,
+            })}`
       }
-      <div class="field">
-        <div class="ae-actions-header">
-          <label class="field-label">
-            ${this._localize("device.automation_action")}
-          </label>
-          <button
-            type="button"
-            class="ae-section-add"
-            ?disabled=${disabled || actions.length === 0}
-            @click=${() => this._actionList?.openPicker()}
-          >
-            <wa-icon library="mdi" name="plus"></wa-icon>
-            ${this._localize("device.add_action")}
-          </button>
-        </div>
-        <p class="field-description">
-          ${renderMarkdown(this._localize("device.automation_actions_description"))}
-        </p>
-        <esphome-automation-action-list
-          no-header
-          hide-add
-          .actions=${automation.actions}
-          .catalog=${actions}
-          .conditionCatalog=${conditions}
-          .scripts=${scripts}
-          .devices=${devices}
-          .board=${this.board}
-          .yaml=${this.yaml}
-          ?disabled=${disabled}
-          @actions-change=${this._onActionsChange}
-        ></esphome-automation-action-list>
-      </div>
+      ${renderActionsSection({
+        automation,
+        catalog: actions,
+        conditionCatalog: conditions,
+        scripts,
+        devices,
+        board: this.board,
+        yaml: this.yaml,
+        disabled,
+        localize: this._localize,
+        onOpenPicker: () => this._actionList?.openPicker(),
+        onActionsChange: this._onActionsChange,
+      })}
       ${this._error ? html`<p class="ae-error" role="alert">${this._error}</p>` : nothing}
       ${
         this.location && this.value && !this.addMode
-          ? html`<div class="ae-actions">
-              <button
-                type="button"
-                class="ae-danger"
-                ?disabled=${disabled}
-                @click=${this._onDelete}
-              >
-                <wa-icon library="mdi" name="delete"></wa-icon>
-                ${this._localize("device.delete_automation")}
-              </button>
-            </div>`
+          ? renderDeleteRow(this._localize, disabled, this._onDelete)
           : nothing
       }
-    `;
-  }
-
-  /**
-   * Trigger param form for edit-mode. The target / trigger
-   * dropdowns are gone — those become read-only metadata in the
-   * header. Only the trigger's ``config_entries`` need a form,
-   * since those ARE editable on an existing automation (e.g.
-   * tweaking ``min_length`` on an ``on_click`` trigger after the
-   * fact).
-   *
-   * ``interval`` automations special-case: the trigger
-   * (``interval.then``) carries no config_entries, but the parent
-   * ``interval`` *component* does — ``interval:`` (time), ``id:``,
-   * ``startup_delay:`` etc. all live in ``trigger_params`` in the
-   * AutomationTree, so render them from the component schema
-   * (filtered to drop ``then:``, which is the actions block).
-   */
-  private _renderTriggerParamsForm(
-    activeTrigger: AutomationTrigger | null,
-    automation: AutomationTree,
-    disabled: boolean
-  ) {
-    const entries = this._paramFormEntries(activeTrigger);
-    if (entries.length === 0) return nothing;
-    // No outer wrapper / no synthetic group label: the form renders
-    // each entry with its own catalog-derived label + description,
-    // and a section header above that ("Interval" / "Trigger
-    // options") would just duplicate the first field's name. Sit as
-    // a sibling of the header and the action-list so the :host gap
-    // alone handles vertical rhythm.
-    return html`
-      <esphome-config-entry-form
-        .entries=${entries}
-        .values=${automation.trigger_params}
-        .board=${this.board}
-        .yaml=${this.yaml}
-        ?disabled=${disabled}
-        advanced-section
-        ?show-advanced=${this._showAdvanced}
-        @value-change=${this._onTriggerParamsValueChange}
-        @advanced-toggle=${this._onAdvancedToggle}
-      ></esphome-config-entry-form>
     `;
   }
 
   private _onAdvancedToggle = (e: CustomEvent<{ show: boolean }>) => {
     this._showAdvanced = e.detail.show;
   };
-
-  /** Resolve the config_entries list that drives the trigger-params
-   *  form. Interval pulls from the component schema (since
-   *  ``interval.then``'s own config_entries is empty); everything
-   *  else stays on the trigger's own config_entries. */
-  private _paramFormEntries(activeTrigger: AutomationTrigger | null): ConfigEntry[] {
-    return triggerParamFormEntries(this.location, this._intervalComponent, activeTrigger);
-  }
-
-  /**
-   * Legacy add-mode pickers. The "+ Add automation" wizard now
-   * collects target / trigger before mounting the editor, so this
-   * path isn't normally reached from the navigator — kept for
-   * back-compat if a parent ever instantiates the editor in
-   * add-mode directly.
-   */
-  private _renderAddModePickers(
-    target: AutomationLocation | null,
-    triggers: AutomationTrigger[],
-    devices: AvailableComponentInstance[],
-    scripts: AvailableScript[],
-    effectiveTriggerId: string | null,
-    automation: AutomationTree,
-    disabled: boolean
-  ) {
-    return html`
-      <esphome-automation-target-picker
-        .value=${target}
-        .devices=${devices}
-        .scripts=${scripts}
-        ?disabled=${disabled}
-        @target-change=${this._onTargetChange}
-      ></esphome-automation-target-picker>
-      <esphome-automation-trigger-picker
-        .target=${target}
-        .triggers=${triggers}
-        .devices=${devices}
-        .triggerId=${effectiveTriggerId}
-        .triggerParams=${automation.trigger_params}
-        .board=${this.board}
-        .yaml=${this.yaml}
-        ?disabled=${disabled}
-        @trigger-change=${this._onTriggerChange}
-        @trigger-params-change=${this._onTriggerParamsChange}
-      ></esphome-automation-trigger-picker>
-    `;
-  }
 
   private _onTriggerParamsValueChange = (
     e: CustomEvent<{ path: string[]; value: unknown }>
@@ -594,128 +459,6 @@ export class ESPHomeAutomationEditor extends LitElement {
     const next = applyParamChange(automation.trigger_params, path, value);
     this._engine.withValue({ trigger_params: next });
   };
-
-  /**
-   * Component-style header card. Title is the catalog-resolved
-   * domain + trigger name (``Switch → Turn on``) so it matches the
-   * navigator's primary label and gives the user the same eye-line
-   * cue they get from clicking a regular component.
-   *
-   * For ``interval`` automations we reach further and pull the
-   * ``interval`` component catalog entry so the user gets the same
-   * name / description / docs / image they'd see in a regular
-   * component editor — no more bland generic "Automation".
-   *
-   * Title decomposes to the kind label (``Automation``) when we
-   * don't have enough metadata yet — fresh add-mode (no trigger
-   * picked) or script / light_effect locations.
-   */
-  private _renderHeader(activeTrigger: AutomationTrigger | null) {
-    const loc = this.location;
-    const intervalComp = loc?.kind === "interval" ? this._intervalComponent : null;
-    const title = intervalComp?.name ?? this._headerTitle(activeTrigger);
-    const docsUrl = intervalComp?.docs_url ?? activeTrigger?.docs_url ?? "";
-    const descText =
-      intervalComp?.description ??
-      activeTrigger?.description ??
-      this._localize("device.automation_header_description");
-    const imageUrl = intervalComp?.image_url ?? "";
-    return html`<div class="ae-header">
-      <div class="ae-header-text">
-        <h2 class="ae-header-title">${title}</h2>
-        ${
-          docsUrl
-            ? html`<a
-                class="ae-header-docs"
-                href=${docsUrl}
-                target="_blank"
-                rel="noreferrer"
-              >
-                ${this._localize("device.docs")}
-                <wa-icon library="mdi" name="open-in-new"></wa-icon>
-              </a>`
-            : nothing
-        }
-        <p class="ae-header-desc">${renderMarkdown(descText)}</p>
-      </div>
-      <div class="ae-header-icon">
-        ${
-          imageUrl
-            ? html`<img alt="" src=${imageUrl} />`
-            : html`<wa-icon library="mdi" name="arrow-decision-outline"></wa-icon>`
-        }
-      </div>
-    </div>`;
-  }
-
-  /**
-   * Compose the header title:
-   *
-   *   device_on / component_on (trigger picked)  → catalog's
-   *     ``trigger.name`` ("Switch → On Turn On") — already domain-
-   *     qualified, no extra prefix.
-   *   interval                                   → catalog component
-   *     name (handled by ``_renderHeader``); this is the fallback
-   *     when the component hasn't loaded yet.
-   *   anything else / fallback                   → static "Automation"
-   */
-  private _headerTitle(trigger: AutomationTrigger | null): string {
-    return automationHeaderTitle(this.location, trigger, this._localize);
-  }
-
-  /**
-   * Read-only target field — the only identity field we still
-   * surface, and only for ``component_on``: the catalog name
-   * (``Switch → On Turn On``) already sits as the editor's header
-   * title so a separate "Trigger" row underneath was just a copy
-   * of it, and ``device_on`` / ``interval`` have no meaningful
-   * target to display either ("the device itself" / "Interval #1"
-   * read as filler). Leaves only "which component instance is
-   * this automation bound to" — the one piece of identity the
-   * header can't carry.
-   */
-  private _renderIdentityFields(_activeTrigger: AutomationTrigger | null) {
-    const loc = this.location;
-    if (!loc) return nothing;
-    if (loc.kind !== "component_on" && loc.kind !== "component_action") return nothing;
-    const targetValue = this._targetMetadataValue(loc);
-    return renderTargetField(
-      targetValue,
-      this._parseSubstitutions(this.yaml),
-      this._localize
-    );
-  }
-
-  /**
-   * Compose the single TARGET row value. For component_on this is
-   * the bound device's display name + catalog id (e.g.
-   * "Warmtepomp (switch.gpio)") — no separate "Which component?"
-   * row. For device_on it's "The device itself"; for interval
-   * it's "Interval #N"; for script / light_effect we fall back
-   * to the kind label (those land in their own editors anyway).
-   */
-  private _targetMetadataValue(loc: AutomationLocation): string {
-    switch (loc.kind) {
-      case "device_on":
-        return this._localize("device.automation_target_device");
-      case "component_on":
-      case "component_action": {
-        const device = this._available?.devices.find((d) => d.id === loc.component_id);
-        if (!device) return loc.component_id;
-        return `${instanceName(device)} (${device.component_id})`;
-      }
-      case "interval":
-        return this._localize("device.automation_target_interval_n", {
-          index: loc.index + 1,
-        });
-      case "script":
-        return loc.id;
-      case "api_action":
-        return loc.action_name;
-      case "light_effect":
-        return loc.component_id;
-    }
-  }
 
   // ─── State mutations ─────────────────────────────────────────
 
@@ -750,47 +493,15 @@ export class ESPHomeAutomationEditor extends LitElement {
     // ``on_*:`` key the writer renders under). Mirror the new
     // trigger id into the location so save/delete target the right
     // range. ``interval`` / ``script`` / ``light_effect`` carry no
-    // ``trigger`` field.
-    //
-    // Wire-shape detail: ``AutomationTree.trigger_id`` is the
-    // catalog-qualified id (``"switch.on_turn_on"`` — what
-    // ``catalog.trigger_by_id`` returns a hit for).
-    // ``location.component_on.trigger`` is the BARE YAML key
-    // (``"on_turn_on"``) the writer splices under the component;
-    // the backend reconstructs the catalog id by combining the
-    // component's domain with the bare key. Device-level catalog
-    // ids carry no domain prefix so the two coincide for
-    // ``device_on``.
+    // ``trigger`` field. The catalog-qualified vs bare-YAML-key id
+    // forms are documented in ``trigger-identity.ts``.
     if (this.location?.kind === "device_on") {
       this.location = { ...this.location, trigger: e.detail.triggerId };
     } else if (this.location?.kind === "component_on") {
-      const bare = this._bareTriggerKey(e.detail.triggerId);
+      const bare = bareTriggerKey(e.detail.triggerId);
       this.location = { ...this.location, trigger: bare };
     }
   };
-
-  /**
-   * Drop the ``<domain>.`` prefix from a catalog trigger id to get
-   * the bare YAML key. ``"switch.on_turn_on"`` → ``"on_turn_on"``.
-   * Ids that already lack a domain are passed through.
-   */
-  private _bareTriggerKey(catalogId: string): string {
-    const dotIdx = catalogId.indexOf(".");
-    return dotIdx >= 0 ? catalogId.slice(dotIdx + 1) : catalogId;
-  }
-
-  /**
-   * Build the catalog-qualified trigger id for a ``component_on``
-   * location, using the bound device's domain. Returns ``null``
-   * when the device isn't yet loaded or the location has no
-   * trigger picked.
-   */
-  private _catalogIdFor(loc: AutomationLocation): string | null {
-    if (loc.kind !== "component_on" || !loc.trigger) return null;
-    const device = this._available?.devices.find((d) => d.id === loc.component_id);
-    const domain = device ? componentDomain(device.component_id) : null;
-    return domain ? `${domain}.${loc.trigger}` : loc.trigger;
-  }
 
   private _onTriggerParamsChange = (
     e: CustomEvent<{ params: Record<string, unknown> }>

--- a/src/components/device/automation-editor/load-interval-component.ts
+++ b/src/components/device/automation-editor/load-interval-component.ts
@@ -1,0 +1,28 @@
+/**
+ * Lazy fetch of the ``interval`` component catalog entry. Reuses the
+ * shared component-name cache so the navigator's pre-fetch (for the
+ * label) doubles as the editor's source. Resolves ``null`` when no
+ * catalog entry is available or the fetch fails — the editor falls
+ * back to the static label; transient backend hiccups shouldn't
+ * surface as an error here.
+ */
+import type { ESPHomeAPI } from "../../../api/index.js";
+import type { ComponentCatalogEntry } from "../../../api/types/components.js";
+import {
+  fetchComponent,
+  getCachedComponent,
+} from "../../../util/component-name-cache.js";
+
+export async function loadIntervalComponent(
+  api: ESPHomeAPI,
+  platform: string | undefined,
+  boardId: string | undefined
+): Promise<ComponentCatalogEntry | null> {
+  const cached = getCachedComponent(`interval`, platform, boardId);
+  if (cached) return cached;
+  try {
+    return (await fetchComponent(api, `interval`, platform, boardId)) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/device/automation-editor/render-automation-header.ts
+++ b/src/components/device/automation-editor/render-automation-header.ts
@@ -1,0 +1,81 @@
+/**
+ * The automation editor's component-style header card. Kept as a
+ * pure function (not a method) matching ``render-target-field.ts``,
+ * so it stays testable without mounting the editor.
+ *
+ * Title is the catalog-resolved domain + trigger name
+ * (``Switch → Turn on``) so it matches the navigator's primary
+ * label and gives the user the same eye-line cue they get from
+ * clicking a regular component.
+ *
+ * For ``interval`` automations we reach further and pull the
+ * ``interval`` component catalog entry so the user gets the same
+ * name / description / docs / image they'd see in a regular
+ * component editor — no more bland generic "Automation".
+ *
+ * Title decomposes to the kind label (``Automation``) when we
+ * don't have enough metadata yet — fresh add-mode (no trigger
+ * picked) or script / light_effect locations.
+ */
+import { mdiArrowDecisionOutline, mdiOpenInNew } from "@mdi/js";
+import { html, nothing } from "lit";
+
+import type {
+  AutomationLocation,
+  AutomationTrigger,
+} from "../../../api/types/automations.js";
+import type { ComponentCatalogEntry } from "../../../api/types/components.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { automationHeaderTitle } from "../../../util/automation-header-title.js";
+import { renderMarkdown } from "../../../util/markdown.js";
+import { registerMdiIcons } from "../../../util/register-icons.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  "arrow-decision-outline": mdiArrowDecisionOutline,
+  "open-in-new": mdiOpenInNew,
+});
+
+export function renderAutomationHeader(
+  location: AutomationLocation | null,
+  intervalComponent: ComponentCatalogEntry | null,
+  activeTrigger: AutomationTrigger | null,
+  localize: LocalizeFunc
+) {
+  const intervalComp = location?.kind === "interval" ? intervalComponent : null;
+  const title =
+    intervalComp?.name ?? automationHeaderTitle(location, activeTrigger, localize);
+  const docsUrl = intervalComp?.docs_url ?? activeTrigger?.docs_url ?? "";
+  const descText =
+    intervalComp?.description ??
+    activeTrigger?.description ??
+    localize("device.automation_header_description");
+  const imageUrl = intervalComp?.image_url ?? "";
+  return html`<div class="ae-header">
+    <div class="ae-header-text">
+      <h2 class="ae-header-title">${title}</h2>
+      ${
+        docsUrl
+          ? html`<a
+              class="ae-header-docs"
+              href=${docsUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              ${localize("device.docs")}
+              <wa-icon library="mdi" name="open-in-new"></wa-icon>
+            </a>`
+          : nothing
+      }
+      <p class="ae-header-desc">${renderMarkdown(descText)}</p>
+    </div>
+    <div class="ae-header-icon">
+      ${
+        imageUrl
+          ? html`<img alt="" src=${imageUrl} />`
+          : html`<wa-icon library="mdi" name="arrow-decision-outline"></wa-icon>`
+      }
+    </div>
+  </div>`;
+}

--- a/src/components/device/automation-editor/render-automation-sections.ts
+++ b/src/components/device/automation-editor/render-automation-sections.ts
@@ -1,0 +1,228 @@
+/**
+ * The automation editor's body sections, as pure render functions
+ * (matching ``render-target-field.ts``): the legacy add-mode
+ * pickers, the edit-mode trigger-params form, the actions list
+ * section, and the delete footer. State stays in
+ * ``<esphome-automation-editor>``; each section receives values
+ * plus the host's stable handler references.
+ */
+import { mdiDelete } from "@mdi/js";
+import { html, nothing } from "lit";
+
+import type {
+  AutomationAction,
+  AutomationCondition,
+  AutomationLocation,
+  AutomationTree,
+  AutomationTrigger,
+  AvailableComponentInstance,
+  AvailableScript,
+} from "../../../api/types/automations.js";
+import type { BoardCatalogEntry } from "../../../api/types/boards.js";
+import type { ComponentCatalogEntry } from "../../../api/types/components.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { renderMarkdown } from "../../../util/markdown.js";
+import { registerMdiIcons } from "../../../util/register-icons.js";
+import { triggerParamFormEntries } from "../../../util/trigger-param-form-entries.js";
+import "../config-entry-form.js";
+import "./automation-action-list.js";
+import "./automation-target-picker.js";
+import "./automation-trigger-picker.js";
+import { renderTargetField } from "./render-target-field.js";
+import { targetMetadataValue } from "./trigger-identity.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({ delete: mdiDelete });
+
+/**
+ * Legacy add-mode pickers. The "+ Add automation" wizard now
+ * collects target / trigger before mounting the editor, so this
+ * path isn't normally reached from the navigator — kept for
+ * back-compat if a parent ever instantiates the editor in
+ * add-mode directly.
+ */
+export function renderAddModePickers(opts: {
+  target: AutomationLocation | null;
+  triggers: AutomationTrigger[];
+  devices: AvailableComponentInstance[];
+  scripts: AvailableScript[];
+  effectiveTriggerId: string | null;
+  automation: AutomationTree;
+  board: BoardCatalogEntry | null;
+  yaml: string;
+  disabled: boolean;
+  onTargetChange: (e: CustomEvent<{ target: AutomationLocation | null }>) => void;
+  onTriggerChange: (
+    e: CustomEvent<{ triggerId: string; params: Record<string, unknown> }>
+  ) => void;
+  onTriggerParamsChange: (e: CustomEvent<{ params: Record<string, unknown> }>) => void;
+}) {
+  return html`
+    <esphome-automation-target-picker
+      .value=${opts.target}
+      .devices=${opts.devices}
+      .scripts=${opts.scripts}
+      ?disabled=${opts.disabled}
+      @target-change=${opts.onTargetChange}
+    ></esphome-automation-target-picker>
+    <esphome-automation-trigger-picker
+      .target=${opts.target}
+      .triggers=${opts.triggers}
+      .devices=${opts.devices}
+      .triggerId=${opts.effectiveTriggerId}
+      .triggerParams=${opts.automation.trigger_params}
+      .board=${opts.board}
+      .yaml=${opts.yaml}
+      ?disabled=${opts.disabled}
+      @trigger-change=${opts.onTriggerChange}
+      @trigger-params-change=${opts.onTriggerParamsChange}
+    ></esphome-automation-trigger-picker>
+  `;
+}
+
+/**
+ * Trigger param form for edit-mode. The target / trigger
+ * dropdowns are gone — those become read-only metadata in the
+ * header. Only the trigger's ``config_entries`` need a form,
+ * since those ARE editable on an existing automation (e.g.
+ * tweaking ``min_length`` on an ``on_click`` trigger after the
+ * fact).
+ *
+ * ``interval`` automations special-case: the trigger
+ * (``interval.then``) carries no config_entries, but the parent
+ * ``interval`` *component* does — ``interval:`` (time), ``id:``,
+ * ``startup_delay:`` etc. all live in ``trigger_params`` in the
+ * AutomationTree, so render them from the component schema
+ * (filtered to drop ``then:``, which is the actions block).
+ */
+export function renderTriggerParamsForm(opts: {
+  location: AutomationLocation | null;
+  intervalComponent: ComponentCatalogEntry | null;
+  activeTrigger: AutomationTrigger | null;
+  automation: AutomationTree;
+  board: BoardCatalogEntry | null;
+  yaml: string;
+  disabled: boolean;
+  showAdvanced: boolean;
+  onValueChange: (e: CustomEvent<{ path: string[]; value: unknown }>) => void;
+  onAdvancedToggle: (e: CustomEvent<{ show: boolean }>) => void;
+}) {
+  const entries = triggerParamFormEntries(
+    opts.location,
+    opts.intervalComponent,
+    opts.activeTrigger
+  );
+  if (entries.length === 0) return nothing;
+  // No outer wrapper / no synthetic group label: the form renders
+  // each entry with its own catalog-derived label + description,
+  // and a section header above that ("Interval" / "Trigger
+  // options") would just duplicate the first field's name. Sit as
+  // a sibling of the header and the action-list so the :host gap
+  // alone handles vertical rhythm.
+  return html`
+    <esphome-config-entry-form
+      .entries=${entries}
+      .values=${opts.automation.trigger_params}
+      .board=${opts.board}
+      .yaml=${opts.yaml}
+      ?disabled=${opts.disabled}
+      advanced-section
+      ?show-advanced=${opts.showAdvanced}
+      @value-change=${opts.onValueChange}
+      @advanced-toggle=${opts.onAdvancedToggle}
+    ></esphome-config-entry-form>
+  `;
+}
+
+/** The Actions section: label + header-positioned Add button
+ *  (opens the picker dialog living inside the action-list) and
+ *  the recursive action list itself. */
+export function renderActionsSection(opts: {
+  automation: AutomationTree;
+  catalog: AutomationAction[];
+  conditionCatalog: AutomationCondition[];
+  scripts: AvailableScript[];
+  devices: AvailableComponentInstance[];
+  board: BoardCatalogEntry | null;
+  yaml: string;
+  disabled: boolean;
+  localize: LocalizeFunc;
+  onOpenPicker: () => void;
+  onActionsChange: (e: CustomEvent<{ actions: AutomationTree["actions"] }>) => void;
+}) {
+  return html`
+    <div class="field">
+      <div class="ae-actions-header">
+        <label class="field-label"> ${opts.localize("device.automation_action")} </label>
+        <button
+          type="button"
+          class="ae-section-add"
+          ?disabled=${opts.disabled || opts.catalog.length === 0}
+          @click=${opts.onOpenPicker}
+        >
+          <wa-icon library="mdi" name="plus"></wa-icon>
+          ${opts.localize("device.add_action")}
+        </button>
+      </div>
+      <p class="field-description">
+        ${renderMarkdown(opts.localize("device.automation_actions_description"))}
+      </p>
+      <esphome-automation-action-list
+        no-header
+        hide-add
+        .actions=${opts.automation.actions}
+        .catalog=${opts.catalog}
+        .conditionCatalog=${opts.conditionCatalog}
+        .scripts=${opts.scripts}
+        .devices=${opts.devices}
+        .board=${opts.board}
+        .yaml=${opts.yaml}
+        ?disabled=${opts.disabled}
+        @actions-change=${opts.onActionsChange}
+      ></esphome-automation-action-list>
+    </div>
+  `;
+}
+
+/**
+ * Read-only target field — the only identity field we still
+ * surface, and only for ``component_on`` / ``component_action``:
+ * the catalog name (``Switch → On Turn On``) already sits as the
+ * editor's header title so a separate "Trigger" row underneath was
+ * just a copy of it, and ``device_on`` / ``interval`` have no
+ * meaningful target to display either ("the device itself" /
+ * "Interval #1" read as filler). Leaves only "which component
+ * instance is this automation bound to" — the one piece of
+ * identity the header can't carry.
+ */
+export function renderIdentityFields(
+  location: AutomationLocation | null,
+  devices: AvailableComponentInstance[],
+  substitutions: Map<string, string>,
+  localize: LocalizeFunc
+) {
+  if (!location) return nothing;
+  if (location.kind !== "component_on" && location.kind !== "component_action") {
+    return nothing;
+  }
+  return renderTargetField(
+    targetMetadataValue(location, devices, localize),
+    substitutions,
+    localize
+  );
+}
+
+/** Edit-mode footer: the destructive Delete button. */
+export function renderDeleteRow(
+  localize: LocalizeFunc,
+  disabled: boolean,
+  onDelete: () => void
+) {
+  return html`<div class="ae-actions">
+    <button type="button" class="ae-danger" ?disabled=${disabled} @click=${onDelete}>
+      <wa-icon library="mdi" name="delete"></wa-icon>
+      ${localize("device.delete_automation")}
+    </button>
+  </div>`;
+}

--- a/src/components/device/automation-editor/trigger-identity.ts
+++ b/src/components/device/automation-editor/trigger-identity.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure trigger / target identity helpers for the automation editor.
+ * Kept as plain functions (not methods) so the id round-tripping can
+ * be unit-tested without mounting the editor, which pulls in
+ * CodeMirror.
+ *
+ * Wire-shape background: ``AutomationTree.trigger_id`` is the
+ * catalog-qualified id (``"switch.on_turn_on"`` — what
+ * ``catalog.trigger_by_id`` returns a hit for), while
+ * ``location.component_on.trigger`` is the BARE YAML key
+ * (``"on_turn_on"``) the writer splices under the component; the
+ * backend reconstructs the catalog id by combining the component's
+ * domain with the bare key. Device-level catalog ids carry no domain
+ * prefix, so the two forms coincide for ``device_on``.
+ */
+import type {
+  AutomationLocation,
+  AutomationTree,
+  AvailableComponentInstance,
+} from "../../../api/types/automations.js";
+import type { LocalizeFunc } from "../../../common/localize.js";
+import { componentDomain, instanceName } from "./component-targets.js";
+
+/**
+ * Drop the ``<domain>.`` prefix from a catalog trigger id to get
+ * the bare YAML key. ``"switch.on_turn_on"`` → ``"on_turn_on"``.
+ * Ids that already lack a domain are passed through.
+ */
+export function bareTriggerKey(catalogId: string): string {
+  const dotIdx = catalogId.indexOf(".");
+  return dotIdx >= 0 ? catalogId.slice(dotIdx + 1) : catalogId;
+}
+
+/**
+ * Build the catalog-qualified trigger id for a ``component_on``
+ * location, using the bound device's domain. Returns ``null``
+ * when the device isn't yet loaded or the location has no
+ * trigger picked.
+ */
+export function catalogTriggerIdFor(
+  loc: AutomationLocation,
+  devices: AvailableComponentInstance[]
+): string | null {
+  if (loc.kind !== "component_on" || !loc.trigger) return null;
+  const device = devices.find((d) => d.id === loc.component_id);
+  const domain = device ? componentDomain(device.component_id) : null;
+  return domain ? `${domain}.${loc.trigger}` : loc.trigger;
+}
+
+/**
+ * The editor's effective trigger id. For ``device_on`` and
+ * ``component_on`` the trigger lives in the location alongside the
+ * YAML splice destination; mirror it into the effective id so the
+ * picker shows the right selection on first paint without a manual
+ * sync step. ``device_on``'s two id forms coincide (no domain
+ * prefix), so its bare key passes through unqualified.
+ */
+export function effectiveTriggerIdFor(
+  automation: AutomationTree,
+  target: AutomationLocation | null,
+  devices: AvailableComponentInstance[]
+): string | null {
+  return (
+    automation.trigger_id ??
+    (target?.kind === "device_on"
+      ? target.trigger || null
+      : target?.kind === "component_on"
+        ? catalogTriggerIdFor(target, devices) || null
+        : null)
+  );
+}
+
+/**
+ * Compose the single TARGET row value. For component_on this is
+ * the bound device's display name + catalog id (e.g.
+ * "Warmtepomp (switch.gpio)") — no separate "Which component?"
+ * row. For device_on it's "The device itself"; for interval
+ * it's "Interval #N"; for script / light_effect we fall back
+ * to the kind label (those land in their own editors anyway).
+ */
+export function targetMetadataValue(
+  loc: AutomationLocation,
+  devices: AvailableComponentInstance[],
+  localize: LocalizeFunc
+): string {
+  switch (loc.kind) {
+    case "device_on":
+      return localize("device.automation_target_device");
+    case "component_on":
+    case "component_action": {
+      const device = devices.find((d) => d.id === loc.component_id);
+      if (!device) return loc.component_id;
+      return `${instanceName(device)} (${device.component_id})`;
+    }
+    case "interval":
+      return localize("device.automation_target_interval_n", {
+        index: loc.index + 1,
+      });
+    case "script":
+      return loc.id;
+    case "api_action":
+      return loc.action_name;
+    case "light_effect":
+      return loc.component_id;
+  }
+}

--- a/src/components/device/automation-editor/trigger-identity.ts
+++ b/src/components/device/automation-editor/trigger-identity.ts
@@ -34,8 +34,9 @@ export function bareTriggerKey(catalogId: string): string {
 /**
  * Build the catalog-qualified trigger id for a ``component_on``
  * location, using the bound device's domain. Returns ``null``
- * when the device isn't yet loaded or the location has no
- * trigger picked.
+ * for other location kinds or when no trigger is picked; while
+ * the device list hasn't loaded yet the bare trigger key is
+ * returned unqualified so the caller still has a usable id.
  */
 export function catalogTriggerIdFor(
   loc: AutomationLocation,
@@ -75,8 +76,9 @@ export function effectiveTriggerIdFor(
  * the bound device's display name + catalog id (e.g.
  * "Warmtepomp (switch.gpio)") — no separate "Which component?"
  * row. For device_on it's "The device itself"; for interval
- * it's "Interval #N"; for script / light_effect we fall back
- * to the kind label (those land in their own editors anyway).
+ * it's "Interval #N"; for script / api_action / light_effect
+ * the row shows their own identifier (script id, action name,
+ * component id) since those land in their own editors anyway.
  */
 export function targetMetadataValue(
   loc: AutomationLocation,

--- a/test/components/device/automation-editor/trigger-identity.test.ts
+++ b/test/components/device/automation-editor/trigger-identity.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AutomationLocation,
+  AutomationTree,
+  AvailableComponentInstance,
+} from "../../../../src/api/types/automations.js";
+import type { LocalizeFunc } from "../../../../src/common/localize.js";
+import {
+  bareTriggerKey,
+  catalogTriggerIdFor,
+  effectiveTriggerIdFor,
+  targetMetadataValue,
+} from "../../../../src/components/device/automation-editor/trigger-identity.js";
+
+const localize: LocalizeFunc = (key, values) => (values ? `${key}#${values.index}` : key);
+
+const inst = (
+  over: Partial<AvailableComponentInstance> & { id: string; component_id: string }
+): AvailableComponentInstance => over;
+
+const relay = inst({ id: "relay_1", component_id: "switch.gpio", name: "Warmtepomp" });
+const devices = [relay];
+
+const tree = (trigger_id: string | null = null): AutomationTree => ({
+  trigger_id,
+  trigger_params: {},
+  actions: [],
+});
+
+const componentOn = (trigger: string): AutomationLocation => ({
+  kind: "component_on",
+  component_id: "relay_1",
+  trigger,
+});
+
+describe("bareTriggerKey", () => {
+  it("drops the domain prefix from a catalog id", () => {
+    expect(bareTriggerKey("switch.on_turn_on")).toBe("on_turn_on");
+  });
+
+  it("passes an already-bare key through", () => {
+    expect(bareTriggerKey("on_boot")).toBe("on_boot");
+  });
+});
+
+describe("catalogTriggerIdFor", () => {
+  it("qualifies a component_on trigger with the bound device's domain", () => {
+    expect(catalogTriggerIdFor(componentOn("on_turn_on"), devices)).toBe(
+      "switch.on_turn_on"
+    );
+  });
+
+  it("falls back to the bare key when the device isn't loaded yet", () => {
+    expect(catalogTriggerIdFor(componentOn("on_turn_on"), [])).toBe("on_turn_on");
+  });
+
+  it("returns null without a picked trigger or for other location kinds", () => {
+    expect(catalogTriggerIdFor(componentOn(""), devices)).toBeNull();
+    expect(catalogTriggerIdFor({ kind: "script", id: "s" }, devices)).toBeNull();
+  });
+});
+
+describe("effectiveTriggerIdFor", () => {
+  it("prefers the tree's own trigger_id", () => {
+    expect(
+      effectiveTriggerIdFor(tree("binary_sensor.on_press"), componentOn("x"), devices)
+    ).toBe("binary_sensor.on_press");
+  });
+
+  it("mirrors a device_on location's trigger as-is (no domain prefix)", () => {
+    expect(
+      effectiveTriggerIdFor(tree(), { kind: "device_on", trigger: "on_boot" }, devices)
+    ).toBe("on_boot");
+  });
+
+  it("qualifies a component_on location's bare trigger key", () => {
+    expect(effectiveTriggerIdFor(tree(), componentOn("on_turn_on"), devices)).toBe(
+      "switch.on_turn_on"
+    );
+  });
+
+  it("returns null when neither the tree nor the location carries one", () => {
+    expect(effectiveTriggerIdFor(tree(), { kind: "interval", index: 0 }, devices)).toBe(
+      null
+    );
+    expect(effectiveTriggerIdFor(tree(), null, devices)).toBeNull();
+  });
+});
+
+describe("targetMetadataValue", () => {
+  it("labels device_on as the device itself", () => {
+    expect(
+      targetMetadataValue({ kind: "device_on", trigger: "" }, devices, localize)
+    ).toBe("device.automation_target_device");
+  });
+
+  it("labels component_on with the instance name + catalog id", () => {
+    expect(targetMetadataValue(componentOn("on_turn_on"), devices, localize)).toBe(
+      "Warmtepomp (switch.gpio)"
+    );
+  });
+
+  it("falls back to the raw component_id when the device isn't loaded", () => {
+    expect(targetMetadataValue(componentOn("on_turn_on"), [], localize)).toBe("relay_1");
+  });
+
+  it("labels interval with its 1-based index", () => {
+    expect(targetMetadataValue({ kind: "interval", index: 2 }, devices, localize)).toBe(
+      "device.automation_target_interval_n#3"
+    );
+  });
+
+  it("uses the location's own identity for the remaining kinds", () => {
+    expect(targetMetadataValue({ kind: "script", id: "boot" }, devices, localize)).toBe(
+      "boot"
+    );
+    expect(
+      targetMetadataValue({ kind: "api_action", action_name: "ring" }, devices, localize)
+    ).toBe("ring");
+    expect(
+      targetMetadataValue(
+        { kind: "light_effect", component_id: "light.rgb", index: 0 },
+        devices,
+        localize
+      )
+    ).toBe("light.rgb");
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Splits `automation-editor.ts` (837 lines after #1100) below the repo's file size cap by carving along existing seams; the header, add mode pickers, trigger params form, actions section and identity field move to pure render helper modules following the `render-target-field.ts` pattern, and the trigger id / target label logic moves to a plain `trigger-identity.ts` module with unit tests. No behavior change, the element's public props, events and name are untouched.

**Related issue or feature (if applicable):**

- follow up to #1100

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
