### PR TITLE
Refuse flashing chips misdetected as ESP32-P4 with an actionable error

### DIFF
--- a/src/components/dashboard/actions.ts
+++ b/src/components/dashboard/actions.ts
@@ -16,6 +16,7 @@ import {
   isPortPickerCancel,
   readDeviceManifest,
   readMacAddress,
+  UnsupportedChipError,
 } from "../../util/web-serial.js";
 import { chipNameToFilterLabel } from "../wizard/wizard-step-board-platforms.js";
 
@@ -357,9 +358,11 @@ export async function detectAndOpenWizard(
     // failure gets named instead of vanishing (#1414).
     if (!isPortPickerCancel(err) && options.localize) {
       notifyError(
-        options.localize("dashboard.serial_connect_failed", {
-          error: getErrorMessage(err),
-        })
+        err instanceof UnsupportedChipError
+          ? options.localize("serial.unsupported_chip", { chip: err.chipName })
+          : options.localize("dashboard.serial_connect_failed", {
+              error: getErrorMessage(err),
+            })
       );
     }
     createDialog.open("board");

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -16,6 +16,7 @@ import {
   flashFirmware,
   isPortPickerCancel,
   resetAndDisconnect,
+  UnsupportedChipError,
   type DetectedChip,
 } from "../../util/web-serial.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
@@ -88,6 +89,10 @@ export async function startWebSerialInstall(
   } catch (err) {
     if (isPortPickerCancel(err)) {
       host._close();
+      return;
+    }
+    if (err instanceof UnsupportedChipError) {
+      host._fail(host._localize("serial.unsupported_chip", { chip: err.chipName }));
       return;
     }
     // The picker succeeded but the chip never answered — fail loud with

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -487,7 +487,8 @@
     "downloading": "Downloading {file}…",
     "flashing": "Flashing firmware…",
     "resetting": "Resetting device…",
-    "connect_failed": "Could not connect to the device. Unplug and replug the cable, hold the BOOT button while plugging in, or try another USB port or browser."
+    "connect_failed": "Could not connect to the device. Unplug and replug the cable, hold the BOOT button while plugging in, or try another USB port or browser.",
+    "unsupported_chip": "This looks like an {chip}, which browser flashing doesn't support yet. Download the firmware and flash it from the command line with esptool instead."
   },
   "wizard": {
     "title_create": "Create configuration",

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -62,6 +62,64 @@ export function isPortPickerCancel(err: unknown): boolean {
   return err instanceof DOMException && err.name === "NotFoundError";
 }
 
+/** GET_SECURITY_INFO ROM command opcode (esptool.py's ``ESP_GET_SECURITY_INFO``). */
+const ESP_GET_SECURITY_INFO = 0x14;
+
+/** ``chip_id`` a genuine ESP32-P4 reports in its security info. */
+const ESP32P4_CHIP_ID = 18;
+
+// chip_id values (esptool.py IMAGE_CHIP_ID) of chips esptool-js has no target
+// for. They all read 0 at the magic-detect register and get claimed as an
+// ESP32-P4 (espressif/esptool-js#248).
+const UNSUPPORTED_CHIP_NAMES: Record<number, string> = {
+  25: "ESP32-H21",
+  28: "ESP32-H4",
+  31: "ESP32-E22",
+  32: "ESP32-S31",
+};
+
+/** The connected chip has no esptool-js target; flashing needs the esptool CLI. */
+export class UnsupportedChipError extends Error {
+  readonly chipName: string;
+
+  constructor(chipName: string) {
+    super(`${chipName} is not supported by browser flashing yet`);
+    this.name = "UnsupportedChipError";
+    this.chipName = chipName;
+  }
+}
+
+/**
+ * Refuse a "detected ESP32-P4" that is really a newer, unsupported chip.
+ *
+ * esptool-js identifies chips by the legacy magic register alone and maps the
+ * value 0 to ESP32-P4; newer chips (S31, H21, H4, E22, …) read 0 there too, so
+ * they get claimed as a P4 and the P4 stub flasher then wedges the session
+ * (espressif/esptool-js#248, backend log ends at "Uploading stub..."). Cross-
+ * check the ROM's GET_SECURITY_INFO chip_id — the signal esptool.py identifies
+ * these chips by — and throw ``UnsupportedChipError`` before the stub upload.
+ * Fails open on any command / response-shape problem so a genuine P4 that
+ * can't answer keeps today's behaviour.
+ */
+async function guardMisdetectedP4(loader: ESPLoader): Promise<void> {
+  if (loader.chip?.CHIP_NAME !== "ESP32-P4") return;
+  let data: Uint8Array;
+  try {
+    [, data] = await loader.command(ESP_GET_SECURITY_INFO);
+  } catch {
+    return;
+  }
+  // flags(4) + flash_crypt_cnt(1) + key_purposes(7) + chip_id(4) +
+  // api_version(4), then trailing status bytes; chip_id parses from the
+  // front regardless of how many status bytes the ROM appends.
+  if (data.length < 20) return;
+  const chipId = new DataView(data.buffer, data.byteOffset).getUint32(12, true);
+  if (chipId === ESP32P4_CHIP_ID) return;
+  throw new UnsupportedChipError(
+    UNSUPPORTED_CHIP_NAMES[chipId] ?? `unsupported ESP chip (chip id ${chipId})`
+  );
+}
+
 /**
  * The ``127.0.0.1`` equivalent of a dashboard opened on ``0.0.0.0`` — same
  * port and path. ``0.0.0.0`` is reachable only from the same machine (it
@@ -142,6 +200,14 @@ export async function connectToPort(
   });
 
   try {
+    // main() has no hook between magic-register chip detection and the stub
+    // upload, so wrap runStub to cross-check the chip id first. Remove when
+    // espressif/esptool-js#248 lands.
+    const runStub = loader.runStub.bind(loader);
+    loader.runStub = async () => {
+      await guardMisdetectedP4(loader);
+      return runStub();
+    };
     const chipName = await loader.main();
     return { chipName, port, transport, loader };
   } catch (error) {

--- a/src/util/web-serial.ts
+++ b/src/util/web-serial.ts
@@ -83,7 +83,12 @@ export class UnsupportedChipError extends Error {
   readonly chipName: string;
 
   constructor(chipName: string) {
-    super(`${chipName} is not supported by browser flashing yet`);
+    // Surfaces raw through err.message on the wizard / dashboard-scan paths,
+    // so the message itself carries the next step.
+    super(
+      `${chipName} is not supported by browser flashing yet — download the ` +
+        `firmware and flash it with esptool from the command line instead`
+    );
     this.name = "UnsupportedChipError";
     this.chipName = chipName;
   }
@@ -109,10 +114,10 @@ async function guardMisdetectedP4(loader: ESPLoader): Promise<void> {
   } catch {
     return;
   }
-  // flags(4) + flash_crypt_cnt(1) + key_purposes(7) + chip_id(4) +
-  // api_version(4), then trailing status bytes; chip_id parses from the
-  // front regardless of how many status bytes the ROM appends.
-  if (data.length < 20) return;
+  // flags(4) + flash_crypt_cnt(1) + key_purposes(7) + chip_id(4), then
+  // api_version and trailing status bytes; chip_id parses from the front
+  // regardless of how many bytes the ROM appends after it.
+  if (data.length < 16) return;
   const chipId = new DataView(data.buffer, data.byteOffset).getUint32(12, true);
   if (chipId === ESP32P4_CHIP_ID) return;
   throw new UnsupportedChipError(

--- a/test/util/web-serial-unsupported-chip.test.ts
+++ b/test/util/web-serial-unsupported-chip.test.ts
@@ -120,11 +120,24 @@ describe("connectToPort — misdetected-P4 guard", () => {
   });
 
   it("fails open on a response too short to carry a chip id", async () => {
-    state.securityInfo = () => Promise.resolve([0, new Uint8Array(14)]);
+    state.securityInfo = () => Promise.resolve([0, new Uint8Array(15)]);
 
     await connectToPort(fakePort);
 
     expect(state.stubRuns).toBe(1);
+  });
+
+  it("refuses on the minimal 16-byte response carrying a chip id", async () => {
+    state.securityInfo = () => {
+      const data = new Uint8Array(16);
+      new DataView(data.buffer).setUint32(12, 32, true);
+      return Promise.resolve([0, data]);
+    };
+
+    const err = await connectToPort(fakePort).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UnsupportedChipError);
+    expect(state.stubRuns).toBe(0);
   });
 
   it("never queries security info on a non-P4 detection", async () => {

--- a/test/util/web-serial-unsupported-chip.test.ts
+++ b/test/util/web-serial-unsupported-chip.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * esptool-js maps the magic-register value 0 to ESP32-P4, so newer chips it
+ * has no target for (ESP32-S31, H21, H4, E22) are misdetected as a P4 and the
+ * P4 stub upload then wedges the session (espressif/esptool-js#248, #1114).
+ * ``connectToPort`` cross-checks the GET_SECURITY_INFO chip_id before the
+ * stub upload and refuses with ``UnsupportedChipError``; anything short of a
+ * confirmed mismatch fails open to today's behaviour.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state: {
+  chip: { CHIP_NAME: string } | null;
+  securityInfo: () => Promise<[number, Uint8Array]>;
+  stubRuns: number;
+  commandOps: number[];
+} = {
+  chip: null,
+  securityInfo: () => Promise.reject(new Error("unset")),
+  stubRuns: 0,
+  commandOps: [],
+};
+
+vi.mock("esptool-js", () => {
+  class Transport {
+    constructor(
+      public port: unknown,
+      public trace: boolean
+    ) {}
+
+    async disconnect() {}
+  }
+  class ESPLoader {
+    chip: { CHIP_NAME: string } | null = null;
+
+    constructor(public options: unknown) {}
+
+    async command(op: number): Promise<[number, Uint8Array]> {
+      state.commandOps.push(op);
+      return state.securityInfo();
+    }
+
+    async runStub() {
+      state.stubRuns += 1;
+      return this.chip;
+    }
+
+    // Mirrors the real main() order: chip detection first, stub upload after.
+    async main() {
+      this.chip = state.chip;
+      await this.runStub();
+      return this.chip?.CHIP_NAME ?? "unknown";
+    }
+  }
+  class UsbJtagSerialReset {}
+  return { ESPLoader, Transport, UsbJtagSerialReset };
+});
+
+import { connectToPort, UnsupportedChipError } from "../../src/util/web-serial.js";
+
+const GET_SECURITY_INFO = 0x14;
+
+const fakePort = { close: vi.fn().mockResolvedValue(undefined) } as unknown as SerialPort;
+
+// 20-byte security-info payload (flags, flash_crypt_cnt, key_purposes,
+// chip_id, api_version) plus 2 trailing status bytes.
+function securityInfo(chipId: number): [number, Uint8Array] {
+  const data = new Uint8Array(22);
+  new DataView(data.buffer).setUint32(12, chipId, true);
+  return [0, data];
+}
+
+beforeEach(() => {
+  state.chip = { CHIP_NAME: "ESP32-P4" };
+  state.securityInfo = () => Promise.reject(new Error("unset"));
+  state.stubRuns = 0;
+  state.commandOps = [];
+});
+
+describe("connectToPort — misdetected-P4 guard", () => {
+  it("refuses an ESP32-S31 before the stub upload", async () => {
+    state.securityInfo = () => Promise.resolve(securityInfo(32));
+
+    const err = await connectToPort(fakePort).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UnsupportedChipError);
+    expect((err as UnsupportedChipError).chipName).toBe("ESP32-S31");
+    expect(state.stubRuns).toBe(0);
+    expect(state.commandOps).toEqual([GET_SECURITY_INFO]);
+  });
+
+  it("names an unknown chip id it has no name for", async () => {
+    state.securityInfo = () => Promise.resolve(securityInfo(99));
+
+    const err = await connectToPort(fakePort).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UnsupportedChipError);
+    expect((err as UnsupportedChipError).chipName).toBe(
+      "unsupported ESP chip (chip id 99)"
+    );
+  });
+
+  it("lets a genuine ESP32-P4 through to the stub", async () => {
+    state.securityInfo = () => Promise.resolve(securityInfo(18));
+
+    const detected = await connectToPort(fakePort);
+
+    expect(detected.chipName).toBe("ESP32-P4");
+    expect(state.stubRuns).toBe(1);
+  });
+
+  it("fails open when GET_SECURITY_INFO errors", async () => {
+    state.securityInfo = () => Promise.reject(new Error("command not supported"));
+
+    const detected = await connectToPort(fakePort);
+
+    expect(detected.chipName).toBe("ESP32-P4");
+    expect(state.stubRuns).toBe(1);
+  });
+
+  it("fails open on a response too short to carry a chip id", async () => {
+    state.securityInfo = () => Promise.resolve([0, new Uint8Array(14)]);
+
+    await connectToPort(fakePort);
+
+    expect(state.stubRuns).toBe(1);
+  });
+
+  it("never queries security info on a non-P4 detection", async () => {
+    state.chip = { CHIP_NAME: "ESP32-S3" };
+
+    const detected = await connectToPort(fakePort);
+
+    expect(detected.chipName).toBe("ESP32-S3");
+    expect(state.commandOps).toEqual([]);
+    expect(state.stubRuns).toBe(1);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

esptool-js identifies chips by the legacy magic register alone and maps the value 0 to ESP32-P4. Newer chips it has no target for (ESP32-S31, H21, H4, E22) read 0 there too, so they get claimed as a P4, the P4 stub flasher is uploaded to them, and the session dies mid upload. The user then sees the generic "Could not connect to the device. Unplug and replug the cable..." advice for what is actually unsupported silicon (#1114).

`connectToPort` now cross-checks the ROM's GET_SECURITY_INFO chip_id (the signal Python esptool identifies these chips by) whenever the magic detect claims a P4, and refuses before the stub upload with a typed `UnsupportedChipError`. The install dialog shows "This looks like an ESP32-S31, which browser flashing doesn't support yet. Download the firmware and flash it from the command line with esptool instead."; the wizard and dashboard entry points surface the error's own message through their existing error paths.

The guard fails open: non-P4 detections skip it entirely, and any command error or short response proceeds to the stub exactly as today, so a genuine P4 can't be locked out by the check. Real browser flashing support for these chips is upstream work, tracked in espressif/esptool-js#248; this PR only replaces the doomed stub upload and misleading advice with an honest, actionable error.

**Related issue or feature (if applicable):**

- fixes #1114 (ESP32-S31 flashing itself is upstream work: espressif/esptool-js#248)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
