### PR TITLE
Say a device has no Native API instead of waiting on mDNS

### DIFF
--- a/src/components/dashboard/device-drawer-content/render-sections.ts
+++ b/src/components/dashboard/device-drawer-content/render-sections.ts
@@ -47,6 +47,17 @@ export function renderRow(
   `;
 }
 
+// MAC address and deployed config hash reach the dashboard only over the
+// native-API mDNS service (_esphomelib._tcp); a device with no api: never
+// broadcasts them, so a "waiting for mDNS" spinner would spin forever. Gate on
+// api_enabled (the field can never arrive), not mdnsOnline() (only whether mDNS
+// is live right now). Mirrors the api_enabled gate in encryption-state.
+function emptyMdnsText(d: ConfiguredDevice, localize: LocalizeFunc): string {
+  return localize(
+    d.api_enabled ? "dashboard.drawer_waiting_for_mdns" : "dashboard.drawer_no_native_api"
+  );
+}
+
 export function renderEncryptionBadge(
   localize: LocalizeFunc,
   state: EncryptionState
@@ -232,7 +243,7 @@ export function renderConfigHashSection(
                 localize("dashboard.drawer_config_hash_deployed"),
                 deployed,
                 true,
-                localize("dashboard.drawer_waiting_for_mdns")
+                emptyMdnsText(d, localize)
               )}
             `
       }
@@ -360,7 +371,7 @@ export function renderMacAddressRow(
     localize("dashboard.drawer_mac_address"),
     d.mac_address,
     true,
-    localize("dashboard.drawer_waiting_for_mdns")
+    emptyMdnsText(d, localize)
   );
 }
 
@@ -392,7 +403,9 @@ export function renderEthernetMacRow(
       true
     );
   }
-  if (!d.mac_address && deviceHasEthernet(d)) {
+  // Only a waiting hint; hidden when there's no native API to deliver it (the
+  // primary MAC row already says so, so don't repeat it here).
+  if (!d.mac_address && d.api_enabled && deviceHasEthernet(d)) {
     return renderRow(
       "ethernet",
       localize("dashboard.drawer_ethernet_mac"),
@@ -416,7 +429,7 @@ export function renderBluetoothMacRow(
       true
     );
   }
-  if (!d.mac_address && deviceHasBluetooth(d)) {
+  if (!d.mac_address && d.api_enabled && deviceHasBluetooth(d)) {
     return renderRow(
       "bluetooth",
       localize("dashboard.drawer_bluetooth_mac"),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -233,6 +233,7 @@
     "drawer_round_trip_ms": "{n} ms",
     "drawer_waiting_for_signal": "Waiting for first signal…",
     "drawer_waiting_for_mdns": "Waiting for mDNS discovery…",
+    "drawer_no_native_api": "This device does not have Native API",
     "drawer_show_mdns_txt_records": "{count, plural, one {Show # mDNS TXT record} other {Show # mDNS TXT records}}",
     "drawer_mdns_expires_in": "Expires in {t}",
     "drawer_mdns_expires_soon": "Expires soon",

--- a/test/components/dashboard/render-mac-address-row.test.ts
+++ b/test/components/dashboard/render-mac-address-row.test.ts
@@ -1,6 +1,11 @@
 /**
- * Pins that mDNS-derived rows (MAC, deployed version) show
- * "Waiting for mDNS discovery" instead of a bare dash while empty (#1453).
+ * Empty-state behaviour of the drawer's mDNS-derived rows.
+ *
+ * MAC address and deployed config hash show "Waiting for mDNS discovery" while a
+ * native-API device hasn't announced (#1453), but "This device does not have
+ * Native API" for a no-api device whose MAC / config hash can never arrive; the
+ * ethernet / bluetooth waiting rows hide entirely for such devices. The deployed
+ * version row is exempt: it can still arrive over the _http._tcp fallback.
  */
 import { nothing } from "lit";
 import { describe, expect, it } from "vitest";
@@ -22,9 +27,20 @@ const valueTexts = (result: unknown): unknown[] =>
   findTemplatesByAnchor(result, 'class="value').flatMap((t) => t.values);
 
 describe("renderMacAddressRow", () => {
-  it("shows the waiting-for-mDNS message when mac_address is empty", () => {
-    const result = renderMacAddressRow(_device({ mac_address: "" }), _localize);
+  it("shows the waiting-for-mDNS message when a native-API device hasn't announced", () => {
+    const result = renderMacAddressRow(
+      _device({ mac_address: "", api_enabled: true }),
+      _localize
+    );
     expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("says the device has no Native API when api is disabled", () => {
+    const result = renderMacAddressRow(
+      _device({ mac_address: "", api_enabled: false }),
+      _localize
+    );
+    expect(valueTexts(result)).toContain("dashboard.drawer_no_native_api");
   });
 
   it("shows the MAC when present", () => {
@@ -50,6 +66,7 @@ describe("renderEthernetMacRow", () => {
       _device({
         mac_address: "",
         ethernet_mac: "",
+        api_enabled: true,
         loaded_integrations: ["ethernet", "wifi"],
       }),
       _localize
@@ -57,9 +74,27 @@ describe("renderEthernetMacRow", () => {
     expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
   });
 
+  it("hides the waiting hint when the device has no Native API", () => {
+    const result = renderEthernetMacRow(
+      _device({
+        mac_address: "",
+        ethernet_mac: "",
+        api_enabled: false,
+        loaded_integrations: ["ethernet", "wifi"],
+      }),
+      _localize
+    );
+    expect(result).toBe(nothing);
+  });
+
   it("hides when the device has no ethernet integration", () => {
     const result = renderEthernetMacRow(
-      _device({ mac_address: "", ethernet_mac: "", loaded_integrations: ["wifi"] }),
+      _device({
+        mac_address: "",
+        ethernet_mac: "",
+        api_enabled: true,
+        loaded_integrations: ["wifi"],
+      }),
       _localize
     );
     expect(result).toBe(nothing);
@@ -84,6 +119,7 @@ describe("renderBluetoothMacRow", () => {
       _device({
         mac_address: "",
         bluetooth_mac: "",
+        api_enabled: true,
         loaded_integrations: ["esp32_ble_tracker"],
       }),
       _localize
@@ -91,9 +127,27 @@ describe("renderBluetoothMacRow", () => {
     expect(valueTexts(result)).toContain("dashboard.drawer_waiting_for_mdns");
   });
 
+  it("hides the waiting hint when the device has no Native API", () => {
+    const result = renderBluetoothMacRow(
+      _device({
+        mac_address: "",
+        bluetooth_mac: "",
+        api_enabled: false,
+        loaded_integrations: ["esp32_ble_tracker"],
+      }),
+      _localize
+    );
+    expect(result).toBe(nothing);
+  });
+
   it("hides when the device loads no bluetooth integration", () => {
     const result = renderBluetoothMacRow(
-      _device({ mac_address: "", bluetooth_mac: "", loaded_integrations: ["wifi"] }),
+      _device({
+        mac_address: "",
+        bluetooth_mac: "",
+        api_enabled: true,
+        loaded_integrations: ["wifi"],
+      }),
       _localize
     );
     expect(result).toBe(nothing);
@@ -102,6 +156,8 @@ describe("renderBluetoothMacRow", () => {
 
 describe("renderVersionSection deployed row", () => {
   it("shows waiting-for-mDNS on the deployed row when only the local version is known", () => {
+    // Version is NOT gated on api_enabled: it can still arrive over the
+    // _http._tcp mDNS fallback for MQTT-only devices.
     const result = renderVersionSection(
       _device({ current_version: "2026.5.2", deployed_version: "" }),
       _localize
@@ -113,13 +169,31 @@ describe("renderVersionSection deployed row", () => {
 });
 
 describe("renderConfigHashSection deployed row", () => {
-  it("shows waiting-for-mDNS on the deployed hash when only the local hash is known", () => {
+  it("shows waiting-for-mDNS on the deployed hash for a native-API device", () => {
     const result = renderConfigHashSection(
-      _device({ expected_config_hash: "abc123", deployed_config_hash: "" }),
+      _device({
+        expected_config_hash: "abc123",
+        deployed_config_hash: "",
+        api_enabled: true,
+      }),
       _localize
     );
     const texts = valueTexts(result);
     expect(texts).toContain("abc123");
     expect(texts).toContain("dashboard.drawer_waiting_for_mdns");
+  });
+
+  it("says the device has no Native API on the deployed hash when api is disabled", () => {
+    const result = renderConfigHashSection(
+      _device({
+        expected_config_hash: "abc123",
+        deployed_config_hash: "",
+        api_enabled: false,
+      }),
+      _localize
+    );
+    const texts = valueTexts(result);
+    expect(texts).toContain("abc123");
+    expect(texts).toContain("dashboard.drawer_no_native_api");
   });
 });


### PR DESCRIPTION
# What does this implement/fix?

A device with `mqtt:` but no `api:` can never report its MAC address or deployed config hash; those only arrive over the native-API mDNS service (`_esphomelib._tcp`). The drawer still showed "Waiting for mDNS discovery…" on those rows, so they spun forever. This shows "This device does not have Native API" on the MAC and deployed config hash rows instead, and hides the redundant ethernet/bluetooth waiting rows for such devices since the primary MAC row already carries the message. It mirrors the existing `api_enabled` gate in `encryption-state`.

The deployed version row is deliberately left alone; a version can still arrive over the `_http._tcp` mDNS fallback for these devices, so "Waiting for mDNS…" there is still accurate.

**Related issue or feature (if applicable):**

- Related to esphome/device-builder#1865

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
