### PR TITLE
Align darkModeContext fallbacks on a shared initial value

### DIFF
--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -57,7 +57,12 @@ import {
   versionHistoryEnabledContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
-import { initialDarkMode, THEME_STORAGE_KEY, themeIsDark } from "../util/dark-mode.js";
+import {
+  initialDarkMode,
+  persistTheme,
+  storedTheme,
+  themeIsDark,
+} from "../util/dark-mode.js";
 import { isExpert } from "../util/experience.js";
 import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
@@ -403,7 +408,7 @@ export class ESPHomeApp extends LitElement {
   }
 
   applyTheme(theme: Theme) {
-    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    persistTheme(theme);
     const prefersDark = themeIsDark(theme);
     this._darkMode = prefersDark;
     document.documentElement.classList.toggle("wa-dark", prefersDark);
@@ -411,8 +416,7 @@ export class ESPHomeApp extends LitElement {
   }
 
   private _initDarkMode() {
-    const saved = (localStorage.getItem(THEME_STORAGE_KEY) as Theme) ?? Theme.SYSTEM;
-    this.applyTheme(saved);
+    this.applyTheme(storedTheme());
   }
 
   private async _init() {

--- a/src/components/app-shell.ts
+++ b/src/components/app-shell.ts
@@ -57,6 +57,7 @@ import {
   versionHistoryEnabledContext,
 } from "../context/index.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { initialDarkMode, THEME_STORAGE_KEY, themeIsDark } from "../util/dark-mode.js";
 import { isExpert } from "../util/experience.js";
 import { notifyInfo } from "../util/notify.js";
 import { isRecentSerialActivity, markSerialActivity } from "../util/web-serial.js";
@@ -126,7 +127,7 @@ export class ESPHomeApp extends LitElement {
   @provide({ context: desktopUpdateCapableContext })
   @state()
   _desktopUpdateCapable = false;
-  @provide({ context: darkModeContext }) @state() _darkMode = false;
+  @provide({ context: darkModeContext }) @state() _darkMode = initialDarkMode();
   @provide({ context: isHaIngressContext }) @state() _isHaIngress = false;
   @provide({ context: activeJobsContext }) @state() _activeJobs: Map<
     string,
@@ -402,18 +403,15 @@ export class ESPHomeApp extends LitElement {
   }
 
   applyTheme(theme: Theme) {
-    localStorage.setItem("esphome-theme", theme);
-    const prefersDark =
-      theme === Theme.SYSTEM
-        ? window.matchMedia("(prefers-color-scheme: dark)").matches
-        : theme === Theme.DARK;
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    const prefersDark = themeIsDark(theme);
     this._darkMode = prefersDark;
     document.documentElement.classList.toggle("wa-dark", prefersDark);
     document.documentElement.classList.toggle("wa-light", !prefersDark);
   }
 
   private _initDarkMode() {
-    const saved = (localStorage.getItem("esphome-theme") as Theme) ?? Theme.SYSTEM;
+    const saved = (localStorage.getItem(THEME_STORAGE_KEY) as Theme) ?? Theme.SYSTEM;
     this.applyTheme(saved);
   }
 

--- a/src/components/command-dialog.ts
+++ b/src/components/command-dialog.ts
@@ -32,6 +32,7 @@ import {
 } from "../context/index.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { dispatchShowLogsAfterInstall } from "../util/post-install-logs.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -88,7 +89,8 @@ export class ESPHomeCommandDialog extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   _localize: LocalizeFunc = (key) => key;
-  @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode = true;
+  @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode =
+    initialDarkMode();
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
   // Live firmware-job snapshot keyed by job_id. Drives the queued overlay so

--- a/src/components/device/config-entry-renderers/lambda-editor.ts
+++ b/src/components/device/config-entry-renderers/lambda-editor.ts
@@ -28,6 +28,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../../../common/localize.js";
 import { darkModeContext, localizeContext } from "../../../context/index.js";
 import { editorHeightTheme, selectEditorTheme } from "../../../util/codemirror-theme.js";
+import { initialDarkMode } from "../../../util/dark-mode.js";
 import { editorSearchPhrases } from "../../../util/editor-search-phrases.js";
 import { CodeMirrorEditorElement } from "../../codemirror-editor-element.js";
 
@@ -40,7 +41,7 @@ const externalSync = Annotation.define<boolean>();
 export class ESPHomeLambdaEditor extends CodeMirrorEditorElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
-  private _darkMode = false;
+  private _darkMode = initialDarkMode();
 
   // Not subscribed: phrases are captured at mount, so the panel localizes at mount only.
   @consume({ context: localizeContext })

--- a/src/components/firmware-install-dialog.ts
+++ b/src/components/firmware-install-dialog.ts
@@ -18,6 +18,7 @@ import type { LocalizeFunc } from "../common/localize.js";
 import { apiContext, darkModeContext, localizeContext } from "../context/index.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { registerMdiIcons } from "../util/register-icons.js";
 import type { DetectedChip } from "../util/web-serial.js";
 import {
@@ -76,7 +77,8 @@ export class ESPHomeFirmwareInstallDialog extends LitElement {
   @consume({ context: localizeContext, subscribe: true })
   @state()
   _localize: LocalizeFunc = (key) => key;
-  @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode = true;
+  @consume({ context: darkModeContext, subscribe: true }) @state() _darkMode =
+    initialDarkMode();
   @consume({ context: apiContext }) _api!: ESPHomeAPI;
 
   @state() _open = false;

--- a/src/components/logs-dialog.ts
+++ b/src/components/logs-dialog.ts
@@ -19,6 +19,7 @@ import { apiContext, darkModeContext, localizeContext } from "../context/index.j
 import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { fullscreenMobileDialog } from "../styles/dialog-mobile.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { configurationStem, downloadAnsiText } from "../util/download-text.js";
 import { notifyError } from "../util/notify.js";
 import { registerMdiIcons } from "../util/register-icons.js";
@@ -69,7 +70,7 @@ export class ESPHomeLogsDialog extends LitElement {
 
   @consume({ context: darkModeContext, subscribe: true })
   @state()
-  private _darkMode = true;
+  private _darkMode = initialDarkMode();
 
   @consume({ context: apiContext })
   private _api!: ESPHomeAPI;

--- a/src/components/remote-build-job-dialog.ts
+++ b/src/components/remote-build-job-dialog.ts
@@ -20,6 +20,7 @@ import { dialogActionButtonStyles } from "../styles/dialog-action-buttons.js";
 import { inputStyles } from "../styles/inputs.js";
 import { jobStatusPillStyles } from "../styles/job-status-pill.js";
 import { espHomeStyles } from "../styles/shared.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { isTerminalJobStatus } from "../util/firmware-job-status.js";
 import { renderErrorBanner } from "../util/render-error.js";
 import { remoteBuildJobDialogStyles } from "./remote-build-job-dialog.styles.js";
@@ -102,7 +103,7 @@ export class ESPHomeRemoteBuildJobDialog extends LitElement {
 
   @consume({ context: darkModeContext, subscribe: true })
   @state()
-  private _darkMode = false;
+  private _darkMode = initialDarkMode();
 
   @state() private _open = false;
   @state() private _step: Step = "input";

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -13,6 +13,7 @@ import {
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
+import { THEME_STORAGE_KEY } from "../../util/dark-mode.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import { renderToggleRow } from "./settings-rows.js";
@@ -65,7 +66,7 @@ export class ESPHomeSettingsAppearance extends LitElement {
   private _versionHistoryEnabled = true;
 
   @state()
-  private _theme: string = localStorage.getItem("esphome-theme") ?? "system";
+  private _theme: string = localStorage.getItem(THEME_STORAGE_KEY) ?? "system";
 
   // Collapsed by default so the feature list doesn't lengthen the page.
   @state()

--- a/src/components/settings-dialog/appearance-section.ts
+++ b/src/components/settings-dialog/appearance-section.ts
@@ -13,7 +13,7 @@ import {
 import { disclosureStyles } from "../../styles/disclosure.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { espHomeStyles } from "../../styles/shared.js";
-import { THEME_STORAGE_KEY } from "../../util/dark-mode.js";
+import { storedTheme } from "../../util/dark-mode.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { renderDisclosure } from "../shared/disclosure.js";
 import { renderToggleRow } from "./settings-rows.js";
@@ -66,7 +66,7 @@ export class ESPHomeSettingsAppearance extends LitElement {
   private _versionHistoryEnabled = true;
 
   @state()
-  private _theme: string = localStorage.getItem(THEME_STORAGE_KEY) ?? "system";
+  private _theme: string = storedTheme();
 
   // Collapsed by default so the feature list doesn't lengthen the page.
   @state()

--- a/src/components/yaml-diff.ts
+++ b/src/components/yaml-diff.ts
@@ -3,13 +3,14 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LocalizeFunc } from "../common/localize.js";
 import { darkModeContext, localizeContext } from "../context/index.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { diffLines, type DiffLine } from "../util/diff-lines.js";
 
 @customElement("esphome-yaml-diff")
 export class ESPHomeYamlDiff extends LitElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
-  private _darkMode = false;
+  private _darkMode = initialDarkMode();
 
   @consume({ context: localizeContext, subscribe: true })
   @state()

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -25,6 +25,7 @@ import {
   lightHighlight,
   selectEditorTheme,
 } from "../util/codemirror-theme.js";
+import { initialDarkMode } from "../util/dark-mode.js";
 import { editorSearchPhrases } from "../util/editor-search-phrases.js";
 import { ESPHOME_YAML_INDENT, esphomeYaml } from "../util/esphome-yaml-lang.js";
 import { idleCompletion } from "../util/idle-completion.js";
@@ -109,7 +110,7 @@ const highlightField = StateField.define<DecorationSet>({
 export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
   @consume({ context: darkModeContext, subscribe: true })
   @state()
-  private _darkMode = false;
+  private _darkMode = initialDarkMode();
 
   @consume({ context: apiContext })
   @state()

--- a/src/util/dark-mode.ts
+++ b/src/util/dark-mode.ts
@@ -1,0 +1,35 @@
+import { Theme } from "../api/types/system.js";
+
+/** localStorage key ``app-shell`` persists the chosen theme under. */
+export const THEME_STORAGE_KEY = "esphome-theme";
+
+/** Resolve a theme choice to a concrete dark-mode boolean. */
+export function themeIsDark(theme: Theme): boolean {
+  if (theme === Theme.SYSTEM) {
+    return typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : false;
+  }
+  return theme === Theme.DARK;
+}
+
+/**
+ * The dark-mode value ``app-shell`` will provide once it connects,
+ * computed the same way it computes it (persisted theme, falling back
+ * to the OS preference).
+ *
+ * Use this as the ``@consume(darkModeContext)`` fallback initializer so
+ * a component's first paint agrees with the provider instead of
+ * hardcoding ``true`` or ``false`` — consumers used to disagree with
+ * each other, which showed as a one-frame theme flash in heavy dialogs
+ * and as divergent defaults in provider-less tests.
+ */
+export function initialDarkMode(): boolean {
+  try {
+    const saved =
+      (localStorage.getItem(THEME_STORAGE_KEY) as Theme | null) ?? Theme.SYSTEM;
+    return themeIsDark(saved);
+  } catch {
+    return false;
+  }
+}

--- a/src/util/dark-mode.ts
+++ b/src/util/dark-mode.ts
@@ -13,6 +13,28 @@ export function themeIsDark(theme: Theme): boolean {
   return theme === Theme.DARK;
 }
 
+/** The persisted theme choice, or ``SYSTEM`` when nothing is stored or
+ *  storage access throws (private mode / sandboxed iframe — any
+ *  localStorage call can throw, see ``split-ratio.ts`` for the same
+ *  treatment). */
+export function storedTheme(): Theme {
+  try {
+    return (localStorage.getItem(THEME_STORAGE_KEY) as Theme | null) ?? Theme.SYSTEM;
+  } catch {
+    return Theme.SYSTEM;
+  }
+}
+
+/** Persist the chosen theme; drops the write when storage is
+ *  unavailable so theme switching still applies for the session. */
+export function persistTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Blocked storage must not break the theme switch itself.
+  }
+}
+
 /**
  * The dark-mode value ``app-shell`` will provide once it connects,
  * computed the same way it computes it (persisted theme, falling back
@@ -25,11 +47,5 @@ export function themeIsDark(theme: Theme): boolean {
  * and as divergent defaults in provider-less tests.
  */
 export function initialDarkMode(): boolean {
-  try {
-    const saved =
-      (localStorage.getItem(THEME_STORAGE_KEY) as Theme | null) ?? Theme.SYSTEM;
-    return themeIsDark(saved);
-  } catch {
-    return false;
-  }
+  return themeIsDark(storedTheme());
 }

--- a/test/util/dark-mode.test.ts
+++ b/test/util/dark-mode.test.ts
@@ -9,6 +9,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { Theme } from "../../src/api/types/system.js";
 import {
   initialDarkMode,
+  persistTheme,
+  storedTheme,
   THEME_STORAGE_KEY,
   themeIsDark,
 } from "../../src/util/dark-mode.js";
@@ -70,5 +72,21 @@ describe("initialDarkMode", () => {
       },
     });
     expect(initialDarkMode()).toBe(false);
+  });
+});
+
+describe("persistTheme", () => {
+  it("round-trips through storedTheme", () => {
+    persistTheme(Theme.DARK);
+    expect(storedTheme()).toBe(Theme.DARK);
+  });
+
+  it("drops the write when storage throws, so the switch still applies", () => {
+    vi.stubGlobal("localStorage", {
+      setItem() {
+        throw new Error("denied");
+      },
+    });
+    expect(() => persistTheme(Theme.DARK)).not.toThrow();
   });
 });

--- a/test/util/dark-mode.test.ts
+++ b/test/util/dark-mode.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the shared theme -> dark-mode resolution so every
+ * darkModeContext consumer's fallback initializer agrees with what
+ * app-shell will provide.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Theme } from "../../src/api/types/system.js";
+import {
+  initialDarkMode,
+  THEME_STORAGE_KEY,
+  themeIsDark,
+} from "../../src/util/dark-mode.js";
+
+afterEach(() => {
+  localStorage.removeItem(THEME_STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
+function mockPrefersDark(matches: boolean): void {
+  vi.spyOn(window, "matchMedia").mockReturnValue({
+    matches,
+  } as MediaQueryList);
+}
+
+describe("themeIsDark", () => {
+  it("maps the explicit themes directly", () => {
+    expect(themeIsDark(Theme.DARK)).toBe(true);
+    expect(themeIsDark(Theme.LIGHT)).toBe(false);
+  });
+
+  it("resolves SYSTEM through the prefers-color-scheme query", () => {
+    mockPrefersDark(true);
+    expect(themeIsDark(Theme.SYSTEM)).toBe(true);
+    mockPrefersDark(false);
+    expect(themeIsDark(Theme.SYSTEM)).toBe(false);
+  });
+});
+
+describe("initialDarkMode", () => {
+  it("reads the persisted theme app-shell stores", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, Theme.DARK);
+    expect(initialDarkMode()).toBe(true);
+    localStorage.setItem(THEME_STORAGE_KEY, Theme.LIGHT);
+    expect(initialDarkMode()).toBe(false);
+  });
+
+  it("falls back to the OS preference with nothing persisted", () => {
+    mockPrefersDark(true);
+    expect(initialDarkMode()).toBe(true);
+  });
+});

--- a/test/util/dark-mode.test.ts
+++ b/test/util/dark-mode.test.ts
@@ -14,11 +14,13 @@ import {
 } from "../../src/util/dark-mode.js";
 
 afterEach(() => {
-  localStorage.removeItem(THEME_STORAGE_KEY);
-  // stubGlobal restores whether or not the environment defined
-  // matchMedia in the first place — happy-dom shares one window per
-  // suite file, so a leaked stub would bleed into later tests.
+  // Unstub first: the storage-throws test replaces localStorage with an
+  // object that has no removeItem. stubGlobal restores whether or not
+  // the environment defined the global in the first place — happy-dom
+  // shares one window per suite file, so a leaked stub would bleed into
+  // later tests.
   vi.unstubAllGlobals();
+  localStorage.removeItem(THEME_STORAGE_KEY);
 });
 
 function mockPrefersDark(matches: boolean): void {
@@ -37,6 +39,13 @@ describe("themeIsDark", () => {
     mockPrefersDark(false);
     expect(themeIsDark(Theme.SYSTEM)).toBe(false);
   });
+
+  it("returns false for SYSTEM when matchMedia is unavailable", () => {
+    // The guard that keeps field initializers safe in environments
+    // without a matchMedia implementation.
+    vi.stubGlobal("matchMedia", undefined);
+    expect(themeIsDark(Theme.SYSTEM)).toBe(false);
+  });
 });
 
 describe("initialDarkMode", () => {
@@ -50,5 +59,16 @@ describe("initialDarkMode", () => {
   it("falls back to the OS preference with nothing persisted", () => {
     mockPrefersDark(true);
     expect(initialDarkMode()).toBe(true);
+  });
+
+  it("returns false when localStorage access throws", () => {
+    // Privacy-mode / blocked-storage guard: the catch is what makes
+    // the util safe to call from every consumer's field initializer.
+    vi.stubGlobal("localStorage", {
+      getItem() {
+        throw new Error("denied");
+      },
+    });
+    expect(initialDarkMode()).toBe(false);
   });
 });

--- a/test/util/dark-mode.test.ts
+++ b/test/util/dark-mode.test.ts
@@ -15,13 +15,14 @@ import {
 
 afterEach(() => {
   localStorage.removeItem(THEME_STORAGE_KEY);
-  vi.restoreAllMocks();
+  // stubGlobal restores whether or not the environment defined
+  // matchMedia in the first place — happy-dom shares one window per
+  // suite file, so a leaked stub would bleed into later tests.
+  vi.unstubAllGlobals();
 });
 
 function mockPrefersDark(matches: boolean): void {
-  vi.spyOn(window, "matchMedia").mockReturnValue({
-    matches,
-  } as MediaQueryList);
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches } as MediaQueryList));
 }
 
 describe("themeIsDark", () => {


### PR DESCRIPTION
# What does this implement/fix?

The `@consume(darkModeContext)` fallback initializer disagreed across consumers, three dialogs assumed dark and four editors assumed light, and the provider itself started at `false` regardless of the real theme. This adds `src/util/dark-mode.ts` with the theme resolution `app-shell` already used inline (`themeIsDark`, `initialDarkMode`, and the `THEME_STORAGE_KEY` constant) and points the provider plus all seven consumers at it, so the first paint agrees with what the provider will supply. The appearance section now reads the storage key from the same constant. Unit tests cover the resolution and the persisted key.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1132

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
