### PR TITLE
Autofocus the marked input once a base dialog fully shows

### DIFF
--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -177,6 +177,25 @@ export class ESPHomeBaseDialog extends LitElement {
     }
   }
 
+  // Focus a consumer-marked ``[autofocus]`` control once the dialog has
+  // fully shown. wa-dialog performs this lookup itself, but only against
+  // its own light DOM — which is just our forwarding slot — so slotted
+  // dialog content is never found and a show-time rAF focuses the modal
+  // <dialog> panel instead. That rAF runs after any focus we could set
+  // during the open update (verified in a live session: the panel ends
+  // up focused and early keystrokes go nowhere), so the one hook
+  // guaranteed to run after wa-dialog is completely done is
+  // ``wa-after-show``.
+  private _onWaAfterShow = (): void => {
+    if (!this.open) return;
+    const el = this.querySelector<HTMLElement>("[autofocus]");
+    if (!el) return;
+    el.focus();
+    // Select-all so typing replaces a prefilled value (rename opens with
+    // the current name; a fresh field selects nothing).
+    if (el instanceof HTMLInputElement) el.select();
+  };
+
   private _onWaHide = (e: Event): void => {
     // wa-dialog fires the cancelable ``wa-hide`` to request a
     // close (Escape / X / outside-click / reactive ?open flip);
@@ -227,6 +246,7 @@ export class ESPHomeBaseDialog extends LitElement {
         ?open=${this.open}
         ?light-dismiss=${!this.busy}
         @wa-hide=${this._onWaHide}
+        @wa-after-show=${this._onWaAfterShow}
         @wa-after-hide=${this._onWaAfterHide}
       >
         <header slot="label" part="label-row">

--- a/src/components/base-dialog.ts
+++ b/src/components/base-dialog.ts
@@ -186,14 +186,27 @@ export class ESPHomeBaseDialog extends LitElement {
   // up focused and early keystrokes go nowhere), so the one hook
   // guaranteed to run after wa-dialog is completely done is
   // ``wa-after-show``.
-  private _onWaAfterShow = (): void => {
+  private _onWaAfterShow = (e: Event): void => {
+    // Same nested-wa-dialog leak as the hide handlers: a stacked inner
+    // dialog's ``wa-after-show`` bubbles up here and would re-focus our
+    // own ``[autofocus]`` control, stealing focus from the inner dialog.
+    if (e.target !== e.currentTarget) return;
     if (!this.open) return;
     const el = this.querySelector<HTMLElement>("[autofocus]");
     if (!el) return;
     el.focus();
     // Select-all so typing replaces a prefilled value (rename opens with
-    // the current name; a fresh field selects nothing).
-    if (el instanceof HTMLInputElement) el.select();
+    // the current name; a fresh field selects nothing). ``select()``
+    // throws on input types without selection ranges (number, date, …),
+    // so gate on the text-like types.
+    if (el instanceof HTMLTextAreaElement) {
+      el.select();
+    } else if (
+      el instanceof HTMLInputElement &&
+      /^(?:text|search|url|tel|password)$/.test(el.type)
+    ) {
+      el.select();
+    }
   };
 
   private _onWaHide = (e: Event): void => {

--- a/src/components/clone-device-dialog.ts
+++ b/src/components/clone-device-dialog.ts
@@ -122,6 +122,7 @@ export class ESPHomeCloneDeviceDialog extends LitElement {
           <input
             id="clone-new-name"
             type="text"
+            autofocus
             class=${err ? "invalid" : ""}
             .value=${this._name}
             placeholder=${this.sourceName}

--- a/src/components/edit-pairing-endpoint-dialog.ts
+++ b/src/components/edit-pairing-endpoint-dialog.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { LitElement, css, html, nothing, type PropertyValues } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 
 import { APIError } from "../api/api-error.js";
 import type { ESPHomeAPI } from "../api/index.js";
@@ -70,8 +70,6 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
   @state() private _submitting = false;
   @state() private _errorMessage = "";
 
-  @query("input[name='hostname']") private _hostInput?: HTMLInputElement;
-
   // Enter saves while the dialog is open; mirrors the Save button's guard.
   private _enter = new EnterController(this, () => {
     if (!this._saveDisabled()) void this._onSave();
@@ -106,14 +104,10 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
     this._initialPort = this._port;
     this._submitting = false;
     this._errorMessage = "";
+    // Focus + select of the hostname field rides on its ``autofocus``
+    // attribute — <esphome-base-dialog> honours it once the dialog has
+    // fully shown (wa-after-show).
     this._open = true;
-    // Autofocus the hostname field on next paint. ``_open``
-    // gates the whole render tree, so the input doesn't
-    // exist until ``updateComplete`` fires.
-    void this.updateComplete.then(() => {
-      this._hostInput?.focus();
-      this._hostInput?.select();
-    });
   }
 
   private _close = () => {
@@ -273,6 +267,7 @@ export class ESPHomeEditPairingEndpointDialog extends LitElement {
             id="ep-hostname"
             name="hostname"
             type="text"
+            autofocus
             autocomplete="off"
             spellcheck="false"
             .value=${this._hostname}

--- a/src/components/friendly-name-dialog.ts
+++ b/src/components/friendly-name-dialog.ts
@@ -135,6 +135,7 @@ export class ESPHomeFriendlyNameDialog extends LitElement {
           <input
             id="friendly-name-input"
             type="text"
+            autofocus
             class=${err ? "invalid" : ""}
             .value=${this._value}
             placeholder=${this.currentFriendlyName || this.deviceName}

--- a/src/components/rename-device-dialog.ts
+++ b/src/components/rename-device-dialog.ts
@@ -89,6 +89,7 @@ export class ESPHomeRenameDeviceDialog extends LitElement {
           <label>${this._localize("dashboard.action_rename_label")}</label>
           <input
             type="text"
+            autofocus
             class=${err ? "invalid" : ""}
             .value=${this._value}
             @input=${(e: Event) => {

--- a/test/components/base-dialog.test.ts
+++ b/test/components/base-dialog.test.ts
@@ -127,4 +127,31 @@ describe("esphome-base-dialog [autofocus]", () => {
     fireAfterShow(el);
     expect(document.activeElement).not.toBe(input);
   });
+
+  it("ignores a nested dialog's after-show bubbling through the slot", async () => {
+    const el = await mount(new ESPHomeBaseDialog());
+    const input = document.createElement("input");
+    input.setAttribute("autofocus", "");
+    el.appendChild(input);
+    // Stands in for a stacked inner wa-dialog living in slotted content;
+    // its after-show bubbles up to the wrapper's own wa-dialog listener.
+    const nested = document.createElement("div");
+    el.appendChild(nested);
+    el.open = true;
+    await el.updateComplete;
+    nested.dispatchEvent(new CustomEvent("wa-after-show", { bubbles: true }));
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("focuses a non-text input without attempting select()", async () => {
+    const el = await mount(new ESPHomeBaseDialog());
+    const input = document.createElement("input");
+    input.type = "number";
+    input.setAttribute("autofocus", "");
+    el.appendChild(input);
+    el.open = true;
+    await el.updateComplete;
+    fireAfterShow(el); // must not throw (select() is illegal on number)
+    expect(document.activeElement).toBe(input);
+  });
 });

--- a/test/components/base-dialog.test.ts
+++ b/test/components/base-dialog.test.ts
@@ -84,3 +84,47 @@ describe("esphome-base-dialog confirmOnEnter", () => {
     expect(confirmOnEnter).not.toHaveBeenCalled();
   });
 });
+
+describe("esphome-base-dialog [autofocus]", () => {
+  // The stubbed wa-dialog never animates, so fire the hook the real one
+  // dispatches once fully shown.
+  function fireAfterShow(el: ESPHomeBaseDialog): void {
+    el.shadowRoot!.querySelector("wa-dialog")!.dispatchEvent(
+      new CustomEvent("wa-after-show")
+    );
+  }
+
+  it("focuses and selects the marked input after the dialog shows", async () => {
+    const el = await mount(new ESPHomeBaseDialog());
+    const input = document.createElement("input");
+    input.setAttribute("autofocus", "");
+    input.value = "prefilled";
+    el.appendChild(input);
+    el.open = true;
+    await el.updateComplete;
+    fireAfterShow(el);
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("prefilled".length);
+  });
+
+  it("does nothing without an [autofocus] child", async () => {
+    const el = await mount(new ESPHomeBaseDialog());
+    const input = document.createElement("input");
+    el.appendChild(input);
+    el.open = true;
+    await el.updateComplete;
+    fireAfterShow(el);
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("ignores a stray after-show while closed", async () => {
+    const el = await mount(new ESPHomeBaseDialog());
+    const input = document.createElement("input");
+    input.setAttribute("autofocus", "");
+    el.appendChild(input);
+    await el.updateComplete;
+    fireAfterShow(el);
+    expect(document.activeElement).not.toBe(input);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Opening the single input dialogs (Duplicate, Rename hostname, Edit friendly name) left focus on the dialog panel, so a keyboard user's first keystrokes went nowhere. `wa-dialog` does look for an `[autofocus]` element on show, but only in its own light DOM, which through our wrapper is just a forwarding slot; its fallback then focuses the modal panel in a show time rAF, which also silently defeated the edit pairing dialog's hand rolled focus.

`esphome-base-dialog` now honours an `[autofocus]` marked control in its light DOM on `wa-after-show`, the one hook guaranteed to run after wa-dialog is completely done, and select-alls a prefilled input so typing replaces the value. The four dialogs opt in with a plain `autofocus` attribute; edit pairing drops its hand rolled focus block.

Verified in the running dashboard through the real card menu path: typing immediately after opening Duplicate lands in the hostname field, and typing over the rename prefill replaces it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1133

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
