### PR TITLE
Persist table columns and rows per page across card/list view toggle

### DIFF
--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -128,15 +128,15 @@ export class ESPHomeDeviceTable extends LitElement {
   @property({ attribute: false })
   recentJobs = new Map<string, FirmwareJob>();
 
-  /** Initial sorting from preferences — applied once when first set. */
+  /** Sorting from preferences — the host mirrors saves back, so a remount reseeds it. */
   @property({ attribute: false })
   initialSorting: SortingState | null = null;
 
-  /** Initial column visibility from preferences — applied once when first set. */
+  /** Column visibility from preferences — the host mirrors saves back, so a remount reseeds it. */
   @property({ attribute: false })
   initialColumnVisibility: VisibilityState | null = null;
 
-  /** Initial page size from preferences — applied once when first set. */
+  /** Page size from preferences — the host mirrors saves back, so a remount reseeds it. */
   @property({ type: Number, attribute: "initial-page-size" })
   initialPageSize = 25;
 
@@ -233,7 +233,7 @@ export class ESPHomeDeviceTable extends LitElement {
   // ─── Lifecycle ───
 
   protected willUpdate(changed: PropertyValues) {
-    // Apply initial values from preferences when they arrive
+    // Apply preference values when they arrive or the host mirrors a save back
     if (changed.has("initialSorting") && this.initialSorting !== null) {
       this._sorting = this.initialSorting;
     }

--- a/src/components/dashboard/device-table.ts
+++ b/src/components/dashboard/device-table.ts
@@ -244,7 +244,10 @@ export class ESPHomeDeviceTable extends LitElement {
         ...this.initialColumnVisibility,
       };
     }
-    if (changed.has("initialPageSize")) {
+    // The equality guard skips the echo of the table's own
+    // page-size-change dispatch (mirrored back through the host) so
+    // it can't reset the page index mid-session.
+    if (changed.has("initialPageSize") && this.initialPageSize !== this._pageSize) {
       this._pageSize = this.initialPageSize;
       this._pageIndex = 0;
     }

--- a/src/components/dashboard/prefs.ts
+++ b/src/components/dashboard/prefs.ts
@@ -23,11 +23,7 @@ export async function loadPreferences(host: ESPHomePageDashboard): Promise<void>
   }
 }
 
-/**
- * Persist a table preference and mirror it onto the host state that
- * seeds a remounted table, so a Card ↔ List toggle (which destroys
- * the table element) doesn't reset in-session changes (#1899).
- */
+/** Persist a table preference and mirror it onto the host state that seeds a remounted table. */
 export function saveTablePreference(host: ESPHomePageDashboard, e: CustomEvent): void {
   const type = e.type;
   if (type === "table-sort-change") {

--- a/src/components/dashboard/prefs.ts
+++ b/src/components/dashboard/prefs.ts
@@ -23,11 +23,17 @@ export async function loadPreferences(host: ESPHomePageDashboard): Promise<void>
   }
 }
 
+/**
+ * Persist a table preference and mirror it onto the host state that
+ * seeds a remounted table, so a Card ↔ List toggle (which destroys
+ * the table element) doesn't reset in-session changes (#1899).
+ */
 export function saveTablePreference(host: ESPHomePageDashboard, e: CustomEvent): void {
   const type = e.type;
   if (type === "table-sort-change") {
     const sorting = (e as CustomEvent<SortingState>).detail;
     const first = sorting[0] ?? null;
+    host._tableSorting = sorting;
     host._api
       .updatePreferences({
         table_sort_column: first?.id ?? null,
@@ -39,14 +45,12 @@ export function saveTablePreference(host: ESPHomePageDashboard, e: CustomEvent):
       })
       .catch(() => {});
   } else if (type === "table-visibility-change") {
-    host._api
-      .updatePreferences({
-        table_column_visibility: (e as CustomEvent<VisibilityState>).detail,
-      })
-      .catch(() => {});
+    const visibility = (e as CustomEvent<VisibilityState>).detail;
+    host._tableColumnVisibility = visibility;
+    host._api.updatePreferences({ table_column_visibility: visibility }).catch(() => {});
   } else if (type === "table-page-size-change") {
-    host._api
-      .updatePreferences({ table_page_size: (e as CustomEvent<number>).detail })
-      .catch(() => {});
+    const pageSize = (e as CustomEvent<number>).detail;
+    host._tablePageSize = pageSize;
+    host._api.updatePreferences({ table_page_size: pageSize }).catch(() => {});
   }
 }

--- a/src/components/dashboard/prefs.ts
+++ b/src/components/dashboard/prefs.ts
@@ -1,4 +1,5 @@
 import type { SortingState, VisibilityState } from "@tanstack/lit-table";
+import type { UserPreferences } from "../../api/types/system.js";
 import { SortDirection } from "../../api/types/system.js";
 import type { ESPHomePageDashboard } from "../../pages/dashboard.js";
 
@@ -26,27 +27,33 @@ export async function loadPreferences(host: ESPHomePageDashboard): Promise<void>
 /** Persist a table preference and mirror it onto the host state that seeds a remounted table. */
 export function saveTablePreference(host: ESPHomePageDashboard, e: CustomEvent): void {
   const type = e.type;
+  let patch: Partial<UserPreferences>;
   if (type === "table-sort-change") {
     const sorting = (e as CustomEvent<SortingState>).detail;
     const first = sorting[0] ?? null;
     host._tableSorting = sorting;
-    host._api
-      .updatePreferences({
-        table_sort_column: first?.id ?? null,
-        table_sort_direction: first
-          ? first.desc
-            ? SortDirection.DESC
-            : SortDirection.ASC
-          : null,
-      })
-      .catch(() => {});
+    patch = {
+      table_sort_column: first?.id ?? null,
+      table_sort_direction: first
+        ? first.desc
+          ? SortDirection.DESC
+          : SortDirection.ASC
+        : null,
+    };
   } else if (type === "table-visibility-change") {
     const visibility = (e as CustomEvent<VisibilityState>).detail;
     host._tableColumnVisibility = visibility;
-    host._api.updatePreferences({ table_column_visibility: visibility }).catch(() => {});
+    patch = { table_column_visibility: visibility };
   } else if (type === "table-page-size-change") {
     const pageSize = (e as CustomEvent<number>).detail;
     host._tablePageSize = pageSize;
-    host._api.updatePreferences({ table_page_size: pageSize }).catch(() => {});
+    patch = { table_page_size: pageSize };
+  } else {
+    return;
   }
+  // The mirror is kept on failure — cosmetic prefs, self-healing on
+  // the next mount — but a failing write shouldn't be invisible.
+  host._api.updatePreferences(patch).catch((err) => {
+    console.warn("Failed to save table preferences", err);
+  });
 }

--- a/test/components/dashboard/device-table.test.ts
+++ b/test/components/dashboard/device-table.test.ts
@@ -88,3 +88,40 @@ describe("device-table All rendering", () => {
     expect(pageSizeAttr(el)).toBe("0");
   });
 });
+
+describe("device-table initialPageSize seeding", () => {
+  const pagination = (el: ESPHomeDeviceTable) =>
+    el.shadowRoot!.querySelector("esphome-table-pagination")!;
+  const firstRowConfig = (el: ESPHomeDeviceTable) =>
+    el
+      .shadowRoot!.querySelector("tbody tr[data-configuration]")
+      ?.getAttribute("data-configuration");
+
+  it("ignores the host echo of its own page-size change (keeps the page index)", async () => {
+    const el = await mount(30, 25);
+
+    pagination(el).dispatchEvent(new CustomEvent("page-size-change", { detail: 10 }));
+    await el.updateComplete;
+    pagination(el).dispatchEvent(new CustomEvent("page-change", { detail: 2 }));
+    await el.updateComplete;
+    expect(firstRowConfig(el)).toBe("demo-20.yaml");
+
+    // The dashboard mirrors the change back into initialPageSize.
+    el.initialPageSize = 10;
+    await el.updateComplete;
+    expect(firstRowConfig(el)).toBe("demo-20.yaml");
+    expect(pageSizeAttr(el)).toBe("10");
+  });
+
+  it("applies a genuinely new initialPageSize and resets to the first page", async () => {
+    const el = await mount(30, 25);
+    pagination(el).dispatchEvent(new CustomEvent("page-change", { detail: 1 }));
+    await el.updateComplete;
+    expect(firstRowConfig(el)).toBe("demo-25.yaml");
+
+    el.initialPageSize = 10;
+    await el.updateComplete;
+    expect(firstRowConfig(el)).toBe("demo-0.yaml");
+    expect(rowCount(el)).toBe(10);
+  });
+});

--- a/test/components/dashboard/prefs.test.ts
+++ b/test/components/dashboard/prefs.test.ts
@@ -1,9 +1,8 @@
 /**
  * @vitest-environment happy-dom
  *
- * saveTablePreference must mirror each change onto the host fields
- * that seed a remounted table, or a Card ↔ List toggle resets
- * in-session column/page-size/sort changes (#1899).
+ * saveTablePreference mirrors each change onto the host fields that
+ * seed a remounted table.
  */
 import type { VisibilityState } from "@tanstack/lit-table";
 import { describe, expect, it, vi } from "vitest";
@@ -61,13 +60,5 @@ describe("saveTablePreference", () => {
       table_sort_column: null,
       table_sort_direction: null,
     });
-  });
-
-  it("keeps the mirrored value when the backend write fails", async () => {
-    const { host, updatePreferences } = makeHost();
-    updatePreferences.mockRejectedValueOnce(new Error("offline"));
-    saveTablePreference(host, event("table-page-size-change", 10));
-    await Promise.resolve();
-    expect(host._tablePageSize).toBe(10);
   });
 });

--- a/test/components/dashboard/prefs.test.ts
+++ b/test/components/dashboard/prefs.test.ts
@@ -61,4 +61,16 @@ describe("saveTablePreference", () => {
       table_sort_direction: null,
     });
   });
+
+  it("logs a failed persist instead of swallowing it, keeping the mirror", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { host, updatePreferences } = makeHost();
+    const boom = new Error("offline");
+    updatePreferences.mockRejectedValueOnce(boom);
+    saveTablePreference(host, event("table-page-size-change", 10));
+    await Promise.resolve();
+    expect(host._tablePageSize).toBe(10);
+    expect(warn).toHaveBeenCalledWith("Failed to save table preferences", boom);
+    warn.mockRestore();
+  });
 });

--- a/test/components/dashboard/prefs.test.ts
+++ b/test/components/dashboard/prefs.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * saveTablePreference must mirror each change onto the host fields
+ * that seed a remounted table, or a Card ↔ List toggle resets
+ * in-session column/page-size/sort changes (#1899).
+ */
+import type { VisibilityState } from "@tanstack/lit-table";
+import { describe, expect, it, vi } from "vitest";
+import { SortDirection } from "../../../src/api/types/system.js";
+import { saveTablePreference } from "../../../src/components/dashboard/prefs.js";
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+
+function makeHost() {
+  const updatePreferences = vi.fn(async () => {});
+  const host = {
+    _api: { updatePreferences },
+    _tablePageSize: 25,
+    _tableColumnVisibility: null,
+    _tableSorting: null,
+  } as unknown as ESPHomePageDashboard;
+  return { host, updatePreferences };
+}
+
+const event = (type: string, detail: unknown) => new CustomEvent(type, { detail });
+
+describe("saveTablePreference", () => {
+  it("mirrors a page-size change onto the host and persists it", () => {
+    const { host, updatePreferences } = makeHost();
+    saveTablePreference(host, event("table-page-size-change", 50));
+    expect(host._tablePageSize).toBe(50);
+    expect(updatePreferences).toHaveBeenCalledWith({ table_page_size: 50 });
+  });
+
+  it("mirrors a column-visibility change onto the host and persists it", () => {
+    const { host, updatePreferences } = makeHost();
+    const visibility: VisibilityState = { comment: true, ip: false };
+    saveTablePreference(host, event("table-visibility-change", visibility));
+    expect(host._tableColumnVisibility).toBe(visibility);
+    expect(updatePreferences).toHaveBeenCalledWith({
+      table_column_visibility: visibility,
+    });
+  });
+
+  it("mirrors a sort change onto the host and persists it", () => {
+    const { host, updatePreferences } = makeHost();
+    const sorting = [{ id: "name", desc: true }];
+    saveTablePreference(host, event("table-sort-change", sorting));
+    expect(host._tableSorting).toBe(sorting);
+    expect(updatePreferences).toHaveBeenCalledWith({
+      table_sort_column: "name",
+      table_sort_direction: SortDirection.DESC,
+    });
+  });
+
+  it("mirrors a cleared sort as an empty list and null columns", () => {
+    const { host, updatePreferences } = makeHost();
+    saveTablePreference(host, event("table-sort-change", []));
+    expect(host._tableSorting).toEqual([]);
+    expect(updatePreferences).toHaveBeenCalledWith({
+      table_sort_column: null,
+      table_sort_direction: null,
+    });
+  });
+
+  it("keeps the mirrored value when the backend write fails", async () => {
+    const { host, updatePreferences } = makeHost();
+    updatePreferences.mockRejectedValueOnce(new Error("offline"));
+    saveTablePreference(host, event("table-page-size-change", 10));
+    await Promise.resolve();
+    expect(host._tablePageSize).toBe(10);
+  });
+});


### PR DESCRIPTION
# What does this implement/fix?

Switching from List view to Card view destroys the table element, and switching back re-seeded it from host state that was only ever written at page load; any in-session change to visible columns, rows per page, or sorting was lost. `saveTablePreference` now mirrors each change onto the host fields that seed a remounted table, so the toggle keeps the user's settings; the table also ignores the echo of its own page-size dispatch so it cannot reset the current page.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1899

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
