### PR TITLE
Share a dashboard host stub factory across dashboard tests

### DIFF
--- a/test/components/dashboard/_host.ts
+++ b/test/components/dashboard/_host.ts
@@ -1,0 +1,19 @@
+import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { identityLocalize } from "../../_dom.js";
+
+/**
+ * Overrides-based stub for helpers that take the dashboard page as host.
+ *
+ * Defaults cover the fields every consumer reads; pass surface-specific
+ * state, spies, and the ``_api`` method subset through ``overrides``.
+ */
+export function makeDashboardHost(
+  overrides: Record<string, unknown> = {}
+): ESPHomePageDashboard {
+  return {
+    _localize: identityLocalize,
+    _yamlMode: false,
+    _search: "",
+    ...overrides,
+  } as unknown as ESPHomePageDashboard;
+}

--- a/test/components/dashboard/_host.ts
+++ b/test/components/dashboard/_host.ts
@@ -4,7 +4,7 @@ import { identityLocalize } from "../../_dom.js";
 /**
  * Overrides-based stub for helpers that take the dashboard page as host.
  *
- * Defaults cover the fields every consumer reads; pass surface-specific
+ * Common dashboard-host fields get inert defaults; pass surface-specific
  * state, spies, and the ``_api`` method subset through ``overrides``.
  */
 export function makeDashboardHost(

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../src/components/dashboard/render-dialogs.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
 import { makeConfiguredDevice } from "../../_make-configured-device.js";
+import { makeDashboardHost } from "./_host.js";
 
 const { toastError, toastSuccess } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -47,7 +48,7 @@ function makeHost(
   state: DeviceState = DeviceState.ONLINE
 ): { host: ESPHomePageDashboard; openConfirm: ReturnType<typeof vi.fn> } {
   const openConfirm = vi.fn();
-  const host = {
+  const host = makeDashboardHost({
     _actionDevice: {
       name: "rename_test",
       friendly_name: "Rename_Test",
@@ -57,7 +58,7 @@ function makeHost(
     _api: { renameDevice } as unknown as ESPHomeAPI,
     _localize: localize,
     _openConfirm: openConfirm,
-  } as unknown as ESPHomePageDashboard;
+  });
   return { host, openConfirm };
 }
 
@@ -77,7 +78,7 @@ describe("openLogsWithMethod web-serial", () => {
 
   it("blocks serial logs and notifies when logging is disabled (baud_rate 0)", async () => {
     vi.stubGlobal("navigator", { serial: {} });
-    const host = { _localize: localize } as unknown as ESPHomePageDashboard;
+    const host = makeDashboardHost({ _localize: localize });
     const device = {
       configuration: "x.yaml",
       name: "x",
@@ -201,10 +202,10 @@ describe("clear-queued-update confirm", () => {
   function makeClearHost(
     firmwareClearQueuedUpdate: ESPHomeAPI["firmwareClearQueuedUpdate"]
   ): ESPHomePageDashboard {
-    return {
+    return makeDashboardHost({
       _api: { firmwareClearQueuedUpdate } as unknown as ESPHomeAPI,
       _localize: localize,
-    } as unknown as ESPHomePageDashboard;
+    });
   }
 
   it("is a non-destructive confirm naming the device", () => {

--- a/test/components/dashboard/actions-ui.test.ts
+++ b/test/components/dashboard/actions-ui.test.ts
@@ -78,7 +78,7 @@ describe("openLogsWithMethod web-serial", () => {
 
   it("blocks serial logs and notifies when logging is disabled (baud_rate 0)", async () => {
     vi.stubGlobal("navigator", { serial: {} });
-    const host = makeDashboardHost({ _localize: localize });
+    const host = makeDashboardHost();
     const device = {
       configuration: "x.yaml",
       name: "x",

--- a/test/components/dashboard/prefs.test.ts
+++ b/test/components/dashboard/prefs.test.ts
@@ -8,16 +8,16 @@ import type { VisibilityState } from "@tanstack/lit-table";
 import { describe, expect, it, vi } from "vitest";
 import { SortDirection } from "../../../src/api/types/system.js";
 import { saveTablePreference } from "../../../src/components/dashboard/prefs.js";
-import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
+import { makeDashboardHost } from "./_host.js";
 
 function makeHost() {
   const updatePreferences = vi.fn(async () => {});
-  const host = {
+  const host = makeDashboardHost({
     _api: { updatePreferences },
     _tablePageSize: 25,
     _tableColumnVisibility: null,
     _tableSorting: null,
-  } as unknown as ESPHomePageDashboard;
+  });
   return { host, updatePreferences };
 }
 

--- a/test/components/dashboard/render-facets.test.ts
+++ b/test/components/dashboard/render-facets.test.ts
@@ -11,18 +11,16 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 
 import { renderFacets } from "../../../src/components/dashboard/render-facets.js";
-import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
-import { identityLocalize, renderInto } from "../../_dom.js";
+import { renderInto } from "../../_dom.js";
+import { makeDashboardHost } from "./_host.js";
 
 // Minimal host-shaped fake. Empty _devices means the Area/Platform
 // facets compute no options and self-suppress, so the popover
 // reduces to the always-present labels + status sections — enough to
 // assert the wrapper choice without standing up the page.
 function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
-  return {
+  return makeDashboardHost({
     _devices: [],
-    _localize: identityLocalize,
-    _yamlMode: false,
     _selectedLabels: [],
     _selectedAreas: [],
     _selectedPlatforms: [],
@@ -36,7 +34,7 @@ function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
     _labelDialogOpen: false,
     _labelDialogEditing: null,
     ...overrides,
-  } as unknown as ESPHomePageDashboard;
+  });
 }
 
 const sectionByName = (root: HTMLElement, name: string) =>

--- a/test/components/dashboard/render-toolbar.test.ts
+++ b/test/components/dashboard/render-toolbar.test.ts
@@ -16,18 +16,16 @@ import {
   renderViewToggle,
 } from "../../../src/components/dashboard/render-toolbar.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
-import { identityLocalize, renderInto } from "../../_dom.js";
+import { renderInto } from "../../_dom.js";
+import { makeDashboardHost } from "./_host.js";
 
 function makeHost(overrides: Partial<Record<string, unknown>> = {}) {
-  return {
-    _localize: identityLocalize,
-    _yamlMode: false,
-    _search: "",
+  return makeDashboardHost({
     _syncYamlSearch: vi.fn(),
     _onSearchKeyDown: vi.fn(),
     _clearSearch: vi.fn(),
     ...overrides,
-  } as unknown as ESPHomePageDashboard;
+  });
 }
 
 describe("renderSearchInput", () => {

--- a/test/components/dashboard/render-yaml.test.ts
+++ b/test/components/dashboard/render-yaml.test.ts
@@ -12,7 +12,8 @@ vi.mock("@home-assistant/webawesome/dist/components/icon/icon.js", () => ({}));
 import type { YamlSearchHit } from "../../../src/api/types/devices.js";
 import { renderYamlMode } from "../../../src/components/dashboard/render-yaml.js";
 import type { ESPHomePageDashboard } from "../../../src/pages/dashboard.js";
-import { identityLocalize, renderInto } from "../../_dom.js";
+import { renderInto } from "../../_dom.js";
+import { makeDashboardHost } from "./_host.js";
 
 function makeHit(): YamlSearchHit {
   return {
@@ -31,11 +32,7 @@ function makeHit(): YamlSearchHit {
 }
 
 function makeHost(hits: YamlSearchHit[]): ESPHomePageDashboard {
-  return {
-    _localize: identityLocalize,
-    _search: "living",
-    _yamlSearch: { hits },
-  } as unknown as ESPHomePageDashboard;
+  return makeDashboardHost({ _search: "living", _yamlSearch: { hits } });
 }
 
 describe("renderYamlMode hit header", () => {


### PR DESCRIPTION
# What does this implement/fix?

Five dashboard test files each rolled their own stub host literal with the same as unknown as ESPHomePageDashboard cast; test/components/dashboard/_host.ts now exports an overrides based makeDashboardHost that owns the cast and the shared defaults (_localize, _yamlMode, _search), and the per file factories shrink to their surface specific fields. open-logs.test.ts keeps its typed StubHost on purpose, its Pick based _api and spy typed _logsDialog give real type checking the cast would lose; the app shell Pick factories stay out of scope for the same reason.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder-frontend/issues/1143

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `npm run lint` passes.
- [x] `npm run test` passes.
- [x] Tests have been added to verify that the new code works (where applicable).
