### PR TITLE
Attribute and target id-less sub-entities via synthetic ids

### DIFF
--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -217,11 +217,13 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     const prefillContainer = this._prefillContainer();
     const showComponentRow =
       this._kind === "component_on" && (!this._prefilled || !!prefillContainer);
-    // A container with no configured sub-entities has no valid target;
+    // A container with no selectable sub-entities has no valid target;
     // explain instead of showing an empty picker with a dead Add button.
     const containerEmpty =
       !!prefillContainer &&
-      !this._available?.devices.some((d) => d.parent_id === prefillContainer.id);
+      !firstSelectableTarget(
+        scopeToContainer(this._available?.devices ?? [], prefillContainer)
+      );
     return html`
       <p class="intro">
         ${renderMarkdown(this._localize("device.automation_header_description"))}

--- a/src/components/device/add-automation-dialog.ts
+++ b/src/components/device/add-automation-dialog.ts
@@ -217,6 +217,11 @@ export class ESPHomeAddAutomationDialog extends LitElement {
     const prefillContainer = this._prefillContainer();
     const showComponentRow =
       this._kind === "component_on" && (!this._prefilled || !!prefillContainer);
+    // A container with no configured sub-entities has no valid target;
+    // explain instead of showing an empty picker with a dead Add button.
+    const containerEmpty =
+      !!prefillContainer &&
+      !this._available?.devices.some((d) => d.parent_id === prefillContainer.id);
     return html`
       <p class="intro">
         ${renderMarkdown(this._localize("device.automation_header_description"))}
@@ -250,9 +255,17 @@ export class ESPHomeAddAutomationDialog extends LitElement {
             </div>`
           : nothing
       }
-      ${showComponentRow ? this._renderComponentRow(prefillContainer) : nothing}
-      ${this._kind === "interval" ? this._renderIntervalRow() : nothing}
-      ${!triggerLocked ? this._renderTriggerRow(filteredTriggers) : nothing}
+      ${
+        containerEmpty
+          ? html`<p class="field-desc">
+              ${this._localize("device.automation_container_no_entities")}
+            </p>`
+          : html`
+              ${showComponentRow ? this._renderComponentRow(prefillContainer) : nothing}
+              ${this._kind === "interval" ? this._renderIntervalRow() : nothing}
+              ${!triggerLocked ? this._renderTriggerRow(filteredTriggers) : nothing}
+            `
+      }
       ${this._error ? html`<p class="error" role="alert">${this._error}</p>` : nothing}
       <div class="actions">
         <button

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -855,6 +855,7 @@
     "automation_pick_no_results": "Nothing matched your search.",
     "automation_trigger_on_component": "Trigger fired by {component} ({domain})",
     "automation_trigger_none_available": "No triggers available for this target.",
+    "automation_container_no_entities": "This component has no entities enabled yet. Enable one of its entities first, then add the automation.",
     "automation_trigger": "Trigger",
     "automation_trigger_label": "When",
     "automation_action_field_edit": "Edit actions",

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -31,7 +31,7 @@ const _COMPONENT_ACTION_FIELD_RE = /^(\s+)([a-z0-9_]+_action):/;
 /** An inline ``on_*:`` trigger handler: group 1 the indent, group 2 the key. */
 const _ON_HANDLER_RE = /^(\s+)(on_[a-zA-Z_]+):/;
 /** A bare mapping-key line (``temperature:``) — key, no value, optional comment. */
-const _BARE_MAPPING_KEY_RE = /^ *[A-Za-z_][\w.]*:\s*(#.*)?$/;
+const _BARE_MAPPING_KEY_RE = /^ *([A-Za-z_][\w.]*):\s*(#.*)?$/;
 
 /**
  * Synchronous fallback parser for automation sections. The navigator
@@ -312,14 +312,17 @@ function _subEntity(
   childIndent: number
 ): { id: string | null; key: string; name?: string } | null {
   let headerIdx = -1;
+  let key = "";
   for (let j = handlerIdx - 1; j >= 0; j--) {
     if (isBlankOrCommentLine(lines[j])) continue;
     const ind = lineIndent(lines[j]);
     if (ind < childIndent) return null; // left the instance's children
     if (ind === childIndent) {
       // Must be a bare mapping key (``temperature:``), not a sibling scalar.
-      if (!_BARE_MAPPING_KEY_RE.test(lines[j])) return null;
+      const header = lines[j].match(_BARE_MAPPING_KEY_RE);
+      if (!header) return null;
       headerIdx = j;
+      key = header[1];
       break;
     }
   }
@@ -339,7 +342,6 @@ function _subEntity(
     id = readInstanceScalar(lines[k], "id") ?? id;
     name = readInstanceScalar(lines[k], "name") ?? name;
   }
-  const key = lines[headerIdx].trim().replace(/:.*$/, "");
   return { id, key, name };
 }
 

--- a/src/util/yaml-automations.ts
+++ b/src/util/yaml-automations.ts
@@ -291,23 +291,26 @@ function _resolveHandlerScope(
   if (allowSubEntity && indent > childIndent) {
     const sub = _subEntity(lines, handlerIdx, childIndent);
     if (sub) {
+      const parentComponentId = instanceComponentId(sections, host);
       return {
-        componentId: sub.id,
+        // An id-less sub-block keys on the backend's synthetic
+        // <parent>_<sub_key> id, mirroring the <domain>_<idx> convention.
+        componentId: sub.id ?? `${parentComponentId}_${sub.key}`,
         displayName: sub.name,
-        parentComponentId: instanceComponentId(sections, host),
+        parentComponentId,
       };
     }
   }
   return null;
 }
 
-/** The ided sub-entity block (``temperature:`` / ``humidity:``) enclosing the
+/** The sub-entity block (``temperature:`` / ``humidity:``) enclosing the
  *  handler at ``handlerIdx``, or ``null`` when it isn't inside one. */
 function _subEntity(
   lines: string[],
   handlerIdx: number,
   childIndent: number
-): { id: string; name?: string } | null {
+): { id: string | null; key: string; name?: string } | null {
   let headerIdx = -1;
   for (let j = handlerIdx - 1; j >= 0; j--) {
     if (isBlankOrCommentLine(lines[j])) continue;
@@ -336,7 +339,8 @@ function _subEntity(
     id = readInstanceScalar(lines[k], "id") ?? id;
     name = readInstanceScalar(lines[k], "name") ?? name;
   }
-  return id ? { id, name } : null;
+  const key = lines[headerIdx].trim().replace(/:.*$/, "");
+  return { id, key, name };
 }
 
 /** Index of the first line past the block opened at ``startIdx`` (its key

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -430,6 +430,42 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
       (dialog as any)._filteredTriggers().map((t: { id: string }) => t.id)
     ).toContain("sensor.on_value_range");
   });
+
+  it("explains an empty container prefill instead of showing a dead picker", async () => {
+    // A multi-entity component with no sub-entities configured (#1886): the
+    // shortcut still opens the dialog, which must say why there is nothing
+    // to target and keep the submit blocked.
+    const emptyContainer = {
+      ...ahtAvailable(),
+      devices: [
+        {
+          id: "aht20",
+          name: "AHT20",
+          component_id: "sensor.aht10",
+          is_entity_container: true,
+        },
+      ],
+    } as AvailableAutomations;
+    const api = {
+      getAvailableAutomations: vi.fn(() => Promise.resolve(emptyContainer)),
+    } as unknown as ESPHomeAPI;
+    const dialog = await mountDialog(api);
+    dialog.open({ kind: "component_on", componentId: "aht20" });
+    await dialog.updateComplete;
+    await flushPending();
+    await dialog.updateComplete;
+
+    expect(dialog.shadowRoot!.textContent).toContain(
+      "device.automation_container_no_entities"
+    );
+    expect(
+      dialog.shadowRoot!.querySelector("esphome-component-target-picker")
+    ).toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._componentId).toBe("");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((dialog as any)._canContinue()).toBe(false);
+  });
 });
 
 // The migration onto esphome-base-dialog swapped the imperative

--- a/test/util/yaml-sections.test.ts
+++ b/test/util/yaml-sections.test.ts
@@ -608,6 +608,40 @@ describe("parseYamlAutomations", () => {
     expect(items[1].name).toBeUndefined();
   });
 
+  it("scopes an id-less sub-entity handler to the synthetic <parent>_<sub_key> id", () => {
+    const yaml = `sensor:
+  - platform: aht10
+    id: aht20
+    temperature:
+      name: "Kit Temperature"
+      on_value:
+        then:
+          - light.toggle: led
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:")
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("aht20_temperature");
+    expect(items[0].name).toBe("Kit Temperature");
+    expect(items[0].parentComponentId).toBe("aht20");
+  });
+
+  it("composes the synthetic sub-entity id on an id-less parent's positional id", () => {
+    const yaml = `sensor:
+  - platform: aht10
+    temperature:
+      on_value:
+        - logger.log: t
+`;
+    const items = parseYamlAutomations(yaml).filter((s) =>
+      s.key.startsWith("automation:component_on:")
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("sensor_0_temperature");
+    expect(items[0].parentComponentId).toBe("sensor_0");
+  });
+
   it("ignores a nested id: in the handler body when scoping a sub-entity", () => {
     // A globals.set action inside the handler carries its own id: at a deeper
     // indent; it must not retarget the automation away from the sub-sensor.
@@ -1059,11 +1093,10 @@ describe("parseYamlAutomations", () => {
     expect(entry.key).toBe("automation:component_on:my_relay:on_turn_on");
   });
 
-  it("leaves a nested sub-component on_* unscoped (backend parses direct keys only)", () => {
-    // ``on_value`` lives under the ``temperature:`` sub-mapping, not as a
-    // direct key on the dht list item, so the backend's instance.items()
-    // scan never sees it. The fallback parser must not claim a
-    // ``sensor_0`` handle ``automations/parse`` won't confirm.
+  it("scopes a nested id-less sub-block handler to the synthetic sub-entity id", () => {
+    // ``on_value`` lives under the ``temperature:`` sub-mapping; the backend
+    // parses it to the synthetic ``<parent>_<sub_key>`` id, so the fallback
+    // parser claims the same handle instead of leaving the row unscoped.
     const yaml = `sensor:
   - platform: dht
     temperature:
@@ -1072,8 +1105,10 @@ describe("parseYamlAutomations", () => {
         - logger.log: "x"
 `;
     const entry = parseYamlAutomations(yaml).find((s) => s.key.includes("on_value"));
-    expect(entry?.key).toBe("automation:unscoped:on_value:5");
-    expect(entry?.id).toBeUndefined();
+    expect(entry?.key).toBe("automation:component_on:sensor_0_temperature:on_value");
+    expect(entry?.id).toBe("sensor_0_temperature");
+    expect(entry?.name).toBe("Temp");
+    expect(entry?.parentComponentId).toBe("sensor_0");
   });
 
   it("scopes a flat block's on_* to its declared id", () => {


### PR DESCRIPTION
# What does this implement/fix?

Companion to esphome/device-builder#1887 (see esphome/device-builder issue 1886). The backend now surfaces id-less multi-entity sub-sensors on synthetic `<parent_instance_id>_<sub_key>` ids and marks a multi-entity platform item as an entity container even when no sub-blocks are configured. Two frontend adjustments keep the editor in lockstep:

- The fallback automation parser (`_subEntity` in `yaml-automations.ts`) now attributes a handler under an id-less sub-block (`temperature:` without `id:`) to the same synthetic id instead of leaving the row unscoped, composing with the existing `<domain>_<idx>` convention from `instanceComponentId`.
- When a per-section "+ Add automation" shortcut prefills a container that has no configured sub-entities (the reporter's AHT20 with both sensors disabled), the dialog now explains that no entities are enabled yet instead of rendering an empty picker with a dead Add button. Submit was already blocked by `_canContinue`; this adds the why.

**Related issue or feature (if applicable):**

- see esphome/device-builder#1886 (closed by the backend PR; not using a closing keyword here so the merge of this PR does not auto-close it)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
