### PR TITLE
Share isValidationFailureLine between the command and install dialogs

### DIFF
--- a/src/components/command-dialog/commands.ts
+++ b/src/components/command-dialog/commands.ts
@@ -1,8 +1,8 @@
 import { APIError } from "../../api/api-error.js";
 import { type FirmwareJob, JobStatus, JobType } from "../../api/types/firmware-jobs.js";
 import { ErrorCode } from "../../api/types/protocol.js";
-import { stripAnsiSgr } from "../../util/ansi-escapes.js";
 import { isTerminalJobStatus } from "../../util/firmware-job-status.js";
+import { isValidationFailureLine } from "../../util/validation-log.js";
 import { classifyNoCompatiblePeerReason } from "../../util/version-mismatch.js";
 import type { CommandType, ESPHomeCommandDialog } from "../command-dialog.js";
 
@@ -44,20 +44,6 @@ export function findDependentUpload(
     if (j.depends_on === job.job_id && j.job_type === JobType.UPLOAD) return j;
   }
   return undefined;
-}
-
-// Anchored ERROR prefix so a debug line that quotes the phrase can't match.
-// Log format is "<asctime>? <LEVEL> <message>" (esphome/log.py).
-const LOADER_ERROR = /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
-
-// Two distinct ESPHome validation-failure markers:
-//   "Failed config" — schema-validator banner from esphome/config.py
-//   "ERROR Error while reading config: …" — YAML-load step _LOGGER.error
-// Both indicate the build never reached C++ compile; clean/reset can't help.
-export function isValidationFailureLine(line: string): boolean {
-  const stripped = stripAnsiSgr(line).trim();
-  if (stripped === "Failed config") return true;
-  return LOADER_ERROR.test(stripped);
 }
 
 export async function detachStream(host: ESPHomeCommandDialog): Promise<void> {

--- a/src/components/firmware-install-dialog/install-flow.ts
+++ b/src/components/firmware-install-dialog/install-flow.ts
@@ -3,7 +3,6 @@ import {
   JobStatus,
   type FirmwareBinary,
 } from "../../api/types/firmware-jobs.js";
-import { stripAnsiSgr } from "../../util/ansi-escapes.js";
 import { fetchBoard } from "../../util/board-body-cache.js";
 import { chipNameToVariant, chipPlatformFamily } from "../../util/chip-variant.js";
 import { triggerDownload } from "../../util/download-text.js";
@@ -11,6 +10,7 @@ import { getErrorMessage } from "../../util/error-message.js";
 import { formatApiError } from "../../util/format-api-error.js";
 import { dispatchShowLogsAfterInstall } from "../../util/post-install-logs.js";
 import { openFlasher } from "../../util/usb-flasher.js";
+import { isValidationFailureLine } from "../../util/validation-log.js";
 import {
   detectChip,
   disconnect,
@@ -22,16 +22,6 @@ import {
 } from "../../util/web-serial.js";
 import type { ESPHomeFirmwareInstallDialog } from "../firmware-install-dialog.js";
 import { OTA_PORT } from "../logs-session.js";
-
-const LOADER_ERROR = /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
-
-// "Failed config" — bold-red schema-validator banner; ERROR-prefixed line is
-// the YAML-load step's _LOGGER.error. Both mean the build never reached C++.
-export function isValidationFailureLine(line: string): boolean {
-  const stripped = stripAnsiSgr(line).trim();
-  if (stripped === "Failed config") return true;
-  return LOADER_ERROR.test(stripped);
-}
 
 export function compileFailureDetail(err: unknown): string {
   return err instanceof Error ? err.message.trim() : String(err ?? "").trim();

--- a/src/util/validation-log.ts
+++ b/src/util/validation-log.ts
@@ -1,0 +1,21 @@
+import { stripAnsiSgr } from "./ansi-escapes.js";
+
+// Anchored ERROR prefix so a debug line that quotes the phrase can't match.
+// Log format is "<asctime>? <LEVEL> <message>" (esphome/log.py).
+const LOADER_ERROR = /^(?:\d{2}:\d{2}:\d{2}\s+)?ERROR Error while reading config:/;
+
+/**
+ * True when a compile-log line marks an ESPHome validation failure.
+ *
+ * Two distinct markers:
+ *   "Failed config" — bold-red schema-validator banner from esphome/config.py
+ *   "ERROR Error while reading config: …" — YAML-load step _LOGGER.error
+ * Both indicate the build never reached C++ compile, so clean/reset
+ * suggestions can't help; the command and firmware-install dialogs use
+ * this to route the user to the YAML editor instead.
+ */
+export function isValidationFailureLine(line: string): boolean {
+  const stripped = stripAnsiSgr(line).trim();
+  if (stripped === "Failed config") return true;
+  return LOADER_ERROR.test(stripped);
+}

--- a/test/util/validation-log.test.ts
+++ b/test/util/validation-log.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isValidationFailureLine } from "../../src/util/validation-log.js";
+
+describe("isValidationFailureLine", () => {
+  it("matches the bare schema-validator banner", () => {
+    expect(isValidationFailureLine("Failed config")).toBe(true);
+  });
+
+  it("matches the banner wrapped in SGR colour codes", () => {
+    /* The dashboard stream pins the escaped ``\033`` form; the raw
+       ESC-byte branch is defensive. Both must classify. */
+    expect(isValidationFailureLine("\\033[1;31mFailed config\\033[0m")).toBe(true);
+    expect(isValidationFailureLine("\u001b[1;31mFailed config\u001b[0m")).toBe(true);
+  });
+
+  it("matches the YAML-load ERROR line with and without a timestamp", () => {
+    expect(
+      isValidationFailureLine("ERROR Error while reading config: yaml scan error")
+    ).toBe(true);
+    expect(
+      isValidationFailureLine("12:34:56 ERROR Error while reading config: bad key")
+    ).toBe(true);
+  });
+
+  it("ignores ordinary log lines", () => {
+    expect(isValidationFailureLine("INFO Compiling firmware")).toBe(false);
+    expect(isValidationFailureLine("")).toBe(false);
+  });
+
+  it("ignores a line that merely quotes the markers mid-sentence", () => {
+    /* LOADER_ERROR is anchored so a debug line that quotes the phrase
+       can't match, and the banner check is exact-equality. */
+    expect(
+      isValidationFailureLine("DEBUG saw 'ERROR Error while reading config:' earlier")
+    ).toBe(false);
+    expect(isValidationFailureLine("Failed config parsing will retry")).toBe(false);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

`command-dialog/commands.ts` and `firmware-install-dialog/install-flow.ts` carried byte identical copies of `isValidationFailureLine()` and its `LOADER_ERROR` regex, so any tweak to how we classify a failed validate line had to be made twice. This moves the helper to `src/util/validation-log.ts`, imports it from both dialogs, and adds unit tests for the two markers, the ANSI wrapped forms, and the anchored non-matches; no behavior change.

Uses the shared `stripAnsiSgr` from #1127, which has since merged; the branch is rebased onto main.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1124

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
