### PR TITLE
Centralize test flush helpers in test/_dom.ts

### DIFF
--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -8,6 +8,7 @@
  * ``document.body`` cleanup between tests.
  */
 import { render } from "lit";
+import { vi } from "vitest";
 
 /**
  * Append ``el`` to ``document.body`` and wait for its first render.
@@ -62,4 +63,24 @@ export async function baseDialogSettled(el: HTMLElement): Promise<void> {
   await (el as { updateComplete?: Promise<unknown> }).updateComplete;
   const base = el.shadowRoot?.querySelector("esphome-base-dialog");
   await (base as { updateComplete?: Promise<unknown> } | null)?.updateComplete;
+}
+
+/** Resolve after a zero-delay timeout so queued real-timer callbacks run. */
+export const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * Drain ``times`` microtask turns.
+ *
+ * Suites pass the count their async chain needs — a plain await per
+ * ``.then`` link — so keep the caller's tuned value when migrating.
+ */
+export async function flushMicrotasks(times = 1): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+/** ``flush`` for suites under ``vi.useFakeTimers``: run zero-delay fake timers. */
+export async function flushTimers(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
 }

--- a/test/_dom.ts
+++ b/test/_dom.ts
@@ -1,11 +1,13 @@
 /**
- * Shared DOM helpers for the happy-dom test suites.
+ * Shared DOM and settle helpers for the test suites.
  *
  * Nearly every component/dialog test used to hand-roll the same snippets:
  * an async mount (append + settle), a render-into-a-container helper for
- * pure template functions, and an identity localize stub for host fakes.
- * They live here once instead; ``test/_setup-dom.ts`` owns the matching
- * ``document.body`` cleanup between tests.
+ * pure template functions, an identity localize stub for host fakes, and
+ * a flush helper in one of three shapes (zero-delay timeout, microtask
+ * drain, fake-timer advance). They live here once instead;
+ * ``test/_setup-dom.ts`` owns the matching ``document.body`` cleanup
+ * between tests.
  */
 import { render } from "lit";
 import { vi } from "vitest";
@@ -68,13 +70,8 @@ export async function baseDialogSettled(el: HTMLElement): Promise<void> {
 /** Resolve after a zero-delay timeout so queued real-timer callbacks run. */
 export const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
-/**
- * Drain ``times`` microtask turns.
- *
- * Suites pass the count their async chain needs — a plain await per
- * ``.then`` link — so keep the caller's tuned value when migrating.
- */
-export async function flushMicrotasks(times = 1): Promise<void> {
+/** Drain ``times`` microtask turns — one per await/``.then`` link the chain under test needs. */
+export async function flushMicrotasks(times: number): Promise<void> {
   for (let i = 0; i < times; i++) {
     await Promise.resolve();
   }

--- a/test/components/app-shell/settings-actions.test.ts
+++ b/test/components/app-shell/settings-actions.test.ts
@@ -13,7 +13,7 @@ import {
   onSetTheme,
   onSetVersionHistoryEnabled,
 } from "../../../src/components/app-shell/settings-actions.js";
-import { identityLocalize } from "../../_dom.js";
+import { flush, identityLocalize } from "../../_dom.js";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 vi.mock("sonner-js", () => ({
@@ -21,9 +21,6 @@ vi.mock("sonner-js", () => ({
     error: (...args: unknown[]) => toastError(...args),
   },
 }));
-
-/** Let pending .catch()/.finally() microtasks run. */
-const flush = () => new Promise((r) => setTimeout(r, 0));
 
 type PrefsHost = Pick<
   ESPHomeApp,

--- a/test/components/dashboard/stream-serial-to-dialog.test.ts
+++ b/test/components/dashboard/stream-serial-to-dialog.test.ts
@@ -11,6 +11,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { streamSerialToDialog } from "../../../src/components/dashboard/actions.js";
+import { flushMicrotasks } from "../../_dom.js";
 
 interface MockDialog {
   _lines: string[];
@@ -66,11 +67,7 @@ function createMockPort(chunks: Uint8Array[]) {
 }
 
 /** Drain pending microtasks so the read loop advances past awaits. */
-async function flush() {
-  for (let i = 0; i < 5; i++) {
-    await Promise.resolve();
-  }
-}
+const flush = () => flushMicrotasks(5);
 
 describe("streamSerialToDialog", () => {
   beforeEach(() => {

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -23,6 +23,8 @@ import type { AvailableAutomations } from "../../../src/api/types/automations.js
 import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
 import { flushMicrotasks, identityLocalize } from "../../_dom.js";
 
+const flush = () => flushMicrotasks(5);
+
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   let resolve!: (v: T) => void;
   const promise = new Promise<T>((r) => (resolve = r));
@@ -48,7 +50,7 @@ async function mountDialog(api: ESPHomeAPI): Promise<ESPHomeAddAutomationDialog>
   dialog.configuration = "device.yaml";
   document.body.appendChild(dialog);
   await dialog.updateComplete;
-  await flushMicrotasks(5);
+  await flush();
   return dialog;
 }
 
@@ -64,7 +66,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
 
     // First load in flight: spinner up, form (and its selects) absent.
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).not.toBeNull();
@@ -72,7 +74,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
 
     first.resolve(slimAvailable());
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
 
     // Data landed: form rendered, spinner gone.
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
@@ -91,10 +93,10 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     first.resolve(slimAvailable());
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
 
     const selectBeforeReopen = kindSelect(dialog);
     expect(selectBeforeReopen).not.toBeNull();
@@ -104,13 +106,13 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     // wa-select element must survive rather than be recreated.
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
 
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
     expect(kindSelect(dialog)).toBe(selectBeforeReopen);
 
     second.resolve(slimAvailable());
-    await flushMicrotasks(5);
+    await flush();
   });
 
   it("scopes available automations off the unsaved draft yaml (#1348)", async () => {
@@ -121,7 +123,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     dialog.yaml = "esphome:\n  name: drafty\n";
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
 
     expect(getAvailableAutomations).toHaveBeenCalledWith(
       "device.yaml",
@@ -171,7 +173,7 @@ describe("add-automation-dialog list-shaped triggers (#1080)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     dialog.yaml = ON_TIME_YAML;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "component_on";
@@ -258,7 +260,7 @@ describe("add-automation-dialog device-level list triggers (#1283)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     dialog.yaml = ON_BOOT_LIST_YAML;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "device_on";
@@ -329,7 +331,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "component_on";
     await dialog.updateComplete;
@@ -403,7 +405,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open({ kind: "component_on", componentId: "aht20" });
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     await dialog.updateComplete;
 
     // Landed on the first sub-entity, not the container.
@@ -448,7 +450,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open({ kind: "component_on", componentId: "aht20" });
     await dialog.updateComplete;
-    await flushMicrotasks(5);
+    await flush();
     await dialog.updateComplete;
 
     expect(dialog.shadowRoot!.textContent).toContain(

--- a/test/components/device/add-automation-dialog.test.ts
+++ b/test/components/device/add-automation-dialog.test.ts
@@ -21,11 +21,7 @@ vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 import type { ESPHomeAPI } from "../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../src/api/types/automations.js";
 import { ESPHomeAddAutomationDialog } from "../../../src/components/device/add-automation-dialog.js";
-import { identityLocalize } from "../../_dom.js";
-
-async function flushPending(times = 5): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
+import { flushMicrotasks, identityLocalize } from "../../_dom.js";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   let resolve!: (v: T) => void;
@@ -52,7 +48,7 @@ async function mountDialog(api: ESPHomeAPI): Promise<ESPHomeAddAutomationDialog>
   dialog.configuration = "device.yaml";
   document.body.appendChild(dialog);
   await dialog.updateComplete;
-  await flushPending();
+  await flushMicrotasks(5);
   return dialog;
 }
 
@@ -68,7 +64,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     // First load in flight: spinner up, form (and its selects) absent.
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).not.toBeNull();
@@ -76,7 +72,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
 
     first.resolve(slimAvailable());
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     // Data landed: form rendered, spinner gone.
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
@@ -95,10 +91,10 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     first.resolve(slimAvailable());
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     const selectBeforeReopen = kindSelect(dialog);
     expect(selectBeforeReopen).not.toBeNull();
@@ -108,13 +104,13 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     // wa-select element must survive rather than be recreated.
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     expect(dialog.shadowRoot?.querySelector("wa-spinner")).toBeNull();
     expect(kindSelect(dialog)).toBe(selectBeforeReopen);
 
     second.resolve(slimAvailable());
-    await flushPending();
+    await flushMicrotasks(5);
   });
 
   it("scopes available automations off the unsaved draft yaml (#1348)", async () => {
@@ -125,7 +121,7 @@ describe("add-automation-dialog render gate (behavioral)", () => {
     dialog.yaml = "esphome:\n  name: drafty\n";
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     expect(getAvailableAutomations).toHaveBeenCalledWith(
       "device.yaml",
@@ -175,7 +171,7 @@ describe("add-automation-dialog list-shaped triggers (#1080)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     dialog.yaml = ON_TIME_YAML;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "component_on";
@@ -262,7 +258,7 @@ describe("add-automation-dialog device-level list triggers (#1283)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     dialog.yaml = ON_BOOT_LIST_YAML;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "device_on";
@@ -333,7 +329,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open();
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog as any)._kind = "component_on";
     await dialog.updateComplete;
@@ -407,7 +403,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open({ kind: "component_on", componentId: "aht20" });
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     await dialog.updateComplete;
 
     // Landed on the first sub-entity, not the container.
@@ -452,7 +448,7 @@ describe("add-automation-dialog sub-entity targets (#1263)", () => {
     const dialog = await mountDialog(api);
     dialog.open({ kind: "component_on", componentId: "aht20" });
     await dialog.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
     await dialog.updateComplete;
 
     expect(dialog.shadowRoot!.textContent).toContain(

--- a/test/components/device/add-component-form-provides-dep.test.ts
+++ b/test/components/device/add-component-form-provides-dep.test.ts
@@ -16,6 +16,7 @@ import type { ComponentCatalogEntry } from "../../../src/api/types/components.js
 import { ESPHomeAddComponentForm } from "../../../src/components/device/add-component-form.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
 import { _clearProvidesCache } from "../../../src/util/provides-cache.js";
+import { flushMicrotasks } from "../../_dom.js";
 import { makeComponentEntry } from "../../util/_make-component-entry.js";
 
 function providersResponse(ids: string[]) {
@@ -55,7 +56,7 @@ async function mountForm(
   // provides lookup settles (a few microtask hops through the cache), a
   // re-render clears it. Flush generously, then await the final update.
   await el.updateComplete;
-  for (let i = 0; i < 10; i++) await Promise.resolve();
+  await flushMicrotasks(10);
   await el.updateComplete;
   return el;
 }
@@ -136,7 +137,7 @@ describe("add-component-form provides-satisfied dependency", () => {
 
     // A finally resolves with libretiny providers, after the seq moved on.
     resolveA(providersResponse(["bk72xx"]));
-    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await flushMicrotasks(10);
     await el.updateComplete;
 
     const inst = el as unknown as { _providedDeps: ReadonlySet<string> };
@@ -174,7 +175,7 @@ describe("add-component-form provides-satisfied dependency", () => {
     const providedRef = inst._providedDeps;
 
     // Let the provides lookup settle.
-    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await flushMicrotasks(10);
     await el.updateComplete;
 
     expect(getComponents).toHaveBeenCalled(); // the lookup did run

--- a/test/components/device/automation-editor/api-action-editor-mount.test.ts
+++ b/test/components/device/automation-editor/api-action-editor-mount.test.ts
@@ -26,6 +26,7 @@ import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeApiActionEditor } from "../../../../src/components/device/automation-editor/api-action-editor.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+import { flushMicrotasks } from "../../../_dom.js";
 
 const slimWithLoggerAction = (): AvailableAutomations =>
   ({
@@ -43,10 +44,6 @@ const loggerBodies = () => ({
   },
 });
 
-async function flushPending(times = 30): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
-
 async function mountEditor(
   api: ESPHomeAPI,
   configuration?: string
@@ -57,7 +54,7 @@ async function mountEditor(
   if (configuration !== undefined) editor.configuration = configuration;
   document.body.appendChild(editor);
   await editor.updateComplete;
-  await flushPending();
+  await flushMicrotasks(30);
   return editor;
 }
 

--- a/test/components/device/automation-editor/auto-apply-controller.test.ts
+++ b/test/components/device/automation-editor/auto-apply-controller.test.ts
@@ -27,6 +27,7 @@ import {
   type AutoApplyHost,
   type AutoApplyOptions,
 } from "../../../../src/components/device/automation-editor/auto-apply-controller.js";
+import { flushTimers } from "../../../_dom.js";
 
 const SCRIPT: AutomationLocation = {
   kind: "script",
@@ -189,7 +190,7 @@ describe("AutoApplyController auto-apply", () => {
     expect(upsertAutomation).toHaveBeenCalledTimes(1);
 
     resolveFirst({ yaml_diff: DIFF });
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     // Exactly one re-run so the latest value wins.
     expect(upsertAutomation).toHaveBeenCalledTimes(2);
     expect(controller.inFlightWrite).toBe(false);

--- a/test/components/device/automation-editor/automation-editor-mount.test.ts
+++ b/test/components/device/automation-editor/automation-editor-mount.test.ts
@@ -30,6 +30,7 @@ vi.mock("sonner-js", () => ({ default: { error: vi.fn() } }));
 import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
+import { flushMicrotasks } from "../../../_dom.js";
 
 const slimAvailable = (): AvailableAutomations =>
   ({
@@ -39,10 +40,6 @@ const slimAvailable = (): AvailableAutomations =>
     scripts: [],
     devices: [],
   }) as unknown as AvailableAutomations;
-
-async function flushPending(times = 5): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
 
 /** Construct an editor, plant the api on its consumer-private
  *  ``_api`` slot (no Lit context provider in the test tree),
@@ -58,7 +55,7 @@ async function mountEditor(
   if (configuration !== undefined) editor.configuration = configuration;
   document.body.appendChild(editor);
   await editor.updateComplete;
-  await flushPending();
+  await flushMicrotasks(5);
   return editor;
 }
 
@@ -115,7 +112,7 @@ describe("automation-editor mount-time load (behavioral)", () => {
     expect((editor as any)._loading).toBe(false);
 
     resolveBodies({});
-    await flushPending();
+    await flushMicrotasks(5);
   });
 
   it("setting configuration after mount triggers the load", async () => {
@@ -128,7 +125,7 @@ describe("automation-editor mount-time load (behavioral)", () => {
 
     editor.configuration = "device.yaml";
     await editor.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     expect(getAvailableAutomations).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +153,7 @@ describe("automation-editor mount-time load (behavioral)", () => {
     (editor as any).value = { trigger_id: null, trigger_params: {}, actions: [] };
     document.body.appendChild(editor);
     await editor.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     // Header derives from the field (no trigger to name); edit-mode means
     // the add-only trigger picker is never instantiated.

--- a/test/components/device/automation-editor/automation-editor-uneditable.test.ts
+++ b/test/components/device/automation-editor/automation-editor-uneditable.test.ts
@@ -32,6 +32,7 @@ import type {
   ParsedAutomation,
 } from "../../../../src/api/types/automations.js";
 import { ESPHomeAutomationEditor } from "../../../../src/components/device/automation-editor/automation-editor.js";
+import { flushMicrotasks } from "../../../_dom.js";
 
 const ON_BOOT: AutomationLocation = {
   kind: "device_on",
@@ -70,10 +71,6 @@ const slimAvailable = (): AvailableAutomations =>
     devices: [],
   }) as unknown as AvailableAutomations;
 
-async function flushPending(times = 8): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
-
 describe("automation-editor uneditable (errored parse)", () => {
   it("renders read-only and never upserts when the parsed automation has an error", async () => {
     const upsertAutomation = vi.fn();
@@ -91,7 +88,7 @@ describe("automation-editor uneditable (errored parse)", () => {
     editor.location = ON_BOOT;
     document.body.appendChild(editor);
     await editor.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
 
     // The errored automation is flagged read-only; its empty tree was
     // not adopted, and the error surfaces in the rendered panel.
@@ -155,7 +152,7 @@ describe("automation-editor parse-error banner", () => {
     editor.yaml = "broken: [";
     document.body.appendChild(editor);
     await editor.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
     // The failed parse surfaced an error banner.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((editor as any)._error).toContain("Failed to parse");
@@ -164,7 +161,7 @@ describe("automation-editor parse-error banner", () => {
     editor.yaml = "on_boot:\n  then: []\n";
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (editor as any).reload();
-    await flushPending();
+    await flushMicrotasks(8);
     // A successful parse clears the stale error.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((editor as any)._error).toBe("");

--- a/test/components/device/automation-editor/script-editor-mount.test.ts
+++ b/test/components/device/automation-editor/script-editor-mount.test.ts
@@ -29,6 +29,7 @@ import type { ESPHomeAPI } from "../../../../src/api/index.js";
 import type { AvailableAutomations } from "../../../../src/api/types/automations.js";
 import { ESPHomeScriptEditor } from "../../../../src/components/device/automation-editor/script-editor.js";
 import { _clearAutomationBodyCache } from "../../../../src/util/automation-body-cache.js";
+import { flushMicrotasks } from "../../../_dom.js";
 
 const slimWithLoggerAction = (): AvailableAutomations =>
   ({
@@ -46,10 +47,6 @@ const loggerBodies = () => ({
   },
 });
 
-async function flushPending(times = 30): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
-
 async function mountEditor(
   api: ESPHomeAPI,
   configuration?: string
@@ -60,7 +57,7 @@ async function mountEditor(
   if (configuration !== undefined) editor.configuration = configuration;
   document.body.appendChild(editor);
   await editor.updateComplete;
-  await flushPending();
+  await flushMicrotasks(30);
   return editor;
 }
 

--- a/test/components/device/config-entry-form-providers.test.ts
+++ b/test/components/device/config-entry-form-providers.test.ts
@@ -15,6 +15,7 @@ vi.mock("sonner-js", () => ({
 import type { ComponentCatalogEntry } from "../../../src/api/types/components.js";
 import { ESPHomeConfigEntryForm } from "../../../src/components/device/config-entry-form.js";
 import type { ComponentProvider } from "../../../src/util/config-entry-yaml-scan.js";
+import { flushMicrotasks } from "../../_dom.js";
 
 const resolve = (
   form: ESPHomeConfigEntryForm,
@@ -26,12 +27,8 @@ const resolve = (
     }
   )._resolveInterfaceProviders(name);
 
-const flush = async () => {
-  // Let the getComponents promise's then/catch/finally chain settle.
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-};
+// Let the getComponents promise's then/catch/finally chain settle.
+const flush = () => flushMicrotasks(3);
 
 function withApi(getComponents: ReturnType<typeof vi.fn>): ESPHomeConfigEntryForm {
   const form = new ESPHomeConfigEntryForm();

--- a/test/components/device/device-navigator-coalesce.test.ts
+++ b/test/components/device/device-navigator-coalesce.test.ts
@@ -18,10 +18,7 @@ import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { ESPHomeDeviceNavigator } from "../../../src/components/device/device-navigator.js";
 import { _clearAutomationCatalogCache } from "../../../src/util/automation-catalog-cache.js";
 import { _clearComponentCache } from "../../../src/util/component-name-cache.js";
-
-async function flushPending(times = 5): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
+import { flushMicrotasks } from "../../_dom.js";
 
 async function mountNavigator(
   api: ESPHomeAPI,
@@ -39,7 +36,7 @@ async function mountNavigator(
   if (props.platformReady !== undefined) nav.platformReady = props.platformReady;
   document.body.appendChild(nav);
   await nav.updateComplete;
-  await flushPending();
+  await flushMicrotasks(5);
   return nav;
 }
 
@@ -77,7 +74,7 @@ describe("device-navigator kickoff gating", () => {
     const nav = await mountNavigator(api, { yaml: "", platformReady: false });
     nav.platformReady = true;
     await nav.updateComplete;
-    await flushPending();
+    await flushMicrotasks(5);
 
     expect(getAutomationTriggers).not.toHaveBeenCalled();
     expect(getComponentBodies).not.toHaveBeenCalled();
@@ -98,7 +95,7 @@ describe("device-navigator kickoff gating", () => {
     nav.platformReady = true;
     await nav.updateComplete;
     // Microtask-batched body cache; let queued fetches flush.
-    await flushPending(10);
+    await flushMicrotasks(10);
 
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
     expect(getAutomationTriggers).toHaveBeenCalledWith("esp32", undefined);
@@ -121,7 +118,7 @@ describe("device-navigator kickoff gating", () => {
 
     nav.yaml = YAML;
     await nav.updateComplete;
-    await flushPending(10);
+    await flushMicrotasks(10);
 
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
     expect(getAutomationTriggers).toHaveBeenCalledWith("esp32", undefined);
@@ -137,7 +134,7 @@ describe("device-navigator kickoff gating", () => {
     const nav = await mountNavigator(api, { yaml: YAML, platformReady: false });
     nav.platformReady = true;
     await nav.updateComplete;
-    await flushPending(10);
+    await flushMicrotasks(10);
 
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
     expect(getAutomationTriggers).toHaveBeenCalledWith(undefined, undefined);
@@ -152,14 +149,14 @@ describe("device-navigator kickoff gating", () => {
       platform: "esp32",
       platformReady: true,
     });
-    await flushPending(10);
+    await flushMicrotasks(10);
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
 
     // An unrelated prop change shouldn't refire (selection update
     // doesn't touch yaml / platform / platformReady).
     nav.selectedKey = "wifi";
     await nav.updateComplete;
-    await flushPending(10);
+    await flushMicrotasks(10);
 
     expect(getAutomationTriggers).toHaveBeenCalledTimes(1);
   });

--- a/test/components/device/secret-picker.test.ts
+++ b/test/components/device/secret-picker.test.ts
@@ -32,6 +32,7 @@ import {
   _resetSecretKeysCache,
   fetchSecretKeys,
 } from "../../../src/util/secrets-cache.js";
+import { flush } from "../../_dom.js";
 
 const makeApi = (keys: string[]): ESPHomeAPI =>
   ({ getSecretKeys: vi.fn(async () => keys) }) as unknown as ESPHomeAPI;
@@ -253,7 +254,7 @@ describe("esphome-secret-picker", () => {
     el.addEventListener("secret-selected", onSelected as EventListener);
 
     fireSelectItem(el, ".manual");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
 
     expect(api.getConfig).toHaveBeenCalledWith("secrets.yaml");
     expect((onSelected.mock.calls[0][0] as CustomEvent).detail.value).toBe("myssid");
@@ -273,7 +274,7 @@ describe("esphome-secret-picker", () => {
     el.addEventListener("secret-selected", onSelected as EventListener);
 
     fireSelectItem(el, ".manual");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
 
     // A transient read failure must not replace the reference with a blank.
     expect(onSelected).not.toHaveBeenCalled();
@@ -291,7 +292,7 @@ describe("esphome-secret-picker", () => {
     el.addEventListener("secret-selected", onSelected as EventListener);
 
     fireSelectItem(el, ".manual");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
 
     // Key absent (read succeeded) → a legit empty inline, not an error.
     expect((onSelected.mock.calls[0][0] as CustomEvent).detail.value).toBe("");
@@ -315,7 +316,7 @@ describe("esphome-secret-picker", () => {
     window.addEventListener("secrets-saved", saved as EventListener);
 
     fireSelectItem(el, ".migrate");
-    await new Promise((r) => setTimeout(r, 0)); // let the async write settle
+    await flush(); // let the async write settle
 
     // The double-underscore form is created (create-if-absent), never the alias.
     expect(api.setSecret).toHaveBeenCalledWith(
@@ -347,7 +348,7 @@ describe("esphome-secret-picker", () => {
     el.addEventListener("secret-selected", onSelected as EventListener);
 
     fireSelectItem(el, ".migrate");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
 
     // A failed write must never change the field to a !secret ref.
     expect(onSelected).not.toHaveBeenCalled();
@@ -369,7 +370,7 @@ describe("esphome-secret-picker", () => {
     el.addEventListener("secret-selected", onSelected as EventListener);
 
     fireSelectItem(el, ".migrate");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
 
     // create-if-absent left the existing value; reference the key with a distinct
     // "linked" toast (its value may differ from what the user typed).

--- a/test/components/device/secret-value.test.ts
+++ b/test/components/device/secret-value.test.ts
@@ -28,6 +28,7 @@ import toast from "sonner-js";
 import type { ESPHomeAPI } from "../../../src/api/esphome-api.js";
 import { ESPHomeSecretValue } from "../../../src/components/device/secret-value.js";
 import { _resetSecretKeysCache } from "../../../src/util/secrets-cache.js";
+import { flush } from "../../_dom.js";
 
 async function mount(
   api: Partial<ESPHomeAPI>,
@@ -43,14 +44,14 @@ async function mount(
   document.body.appendChild(el);
   await el.updateComplete;
   // Present mode prefills the field from secrets.yaml via an async load.
-  await new Promise((r) => setTimeout(r, 0));
+  await flush();
   await el.updateComplete;
   return el;
 }
 
 const click = async (el: ESPHomeSecretValue, selector: string): Promise<void> => {
   (el.shadowRoot!.querySelector(selector) as HTMLElement).click();
-  await new Promise((r) => setTimeout(r, 0));
+  await flush();
   await el.updateComplete;
 };
 
@@ -108,7 +109,7 @@ describe("esphome-secret-value", () => {
     el.shadowRoot!.querySelector("esphome-password-input")!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
     );
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(api.updateConfig).not.toHaveBeenCalled();
 
     await typeValue(el, "real");
@@ -182,7 +183,7 @@ describe("esphome-secret-value", () => {
     el.shadowRoot!.querySelector("esphome-confirm-dialog")!.dispatchEvent(
       new CustomEvent("confirm")
     );
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
 
     expect(api.setSecret).toHaveBeenCalledWith("wifi_password", "newpass", true);
@@ -228,7 +229,7 @@ describe("esphome-secret-value", () => {
     expect(copyBtn().disabled).toBe(true);
 
     resolveGet("api_key: stored\n");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
 
     expect(pwInput(el).value).toBe("stored");
@@ -254,7 +255,7 @@ describe("esphome-secret-value", () => {
 
     // Retry re-fetches and recovers.
     await click(el, ".retry");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
     expect(pwInput(el).value).toBe("real");
   });
@@ -281,7 +282,7 @@ describe("esphome-secret-value", () => {
     expect((api.getConfig as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
 
     resolveGet("api_key: stored\n");
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
     expect(pwInput(el).value).toBe("stored");
   });
@@ -318,13 +319,13 @@ describe("esphome-secret-value", () => {
     // The stale write A resolves — must NOT clear B's busy (else B's button
     // re-enables mid-write). Without the op-token guard this would be enabled.
     resolveA();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
     expect(saveBtn().disabled).toBe(true);
 
     // B completes normally (both writes were issued).
     resolveB();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
     expect((api.setSecret as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
   });
@@ -341,7 +342,7 @@ describe("esphome-secret-value", () => {
     await el.updateComplete;
     el.present = true;
     await el.updateComplete;
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     await el.updateComplete;
 
     // Back to the freshly-loaded stored value, not the abandoned draft.

--- a/test/components/device/trigger-catalog-controller.test.ts
+++ b/test/components/device/trigger-catalog-controller.test.ts
@@ -8,6 +8,7 @@ import {
   fetchAutomationTriggers,
   getCachedAutomationTriggers,
 } from "../../../src/util/automation-catalog-cache.js";
+import { flush } from "../../_dom.js";
 import { fakeHost } from "../../_fake-host.js";
 
 const trigger = (id: string, name: string): AutomationTrigger => ({
@@ -23,8 +24,6 @@ const trigger = (id: string, name: string): AutomationTrigger => ({
 
 const fakeApi = (triggers: AutomationTrigger[]): ESPHomeAPI =>
   ({ getAutomationTriggers: vi.fn(async () => triggers) }) as unknown as ESPHomeAPI;
-
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 afterEach(() => _clearAutomationCatalogCache());
 

--- a/test/components/install-method-dialog-ota-submit-label.test.ts
+++ b/test/components/install-method-dialog-ota-submit-label.test.ts
@@ -15,10 +15,7 @@ vi.mock("@home-assistant/webawesome/dist/components/spinner/spinner.js", () => (
 import { DeviceState } from "../../src/api/types/devices.js";
 import { defaultLocalize } from "../../src/common/localize.js";
 import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
-
-async function flushPending(times = 5): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
+import { flushMicrotasks } from "../_dom.js";
 
 async function mountWithOtaCardOpen(
   mode: "install" | "logs"
@@ -42,7 +39,7 @@ async function mountWithOtaCardOpen(
   (dialog as any)._otaAddressCardExpanded = true;
   document.body.appendChild(dialog);
   await dialog.updateComplete;
-  await flushPending();
+  await flushMicrotasks(5);
   return dialog;
 }
 

--- a/test/components/install-method-dialog-port-poll.test.ts
+++ b/test/components/install-method-dialog-port-poll.test.ts
@@ -15,6 +15,7 @@ import type { SerialPort } from "../../src/api/types/system.js";
 import { defaultLocalize } from "../../src/common/localize.js";
 import { ESPHomeInstallMethodDialog } from "../../src/components/install-method-dialog.js";
 import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../src/util/serial-ports-poll-controller.js";
+import { flushTimers } from "../_dom.js";
 import { makeSerialPort } from "../_make-serial-port.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -48,7 +49,7 @@ describe("install-method-dialog port polling", () => {
     const getSerialPorts = vi.fn(async () => ports);
     const dialog = await mount(getSerialPorts);
 
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     await dialog.updateComplete;
     expect(portRows(dialog)).toHaveLength(1);
 
@@ -72,7 +73,7 @@ describe("install-method-dialog port polling", () => {
       makeSerialPort("/dev/ttyUSB0", "CP2102", { vid: 0x10c4, hint: "bridge" }),
     ];
     const dialog = await mount(async () => ports);
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     await dialog.updateComplete;
 
     const rows = portRows(dialog);
@@ -83,7 +84,7 @@ describe("install-method-dialog port polling", () => {
 
   it("omits the replug hint when a single port leaves no room for doubt", async () => {
     const dialog = await mount(async () => [makeSerialPort("/dev/ttyUSB0", "CP2102")]);
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     await dialog.updateComplete;
 
     expect(dialog.shadowRoot!.querySelector(".port-hint")).toBeNull();
@@ -92,7 +93,7 @@ describe("install-method-dialog port polling", () => {
   it("stops polling when the dialog closes", async () => {
     const getSerialPorts = vi.fn(async () => [] as SerialPort[]);
     const dialog = await mount(getSerialPorts);
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     expect(getSerialPorts).toHaveBeenCalledTimes(1);
 
     dialog.open = false;

--- a/test/components/wizard/create-config-dialog.test.ts
+++ b/test/components/wizard/create-config-dialog.test.ts
@@ -29,6 +29,7 @@ import type { ESPHomeAPI } from "../../../src/api/index.js";
 import { ESPHomeCreateConfigDialog } from "../../../src/components/wizard/create-config-dialog.js";
 import enMessages from "../../../src/translations/en.json";
 import { _clearBoardBodyCache } from "../../../src/util/board-body-cache.js";
+import { flushMicrotasks } from "../../_dom.js";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   let resolve!: (v: T) => void;
@@ -36,13 +37,11 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
   return { promise, resolve };
 }
 
-const flush = async (): Promise<void> => {
-  // Drain enough microtasks for the setup-step board upgrade to settle: it
-  // now hops through the shared ``board-body-cache`` (queueMicrotask batch +
-  // a getBoard round trip), a deeper async chain than the former direct
-  // ``await getBoard`` call.
-  for (let i = 0; i < 12; i++) await Promise.resolve();
-};
+// Drain enough microtasks for the setup-step board upgrade to settle: it
+// now hops through the shared ``board-body-cache`` (queueMicrotask batch +
+// a getBoard round trip), a deeper async chain than the former direct
+// ``await getBoard`` call.
+const flush = () => flushMicrotasks(12);
 
 // Render an en.json key with real ICU MessageFormat so the full-setup tests
 // exercise the actual template (the name cap and =0/other plural branches

--- a/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
+++ b/test/components/wizard/wizard-step-board-port-error-recovery.test.ts
@@ -16,6 +16,7 @@ import { defaultLocalize } from "../../../src/common/localize.js";
 import type { ESPHomeWizardStepBoardPortSelect } from "../../../src/components/wizard/wizard-step-board-port-select.js";
 import { ESPHomeWizardStepBoard } from "../../../src/components/wizard/wizard-step-board.js";
 import { SERIAL_PORTS_POLL_INTERVAL_MS } from "../../../src/util/serial-ports-poll-controller.js";
+import { flushTimers } from "../../_dom.js";
 import { makeSerialPort } from "../../_make-serial-port.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -58,7 +59,7 @@ describe("wizard-step-board port fetch error recovery", () => {
     });
     const el = await mount(getSerialPorts);
 
-    await vi.advanceTimersByTimeAsync(0);
+    await flushTimers();
     await el.updateComplete;
     expect(portSelect(el).errorMessage).toBe("backend offline");
 

--- a/test/pages/dashboard-pending-serial-setup.test.ts
+++ b/test/pages/dashboard-pending-serial-setup.test.ts
@@ -17,12 +17,9 @@ vi.mock("../../src/components/dashboard/actions.js", async (importActual) => ({
 
 import { detectAndOpenWizard } from "../../src/components/dashboard/actions.js";
 import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
+import { flushMicrotasks } from "../_dom.js";
 
 const fakePort = {} as SerialPort;
-
-async function flushPending(times = 8): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
 
 async function mountDashboard(
   hideDeviceCreation: boolean
@@ -36,7 +33,7 @@ async function mountDashboard(
   (page as any)._remoteComputeOnly = hideDeviceCreation;
   document.body.appendChild(page);
   await page.updateComplete;
-  await flushPending();
+  await flushMicrotasks(8);
   return page;
 }
 
@@ -78,7 +75,7 @@ describe("dashboard pending serial setup", () => {
     document.body.appendChild(page); // connectedCallback consumes + schedules
     page.remove(); // disconnect before updateComplete resolves
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
     expect(detectAndOpenWizard).not.toHaveBeenCalled();
   });
 });

--- a/test/pages/dashboard-yaml-attr.test.ts
+++ b/test/pages/dashboard-yaml-attr.test.ts
@@ -12,10 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { ESPHomePageDashboard } from "../../src/pages/dashboard.js";
-
-async function flushPending(times = 8): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
-}
+import { flushMicrotasks } from "../_dom.js";
 
 async function mountDashboard(
   yamlMode: boolean,
@@ -30,7 +27,7 @@ async function mountDashboard(
   (page as any)._yamlMode = yamlMode;
   document.body.appendChild(page);
   await page.updateComplete;
-  await flushPending();
+  await flushMicrotasks(8);
   return page;
 }
 
@@ -71,13 +68,13 @@ describe("dashboard yaml host attribute", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (page as any)._yamlMode = true;
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
     expect(page.hasAttribute("yaml")).toBe(true);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (page as any)._yamlMode = false;
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
     expect(page.hasAttribute("yaml")).toBe(false);
   });
 });

--- a/test/pages/device-platform-ready.test.ts
+++ b/test/pages/device-platform-ready.test.ts
@@ -34,6 +34,7 @@ import type { BoardCatalogEntry } from "../../src/api/types/boards.js";
 import type { ConfiguredDevice } from "../../src/api/types/devices.js";
 import { ESPHomePageDevice } from "../../src/pages/device.js";
 import { _clearBoardBodyCache } from "../../src/util/board-body-cache.js";
+import { flushMicrotasks } from "../_dom.js";
 
 const board = (overrides: Partial<BoardCatalogEntry> = {}): BoardCatalogEntry =>
   ({
@@ -86,12 +87,8 @@ async function mountPage(
   page.id = id;
   document.body.appendChild(page);
   await page.updateComplete;
-  await flushPending();
+  await flushMicrotasks(8);
   return page;
-}
-
-async function flushPending(times = 8): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
 }
 
 function readPlatformReady(page: ESPHomePageDevice): boolean {
@@ -155,7 +152,7 @@ describe("device page _platformReady lifecycle", () => {
     (page as any)._devices = [device({ board_id: "rp2040-rpi-pico" })];
     page.requestUpdate();
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
 
     expect(readPlatformReady(page)).toBe(true);
     expect(readBoard(page)).toBeNull();
@@ -192,7 +189,7 @@ describe("device page _platformReady lifecycle", () => {
     (page as any)._devicesLoaded = true;
     page.requestUpdate();
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
 
     expect(readPlatformReady(page)).toBe(true);
     expect(readBoard(page)?.id).toBe("esp32cam");
@@ -220,7 +217,7 @@ describe("device page _platformReady lifecycle", () => {
     (page as any)._devices = [device({ configuration: "bedroom.yaml", name: "bedroom" })];
     page.requestUpdate();
     await page.updateComplete;
-    await flushPending();
+    await flushMicrotasks(8);
 
     // Eventually true again after the new board fetch resolves.
     expect(readPlatformReady(page)).toBe(true);

--- a/test/util/ensure-secret-with-toast.test.ts
+++ b/test/util/ensure-secret-with-toast.test.ts
@@ -18,7 +18,7 @@ import {
   setSecretWithToast,
 } from "../../src/util/ensure-secret-with-toast.js";
 import { _resetSecretKeysCache } from "../../src/util/secrets-cache.js";
-import { identityLocalize } from "../_dom.js";
+import { flush, identityLocalize } from "../_dom.js";
 
 const localize = identityLocalize as (key: string, args?: unknown) => string;
 const messages = {
@@ -26,7 +26,6 @@ const messages = {
   errorKey: "device.error",
   logLabel: "create failed",
 };
-const flush = () => new Promise((r) => setTimeout(r, 0));
 
 /** Stub API whose ``setSecret`` reports the given create/overwrite outcome. */
 function apiWith(created: boolean, keys: string[]) {

--- a/test/util/paged-list-controller.test.ts
+++ b/test/util/paged-list-controller.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PagedListController } from "../../src/util/paged-list-controller.js";
+import { flushTimers } from "../_dom.js";
 import { FakeHost } from "../_fake-host.js";
-
-const flush = () => vi.advanceTimersByTimeAsync(0);
 
 // A fetcher over a fixed dataset that slices by offset/limit.
 function datasetFetch(total: number) {
@@ -38,7 +37,7 @@ describe("PagedListController", () => {
     ctrl.reset(fetchPage);
     expect(ctrl.loading).toBe(true);
     expect(ctrl.hasLoaded).toBe(false);
-    await flush();
+    await flushTimers();
 
     expect(fetchPage).toHaveBeenCalledWith(0, 50);
     expect(ctrl.items).toHaveLength(50);
@@ -52,18 +51,18 @@ describe("PagedListController", () => {
     const { ctrl } = make();
     const { fetchPage } = datasetFetch(120);
     ctrl.reset(fetchPage);
-    await flush();
+    await flushTimers();
 
     ctrl.loadMore();
     expect(ctrl.loadingMore).toBe(true);
-    await flush();
+    await flushTimers();
     expect(fetchPage).toHaveBeenLastCalledWith(50, 50);
     expect(ctrl.items).toHaveLength(100);
     expect(ctrl.items[50]).toBe(50);
     expect(ctrl.hasMore).toBe(true);
 
     ctrl.loadMore();
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toHaveLength(120);
     expect(ctrl.hasMore).toBe(false);
   });
@@ -76,23 +75,23 @@ describe("PagedListController", () => {
     // Painted immediately, before the fetch resolves, so the loading state
     // shows even when reset comes off a debounced (non-reactive) callback.
     expect(host.updates).toBe(1);
-    await flush();
+    await flushTimers();
     const afterFirstPage = host.updates;
 
     ctrl.loadMore();
     expect(host.updates).toBe(afterFirstPage + 1);
-    await flush();
+    await flushTimers();
   });
 
   it("loadMore is a no-op when the list is already full", async () => {
     const { ctrl } = make();
     const { fetchPage } = datasetFetch(30);
     ctrl.reset(fetchPage);
-    await flush();
+    await flushTimers();
     expect(ctrl.hasMore).toBe(false);
 
     ctrl.loadMore();
-    await flush();
+    await flushTimers();
     expect(fetchPage).toHaveBeenCalledTimes(1);
   });
 
@@ -107,13 +106,13 @@ describe("PagedListController", () => {
 
     const { fetchPage: fast } = datasetFetch(10);
     ctrl.reset(fast);
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toHaveLength(10);
     expect(ctrl.total).toBe(10);
 
     // The superseded first page resolves late — it must not clobber the list.
     release({ items: [999, 998, 997], total: 999 });
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toHaveLength(10);
     expect(ctrl.total).toBe(10);
   });
@@ -128,7 +127,7 @@ describe("PagedListController", () => {
         : new Promise<{ items: number[]; total: number }>((r) => (release = r))
     );
     ctrl.reset(fetchPage);
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toEqual([0, 1, 2]);
 
     ctrl.loadMore();
@@ -136,13 +135,13 @@ describe("PagedListController", () => {
 
     const { fetchPage: fast } = datasetFetch(5);
     ctrl.reset(fast);
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toEqual([0, 1, 2, 3, 4]);
     expect(ctrl.loadingMore).toBe(false);
 
     // The stale loadMore resolves; it must not append onto the new query.
     release({ items: [100, 101], total: 9 });
-    await flush();
+    await flushTimers();
     expect(ctrl.items).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -152,7 +151,7 @@ describe("PagedListController", () => {
     ctrl.reset(async () => {
       throw boom;
     });
-    await flush();
+    await flushTimers();
     expect(ctrl.error).toBe(boom);
     expect(ctrl.loading).toBe(false);
     expect(ctrl.items).toEqual([]);

--- a/test/util/secrets-cache-invalidation.test.ts
+++ b/test/util/secrets-cache-invalidation.test.ts
@@ -13,11 +13,10 @@ import {
   getCachedSecretKeys,
   subscribeSecretKeys,
 } from "../../src/util/secrets-cache.js";
+import { flush } from "../_dom.js";
 
 const makeApi = (impl: () => Promise<string[]>): ESPHomeAPI =>
   ({ getSecretKeys: vi.fn(impl) }) as unknown as ESPHomeAPI;
-
-const tick = () => new Promise((r) => setTimeout(r, 0));
 
 afterEach(() => {
   _resetSecretKeysCache();
@@ -36,7 +35,7 @@ describe("secrets-cache refresh on secrets-saved", () => {
     // A save elsewhere refreshes the cache in place (no empty flash).
     keys = ["wifi_ssid", "fresh_secret"];
     window.dispatchEvent(new CustomEvent("secrets-saved", { detail: { source: {} } }));
-    await tick();
+    await flush();
 
     expect(api.getSecretKeys).toHaveBeenCalledTimes(2);
     expect(getCachedSecretKeys()).toEqual(["wifi_ssid", "fresh_secret"]);
@@ -46,7 +45,7 @@ describe("secrets-cache refresh on secrets-saved", () => {
   it("does nothing before any fetch has provided an api", async () => {
     // No picker ever mounted → no api captured → the handler is a no-op.
     window.dispatchEvent(new CustomEvent("secrets-saved", { detail: { source: {} } }));
-    await tick();
+    await flush();
     expect(getCachedSecretKeys()).toBeUndefined();
   });
 });

--- a/test/util/secrets-write.test.ts
+++ b/test/util/secrets-write.test.ts
@@ -10,8 +10,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { ensureSecretInYaml, setSecretInYaml } from "../../src/util/secrets-write.js";
-
-const tick = () => new Promise((r) => setTimeout(r, 0));
+import { flush } from "../_dom.js";
 
 function apiWith(created: boolean) {
   return {
@@ -29,7 +28,7 @@ describe("ensureSecretInYaml", () => {
 
     expect(result).toEqual({ created: true });
     expect(api.setSecret).toHaveBeenCalledWith("kitchen__encryption_key", "oQ3==", false);
-    await tick();
+    await flush();
     expect(saved).toHaveBeenCalled();
     window.removeEventListener("secrets-saved", saved as EventListener);
   });
@@ -42,7 +41,7 @@ describe("ensureSecretInYaml", () => {
     const result = await ensureSecretInYaml(api, "kitchen__encryption_key", "new");
 
     expect(result).toEqual({ created: false });
-    await tick();
+    await flush();
     expect(saved).not.toHaveBeenCalled();
     window.removeEventListener("secrets-saved", saved as EventListener);
   });
@@ -67,7 +66,7 @@ describe("setSecretInYaml", () => {
     await setSecretInYaml(api, "kitchen__encryption_key", "new");
 
     expect(api.setSecret).toHaveBeenCalledWith("kitchen__encryption_key", "new", true);
-    await tick();
+    await flush();
     expect(saved).toHaveBeenCalled();
     window.removeEventListener("secrets-saved", saved as EventListener);
   });

--- a/test/util/serial-ports-poll-controller.test.ts
+++ b/test/util/serial-ports-poll-controller.test.ts
@@ -6,6 +6,7 @@ import {
   SerialPortsPollController,
   sortSerialPorts,
 } from "../../src/util/serial-ports-poll-controller.js";
+import { flushTimers } from "../_dom.js";
 import { FakeHost } from "../_fake-host.js";
 import { makeSerialPort } from "../_make-serial-port.js";
 
@@ -33,7 +34,6 @@ function make(initial: SerialPort[] = [A]) {
   };
 }
 
-const flush = () => vi.advanceTimersByTimeAsync(0);
 const tick = () => vi.advanceTimersByTimeAsync(SERIAL_PORTS_POLL_INTERVAL_MS);
 
 beforeEach(() => {
@@ -53,7 +53,7 @@ describe("SerialPortsPollController", () => {
 
     ctrl.set(true);
     expect(ctrl.loading).toBe(true);
-    await flush();
+    await flushTimers();
     expect(getSerialPorts).toHaveBeenCalledTimes(1);
     expect(ctrl.loading).toBe(false);
     expect(ctrl.ports).toEqual([A]);
@@ -68,7 +68,7 @@ describe("SerialPortsPollController", () => {
   it("flags ports that appear after the first fetch and keeps them flagged while present", async () => {
     const { ctrl, respond } = make([A]);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
 
     respond([A, B]);
     await tick();
@@ -90,14 +90,14 @@ describe("SerialPortsPollController", () => {
   it("stops polling on deactivation and on host disconnect", async () => {
     const { ctrl, getSerialPorts } = make();
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     ctrl.set(false);
     await tick();
     await tick();
     expect(getSerialPorts).toHaveBeenCalledTimes(1);
 
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     expect(getSerialPorts).toHaveBeenCalledTimes(2);
     ctrl.hostDisconnected();
     await tick();
@@ -107,7 +107,7 @@ describe("SerialPortsPollController", () => {
   it("does not fetch from an interval callback that was queued before deactivation", async () => {
     const { ctrl, getSerialPorts } = make();
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     ctrl.set(false);
     // A callback already queued when clearInterval ran still fires.
     await (ctrl as unknown as { _poll(): Promise<void> })._poll();
@@ -117,7 +117,7 @@ describe("SerialPortsPollController", () => {
   it("resets the list and the new-port baseline on each activation", async () => {
     const { ctrl, respond } = make([A]);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     respond([A, B]);
     await tick();
     expect(ctrl.newPorts.has(B.port)).toBe(true);
@@ -127,7 +127,7 @@ describe("SerialPortsPollController", () => {
 
     ctrl.set(true);
     expect(ctrl.ports).toEqual([]);
-    await flush();
+    await flushTimers();
     expect(ctrl.ports).toEqual([A, B]);
     expect(ctrl.newPorts.size).toBe(0);
   });
@@ -135,7 +135,7 @@ describe("SerialPortsPollController", () => {
   it("only requests a host update when the list actually changes", async () => {
     const { ctrl, host } = make([A]);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     const after = host.updates;
     await tick();
     await tick();
@@ -147,7 +147,7 @@ describe("SerialPortsPollController", () => {
     const boom = new Error("boom");
     respond(boom);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     expect(ctrl.error).toBe(boom);
     expect(ctrl.loading).toBe(false);
     expect(host.updates).toBe(1);
@@ -170,7 +170,7 @@ describe("SerialPortsPollController", () => {
     const { ctrl, respond } = make();
     respond(new Error("boom"));
     ctrl.set(true);
-    await flush();
+    await flushTimers();
 
     respond([A, B]);
     await tick();
@@ -197,14 +197,14 @@ describe("SerialPortsPollController", () => {
 
     const { ctrl } = make([generic, bridge, esp]);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
     expect(ctrl.ports).toEqual([esp, bridge, generic]);
   });
 
   it("swallows poll errors after a successful fetch, keeping the last good list", async () => {
     const { ctrl, respond } = make([A]);
     ctrl.set(true);
-    await flush();
+    await flushTimers();
 
     respond(new Error("transient"));
     await tick();

--- a/test/util/session-blob-cache-controller.test.ts
+++ b/test/util/session-blob-cache-controller.test.ts
@@ -3,11 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { ESPHomeAPI } from "../../src/api/esphome-api.js";
 import { SessionBlobCacheController } from "../../src/util/session-blob-cache-controller.js";
 import { createSessionBlobCache } from "../../src/util/session-blob-cache.js";
+import { flush } from "../_dom.js";
 import { fakeHost } from "../_fake-host.js";
 
 const fakeApi = (): ESPHomeAPI => ({}) as unknown as ESPHomeAPI;
-
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 /** A no-arg session-blob cache over a fetcher that resolves to ``payload``,
  *  exposed as the {@link SessionBlobCacheBinding} a controller consumes. */

--- a/test/util/yaml-lint-humanize.test.ts
+++ b/test/util/yaml-lint-humanize.test.ts
@@ -18,8 +18,7 @@ import {
   type BannerError,
   type MappedValidationError,
 } from "../../src/util/yaml-lint-backend.js";
-
-const flush = () => new Promise((r) => setTimeout(r, 0));
+import { flush } from "../_dom.js";
 
 // Echo the key + line so a humanized hit is distinguishable from raw text.
 const localize = (key: string, values?: Record<string, string | number>): string =>

--- a/test/util/yaml-lint-relint.test.ts
+++ b/test/util/yaml-lint-relint.test.ts
@@ -17,8 +17,7 @@ import {
   createBackendYamlLinter,
   relintEffect,
 } from "../../src/util/yaml-lint-backend.js";
-
-const flush = () => new Promise((r) => setTimeout(r, 0));
+import { flush } from "../_dom.js";
 
 function mountView(validateYaml: ESPHomeAPI["validateYaml"]): EditorView {
   const api = { validateYaml } as unknown as ESPHomeAPI;


### PR DESCRIPTION
# What does this implement/fix?

The flush helper was re-implemented in 23 test files with three slightly different shapes; test/_dom.ts now exports flush (zero delay timeout), flushMicrotasks(times) (microtask drain, callers keep their tuned counts), and flushTimers (fake timer variant), and every local copy imports the shared one instead. The interval advancing tick in the serial ports poll test is left alone since it means something different.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1144

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
