### PR TITLE
Move the invalid banner in flow and damp its reveal while typing

### DIFF
--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -5,24 +5,6 @@ export const deviceEditorStyles = css`
     display: contents;
   }
 
-  .invalid-banner-goto {
-    appearance: none;
-    margin-left: 0.35em;
-    padding: 0;
-    border: none;
-    background: none;
-    color: inherit;
-    font: inherit;
-    font-weight: var(--wa-font-weight-semibold);
-    text-decoration: underline;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .invalid-banner-goto:hover {
-    text-decoration: none;
-  }
-
   .card {
     background: var(--wa-color-surface-default);
     border-radius: var(--editor-border-radius, var(--wa-border-radius-l));
@@ -392,25 +374,6 @@ export const deviceEditorStyles = css`
     margin: 0;
     font-size: var(--wa-font-size-s);
     font-weight: var(--wa-font-weight-bold);
-  }
-
-  /* Document-level "configuration invalid" banner (shape from
-     dangerBannerStyles). Floats over the bottom of the code pane (just
-     above the action-row reserve) instead of sitting in flow above the
-     editor — a lint pass adding or clearing it must not reflow the code
-     under the user's cursor. */
-  .invalid-banner {
-    position: absolute;
-    left: var(--wa-space-xs);
-    right: var(--wa-space-xs);
-    bottom: calc(2.25rem + var(--wa-space-xs) * 2);
-    z-index: 9;
-    box-shadow: var(--wa-elevation-02);
-  }
-
-  .invalid-banner-more {
-    font-size: var(--wa-font-size-2xs);
-    opacity: 0.85;
   }
 
   .editor-pane-body {

--- a/src/components/device/device-editor.styles.ts
+++ b/src/components/device/device-editor.styles.ts
@@ -362,8 +362,7 @@ export const deviceEditorStyles = css`
   /* The code editor brings its own line-number gutter, so the full
      var(--wa-space-m) inset the config form needs reads as wasted padding that
      shrinks the text area. Trim the editor pane to a tighter, even inset on the
-     top + sides; the bottom keeps the action-row reserve above. Also the
-     positioning context for the floating invalid banner. */
+     top + sides; the bottom keeps the action-row reserve above. */
   .editor-pane--right {
     position: relative;
     padding-top: var(--wa-space-xs);

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -213,8 +213,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   private _editorFocused = false;
 
   /** performance.now() of the last YAML edit; read by the banner through
-   *  the stable accessor below so keystrokes don't re-render this host. */
-  private _lastEditAt = 0;
+   *  the stable accessor below so keystrokes don't re-render this host.
+   *  Starts (and resets, on device switch) to -Infinity — "never typed",
+   *  so a pre-existing error is never deferred by the idle backstop. */
+  private _lastEditAt = Number.NEGATIVE_INFINITY;
 
   private _getLastEditAt = () => this._lastEditAt;
 
@@ -492,6 +494,7 @@ export class ESPHomeDeviceEditor extends LitElement {
     if (changed.has("configuration")) {
       if (this._liveErrors.length) this._liveErrors = [];
       this._caretLine = 0;
+      this._lastEditAt = Number.NEGATIVE_INFINITY;
     }
     if (this._showDiff && changed.has("_showDiffButton") && !this._showDiffButton) {
       this._showDiff = false;

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -393,6 +393,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                         .revealSensitive=${this._revealSensitive}
                         @yaml-change=${this._onYamlChange}
                         @yaml-diagnostics=${this._onYamlDiagnostics}
+                        @yaml-auto-fix=${this._onBannerAutoFix}
                         @yaml-cursor-line=${this._onYamlCursorLine}
                         @focusin=${this._onEditorFocusIn}
                         @focusout=${this._onEditorFocusOut}

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -212,6 +212,10 @@ export class ESPHomeDeviceEditor extends LitElement {
   @state()
   private _editorFocused = false;
 
+  /** The editor's completion popup is showing; holds the banner reveal. */
+  @state()
+  private _completionOpen = false;
+
   /** performance.now() of the last YAML edit; read by the banner through
    *  the stable accessor below so keystrokes don't re-render this host.
    *  Starts (and resets, on device switch) to -Infinity — "never typed",
@@ -397,6 +401,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                         @yaml-diagnostics=${this._onYamlDiagnostics}
                         @yaml-auto-fix=${this._onBannerAutoFix}
                         @yaml-cursor-line=${this._onYamlCursorLine}
+                        @yaml-completion-open=${this._onYamlCompletionOpen}
                         @focusin=${this._onEditorFocusIn}
                         @focusout=${this._onEditorFocusOut}
                       ></esphome-yaml-editor>`
@@ -408,6 +413,7 @@ export class ESPHomeDeviceEditor extends LitElement {
                       .errors=${this._liveErrors}
                       .caretLine=${this._caretLine}
                       .editorFocused=${this._editorFocused}
+                      .completionOpen=${this._completionOpen}
                       .getLastEditAt=${this._getLastEditAt}
                       @banner-auto-fix=${this._onBannerAutoFix}
                       @banner-goto-line=${this._onBannerGotoLine}
@@ -534,6 +540,10 @@ export class ESPHomeDeviceEditor extends LitElement {
 
   private _onYamlCursorLine(e: CustomEvent<{ line: number }>) {
     this._caretLine = e.detail.line;
+  }
+
+  private _onYamlCompletionOpen(e: CustomEvent<{ open: boolean }>) {
+    this._completionOpen = e.detail.open;
   }
 
   private _onEditorFocusIn = () => {

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -501,6 +501,12 @@ export class ESPHomeDeviceEditor extends LitElement {
       if (this._liveErrors.length) this._liveErrors = [];
       this._caretLine = 0;
       this._lastEditAt = Number.NEGATIVE_INFINITY;
+      // The editor remounts on a device switch, silently dropping focus and
+      // any open completion popup (a removed focused node fires no focusout,
+      // and the popup's close never transitions on a fresh view) — clear
+      // both so the new config's banner can't stay suppressed.
+      this._editorFocused = false;
+      this._completionOpen = false;
     }
     if (this._showDiff && changed.has("_showDiffButton") && !this._showDiffButton) {
       this._showDiff = false;
@@ -527,6 +533,7 @@ export class ESPHomeDeviceEditor extends LitElement {
         return (
           err.message === prev.message &&
           err.line === prev.line &&
+          err.kind === prev.kind &&
           err.fix?.line === prev.fix?.line &&
           err.fix?.indent === prev.fix?.indent &&
           err.fix?.key === prev.fix?.key

--- a/src/components/device/device-editor.ts
+++ b/src/components/device/device-editor.ts
@@ -1,6 +1,5 @@
 import { consume } from "@lit/context";
 import {
-  mdiAlertCircleOutline,
   mdiCheckCircleOutline,
   mdiChevronDown,
   mdiContentSave,
@@ -17,13 +16,11 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { BoardCatalogEntry } from "../../api/types/boards.js";
 import type { LocalizeFunc } from "../../common/localize.js";
 import { expertModeContext, localizeContext } from "../../context/index.js";
-import { dangerBannerStyles } from "../../styles/banners.js";
 import { espHomeStyles } from "../../styles/shared.js";
 import {
   NO_INSTANCE_ERRORS,
   type InstanceBackendErrors,
 } from "../../util/backend-field-errors.js";
-import { renderTextLinks } from "../../util/markdown.js";
 import { notifyError, notifyWarning } from "../../util/notify.js";
 import { registerMdiIcons } from "../../util/register-icons.js";
 import { SaveShortcutController } from "../../util/save-shortcut-controller.js";
@@ -40,6 +37,10 @@ import type { ESPHomeConfirmDialog } from "../confirm-dialog.js";
 import type { ESPHomeYamlEditor, HighlightRange } from "../yaml-editor.js";
 import { renderEditorToolbar } from "./device-editor-toolbar.js";
 import { deviceEditorStyles } from "./device-editor.styles.js";
+import type {
+  BannerAutoFixDetail,
+  BannerGotoLineDetail,
+} from "./editor-invalid-banner.js";
 import { renderInstallAction } from "./install-action.js";
 
 import "@home-assistant/webawesome/dist/components/button/button.js";
@@ -49,9 +50,9 @@ import "../confirm-dialog.js";
 import "../yaml-diff.js";
 import "../yaml-editor.js";
 import "./device-board-info.js";
+import "./editor-invalid-banner.js";
 
 registerMdiIcons({
-  "alert-circle-outline": mdiAlertCircleOutline,
   "check-circle-outline": mdiCheckCircleOutline,
   "chevron-down": mdiChevronDown,
   "content-save": mdiContentSave,
@@ -65,9 +66,6 @@ registerMdiIcons({
 });
 
 export type DeviceLayoutMode = "both" | "left" | "right";
-
-/** Cap the errors listed in the invalid banner; the rest collapse to "+N more". */
-const MAX_BANNER_ERRORS = 6;
 
 @customElement("esphome-device-editor")
 export class ESPHomeDeviceEditor extends LitElement {
@@ -202,9 +200,23 @@ export class ESPHomeDeviceEditor extends LitElement {
   private _revealSensitive = false;
 
   /** Live lint error messages from the editor's backend linter. Drives the
-   *  "configuration invalid" banner above the editor. */
+   *  "configuration invalid" banner below the editor. */
   @state()
   private _liveErrors: BannerError[] = [];
+
+  /** Caret's 1-indexed line from the yaml-cursor-line event; feeds the banner's
+   *  near-caret reveal suppression. */
+  @state()
+  private _caretLine = 0;
+
+  @state()
+  private _editorFocused = false;
+
+  /** performance.now() of the last YAML edit; read by the banner through
+   *  the stable accessor below so keystrokes don't re-render this host. */
+  private _lastEditAt = 0;
+
+  private _getLastEditAt = () => this._lastEditAt;
 
   @state()
   private _splitRatio = loadSplitRatio();
@@ -221,7 +233,7 @@ export class ESPHomeDeviceEditor extends LitElement {
   @query("esphome-confirm-dialog.auto-fix-confirm")
   private _autoFixConfirmDialog?: ESPHomeConfirmDialog;
 
-  static styles = [espHomeStyles, dangerBannerStyles, deviceEditorStyles];
+  static styles = [espHomeStyles, deviceEditorStyles];
 
   protected render() {
     // On mobile we collapse the split view down to a single pane to
@@ -365,57 +377,6 @@ export class ESPHomeDeviceEditor extends LitElement {
                 : nothing
             }
             <div class="editor-pane editor-pane--right">
-              ${
-                !this._showDiff && this._liveErrors.length > 0
-                  ? html`<div class="danger-banner invalid-banner" role="alert">
-                      <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
-                      <div class="danger-banner-text">
-                        ${this._liveErrors.slice(0, MAX_BANNER_ERRORS).map(
-                          (err) =>
-                            html`<span
-                              >${renderTextLinks(err.message)}${
-                                err.fix
-                                  ? html`
-                                      <button
-                                        type="button"
-                                        class="invalid-banner-goto"
-                                        title=${this._localize("yaml_editor.error_auto_fix_hint")}
-                                        @click=${() => this._autoFix(err.fix!)}
-                                      >
-                                        ${this._localize("yaml_editor.error_auto_fix")}
-                                      </button>
-                                    `
-                                  : nothing
-                              }${
-                                err.line
-                                  ? html`
-                                      <button
-                                        type="button"
-                                        class="invalid-banner-goto"
-                                        @click=${() => this._gotoErrorLine(err.line!)}
-                                      >
-                                        ${this._localize("yaml_editor.error_go_to_line", {
-                                          line: err.line,
-                                        })}
-                                      </button>
-                                    `
-                                  : nothing
-                              }</span
-                            >`
-                        )}
-                        ${
-                          this._liveErrors.length > MAX_BANNER_ERRORS
-                            ? html`<span class="invalid-banner-more"
-                                >${this._localize("device.editor_invalid_more", {
-                                  count: this._liveErrors.length - MAX_BANNER_ERRORS,
-                                })}</span
-                              >`
-                            : nothing
-                        }
-                      </div>
-                    </div>`
-                  : nothing
-              }
               <div class="editor-pane-body">
                 ${
                   this._showDiff
@@ -432,9 +393,24 @@ export class ESPHomeDeviceEditor extends LitElement {
                         .revealSensitive=${this._revealSensitive}
                         @yaml-change=${this._onYamlChange}
                         @yaml-diagnostics=${this._onYamlDiagnostics}
+                        @yaml-cursor-line=${this._onYamlCursorLine}
+                        @focusin=${this._onEditorFocusIn}
+                        @focusout=${this._onEditorFocusOut}
                       ></esphome-yaml-editor>`
                 }
               </div>
+              ${
+                !this._showDiff
+                  ? html`<esphome-editor-invalid-banner
+                      .errors=${this._liveErrors}
+                      .caretLine=${this._caretLine}
+                      .editorFocused=${this._editorFocused}
+                      .getLastEditAt=${this._getLastEditAt}
+                      @banner-auto-fix=${this._onBannerAutoFix}
+                      @banner-goto-line=${this._onBannerGotoLine}
+                    ></esphome-editor-invalid-banner>`
+                  : nothing
+              }
             </div>
           </div>
         </div>
@@ -512,8 +488,9 @@ export class ESPHomeDeviceEditor extends LitElement {
   willUpdate(changed: Map<string, unknown>) {
     // Switching device clears the banner until the new file re-lints, so a
     // stale "invalid" never flashes over a freshly-opened valid config.
-    if (changed.has("configuration") && this._liveErrors.length) {
-      this._liveErrors = [];
+    if (changed.has("configuration")) {
+      if (this._liveErrors.length) this._liveErrors = [];
+      this._caretLine = 0;
     }
     if (this._showDiff && changed.has("_showDiffButton") && !this._showDiffButton) {
       this._showDiff = false;
@@ -549,6 +526,31 @@ export class ESPHomeDeviceEditor extends LitElement {
       return;
     }
     this._liveErrors = next;
+  }
+
+  private _onYamlCursorLine(e: CustomEvent<{ line: number }>) {
+    this._caretLine = e.detail.line;
+  }
+
+  private _onEditorFocusIn = () => {
+    this._editorFocused = true;
+  };
+
+  /** CM-internal focus shifts (tooltips, completion) stay inside the
+   *  editor's shadow tree, so their retargeted relatedTarget is the editor
+   *  host itself — only a move outside it counts as leaving. */
+  private _onEditorFocusOut = (e: FocusEvent) => {
+    const editor = e.currentTarget as HTMLElement;
+    this._editorFocused =
+      e.relatedTarget instanceof Node && editor.contains(e.relatedTarget);
+  };
+
+  private _onBannerAutoFix(e: CustomEvent<BannerAutoFixDetail>) {
+    this._autoFix(e.detail.fix);
+  }
+
+  private _onBannerGotoLine(e: CustomEvent<BannerGotoLineDetail>) {
+    this._gotoErrorLine(e.detail.line);
   }
 
   /** Apply a banner error's one-click indentation repair in the editor. The
@@ -704,6 +706,7 @@ export class ESPHomeDeviceEditor extends LitElement {
   }
 
   private _onYamlChange(e: CustomEvent) {
+    this._lastEditAt = performance.now();
     this.dispatchEvent(
       new CustomEvent("yaml-change", {
         detail: e.detail,

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -227,6 +227,13 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
       this._visible = this.errors;
       return;
     }
+    // The completion popup holds reveals without a deadline; closing it
+    // re-evaluates through the property change, so no timer churns while
+    // it stays open.
+    if (this.completionOpen) {
+      this._cancelRevealTimer();
+      return;
+    }
     this._armRevealTimer();
   }
 

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -7,12 +7,13 @@
  * overlay).
  *
  * The reveal is damped so the banner doesn't pop over a half-typed token:
- * while the editor is focused and every locatable error sits within
+ * while the editor is focused and every error is a YAML parse error within
  * NEAR_CARET_LINES of the caret, new errors stay squiggle-only until the
  * caret moves away, the editor loses focus, or the user has been idle for
- * REVEAL_IDLE_MS. An error far from the caret is real breakage and shows
- * as soon as the lint pass lands; a fixed config clears the banner
- * immediately; a banner already on screen tracks lint updates live.
+ * REVEAL_IDLE_MS. A parse error far from the caret, or any validation
+ * error (the document parses — real breakage), shows as soon as the lint
+ * pass lands; a fixed config clears the banner immediately; a banner
+ * already on screen tracks lint updates live.
  */
 import { consume } from "@lit/context";
 import { mdiAlertCircleOutline } from "@mdi/js";
@@ -222,8 +223,12 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
 
   private _shouldReveal(): boolean {
     if (!this.editorFocused) return true;
-    // A locatable error far from the caret isn't the user's in-progress
-    // token. Line-less (whole-config) errors count as near — suppressible.
+    // Only a YAML parse error is plausibly the user's half-typed token; a
+    // validation error means the document parses, so it's real breakage (a
+    // deleted esp32: block, an included-file error) — show it right away.
+    if (this.errors.some((err) => err.kind !== "parse")) return true;
+    // A locatable parse error far from the caret isn't the in-progress
+    // token either. Line-less parse errors count as near — suppressible.
     if (
       this.errors.some(
         (err) =>

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -7,13 +7,15 @@
  * overlay).
  *
  * The reveal is damped so the banner doesn't pop over a half-typed token:
- * while the editor is focused and every error is a YAML parse error within
- * NEAR_CARET_LINES of the caret, new errors stay squiggle-only until the
- * caret moves away, the editor loses focus, or the user has been idle for
- * REVEAL_IDLE_MS. A parse error far from the caret, or any validation
- * error (the document parses — real breakage), shows as soon as the lint
- * pass lands; a fixed config clears the banner immediately; a banner
- * already on screen tracks lint updates live.
+ * while the editor is focused and every error — parse or validation — is
+ * anchored within NEAR_CARET_LINES of the caret, new errors stay
+ * squiggle-only until the caret moves away, the editor loses focus, or
+ * the user has been idle for REVEAL_IDLE_MS. An error anchored far from
+ * the caret, or a line-less validation error (whole-config breakage like
+ * a missing platform), shows as soon as the lint pass lands — except
+ * while the completion popup is open, which holds every reveal. A fixed
+ * config clears the banner immediately; a banner already on screen
+ * tracks lint updates live.
  */
 import { consume } from "@lit/context";
 import { mdiAlertCircleOutline } from "@mdi/js";

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -1,0 +1,266 @@
+/**
+ * Document-level "configuration invalid" banner for the YAML editor.
+ *
+ * Renders the live lint errors below the code pane, in flow — the editor
+ * shrinks to make room, so the banner can never cover the line it is
+ * complaining about (an error at EOF has no scroll room to escape an
+ * overlay).
+ *
+ * The reveal is damped so the banner doesn't pop over a half-typed token:
+ * while the editor is focused and every locatable error sits within
+ * NEAR_CARET_LINES of the caret, new errors stay squiggle-only until the
+ * caret moves away, the editor loses focus, or the user has been idle for
+ * REVEAL_IDLE_MS. An error far from the caret is real breakage and shows
+ * as soon as the lint pass lands; a fixed config clears the banner
+ * immediately; a banner already on screen tracks lint updates live.
+ */
+import { consume } from "@lit/context";
+import { mdiAlertCircleOutline } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type { LocalizeFunc } from "../../common/localize.js";
+import { localizeContext } from "../../context/index.js";
+import { dangerBannerStyles } from "../../styles/banners.js";
+import { renderTextLinks } from "../../util/markdown.js";
+import { registerMdiIcons } from "../../util/register-icons.js";
+import type { BannerError, YamlAutoFix } from "../../util/yaml-lint-backend.js";
+
+import "@home-assistant/webawesome/dist/components/icon/icon.js";
+
+registerMdiIcons({
+  "alert-circle-outline": mdiAlertCircleOutline,
+});
+
+/** Cap the errors listed in the banner; the rest collapse to "+N more". */
+const MAX_BANNER_ERRORS = 6;
+
+/** Caret distance (lines) within which a new error reads as the token the
+ *  user is mid-way through typing. PyYAML blames the line where parsing
+ *  broke, often one or two lines below the caret's half-typed key. */
+const NEAR_CARET_LINES = 3;
+
+/** Idle backstop: reveal a suppressed banner after this long with no edit. */
+const REVEAL_IDLE_MS = 15_000;
+
+/** Detail of the banner-auto-fix event: the clicked error's repair. */
+export interface BannerAutoFixDetail {
+  fix: YamlAutoFix;
+}
+
+/** Detail of the banner-goto-line event: the clicked error's 1-indexed line. */
+export interface BannerGotoLineDetail {
+  line: number;
+}
+
+@customElement("esphome-editor-invalid-banner")
+export class ESPHomeEditorInvalidBanner extends LitElement {
+  @consume({ context: localizeContext, subscribe: true })
+  @state()
+  private _localize: LocalizeFunc = (key) => key;
+
+  /** Live lint errors from the host's backend linter. */
+  @property({ attribute: false })
+  errors: BannerError[] = [];
+
+  /** Caret's current 1-indexed line, for the near-caret suppression. */
+  @property({ type: Number })
+  caretLine = 0;
+
+  /** Whether the YAML editor currently holds focus. */
+  @property({ type: Boolean })
+  editorFocused = false;
+
+  /** Timestamp accessor (performance.now clock) of the last YAML edit — a
+   *  pull accessor so the host doesn't re-render per keystroke. */
+  @property({ attribute: false })
+  getLastEditAt: () => number = () => 0;
+
+  /** The errors actually on screen; empty renders nothing (the host's
+   *  display: contents means no flex box and no pane gap either). */
+  @state()
+  private _visible: BannerError[] = [];
+
+  private _revealTimer: ReturnType<typeof setTimeout> | undefined;
+
+  static styles = [
+    dangerBannerStyles,
+    css`
+      :host {
+        display: contents;
+      }
+
+      .invalid-banner {
+        flex: 0 0 auto;
+      }
+
+      .invalid-banner-goto {
+        appearance: none;
+        margin-left: 0.35em;
+        padding: 0;
+        border: none;
+        background: none;
+        color: inherit;
+        font: inherit;
+        font-weight: var(--wa-font-weight-semibold);
+        text-decoration: underline;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .invalid-banner-goto:hover {
+        text-decoration: none;
+      }
+
+      .invalid-banner-more {
+        font-size: var(--wa-font-size-2xs);
+        opacity: 0.85;
+      }
+    `,
+  ];
+
+  willUpdate(changed: Map<string, unknown>) {
+    if (
+      changed.has("errors") ||
+      changed.has("caretLine") ||
+      changed.has("editorFocused")
+    ) {
+      this._evaluate();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._cancelRevealTimer();
+  }
+
+  protected render() {
+    if (this._visible.length === 0) return nothing;
+    return html`<div class="danger-banner invalid-banner" role="alert">
+      <wa-icon library="mdi" name="alert-circle-outline"></wa-icon>
+      <div class="danger-banner-text">
+        ${this._visible.slice(0, MAX_BANNER_ERRORS).map(
+          (err) =>
+            html`<span
+              >${renderTextLinks(err.message)}${
+                err.fix
+                  ? html`
+                      <button
+                        type="button"
+                        class="invalid-banner-goto"
+                        title=${this._localize("yaml_editor.error_auto_fix_hint")}
+                        @click=${() => this._onAutoFix(err.fix!)}
+                      >
+                        ${this._localize("yaml_editor.error_auto_fix")}
+                      </button>
+                    `
+                  : nothing
+              }${
+                err.line
+                  ? html`
+                      <button
+                        type="button"
+                        class="invalid-banner-goto"
+                        @click=${() => this._onGotoLine(err.line!)}
+                      >
+                        ${this._localize("yaml_editor.error_go_to_line", {
+                          line: err.line,
+                        })}
+                      </button>
+                    `
+                  : nothing
+              }</span
+            >`
+        )}
+        ${
+          this._visible.length > MAX_BANNER_ERRORS
+            ? html`<span class="invalid-banner-more"
+                >${this._localize("device.editor_invalid_more", {
+                  count: this._visible.length - MAX_BANNER_ERRORS,
+                })}</span
+              >`
+            : nothing
+        }
+      </div>
+    </div>`;
+  }
+
+  private _onAutoFix(fix: YamlAutoFix) {
+    this.dispatchEvent(
+      new CustomEvent<BannerAutoFixDetail>("banner-auto-fix", {
+        detail: { fix },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private _onGotoLine(line: number) {
+    this.dispatchEvent(
+      new CustomEvent<BannerGotoLineDetail>("banner-goto-line", {
+        detail: { line },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  /** Settle _visible against the current inputs, (re)arming the idle
+   *  timer when the only path left to reveal is the user going idle. */
+  private _evaluate() {
+    if (this.errors.length === 0) {
+      this._cancelRevealTimer();
+      if (this._visible.length) this._visible = [];
+      return;
+    }
+    if (this._visible.length > 0 || this._shouldReveal()) {
+      this._cancelRevealTimer();
+      this._visible = this.errors;
+      return;
+    }
+    this._armRevealTimer();
+  }
+
+  private _shouldReveal(): boolean {
+    if (!this.editorFocused) return true;
+    // A locatable error far from the caret isn't the user's in-progress
+    // token. Line-less (whole-config) errors count as near — suppressible.
+    if (
+      this.errors.some(
+        (err) =>
+          err.line !== undefined && Math.abs(err.line - this.caretLine) > NEAR_CARET_LINES
+      )
+    ) {
+      return true;
+    }
+    return performance.now() - this.getLastEditAt() >= REVEAL_IDLE_MS;
+  }
+
+  /** The timer re-evaluates rather than reveals: the idle clock restarts
+   *  with every keystroke (and a deduped identical lint result never
+   *  reassigns the errors prop), so on fire the remaining idle is re-measured and
+   *  the timer re-armed until a full quiet window has actually elapsed. */
+  private _armRevealTimer() {
+    this._cancelRevealTimer();
+    const remaining = REVEAL_IDLE_MS - (performance.now() - this.getLastEditAt());
+    this._revealTimer = setTimeout(
+      () => {
+        this._revealTimer = undefined;
+        this._evaluate();
+      },
+      Math.max(remaining, 100)
+    );
+  }
+
+  private _cancelRevealTimer() {
+    if (this._revealTimer !== undefined) {
+      clearTimeout(this._revealTimer);
+      this._revealTimer = undefined;
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-editor-invalid-banner": ESPHomeEditorInvalidBanner;
+  }
+}

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -72,9 +72,10 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
   editorFocused = false;
 
   /** Timestamp accessor (performance.now clock) of the last YAML edit — a
-   *  pull accessor so the host doesn't re-render per keystroke. */
+   *  pull accessor so the host doesn't re-render per keystroke. -Infinity
+   *  means "never typed": the idle backstop is already satisfied. */
   @property({ attribute: false })
-  getLastEditAt: () => number = () => 0;
+  getLastEditAt: () => number = () => Number.NEGATIVE_INFINITY;
 
   /** The errors actually on screen; empty renders nothing (the host's
    *  display: contents means no flex box and no pane gap either). */

--- a/src/components/device/editor-invalid-banner.ts
+++ b/src/components/device/editor-invalid-banner.ts
@@ -71,6 +71,11 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
   @property({ type: Boolean })
   editorFocused = false;
 
+  /** The completion popup is open — the user is mid-decision, so every
+   *  reveal (including line-less validation errors) holds until it closes. */
+  @property({ type: Boolean })
+  completionOpen = false;
+
   /** Timestamp accessor (performance.now clock) of the last YAML edit — a
    *  pull accessor so the host doesn't re-render per keystroke. -Infinity
    *  means "never typed": the idle backstop is already satisfied. */
@@ -124,7 +129,8 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
     if (
       changed.has("errors") ||
       changed.has("caretLine") ||
-      changed.has("editorFocused")
+      changed.has("editorFocused") ||
+      changed.has("completionOpen")
     ) {
       this._evaluate();
     }
@@ -223,13 +229,21 @@ export class ESPHomeEditorInvalidBanner extends LitElement {
   }
 
   private _shouldReveal(): boolean {
+    // An open completion popup means the user is still picking — hold
+    // everything; closing it re-evaluates through the property change.
+    if (this.completionOpen) return false;
     if (!this.editorFocused) return true;
-    // Only a YAML parse error is plausibly the user's half-typed token; a
-    // validation error means the document parses, so it's real breakage (a
-    // deleted esp32: block, an included-file error) — show it right away.
-    if (this.errors.some((err) => err.kind !== "parse")) return true;
-    // A locatable parse error far from the caret isn't the in-progress
-    // token either. Line-less parse errors count as near — suppressible.
+    // A line-less validation error is whole-config breakage (a deleted
+    // esp32: block, an included-file error) — nothing ties it to what the
+    // user is typing, so show it right away. Anything anchored near the
+    // caret is plausibly the half-typed token, whether the parser or the
+    // validator complained (a lone "l" under "logger:" parses as a string
+    // and surfaces as "expected a dictionary."), so it stays damped. A
+    // line-less PARSE error is an unplaceable artifact of mid-edit YAML —
+    // suppressible.
+    if (this.errors.some((err) => err.kind !== "parse" && err.line === undefined)) {
+      return true;
+    }
     if (
       this.errors.some(
         (err) =>

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -36,11 +36,10 @@ import {
   blankLineContext,
   fieldPathByIndent,
   keyPathByIndent,
-  parseListItemMarker,
 } from "../util/yaml-line-walker.js";
 import {
+  analyzeIndentMismatch,
   createBackendYamlLinter,
-  firstPropertyDelta,
   lintErrorLineGutter,
   relintEffect,
   type YamlAutoFix,
@@ -611,30 +610,44 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     confirm?: () => Promise<boolean>
   ): Promise<AutoFixOutcome> {
     const view = this._view;
-    if (!view || !this._api || fix.indent <= 0) return "unavailable";
-    // Resolve the target only when it is still the same `- <key>` item that
-    // still needs exactly `fix.indent` — recomputing the delta from its first
-    // property bails on an item the user already fixed by hand (whose key still
-    // matches), so a stale click can't double-indent it.
+    if (!view || !this._api || fix.indent === 0) return "unavailable";
+    // Resolve the target only when re-running the analysis on the fix line
+    // still yields this exact repair — a stale click on an item the user
+    // already re-indented by hand (whose key still matches) can't move it
+    // again. Every analysis shape blames the line it would move except the
+    // classic over-indented-properties case, where re-analyzing the marker
+    // line itself reproduces the fix through the properties below it.
     const targetFrom = (): number | null => {
       const doc = view.state.doc;
       if (fix.line < 1 || fix.line > doc.lines) return null;
       const t = doc.line(fix.line);
-      const marker = parseListItemMarker(t.text);
-      if (!marker || marker.key !== fix.key) return null;
       const readLine = (n: number) =>
         n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
-      if (firstPropertyDelta(readLine, fix.line, marker.contentCol) !== fix.indent) {
+      const cur = analyzeIndentMismatch(readLine, fix.line);
+      if (
+        !cur ||
+        cur.markerLine !== fix.line ||
+        cur.markerKey !== fix.key ||
+        cur.delta !== fix.indent
+      ) {
         return null;
       }
+      // A dedent must have the spaces it wants to remove.
+      if (fix.indent < 0 && /[^ ]/.test(t.text.slice(0, -fix.indent))) return null;
       return t.from;
     };
     const from = targetFrom();
     if (from === null) return "stale";
 
     const doc = view.state.doc;
-    const spaces = " ".repeat(fix.indent);
-    const proposed = doc.sliceString(0, from) + spaces + doc.sliceString(from);
+    const changeAt = (at: number) =>
+      fix.indent > 0
+        ? { from: at, insert: " ".repeat(fix.indent) }
+        : { from: at, to: at - fix.indent };
+    const proposed =
+      fix.indent > 0
+        ? doc.sliceString(0, from) + " ".repeat(fix.indent) + doc.sliceString(from)
+        : doc.sliceString(0, from) + doc.sliceString(from - fix.indent);
     // A validation failure propagates: don't apply blindly, and let the caller
     // surface it rather than swallowing the click.
     const res = await this._api.validateYaml(this.configuration, proposed);
@@ -647,7 +660,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     const settled = targetFrom();
     if (settled === null) return "stale";
     view.dispatch({
-      changes: { from: settled, insert: spaces },
+      changes: changeAt(settled),
       scrollIntoView: true,
     });
     view.focus();

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -1,4 +1,4 @@
-import { autocompletion } from "@codemirror/autocomplete";
+import { autocompletion, completionStatus } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
 import { forceLinting } from "@codemirror/lint";
@@ -166,6 +166,9 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
    *  whole path keeps both section- and field-following in sync without
    *  churning on plain column moves. */
   private _lastReportedPathKey = "";
+
+  /** Last completion-popup visibility emitted as `yaml-completion-open`. */
+  private _lastCompletionOpen = false;
 
   static styles = css`
     :host {
@@ -424,6 +427,19 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         },
       }),
       EditorView.updateListener.of((update) => {
+        // Surface completion-popup visibility so the host can hold the
+        // invalid banner while the user is still picking an option.
+        const completionOpen = completionStatus(update.state) === "active";
+        if (completionOpen !== this._lastCompletionOpen) {
+          this._lastCompletionOpen = completionOpen;
+          this.dispatchEvent(
+            new CustomEvent("yaml-completion-open", {
+              detail: { open: completionOpen },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
         // LOAD-BEARING ORDER: `yaml-change` MUST be dispatched
         // before `yaml-cursor-line` within a single update.
         // The page's `_onYamlChange` writes `_yaml` from the
@@ -570,6 +586,19 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
           icons: true,
           closeOnBlur: true,
           maxRenderedOptions: 60,
+          // Pin the option-docs panel beside the list, or flush below it
+          // when the side lacks room — the default "narrow" placement lays
+          // the panel over the options themselves.
+          positionInfo: (view, list, option) => {
+            const space = view.scrollDOM.getBoundingClientRect();
+            const listW = list.right - list.left;
+            if (space.right - list.right >= 320) {
+              return {
+                style: `top: ${Math.max(0, option.top - list.top)}px; left: ${listW}px`,
+              };
+            }
+            return { style: `top: ${list.bottom - list.top}px; left: 0px` };
+          },
         }),
         // Open the popup when the caret idles on a blank/empty line, so
         // keys/values are discoverable without typing a partial first.
@@ -700,6 +729,7 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     this._container.innerHTML = "";
     this._lastReportedCursorLine = 0;
     this._lastReportedPathKey = "";
+    this._lastCompletionOpen = false;
     this._mountEditor();
   }
 

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -2,8 +2,8 @@ import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, undoDepth } from "@codemirror/commands";
 import { indentUnit } from "@codemirror/language";
 import { forceLinting } from "@codemirror/lint";
-import { StateEffect, StateField, Transaction, type Text } from "@codemirror/state";
-import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
+import { StateEffect, StateField, Transaction } from "@codemirror/state";
+import { Decoration, keymap, tooltips, type DecorationSet } from "@codemirror/view";
 import { consume } from "@lit/context";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { basicSetup, EditorView } from "codemirror";
@@ -35,12 +35,12 @@ import { createYamlHoverTooltip } from "../util/yaml-hover.js";
 import {
   blankLineContext,
   fieldPathByIndent,
-  indentOf,
   keyPathByIndent,
   parseListItemMarker,
 } from "../util/yaml-line-walker.js";
 import {
   createBackendYamlLinter,
+  firstPropertyDelta,
   lintErrorLineGutter,
   relintEffect,
   type YamlAutoFix,
@@ -208,6 +208,12 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
         colors: INDENT_GUIDE_COLORS,
       }),
       highlightField,
+      // Keep every tooltip (lint hover, docs hover, completion) inside the
+      // code pane: near the bottom they flip above the line instead of
+      // spilling over the invalid banner / action row below the editor.
+      tooltips({
+        tooltipSpace: (view) => view.scrollDOM.getBoundingClientRect(),
+      }),
       sensitiveValueMaskExtension(this.revealSensitive, this.maskAllValues),
       yamlStickyScroll({
         highlightStyle: this._darkMode ? darkHighlight : lightHighlight,
@@ -541,6 +547,14 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
                 composed: true,
               })
             ),
+          onAutoFix: (fix) =>
+            this.dispatchEvent(
+              new CustomEvent<{ fix: YamlAutoFix }>("yaml-auto-fix", {
+                detail: { fix },
+                bubbles: true,
+                composed: true,
+              })
+            ),
         }),
         lintErrorLineGutter
       );
@@ -608,7 +622,9 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
       const t = doc.line(fix.line);
       const marker = parseListItemMarker(t.text);
       if (!marker || marker.key !== fix.key) return null;
-      if (this._firstPropertyDelta(doc, fix.line, marker.contentCol) !== fix.indent) {
+      const readLine = (n: number) =>
+        n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
+      if (firstPropertyDelta(readLine, fix.line, marker.contentCol) !== fix.indent) {
         return null;
       }
       return t.from;
@@ -636,24 +652,6 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     });
     view.focus();
     return "applied";
-  }
-
-  /** Indent of the list item's first property line minus `contentCol` (where
-   *  its key starts), or null when the item has no property line — the next
-   *  content is a shallower sibling/dedent (indent below `contentCol`), not a
-   *  property, so it never reports a spurious negative delta. */
-  private _firstPropertyDelta(
-    doc: Text,
-    line: number,
-    contentCol: number
-  ): number | null {
-    for (let n = line + 1; n <= doc.lines; n++) {
-      const text = doc.line(n).text;
-      if (!text.trim() || text.trimStart().startsWith("#")) continue;
-      const indent = indentOf(text);
-      return indent < contentCol ? null : indent - contentCol;
-    }
-    return null;
   }
 
   /** Set (or clear) the highlight mark and scroll it into view. */

--- a/src/components/yaml-editor.ts
+++ b/src/components/yaml-editor.ts
@@ -729,7 +729,19 @@ export class ESPHomeYamlEditor extends CodeMirrorEditorElement {
     this._container.innerHTML = "";
     this._lastReportedCursorLine = 0;
     this._lastReportedPathKey = "";
-    this._lastCompletionOpen = false;
+    // A remount destroys any open completion popup without a state
+    // transition the update listener could see — emit the close ourselves
+    // or the host would hold the invalid banner forever.
+    if (this._lastCompletionOpen) {
+      this._lastCompletionOpen = false;
+      this.dispatchEvent(
+        new CustomEvent("yaml-completion-open", {
+          detail: { open: false },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
     this._mountEditor();
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1118,6 +1118,7 @@
     "sticky_jump_to_line": "Jump to line {line}",
     "error_indent_fix": "Indentation mismatch: line {line} \"- {key}\" is indented less than its properties. Indent line {line} by {spaces, plural, one {# space} other {# spaces}} so \"- {key}\" lines up with them.",
     "error_indent_hint": "YAML indentation problem near line {line}. Make sure each list item's properties are indented consistently under its \"- \" marker; an over-indented or under-indented line, or a stray \":\" in a value, causes this.",
+    "error_missing_colon_hint": "Line {line}: \"{key}\" looks like an option name without a value. Add \":\" and a value after it, or remove the line.",
     "error_tab_hint": "A tab is used for indentation near line {line}; YAML needs spaces. Replace the tab with spaces.",
     "error_char_hint": "Unexpected character near line {line}; a value starting with a symbol such as @, %, or * must be wrapped in quotes.",
     "error_unterminated_string_hint": "Unterminated string near line {line}; a quote was opened but not closed. Add the missing closing quote.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1117,6 +1117,9 @@
   "yaml_editor": {
     "sticky_jump_to_line": "Jump to line {line}",
     "error_indent_fix": "Indentation mismatch: line {line} \"- {key}\" is indented less than its properties. Indent line {line} by {spaces, plural, one {# space} other {# spaces}} so \"- {key}\" lines up with them.",
+    "error_misaligned_indent_fix": "Indentation mismatch: line {line} \"{key}\" is indented too little. Indent line {line} by {spaces, plural, one {# space} other {# spaces}} so it lines up.",
+    "error_misaligned_dedent_fix": "Indentation mismatch: line {line} \"{key}\" is indented too deep. Remove {spaces, plural, one {# space} other {# spaces}} from the start of line {line} so it lines up.",
+    "error_nested_list_hint": "The \"- \" items below \"{key}\" are indented as its value. If they should be separate list entries, dedent them to line up with \"- {key}\".",
     "error_indent_hint": "YAML indentation problem near line {line}. Make sure each list item's properties are indented consistently under its \"- \" marker; an over-indented or under-indented line, or a stray \":\" in a value, causes this.",
     "error_missing_colon_hint": "Line {line}: \"{key}\" looks like an option name without a value. Add \":\" and a value after it, or remove the line.",
     "error_tab_hint": "A tab is used for indentation near line {line}; YAML needs spaces. Replace the tab with spaces.",
@@ -1126,7 +1129,7 @@
     "error_flow_hint": "Unclosed bracket near line {line}; a \"[\" list or \"{\" mapping is missing its closing \"]\" or \"}\".",
     "error_go_to_line": "Go to line {line}",
     "error_auto_fix": "Try auto-fix",
-    "error_auto_fix_hint": "Best-effort guess: it indents the marked line. Review the result and undo it if that is not the fix you wanted.",
+    "error_auto_fix_hint": "Best-effort guess: it re-indents the marked line. Review the result and undo it if that is not the fix you wanted.",
     "auto_fix_failed": "Couldn't run auto-fix; the config could not be validated. Please try again.",
     "auto_fix_stale": "The config changed; re-check the error and try again.",
     "auto_fix_confirm_heading": "Apply the fix anyway?",

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -230,13 +230,15 @@ export function firstPropertyDelta(
   line: number,
   contentCol: number
 ): number | null {
-  for (let n = line + 1; ; n++) {
+  // Bound the walk so a huge run of blanks can't turn a lint pass into a scan.
+  for (let n = line + 1; n <= line + 50; n++) {
     const text = readLine(n);
     if (text === undefined) return null;
     if (!text.trim() || text.trimStart().startsWith("#")) continue;
     const indent = indentOf(text);
     return indent < contentCol ? null : indent - contentCol;
   }
+  return null;
 }
 
 /** Don't guess a sibling alignment beyond this many spaces — a large

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -417,6 +417,30 @@ export function describeNestedListValue(
   return null;
 }
 
+/**
+ * Add the misindent / half-typed-key cause to a wrong-value-type
+ * validation message ("expected a dictionary.") anchored at *line*: a
+ * value-less `- key:` whose items landed one level deeper, or a bare word
+ * with no ':' (a lone "le" under "logger:" parses as its string value).
+ * Null when the anchored line is neither shape.
+ */
+export function describeValueTypeCause(
+  readLine: ReadLine,
+  line: number,
+  localize: LocalizeFunc
+): string | null {
+  const nested = describeNestedListValue(readLine, line, localize);
+  if (nested) return nested;
+  const token = readLine(line)?.trim();
+  if (token && !token.includes(":") && !token.startsWith("#") && !token.startsWith("-")) {
+    return localize("yaml_editor.error_missing_colon_hint", {
+      line,
+      key: token.length > 24 ? `${token.slice(0, 24)}…` : token,
+    });
+  }
+  return null;
+}
+
 /** A one-click indentation repair: add `indent` spaces at the start of
  *  `line` (or remove them, when negative). */
 export interface YamlAutoFix {
@@ -778,11 +802,11 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           bannerErrors.push({ message, kind: "validation" });
           continue;
         }
-        // A bare "expected a dictionary." on a value-less `- key:` whose
-        // list items landed one level deeper reads as nonsense — name the
-        // indentation mistake that made those items the key's value.
+        // A bare "expected a dictionary." reads as nonsense — when the
+        // anchored line shows why the value took the wrong type (nested
+        // list items, a half-typed key with no ':'), name that cause.
         const squiggleLineNum = doc.lineAt(from).number;
-        const hint = describeNestedListValue(readLine, squiggleLineNum, opts.localize);
+        const hint = describeValueTypeCause(readLine, squiggleLineNum, opts.localize);
         if (hint) message = `${message} ${hint}`;
         diagnostics.push({
           from,

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -239,61 +239,190 @@ export function firstPropertyDelta(
   }
 }
 
+/** Don't guess a sibling alignment beyond this many spaces — a large
+ *  mismatch is structural confusion, where the generic hint beats a
+ *  confidently wrong auto-fix. */
+const MAX_SIBLING_ALIGN = 3;
+
 /**
- * Pinpoint the exact indentation fix behind a `mapping values ...` error.
- *
- * The classic cause is a list item whose properties are indented deeper
- * than the item's own key: `- platform: dht` then `    model:` makes the
- * `dht` scalar swallow `model`, and the scanner blames the property
- * line. Walk up from that line to the owning `- ` marker; when the
- * properties sit deeper than the marker's content column, the fix is to
- * indent the marker so the two line up. The under-indented mirror — a
- * `- ` marker dedented out of its list, which the scanner blames
- * directly (`expected <block end>, but found '-'`) — resolves against
- * the properties *below* it instead. Returns the marker's line, key,
- * and the space delta, or `null` when the shape is neither mismatch.
+ * Signed delta re-aligning a blamed `- ` marker with the sibling marker
+ * above it, skipping the previous item's deeper property lines. Null when
+ * no sibling marker is found before the walk leaves the list (a line at or
+ * below the blamed indent), when the sibling already lines up, or when the
+ * mismatch exceeds MAX_SIBLING_ALIGN.
  */
-export function analyzeIndentMismatch(
+function siblingMarkerDelta(
   readLine: ReadLine,
-  errorLine: number
-): { markerLine: number; markerKey: string; delta: number } | null {
-  const errText = readLine(errorLine);
-  if (errText === undefined || !errText.trim()) return null;
-  // Blamed line is itself a list-item marker: its own properties (the
-  // deeper-indented lines that follow) say how far to indent it back.
-  const errMarker = parseListItemMarker(errText);
-  if (errMarker) {
-    const delta = firstPropertyDelta(readLine, errorLine, errMarker.contentCol);
-    return delta !== null && delta > 0
-      ? { markerLine: errorLine, markerKey: errMarker.key, delta }
-      : null;
-  }
-  const propIndent = indentOf(errText);
-  // Bound the walk so a huge doc can't turn one lint pass into a scan.
-  for (let n = errorLine - 1; n >= 1 && n >= errorLine - 50; n--) {
+  line: number,
+  markerIndent: number
+): number | null {
+  for (let n = line - 1; n >= 1 && n >= line - 50; n--) {
     const text = readLine(n);
-    if (text === undefined || !text.trim()) continue;
-    const marker = parseListItemMarker(text);
-    if (!marker) {
-      // Left the item's block once a line is shallower than the property.
-      if (indentOf(text) < propIndent) return null;
-      continue;
+    if (text === undefined) return null;
+    if (!text.trim() || text.trimStart().startsWith("#")) continue;
+    const indent = indentOf(text);
+    if (parseListItemMarker(text)) {
+      const delta = indent - markerIndent;
+      return delta !== 0 && Math.abs(delta) <= MAX_SIBLING_ALIGN ? delta : null;
     }
-    if (propIndent <= marker.contentCol) return null;
-    return {
-      markerLine: n,
-      markerKey: marker.key,
-      delta: propIndent - marker.contentCol,
-    };
+    if (indent <= markerIndent) return null;
   }
   return null;
 }
 
-/** A one-click indentation repair: add `indent` spaces at the start of `line`. */
+/** First key token of a line — a list item's key, a plain `key:`, or null. */
+function lineKeyToken(text: string): string | null {
+  const marker = parseListItemMarker(text);
+  if (marker) return marker.key;
+  const hit = text.match(/^\s*([^\s:#][^:]*?)\s*:(?:\s|$)/);
+  return hit ? hit[1] : null;
+}
+
+/**
+ * A pinpointed indentation repair for the line the scanner blamed (or, for
+ * `reason: "props-below"`, the marker above it). `delta` is signed: positive
+ * inserts spaces, negative removes them. `reason` picks the message:
+ * "props-below" is the marker-vs-its-properties mismatch; "align" re-indents
+ * the blamed line to match the sibling structure around it.
+ */
+export interface IndentMismatch {
+  markerLine: number;
+  markerKey: string;
+  delta: number;
+  reason: "props-below" | "align";
+}
+
+/**
+ * Pinpoint the exact indentation fix behind a YAML indentation error.
+ *
+ * Shapes covered, in priority order:
+ * - Blamed line is a `- ` marker whose properties below sit deeper than its
+ *   content column (a marker dedented out of its list, blamed directly with
+ *   `expected <block end>, but found '-'`): indent the marker to match.
+ * - Blamed marker misaligned with the marker directly above it (one space
+ *   off in either direction): re-indent the blamed marker to line up.
+ * - Blamed property line: the classic over-indent (`- platform: dht` then
+ *   `    model:` — the scanner blames the property, the marker is what
+ *   moves), or a property out of line with siblings already sitting at the
+ *   marker's content column (re-indent the blamed line instead).
+ */
+export function analyzeIndentMismatch(
+  readLine: ReadLine,
+  errorLine: number
+): IndentMismatch | null {
+  const errText = readLine(errorLine);
+  if (errText === undefined || !errText.trim()) return null;
+  const errIndent = indentOf(errText);
+  const errMarker = parseListItemMarker(errText);
+  if (errMarker) {
+    const delta = firstPropertyDelta(readLine, errorLine, errMarker.contentCol);
+    if (delta !== null && delta > 0) {
+      return {
+        markerLine: errorLine,
+        markerKey: errMarker.key,
+        delta,
+        reason: "props-below",
+      };
+    }
+    const align = siblingMarkerDelta(readLine, errorLine, errIndent);
+    if (align !== null) {
+      return {
+        markerLine: errorLine,
+        markerKey: errMarker.key,
+        delta: align,
+        reason: "align",
+      };
+    }
+    return null;
+  }
+  const propIndent = errIndent;
+  // Nearest shallower non-marker line passed on the way up — when it sits
+  // exactly at the marker's content column, the surrounding structure is
+  // consistent and the blamed line is the one to move.
+  let shallowerIndent: number | null = null;
+  // Bound the walk so a huge doc can't turn one lint pass into a scan.
+  for (let n = errorLine - 1; n >= 1 && n >= errorLine - 50; n--) {
+    const text = readLine(n);
+    if (text === undefined || !text.trim() || text.trimStart().startsWith("#")) {
+      continue;
+    }
+    const marker = parseListItemMarker(text);
+    if (!marker) {
+      const indent = indentOf(text);
+      if (indent < propIndent) {
+        // A top-level line means we left every block without a marker.
+        if (indent === 0) return null;
+        if (shallowerIndent === null) shallowerIndent = indent;
+      }
+      continue;
+    }
+    const errKey = lineKeyToken(errText);
+    if (propIndent > marker.contentCol) {
+      // Siblings already aligned at the content column → the blamed line is
+      // the odd one out; otherwise assume the marker is what needs to move.
+      if (shallowerIndent === marker.contentCol && errKey) {
+        return {
+          markerLine: errorLine,
+          markerKey: errKey,
+          delta: marker.contentCol - propIndent,
+          reason: "align",
+        };
+      }
+      return {
+        markerLine: n,
+        markerKey: marker.key,
+        delta: propIndent - marker.contentCol,
+        reason: "props-below",
+      };
+    }
+    if (propIndent < marker.contentCol && propIndent > indentOf(text) && errKey) {
+      return {
+        markerLine: errorLine,
+        markerKey: errKey,
+        delta: marker.contentCol - propIndent,
+        reason: "align",
+      };
+    }
+    return null;
+  }
+  return null;
+}
+
+/** Matches a value-less `- key:` list item (optionally with a comment). */
+const BARE_ITEM_KEY_RE = /^\s*-\s+[^\s:#]+:\s*(?:#.*)?$/;
+
+/**
+ * A plain-language hint for the misindent behind "expected a dictionary.":
+ * a value-less `- key:` whose following `- ` items sit at its content
+ * column, making them the key's *value* instead of its list siblings.
+ * Returns null when the line isn't that shape.
+ */
+export function describeNestedListValue(
+  readLine: ReadLine,
+  line: number,
+  localize: LocalizeFunc
+): string | null {
+  const text = readLine(line);
+  if (text === undefined || !BARE_ITEM_KEY_RE.test(text)) return null;
+  const marker = parseListItemMarker(text);
+  if (!marker) return null;
+  for (let n = line + 1; n <= line + 50; n++) {
+    const next = readLine(n);
+    if (next === undefined) return null;
+    if (!next.trim() || next.trimStart().startsWith("#")) continue;
+    return parseListItemMarker(next) && indentOf(next) === marker.contentCol
+      ? localize("yaml_editor.error_nested_list_hint", { key: marker.key })
+      : null;
+  }
+  return null;
+}
+
+/** A one-click indentation repair: add `indent` spaces at the start of
+ *  `line` (or remove them, when negative). */
 export interface YamlAutoFix {
   line: number;
   indent: number;
-  /** The list item's own key, so the apply site can confirm the line still
+  /** The target line's own key, so the apply site can confirm the line still
    *  targets the same item after edits shift line numbers. */
   key: string;
 }
@@ -384,11 +513,24 @@ export function describeYamlError(
   ) {
     const fix = readLine ? analyzeIndentMismatch(readLine, line) : null;
     if (fix) {
+      // "- key" for a list marker, plain "key" for a property line, so the
+      // message names the line the way the user sees it.
+      const targetText = readLine?.(fix.markerLine) ?? "";
+      const display = parseListItemMarker(targetText)
+        ? `- ${fix.markerKey}`
+        : fix.markerKey;
+      const messageKey =
+        fix.reason === "props-below"
+          ? "yaml_editor.error_indent_fix"
+          : fix.delta > 0
+            ? "yaml_editor.error_misaligned_indent_fix"
+            : "yaml_editor.error_misaligned_dedent_fix";
       return {
-        text: localize("yaml_editor.error_indent_fix", {
+        text: localize(messageKey, {
           line: fix.markerLine,
-          key: fix.markerKey,
-          spaces: fix.delta,
+          // error_indent_fix's template writes the "- " itself.
+          key: fix.reason === "props-below" ? fix.markerKey : display,
+          spaces: Math.abs(fix.delta),
         }),
         jumpLine: fix.markerLine,
         fix: { line: fix.markerLine, indent: fix.delta, key: fix.markerKey },
@@ -572,6 +714,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
       const doc = view.state.doc;
       const readLine: ReadLine = (n) =>
         n >= 1 && n <= doc.lines ? doc.line(n).text : undefined;
+      const onAutoFix = opts.onAutoFix;
       for (const err of res.yaml_errors ?? []) {
         const msg = err.message ?? "";
         const pos = parseYamlErrorPosition(msg);
@@ -601,14 +744,15 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           // Offer the same one-click repair on the squiggle's hover tooltip
           // as on the banner button — while the banner reveal is damped
           // during typing, the tooltip is where the fix is discoverable.
-          actions: fix
-            ? [
-                {
-                  name: opts.localize("yaml_editor.error_auto_fix"),
-                  apply: () => opts.onAutoFix?.(fix),
-                },
-              ]
-            : undefined,
+          actions:
+            fix && onAutoFix
+              ? [
+                  {
+                    name: opts.localize("yaml_editor.error_auto_fix"),
+                    apply: () => onAutoFix(fix),
+                  },
+                ]
+              : undefined,
         });
         // Also surface it in the persistent banner — a squiggle plus a
         // gutter dot is easy to miss — with the fix site to jump to and,
@@ -618,7 +762,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
 
       // Schema/validation errors carry an explicit range.
       for (const err of res.validation_errors ?? []) {
-        const message =
+        let message =
           sanitizeMessage((err.message ?? "").trim()) || "Invalid configuration";
         // The upstream validator emits a null range when it can't place the
         // error, and a foreign document when the error lives in an included
@@ -634,6 +778,12 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           bannerErrors.push({ message, kind: "validation" });
           continue;
         }
+        // A bare "expected a dictionary." on a value-less `- key:` whose
+        // list items landed one level deeper reads as nonsense — name the
+        // indentation mistake that made those items the key's value.
+        const squiggleLineNum = doc.lineAt(from).number;
+        const hint = describeNestedListValue(readLine, squiggleLineNum, opts.localize);
+        if (hint) message = `${message} ${hint}`;
         diagnostics.push({
           from,
           to,
@@ -669,9 +819,10 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         }
         // No form field to carry the message (a bare section header, or the
         // AST couldn't place it) — keep it in the banner; a section-level
-        // error still badges the navigator through the mapped entry.
+        // error still badges the navigator through the mapped entry. The
+        // anchor line gives the banner its "Go to line" jump.
         if (formRelativePath(keyPath).length === 0) {
-          bannerErrors.push({ message, kind: "validation" });
+          bannerErrors.push({ message, line: squiggleLineNum, kind: "validation" });
         }
       }
 

--- a/src/util/yaml-lint-backend.ts
+++ b/src/util/yaml-lint-backend.ts
@@ -49,6 +49,10 @@ export interface BannerError {
   line?: number;
   /** A one-click indentation repair, when the error can be fixed deterministically. */
   fix?: YamlAutoFix;
+  /** What produced it: a YAML parse failure (often a half-typed token, so
+   *  the banner damps its reveal while the user types) or a validation
+   *  error on a parseable config (real breakage — reveal right away). */
+  kind: "parse" | "validation";
 }
 
 /** Detail payload of the yaml-diagnostics event the editor re-emits. */
@@ -81,6 +85,12 @@ interface BackendLinterOptions {
     mapped: MappedValidationError[],
     configuration: string
   ) => void;
+  /**
+   * Called when the user picks the auto-fix action on a diagnostic's hover
+   * tooltip, with the same repair payload the banner button carries — the
+   * host routes both through one validate-confirm-apply path.
+   */
+  onAutoFix?: (fix: YamlAutoFix) => void;
 }
 
 /**
@@ -187,8 +197,47 @@ export function parseYamlErrorPosition(
   return null;
 }
 
+/**
+ * The FIRST position in a PyYAML message — the context mark, where the
+ * construct the scanner choked on begins (e.g. the simple key it was
+ * scanning), as opposed to where scanning gave up.
+ */
+export function parseYamlErrorContext(
+  message: string
+): { line: number; col: number | null } | null {
+  const colMatch = [...message.matchAll(YAML_LINE_COL_RE)][0];
+  if (colMatch) {
+    return {
+      line: Number.parseInt(colMatch[1], 10),
+      col: Number.parseInt(colMatch[2], 10),
+    };
+  }
+  const lineMatch = [...message.matchAll(YAML_LINE_RE)][0];
+  return lineMatch ? { line: Number.parseInt(lineMatch[1], 10), col: null } : null;
+}
+
 /** A line accessor over the current document; `undefined` past the ends. */
 export type ReadLine = (line1: number) => string | undefined;
+
+/**
+ * Indent of a list item's first property line minus *contentCol* (where its
+ * key starts), or `null` when the item has no property line — the next
+ * content is a shallower sibling/dedent (indent below *contentCol*), not a
+ * property, so it never reports a spurious negative delta.
+ */
+export function firstPropertyDelta(
+  readLine: ReadLine,
+  line: number,
+  contentCol: number
+): number | null {
+  for (let n = line + 1; ; n++) {
+    const text = readLine(n);
+    if (text === undefined) return null;
+    if (!text.trim() || text.trimStart().startsWith("#")) continue;
+    const indent = indentOf(text);
+    return indent < contentCol ? null : indent - contentCol;
+  }
+}
 
 /**
  * Pinpoint the exact indentation fix behind a `mapping values ...` error.
@@ -198,8 +247,11 @@ export type ReadLine = (line1: number) => string | undefined;
  * `dht` scalar swallow `model`, and the scanner blames the property
  * line. Walk up from that line to the owning `- ` marker; when the
  * properties sit deeper than the marker's content column, the fix is to
- * indent the marker so the two line up. Returns the marker's line, key,
- * and the space delta, or `null` when the shape isn't this mismatch.
+ * indent the marker so the two line up. The under-indented mirror — a
+ * `- ` marker dedented out of its list, which the scanner blames
+ * directly (`expected <block end>, but found '-'`) — resolves against
+ * the properties *below* it instead. Returns the marker's line, key,
+ * and the space delta, or `null` when the shape is neither mismatch.
  */
 export function analyzeIndentMismatch(
   readLine: ReadLine,
@@ -207,6 +259,15 @@ export function analyzeIndentMismatch(
 ): { markerLine: number; markerKey: string; delta: number } | null {
   const errText = readLine(errorLine);
   if (errText === undefined || !errText.trim()) return null;
+  // Blamed line is itself a list-item marker: its own properties (the
+  // deeper-indented lines that follow) say how far to indent it back.
+  const errMarker = parseListItemMarker(errText);
+  if (errMarker) {
+    const delta = firstPropertyDelta(readLine, errorLine, errMarker.contentCol);
+    return delta !== null && delta > 0
+      ? { markerLine: errorLine, markerKey: errMarker.key, delta }
+      : null;
+  }
   const propIndent = indentOf(errText);
   // Bound the walk so a huge doc can't turn one lint pass into a scan.
   for (let n = errorLine - 1; n >= 1 && n >= errorLine - 50; n--) {
@@ -242,6 +303,9 @@ export interface YamlErrorDescription {
   text: string;
   jumpLine: number | null;
   fix?: YamlAutoFix;
+  /** Overrides the squiggle's line when the scanner's problem mark blames
+   *  the wrong place (e.g. a missing-colon error marks lines later). */
+  squiggleLine?: number;
 }
 
 /**
@@ -283,6 +347,24 @@ export function describeYamlError(
     lower.includes("while scanning a quoted scalar")
   ) {
     return hint("yaml_editor.error_unterminated_string_hint");
+  }
+  // A bare word where a `key: value` was expected: the scanner reads it as
+  // a "simple key" and then never finds the ':', blaming wherever it gave
+  // up — often lines later. The context mark points at the word itself;
+  // when that line really has no ':', name it instead of the indent hint.
+  if (lower.includes("could not find expected ':'") && lower.includes("simple key")) {
+    const ctx = parseYamlErrorContext(message);
+    const token = ctx && readLine ? readLine(ctx.line)?.trim() : undefined;
+    if (ctx && token && !token.includes(":")) {
+      return {
+        text: localize("yaml_editor.error_missing_colon_hint", {
+          line: ctx.line,
+          key: token.length > 24 ? `${token.slice(0, 24)}…` : token,
+        }),
+        jumpLine: ctx.line,
+        squiggleLine: ctx.line,
+      };
+    }
   }
   // Same option set twice in a block.
   if (lower.includes("duplicate key")) {
@@ -499,12 +581,16 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           text: message,
           jumpLine,
           fix,
+          squiggleLine,
         } = describeYamlError(msg, pos, opts.localize, readLine);
         if (pos === null) {
-          bannerErrors.push({ message }); // no position to squiggle
+          bannerErrors.push({ message, kind: "parse" }); // no position to squiggle
           continue;
         }
-        const { from, to } = lineToOffsets(view, pos.line, pos.col);
+        const { from, to } =
+          squiggleLine !== undefined
+            ? lineToOffsets(view, squiggleLine, null)
+            : lineToOffsets(view, pos.line, pos.col);
         diagnostics.push({
           from,
           to,
@@ -512,11 +598,22 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
           source: "yaml",
           message,
           renderMessage: () => renderMessageNode(message),
+          // Offer the same one-click repair on the squiggle's hover tooltip
+          // as on the banner button — while the banner reveal is damped
+          // during typing, the tooltip is where the fix is discoverable.
+          actions: fix
+            ? [
+                {
+                  name: opts.localize("yaml_editor.error_auto_fix"),
+                  apply: () => opts.onAutoFix?.(fix),
+                },
+              ]
+            : undefined,
         });
         // Also surface it in the persistent banner — a squiggle plus a
         // gutter dot is easy to miss — with the fix site to jump to and,
         // when we can pinpoint it, a one-click auto-fix.
-        bannerErrors.push({ message, line: jumpLine ?? pos.line, fix });
+        bannerErrors.push({ message, line: jumpLine ?? pos.line, fix, kind: "parse" });
       }
 
       // Schema/validation errors carry an explicit range.
@@ -527,14 +624,14 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // error, and a foreign document when the error lives in an included
         // file — neither has a location in this buffer.
         if (!err.range || !isOpenConfigFile(err.range.document ?? "", configuration)) {
-          bannerErrors.push({ message });
+          bannerErrors.push({ message, kind: "validation" });
           continue;
         }
         const anchor = trimRangeToContent(doc, rangeToOffsets(view, err.range));
         const { from, to } = retargetBlockDiagnostic(doc, anchor);
         // Pinned on the `esphome:` core block → whole-config error → banner.
         if (keyAt(doc, from) === CORE_BLOCK_KEY) {
-          bannerErrors.push({ message });
+          bannerErrors.push({ message, kind: "validation" });
           continue;
         }
         diagnostics.push({
@@ -574,7 +671,7 @@ export function createBackendYamlLinter(opts: BackendLinterOptions): Extension {
         // AST couldn't place it) — keep it in the banner; a section-level
         // error still badges the navigator through the mapped entry.
         if (formRelativePath(keyPath).length === 0) {
-          bannerErrors.push({ message });
+          bannerErrors.push({ message, kind: "validation" });
         }
       }
 

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -118,6 +118,17 @@ describe("editor-invalid-banner smart reveal", () => {
     expect(banner(el)).not.toBeNull();
   });
 
+  it("shows a pre-existing error promptly when the user never typed", async () => {
+    const el = document.createElement("esphome-editor-invalid-banner");
+    el.editorFocused = true;
+    el.caretLine = 57; // near the error, but the idle clock reads never-typed
+    document.body.appendChild(el);
+    await el.updateComplete;
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
   it("treats a line-less error as suppressible", async () => {
     const { el } = await mountBanner({ caret: 55 });
     el.errors = [err(undefined)];

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -142,6 +142,8 @@ describe("editor-invalid-banner smart reveal", () => {
     el.errors = [{ message: "Platform missing.", kind: "validation" }];
     await el.updateComplete;
     expect(banner(el)).toBeNull();
+    // The hold is timerless — closing the popup is the only wake signal.
+    expect(vi.getTimerCount()).toBe(0);
 
     vi.advanceTimersByTime(20_000); // even the idle backstop waits
     await el.updateComplete;

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pins the invalid-banner's smart reveal: errors near the caret stay
+ * squiggle-only while the user is typing, and the banner surfaces on
+ * caret-move / blur / idle — never over a half-typed token.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ESPHomeEditorInvalidBanner } from "../../src/components/device/editor-invalid-banner.js";
+import type { BannerError } from "../../src/util/yaml-lint-backend.js";
+
+import "../../src/components/device/editor-invalid-banner.js";
+
+const err = (line?: number): BannerError => ({
+  message: `boom at ${line ?? "nowhere"}`,
+  line,
+});
+
+interface Harness {
+  el: ESPHomeEditorInvalidBanner;
+  bumpEdit: () => void;
+}
+
+async function mountBanner({
+  focused = true,
+  caret = 55,
+}: { focused?: boolean; caret?: number } = {}): Promise<Harness> {
+  const el = document.createElement("esphome-editor-invalid-banner");
+  let lastEditAt = performance.now();
+  el.getLastEditAt = () => lastEditAt;
+  el.editorFocused = focused;
+  el.caretLine = caret;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return { el, bumpEdit: () => (lastEditAt = performance.now()) };
+}
+
+const banner = (el: ESPHomeEditorInvalidBanner) =>
+  el.shadowRoot!.querySelector(".invalid-banner");
+
+describe("editor-invalid-banner smart reveal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "performance"],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("suppresses an error near the caret until the idle backstop", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(14_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(1_200);
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("continued edits keep deferring the idle reveal", async () => {
+    const { el, bumpEdit } = await mountBanner({ caret: 55 });
+    el.errors = [err(57)];
+    await el.updateComplete;
+
+    vi.advanceTimersByTime(10_000);
+    bumpEdit();
+    vi.advanceTimersByTime(14_000); // 24s total, only 14s since last edit
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(1_200);
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("reveals when the caret moves away from the error", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    el.caretLine = 70;
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("reveals when the editor loses focus", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    el.editorFocused = false;
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("shows an error far from the caret immediately", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(10)];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("treats a line-less error as suppressible", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(undefined)];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    el.editorFocused = false;
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("clears immediately and cancels a pending reveal", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    el.errors = [];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(30_000);
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
+  it("clears a visible banner immediately", async () => {
+    const { el } = await mountBanner({ focused: false });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+
+    el.errors = [];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+  });
+
+  it("updates a visible banner in place without waiting", async () => {
+    const { el } = await mountBanner({ focused: false });
+    el.errors = [err(57)];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+
+    el.editorFocused = true;
+    el.errors = [err(60), err(61)];
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelectorAll(".danger-banner-text > span")).toHaveLength(2);
+  });
+
+  it("caps the list at six errors and collapses the rest", async () => {
+    const { el } = await mountBanner({ focused: false });
+    el.errors = Array.from({ length: 7 }, (_, i) => err(i + 1));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelectorAll(".danger-banner-text > span")).toHaveLength(
+      7 // 6 errors + the "+N more" span
+    );
+    expect(el.shadowRoot!.querySelector(".invalid-banner-more")).not.toBeNull();
+  });
+});
+
+describe("editor-invalid-banner events", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "performance"],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dispatches banner-goto-line and banner-auto-fix from the buttons", async () => {
+    const { el } = await mountBanner({ focused: false });
+    const fix = { line: 57, indent: 2, key: "platform" };
+    el.errors = [{ message: "boom", line: 57, fix }];
+    await el.updateComplete;
+
+    const gotoLines: number[] = [];
+    const fixes: unknown[] = [];
+    el.addEventListener("banner-goto-line", (e) =>
+      gotoLines.push((e as CustomEvent).detail.line)
+    );
+    el.addEventListener("banner-auto-fix", (e) =>
+      fixes.push((e as CustomEvent).detail.fix)
+    );
+
+    const buttons =
+      el.shadowRoot!.querySelectorAll<HTMLButtonElement>(".invalid-banner-goto");
+    expect(buttons).toHaveLength(2); // auto-fix first, then go-to-line
+    buttons[0].click();
+    buttons[1].click();
+
+    expect(fixes).toEqual([fix]);
+    expect(gotoLines).toEqual([57]);
+  });
+});

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -15,6 +15,7 @@ import "../../src/components/device/editor-invalid-banner.js";
 const err = (line?: number): BannerError => ({
   message: `boom at ${line ?? "nowhere"}`,
   line,
+  kind: "parse",
 });
 
 interface Harness {
@@ -110,6 +111,13 @@ describe("editor-invalid-banner smart reveal", () => {
     expect(banner(el)).not.toBeNull();
   });
 
+  it("shows a validation error immediately even near the caret", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [{ message: "Platform missing.", kind: "validation" }];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
   it("treats a line-less error as suppressible", async () => {
     const { el } = await mountBanner({ caret: 55 });
     el.errors = [err(undefined)];
@@ -182,7 +190,7 @@ describe("editor-invalid-banner events", () => {
   it("dispatches banner-goto-line and banner-auto-fix from the buttons", async () => {
     const { el } = await mountBanner({ focused: false });
     const fix = { line: 57, indent: 2, key: "platform" };
-    el.errors = [{ message: "boom", line: 57, fix }];
+    el.errors = [{ message: "boom", line: 57, fix, kind: "parse" }];
     await el.updateComplete;
 
     const gotoLines: number[] = [];

--- a/test/components/editor-invalid-banner.test.ts
+++ b/test/components/editor-invalid-banner.test.ts
@@ -111,9 +111,43 @@ describe("editor-invalid-banner smart reveal", () => {
     expect(banner(el)).not.toBeNull();
   });
 
-  it("shows a validation error immediately even near the caret", async () => {
+  it("shows a line-less validation error immediately even while typing", async () => {
     const { el } = await mountBanner({ caret: 55 });
     el.errors = [{ message: "Platform missing.", kind: "validation" }];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("damps a validation error anchored near the caret like a parse error", async () => {
+    const { el } = await mountBanner({ caret: 15 });
+    el.errors = [{ message: "expected a dictionary.", line: 15, kind: "validation" }];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(15_200);
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("shows a validation error anchored far from the caret immediately", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.errors = [{ message: "expected a dictionary.", line: 15, kind: "validation" }];
+    await el.updateComplete;
+    expect(banner(el)).not.toBeNull();
+  });
+
+  it("holds every reveal while the completion popup is open", async () => {
+    const { el } = await mountBanner({ caret: 55 });
+    el.completionOpen = true;
+    el.errors = [{ message: "Platform missing.", kind: "validation" }];
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    vi.advanceTimersByTime(20_000); // even the idle backstop waits
+    await el.updateComplete;
+    expect(banner(el)).toBeNull();
+
+    el.completionOpen = false;
     await el.updateComplete;
     expect(banner(el)).not.toBeNull();
   });

--- a/test/components/yaml-editor-auto-fix.test.ts
+++ b/test/components/yaml-editor-auto-fix.test.ts
@@ -143,6 +143,38 @@ describe("yaml-editor applyIndentFix (#1884)", () => {
     expect(validateYaml).not.toHaveBeenCalled();
   });
 
+  it("applies a negative fix by removing leading spaces (sibling dedent)", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const broken =
+      "light:\n  - platform: x\n    effects:\n" +
+      "      - addressable_twinkle:\n      - flicker:\n       - pulse:\n";
+    const fixed =
+      "light:\n  - platform: x\n    effects:\n" +
+      "      - addressable_twinkle:\n      - flicker:\n      - pulse:\n";
+    const el = await mountEditor(validateYaml, broken);
+    const view = viewOf(el);
+
+    expect(await el.applyIndentFix({ line: 6, indent: -1, key: "pulse" })).toBe(
+      "applied"
+    );
+
+    expect(view.state.doc.toString()).toBe(fixed);
+    expect(validateYaml).toHaveBeenCalledWith("x.yaml", fixed);
+    undo(view);
+    expect(view.state.doc.toString()).toBe(broken);
+  });
+
+  it("no-ops a stale dedent whose line already lines up", async () => {
+    const validateYaml = vi.fn(async () => CLEAN);
+    const doc =
+      "light:\n  - platform: x\n    effects:\n" +
+      "      - addressable_twinkle:\n      - flicker:\n      - pulse:\n";
+    const el = await mountEditor(validateYaml, doc);
+
+    expect(await el.applyIndentFix({ line: 6, indent: -1, key: "pulse" })).toBe("stale");
+    expect(validateYaml).not.toHaveBeenCalled();
+  });
+
   it("no-ops when the item is followed by a shallower sibling, not a property", async () => {
     const validateYaml = vi.fn(async () => CLEAN);
     // `- platform: dht` (contentCol 2) followed by a top-level sibling, not a

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -181,6 +181,41 @@ describe("analyzeIndentMismatch", () => {
       ["esphome:", "  name: x", "  bogus: y"][n - 1];
     expect(analyzeIndentMismatch(plain, 3)).toBeNull();
   });
+
+  // The mirror shape: the marker itself dedented out of its list, which the
+  // scanner blames directly ("expected <block end>, but found '-'").
+  it("pinpoints an under-indented marker from the properties below it", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const dedented = (n: number): string | undefined =>
+      [
+        "time:", // 1
+        "  - platform: homeassistant", // 2
+        "    id: ha_time", // 3
+        "", // 4
+        "- platform: sntp", // 5
+        "    id: sntp_time", // 6
+        "    servers: kkk", // 7
+      ][n - 1];
+    expect(analyzeIndentMismatch(dedented, 5)).toEqual({
+      markerLine: 5,
+      markerKey: "platform",
+      delta: 2,
+    });
+  });
+
+  it("returns null for a blamed marker followed by a shallower sibling", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const bare = (n: number): string | undefined =>
+      ["time:", "- platform: sntp", "sensor:"][n - 1];
+    expect(analyzeIndentMismatch(bare, 2)).toBeNull();
+  });
+
+  it("returns null for a blamed marker whose properties already line up", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const aligned = (n: number): string | undefined =>
+      ["time:", "- platform: sntp", "  id: sntp_time"][n - 1];
+    expect(analyzeIndentMismatch(aligned, 2)).toBeNull();
+  });
 });
 
 describe("describeYamlError", () => {
@@ -218,6 +253,42 @@ describe("describeYamlError", () => {
     expect(
       describeYamlError("mapping values are not allowed here", pos(3), localize, read)
     ).toEqual({ text: 'yaml_editor.error_indent_hint:{"line":3}', jumpLine: 3 });
+  });
+
+  // Real PyYAML shape for a bare `kkk` inside a list item: the context mark
+  // (first position) names the word's own line; the problem mark (last)
+  // blames wherever scanning gave up, lines later.
+  it("names the bare key missing its ':' instead of the indent hint", async () => {
+    const { describeYamlError } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = [
+      "time:", // 1
+      "  - platform: homeassistant", // 2
+      "    id: ha_time", // 3
+      "    kkk", // 4
+      "", // 5
+      "  - platform: sntp", // 6
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    const msg =
+      'while scanning a simple key\n  in "x.yaml", line 4, column 5\n' +
+      "could not find expected ':'\n  in \"x.yaml\", line 6, column 3";
+    expect(describeYamlError(msg, { line: 6, col: 3 }, localize, read)).toEqual({
+      text: 'yaml_editor.error_missing_colon_hint:{"line":4,"key":"kkk"}',
+      jumpLine: 4,
+      squiggleLine: 4,
+    });
+  });
+
+  it("keeps the indent hint for a missing ':' whose context line has one", async () => {
+    const { describeYamlError } = await import("../../src/util/yaml-lint-backend.js");
+    const aligned = ["sensor:", "  - platform: dht", "    model: DHT11"];
+    const read = (n: number): string | undefined => aligned[n - 1];
+    const msg =
+      'while scanning a simple key\n  in "x.yaml", line 2, column 3\n' +
+      "could not find expected ':'\n  in \"x.yaml\", line 3, column 1";
+    expect(describeYamlError(msg, { line: 3, col: 1 }, localize, read).text).toBe(
+      'yaml_editor.error_indent_hint:{"line":3}'
+    );
   });
 
   it("maps the indentation family to the indent hint", async () => {

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -178,6 +178,11 @@ describe("describeNestedListValue", () => {
       ["    - platform: gpio", "      - nested:"][n - 1];
     expect(describeNestedListValue(valued, 1, localize)).toBeNull();
   });
+});
+
+describe("describeValueTypeCause", () => {
+  const localize = (key: string, values?: Record<string, string | number>): string =>
+    values ? `${key}:${JSON.stringify(values)}` : key;
 
   it("names a bare half-typed word that became the key's string value", async () => {
     const { describeValueTypeCause } =

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -178,6 +178,17 @@ describe("describeNestedListValue", () => {
       ["    - platform: gpio", "      - nested:"][n - 1];
     expect(describeNestedListValue(valued, 1, localize)).toBeNull();
   });
+
+  it("names a bare half-typed word that became the key's string value", async () => {
+    const { describeValueTypeCause } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined => ["logger:", "  le"][n - 1];
+    expect(describeValueTypeCause(doc, 2, localize)).toBe(
+      'yaml_editor.error_missing_colon_hint:{"line":2,"key":"le"}'
+    );
+    const keyed = (n: number): string | undefined => ["logger:", "  level: DEBUG"][n - 1];
+    expect(describeValueTypeCause(keyed, 2, localize)).toBeNull();
+  });
 });
 
 describe("analyzeIndentMismatch", () => {

--- a/test/util/yaml-lint-backend.test.ts
+++ b/test/util/yaml-lint-backend.test.ts
@@ -149,6 +149,37 @@ describe("parseYamlErrorPosition", () => {
   });
 });
 
+describe("describeNestedListValue", () => {
+  const localize = (key: string, values?: Record<string, string | number>): string =>
+    values ? `${key}:${JSON.stringify(values)}` : key;
+
+  it("names the nested-list misindent behind 'expected a dictionary.'", async () => {
+    const { describeNestedListValue } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const doc = [
+      "    effects:", // 1
+      "    - addressable_twinkle:", // 2
+      "      - flicker:", // 3
+      "      - pulse:", // 4
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    expect(describeNestedListValue(read, 2, localize)).toBe(
+      'yaml_editor.error_nested_list_hint:{"key":"addressable_twinkle"}'
+    );
+  });
+
+  it("stays silent for a key with a real value or aligned siblings", async () => {
+    const { describeNestedListValue } =
+      await import("../../src/util/yaml-lint-backend.js");
+    const aligned = (n: number): string | undefined =>
+      ["    effects:", "      - addressable_twinkle:", "      - flicker:"][n - 1];
+    expect(describeNestedListValue(aligned, 2, localize)).toBeNull();
+    const valued = (n: number): string | undefined =>
+      ["    - platform: gpio", "      - nested:"][n - 1];
+    expect(describeNestedListValue(valued, 1, localize)).toBeNull();
+  });
+});
+
 describe("analyzeIndentMismatch", () => {
   // The reproduction: dash at column 0, properties indented 4 spaces.
   const lines = [
@@ -165,6 +196,7 @@ describe("analyzeIndentMismatch", () => {
       markerLine: 2,
       markerKey: "platform",
       delta: 2,
+      reason: "props-below",
     });
   });
 
@@ -200,6 +232,7 @@ describe("analyzeIndentMismatch", () => {
       markerLine: 5,
       markerKey: "platform",
       delta: 2,
+      reason: "props-below",
     });
   });
 
@@ -215,6 +248,109 @@ describe("analyzeIndentMismatch", () => {
     const aligned = (n: number): string | undefined =>
       ["time:", "- platform: sntp", "  id: sntp_time"][n - 1];
     expect(analyzeIndentMismatch(aligned, 2)).toBeNull();
+  });
+
+  // Sibling alignment: a marker one space off from the marker above it, in
+  // either direction ("expected <block end>, but found '<block sequence
+  // start>'" blames the odd marker directly).
+  it("dedents a blamed marker sitting deeper than the marker above it", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "    effects:", // 1
+        "      - addressable_twinkle:", // 2
+        "      - flicker:", // 3
+        "       - pulse:", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 4)).toEqual({
+      markerLine: 4,
+      markerKey: "pulse",
+      delta: -1,
+      reason: "align",
+    });
+  });
+
+  it("indents a blamed marker sitting shallower than the marker above it", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "    effects:", // 1
+        "      - addressable_twinkle:", // 2
+        "     - flicker:", // 3
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 3)).toEqual({
+      markerLine: 3,
+      markerKey: "flicker",
+      delta: 1,
+      reason: "align",
+    });
+  });
+
+  it("skips the previous item's properties to find the sibling marker", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "time:", // 1
+        "  - platform: homeassistant", // 2
+        "    id: homeassistant_time", // 3
+        "", // 4
+        "   - platform: sntp", // 5
+        "    id: sntp_time", // 6
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 5)).toEqual({
+      markerLine: 5,
+      markerKey: "platform",
+      delta: -1,
+      reason: "align",
+    });
+  });
+
+  it("won't guess a sibling alignment beyond a few spaces", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "  - platform: x", // 1
+        "    effects:", // 2
+        "      - twinkle:", // 3
+        " - platform: y", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 4)).toBeNull();
+  });
+
+  // Property alignment: the blamed property is the odd one out when its
+  // siblings already sit at the marker's content column.
+  it("indents a blamed property indented less than its siblings", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "output:", // 1
+        "   - platform: ledc", // 2
+        "     pin: 18", // 3
+        "    id: buzzer_output", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 4)).toEqual({
+      markerLine: 4,
+      markerKey: "id",
+      delta: 1,
+      reason: "align",
+    });
+  });
+
+  it("dedents a blamed property indented deeper than an aligned sibling", async () => {
+    const { analyzeIndentMismatch } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = (n: number): string | undefined =>
+      [
+        "output:", // 1
+        "   - platform: ledc", // 2
+        "     pin: 18", // 3
+        "      id: buzzer_output", // 4
+      ][n - 1];
+    expect(analyzeIndentMismatch(doc, 4)).toEqual({
+      markerLine: 4,
+      markerKey: "id",
+      delta: -1,
+      reason: "align",
+    });
   });
 });
 
@@ -289,6 +425,52 @@ describe("describeYamlError", () => {
     expect(describeYamlError(msg, { line: 3, col: 1 }, localize, read).text).toBe(
       'yaml_editor.error_indent_hint:{"line":3}'
     );
+  });
+
+  it("names the sibling-alignment fix with a signed dedent", async () => {
+    const { describeYamlError } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = [
+      "    effects:", // 1
+      "      - addressable_twinkle:", // 2
+      "      - flicker:", // 3
+      "       - pulse:", // 4
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    expect(
+      describeYamlError(
+        "expected <block end>, but found '<block sequence start>'",
+        { line: 4, col: 8 },
+        localize,
+        read
+      )
+    ).toEqual({
+      text: 'yaml_editor.error_misaligned_dedent_fix:{"line":4,"key":"- pulse","spaces":1}',
+      jumpLine: 4,
+      fix: { line: 4, indent: -1, key: "pulse" },
+    });
+  });
+
+  it("names the misaligned-property fix on the property's own line", async () => {
+    const { describeYamlError } = await import("../../src/util/yaml-lint-backend.js");
+    const doc = [
+      "output:", // 1
+      "   - platform: ledc", // 2
+      "     pin: 18", // 3
+      "    id: buzzer_output", // 4
+    ];
+    const read = (n: number): string | undefined => doc[n - 1];
+    expect(
+      describeYamlError(
+        "mapping values are not allowed here",
+        { line: 4, col: 5 },
+        localize,
+        read
+      )
+    ).toEqual({
+      text: 'yaml_editor.error_misaligned_indent_fix:{"line":4,"key":"id","spaces":1}',
+      jumpLine: 4,
+      fix: { line: 4, indent: 1, key: "id" },
+    });
   });
 
   it("maps the indentation family to the indent hint", async () => {

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -28,13 +28,14 @@ const localize = (key: string, values?: Record<string, string | number>): string
 function mountView(
   validateYaml: ESPHomeAPI["validateYaml"],
   onResult: (errors: BannerError[], mapped: MappedValidationError[]) => void,
-  onAutoFix?: (fix: YamlAutoFix) => void
+  onAutoFix?: (fix: YamlAutoFix) => void,
+  // Three lines so the parse error at line 3 has an offset to map to.
+  doc = "sensor:\n- platform: dht\n    model: DHT11\n"
 ): EditorView {
   const api = { validateYaml } as unknown as ESPHomeAPI;
   return new EditorView({
     state: EditorState.create({
-      // Three lines so the parse error at line 3 has an offset to map to.
-      doc: "sensor:\n- platform: dht\n    model: DHT11\n",
+      doc,
       extensions: [
         createBackendYamlLinter({
           api,
@@ -120,6 +121,80 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
 
       actions[0].apply(view, 0, 0);
       expect(fixes).toEqual([{ line: 2, indent: 2, key: "platform" }]);
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("omits the tooltip action when no onAutoFix handler is wired", async () => {
+    const validateYaml = vi.fn(async () => ({
+      yaml_errors: [
+        {
+          message:
+            'mapping values are not allowed here\n  in "x.yaml", line 3, column 10',
+        },
+      ],
+      validation_errors: [],
+    })) as unknown as ESPHomeAPI["validateYaml"];
+
+    const view = mountView(validateYaml, () => {});
+    try {
+      forceLinting(view);
+      await flush();
+      const actions: unknown[] = [];
+      forEachDiagnostic(view.state, (d) => actions.push(...(d.actions ?? [])));
+      expect(actions).toEqual([]);
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("banners a locatable validation error with its line and nested-list hint", async () => {
+    const doc = [
+      "light:", // 1
+      "  - platform: x", // 2
+      "    effects:", // 3
+      "    - addressable_twinkle:", // 4
+      "      - flicker:", // 5
+      "      - pulse:", // 6
+      "",
+    ].join("\n");
+    const twinkleStart = doc.indexOf("- addressable_twinkle");
+    const line4 = doc.split("\n")[3];
+    const validateYaml = vi.fn(async () => ({
+      yaml_errors: [],
+      validation_errors: [
+        {
+          message: "expected a dictionary.",
+          range: {
+            document: "x.yaml",
+            start_line: 3,
+            start_col: line4.indexOf("addressable_twinkle"),
+            end_line: 3,
+            end_col: line4.length,
+          },
+        },
+      ],
+    })) as unknown as ESPHomeAPI["validateYaml"];
+    void twinkleStart;
+
+    let banner: BannerError[] = [];
+    const view = mountView(
+      validateYaml,
+      (errors) => {
+        banner = errors;
+      },
+      undefined,
+      doc
+    );
+    try {
+      forceLinting(view);
+      await flush();
+      expect(banner).toHaveLength(1);
+      expect(banner[0].kind).toBe("validation");
+      expect(banner[0].line).toBe(4);
+      expect(banner[0].message).toContain("expected a dictionary.");
+      expect(banner[0].message).toContain("yaml_editor.error_nested_list_hint");
     } finally {
       view.destroy();
     }

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -16,6 +16,7 @@ import {
   createBackendYamlLinter,
   type BannerError,
   type MappedValidationError,
+  type YamlAutoFix,
 } from "../../src/util/yaml-lint-backend.js";
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -26,7 +27,8 @@ const localize = (key: string, values?: Record<string, string | number>): string
 
 function mountView(
   validateYaml: ESPHomeAPI["validateYaml"],
-  onResult: (errors: BannerError[], mapped: MappedValidationError[]) => void
+  onResult: (errors: BannerError[], mapped: MappedValidationError[]) => void,
+  onAutoFix?: (fix: YamlAutoFix) => void
 ): EditorView {
   const api = { validateYaml } as unknown as ESPHomeAPI;
   return new EditorView({
@@ -39,6 +41,7 @@ function mountView(
           getConfiguration: () => "x.yaml",
           localize,
           onResult: (errors, mapped) => onResult(errors, mapped),
+          onAutoFix,
         }),
       ],
     }),
@@ -74,6 +77,7 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
           message: "yaml_editor.error_indent_fix:2",
           line: 2,
           fix: { line: 2, indent: 2, key: "platform" },
+          kind: "parse",
         },
       ]);
 
@@ -81,6 +85,41 @@ describe("backend linter humanizes + banners a locatable parse error", () => {
       const messages: string[] = [];
       forEachDiagnostic(view.state, (d) => messages.push(d.message));
       expect(messages).toEqual(["yaml_editor.error_indent_fix:2"]);
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("carries the auto-fix as a hover-tooltip action on the diagnostic", async () => {
+    const validateYaml = vi.fn(async () => ({
+      yaml_errors: [
+        {
+          message:
+            'mapping values are not allowed here\n  in "x.yaml", line 3, column 10',
+        },
+      ],
+      validation_errors: [],
+    })) as unknown as ESPHomeAPI["validateYaml"];
+
+    const fixes: YamlAutoFix[] = [];
+    const view = mountView(
+      validateYaml,
+      () => {},
+      (fix) => fixes.push(fix)
+    );
+    try {
+      forceLinting(view);
+      await flush();
+
+      const actions: {
+        name: string;
+        apply: (v: EditorView, a: number, b: number) => void;
+      }[] = [];
+      forEachDiagnostic(view.state, (d) => actions.push(...(d.actions ?? [])));
+      expect(actions.map((a) => a.name)).toEqual(["yaml_editor.error_auto_fix"]);
+
+      actions[0].apply(view, 0, 0);
+      expect(fixes).toEqual([{ line: 2, indent: 2, key: "platform" }]);
     } finally {
       view.destroy();
     }


### PR DESCRIPTION
# What does this implement/fix?

The invalid banner floated over the bottom of the YAML pane, so an error near the end of the file could never scroll out from behind it; the go to line link landed the target under the banner. It also popped up 600ms after any pause while typing, right on top of the half typed token that caused it.

The banner now sits in flow below the code pane and the editor shrinks to make room. While typing, an error near the caret stays as a squiggle only; the banner appears once the caret moves away, the editor loses focus, or after 15s of no typing. An error far from the caret still shows right away, and fixing the config clears the banner immediately.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
