### PR TITLE
Make the search shortcut hint translatable

### DIFF
--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -57,11 +57,15 @@ registerMdiIcons({
 
 /** True on Apple platforms, where the search shortcut uses the ⌘ glyph.
  *  ``userAgentData`` first; ``navigator.platform`` is deprecated but remains
- *  the only signal on Firefox and Safari. */
-const IS_APPLE_PLATFORM = /mac|iphone|ipad/i.test(
-  (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ??
-    navigator.platform
-);
+ *  the only signal on Firefox and Safari. Read lazily and guarded so importing
+ *  the module never touches an absent ``navigator``. */
+function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /mac|iphone|ipad/i.test(
+    (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ??
+      navigator.platform
+  );
+}
 
 @customElement("esphome-header-actions")
 export class ESPHomeHeaderActions extends LitElement {
@@ -161,7 +165,7 @@ export class ESPHomeHeaderActions extends LitElement {
     const hasAlerts = this._offloaderAlertsCount() > 0;
     const ignoredCount = this._importableDevices.filter((d) => d.ignored).length;
     // ⌘ is a locale-independent Apple glyph; the "Ctrl" label localizes (STRG in German).
-    const searchShortcut = IS_APPLE_PLATFORM
+    const searchShortcut = isApplePlatform()
       ? "⌘K"
       : this._localize("layout.search_shortcut");
     return html`

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -55,15 +55,13 @@ registerMdiIcons({
   "wifi-cog": mdiWifiCog,
 });
 
-/** Cmd+K on Apple platforms, Ctrl K elsewhere — matches the command
- *  palette binding. ``userAgentData`` first; ``navigator.platform`` is
- *  deprecated but remains the only signal on Firefox and Safari. */
-const SEARCH_SHORTCUT = /mac|iphone|ipad/i.test(
+/** True on Apple platforms, where the search shortcut uses the ⌘ glyph.
+ *  ``userAgentData`` first; ``navigator.platform`` is deprecated but remains
+ *  the only signal on Firefox and Safari. */
+const IS_APPLE_PLATFORM = /mac|iphone|ipad/i.test(
   (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ??
     navigator.platform
-)
-  ? "⌘K"
-  : "Ctrl K";
+);
 
 @customElement("esphome-header-actions")
 export class ESPHomeHeaderActions extends LitElement {
@@ -162,6 +160,10 @@ export class ESPHomeHeaderActions extends LitElement {
         : this._localize("dashboard.more_options");
     const hasAlerts = this._offloaderAlertsCount() > 0;
     const ignoredCount = this._importableDevices.filter((d) => d.ignored).length;
+    // ⌘ is a locale-independent Apple glyph; the "Ctrl" label localizes (STRG in German).
+    const searchShortcut = IS_APPLE_PLATFORM
+      ? "⌘K"
+      : this._localize("layout.search_shortcut");
     return html`
       <button
         type="button"
@@ -324,7 +326,7 @@ export class ESPHomeHeaderActions extends LitElement {
                 >
                   <wa-icon library="mdi" name="magnify"></wa-icon>
                   <span class="menu-item-label">${this._localize("layout.search")}</span>
-                  <kbd class="menu-item-shortcut">${SEARCH_SHORTCUT}</kbd>
+                  <kbd class="menu-item-shortcut">${searchShortcut}</kbd>
                 </div>
                 <div class="menu-divider" role="separator"></div>
                 <div

--- a/src/components/esphome-header-actions.ts
+++ b/src/components/esphome-header-actions.ts
@@ -131,6 +131,10 @@ export class ESPHomeHeaderActions extends LitElement {
   @state()
   private _desktopUpdateCapable = false;
 
+  /** Computed once per instance: the platform is constant for a session, so
+   *  the search-shortcut check needn't re-run the regex on every render. */
+  private readonly _isApplePlatform = isApplePlatform();
+
   static styles = [espHomeStyles, dropdownMenuStyles, headerActionsStyles];
 
   connectedCallback(): void {
@@ -165,7 +169,7 @@ export class ESPHomeHeaderActions extends LitElement {
     const hasAlerts = this._offloaderAlertsCount() > 0;
     const ignoredCount = this._importableDevices.filter((d) => d.ignored).length;
     // ⌘ is a locale-independent Apple glyph; the "Ctrl" label localizes (STRG in German).
-    const searchShortcut = isApplePlatform()
+    const searchShortcut = this._isApplePlatform
       ? "⌘K"
       : this._localize("layout.search_shortcut");
     return html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -995,6 +995,7 @@
     "theme_system": "System",
     "settings": "Settings",
     "search": "Search commands",
+    "search_shortcut": "Ctrl K",
     "archived_devices": "Archived devices",
     "show_ignored_discoveries": "Show ignored discoveries ({count})",
     "hide_ignored_discoveries": "Hide ignored discoveries",

--- a/test/components/_esphome-header-actions-helpers.ts
+++ b/test/components/_esphome-header-actions-helpers.ts
@@ -6,17 +6,20 @@
  * gating prop they set first, so that boilerplate lives here rather than
  * getting copy-pasted per suite.
  */
+import type { LocalizeFunc } from "../../src/common/localize.js";
 import { ESPHomeHeaderActions } from "../../src/components/esphome-header-actions.js";
 
 /**
  * Gating flags the kebab-menu suites toggle before opening the menu — the
  * public ``dashboardRoute`` prop and the private ``_desktopUpdateCapable``
- * state. Narrowly typed (rather than ``Record<string, unknown>``) so a typo
- * in a gate name is a compile error; extend it as new suites need more gates.
+ * state, plus a ``_localize`` stub for suites asserting localized copy.
+ * Narrowly typed (rather than ``Record<string, unknown>``) so a typo in a
+ * gate name is a compile error; extend it as new suites need more gates.
  */
 export interface HeaderMenuOverrides {
   dashboardRoute?: boolean;
   _desktopUpdateCapable?: boolean;
+  _localize?: LocalizeFunc;
 }
 
 /**

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -32,6 +32,23 @@ describe("header-actions Search item", () => {
     );
   });
 
+  it("keeps the ⌘ glyph on Apple platforms, never the localized label", async () => {
+    Object.defineProperty(navigator, "userAgentData", {
+      value: { platform: "macOS" },
+      configurable: true,
+    });
+    try {
+      const el = await renderOpenHeaderMenu({
+        _localize: (key) => (key === "layout.search_shortcut" ? "Strg K" : key),
+      });
+      expect(
+        el.shadowRoot!.querySelector(".menu-item-shortcut")!.textContent!.trim()
+      ).toBe("⌘K");
+    } finally {
+      Reflect.deleteProperty(navigator, "userAgentData");
+    }
+  });
+
   it("fires the open-palette event and closes the menu on click", async () => {
     const el = await renderOpenHeaderMenu();
     const listener = vi.fn();

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -23,6 +23,15 @@ describe("header-actions Search item", () => {
     expect(el.shadowRoot!.querySelector(".menu-item-shortcut")).not.toBeNull();
   });
 
+  it("localizes the Ctrl shortcut hint so it can be translated (e.g. STRG)", async () => {
+    const el = await renderOpenHeaderMenu({
+      _localize: (key) => (key === "layout.search_shortcut" ? "Strg K" : key),
+    });
+    expect(el.shadowRoot!.querySelector(".menu-item-shortcut")!.textContent!.trim()).toBe(
+      "Strg K"
+    );
+  });
+
   it("fires the open-palette event and closes the menu on click", async () => {
     const el = await renderOpenHeaderMenu();
     const listener = vi.fn();

--- a/test/components/esphome-header-actions-search.test.ts
+++ b/test/components/esphome-header-actions-search.test.ts
@@ -33,6 +33,7 @@ describe("header-actions Search item", () => {
   });
 
   it("keeps the ⌘ glyph on Apple platforms, never the localized label", async () => {
+    const original = Object.getOwnPropertyDescriptor(navigator, "userAgentData");
     Object.defineProperty(navigator, "userAgentData", {
       value: { platform: "macOS" },
       configurable: true,
@@ -45,7 +46,11 @@ describe("header-actions Search item", () => {
         el.shadowRoot!.querySelector(".menu-item-shortcut")!.textContent!.trim()
       ).toBe("⌘K");
     } finally {
-      Reflect.deleteProperty(navigator, "userAgentData");
+      if (original) {
+        Object.defineProperty(navigator, "userAgentData", original);
+      } else {
+        Reflect.deleteProperty(navigator, "userAgentData");
+      }
     }
   });
 


### PR DESCRIPTION
# What does this implement/fix?

The Ctrl+K search shortcut hint in the header menu was hardcoded, so it always read "Ctrl K" no matter the language; on a German keyboard the Control key is labelled STRG. This routes the non-Apple label through the existing localization system so translators can localize it, for example "Strg K". The Apple command glyph stays hardcoded since it is the same in every locale.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1860

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
