### PR TITLE
Extract shared field styles for the text-input dialogs

### DIFF
--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -8,6 +8,7 @@ import {
   dialogActionsRowStyles,
 } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
+import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
@@ -60,6 +61,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
     quietCloseButtonStyles,
     dialogActionsRowStyles,
     dialogActionButtonStyles,
+    dialogFieldStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -67,37 +69,6 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
 
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      .field {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-xs);
-        padding-bottom: var(--wa-space-m);
-      }
-
-      label {
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .helper {
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-quiet);
-        margin-top: var(--wa-space-2xs);
-      }
-
-      .field-error {
-        color: var(--esphome-error);
-        font-size: var(--wa-font-size-xs);
-        margin-top: var(--wa-space-2xs);
-      }
-
-      .field-warning {
-        color: var(--esphome-warning, #d97706);
-        font-size: var(--wa-font-size-xs);
-        margin-top: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -8,6 +8,7 @@ import {
   dialogActionsRowStyles,
 } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles } from "../styles/dialog-chrome.js";
+import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { EnterController } from "../util/enter-controller.js";
@@ -64,6 +65,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
     dialogChromeStyles,
     dialogActionsRowStyles,
     dialogActionButtonStyles,
+    dialogFieldStyles,
     css`
       esphome-base-dialog {
         --width: 460px;
@@ -71,25 +73,6 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
 
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      .field {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-xs);
-        padding-bottom: var(--wa-space-m);
-      }
-
-      label {
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .helper {
-        font-size: var(--wa-font-size-xs);
-        color: var(--wa-color-text-quiet);
-        margin-top: var(--wa-space-2xs);
       }
 
       .install-row {
@@ -102,12 +85,6 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
       .install-row .helper {
         margin-top: 0;
         flex: 1;
-      }
-
-      .field-error {
-        color: var(--esphome-error);
-        font-size: var(--wa-font-size-xs);
-        margin-top: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -8,6 +8,7 @@ import {
   dialogActionsRowStyles,
 } from "../styles/dialog-action-buttons.js";
 import { dialogChromeStyles, quietCloseButtonStyles } from "../styles/dialog-chrome.js";
+import { dialogFieldStyles } from "../styles/dialog-fields.js";
 import { inputStyles } from "../styles/inputs.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { getDeviceNameWarning, validateDeviceName } from "../util/config-validation.js";
@@ -39,6 +40,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
     quietCloseButtonStyles,
     dialogActionsRowStyles,
     dialogActionButtonStyles,
+    dialogFieldStyles,
     css`
       esphome-base-dialog {
         --width: 420px;
@@ -46,34 +48,6 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
 
       esphome-base-dialog::part(body) {
         padding: 0 var(--wa-space-l);
-      }
-
-      .field {
-        display: flex;
-        flex-direction: column;
-        gap: var(--wa-space-xs);
-        padding-bottom: var(--wa-space-m);
-      }
-
-      label {
-        font-size: var(--wa-font-size-xs);
-        font-weight: var(--wa-font-weight-bold);
-        color: var(--wa-color-text-quiet);
-      }
-
-      .field-error {
-        color: var(--esphome-error);
-        font-size: var(--wa-font-size-xs);
-        margin-top: var(--wa-space-2xs);
-      }
-
-      /* Soft warning shown alongside the input — same slot as the
-         hard error but warning-coloured so the user can tell the two
-         apart, and the submit button stays enabled. */
-      .field-warning {
-        color: var(--esphome-warning, #d97706);
-        font-size: var(--wa-font-size-xs);
-        margin-top: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/styles/dialog-fields.ts
+++ b/src/styles/dialog-fields.ts
@@ -1,0 +1,50 @@
+import { css } from "lit";
+
+/**
+ * Shared field-stack styles for the single-text-input dialogs
+ * (rename-device, clone-device, friendly-name): the labelled column
+ * around the input plus the helper / error / warning lines beneath it.
+ *
+ * Distinct from ``formFieldStyles`` (form-fields.ts) on purpose — the
+ * automation "add"-family dialogs use a different convention
+ * (``.field-label`` / ``.error``, normal-weight text) and unifying the
+ * two is a larger visual change than a style extraction should make.
+ *
+ * Consumers keep their own ``esphome-base-dialog { --width }`` and
+ * ``::part(body)`` padding local and layer overrides after this.
+ */
+export const dialogFieldStyles = css`
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-xs);
+    padding-bottom: var(--wa-space-m);
+  }
+
+  label {
+    font-size: var(--wa-font-size-xs);
+    font-weight: var(--wa-font-weight-bold);
+    color: var(--wa-color-text-quiet);
+  }
+
+  .helper {
+    font-size: var(--wa-font-size-xs);
+    color: var(--wa-color-text-quiet);
+    margin-top: var(--wa-space-2xs);
+  }
+
+  .field-error {
+    color: var(--esphome-error);
+    font-size: var(--wa-font-size-xs);
+    margin-top: var(--wa-space-2xs);
+  }
+
+  /* Soft warning shown alongside the input — same slot as the hard
+     error but warning-coloured so the user can tell the two apart,
+     and the submit button stays enabled. */
+  .field-warning {
+    color: var(--esphome-warning, #d97706);
+    font-size: var(--wa-font-size-xs);
+    margin-top: var(--wa-space-2xs);
+  }
+`;


### PR DESCRIPTION
# What does this implement/fix?

The rename-device, clone-device, and friendly-name dialogs each re-declared the same field stack CSS inline (`.field`, the field `label`, `.helper`, `.field-error`, `.field-warning`). This moves those rules into a shared `dialogFieldStyles` export (`src/styles/dialog-fields.ts`) and adopts it in the three dialogs; per dialog width and body padding stay local.

Verified no visual change by comparing computed styles in the running dashboard before and after, including the error and underscore warning states. The `edit-pairing-endpoint` and `adopt` dialogs keep their own field CSS on purpose, their spacing values differ so adopting the shared block would be a visual change. The parallel `formFieldStyles` convention used by the add-automation family is out of scope, see the issue for context.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1125

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [ ] Tests have been added to verify that the new code works (where applicable).
