### PR TITLE
Highlight likely ESP devices in the serial port pickers

### DIFF
--- a/src/api/types/system.ts
+++ b/src/api/types/system.ts
@@ -6,9 +6,19 @@
 
 // ─── Config / System ─────────────────────────────────────────
 
+export type SerialPortHint = "esp" | "bridge";
+
 export interface SerialPort {
   port: string;
   desc: string;
+  /** USB vendor/product ids; ``null`` when the port carries no USB
+   *  metadata (e.g. a by-id symlink entry). */
+  vid: number | null;
+  pid: number | null;
+  /** Backend VID classification: ``esp`` is an Espressif native-USB
+   *  device (definitely an ESP), ``bridge`` a common USB-UART bridge
+   *  chip (CP210x, CH340, FTDI, Prolific). */
+  hint: SerialPortHint | null;
 }
 
 /**

--- a/src/components/install-method-dialog.ts
+++ b/src/components/install-method-dialog.ts
@@ -22,6 +22,7 @@ import { primaryDialogHeaderStyles } from "../styles/dialog-header.js";
 import { disclosureStyles } from "../styles/disclosure.js";
 import { inputStyles } from "../styles/inputs.js";
 import { newItemHighlightStyles } from "../styles/new-item-highlight.js";
+import { serialPortHintStyles } from "../styles/serial-port-hints.js";
 import { espHomeStyles } from "../styles/shared.js";
 import { detectEnvironment, type DeploymentEnvironment } from "../util/environment.js";
 import { isEsptoolPlatform } from "../util/esptool-platform.js";
@@ -34,6 +35,10 @@ import {
 } from "../util/web-serial.js";
 import { installMethodDialogStyles } from "./install-method-dialog.styles.js";
 import { renderDisclosure } from "./shared/disclosure.js";
+import {
+  renderSerialPortBadges,
+  renderSerialPortReplugHint,
+} from "./shared/serial-port-hints.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -149,6 +154,7 @@ export class ESPHomeInstallMethodDialog extends LitElement {
     primaryDialogHeaderStyles,
     inputStyles,
     newItemHighlightStyles,
+    serialPortHintStyles,
     installMethodDialogStyles,
   ];
 
@@ -394,17 +400,12 @@ export class ESPHomeInstallMethodDialog extends LitElement {
                         <span class="title">${p.port}</span>
                         ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
                       </div>
-                      ${
-                        this._portsPoll.newPorts.has(p.port)
-                          ? html`<span class="new-badge"
-                              >${this._localize("dashboard.serial_port_new")}</span
-                            >`
-                          : nothing
-                      }
+                      ${renderSerialPortBadges(p, this._portsPoll.newPorts, this._localize)}
                     </div>
                   `
                 )}
               </div>
+              ${renderSerialPortReplugHint(this._portsPoll.ports, this._localize)}
             `
       }
     `;

--- a/src/components/shared/serial-port-hints.ts
+++ b/src/components/shared/serial-port-hints.ts
@@ -1,0 +1,46 @@
+import { type TemplateResult, html, nothing } from "lit";
+
+import type { SerialPort } from "../../api/types/system.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+
+/**
+ * Badge column for a server serial-port row: an outlined "ESP device"
+ * badge when the backend identified an Espressif native-USB port, plus
+ * the filled "New" badge for a port that appeared while the picker was
+ * open. Pair with `serialPortHintStyles` (src/styles/serial-port-hints.ts)
+ * and `newItemHighlightStyles` in the consumer's `static styles`.
+ */
+export function renderSerialPortBadges(
+  port: SerialPort,
+  newPorts: ReadonlySet<string>,
+  localize: LocalizeFunc
+): TemplateResult | typeof nothing {
+  const isEsp = port.hint === "esp";
+  const isNew = newPorts.has(port.port);
+  if (!isEsp && !isNew) return nothing;
+  return html`<span class="badges">
+    ${
+      isEsp
+        ? html`<span class="esp-badge">${localize("dashboard.serial_port_esp")}</span>`
+        : nothing
+    }
+    ${
+      isNew
+        ? html`<span class="new-badge">${localize("dashboard.serial_port_new")}</span>`
+        : nothing
+    }
+  </span>`;
+}
+
+/**
+ * Beginner guidance under a multi-port list: replugging the board makes
+ * the right port stand out with the "New" badge. Renders nothing when a
+ * single port leaves no room for doubt.
+ */
+export function renderSerialPortReplugHint(
+  ports: readonly SerialPort[],
+  localize: LocalizeFunc
+): TemplateResult | typeof nothing {
+  if (ports.length < 2) return nothing;
+  return html`<p class="port-hint">${localize("dashboard.serial_port_unsure_hint")}</p>`;
+}

--- a/src/components/wizard/wizard-step-board-port-select.ts
+++ b/src/components/wizard/wizard-step-board-port-select.ts
@@ -8,9 +8,14 @@ import type { LocalizeFunc } from "../../common/localize.js";
 import { localizeContext } from "../../context/index.js";
 import { inputStyles } from "../../styles/inputs.js";
 import { newItemHighlightStyles } from "../../styles/new-item-highlight.js";
+import { serialPortHintStyles } from "../../styles/serial-port-hints.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import type { DeploymentEnvironment } from "../../util/environment.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
+import {
+  renderSerialPortBadges,
+  renderSerialPortReplugHint,
+} from "../shared/serial-port-hints.js";
 
 import "@home-assistant/webawesome/dist/components/icon/icon.js";
 import "@home-assistant/webawesome/dist/components/spinner/spinner.js";
@@ -56,6 +61,7 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
     espHomeStyles,
     inputStyles,
     newItemHighlightStyles,
+    serialPortHintStyles,
     css`
       :host {
         display: flex;
@@ -227,17 +233,12 @@ export class ESPHomeWizardStepBoardPortSelect extends LitElement {
                 <span class="title">${p.port}</span>
                 ${p.desc ? html`<span class="desc">${p.desc}</span>` : nothing}
               </div>
-              ${
-                this.newPorts.has(p.port)
-                  ? html`<span class="new-badge"
-                      >${this._localize("dashboard.serial_port_new")}</span
-                    >`
-                  : nothing
-              }
+              ${renderSerialPortBadges(p, this.newPorts, this._localize)}
             </button>
           `
         )}
       </div>
+      ${renderSerialPortReplugHint(this.ports, this._localize)}
     `;
   }
 

--- a/src/styles/serial-port-hints.ts
+++ b/src/styles/serial-port-hints.ts
@@ -1,0 +1,36 @@
+import { css } from "lit";
+
+/**
+ * Styles for the serial-port badge column and the replug hint rendered
+ * by `renderSerialPortBadges` / `renderSerialPortReplugHint`
+ * (src/components/shared/serial-port-hints.ts). The "New" badge itself
+ * comes from `newItemHighlightStyles`.
+ */
+export const serialPortHintStyles = css`
+  .badges {
+    flex-shrink: 0;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+  }
+
+  .esp-badge {
+    flex-shrink: 0;
+    padding: 1px var(--wa-space-xs);
+    border-radius: var(--wa-border-radius-pill, 999px);
+    border: var(--wa-border-width-s) solid var(--esphome-primary);
+    color: var(--esphome-primary);
+    font-size: var(--wa-font-size-2xs);
+    font-weight: var(--wa-font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .port-hint {
+    margin: 0;
+    color: var(--wa-color-text-quiet);
+    font-size: var(--wa-font-size-2xs);
+    line-height: 1.4;
+  }
+`;

--- a/src/styles/serial-port-hints.ts
+++ b/src/styles/serial-port-hints.ts
@@ -28,7 +28,7 @@ export const serialPortHintStyles = css`
   }
 
   .port-hint {
-    margin: 0;
+    margin: var(--wa-space-s) 0 var(--wa-space-2xs);
     color: var(--wa-color-text-quiet);
     font-size: var(--wa-font-size-2xs);
     line-height: 1.4;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -196,6 +196,8 @@
     "install_method_loading_ports": "Scanning for serial ports…",
     "install_method_back": "Back",
     "serial_port_new": "New",
+    "serial_port_esp": "ESP device",
+    "serial_port_unsure_hint": "Not sure which port? Unplug the device, plug it back in, then pick the port marked New.",
     "table_columns": "Columns",
     "table_toggle_columns": "Toggle columns",
     "view_cards": "Card view",

--- a/src/util/serial-ports-poll-controller.ts
+++ b/src/util/serial-ports-poll-controller.ts
@@ -4,6 +4,20 @@ import type { SerialPort } from "../api/types/system.js";
 
 export const SERIAL_PORTS_POLL_INTERVAL_MS = 5000;
 
+const HINT_RANK: Record<string, number> = { esp: 0, bridge: 1 };
+
+const hintRank = (p: SerialPort) => (p.hint !== null ? (HINT_RANK[p.hint] ?? 2) : 2);
+
+/**
+ * Likely ESP candidates first: Espressif native-USB ports, then known
+ * USB-UART bridges, then everything else; path order within a tier.
+ */
+export function sortSerialPorts(ports: SerialPort[]): SerialPort[] {
+  return [...ports].sort(
+    (a, b) => hintRank(a) - hintRank(b) || a.port.localeCompare(b.port)
+  );
+}
+
 /**
  * Reactive controller that polls ``config/serial_ports`` while a
  * port-picker surface is visible. Hosts call ``set(visible)`` from
@@ -88,7 +102,8 @@ export class SerialPortsPollController implements ReactiveController {
     }
   }
 
-  private _apply(ports: SerialPort[]) {
+  private _apply(unsorted: SerialPort[]) {
+    const ports = sortSerialPorts(unsorted);
     const paths = new Set(ports.map((p) => p.port));
     // A port absent from the previous fetch is new, and stays flagged
     // while present; pruning unplugged ports lets a replug re-flag.
@@ -102,7 +117,10 @@ export class SerialPortsPollController implements ReactiveController {
       this.error !== null ||
       ports.length !== this.ports.length ||
       ports.some(
-        (p, i) => p.port !== this.ports[i].port || p.desc !== this.ports[i].desc
+        (p, i) =>
+          p.port !== this.ports[i].port ||
+          p.desc !== this.ports[i].desc ||
+          p.hint !== this.ports[i].hint
       ) ||
       fresh.size !== this.newPorts.size ||
       [...fresh].some((path) => !this.newPorts.has(path));

--- a/src/util/serial-ports-poll-controller.ts
+++ b/src/util/serial-ports-poll-controller.ts
@@ -1,12 +1,12 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ESPHomeAPI } from "../api/index.js";
-import type { SerialPort } from "../api/types/system.js";
+import type { SerialPort, SerialPortHint } from "../api/types/system.js";
 
 export const SERIAL_PORTS_POLL_INTERVAL_MS = 5000;
 
-const HINT_RANK: Record<string, number> = { esp: 0, bridge: 1 };
+const HINT_RANK: Record<SerialPortHint, number> = { esp: 0, bridge: 1 };
 
-const hintRank = (p: SerialPort) => (p.hint !== null ? (HINT_RANK[p.hint] ?? 2) : 2);
+const hintRank = (p: SerialPort) => (p.hint !== null ? HINT_RANK[p.hint] : 2);
 
 /**
  * Likely ESP candidates first: Espressif native-USB ports, then known
@@ -120,6 +120,8 @@ export class SerialPortsPollController implements ReactiveController {
         (p, i) =>
           p.port !== this.ports[i].port ||
           p.desc !== this.ports[i].desc ||
+          p.vid !== this.ports[i].vid ||
+          p.pid !== this.ports[i].pid ||
           p.hint !== this.ports[i].hint
       ) ||
       fresh.size !== this.newPorts.size ||

--- a/src/util/serial-ports-poll-controller.ts
+++ b/src/util/serial-ports-poll-controller.ts
@@ -8,13 +8,20 @@ const HINT_RANK: Record<SerialPortHint, number> = { esp: 0, bridge: 1 };
 
 const hintRank = (p: SerialPort) => (p.hint !== null ? HINT_RANK[p.hint] : 2);
 
+/** Numeric-aware so COM2 sorts before COM10 (same shape as
+ *  DEVICE_SORT_COLLATOR in device-sort.ts). */
+const PORT_COLLATOR = new Intl.Collator(undefined, {
+  sensitivity: "base",
+  numeric: true,
+});
+
 /**
  * Likely ESP candidates first: Espressif native-USB ports, then known
  * USB-UART bridges, then everything else; path order within a tier.
  */
 export function sortSerialPorts(ports: SerialPort[]): SerialPort[] {
   return [...ports].sort(
-    (a, b) => hintRank(a) - hintRank(b) || a.port.localeCompare(b.port)
+    (a, b) => hintRank(a) - hintRank(b) || PORT_COLLATOR.compare(a.port, b.port)
   );
 }
 

--- a/test/_make-serial-port.ts
+++ b/test/_make-serial-port.ts
@@ -1,0 +1,9 @@
+import type { SerialPort } from "../src/api/types/system.js";
+
+export function makeSerialPort(
+  port: string,
+  desc: string,
+  overrides: Partial<SerialPort> = {}
+): SerialPort {
+  return { port, desc, vid: null, pid: null, hint: null, ...overrides };
+}

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -63,6 +63,32 @@ describe("install-method-dialog port polling", () => {
     expect(rows[1].querySelector(".new-badge")?.textContent).toBe("New");
   });
 
+  it("badges Espressif native-USB ports and shows the replug hint on multi-port lists", async () => {
+    const ports = [
+      makeSerialPort("/dev/ttyACM0", "USB JTAG/serial debug unit", {
+        vid: 0x303a,
+        hint: "esp",
+      }),
+      makeSerialPort("/dev/ttyUSB0", "CP2102", { vid: 0x10c4, hint: "bridge" }),
+    ];
+    const dialog = await mount(async () => ports);
+    await vi.advanceTimersByTimeAsync(0);
+    await dialog.updateComplete;
+
+    const rows = portRows(dialog);
+    expect(rows[0].querySelector(".esp-badge")?.textContent).toBe("ESP device");
+    expect(rows[1].querySelector(".esp-badge")).toBeNull();
+    expect(dialog.shadowRoot!.querySelector(".port-hint")).not.toBeNull();
+  });
+
+  it("omits the replug hint when a single port leaves no room for doubt", async () => {
+    const dialog = await mount(async () => [makeSerialPort("/dev/ttyUSB0", "CP2102")]);
+    await vi.advanceTimersByTimeAsync(0);
+    await dialog.updateComplete;
+
+    expect(dialog.shadowRoot!.querySelector(".port-hint")).toBeNull();
+  });
+
   it("stops polling when the dialog closes", async () => {
     const getSerialPorts = vi.fn(async () => [] as SerialPort[]);
     const dialog = await mount(getSerialPorts);

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -15,6 +15,7 @@ import type { SerialPort } from "../../src/api/types/system.js";
 import { defaultLocalize } from "../../src/common/localize.js";
 import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
 import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../src/util/serial-ports-poll-controller.js";
+import { makeSerialPort } from "../_make-serial-port.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mount(getSerialPorts: () => Promise<SerialPort[]>) {
@@ -43,7 +44,7 @@ afterEach(() => {
 
 describe("install-method-dialog port polling", () => {
   it("refreshes the open port list and highlights the newly connected port", async () => {
-    let ports: SerialPort[] = [{ port: "/dev/ttyUSB0", desc: "CP2102" }];
+    let ports: SerialPort[] = [makeSerialPort("/dev/ttyUSB0", "CP2102")];
     const getSerialPorts = vi.fn(async () => ports);
     const dialog = await mount(getSerialPorts);
 
@@ -51,7 +52,7 @@ describe("install-method-dialog port polling", () => {
     await dialog.updateComplete;
     expect(portRows(dialog)).toHaveLength(1);
 
-    ports = [...ports, { port: "/dev/ttyUSB1", desc: "CH340" }];
+    ports = [...ports, makeSerialPort("/dev/ttyUSB1", "CH340")];
     await vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
     await dialog.updateComplete;
 

--- a/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
+++ b/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
@@ -16,6 +16,7 @@ import { defaultLocalize } from "../../../src/common/localize.js";
 import type { ESPHomeWizardStepBoardPortSelect } from "../../../src/components/wizard/wizard-step-board-port-select.js";
 import { ESPHomeWizardStepBoard } from "../../../src/components/wizard/wizard-step-board.js";
 import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../../src/util/serial-ports-poll-controller.js";
+import { makeSerialPort } from "../../_make-serial-port.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mount(getSerialPorts: () => Promise<SerialPort[]>) {
@@ -53,7 +54,7 @@ describe("wizard-step-board port fetch error recovery", () => {
     let fail = true;
     const getSerialPorts = vi.fn(async () => {
       if (fail) throw new Error("backend offline");
-      return [{ port: "/dev/ttyUSB0", desc: "CP2102" }];
+      return [makeSerialPort("/dev/ttyUSB0", "CP2102")];
     });
     const el = await mount(getSerialPorts);
 
@@ -65,6 +66,6 @@ describe("wizard-step-board port fetch error recovery", () => {
     await vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
     await el.updateComplete;
     expect(portSelect(el).errorMessage).toBe("");
-    expect(portSelect(el).ports).toEqual([{ port: "/dev/ttyUSB0", desc: "CP2102" }]);
+    expect(portSelect(el).ports).toEqual([makeSerialPort("/dev/ttyUSB0", "CP2102")]);
   });
 });

--- a/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
+++ b/test/components/wizard/wizard-step-board-port-select-new-badge.test.ts
@@ -11,6 +11,7 @@ vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => (
 
 import { defaultLocalize } from "../../../src/common/localize.js";
 import { ESPHomeWizardStepBoardPortSelect } from "../../../src/components/wizard/wizard-step-board-port-select.js";
+import { makeSerialPort } from "../../_make-serial-port.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function mount(
@@ -29,8 +30,8 @@ describe("wizard-step-board-port-select new-port badge", () => {
   it("highlights only the ports flagged as new", async () => {
     const el = await mount({
       ports: [
-        { port: "/dev/ttyUSB0", desc: "CP2102" },
-        { port: "/dev/ttyUSB1", desc: "CH340" },
+        makeSerialPort("/dev/ttyUSB0", "CP2102"),
+        makeSerialPort("/dev/ttyUSB1", "CH340"),
       ],
       newPorts: new Set(["/dev/ttyUSB1"]),
     });
@@ -40,5 +41,30 @@ describe("wizard-step-board-port-select new-port badge", () => {
     expect(rows[0].querySelector(".new-badge")).toBeNull();
     expect(rows[1].classList.contains("is-new")).toBe(true);
     expect(rows[1].querySelector(".new-badge")?.textContent).toBe("New");
+  });
+
+  it("badges Espressif native-USB ports and shows the replug hint on multi-port lists", async () => {
+    const el = await mount({
+      ports: [
+        makeSerialPort("/dev/ttyACM0", "USB JTAG/serial debug unit", {
+          vid: 0x303a,
+          hint: "esp",
+        }),
+        makeSerialPort("/dev/ttyUSB0", "CP2102", { vid: 0x10c4, hint: "bridge" }),
+      ],
+      newPorts: new Set(),
+    });
+    const rows = [...el.shadowRoot!.querySelectorAll(".option")];
+    expect(rows[0].querySelector(".esp-badge")?.textContent).toBe("ESP device");
+    expect(rows[1].querySelector(".esp-badge")).toBeNull();
+    expect(el.shadowRoot!.querySelector(".port-hint")).not.toBeNull();
+  });
+
+  it("omits the replug hint when a single port leaves no room for doubt", async () => {
+    const el = await mount({
+      ports: [makeSerialPort("/dev/ttyUSB0", "CP2102")],
+      newPorts: new Set(),
+    });
+    expect(el.shadowRoot!.querySelector(".port-hint")).toBeNull();
   });
 });

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -4,11 +4,13 @@ import type { SerialPort } from "../../src/api/types/system.js";
 import {
   SERIAL_PORTS_POLL_INTERVAL_MS,
   SerialPortsPollController,
+  sortSerialPorts,
 } from "../../src/util/serial-ports-poll-controller.js";
 import { FakeHost } from "../_fake-host.js";
+import { makeSerialPort } from "../_make-serial-port.js";
 
-const A: SerialPort = { port: "/dev/ttyUSB0", desc: "CP2102" };
-const B: SerialPort = { port: "/dev/ttyUSB1", desc: "CH340" };
+const A: SerialPort = makeSerialPort("/dev/ttyUSB0", "CP2102");
+const B: SerialPort = makeSerialPort("/dev/ttyUSB1", "CH340");
 
 function make(initial: SerialPort[] = [A]) {
   const host = new FakeHost();
@@ -175,6 +177,24 @@ describe("SerialPortsPollController", () => {
     expect(ctrl.error).toBeNull();
     expect(ctrl.ports).toEqual([A, B]);
     expect(ctrl.newPorts.size).toBe(0);
+  });
+
+  it("sorts likely ESP candidates first", async () => {
+    const generic = makeSerialPort("/dev/cu.usbmodem1", "Some webcam");
+    const bridge = makeSerialPort("/dev/cu.usbserial-2", "CH340", {
+      vid: 0x1a86,
+      hint: "bridge",
+    });
+    const esp = makeSerialPort("/dev/cu.usbmodem3", "USB JTAG/serial debug unit", {
+      vid: 0x303a,
+      hint: "esp",
+    });
+    expect(sortSerialPorts([generic, bridge, esp])).toEqual([esp, bridge, generic]);
+
+    const { ctrl } = make([generic, bridge, esp]);
+    ctrl.set(true);
+    await flush();
+    expect(ctrl.ports).toEqual([esp, bridge, generic]);
   });
 
   it("swallows poll errors after a successful fetch, keeping the last good list", async () => {

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -191,6 +191,10 @@ describe("SerialPortsPollController", () => {
     });
     expect(sortSerialPorts([generic, bridge, esp])).toEqual([esp, bridge, generic]);
 
+    const com2 = makeSerialPort("COM2", "CP2102");
+    const com10 = makeSerialPort("COM10", "CP2102");
+    expect(sortSerialPorts([com10, com2])).toEqual([com2, com10]);
+
     const { ctrl } = make([generic, bridge, esp]);
     ctrl.set(true);
     await flush();


### PR DESCRIPTION
# What does this implement/fix?

Beginners picking a server serial port can't tell which entry is their board, especially next to webcams and other USB serial devices. The backend now classifies each port by USB VID (esphome/device-builder#1894); both port pickers (wizard board step and the install method dialog) now show an "ESP device" badge on Espressif native USB ports, sort likely candidates first (ESP, then known USB-UART bridges, then the rest), and show a hint under multi-port lists that replugging the board marks its port New.

**Related issue or feature (if applicable):**

- companion backend PR: esphome/device-builder#1894
- feedback from an Apollo Automation Starter Kit beginner test, "a beginner might need help figuring out which COM port to select"

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
